### PR TITLE
fix: infinite loop if spawning command fails in `pages dev`

### DIFF
--- a/.changeset/moody-pigs-retire.md
+++ b/.changeset/moody-pigs-retire.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: infinite loop if spawning command fails in `pages dev`

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -854,7 +854,9 @@ async function spawnProxyProcess({
 	});
 
 	// Wait for proxy process to start...
-	while (!proxy.pid) {}
+	while (!proxy.pid) {
+		await sleep(0.1);
+	}
 
 	if (port === undefined) {
 		logger.log(


### PR DESCRIPTION
Closes #1544.