### PR TITLE
Support Queue events in tail

### DIFF
--- a/.changeset/warm-queens-taste.md
+++ b/.changeset/warm-queens-taste.md
@@ -1,0 +1,8 @@
+---
+"wrangler": minor
+---
+
+feature: Support Queue consumer events in tail
+
+So that it's less confusing when tailing a worker that consumes events from a
+Queue.

--- a/packages/wrangler/src/__tests__/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages-deployment-tail.test.ts
@@ -15,6 +15,7 @@ import type {
 	EmailEvent,
 	TailEvent,
 	TailInfo,
+	QueueEvent,
 } from "../tail/createTail";
 import type { RequestInit } from "undici";
 import type WebSocket from "ws";
@@ -379,6 +380,20 @@ describe("pages deployment tail", () => {
 			expect(std.out).toMatch(deserializeToJson(serializedMessage));
 		});
 
+		it("logs queue messages in json format", async () => {
+			const api = mockTailAPIs();
+			await runWrangler(
+				"pages deployment tail mock-deployment-id --project-name mock-project --format json"
+			);
+
+			const event = generateMockQueueEvent();
+			const message = generateMockEventMessage({ event });
+			const serializedMessage = serialize(message);
+
+			api.ws.send(serializedMessage);
+			expect(std.out).toMatch(deserializeToJson(serializedMessage));
+		});
+
 		it("logs request messages in pretty format", async () => {
 			const api = mockTailAPIs();
 			await runWrangler(
@@ -484,6 +499,33 @@ describe("pages deployment tail", () => {
 			).toMatchInlineSnapshot(`
 					"Connected to deployment mock-deployment-id, waiting for logs...
 					Email from:${mockEmailEventFrom} to:${mockEmailEventTo} size:${mockEmailEventSize} @ [mock event timestamp] - Ok"
+			`);
+		});
+
+		it("logs queue messages in pretty format", async () => {
+			const api = mockTailAPIs();
+			await runWrangler(
+				"pages deployment tail mock-deployment-id --project-name mock-project --format pretty"
+			);
+
+			const event = generateMockQueueEvent();
+			const message = generateMockEventMessage({ event });
+			const serializedMessage = serialize(message);
+
+			api.ws.send(serializedMessage);
+			expect(
+				std.out
+					.replace(
+						new Date(mockEventTimestamp).toLocaleString(),
+						"[mock timestamp string]"
+					)
+					.replace(
+						mockTailExpiration.toLocaleString(),
+						"[mock expiration date]"
+					)
+			).toMatchInlineSnapshot(`
+					"Connected to deployment mock-deployment-id, waiting for logs...
+					Queue my-queue123 (7 messages) - Ok @ [mock timestamp string]"
 			`);
 		});
 
@@ -666,6 +708,7 @@ function isRequest(
 		| EmailEvent
 		| TailEvent
 		| TailInfo
+		| QueueEvent
 		| undefined
 		| null
 ): event is RequestEvent {
@@ -962,5 +1005,11 @@ function generateMockEmailEvent(opts?: Partial<EmailEvent>): EmailEvent {
 		mailFrom: opts?.mailFrom || mockEmailEventFrom,
 		rcptTo: opts?.rcptTo || mockEmailEventTo,
 		rawSize: opts?.rawSize || mockEmailEventSize,
+	};
+}
+function generateMockQueueEvent(opts?: Partial<QueueEvent>): QueueEvent {
+	return {
+		queue: opts?.queue || "my-queue123",
+		batchSize: opts?.batchSize || 7,
 	};
 }

--- a/packages/wrangler/src/tail/createTail.ts
+++ b/packages/wrangler/src/tail/createTail.ts
@@ -242,7 +242,8 @@ export type TailEventMessage = {
 	 * The event that triggered the worker. In the case of an HTTP request,
 	 * this will be a RequestEvent. If it's a cron trigger, it'll be a
 	 * ScheduledEvent. If it's a durable object alarm, it's an AlarmEvent.
-	 * If it's a email, it'a an EmailEvent
+	 * If it's a email, it'a an EmailEvent. If it's a Queue consumer event,
+	 * it's a QueueEvent.
 	 *
 	 * Until workers-types exposes individual types for export, we'll have
 	 * to just re-define these types ourselves.
@@ -254,6 +255,7 @@ export type TailEventMessage = {
 		| EmailEvent
 		| TailEvent
 		| TailInfo
+		| QueueEvent
 		| undefined
 		| null;
 };
@@ -429,4 +431,19 @@ export type TailEvent = {
 export type TailInfo = {
 	message: string;
 	type: string;
+};
+
+/*
+ * A event that was triggered by receiving a batch of messages from a Queue for consumption.
+ */
+export type QueueEvent = {
+	/**
+	 * The name of the queue that the message batch came from.
+	 */
+	queue: string;
+
+	/**
+	 * The number of messages in the batch.
+	 */
+	batchSize: number;
 };

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -3,6 +3,7 @@ import { logger } from "../logger";
 import type {
 	AlarmEvent,
 	EmailEvent,
+	QueueEvent,
 	RequestEvent,
 	ScheduledEvent,
 	TailEvent,
@@ -71,6 +72,16 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 		} else if (eventMessage.event.type === "overload-stop") {
 			logger.log(`${chalk.yellow.bold(eventMessage.event.message)}`);
 		}
+	} else if (isQueueEvent(eventMessage.event)) {
+		const outcome = prettifyOutcome(eventMessage.outcome);
+		const datetime = new Date(eventMessage.eventTimestamp).toLocaleString();
+		const queueName = eventMessage.event.queue;
+		const batchSize = eventMessage.event.batchSize;
+		const batchSizeMsg = `${batchSize} message${batchSize !== 1 ? "s" : ""}`;
+
+		logger.log(
+			`Queue ${queueName} (${batchSizeMsg}) - ${outcome} @ ${datetime}`
+		);
 	} else {
 		// Unknown event type
 		const outcome = prettifyOutcome(eventMessage.outcome);
@@ -110,6 +121,10 @@ function isScheduledEvent(
 
 function isEmailEvent(event: TailEventMessage["event"]): event is EmailEvent {
 	return Boolean(event && "mailFrom" in event);
+}
+
+function isQueueEvent(event: TailEventMessage["event"]): event is QueueEvent {
+	return Boolean(event && "queue" in event);
 }
 
 /**


### PR DESCRIPTION
Queue events have an "event" section containing two fields -- "queue" and "batchSize", which contain the queue name and number of messages in the batch. Queue events can be distinguished from other events by the presence of the "queue" field, so that's what I do here.

I've followed the example of RequestEvent more closely than either ScheduledEvent or AlarmEvent here, but am happy to change up the format if there's a reason to do so.

@OilyLime @jbw1991 