### PR TITLE
feat: `config.no_bundle` as a configuration option to prevent bundling

### DIFF
--- a/.changeset/eleven-apes-grow.md
+++ b/.changeset/eleven-apes-grow.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: `config.no_bundle` as a configuration option to prevent bundling
+
+As a configuration parallel to `--no-bundle` (introduced in https://github.com/cloudflare/wrangler2/pull/1300 as `--no-build`, renamed in https://github.com/cloudflare/wrangler2/pull/1399 to `--no-bundle`), this introduces a configuration field `no_bundle` to prevent bundling of the worker before it's published. It's inheritable, which means it can be defined inside environments as well.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -62,6 +62,7 @@ describe("normalizeAndValidateConfig()", () => {
 			data_blobs: undefined,
 			workers_dev: undefined,
 			zone_id: undefined,
+			no_bundle: undefined,
 			minify: undefined,
 			node_compat: undefined,
 		});
@@ -848,6 +849,7 @@ describe("normalizeAndValidateConfig()", () => {
 						},
 					],
 				},
+				no_bundle: true,
 				minify: true,
 				node_compat: true,
 			};
@@ -920,6 +922,7 @@ describe("normalizeAndValidateConfig()", () => {
 				define: {
 					DEF1: 1777,
 				},
+				no_bundle: "INVALID",
 				minify: "INVALID",
 				node_compat: "INVALID",
 			} as unknown as RawEnvironment;
@@ -986,6 +989,7 @@ describe("normalizeAndValidateConfig()", () => {
 			  - Expected \\"main\\" to be of type string but got 1333.
 			  - Expected \\"usage_model\\" field to be one of [\\"bundled\\",\\"unbound\\"] but got \\"INVALID\\".
 			  - The field \\"define.DEF1\\" should be a string but got 1777.
+			  - Expected \\"no_bundle\\" to be of type boolean but got \\"INVALID\\".
 			  - Expected \\"minify\\" to be of type boolean but got \\"INVALID\\".
 			  - Expected \\"node_compat\\" to be of type boolean but got \\"INVALID\\"."
 		`);
@@ -2192,6 +2196,7 @@ describe("normalizeAndValidateConfig()", () => {
 					cwd: "CWD",
 					watch_dir: "WATCH_DIR",
 				},
+				no_bundle: true,
 				minify: true,
 				node_compat: true,
 			};
@@ -2234,6 +2239,7 @@ describe("normalizeAndValidateConfig()", () => {
 					cwd: "ENV_CWD",
 					watch_dir: "ENV_WATCH_DIR",
 				},
+				no_bundle: false,
 				minify: false,
 				node_compat: false,
 			};
@@ -2255,6 +2261,7 @@ describe("normalizeAndValidateConfig()", () => {
 					cwd: "CWD",
 					watch_dir: "WATCH_DIR",
 				},
+				no_bundle: true,
 				minify: true,
 				node_compat: true,
 				env: {
@@ -2515,6 +2522,7 @@ describe("normalizeAndValidateConfig()", () => {
 					cwd: 1555,
 					watch_dir: 1666,
 				},
+				no_bundle: "INVALID",
 				minify: "INVALID",
 				node_compat: "INVALID",
 			} as unknown as RawEnvironment;
@@ -2550,6 +2558,7 @@ describe("normalizeAndValidateConfig()", () => {
 			    - Expected \\"name\\" to be of type string, alphanumeric and lowercase with dashes only but got 111.
 			    - Expected \\"main\\" to be of type string but got 1333.
 			    - Expected \\"usage_model\\" field to be one of [\\"bundled\\",\\"unbound\\"] but got \\"INVALID\\".
+			    - Expected \\"no_bundle\\" to be of type boolean but got \\"INVALID\\".
 			    - Expected \\"minify\\" to be of type boolean but got \\"INVALID\\".
 			    - Expected \\"node_compat\\" to be of type boolean but got \\"INVALID\\"."
 		`);

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -6026,7 +6026,7 @@ addEventListener('fetch', event => {});`
 	});
 
 	describe("--no-bundle", () => {
-		it("should not transform the source code before publishing it", async () => {
+		it("(cli) should not transform the source code before publishing it", async () => {
 			writeWranglerToml();
 			const scriptContent = `
       import X from '@cloudflare/no-such-package'; // let's add an import that doesn't exist
@@ -6034,6 +6034,19 @@ addEventListener('fetch', event => {});`
     `;
 			fs.writeFileSync("index.js", scriptContent);
 			await runWrangler("publish index.js --no-bundle --dry-run --outdir dist");
+			expect(fs.readFileSync("dist/index.js", "utf-8")).toMatch(scriptContent);
+		});
+
+		it("(config) should not transform the source code before publishing it", async () => {
+			writeWranglerToml({
+				no_bundle: true,
+			});
+			const scriptContent = `
+			import X from '@cloudflare/no-such-package'; // let's add an import that doesn't exist
+			const xyz = 123; // a statement that would otherwise be compiled out
+		`;
+			fs.writeFileSync("index.js", scriptContent);
+			await runWrangler("publish index.js --dry-run --outdir dist");
 			expect(fs.readFileSync("dist/index.js", "utf-8")).toMatch(scriptContent);
 		});
 	});

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -184,6 +184,12 @@ interface EnvironmentInheritable {
 	};
 
 	/**
+	 * Skip internal build steps and directly publish script
+	 * @inheritable
+	 */
+	no_bundle: boolean | undefined;
+
+	/**
 	 * Minify the script before uploading.
 	 * @inheritable
 	 */
