### PR TITLE
Add --node-compat to Pages publish

### DIFF
--- a/.changeset/happy-trees-check.md
+++ b/.changeset/happy-trees-check.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add support for `--node-compat` when running `wrangler pages publish`. Support for CI will be coming in the future.

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -76,6 +76,11 @@ interface PagesDeployOptions {
 	// TODO: Allow passing in the API key and plumb it through
 	// to the API calls so that the deploy function does not
 	// rely on the `CLOUDFLARE_API_KEY` environment variable
+
+	/**
+	 * Whether or not to polyfill Node.js APIs
+	 */
+	nodeCompat?: boolean;
 }
 
 /**
@@ -94,6 +99,7 @@ export async function deploy({
 	commitDirty,
 	functionsDirectory: customFunctionsDirectory,
 	bundle,
+	nodeCompat,
 }: PagesDeployOptions) {
 	let _headers: string | undefined,
 		_redirects: string | undefined,
@@ -166,6 +172,17 @@ export async function deploy({
 			`functions-filepath-routing-config-${Math.random()}.json`
 		);
 
+		if (nodeCompat) {
+			if (nodejsCompat) {
+				console.error('You cannot use both the legacy node-compat and the compatibility flag nodejs_compat.');
+				process.exit(1);
+			}
+
+			console.warn(
+				"Enabling node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
+			);
+		}
+
 		try {
 			workerBundle = await buildFunctions({
 				outputConfigPath,
@@ -174,6 +191,7 @@ export async function deploy({
 				buildOutputDirectory: directory,
 				routesOutputPath,
 				local: false,
+				legacyNodeCompat: nodeCompat,
 				nodejsCompat,
 			});
 

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -83,7 +83,6 @@ export function Options(yargs: CommonYargsArgv) {
 				describe: "Enable Node.js compatibility",
 				default: false,
 				type: "boolean",
-				hidden: true,
 			},
 			"compatibility-date": {
 				describe: "Date to use for compatibility checks",

--- a/packages/wrangler/src/pages/deploy.tsx
+++ b/packages/wrangler/src/pages/deploy.tsx
@@ -71,6 +71,11 @@ export function Options(yargs: CommonYargsArgv) {
 				type: "string",
 				hidden: true,
 			},
+			"node-compat": {
+				describe: "Enable node.js compatibility",
+				default: false,
+				type: "boolean",
+			},
 		});
 }
 
@@ -86,6 +91,7 @@ export const Handler = async ({
 	bundle,
 	noBundle,
 	config: wranglerConfig,
+	nodeCompat,
 }: PublishArgs) => {
 	// Check for deprecated `wrangler pages publish` command
 	if (_[1] === "publish") {
@@ -260,6 +266,7 @@ export const Handler = async ({
 		// TODO: Here lies a known bug. If you specify both `--bundle` and `--no-bundle`, this behavior is undefined and you will get unexpected results.
 		// There is no sane way to get the true value out of yargs, so here we are.
 		bundle: bundle ?? !noBundle,
+		nodeCompat,
 	});
 
 	saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -179,7 +179,6 @@ export function Options(yargs: CommonYargsArgv) {
 				describe: "Enable Node.js compatibility",
 				default: false,
 				type: "boolean",
-				hidden: true,
 			},
 			"experimental-local": {
 				describe: "Run on my machine using the Cloudflare Workers runtime",


### PR DESCRIPTION
What this PR solves / how to test:

This adds `--node-compat` support to Pages, this is a common feature request and will allow for the usage of Stripe and other such libs within Functions.

Associated docs issues/PR:
N/A

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #1074
