### PR TITLE
Update messaging to reflect that Wrangler v2 is still Wrangler

### DIFF
--- a/.changeset/witty-penguins-impress.md
+++ b/.changeset/witty-penguins-impress.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+"wranglerjs-compat-webpack-plugin": patch
+---
+
+Update messaging to reflect that Wrangler v2 is still Wrangler
+
+Move to "Wrangler v1" and "Wrangler v2" instead of using "Wrangler 1" and "Wrangler 2", which could result in having an [Angular-like situation](<https://en.wikipedia.org/wiki/Angular_(web_framework)#:~:text=Angular%20(also%20referred%20to%20as%20%22Angular%202%2B%22)>) where we treat different versions of the same product as different products.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Wrangler2 is an open source project and we welcome contributions from you. Thank you!
+Wrangler v2 is an open source project and we welcome contributions from you. Thank you!
 
 Below you can find some guidance on how to be most effective when contributing to the project.
 
@@ -8,7 +8,7 @@ Below you can find some guidance on how to be most effective when contributing t
 
 ### Set up your environment
 
-Wrangler2 is built and run on the Node.js JavaScript runtime.
+Wrangler v2 is built and run on the Node.js JavaScript runtime.
 
 - Install the latest LTS version of [Node.js](https://nodejs.dev/) - we recommend using a Node version manager like [nvm](https://github.com/nvm-sh/nvm).
 - Install a code editor - we recommend using [VS Code](https://code.visualstudio.com/).

--- a/packages/wrangler/CHANGELOG.md
+++ b/packages/wrangler/CHANGELOG.md
@@ -1090,7 +1090,7 @@
 - [#1575](https://github.com/cloudflare/wrangler2/pull/1575) [`5b1f68ee`](https://github.com/cloudflare/wrangler2/commit/5b1f68eece2f328c65f749711cfae5105e1e9651) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - feat: legacy "kv-namespace" not supported
   In previous Wrangler v1, there was a legacy configuration that was considered a "bug" and removed.
   Before it was removed, tutorials, templates, blogs, etc... had utlized that configuration property
-  to handle this in Wrangler 2 we will throw a blocking error that tell the user to utilize "kv_namespaces"
+  to handle this in Wrangler v2 we will throw a blocking error that tell the user to utilize "kv_namespaces"
 
   resolves #1421
 
@@ -2976,7 +2976,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 - [#633](https://github.com/cloudflare/wrangler2/pull/633) [`003f3c4`](https://github.com/cloudflare/wrangler2/commit/003f3c41942ec8e299ae603fe74b3cd2e802b49d) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - refactor: create a custom CLI wrapper around Miniflare API
 
   This allows us to tightly control the options that are passed to Miniflare.
-  The current CLI is setup to be more compatible with how Wrangler v1 works, which is not optimal for Wrangler 2.
+  The current CLI is setup to be more compatible with how Wrangler v1 works, which is not optimal for Wrangler v2.
 
 * [#633](https://github.com/cloudflare/wrangler2/pull/633) [`84c857e`](https://github.com/cloudflare/wrangler2/commit/84c857eabc2c09ad1dd2f4fa3963638b8b7f3daa) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - fix: ensure asset keys are relative to the project root
 

--- a/packages/wrangler/CHANGELOG.md
+++ b/packages/wrangler/CHANGELOG.md
@@ -1064,7 +1064,7 @@
   - `wrangler generate` and `wrangler generate <name>` delegate to `wrangler init`.
   - `wrangler generate <name> <template>` delegates to `create-cloudflare`
 
-  Naming behavior is replicated from wrangler 1, and will auto-increment the
+  Naming behavior is replicated from wrangler v1, and will auto-increment the
   worker name based on pre-existing directories.
 
 * [#1534](https://github.com/cloudflare/wrangler2/pull/1534) [`d3ae16cf`](https://github.com/cloudflare/wrangler2/commit/d3ae16cfb8e13f0e6e5f710b3cb03e46ecb7bf7a) Thanks [@cameron-robey](https://github.com/cameron-robey)! - feat: publish full url on `wrangler publish` for workers.dev workers
@@ -1088,7 +1088,7 @@
   Resolves https://github.com/cloudflare/wrangler2/issues/1540
 
 - [#1575](https://github.com/cloudflare/wrangler2/pull/1575) [`5b1f68ee`](https://github.com/cloudflare/wrangler2/commit/5b1f68eece2f328c65f749711cfae5105e1e9651) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - feat: legacy "kv-namespace" not supported
-  In previous Wrangler 1, there was a legacy configuration that was considered a "bug" and removed.
+  In previous Wrangler v1, there was a legacy configuration that was considered a "bug" and removed.
   Before it was removed, tutorials, templates, blogs, etc... had utlized that configuration property
   to handle this in Wrangler 2 we will throw a blocking error that tell the user to utilize "kv_namespaces"
 
@@ -1589,7 +1589,7 @@
 
 - [#1365](https://github.com/cloudflare/wrangler2/pull/1365) [`b9f7200`](https://github.com/cloudflare/wrangler2/commit/b9f7200afdfd2dbfed277fbb3c29ddbdaaa969da) Thanks [@threepointone](https://github.com/threepointone)! - fix: normalise `account_id = ''` to `account_id: undefined`
 
-  In older templates, (i.e made for wrangler 1.x), `account_id =''` is considered as a valid input, but then ignored. With wrangler 2, when running wrangler dev, we log an error, but it fixes itself after we get an account id. Much like https://github.com/cloudflare/wrangler2/issues/1329, the fix here is to normalise that value when we see it, and replace it with `undefined` while logging a warning.
+  In older templates, (i.e made for wrangler v1.x), `account_id =''` is considered as a valid input, but then ignored. With wrangler v2, when running wrangler dev, we log an error, but it fixes itself after we get an account id. Much like https://github.com/cloudflare/wrangler2/issues/1329, the fix here is to normalise that value when we see it, and replace it with `undefined` while logging a warning.
 
   This fix also tweaks the messaging for a blank route value to suggest some user action.
 
@@ -1629,10 +1629,10 @@
 
 * [#1351](https://github.com/cloudflare/wrangler2/pull/1351) [`c770167`](https://github.com/cloudflare/wrangler2/commit/c770167c8403c6c157cdad91e4f2bd2b1f571df2) Thanks [@geelen](https://github.com/geelen)! - feat: add support for CLOUDFLARE_API_KEY + CLOUDFLARE_EMAIL to authorise
 
-  This adds support for using the CLOUDFLARE_API_KEY + CLOUDFLARE_EMAIL env vars for authorising a user. This also adds support for CF_API_KEY + CF_EMAIL from wrangler 1, with a deprecation warning.
+  This adds support for using the CLOUDFLARE_API_KEY + CLOUDFLARE_EMAIL env vars for authorising a user. This also adds support for CF_API_KEY + CF_EMAIL from wrangler v1, with a deprecation warning.
 
 - [#1352](https://github.com/cloudflare/wrangler2/pull/1352) [`4e03036`](https://github.com/cloudflare/wrangler2/commit/4e03036d72ec831036f0f6223d803be99282022f) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - bugfix: Allow route setting to be `""`
-  Previously Wrangler1 behavior had allowed for `route = ""`. To keep parity it will be possible to set `route = ""` in the config file and represent not setting a route, while providing a warning.
+  Previously Wrangler v1 behavior had allowed for `route = ""`. To keep parity it will be possible to set `route = ""` in the config file and represent not setting a route, while providing a warning.
 
   resolves #1329
 
@@ -1656,9 +1656,9 @@
 
 - [#1287](https://github.com/cloudflare/wrangler2/pull/1287) [`2072e27`](https://github.com/cloudflare/wrangler2/commit/2072e278479bf66b255eb2858dea83bf0608530c) Thanks [@f5io](https://github.com/f5io)! - fix: kv:key put/get binary file
 
-  As raised in https://github.com/cloudflare/wrangler2/issues/1254, it was discovered that binary uploads were being mangled by wrangler 2, whereas they worked in wrangler 1. This is because they were read into a string by providing an explicit encoding of `utf-8`. This fix reads provided files into a node `Buffer` that is then passed directly to the request.
+  As raised in https://github.com/cloudflare/wrangler2/issues/1254, it was discovered that binary uploads were being mangled by wrangler v2, whereas they worked in wrangler v1. This is because they were read into a string by providing an explicit encoding of `utf-8`. This fix reads provided files into a node `Buffer` that is then passed directly to the request.
 
-  Subsequently https://github.com/cloudflare/wrangler2/issues/1273 was raised in relation to a similar issue with gets from wrangler 2. This was happening due to the downloaded file being converted to `utf-8` encoding as it was pushed through `console.log`. By leveraging `process.stdout.write` we can push the fetched `ArrayBuffer` to std out directly without inferring any specific encoding value.
+  Subsequently https://github.com/cloudflare/wrangler2/issues/1273 was raised in relation to a similar issue with gets from wrangler v2. This was happening due to the downloaded file being converted to `utf-8` encoding as it was pushed through `console.log`. By leveraging `process.stdout.write` we can push the fetched `ArrayBuffer` to std out directly without inferring any specific encoding value.
 
 * [#1325](https://github.com/cloudflare/wrangler2/pull/1325) [`bcd066d`](https://github.com/cloudflare/wrangler2/commit/bcd066d2ad82c2bfcc97b4394fe7d1e77a17add6) Thanks [@sidharthachatterjee](https://github.com/sidharthachatterjee)! - fix: Ensure Response is mutable in Pages functions
 
@@ -1768,7 +1768,7 @@
 
 * [#1255](https://github.com/cloudflare/wrangler2/pull/1255) [`2d806dc`](https://github.com/cloudflare/wrangler2/commit/2d806dc981a7119de4c0d2c926992cc27e160cae) Thanks [@f5io](https://github.com/f5io)! - fix: kv:key put binary file upload
 
-  As raised in https://github.com/cloudflare/wrangler2/issues/1254, it was discovered that binary uploads were being mangled by wrangler 2, whereas they worked in wrangler 1. This is because they were read into a string by providing an explicit encoding of `utf-8`. This fix reads provided files into a node `Buffer` that is then passed directly to the request.
+  As raised in https://github.com/cloudflare/wrangler2/issues/1254, it was discovered that binary uploads were being mangled by wrangler v2, whereas they worked in wrangler v1. This is because they were read into a string by providing an explicit encoding of `utf-8`. This fix reads provided files into a node `Buffer` that is then passed directly to the request.
 
 - [#1248](https://github.com/cloudflare/wrangler2/pull/1248) [`db8a0bb`](https://github.com/cloudflare/wrangler2/commit/db8a0bba1f070bce870016a9aecc8b30725694f4) Thanks [@threepointone](https://github.com/threepointone)! - fix: instruct api to exclude script content on worker upload
 
@@ -1869,7 +1869,7 @@
   "All Zone" permissions, this change provides a workaround for most scenarios.
 
   If the bulk-route request fails with an authorization error, then we fallback
-  to the Wrangler 1 approach, which sends individual route updates via a zone-based
+  to the Wrangler v1 approach, which sends individual route updates via a zone-based
   endpoint.
 
   Fixes #651
@@ -2038,7 +2038,7 @@
 - [#1099](https://github.com/cloudflare/wrangler2/pull/1099) [`175737f`](https://github.com/cloudflare/wrangler2/commit/175737fe712c2bae286df59a9a43f1817a05ebec) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - fix: delegate `wrangler build` to `wrangler publish`
 
   Since `wrangler publish --dry-run --outdir=dist` is basically the same result
-  as what Wrangler 1 did with `wrangler build` let's run that for the user if
+  as what Wrangler v1 did with `wrangler build` let's run that for the user if
   they try to run `wrangler build`.
 
 * [#1081](https://github.com/cloudflare/wrangler2/pull/1081) [`8070763`](https://github.com/cloudflare/wrangler2/commit/807076374e7f1c4848d8a2bdfe9b28d5cbd9579a) Thanks [@rozenmd](https://github.com/rozenmd)! - fix: friendlier error for when a subdomain hasn't been configured in dev mode
@@ -2401,9 +2401,9 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
 * [#910](https://github.com/cloudflare/wrangler2/pull/910) [`fe0344d`](https://github.com/cloudflare/wrangler2/commit/fe0344d894fa65a623966710914ef21f542341e1) Thanks [@taylorlee](https://github.com/taylorlee)! - fix: support preview buckets for r2 bindings
 
-  Allows wrangler2 to perform preview & dev sessions with a different bucket than the published worker's binding.
+  Allows wrangler v2 to perform preview & dev sessions with a different bucket than the published worker's binding.
 
-  This matches kv's preview_id behavior, and brings the wrangler2 implementation in sync with wrangler1.
+  This matches kv's preview_id behavior, and brings the wrangler v2 implementation in sync with wrangler v1.
 
 ## 0.0.30
 
@@ -2925,7 +2925,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 * [#680](https://github.com/cloudflare/wrangler2/pull/680) [`8e2cbaf`](https://github.com/cloudflare/wrangler2/commit/8e2cbaf718cfad279947f99107a0485f07b0f3b0) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - refactor: support backwards compatibility with environment names and related CLI flags
 
   1. When in Legacy environment mode we should not compute name field if specified in an environment.
-  2. Throw an Error when `--env` and `--name` are used together in Legacy Environment, except for Secrets & Tail which are using a special case `getLegacyScriptName` for parity with Wrangler1
+  2. Throw an Error when `--env` and `--name` are used together in Legacy Environment, except for Secrets & Tail which are using a special case `getLegacyScriptName` for parity with Wrangler v1
   3. Started the refactor for args being utilized at the Config level, currently checking for Legacy Environment only.
 
   Fixes https://github.com/cloudflare/wrangler2/issues/672
@@ -2976,7 +2976,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 - [#633](https://github.com/cloudflare/wrangler2/pull/633) [`003f3c4`](https://github.com/cloudflare/wrangler2/commit/003f3c41942ec8e299ae603fe74b3cd2e802b49d) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - refactor: create a custom CLI wrapper around Miniflare API
 
   This allows us to tightly control the options that are passed to Miniflare.
-  The current CLI is setup to be more compatible with how Wrangler 1 works, which is not optimal for Wrangler 2.
+  The current CLI is setup to be more compatible with how Wrangler v1 works, which is not optimal for Wrangler 2.
 
 * [#633](https://github.com/cloudflare/wrangler2/pull/633) [`84c857e`](https://github.com/cloudflare/wrangler2/commit/84c857eabc2c09ad1dd2f4fa3963638b8b7f3daa) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - fix: ensure asset keys are relative to the project root
 
@@ -3001,7 +3001,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
 - [#650](https://github.com/cloudflare/wrangler2/pull/650) [`f0eed7f`](https://github.com/cloudflare/wrangler2/commit/f0eed7fe0cc5f6166b4c2b34d193e260b881e4de) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - fix: make validation error messages more consistent
 
-* [#662](https://github.com/cloudflare/wrangler2/pull/662) [`612952b`](https://github.com/cloudflare/wrangler2/commit/612952ba11b198277be14c70d1c4090338c876bc) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - bugfix: use alias `-e` for `--env` to prevent scripts using Wrangler 1 from breaking when switching to Wrangler 2.
+* [#662](https://github.com/cloudflare/wrangler2/pull/662) [`612952b`](https://github.com/cloudflare/wrangler2/commit/612952ba11b198277be14c70d1c4090338c876bc) Thanks [@JacobMGEvans](https://github.com/JacobMGEvans)! - bugfix: use alias `-e` for `--env` to prevent scripts using Wrangler v1 from breaking when switching to Wrangler v2.
 
 - [#671](https://github.com/cloudflare/wrangler2/pull/671) [`ef0aaad`](https://github.com/cloudflare/wrangler2/commit/ef0aaadad180face06e13fb1de079eb040badaf2) Thanks [@GregBrimble](https://github.com/GregBrimble)! - fix: don't exit on initial Pages Functions compilation failure
 
@@ -3034,7 +3034,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
 - [#647](https://github.com/cloudflare/wrangler2/pull/647) [`f3f3907`](https://github.com/cloudflare/wrangler2/commit/f3f3907963e87de17cad9a3733be716e201a8996) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - feat: add support for `--ip` and `config.dev.ip` in the dev command
 
-  Note that this change modifies the default listening address to `localhost`, which is different to `127.0.0.1`, which is what Wrangler 1 does.
+  Note that this change modifies the default listening address to `localhost`, which is different to `127.0.0.1`, which is what Wrangler v1 does.
   For most developers this will make no observable difference, since the default host mapping in most OSes from `localhost` to `127.0.0.1`.
 
   Resolves [#584](https://github.com/cloudflare/wrangler2/issues/584)
@@ -3172,7 +3172,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
 - [#645](https://github.com/cloudflare/wrangler2/pull/645) [`61aea30`](https://github.com/cloudflare/wrangler2/commit/61aea3052f90dc7a05f77dd2d60e8b32af143a83) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - fix: improve authentication logging and warnings
 
-  - If a user has previously logged in via Wrangler 1 with an API token, we now display a helpful warning.
+  - If a user has previously logged in via Wrangler v1 with an API token, we now display a helpful warning.
   - When logging in and out, we no longer display the path to the internal user auh config file.
   - When logging in, we now display an initial message to indicate the authentication flow is starting.
 
@@ -3221,7 +3221,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
 * [#646](https://github.com/cloudflare/wrangler2/pull/646) [`c75cfb8`](https://github.com/cloudflare/wrangler2/commit/c75cfb83df4c98d6f678535439483948ce9fff5b) Thanks [@threepointone](https://github.com/threepointone)! - fix: default `watch_dir` to `src` of project directory
 
-  Via wrangler 1, when using custom builds in `wrangler dev`, `watch_dir` should default to `src` of the "project directory" (i.e - wherever the `wrangler.toml` is defined if it exists, else in the cwd.
+  Via wrangler v1, when using custom builds in `wrangler dev`, `watch_dir` should default to `src` of the "project directory" (i.e - wherever the `wrangler.toml` is defined if it exists, else in the cwd.
 
   Fixes https://github.com/cloudflare/wrangler2/issues/631
 
@@ -3344,7 +3344,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
   main = "src/chat.mjs"
   ```
 
-  This also makes `./dist` a default for `build.upload.dir`, to match wrangler 1's behaviour.
+  This also makes `./dist` a default for `build.upload.dir`, to match wrangler v1's behaviour.
 
   Closes https://github.com/cloudflare/wrangler2/issues/488
 
@@ -3737,7 +3737,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
   - `r2 buckets create`: create a new bucket - will error if the bucket already exists.
   - `r2 buckets delete`: delete a bucket.
 
-  This brings Wrangler 2 inline with the same features in Wrangler 1.
+  This brings Wrangler v2 inline with the same features in Wrangler v1.
 
 * [#455](https://github.com/cloudflare/wrangler2/pull/455) [`80aa106`](https://github.com/cloudflare/wrangler2/commit/80aa10660ee0ef1e6e571b1312a2aa4c8562f543) Thanks [@threepointone](https://github.com/threepointone)! - fix: error when entry doesn't exist
 
@@ -3807,7 +3807,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
 - [#338](https://github.com/cloudflare/wrangler2/pull/338) [`e0d2f35`](https://github.com/cloudflare/wrangler2/commit/e0d2f35542bc37636098a30469e93702dd7a0d35) Thanks [@threepointone](https://github.com/threepointone)! - feat: environments for Worker Sites
 
-  This adds environments support for Workers Sites. Very simply, it uses a separate kv namespace that's indexed by the environment name. This PR also changes the name of the kv namespace generated to match wrangler 1's implementation.
+  This adds environments support for Workers Sites. Very simply, it uses a separate kv namespace that's indexed by the environment name. This PR also changes the name of the kv namespace generated to match wrangler v1's implementation.
 
 * [#329](https://github.com/cloudflare/wrangler2/pull/329) [`e1d2198`](https://github.com/cloudflare/wrangler2/commit/e1d2198b6454fead8a0115c2ed92a37b9def6dba) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - test: support testing in CI on Windows
 
@@ -3940,7 +3940,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
 - [#307](https://github.com/cloudflare/wrangler2/pull/307) [`53c6318`](https://github.com/cloudflare/wrangler2/commit/53c6318739d2d3672a2e508f643857bdf5831676) Thanks [@threepointone](https://github.com/threepointone)! - feat: `wrangler secret * --local`
 
-  This PR implements `wrangler secret` for `--local` mode. The implementation is simply a no-op, since we don't want to actually write secret values to disk (I think?). I also got the messaging for remote mode right by copying from wrangler 1. Further, I added tests for all the `wrangler secret` commands.
+  This PR implements `wrangler secret` for `--local` mode. The implementation is simply a no-op, since we don't want to actually write secret values to disk (I think?). I also got the messaging for remote mode right by copying from wrangler v1. Further, I added tests for all the `wrangler secret` commands.
 
 * [#324](https://github.com/cloudflare/wrangler2/pull/324) [`b816333`](https://github.com/cloudflare/wrangler2/commit/b8163336faaeae26b68736732938cceaaf4dfec4) Thanks [@GregBrimble](https://github.com/GregBrimble)! - Fixes `wrangler pages dev` failing to start for just a folder of static assets (no functions)
 
@@ -3950,7 +3950,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
   Fixes https://github.com/cloudflare/wrangler2/issues/197
 
-  (In wrangler1, we used to restart the whole process, including uploading the worker again, making a new preview token, and so on. It looks like that they may not have been necessary.)
+  (In wrangler v1, we used to restart the whole process, including uploading the worker again, making a new preview token, and so on. It looks like that they may not have been necessary.)
 
 * [#312](https://github.com/cloudflare/wrangler2/pull/312) [`77aa324`](https://github.com/cloudflare/wrangler2/commit/77aa3249ce07d7617582e4b0555201dac9b7578e) Thanks [@threepointone](https://github.com/threepointone)! - fix: remove `--prefer-offline` when running `npm install`
 
@@ -4036,7 +4036,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
 * [#270](https://github.com/cloudflare/wrangler2/pull/270) [`2453577`](https://github.com/cloudflare/wrangler2/commit/2453577c96704ca1d6934582796199a409d7b770) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - feat: add support for include and exclude when publishing site assets
 
-- [#270](https://github.com/cloudflare/wrangler2/pull/270) [`0289882`](https://github.com/cloudflare/wrangler2/commit/0289882a15eba55d802650a591f999ef7b614fb6) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - fix: ensure `kv:key list` matches the output from Wrangler 1
+- [#270](https://github.com/cloudflare/wrangler2/pull/270) [`0289882`](https://github.com/cloudflare/wrangler2/commit/0289882a15eba55d802650a591f999ef7b614fb6) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - fix: ensure `kv:key list` matches the output from Wrangler v1
 
   The previous output was passing an array of objects to console.log, which ended up showing something like
 
@@ -4075,7 +4075,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
   The codebase is now strict-null compliant and the CI checks will fail if a PR tries to introduce code that is not.
 
-- [#277](https://github.com/cloudflare/wrangler2/pull/277) [`6cc9dde`](https://github.com/cloudflare/wrangler2/commit/6cc9dde6665978f5d6435b7d6d56d41d718693c5) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - fix: align publishing sites asset keys with Wrangler 1
+- [#277](https://github.com/cloudflare/wrangler2/pull/277) [`6cc9dde`](https://github.com/cloudflare/wrangler2/commit/6cc9dde6665978f5d6435b7d6d56d41d718693c5) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - fix: align publishing sites asset keys with Wrangler v1
 
   - Use the same hashing strategy for asset keys (xxhash64)
   - Include the full path (from cwd) in the asset key
@@ -4091,7 +4091,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
 * [#280](https://github.com/cloudflare/wrangler2/pull/280) [`f19dde1`](https://github.com/cloudflare/wrangler2/commit/f19dde1a7e71d13e9c249345b7affd1cfef79b2c) Thanks [@petebacondarwin](https://github.com/petebacondarwin)! - fix: skip unwanted files and directories when publishing site assets
 
-  In keeping with Wrangler 1, we now skip node_modules and hidden files and directories.
+  In keeping with Wrangler v1, we now skip node_modules and hidden files and directories.
 
   An exception is made for `.well-known`. See https://datatracker.ietf.org/doc/html/rfc8615.
 
@@ -4129,7 +4129,7 @@ Fixes https://github.com/cloudflare/wrangler2/issues/1026
 
   - `@optional` means providing a value isn't mandatory
   - `@deprecated` means the field itself isn't necessary anymore in wrangler.toml
-  - `@breaking` means the deprecation/optionality is a breaking change from wrangler 1
+  - `@breaking` means the deprecation/optionality is a breaking change from wrangler v1
   - `@todo` means there's more work to be done (with details attached)
   - `@inherited` means the field is copied to all environments
 

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -745,7 +745,7 @@ describe("publish", () => {
 			await runWrangler("publish ./index --env dev --legacy-env false");
 		});
 
-		it("should fallback to the Wrangler 1 zone-based API if the bulk-routes API fails", async () => {
+		it("should fallback to the Wrangler v1 zone-based API if the bulk-routes API fails", async () => {
 			writeWranglerToml({
 				routes: ["example.com/some-route/*"],
 			});

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -169,7 +169,7 @@ describe("publish", () => {
 			Current Deployment ID: undefined"
 		`);
 			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler v1's \`config\` command to login with an API token.[0m
 
 			  This is no longer supported in the current version of Wrangler.
 			  If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\`

--- a/packages/wrangler/src/__tests__/whoami.test.tsx
+++ b/packages/wrangler/src/__tests__/whoami.test.tsx
@@ -174,7 +174,7 @@ describe("getUserInfo()", () => {
 		await getUserInfo();
 
 		expect(std.warn).toMatchInlineSnapshot(`
-		      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler 1's \`config\` command to login with an API token.[0m
+		      "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mIt looks like you have used Wrangler v1's \`config\` command to login with an API token.[0m
 
 		        This is no longer supported in the current version of Wrangler.
 		        If you wish to authenticate via an API token then please set the \`CLOUDFLARE_API_TOKEN\`

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -17,7 +17,7 @@ import type { Environment, RawEnvironment } from "./environment";
  *
  * Legend for the annotations:
  *
- * - `@breaking`: the deprecation/optionality is a breaking change from wrangler 1.
+ * - `@breaking`: the deprecation/optionality is a breaking change from wrangler v1.
  * - `@todo`: there's more work to be done (with details attached).
  */
 export type Config = ConfigFields<DevConfig> & Environment;
@@ -31,7 +31,7 @@ export interface ConfigFields<Dev extends RawDevConfig> {
 	configPath: string | undefined;
 
 	/**
-	 * A boolean to enable "legacy" style wrangler environments (from wrangler 1).
+	 * A boolean to enable "legacy" style wrangler environments (from wrangler v1).
 	 * These have been superseded by Services, but there may be projects that won't
 	 * (or can't) use them. If you're using a legacy environment, you can set this
 	 * to `true` to enable it.

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -78,7 +78,7 @@ interface EnvironmentInheritable {
 	 * Whether we use <name>.<subdomain>.workers.dev to
 	 * test and deploy your worker.
 	 *
-	 * @default `true` (This is a breaking change from wrangler 1)
+	 * @default `true` (This is a breaking change from wrangler v1)
 	 * @breaking
 	 * @inheritable
 	 */
@@ -495,7 +495,7 @@ interface EnvironmentDeprecated {
 	/**
 	 * Legacy way of defining KVNamespaces that is no longer supported.
 	 *
-	 * @deprecated DO NOT USE. This was a legacy bug from wrangler 1, that we do not want to support.
+	 * @deprecated DO NOT USE. This was a legacy bug from wrangler v1, that we do not want to support.
 	 */
 	"kv-namespaces"?: string;
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -741,7 +741,7 @@ function isValidRouteValue(item: unknown): boolean {
 
 /**
  * If account_id has been passed as an empty string, normalise it to undefined.
- * This is to workaround older wrangler1-era templates that have account_id = '',
+ * This is to workaround older wrangler v1 era templates that have account_id = '',
  * which isn't a valid value anyway
  */
 function mutateEmptyStringAccountIDValue(
@@ -760,7 +760,7 @@ function mutateEmptyStringAccountIDValue(
 
 /**
  * Normalize empty string to `undefined` by mutating rawEnv.route value.
- * As part of backward compatibility with Wrangler1 converting empty string to `undefined`
+ * As part of backward compatibility with Wrangler v1 converting empty string to `undefined`
  */
 function mutateEmptyStringRouteValue(
 	diagnostics: Diagnostics,

--- a/packages/wrangler/src/index.tsx
+++ b/packages/wrangler/src/index.tsx
@@ -135,7 +135,7 @@ export function getScriptName(
 }
 
 /**
- * Alternative to the getScriptName() because special Legacy cases allowed "name", and "env" together in Wrangler1
+ * Alternative to the getScriptName() because special Legacy cases allowed "name", and "env" together in Wrangler v1
  */
 export function getLegacyScriptName(
 	args: { name: string | undefined; env: string | undefined },

--- a/packages/wrangler/src/sites.tsx
+++ b/packages/wrangler/src/sites.tsx
@@ -56,7 +56,7 @@ function hashFileContent(hasher: XXHashAPI, content: string): string {
  * Create a hashed asset key for the given asset.
  *
  * The key will change if the file path or content of the asset changes.
- * The algorithm used here matches that of Wrangler 1.
+ * The algorithm used here matches that of Wrangler v1.
  */
 function hashAsset(
 	hasher: XXHashAPI,

--- a/packages/wrangler/src/tail/filters.ts
+++ b/packages/wrangler/src/tail/filters.ts
@@ -7,7 +7,7 @@
 
 /**
  * These are the filters we accept in the CLI. They
- * were copied directly from wrangler 1 in order to
+ * were copied directly from wrangler v1 in order to
  * maintain compatability, so they aren't actually the exact
  * filters we need to send up to the tail worker. They generally map 1:1,
  * but often require some transformation or

--- a/packages/wrangler/src/user/user.tsx
+++ b/packages/wrangler/src/user/user.tsx
@@ -374,7 +374,7 @@ function getAuthTokens(config?: UserAuthConfig): AuthTokens | undefined {
 			};
 		} else if (api_token) {
 			logger.warn(
-				"It looks like you have used Wrangler 1's `config` command to login with an API token.\n" +
+				"It looks like you have used Wrangler v1's `config` command to login with an API token.\n" +
 					"This is no longer supported in the current version of Wrangler.\n" +
 					"If you wish to authenticate via an API token then please set the `CLOUDFLARE_API_TOKEN` environment variable."
 			);

--- a/packages/wrangler/src/user/user.tsx
+++ b/packages/wrangler/src/user/user.tsx
@@ -264,7 +264,7 @@ interface AuthTokens {
 	accessToken?: AccessToken;
 	refreshToken?: RefreshToken;
 	scopes?: Scope[];
-	/** @deprecated - this field was only provided by the deprecated `wrangler1 config` command. */
+	/** @deprecated - this field was only provided by the deprecated `wrangler v1 config` command. */
 	apiToken?: string;
 }
 
@@ -282,7 +282,7 @@ export interface UserAuthConfig {
 	refresh_token?: string;
 	expiration_time?: string;
 	scopes?: string[];
-	/** @deprecated - this field was only provided by the deprecated `wrangler1 config` command. */
+	/** @deprecated - this field was only provided by the deprecated `wrangler v1 config` command. */
 	api_token?: string;
 }
 

--- a/packages/wranglerjs-compat-webpack-plugin/CHANGELOG.md
+++ b/packages/wranglerjs-compat-webpack-plugin/CHANGELOG.md
@@ -42,4 +42,4 @@
 
 - [#759](https://github.com/cloudflare/wrangler2/pull/759) [`698f784`](https://github.com/cloudflare/wrangler2/commit/698f784ec33c574f374144c08638f21718db97a1) Thanks [@caass](https://github.com/caass)! - Create WranglerJsCompatWebpackPlugin
 
-  A webpack@4 plugin to emulate the behavior of wrangler 1's `type=webpack` for users that cannot switch to esbuild and are not already using a custom build.
+  A webpack@4 plugin to emulate the behavior of wrangler v1's `type=webpack` for users that cannot switch to esbuild and are not already using a custom build.

--- a/packages/wranglerjs-compat-webpack-plugin/package.json
+++ b/packages/wranglerjs-compat-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "wranglerjs-compat-webpack-plugin",
 	"version": "0.0.6",
-	"description": "A webpack plugin to emulate the behavior of wrangler1's `type = webpack`",
+	"description": "A webpack plugin to emulate the behavior of wrangler v1's `type = webpack`",
 	"homepage": "https://github.com/cloudflare/wrangler2#readme",
 	"bugs": {
 		"url": "https://github.com/cloudflare/wrangler2/issues"

--- a/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/compare-outputs.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/compare-outputs.ts
@@ -46,7 +46,7 @@ export async function compareOutputs({
 	const wrangler1Dir = path.join(parentDir, "wrangler-1");
 	const wrangler2Dir = path.join(parentDir, "wrangler-2");
 
-	// wrangler 1
+	// wrangler v1
 	fs.mkdirSync(wrangler1Dir);
 	process.chdir(wrangler1Dir);
 
@@ -93,7 +93,7 @@ export async function compareOutputs({
 	});
 	mockSubDomainRequest();
 
-	// wrangler 2
+	// wrangler v2
 	fs.mkdirSync(wrangler2Dir);
 	process.chdir(wrangler2Dir);
 
@@ -197,7 +197,7 @@ const isAssertionError = (e: Error) =>
  * when the `fn` arg is called. All output will be piped through to the
  * `stdout` and `stderr` args, which can be arbitrary streams.
  *
- * Useful for capturing output from webpack when called by wrangler 2.
+ * Useful for capturing output from webpack when called by wrangler v2.
  * @returns the result of calling `fn`
  */
 async function withCapturedChildProcessOutput<T>(

--- a/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/install-wrangler.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/install-wrangler.ts
@@ -26,7 +26,7 @@ export async function installWrangler1() {
 		data: { assets },
 	} = await octokit.request("GET /repos/{owner}/{repo}/releases/latest", {
 		owner: "cloudflare",
-		repo: "wrangler",
+		repo: "wrangler-legacy",
 	});
 
 	// rust targets (and wrangler 1 releases) are named with "target triples",
@@ -52,7 +52,7 @@ export async function installWrangler1() {
 	const assetId = assets.find(({ name }) => name.includes(targetTriple))?.id;
 
 	if (assetId === undefined) {
-		throw new Error("Unable to get wrangler 1 release from github!");
+		throw new Error("Unable to get wrangler v1 release from github!");
 	}
 
 	// since we use Accept: "application/octet-stream" `data` is an ArrayBuffer

--- a/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/install-wrangler.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/install-wrangler.ts
@@ -10,7 +10,7 @@ import {
 } from "./constants";
 
 /**
- * Installs wrangler 1 to node_modules/.cache by downloading
+ * Installs wrangler v1 to node_modules/.cache by downloading
  * artifacts from the latest github release
  */
 export async function installWrangler1() {
@@ -29,9 +29,9 @@ export async function installWrangler1() {
 		repo: "wrangler-legacy",
 	});
 
-	// rust targets (and wrangler 1 releases) are named with "target triples",
+	// rust targets (and wrangler v1 releases) are named with "target triples",
 	// which follow the form <architecture>-<os>-<toolchain>.
-	// M1 fans love ~nodejs~ wrangler2 for its multi-platform support
+	// M1 fans love ~nodejs~ wrangler v2 for its multi-platform support
 	let targetTriple:
 		| "x86_64-pc-windows-msvc"
 		| "x86_64-apple-darwin"

--- a/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/mock-config-dir.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/mock-config-dir.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 /**
- * Create an environment variable telling wrangler 1 where to look for
+ * Create an environment variable telling wrangler v1 where to look for
  * ~/.wrangler/config/default.toml
  */
 export const mockConfigDir = () => {

--- a/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/pipe.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/__tests__/helpers/pipe.ts
@@ -63,7 +63,7 @@ export const cleanMessage = (message: string): string =>
 		.replaceAll(/\d+ms/gm, "[timing]") // standardize timings
 		.replaceAll(process.cwd(), "[dir]") // standardize directories
 		.replaceAll(process.cwd().replaceAll("\\", "/"), "[dir]")
-		.replaceAll(PATH_TO_WRANGLER, "[wrangler 1]") // standardize calls to wrangler 1
+		.replaceAll(PATH_TO_WRANGLER, "[wrangler 1]") // standardize calls to wrangler v1
 		.replaceAll(/found .+ vulnerabilities/gm, "found [some] vulnerabilities") // vuln counts
 		.replaceAll(
 			// remove specific paths to node, wranglerjs, and output file

--- a/packages/wranglerjs-compat-webpack-plugin/src/__tests__/index.spec.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/__tests__/index.spec.ts
@@ -46,7 +46,7 @@ describe("messaging", () => {
 	});
 });
 
-describe("wrangler 1 parity", () => {
+describe("wrangler v1 parity", () => {
 	beforeAll(async () => {
 		await installWrangler1();
 		await execa("npm", ["run", "build:js"]); // ensure tests use latest changes

--- a/packages/wranglerjs-compat-webpack-plugin/src/index.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/index.ts
@@ -126,7 +126,7 @@ export class WranglerJsCompatWebpackPlugin {
 	) {
 		if (context === undefined || entry === undefined) {
 			const weWouldGuess =
-				"With `type = webpack`, wrangler 1 would try to guess where your worker lives.";
+				"With `type = webpack`, wrangler v1 would try to guess where your worker lives.";
 			const noLonger =
 				"Now that you're running webpack outside of wrangler, you need to specify this explicitly.";
 			const docsUrl = "https://v4.webpack.js.org/configuration/entry-context/";

--- a/packages/wranglerjs-compat-webpack-plugin/src/index.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/index.ts
@@ -4,7 +4,7 @@
  *
  * It's kind of gross, and not good for _new_ projects, but it should work ok at
  * getting people using Wrangler v1 with the inbuilt webpack 4 support migrated
- * over to Wrangler 2. Combined with docs on ejecting webpack, the pain of
+ * over to Wrangler v2. Combined with docs on ejecting webpack, the pain of
  * losing 1's (tenuous at best) webpack support should be mostly mitigated.
  *
  * This plugin attempts to replicate Wrangler v1's behavior 1:1 (specifically,

--- a/packages/wranglerjs-compat-webpack-plugin/src/index.ts
+++ b/packages/wranglerjs-compat-webpack-plugin/src/index.ts
@@ -1,13 +1,13 @@
 /*
  * This is a webpack plugin that aims to recreate the functionality of
- * Wrangler 1's `type = wepback` setting for workers projects.
+ * Wrangler v1's `type = wepback` setting for workers projects.
  *
  * It's kind of gross, and not good for _new_ projects, but it should work ok at
- * getting people using Wrangler 1 with the inbuilt webpack 4 support migrated
+ * getting people using Wrangler v1 with the inbuilt webpack 4 support migrated
  * over to Wrangler 2. Combined with docs on ejecting webpack, the pain of
  * losing 1's (tenuous at best) webpack support should be mostly mitigated.
  *
- * This plugin attempts to replicate Wrangler 1's behavior 1:1 (specifically,
+ * This plugin attempts to replicate Wrangler v1's behavior 1:1 (specifically,
  * https://github.com/cloudflare/wrangler/blob/master/src/wranglerjs/mod.rs#L39-L58)
  * so it:
  *
@@ -107,8 +107,8 @@ export class WranglerJsCompatWebpackPlugin {
 	 * Emulates behavior from [`Target::package_dir`](https://github.com/cloudflare/wrangler/blob/master/src/settings/toml/target.rs#L40-L50).
 	 *
 	 * We encourage the user to specify the "context" and "entry" explicitly in
-	 * their webpack config, since wrangler 1 kind of inferred that stuff but
-	 * wrangler 2 is very hands-off for custom builds.
+	 * their webpack config, since wrangler v1 kind of inferred that stuff but
+	 * wrangler v2 is very hands-off for custom builds.
 	 *
 	 * This has to be a synchronous function that only returns something
 	 * if it encounters an error. In webpack 4 `entryOption` is a
@@ -161,7 +161,7 @@ export class WranglerJsCompatWebpackPlugin {
 
 	/**
 	 * Partially equivalent to [`setup_build`](https://github.com/cloudflare/wrangler/blob/master/src/wranglerjs/mod.rs#L154-L210)
-	 * in wrangler 1, with the notable exception of preparing to run webpack
+	 * in wrangler v1, with the notable exception of preparing to run webpack
 	 * since we now have the user do that.
 	 */
 	private async setupBuild() {
@@ -180,7 +180,7 @@ export class WranglerJsCompatWebpackPlugin {
 	/**
 	 * Generate a sites-worker if one doesn't exist already.
 	 * equivalent to [`Site::scaffold_worker`](https://github.com/cloudflare/wrangler/blob/master/src/settings/toml/site.rs#L42-L56)
-	 * in wrangler 1.
+	 * in wrangler v1.
 	 */
 	private async scaffoldSitesWorker() {
 		if (fs.existsSync(this.packageDir)) {


### PR DESCRIPTION
Update messaging to reflect that Wrangler v2 is still Wrangler

Move to "Wrangler v1" and "Wrangler v2" instead of using "Wrangler 1" and "Wrangler 2", which could result in having an [Angular-like situation](<https://en.wikipedia.org/wiki/Angular_(web_framework)#:~:text=Angular%20(also%20referred%20to%20as%20%22Angular%202%2B%22)>) where we treat different versions of the same product as different products.
