### PR TITLE
RFC: Add support for 'export default { fetch() }' in Pages Functions

### DIFF
--- a/.changeset/twenty-fans-deliver.md
+++ b/.changeset/twenty-fans-deliver.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: Add support for `export default { fetch() }` in Pages Functions

--- a/fixtures/pages-functions-app/functions/export-all.ts
+++ b/fixtures/pages-functions-app/functions/export-all.ts
@@ -1,0 +1,1 @@
+export * from "./date";

--- a/fixtures/pages-functions-app/functions/fetch-export.ts
+++ b/fixtures/pages-functions-app/functions/fetch-export.ts
@@ -1,0 +1,7 @@
+export const onRequestGet = () => new Response("hello from an onRequestGet!");
+
+export default {
+	fetch() {
+		return new Response("hello from a fetch handler!");
+	},
+};

--- a/fixtures/pages-functions-app/functions/pass-through-on-exception.ts
+++ b/fixtures/pages-functions-app/functions/pass-through-on-exception.ts
@@ -1,0 +1,4 @@
+export const onRequest = ({ passThroughOnException }) => {
+	passThroughOnException();
+	throw new Response("ha!");
+};

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -111,6 +111,23 @@ describe("Pages Functions", () => {
 		expect(text).toMatch(/\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d/);
 	});
 
+	it("can handle 'export *'", async () => {
+		const response = await waitUntilReady("http://localhost:8789/export-all");
+		const text = await response.text();
+		expect(text).toMatch(/\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d/);
+	});
+
+	it("can handle 'export default { fetch() }'", async () => {
+		let response = await waitUntilReady("http://localhost:8789/fetch-export", {
+			method: "POST",
+		});
+		let text = await response.text();
+		expect(text).toContain("hello from a fetch handler!");
+		response = await waitUntilReady("http://localhost:8789/fetch-export");
+		text = await response.text();
+		expect(text).toContain("hello from an onRequestGet!");
+	});
+
 	it("can use parameters", async () => {
 		const response = await waitUntilReady(
 			"http://localhost:8789/blog/hello-world"

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -3,6 +3,7 @@ import { dirname, relative, resolve } from "node:path";
 import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
 import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
 import { build } from "esbuild";
+import { loader } from "./esbuild";
 
 type Options = {
 	routesModule: string;
@@ -29,10 +30,7 @@ export function buildPlugin({
 		bundle: true,
 		format: "esm",
 		target: "esnext",
-		loader: {
-			".html": "text",
-			".txt": "text",
-		},
+		loader,
 		outfile,
 		minify,
 		sourcemap,

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -4,6 +4,7 @@ import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
 import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
 import { build } from "esbuild";
 import { nanoid } from "nanoid";
+import { loader } from "./esbuild";
 
 type Options = {
 	routesModule: string;
@@ -34,10 +35,7 @@ export function buildWorker({
 		bundle: true,
 		format: "esm",
 		target: "esnext",
-		loader: {
-			".html": "text",
-			".txt": "text",
-		},
+		loader,
 		outfile,
 		minify,
 		sourcemap,

--- a/packages/wrangler/src/pages/functions/esbuild.ts
+++ b/packages/wrangler/src/pages/functions/esbuild.ts
@@ -1,0 +1,6 @@
+import type { BuildOptions } from "esbuild";
+
+export const loader: BuildOptions["loader"] = {
+	".html": "text",
+	".txt": "text",
+};

--- a/packages/wrangler/src/pages/functions/routes.ts
+++ b/packages/wrangler/src/pages/functions/routes.ts
@@ -106,7 +106,9 @@ export function parseConfig(config: Config, baseDir: string) {
 				importMap.set(modulePath, { filepath: resolvedPath, name, identifier });
 			}
 
-			return identifier;
+			return name === "default"
+				? `(context) => ${identifier}.fetch(context.request, context.env, { waitUntil: context.waitUntil.bind(context) })`
+				: identifier;
 		});
 	}
 


### PR DESCRIPTION
This PR makes it possible to use a regular ol' `export default { fetch() }` within Pages Functions.

Any `onRequest(Get|Head|Post|etc)` take precedence, and if an `onRequest` is also included, the `export default { fetch() }` is not invoked.

I welcome feedback on the idea, and on the priority described above.

The only feature that's missing is `passThroughOnException()`, which we don't have in Pages Functions normally anyway.

---

**To Do**

- [ ] Log a warning on conflict between `export const onRequest` and `export default { fetch() }`