### PR TITLE
Lets CF Internal accounts use experimental flags

### DIFF
--- a/.changeset/gorgeous-buttons-report.md
+++ b/.changeset/gorgeous-buttons-report.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Allows Authorized accounts to publish with experimental flags enabled

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -64,6 +64,7 @@ export interface WorkerMetadata {
 	bindings: WorkerMetadataBinding[];
 	keep_bindings?: WorkerMetadataBinding["type"][];
 	logpush?: boolean;
+	experimental?: boolean;
 }
 
 /**
@@ -80,6 +81,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		compatibility_flags,
 		keepVars,
 		logpush,
+		experimental,
 	} = worker;
 
 	let { modules } = worker;
@@ -292,6 +294,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		capnp_schema: bindings.logfwdr?.schema,
 		...(keepVars && { keep_bindings: ["plain_text", "json"] }),
 		...(logpush !== undefined && { logpush }),
+		...(experimental !== undefined && { experimental }),
 	};
 
 	formData.set("metadata", JSON.stringify(metadata));

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -572,6 +572,7 @@ async function createRemoteWorkerInit(props: {
 		usage_model: props.usageModel,
 		keepVars: true,
 		logpush: false,
+		experimental: false,
 	};
 
 	return init;

--- a/packages/wrangler/src/publish/index.ts
+++ b/packages/wrangler/src/publish/index.ts
@@ -176,10 +176,10 @@ export function publishOptions(yargs: Argv<CommonYargsOptions>) {
 				describe:
 					"Send Trace Events from this worker to Workers Logpush.\nThis will not configure a corresponding Logpush job automatically.",
 			})
-			.option("experimental", {
+			.option("enable-experimental-compatibility-flags", {
 				type: "boolean",
 				describe:
-					"Allows publishing of experimental flags if authorized to use them.\nOnly Cloudflare internal accounts for now",
+					"Allows publishing of experimental flags if authorized to use them.\nOnly Cloudflare internal accounts for now.",
 				default: false,
 			})
 	);
@@ -228,6 +228,9 @@ export async function publishHandler(args: ArgumentsCamelCase<PublishArgs>) {
 			"Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.\n"
 		);
 	}
+	if (args.enableExperimentalCompatibilityFlags) {
+		logger.warn("Only Cloudflare internal accounts for now.");
+	}
 
 	const cliVars = collectKeyValues(args.var);
 	const cliDefines = collectKeyValues(args.define);
@@ -272,6 +275,6 @@ export async function publishHandler(args: ArgumentsCamelCase<PublishArgs>) {
 		noBundle: !(args.bundle ?? !config.no_bundle),
 		keepVars: args.keepVars,
 		logpush: args.logpush,
-		experimental: args.experimental,
+		experimentalCompatibilityFlags: args.enableExperimentalCompatibilityFlags,
 	});
 }

--- a/packages/wrangler/src/publish/index.ts
+++ b/packages/wrangler/src/publish/index.ts
@@ -176,6 +176,12 @@ export function publishOptions(yargs: Argv<CommonYargsOptions>) {
 				describe:
 					"Send Trace Events from this worker to Workers Logpush.\nThis will not configure a corresponding Logpush job automatically.",
 			})
+			.option("experimental", {
+				type: "boolean",
+				describe:
+					"Allows publishing of experimental flags if authorized to use them.\nOnly Cloudflare internal accounts for now",
+				default: false,
+			})
 	);
 }
 
@@ -266,5 +272,6 @@ export async function publishHandler(args: ArgumentsCamelCase<PublishArgs>) {
 		noBundle: !(args.bundle ?? !config.no_bundle),
 		keepVars: args.keepVars,
 		logpush: args.logpush,
+		experimental: args.experimental,
 	});
 }

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -62,7 +62,7 @@ type Props = {
 	noBundle: boolean | undefined;
 	keepVars: boolean | undefined;
 	logpush: boolean | undefined;
-	experimental: boolean | undefined;
+	experimentalCompatibilityFlags: boolean | undefined;
 };
 
 type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
@@ -573,7 +573,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			usage_model: config.usage_model,
 			keepVars,
 			logpush: props.logpush !== undefined ? props.logpush : config.logpush,
-			experimental: props.experimental,
+			experimental: props.experimentalCompatibilityFlags,
 		};
 
 		// As this is not deterministic for testing, we detect if in a jest environment and run asynchronously

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -62,6 +62,7 @@ type Props = {
 	noBundle: boolean | undefined;
 	keepVars: boolean | undefined;
 	logpush: boolean | undefined;
+	experimental: boolean | undefined;
 };
 
 type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
@@ -572,6 +573,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			usage_model: config.usage_model,
 			keepVars,
 			logpush: props.logpush !== undefined ? props.logpush : config.logpush,
+			experimental: props.experimental,
 		};
 
 		// As this is not deterministic for testing, we detect if in a jest environment and run asynchronously

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -123,6 +123,7 @@ export const secret = (secretYargs: Argv<CommonYargsOptions>) => {
 								usage_model: undefined,
 								keepVars: false, // this doesn't matter since it's a new script anyway
 								logpush: false,
+								experimental: false,
 							}),
 						}
 					);

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -223,6 +223,7 @@ export interface CfWorkerInit {
 	usage_model: "bundled" | "unbound" | undefined;
 	keepVars: boolean | undefined;
 	logpush: boolean | undefined;
+	experimental: boolean | undefined;
 }
 
 export interface CfWorkerContext {


### PR DESCRIPTION
What this PR solves / how to test:

Associated docs issues/PR:

- EW-7111

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
