### PR TITLE
[WIP] Pages publish fixes

### DIFF
--- a/packages/wrangler/src/pages/prompt-select-project.tsx
+++ b/packages/wrangler/src/pages/prompt-select-project.tsx
@@ -1,6 +1,4 @@
-import { render, Text } from "ink";
-import SelectInput from "ink-select-input";
-import React from "react";
+import { select } from "../dialogs";
 import { listProjects } from "./projects";
 
 export async function promptSelectProject({
@@ -10,22 +8,12 @@ export async function promptSelectProject({
 }): Promise<string> {
 	const projects = await listProjects({ accountId });
 
-	return new Promise((resolve) => {
-		const { unmount } = render(
-			<>
-				<Text>Select a project:</Text>
-				<SelectInput
-					items={projects.map((project) => ({
-						key: project.name,
-						label: project.name,
-						value: project,
-					}))}
-					onSelect={async (selected) => {
-						resolve(selected.value.name);
-						unmount();
-					}}
-				/>
-			</>
-		);
-	});
+	return select(
+		"Select a project:",
+		projects.map((project) => ({
+			label: project.name,
+			value: project.name,
+		})),
+		0
+	);
 }


### PR DESCRIPTION
What this PR solves / how to test:

...

fix: pages publish prompts incorrect projects list

When running `pages publish` without providing a project name, users will
be prompted to chose a project from their projects list (assuming they
chose to publish under an existing project). This list should contain only projects that are **not** connected to a Git provider.

Currently the projects list contains all user's projects. This commit fixes that issue.

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