@@ -191,6 +197,7 @@ interface EnvironmentInheritable {
 
 	/**
 	 * Add polyfills for node builtin modules and globals
+	 * @inheritable
 	 */
 	node_compat: boolean | undefined;
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1030,6 +1030,14 @@ function normalizeAndValidateEnvironment(
 			}
 		),
 		zone_id: rawEnv.zone_id,
+		no_bundle: inheritable(
+			diagnostics,
+			topLevelEnv,
+			rawEnv,
+			"no_bundle",
+			isBoolean,
+			undefined
+		),
 		minify: inheritable(
 			diagnostics,
 			topLevelEnv,

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -82,7 +82,6 @@ export function devOptions(yargs: Argv): Argv<DevArgs> {
 			.option("bundle", {
 				describe: "Run wrangler's compilation step before publishing",
 				type: "boolean",
-				default: true,
 				hidden: true,
 			})
 			.option("no-bundle", {
@@ -454,7 +453,7 @@ export async function startDev(args: ArgumentsCamelCase<DevArgs>) {
 			return (
 				<Dev
 					name={getScriptName({ name: args.name, env: args.env }, config)}
-					noBundle={!args.bundle}
+					noBundle={!(args.bundle ?? !config.no_bundle)}
 					entry={entry}
 					env={args.env}
 					zone={zoneId}

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -379,7 +379,6 @@ function createCLIParser(argv: string[]) {
 					.option("bundle", {
 						describe: "Run wrangler's compilation step before publishing",
 						type: "boolean",
-						default: true,
 						hidden: true,
 					})
 					.option("no-bundle", {
@@ -564,7 +563,7 @@ function createCLIParser(argv: string[]) {
 				isWorkersSite: Boolean(args.site || config.site),
 				outDir: args.outdir,
 				dryRun: args.dryRun,
-				noBundle: !args.bundle,
+				noBundle: !(args.bundle ?? !config.no_bundle),
 			});
 		}
 	);


### PR DESCRIPTION
As a configuration parallel to `--no-bundle` (introduced in https://github.com/cloudflare/wrangler2/pull/1300 as `--no-build`, renamed in https://github.com/cloudflare/wrangler2/pull/1399 to `--no-bundle`), this introduces a configuration field `no_bundle` to prevent bundling of the worker before it's published. It's inheritable, which means it can be defined inside environments as well.