### PR TITLE
Fix Pages directory resolution

### DIFF
--- a/.changeset/selfish-wolves-hide.md
+++ b/.changeset/selfish-wolves-hide.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Correctly resolve directories for 'wrangler pages publish'
+
+Previously, attempting to publish a nested directory or the current directory would result in parsing mangled paths which broke deployments. This has now been fixed.


### PR DESCRIPTION
fix: Correctly resolve directories for 'wrangler pages publish'

Previously, attempting to publish a nested directory or the current directory would result in parsing mangled paths which broke deployments. This has now been fixed.

Fixes #938 