### PR TITLE
Use column layout for hotkeys

### DIFF
--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -207,25 +207,40 @@ function InteractiveDevSession(props: DevProps) {
 	return (
 		<>
 			<DevSession {...props} local={toggles.local} onReady={onReady} />
-			<Box borderStyle="round" paddingLeft={1} paddingRight={1}>
-				<Text bold={true}>[b]</Text>
-				<Text> open a browser, </Text>
-				{props.inspect ? (
-					<>
-						<Text bold={true}>[d]</Text>
-						<Text> open Devtools, </Text>
-					</>
-				) : null}
-				{!props.forceLocal ? (
-					<>
-						<Text bold={true}>[l]</Text>
-						<Text> {toggles.local ? "turn off" : "turn on"} local mode, </Text>
-					</>
-				) : null}
-				<Text bold={true}>[c]</Text>
-				<Text> clear console, </Text>
-				<Text bold={true}>[x]</Text>
-				<Text> to exit</Text>
+			<Box
+				borderStyle="round"
+				paddingLeft={1}
+				paddingRight={1}
+				flexDirection="column"
+			>
+				<Box>
+					<Text bold={true}>[b]</Text>
+					<Text> open a browser</Text>
+				</Box>
+				<Box>
+					{props.inspect ? (
+						<>
+							<Text bold={true}>[d]</Text>
+							<Text> open Devtools</Text>
+						</>
+					) : null}
+				</Box>
+				<Box>
+					{!props.forceLocal ? (
+						<>
+							<Text bold={true}>[l]</Text>
+							<Text> {toggles.local ? "turn off" : "turn on"} local mode</Text>
+						</>
+					) : null}
+				</Box>
+				<Box>
+					<Text bold={true}>[c]</Text>
+					<Text> clear console</Text>
+				</Box>
+				<Box>
+					<Text bold={true}>[x]</Text>
+					<Text> to exit</Text>
+				</Box>
 			</Box>
 		</>
 	);


### PR DESCRIPTION
What this PR solves / how to test:

On small terminal windows, Ink was hiding the keys needed to use the hotkeys interface. This PR switched to a column layout so the keys are visible on more terminal sizes.

Before:
<img width="492" alt="Screenshot 2023-01-05 at 15 15 48" src="https://user-images.githubusercontent.com/28503158/210815491-5791caf7-3b84-495d-a956-277001b69b98.png">

After:
<img width="524" alt="Screenshot 2023-01-05 at 15 22 22" src="https://user-images.githubusercontent.com/28503158/210815548-445a7c5e-6479-408c-8d1f-961407626461.png">

