### PR TITLE
fix: log pubsub beta usage warnings consistently

### DIFF
--- a/.changeset/lovely-bulldogs-repeat.md
+++ b/.changeset/lovely-bulldogs-repeat.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: log pubsub beta usage warnings consistently
+
+This fix makes sure the pubsub beta warnings are logged consistently, once per help menu, through the hierarchy of its command tree.
+
+Fixes https://github.com/cloudflare/wrangler2/issues/1370

--- a/packages/wrangler/src/__tests__/pubsub.test.ts
+++ b/packages/wrangler/src/__tests__/pubsub.test.ts
@@ -21,7 +21,63 @@ describe("wrangler", () => {
 	});
 
 	describe("pubsub", () => {
+		describe("help menu", () => {
+			it("shows usage details", async () => {
+				await runWrangler("pubsub --help");
+				expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "wrangler pubsub
+
+			📮 Interact and manage Pub/Sub Brokers
+
+			Commands:
+			  wrangler pubsub namespace  Manage your Pub/Sub Namespaces
+			  wrangler pubsub broker     Interact with your Pub/Sub Brokers
+
+			Flags:
+			  -c, --config   Path to .toml configuration file  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
+
+			👷🏽 'wrangler pubsub ...' commands are currently in private beta. If your account isn't authorized, commands will fail. Visit the Pub/Sub docs for more info: https://developers.cloudflare.com/pub-sub/",
+			  "warn": "",
+			}
+		`);
+			});
+		});
+
 		describe("namespaces", () => {
+			describe("help menu", () => {
+				it("shows usage details", async () => {
+					await runWrangler("pubsub namespace --help");
+					expect(std).toMatchInlineSnapshot(`
+				Object {
+				  "debug": "",
+				  "err": "",
+				  "out": "wrangler pubsub namespace
+
+				Manage your Pub/Sub Namespaces
+
+				Commands:
+				  wrangler pubsub namespace create <name>    Create a new Pub/Sub Namespace
+				  wrangler pubsub namespace list             List your existing Pub/Sub Namespaces
+				  wrangler pubsub namespace delete <name>    Delete a Pub/Sub Namespace
+				  wrangler pubsub namespace describe <name>  Describe a Pub/Sub Namespace
+
+				Flags:
+				  -c, --config   Path to .toml configuration file  [string]
+				  -h, --help     Show help  [boolean]
+				  -v, --version  Show version number  [boolean]
+
+				👷🏽 'wrangler pubsub ...' commands are currently in private beta. If your account isn't authorized, commands will fail. Visit the Pub/Sub docs for more info: https://developers.cloudflare.com/pub-sub/",
+				  "warn": "",
+				}
+			`);
+				});
+			});
+
 			describe("create", () => {
 				function mockCreateRequest(expectedNamespaceName: string) {
 					const requests = { count: 0 };
@@ -77,6 +133,41 @@ describe("wrangler", () => {
 		});
 
 		describe("brokers", () => {
+			describe("help menu", () => {
+				it("shows usage details", async () => {
+					await runWrangler("pubsub broker --help");
+					expect(std).toMatchInlineSnapshot(`
+				Object {
+				  "debug": "",
+				  "err": "",
+				  "out": "wrangler pubsub broker
+
+				Interact with your Pub/Sub Brokers
+
+				Commands:
+				  wrangler pubsub broker create <name>            Create a new Pub/Sub Broker
+				  wrangler pubsub broker update <name>            Update an existing Pub/Sub Broker's configuration.
+				  wrangler pubsub broker list                     List the Pub/Sub Brokers within a Namespace
+				  wrangler pubsub broker delete <name>            Delete an existing Pub/Sub Broker
+				  wrangler pubsub broker describe <name>          Describe an existing Pub/Sub Broker.
+				  wrangler pubsub broker issue <name>             Issue new client credentials for a specific Pub/Sub Broker.
+				  wrangler pubsub broker revoke <name>            Revoke a set of active client credentials associated with the given Broker
+				  wrangler pubsub broker unrevoke <name>          Restore access to a set of previously revoked client credentials.
+				  wrangler pubsub broker show-revocations <name>  Show all previously revoked client credentials.
+				  wrangler pubsub broker public-keys <name>       Show the public keys used for verifying on-publish hooks and credentials for a Broker.
+
+				Flags:
+				  -c, --config   Path to .toml configuration file  [string]
+				  -h, --help     Show help  [boolean]
+				  -v, --version  Show version number  [boolean]
+
+				👷🏽 'wrangler pubsub ...' commands are currently in private beta. If your account isn't authorized, commands will fail. Visit the Pub/Sub docs for more info: https://developers.cloudflare.com/pub-sub/",
+				  "warn": "",
+				}
+			`);
+				});
+			});
+
 			describe("create", () => {
 				function mockCreateRequest(expectedBrokerName: string) {
 					const requests = { count: 0 };


### PR DESCRIPTION
This fix makes sure the pubsub beta warnings are logged consistently, once per help menu, through the hierarchy of its command tree.

Fixes https://github.com/cloudflare/wrangler2/issues/1370

--- 

(Turn off whitespace for this review. It's mostly mechanical, and some added snapshot tests)