### PR TITLE
🚧 wip: `worker.scheduled()` for `unstable_dev`

### DIFF
--- a/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.scheduled.test.ts
@@ -118,6 +118,22 @@ describe("run scheduled events with middleware", () => {
 			await worker.stop();
 		});
 
+		it("should intercept when middleware is enabled and pass cron", async () => {
+			const worker = await unstable_dev(
+				"index.js",
+				{ testScheduled: true },
+				{ disableExperimentalWarning: true }
+			);
+
+			const resp = await worker.fetch("/__scheduled?cron=*+*+*+*+*");
+			let text;
+			if (resp) text = await resp.text();
+			expect(text).toMatchInlineSnapshot(
+				`"Ran scheduled event with cron \`* * * * *\`"`
+			);
+			await worker.stop();
+		});
+
 		it("should not trigger scheduled event on wrong route", async () => {
 			const worker = await unstable_dev(
 				"index.js",

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -64,6 +64,7 @@ export interface UnstableDevWorker {
 		input?: RequestInfo,
 		init?: RequestInit
 	) => Promise<Response | undefined>;
+	scheduled: (cron?: string) => Promise<Response | undefined>;
 	waitUntilExit: () => Promise<void>;
 }
 /**
@@ -127,6 +128,13 @@ export async function unstable_dev(
 							)
 						);
 					},
+					scheduled: async (cron?: string) => {
+						return await fetch(
+							`http://${readyAddress}:${readyPort}/__scheduled${
+								cron ? "?cron=" + cron : ""
+							}`
+						);
+					},
 					//no-op, does nothing in tests
 					waitUntilExit: async () => {
 						return;
@@ -167,6 +175,13 @@ export async function unstable_dev(
 								init,
 								options?.localProtocol
 							)
+						);
+					},
+					scheduled: async (cron?: string) => {
+						return await fetch(
+							`http://${readyAddress}:${readyPort}/__scheduled${
+								cron ? "?cron=" + cron : ""
+							}`
 						);
 					},
 					waitUntilExit: devServer.devReactElement.waitUntilExit,

--- a/packages/wrangler/templates/middleware/middleware-scheduled.ts
+++ b/packages/wrangler/templates/middleware/middleware-scheduled.ts
@@ -7,7 +7,9 @@ const scheduled: Middleware = async (request, env, _ctx, middlewareCtx) => {
 		const cron = url.searchParams.get("cron") ?? "";
 		await middlewareCtx.dispatch("scheduled", { cron });
 
-		return new Response("Ran scheduled event");
+		return new Response(
+			`Ran scheduled event${cron ? " with cron `" + cron + "`" : ""}`
+		);
 	}
 	return middlewareCtx.next(request, env);
 };


### PR DESCRIPTION
Initial implementation of `worker.scheduled()` for `unstable_dev`. (https://github.com/cloudflare/wrangler2/issues/1804)

```js
const worker = await unstable_dev("index.js");

const resp1 = await worker.fetch("/path");

// We now export a way of testing scheduled events
const resp2 = await worker.scheduled();
// or with a custom cron
const resp3 = await worker.scheduled("* * * * *");
```

There are a few things to think about here:

1. This relies on the middleware for testing scheduled events (https://github.com/cloudflare/wrangler2/pull/1815) - and hence actually requires us to start `unstable_dev` with `testScheduled: true`
We have a couple of options here as it isn't ideal to make people pass through testScheduled:
- Option 1: Only enable `worker.scheduled()` if `testScheduled` is set to true.
- Option 2: Enable `testScheduled` by default. This will always wrap the worker with middleware unless disabled. This would override the route `/__scheduled` which is very unlikely to have been used by people as default behaviour, but we would still expose the option for people to disable it, (and when disabled we would not allow `worker.scheduled()` to work.
- Option 3: We bundle the worker twice, once with the scheduled middleware disabled, and once with it enabled and then start two dev servers and direct traffic to each of the two depending on if people call `worker.fetch()` or `worker.scheduled().
- Option 4: Similar to option 3, just we only start up the second server on the first `worker.scheduled()` request. We could additionally only start up the non-scheduled event middleware (regular) server on the first worker.fetch(). Meaning if only one of `.scheduled()` or `.fetch()` is called we only start up one server and shouldn't(?) lead to any increased loading times overall. This would only be true in testing environments and outside of that would behave as it does now.

For Option 4:
```js
// Initial `unstable_dev` call doesn't start up any servers
const worker = await unstable_dev("index.js");

// First call to `worker.fetch()` bundles and starts up a server
const resp1 = await worker.fetch("/path");

// Subsequent calls to `worker.fetch()` use the existing server 
const resp2 = await worker.fetch("/path");

// First call to `worker.scheduled()` starts up a second server with the scheduled testing middleware bundled
const resp3 = await worker.scheduled();

// Subsequent calls to `worker.scheduled()` use the existing server with middleware bundled
const resp4 = await worker.scheduled("* * * * *");

// shuts down all servers
await worker.stop();
```

2. It is very hard to capture any response out of the scheduled events as scheduled events can't return a response. It is probably worth having a dig into how people are using scheduled events to figure out how might be best to capture something testable out of them.