### PR TITLE
Add support for `node:*` imports with the `nodejs_compat` compatibility flag

### DIFF
--- a/.changeset/rare-houses-rest.md
+++ b/.changeset/rare-houses-rest.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: Add support for the `nodejs_compat` Compatibility Flag when bundling a Worker with Wrangler
+
+This new Compatibility Flag is incompatible with the legacy `--node-compat` CLI argument and `node_compat` configuration option. If you want to use the new runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command or your config file.

--- a/.github/workflows/test-old-node-error.yml
+++ b/.github/workflows/test-old-node-error.yml
@@ -1,4 +1,4 @@
-name: Test old node.js version
+name: Test old Node.js version
 
 on: pull_request
 

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -20,7 +20,7 @@ function runWrangler() {
 		// Note Volta and nvm are also recommended in the official docs:
 		// https://developers.cloudflare.com/workers/get-started/guide#2-install-the-workers-cli
 		console.error(
-			`Wrangler requires at least node.js v${MIN_NODE_VERSION}. You are using v${process.versions.node}. Please update your version of node.js.
+			`Wrangler requires at least Node.js v${MIN_NODE_VERSION}. You are using v${process.versions.node}. Please update your version of Node.js.
 
 Consider using a Node.js version manager such as https://volta.sh/ or https://github.com/nvm-sh/nvm.`
 		);

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1251,7 +1251,7 @@ describe("wrangler dev", () => {
 			      --experimental-local                         Run on my machine using the Cloudflare Workers runtime  [boolean] [default: false]
 			      --experimental-local-remote-kv               Read/write KV data from/to real namespaces on the Cloudflare network  [boolean] [default: false]
 			      --minify                                     Minify the script  [boolean]
-			      --node-compat                                Enable node.js compatibility  [boolean]
+			      --node-compat                                Enable Node.js compatibility  [boolean]
 			      --persist                                    Enable persistence for local mode, using default path: .wrangler/state  [boolean]
 			      --persist-to                                 Specify directory to use for local persistence (implies --persist)  [string]
 			      --live-reload                                Auto reload HTML pages when change is detected in local mode  [boolean]

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1566,6 +1566,21 @@ describe("wrangler dev", () => {
 		`);
 		});
 	});
+
+	describe("`nodejs_compat` compatibility flag", () => {
+		it("should conflict with the --node-compat option", async () => {
+			writeWranglerToml();
+			fs.writeFileSync("index.js", `export default {};`);
+
+			await expect(
+				runWrangler(
+					"dev index.js --compatibility-flag=nodejs_compat --node-compat"
+				)
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`"The \`nodejs_compat\` compatibility flag cannot be used in conjunction with the legacy \`--node-compat\` flag. If you want to use the Workers runtime Node.js compatibility features, please remove the \`--node-compat\` argument from your CLI command or \`node_compat = true\` from your config file."`
+			);
+		});
+	});
 });
 
 function mockGetZones(domain: string, zones: { id: string }[] = []) {

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -6658,7 +6658,7 @@ export default{
 			          "err": "",
 			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        --dry-run: exiting now.",
-			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
+			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
 
 			        ",
 			        }
@@ -6705,7 +6705,7 @@ export default{
 			          "err": "",
 			          "out": "Total Upload: xx KiB / gzip: xx KiB
 			        --dry-run: exiting now.",
-			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
+			          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
 
 			        ",
 			        }
@@ -7125,7 +7125,7 @@ export default{
 				"publish index.js --no-bundle --node-compat --dry-run --outdir dist"
 			);
 			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
 
 
 			[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--node-compat\` and \`--no-bundle\` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process.[0m
@@ -7145,7 +7145,7 @@ export default{
 			fs.writeFileSync("index.js", scriptContent);
 			await runWrangler("publish index.js --dry-run --outdir dist");
 			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details.[0m
 
 
 			[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--node-compat\` and \`--no-bundle\` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process.[0m

--- a/packages/wrangler/src/__tests__/test-old-node-version.js
+++ b/packages/wrangler/src/__tests__/test-old-node-version.js
@@ -1,4 +1,4 @@
-// this test has to be run with a version of node.js older than 16.13 to pass
+// this test has to be run with a version of Node.js older than 16.13 to pass
 
 const { spawn } = require("child_process");
 const path = require("path");
@@ -11,7 +11,7 @@ const wranglerProcess = spawn(
 	{ stdio: "pipe" }
 );
 
-const messageToMatch = "Wrangler requires at least node.js v16.13.0";
+const messageToMatch = "Wrangler requires at least Node.js v16.13.0";
 
 wranglerProcess.once("exit", (code) => {
 	try {
@@ -25,7 +25,7 @@ wranglerProcess.once("exit", (code) => {
 	} catch (err) {
 		console.error("Error:", err);
 		throw new Error(
-			"This test has to be run with a version of node.js under 16.13 to pass"
+			"This test has to be run with a version of Node.js under 16.13 to pass"
 		);
 	}
 });

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -18,7 +18,7 @@ export interface UnstableDevOptions {
 	site?: string; // Root folder of static assets for Workers Sites
 	siteInclude?: string[]; // Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.
 	siteExclude?: string[]; // Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.
-	nodeCompat?: boolean; // Enable node.js compatibility
+	nodeCompat?: boolean; // Enable Node.js compatibility
 	compatibilityDate?: string; // Date to use for compatibility checks
 	compatibilityFlags?: string[]; // Flags to use for compatibility checks
 	persist?: boolean; // Enable persistence for local mode, using default path: .wrangler/state
@@ -163,7 +163,7 @@ export async function unstable_dev(
 					site: options?.site, // Root folder of static assets for Workers Sites
 					siteInclude: options?.siteInclude, // Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.
 					siteExclude: options?.siteExclude, // Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.
-					nodeCompat: options?.nodeCompat, // Enable node.js compatibility
+					nodeCompat: options?.nodeCompat, // Enable Node.js compatibility
 					persist: options?.persist, // Enable persistence for local mode, using default path: .wrangler/state
 					persistTo: options?.persistTo, // Specify directory to use for local persistence (implies --persist)
 					experimentalJsonConfig: undefined,
@@ -252,7 +252,7 @@ export async function unstable_dev(
 					site: options?.site, // Root folder of static assets for Workers Sites
 					siteInclude: options?.siteInclude, // Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.
 					siteExclude: options?.siteExclude, // Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.
-					nodeCompat: options?.nodeCompat, // Enable node.js compatibility
+					nodeCompat: options?.nodeCompat, // Enable Node.js compatibility
 					persist: options?.persist, // Enable persistence for local mode, using default path: .wrangler/state
 					persistTo: options?.persistTo, // Specify directory to use for local persistence (implies --persist)
 					experimentalJsonConfig: undefined,

--- a/packages/wrangler/src/api/pages/publish.tsx
+++ b/packages/wrangler/src/api/pages/publish.tsx
@@ -137,6 +137,11 @@ export async function publish({
 		isProduction = project.production_branch === branch;
 	}
 
+	const deploymentConfig =
+		project.deployment_configs[isProduction ? "production" : "preview"];
+	const nodejsCompat =
+		deploymentConfig.compatibility_flags?.includes("nodejs_compat");
+
 	/**
 	 * Evaluate if this is an Advanced Mode or Pages Functions project. If Advanced Mode, we'll
 	 * go ahead and upload `_worker.js` as is, but if Pages Functions, we need to attempt to build
@@ -176,6 +181,7 @@ export async function publish({
 				routesOutputPath,
 				local: false,
 				d1Databases,
+				nodejsCompat,
 				experimentalWorkerBundle,
 			});
 
@@ -261,6 +267,7 @@ export async function publish({
 				watch: false,
 				onEnd: () => {},
 				betaD1Shims: d1Databases,
+				nodejsCompat,
 				experimentalWorkerBundle,
 			});
 			workerFileContents = readFileSync(outfile, "utf8");

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -85,6 +85,15 @@ Add "node_compat = true" to your wrangler.toml file to enable Node compatibility
 	}
 }
 
+const nodejsCompatPlugin: esbuild.Plugin = {
+	name: "nodejs_compat Plugin",
+	setup(pluginBuild) {
+		pluginBuild.onResolve({ filter: /node:.*/ }, () => {
+			return { external: true };
+		});
+	},
+};
+
 /**
  * Generate a bundle for the worker identified by the arguments passed in.
  */
@@ -103,6 +112,7 @@ export async function bundleWorker(
 		tsconfig?: string;
 		minify?: boolean;
 		legacyNodeCompat?: boolean;
+		nodejsCompat?: boolean;
 		define: Config["define"];
 		checkFetch: boolean;
 		services?: Config["services"];
@@ -132,6 +142,7 @@ export async function bundleWorker(
 		tsconfig,
 		minify,
 		legacyNodeCompat,
+		nodejsCompat,
 		checkFetch,
 		local,
 		assets,
@@ -363,6 +374,7 @@ export async function bundleWorker(
 			...(legacyNodeCompat
 				? [NodeGlobalsPolyfills({ buffer: true }), NodeModulesPolyfills()]
 				: []),
+			...(nodejsCompat ? [nodejsCompatPlugin] : []),
 			...(plugins || []),
 		],
 		...(jsxFactory && { jsxFactory }),

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -102,7 +102,7 @@ export async function bundleWorker(
 		watch?: esbuild.WatchMode | boolean;
 		tsconfig?: string;
 		minify?: boolean;
-		nodeCompat?: boolean;
+		legacyNodeCompat?: boolean;
 		define: Config["define"];
 		checkFetch: boolean;
 		services?: Config["services"];
@@ -131,7 +131,7 @@ export async function bundleWorker(
 		watch,
 		tsconfig,
 		minify,
-		nodeCompat,
+		legacyNodeCompat,
 		checkFetch,
 		local,
 		assets,
@@ -347,7 +347,7 @@ export async function bundleWorker(
 				// use process.env["NODE_ENV" + ""] so that esbuild doesn't replace it
 				// when we do a build of wrangler. (re: https://github.com/cloudflare/workers-sdk/issues/1477)
 				"process.env.NODE_ENV": `"${process.env["NODE_ENV" + ""]}"`,
-				...(nodeCompat ? { global: "globalThis" } : {}),
+				...(legacyNodeCompat ? { global: "globalThis" } : {}),
 				...(checkFetch ? { fetch: "checkedFetch" } : {}),
 				...options.define,
 			},
@@ -360,7 +360,7 @@ export async function bundleWorker(
 		},
 		plugins: [
 			moduleCollector.plugin,
-			...(nodeCompat
+			...(legacyNodeCompat
 				? [NodeGlobalsPolyfills({ buffer: true }), NodeModulesPolyfills()]
 				: []),
 			...(plugins || []),
@@ -378,7 +378,8 @@ export async function bundleWorker(
 	try {
 		result = await esbuild.build(buildOptions);
 	} catch (e) {
-		if (!nodeCompat && isBuildFailure(e)) rewriteNodeCompatBuildFailure(e);
+		if (!legacyNodeCompat && isBuildFailure(e))
+			rewriteNodeCompatBuildFailure(e);
 		throw e;
 	}
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -389,6 +389,7 @@ export async function startDev(args: StartDevOptions) {
 		const {
 			entry,
 			legacyNodeCompat,
+			nodejsCompat,
 			upstreamProtocol,
 			zoneId,
 			host,
@@ -428,6 +429,7 @@ export async function startDev(args: StartDevOptions) {
 					legacyEnv={isLegacyEnv(configParam)}
 					minify={args.minify ?? configParam.minify}
 					legacyNodeCompat={legacyNodeCompat}
+					nodejsCompat={nodejsCompat}
 					build={configParam.build || {}}
 					define={{ ...configParam.define, ...cliDefines }}
 					initialMode={
@@ -524,6 +526,7 @@ export async function startApiDev(args: StartDevOptions) {
 	const {
 		entry,
 		legacyNodeCompat,
+		nodejsCompat,
 		upstreamProtocol,
 		zoneId,
 		host,
@@ -563,6 +566,7 @@ export async function startApiDev(args: StartDevOptions) {
 			legacyEnv: isLegacyEnv(configParam),
 			minify: args.minify ?? configParam.minify,
 			legacyNodeCompat,
+			nodejsCompat,
 			build: configParam.build || {},
 			define: { ...config.define, ...cliDefines },
 			initialMode: args.local ? "local" : "remote",
@@ -749,6 +753,15 @@ async function validateDevServerSettings(
 		);
 	}
 
+	const compatibilityFlags =
+		args.compatibilityFlags ?? config.compatibility_flags;
+	const nodejsCompat = compatibilityFlags?.includes("nodejs_compat");
+	if (legacyNodeCompat && nodejsCompat) {
+		throw new Error(
+			"The `nodejs_compat` compatibility flag cannot be used in conjunction with the legacy `--node-compat` flag. If you want to use the Workers runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command or `node_compat = true` from your config file."
+		);
+	}
+
 	if (args.experimentalEnableLocalPersistence) {
 		logger.warn(
 			`--experimental-enable-local-persistence is deprecated.\n` +
@@ -769,6 +782,7 @@ async function validateDevServerSettings(
 		entry,
 		upstreamProtocol,
 		legacyNodeCompat,
+		nodejsCompat,
 		getLocalPort,
 		getInspectorPort,
 		zoneId,

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -388,7 +388,7 @@ export async function startDev(args: StartDevOptions) {
 
 		const {
 			entry,
-			nodeCompat,
+			legacyNodeCompat,
 			upstreamProtocol,
 			zoneId,
 			host,
@@ -427,7 +427,7 @@ export async function startDev(args: StartDevOptions) {
 					rules={getRules(configParam)}
 					legacyEnv={isLegacyEnv(configParam)}
 					minify={args.minify ?? configParam.minify}
-					nodeCompat={nodeCompat}
+					legacyNodeCompat={legacyNodeCompat}
 					build={configParam.build || {}}
 					define={{ ...configParam.define, ...cliDefines }}
 					initialMode={
@@ -523,7 +523,7 @@ export async function startApiDev(args: StartDevOptions) {
 
 	const {
 		entry,
-		nodeCompat,
+		legacyNodeCompat,
 		upstreamProtocol,
 		zoneId,
 		host,
@@ -562,7 +562,7 @@ export async function startApiDev(args: StartDevOptions) {
 			rules: getRules(configParam),
 			legacyEnv: isLegacyEnv(configParam),
 			minify: args.minify ?? configParam.minify,
-			nodeCompat: nodeCompat,
+			legacyNodeCompat,
 			build: configParam.build || {},
 			define: { ...config.define, ...cliDefines },
 			initialMode: args.local ? "local" : "remote",
@@ -742,8 +742,8 @@ async function validateDevServerSettings(
 				"https://github.com/cloudflare/workers-sdk/issues/583."
 		);
 	}
-	const nodeCompat = args.nodeCompat ?? config.node_compat;
-	if (nodeCompat) {
+	const legacyNodeCompat = args.nodeCompat ?? config.node_compat;
+	if (legacyNodeCompat) {
 		logger.warn(
 			"Enabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
 		);
@@ -768,7 +768,7 @@ async function validateDevServerSettings(
 	return {
 		entry,
 		upstreamProtocol,
-		nodeCompat,
+		legacyNodeCompat,
 		getLocalPort,
 		getInspectorPort,
 		zoneId,

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -229,7 +229,7 @@ export function devOptions(yargs: CommonYargsArgv) {
 				type: "boolean",
 			})
 			.option("node-compat", {
-				describe: "Enable node.js compatibility",
+				describe: "Enable Node.js compatibility",
 				type: "boolean",
 			})
 			.option("experimental-enable-local-persistence", {
@@ -745,7 +745,7 @@ async function validateDevServerSettings(
 	const nodeCompat = args.nodeCompat ?? config.node_compat;
 	if (nodeCompat) {
 		logger.warn(
-			"Enabling node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
+			"Enabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
 		);
 	}
 

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -138,7 +138,7 @@ export type DevProps = {
 	compatibilityFlags: string[] | undefined;
 	usageModel: "bundled" | "unbound" | undefined;
 	minify: boolean | undefined;
-	nodeCompat: boolean | undefined;
+	legacyNodeCompat: boolean | undefined;
 	build: Config["build"];
 	env: string | undefined;
 	legacyEnv: boolean;
@@ -278,7 +278,7 @@ function DevSession(props: DevSessionProps) {
 		),
 		tsconfig: props.tsconfig,
 		minify: props.minify,
-		nodeCompat: props.nodeCompat,
+		legacyNodeCompat: props.legacyNodeCompat,
 		betaD1Shims,
 		define: props.define,
 		noBundle: props.noBundle,

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -139,6 +139,7 @@ export type DevProps = {
 	usageModel: "bundled" | "unbound" | undefined;
 	minify: boolean | undefined;
 	legacyNodeCompat: boolean | undefined;
+	nodejsCompat: boolean | undefined;
 	build: Config["build"];
 	env: string | undefined;
 	legacyEnv: boolean;
@@ -279,6 +280,7 @@ function DevSession(props: DevSessionProps) {
 		tsconfig: props.tsconfig,
 		minify: props.minify,
 		legacyNodeCompat: props.legacyNodeCompat,
+		nodejsCompat: props.nodejsCompat,
 		betaD1Shims,
 		define: props.define,
 		noBundle: props.noBundle,

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -98,7 +98,7 @@ export async function startDevServer(
 			),
 			tsconfig: props.tsconfig,
 			minify: props.minify,
-			nodeCompat: props.nodeCompat,
+			legacyNodeCompat: props.legacyNodeCompat,
 			define: props.define,
 			noBundle: props.noBundle,
 			assets: props.assetsConfig,
@@ -210,7 +210,7 @@ async function runEsbuild({
 	serveAssetsFromWorker,
 	tsconfig,
 	minify,
-	nodeCompat,
+	legacyNodeCompat,
 	define,
 	noBundle,
 	workerDefinitions,
@@ -233,7 +233,7 @@ async function runEsbuild({
 	serveAssetsFromWorker: boolean;
 	tsconfig: string | undefined;
 	minify: boolean | undefined;
-	nodeCompat: boolean | undefined;
+	legacyNodeCompat: boolean | undefined;
 	noBundle: boolean;
 	workerDefinitions: WorkerRegistry;
 	firstPartyWorkerDevFacade: boolean | undefined;
@@ -266,7 +266,7 @@ async function runEsbuild({
 				rules,
 				tsconfig,
 				minify,
-				nodeCompat,
+				legacyNodeCompat,
 				define,
 				checkFetch: true,
 				assets: assets && {

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -99,6 +99,7 @@ export async function startDevServer(
 			tsconfig: props.tsconfig,
 			minify: props.minify,
 			legacyNodeCompat: props.legacyNodeCompat,
+			nodejsCompat: props.nodejsCompat,
 			define: props.define,
 			noBundle: props.noBundle,
 			assets: props.assetsConfig,
@@ -211,6 +212,7 @@ async function runEsbuild({
 	tsconfig,
 	minify,
 	legacyNodeCompat,
+	nodejsCompat,
 	define,
 	noBundle,
 	workerDefinitions,
@@ -234,6 +236,7 @@ async function runEsbuild({
 	tsconfig: string | undefined;
 	minify: boolean | undefined;
 	legacyNodeCompat: boolean | undefined;
+	nodejsCompat: boolean | undefined;
 	noBundle: boolean;
 	workerDefinitions: WorkerRegistry;
 	firstPartyWorkerDevFacade: boolean | undefined;
@@ -267,6 +270,7 @@ async function runEsbuild({
 				tsconfig,
 				minify,
 				legacyNodeCompat,
+				nodejsCompat,
 				define,
 				checkFetch: true,
 				assets: assets && {

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -30,7 +30,7 @@ export function useEsbuild({
 	serveAssetsFromWorker,
 	tsconfig,
 	minify,
-	nodeCompat,
+	legacyNodeCompat,
 	betaD1Shims,
 	define,
 	noBundle,
@@ -54,7 +54,7 @@ export function useEsbuild({
 	serveAssetsFromWorker: boolean;
 	tsconfig: string | undefined;
 	minify: boolean | undefined;
-	nodeCompat: boolean | undefined;
+	legacyNodeCompat: boolean | undefined;
 	betaD1Shims?: string[];
 	noBundle: boolean;
 	workerDefinitions: WorkerRegistry;
@@ -85,7 +85,7 @@ export function useEsbuild({
 		const watchMode: WatchMode = {
 			async onRebuild(error) {
 				if (error !== null) {
-					if (!nodeCompat) rewriteNodeCompatBuildFailure(error);
+					if (!legacyNodeCompat) rewriteNodeCompatBuildFailure(error);
 					logBuildFailure(error);
 					logger.error("Watch build failed:", error.message);
 				} else {
@@ -121,7 +121,7 @@ export function useEsbuild({
 						watch: watchMode,
 						tsconfig,
 						minify,
-						nodeCompat,
+						legacyNodeCompat,
 						betaD1Shims,
 						doBindings: durableObjects.bindings,
 						define,
@@ -188,7 +188,7 @@ export function useEsbuild({
 		exit,
 		noBundle,
 		minify,
-		nodeCompat,
+		legacyNodeCompat,
 		define,
 		assets,
 		services,

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -31,6 +31,7 @@ export function useEsbuild({
 	tsconfig,
 	minify,
 	legacyNodeCompat,
+	nodejsCompat,
 	betaD1Shims,
 	define,
 	noBundle,
@@ -55,6 +56,7 @@ export function useEsbuild({
 	tsconfig: string | undefined;
 	minify: boolean | undefined;
 	legacyNodeCompat: boolean | undefined;
+	nodejsCompat: boolean | undefined;
 	betaD1Shims?: string[];
 	noBundle: boolean;
 	workerDefinitions: WorkerRegistry;
@@ -122,6 +124,7 @@ export function useEsbuild({
 						tsconfig,
 						minify,
 						legacyNodeCompat,
+						nodejsCompat,
 						betaD1Shims,
 						doBindings: durableObjects.bindings,
 						define,
@@ -189,6 +192,7 @@ export function useEsbuild({
 		noBundle,
 		minify,
 		legacyNodeCompat,
+		nodejsCompat,
 		define,
 		assets,
 		services,

--- a/packages/wrangler/src/dev/validate-dev-props.ts
+++ b/packages/wrangler/src/dev/validate-dev-props.ts
@@ -28,4 +28,13 @@ export function validateDevProps(props: DevProps) {
 			"You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure `[rules]` in your wrangler.toml"
 		);
 	}
+
+	if (
+		props.compatibilityFlags?.includes("nodejs_compat") &&
+		props.legacyNodeCompat
+	) {
+		throw new Error(
+			"You cannot use the `nodejs_compat` compatibility flag in conjunction with the legacy `--node-compat` flag. If you want to use the new runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command or your config file."
+		);
+	}
 }

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -109,7 +109,7 @@ export const Handler = async ({
 	watch,
 	plugin,
 	buildOutputDirectory,
-	nodeCompat,
+	nodeCompat: legacyNodeCompat,
 	bindings,
 	experimentalWorkerBundle,
 }: PagesBuildArgs) => {
@@ -118,7 +118,7 @@ export const Handler = async ({
 		logger.log(pagesBetaWarning);
 	}
 
-	if (nodeCompat) {
+	if (legacyNodeCompat) {
 		console.warn(
 			"Enabling Node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
 		);
@@ -199,7 +199,7 @@ We first looked inside the build output directory (${basename(
 				watch,
 				plugin,
 				buildOutputDirectory,
-				nodeCompat,
+				legacyNodeCompat,
 				routesOutputPath,
 				local: false,
 				d1Databases,

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -75,7 +75,7 @@ export function Options(yargs: CommonYargsArgv) {
 				description: "The directory to output static assets to",
 			},
 			"node-compat": {
-				describe: "Enable node.js compatibility",
+				describe: "Enable Node.js compatibility",
 				default: false,
 				type: "boolean",
 				hidden: true,
@@ -120,7 +120,7 @@ export const Handler = async ({
 
 	if (nodeCompat) {
 		console.warn(
-			"Enabling node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
+			"Enabling Node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
 		);
 	}
 

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -80,6 +80,18 @@ export function Options(yargs: CommonYargsArgv) {
 				type: "boolean",
 				hidden: true,
 			},
+			"compatibility-date": {
+				describe: "Date to use for compatibility checks",
+				type: "string",
+				requiresArg: true,
+			},
+			"compatibility-flags": {
+				describe: "Flags to use for compatibility checks",
+				alias: "compatibility-flag",
+				type: "string",
+				requiresArg: true,
+				array: true,
+			},
 			bindings: {
 				type: "string",
 				describe:
@@ -110,6 +122,7 @@ export const Handler = async ({
 	plugin,
 	buildOutputDirectory,
 	nodeCompat: legacyNodeCompat,
+	compatibilityFlags,
 	bindings,
 	experimentalWorkerBundle,
 }: PagesBuildArgs) => {
@@ -121,6 +134,12 @@ export const Handler = async ({
 	if (legacyNodeCompat) {
 		console.warn(
 			"Enabling Node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
+		);
+	}
+	const nodejsCompat = compatibilityFlags?.includes("nodejs_compat");
+	if (legacyNodeCompat && nodejsCompat) {
+		throw new Error(
+			"The `nodejs_compat` compatibility flag cannot be used in conjunction with the legacy `--node-compat` flag. If you want to use the Workers runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command."
 		);
 	}
 
@@ -200,6 +219,7 @@ We first looked inside the build output directory (${basename(
 				plugin,
 				buildOutputDirectory,
 				legacyNodeCompat,
+				nodejsCompat,
 				routesOutputPath,
 				local: false,
 				d1Databases,

--- a/packages/wrangler/src/pages/buildFunctions.ts
+++ b/packages/wrangler/src/pages/buildFunctions.ts
@@ -31,6 +31,7 @@ export async function buildFunctions({
 	buildOutputDirectory,
 	routesOutputPath,
 	legacyNodeCompat,
+	nodejsCompat,
 	local,
 	d1Databases,
 	experimentalWorkerBundle = false,
@@ -54,6 +55,7 @@ export async function buildFunctions({
 	d1Databases?: string[];
 	experimentalWorkerBundle?: boolean;
 	legacyNodeCompat?: boolean;
+	nodejsCompat?: boolean;
 }) {
 	RUNNING_BUILDERS.forEach(
 		(runningBuilder) => runningBuilder.stop && runningBuilder.stop()
@@ -121,6 +123,7 @@ export async function buildFunctions({
 			onEnd,
 			buildOutputDirectory,
 			legacyNodeCompat,
+			nodejsCompat,
 			experimentalWorkerBundle,
 		});
 	}

--- a/packages/wrangler/src/pages/buildFunctions.ts
+++ b/packages/wrangler/src/pages/buildFunctions.ts
@@ -30,7 +30,7 @@ export async function buildFunctions({
 	plugin = false,
 	buildOutputDirectory,
 	routesOutputPath,
-	nodeCompat,
+	legacyNodeCompat,
 	local,
 	d1Databases,
 	experimentalWorkerBundle = false,
@@ -44,7 +44,6 @@ export async function buildFunctions({
 		| "watch"
 		| "plugin"
 		| "buildOutputDirectory"
-		| "nodeCompat"
 	>
 > & {
 	functionsDirectory: string;
@@ -54,6 +53,7 @@ export async function buildFunctions({
 	local: boolean;
 	d1Databases?: string[];
 	experimentalWorkerBundle?: boolean;
+	legacyNodeCompat?: boolean;
 }) {
 	RUNNING_BUILDERS.forEach(
 		(runningBuilder) => runningBuilder.stop && runningBuilder.stop()
@@ -101,7 +101,7 @@ export async function buildFunctions({
 			minify,
 			sourcemap,
 			watch,
-			nodeCompat,
+			legacyNodeCompat,
 			functionsDirectory: absoluteFunctionsDirectory,
 			local,
 			betaD1Shims: d1Databases,
@@ -120,7 +120,7 @@ export async function buildFunctions({
 			betaD1Shims: d1Databases,
 			onEnd,
 			buildOutputDirectory,
-			nodeCompat,
+			legacyNodeCompat,
 			experimentalWorkerBundle,
 		});
 	}

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -270,6 +270,8 @@ export const Handler = async ({
 
 	let scriptPath = "";
 
+	const nodejsCompat = compatibilityFlags?.includes("nodejs_compat");
+
 	if (usingWorkerScript) {
 		scriptPath = workerScriptPath;
 		let runBuild = async () => {
@@ -290,6 +292,7 @@ export const Handler = async ({
 						workerScriptPath,
 						outfile: scriptPath,
 						directory: directory ?? ".",
+						nodejsCompat,
 						local: true,
 						sourcemap: true,
 						watch: true,
@@ -319,6 +322,13 @@ export const Handler = async ({
 			);
 		}
 
+		if (legacyNodeCompat && nodejsCompat) {
+			throw new FatalError(
+				"The `nodejs_compat` compatibility flag cannot be used in conjunction with the legacy `--node-compat` flag. If you want to use the Workers runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command or `node_compat = true` from your config file.",
+				1
+			);
+		}
+
 		logger.log(`Compiling worker to "${scriptPath}"...`);
 		const onEnd = () => scriptReadyResolve();
 		try {
@@ -331,6 +341,7 @@ export const Handler = async ({
 					onEnd,
 					buildOutputDirectory: directory,
 					legacyNodeCompat,
+					nodejsCompat,
 					local: true,
 					experimentalWorkerBundle,
 				});

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -193,7 +193,7 @@ export const Handler = async ({
 	experimentalEnableLocalPersistence,
 	persist,
 	persistTo,
-	nodeCompat,
+	nodeCompat: legacyNodeCompat,
 	experimentalLocal,
 	config: config,
 	_: [_pages, _dev, ...remaining],
@@ -313,7 +313,7 @@ export const Handler = async ({
 		// Try to use Functions
 		scriptPath = join(tmpdir(), `./functionsWorker-${Math.random()}.mjs`);
 
-		if (nodeCompat) {
+		if (legacyNodeCompat) {
 			console.warn(
 				"Enabling Node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
 			);
@@ -330,7 +330,7 @@ export const Handler = async ({
 					watch: true,
 					onEnd,
 					buildOutputDirectory: directory,
-					nodeCompat,
+					legacyNodeCompat,
 					local: true,
 					experimentalWorkerBundle,
 				});
@@ -503,7 +503,7 @@ export const Handler = async ({
 		localProtocol,
 		compatibilityDate,
 		compatibilityFlags,
-		nodeCompat,
+		nodeCompat: legacyNodeCompat,
 		vars: Object.fromEntries(
 			bindings
 				.map((binding) => binding.toString().split("="))

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -147,7 +147,7 @@ export function Options(yargs: CommonYargsArgv) {
 				requiresArg: true,
 			},
 			"node-compat": {
-				describe: "Enable node.js compatibility",
+				describe: "Enable Node.js compatibility",
 				default: false,
 				type: "boolean",
 				hidden: true,
@@ -315,7 +315,7 @@ export const Handler = async ({
 
 		if (nodeCompat) {
 			console.warn(
-				"Enabling node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
+				"Enabling Node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
 			);
 		}
 

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -6,7 +6,10 @@ import { D1_BETA_PREFIX } from "../../worker";
 import { buildNotifierPlugin } from "./buildWorker";
 import type { Options as WorkerOptions } from "./buildWorker";
 
-type Options = Omit<WorkerOptions, "fallbackService" | "buildOutputDirectory">;
+type Options = Omit<
+	WorkerOptions,
+	"fallbackService" | "buildOutputDirectory" | "nodejsCompat"
+>;
 
 export function buildPlugin({
 	routesModule,
@@ -33,6 +36,10 @@ export function buildPlugin({
 			sourcemap,
 			watch,
 			legacyNodeCompat,
+			// We don't currently have a mechanism for Plugins 'requiring' a specific compat date/flag,
+			// but if someone wants to publish a Plugin which does require this new `nodejs_compat` flag
+			// and they document that on their README.md, we should let them.
+			nodejsCompat: true,
 			define: {},
 			betaD1Shims: (betaD1Shims || []).map(
 				(binding) => `${D1_BETA_PREFIX}${binding}`

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -15,7 +15,7 @@ export function buildPlugin({
 	sourcemap = false,
 	watch = false,
 	onEnd = () => {},
-	nodeCompat,
+	legacyNodeCompat,
 	functionsDirectory,
 	local,
 	betaD1Shims,
@@ -32,7 +32,7 @@ export function buildPlugin({
 			minify,
 			sourcemap,
 			watch,
-			nodeCompat,
+			legacyNodeCompat,
 			define: {},
 			betaD1Shims: (betaD1Shims || []).map(
 				(binding) => `${D1_BETA_PREFIX}${binding}`

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -18,6 +18,7 @@ export type Options = {
 	onEnd?: () => void;
 	buildOutputDirectory?: string;
 	legacyNodeCompat?: boolean;
+	nodejsCompat?: boolean;
 	functionsDirectory: string;
 	local: boolean;
 	betaD1Shims?: string[];
@@ -34,6 +35,7 @@ export function buildWorker({
 	onEnd = () => {},
 	buildOutputDirectory,
 	legacyNodeCompat,
+	nodejsCompat,
 	functionsDirectory,
 	local,
 	betaD1Shims,
@@ -52,6 +54,7 @@ export function buildWorker({
 			sourcemap,
 			watch,
 			legacyNodeCompat,
+			nodejsCompat,
 			loader: {
 				".txt": "text",
 				".html": "text",
@@ -163,6 +166,7 @@ export type RawOptions = {
 	onEnd?: () => void;
 	buildOutputDirectory?: string;
 	legacyNodeCompat?: boolean;
+	nodejsCompat?: boolean;
 	local: boolean;
 	betaD1Shims?: string[];
 	experimentalWorkerBundle?: boolean;
@@ -185,6 +189,7 @@ export function buildRawWorker({
 	plugins = [],
 	onEnd = () => {},
 	legacyNodeCompat,
+	nodejsCompat,
 	local,
 	betaD1Shims,
 	experimentalWorkerBundle = false,
@@ -201,6 +206,7 @@ export function buildRawWorker({
 			sourcemap,
 			watch,
 			legacyNodeCompat,
+			nodejsCompat,
 			loader: {
 				".txt": "text",
 				".html": "text",

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -17,7 +17,7 @@ export type Options = {
 	watch?: boolean;
 	onEnd?: () => void;
 	buildOutputDirectory?: string;
-	nodeCompat?: boolean;
+	legacyNodeCompat?: boolean;
 	functionsDirectory: string;
 	local: boolean;
 	betaD1Shims?: string[];
@@ -33,7 +33,7 @@ export function buildWorker({
 	watch = false,
 	onEnd = () => {},
 	buildOutputDirectory,
-	nodeCompat,
+	legacyNodeCompat,
 	functionsDirectory,
 	local,
 	betaD1Shims,
@@ -51,7 +51,7 @@ export function buildWorker({
 			minify,
 			sourcemap,
 			watch,
-			nodeCompat,
+			legacyNodeCompat,
 			loader: {
 				".txt": "text",
 				".html": "text",
@@ -162,7 +162,7 @@ export type RawOptions = {
 	plugins?: Plugin[];
 	onEnd?: () => void;
 	buildOutputDirectory?: string;
-	nodeCompat?: boolean;
+	legacyNodeCompat?: boolean;
 	local: boolean;
 	betaD1Shims?: string[];
 	experimentalWorkerBundle?: boolean;
@@ -184,7 +184,7 @@ export function buildRawWorker({
 	watch = false,
 	plugins = [],
 	onEnd = () => {},
-	nodeCompat,
+	legacyNodeCompat,
 	local,
 	betaD1Shims,
 	experimentalWorkerBundle = false,
@@ -200,7 +200,7 @@ export function buildRawWorker({
 			minify,
 			sourcemap,
 			watch,
-			nodeCompat,
+			legacyNodeCompat,
 			loader: {
 				".txt": "text",
 				".html": "text",

--- a/packages/wrangler/src/paths.ts
+++ b/packages/wrangler/src/paths.ts
@@ -59,7 +59,7 @@ export function readableRelative(to: string) {
 declare const __RELATIVE_PACKAGE_PATH__: string;
 
 /**
- * Use this function (rather than node.js constants like `__dirname`) to specify
+ * Use this function (rather than Node.js constants like `__dirname`) to specify
  * paths that are relative to the base path of the Wrangler package.
  *
  * It is important to use this function because it reliably maps to the root of the package

--- a/packages/wrangler/src/publish/index.ts
+++ b/packages/wrangler/src/publish/index.ts
@@ -158,7 +158,7 @@ export function publishOptions(yargs: CommonYargsArgv) {
 				type: "boolean",
 			})
 			.option("node-compat", {
-				describe: "Enable node.js compatibility",
+				describe: "Enable Node.js compatibility",
 				type: "boolean",
 			})
 			.option("dry-run", {

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -339,8 +339,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	const minify = props.minify ?? config.minify;
 
-	const nodeCompat = props.nodeCompat ?? config.node_compat;
-	if (nodeCompat) {
+	const legacyNodeCompat = props.nodeCompat ?? config.node_compat;
+	if (legacyNodeCompat) {
 		logger.warn(
 			"Enabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
 		);
@@ -353,7 +353,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
-	if (props.noBundle && nodeCompat) {
+	if (props.noBundle && legacyNodeCompat) {
 		logger.warn(
 			"`--node-compat` and `--no-bundle` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process."
 		);
@@ -478,7 +478,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						rules: props.rules,
 						tsconfig: props.tsconfig ?? config.tsconfig,
 						minify,
-						nodeCompat,
+						legacyNodeCompat,
 						define: { ...config.define, ...props.defines },
 						checkFetch: false,
 						assets: config.assets && {

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -346,6 +346,14 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		);
 	}
 
+	const compatibilityFlags =
+		props.compatibilityFlags ?? config.compatibility_flags;
+	const nodejsCompat = compatibilityFlags.includes("nodejs_compat");
+	assert(
+		!(legacyNodeCompat && nodejsCompat),
+		"The `nodejs_compat` compatibility flag cannot be used in conjunction with the legacy `--node-compat` flag. If you want to use the Workers runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command or `node_compat = true` from your config file."
+	);
+
 	// Warn if user tries minify or node-compat with no-bundle
 	if (props.noBundle && minify) {
 		logger.warn(
@@ -479,6 +487,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						tsconfig: props.tsconfig ?? config.tsconfig,
 						minify,
 						legacyNodeCompat,
+						nodejsCompat,
 						define: { ...config.define, ...props.defines },
 						checkFetch: false,
 						assets: config.assets && {
@@ -575,8 +584,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			migrations,
 			modules,
 			compatibility_date: props.compatibilityDate ?? config.compatibility_date,
-			compatibility_flags:
-				props.compatibilityFlags ?? config.compatibility_flags,
+			compatibility_flags: compatibilityFlags,
 			usage_model: config.usage_model,
 			keepVars,
 			logpush: props.logpush !== undefined ? props.logpush : config.logpush,

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -342,7 +342,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	const nodeCompat = props.nodeCompat ?? config.node_compat;
 	if (nodeCompat) {
 		logger.warn(
-			"Enabling node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
+			"Enabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
 		);
 	}
 


### PR DESCRIPTION
What this PR solves / how to test:

This PR does two things:
1. Renames the `--node-compat` CLI/config option _internally_ to `legacyNodeCompat`. Nothing changes externally. You still invoke it with `--node-compat` or `node_compat`. We maybe want to think about moving this to `experimental` as we stabilize the`dev()` API, but that discussion can happen elsewhere.
2. Marks any imports prefixed with `node:` as external when bundling with the `nodejs_compat` compatibility flag.

Associated docs issues/PR:

- https://github.com/cloudflare/workerd/pull/208
- https://github.com/cloudflare/miniflare/issues/473

Author has included the following, where applicable:

- [x] Tests (need a test to check the `publish --dry-run` and `pages functions build` output)
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
