### PR TITLE
validate namespace ids

### DIFF
--- a/.changeset/violet-ducks-return.md
+++ b/.changeset/violet-ducks-return.md
@@ -4,4 +4,4 @@
 
 Display a clearer error message when when trying to delete a KV namespace with an invalid namespace-id.
 
-Previously, there would be a bizarre authentication error when attempting to delete a KV namespace with a name like `my-namespaceඞ`. Now, wrangler will validate that an ID is valid before attempting to delete it.
+Previously, there would be a bizarre authentication error when attempting to delete a KV namespace with an invalid namespace-id like `my-namespaceඞ`. Now, wrangler will validate that an ID is valid before attempting to delete it.

--- a/.changeset/violet-ducks-return.md
+++ b/.changeset/violet-ducks-return.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Clarify the problem when trying to delete a KV namespace that has an invalid name.
+
+Previously, there would be a bizarre authentication error when attempting to delete a KV namespace with a name like `my-namespaceඞ`. Now, wrangler will validate that an ID is valid before attempting to delete it.

--- a/.changeset/violet-ducks-return.md
+++ b/.changeset/violet-ducks-return.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-Clarify the problem when trying to delete a KV namespace that has an invalid name.
+Display a clearer error message when when trying to delete a KV namespace with an invalid namespace-id.
 
 Previously, there would be a bizarre authentication error when attempting to delete a KV namespace with a name like `my-namespaceඞ`. Now, wrangler will validate that an ID is valid before attempting to delete it.

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -13,6 +13,13 @@ import type {
 	KVNamespaceInfo,
 	NamespaceKeyInfo,
 } from "../kv/helpers";
+
+// some dummy values for namespace ids that pass validation
+const KV_NAMESPACE_ID = "1234567890abcdef1234567890abcdef";
+const KV_NAMESPACE_PREVIEW_ID = "abcdef1234567890abcdef1234567890";
+const ENV_KV_NAMESPACE_ID = "0987654321fedcba0987654321fedcba";
+const ENV_KV_NAMESPACE_PREVIEW_ID = "fedcba0987654321fedcba0987654321";
+
 describe("wrangler", () => {
 	mockAccountId();
 	mockApiToken();
@@ -264,16 +271,30 @@ describe("wrangler", () => {
 			}
 
 			it("should delete a namespace specified by id", async () => {
-				const requests = mockDeleteRequest("some-namespace-id");
+				const requests = mockDeleteRequest(KV_NAMESPACE_ID);
 				await runWrangler(
-					`kv:namespace delete --namespace-id some-namespace-id`
+					`kv:namespace delete --namespace-id ${KV_NAMESPACE_ID}`
 				);
 				expect(requests.count).toEqual(1);
 			});
 
+			it("should error when attempting to delete a namespace with an invalid ID", async () => {
+				await expect(
+					runWrangler(`kv:namespace delete --namespace-id this-is-not-a-uuid`)
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`"\\"this-is-not-a-uuid\\" is not a valid KV namespace ID. Try running \`wrangler kv:namespace list\` to see a list of the KV namespaces on your account."`
+				);
+
+				await expect(
+					runWrangler(`kv:namespace delete --namespace-id [namespace-id]`)
+				).rejects.toThrowErrorMatchingInlineSnapshot(
+					`"\\"[namespace-id]\\" is not a valid KV namespace ID. Try running \`wrangler kv:namespace list\` to see a list of the KV namespaces on your account."`
+				);
+			});
+
 			it("should delete a namespace specified by binding name", async () => {
 				writeWranglerConfig();
-				const requests = mockDeleteRequest("bound-id");
+				const requests = mockDeleteRequest(KV_NAMESPACE_ID);
 				await runWrangler(
 					`kv:namespace delete --binding someBinding --preview false`
 				);
@@ -282,7 +303,7 @@ describe("wrangler", () => {
 
 			it("should delete a preview namespace specified by binding name", async () => {
 				writeWranglerConfig();
-				const requests = mockDeleteRequest("preview-bound-id");
+				const requests = mockDeleteRequest(KV_NAMESPACE_PREVIEW_ID);
 				await runWrangler(
 					`kv:namespace delete --binding someBinding --preview`
 				);
@@ -307,14 +328,14 @@ describe("wrangler", () => {
 
 			it("should delete a namespace specified by binding name in a given environment", async () => {
 				writeWranglerConfig();
-				const requests = mockDeleteRequest("env-bound-id");
+				const requests = mockDeleteRequest(ENV_KV_NAMESPACE_ID);
 				await runWrangler(
 					"kv:namespace delete --binding someBinding --env some-environment --preview false"
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-					"Deleting KV namespace env-bound-id.
-					Deleted KV namespace env-bound-id."
+					"Deleting KV namespace 0987654321fedcba0987654321fedcba.
+					Deleted KV namespace 0987654321fedcba0987654321fedcba."
 				`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -322,7 +343,7 @@ describe("wrangler", () => {
 
 			it("should delete a preview namespace specified by binding name in a given environment", async () => {
 				writeWranglerConfig();
-				const requests = mockDeleteRequest("preview-env-bound-id");
+				const requests = mockDeleteRequest(ENV_KV_NAMESPACE_PREVIEW_ID);
 				await runWrangler(
 					`kv:namespace delete --binding someBinding --env some-environment --preview`
 				);
@@ -413,7 +434,7 @@ describe("wrangler", () => {
 
 			it("should put a key in a given namespace specified by binding", async () => {
 				writeWranglerConfig();
-				const requests = mockKeyPutRequest("bound-id", {
+				const requests = mockKeyPutRequest(KV_NAMESPACE_ID, {
 					key: "my-key",
 					value: "my-value",
 				});
@@ -422,7 +443,7 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace bound-id."`
+					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace 1234567890abcdef1234567890abcdef."`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -430,7 +451,7 @@ describe("wrangler", () => {
 
 			it("should put a key in a given preview namespace specified by binding", async () => {
 				writeWranglerConfig();
-				const requests = mockKeyPutRequest("preview-bound-id", {
+				const requests = mockKeyPutRequest(KV_NAMESPACE_PREVIEW_ID, {
 					key: "my-key",
 					value: "my-value",
 				});
@@ -440,7 +461,7 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace preview-bound-id."`
+					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace abcdef1234567890abcdef1234567890."`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -465,7 +486,7 @@ describe("wrangler", () => {
 
 			it("should put a key to the specified environment in a given namespace", async () => {
 				writeWranglerConfig();
-				const requests = mockKeyPutRequest("env-bound-id", {
+				const requests = mockKeyPutRequest(ENV_KV_NAMESPACE_ID, {
 					key: "my-key",
 					value: "my-value",
 				});
@@ -473,7 +494,7 @@ describe("wrangler", () => {
 					"kv:key put my-key my-value --binding someBinding --env some-environment --preview false"
 				);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace env-bound-id."`
+					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace 0987654321fedcba0987654321fedcba."`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -802,7 +823,7 @@ describe("wrangler", () => {
 			it("should list the keys of a namespace specified by binding", async () => {
 				writeWranglerConfig();
 				const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
-				mockKeyListRequest("bound-id", keys);
+				mockKeyListRequest(KV_NAMESPACE_ID, keys);
 
 				await runWrangler("kv:key list --binding someBinding");
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -824,7 +845,7 @@ describe("wrangler", () => {
 			it("should list the keys of a preview namespace specified by binding", async () => {
 				writeWranglerConfig();
 				const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
-				mockKeyListRequest("preview-bound-id", keys);
+				mockKeyListRequest(KV_NAMESPACE_PREVIEW_ID, keys);
 				await runWrangler("kv:key list --binding someBinding --preview");
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.out).toMatchInlineSnapshot(`
@@ -845,7 +866,7 @@ describe("wrangler", () => {
 			it("should list the keys of a namespace specified by binding, in a given environment", async () => {
 				writeWranglerConfig();
 				const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
-				mockKeyListRequest("env-bound-id", keys);
+				mockKeyListRequest(ENV_KV_NAMESPACE_ID, keys);
 				await runWrangler(
 					"kv:key list --binding someBinding --env some-environment"
 				);
@@ -868,7 +889,7 @@ describe("wrangler", () => {
 			it("should list the keys of a preview namespace specified by binding, in a given environment", async () => {
 				writeWranglerConfig();
 				const keys = [{ name: "key-1" }, { name: "key-2" }, { name: "key-3" }];
-				mockKeyListRequest("preview-env-bound-id", keys);
+				mockKeyListRequest(ENV_KV_NAMESPACE_PREVIEW_ID, keys);
 				await runWrangler(
 					"kv:key list --binding someBinding --preview --env some-environment"
 				);
@@ -1013,7 +1034,7 @@ describe("wrangler", () => {
 				writeWranglerConfig();
 				setMockFetchKVGetValue(
 					"some-account-id",
-					"bound-id",
+					KV_NAMESPACE_ID,
 					"my-key",
 					"my-value"
 				);
@@ -1028,7 +1049,7 @@ describe("wrangler", () => {
 				writeWranglerConfig();
 				setMockFetchKVGetValue(
 					"some-account-id",
-					"preview-bound-id",
+					KV_NAMESPACE_PREVIEW_ID,
 					"my-key",
 					"my-value"
 				);
@@ -1041,7 +1062,7 @@ describe("wrangler", () => {
 				writeWranglerConfig();
 				setMockFetchKVGetValue(
 					"some-account-id",
-					"env-bound-id",
+					ENV_KV_NAMESPACE_ID,
 					"my-key",
 					"my-value"
 				);
@@ -1309,7 +1330,7 @@ describe("wrangler", () => {
 
 			it("should delete a key in a namespace specified by binding name", async () => {
 				writeWranglerConfig();
-				const requests = mockDeleteRequest("bound-id", "someKey");
+				const requests = mockDeleteRequest(KV_NAMESPACE_ID, "someKey");
 				await runWrangler(
 					`kv:key delete --binding someBinding --preview false someKey`
 				);
@@ -1318,7 +1339,7 @@ describe("wrangler", () => {
 
 			it("should delete a key in a preview namespace specified by binding name", async () => {
 				writeWranglerConfig();
-				const requests = mockDeleteRequest("preview-bound-id", "someKey");
+				const requests = mockDeleteRequest(KV_NAMESPACE_PREVIEW_ID, "someKey");
 				await runWrangler(
 					`kv:key delete --binding someBinding --preview someKey`
 				);
@@ -1342,12 +1363,12 @@ describe("wrangler", () => {
 
 			it("should delete a key in a namespace specified by binding name in a given environment", async () => {
 				writeWranglerConfig();
-				const requests = mockDeleteRequest("env-bound-id", "someKey");
+				const requests = mockDeleteRequest(ENV_KV_NAMESPACE_ID, "someKey");
 				await runWrangler(
 					`kv:key delete --binding someBinding --env some-environment --preview false someKey`
 				);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Deleting the key \\"someKey\\" on namespace env-bound-id."`
+					`"Deleting the key \\"someKey\\" on namespace 0987654321fedcba0987654321fedcba."`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -1355,7 +1376,10 @@ describe("wrangler", () => {
 
 			it("should delete a key in a preview namespace specified by binding name in a given environment", async () => {
 				writeWranglerConfig();
-				const requests = mockDeleteRequest("preview-env-bound-id", "someKey");
+				const requests = mockDeleteRequest(
+					ENV_KV_NAMESPACE_PREVIEW_ID,
+					"someKey"
+				);
 				await runWrangler(
 					`kv:key delete --binding someBinding --env some-environment --preview someKey`
 				);
@@ -1685,12 +1709,12 @@ function writeWranglerConfig() {
 		[
 			'name = "other-worker"',
 			"kv_namespaces = [",
-			'  { binding = "someBinding", id = "bound-id", preview_id = "preview-bound-id" }',
+			`  { binding = "someBinding", id = "${KV_NAMESPACE_ID}", preview_id = "${KV_NAMESPACE_PREVIEW_ID}" }`,
 			"]",
 			"",
 			"[env.some-environment]",
 			"kv_namespaces = [",
-			'  { binding = "someBinding", id = "env-bound-id", preview_id = "preview-env-bound-id" }',
+			`  { binding = "someBinding", id = "${ENV_KV_NAMESPACE_ID}", preview_id = "${ENV_KV_NAMESPACE_PREVIEW_ID}" }`,
 			"]",
 		].join("\n"),
 		"utf-8"

--- a/packages/wrangler/src/kv/helpers.ts
+++ b/packages/wrangler/src/kv/helpers.ts
@@ -422,7 +422,7 @@ export function getKVNamespaceId(
  * KV namespace ID's must match the pattern `[0-9a-f]{32}`
  */
 export function isValidKVNamespaceID(id: string) {
-	return /^[0-9a-f]{32}$/.test(id);
+	return /^[0-9a-f]{32}$/i.test(id);
 }
 
 /**

--- a/packages/wrangler/src/kv/helpers.ts
+++ b/packages/wrangler/src/kv/helpers.ts
@@ -419,6 +419,13 @@ export function getKVNamespaceId(
 }
 
 /**
+ * KV namespace ID's must match the pattern `[0-9a-f]{32}`
+ */
+export function isValidKVNamespaceID(id: string) {
+	return /^[0-9a-f]{32}$/.test(id);
+}
+
+/**
  * KV namespace binding names must be valid JS identifiers.
  */
 export function isValidKVNamespaceBinding(

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -24,6 +24,7 @@ import {
 	putKVBulkKeyValue,
 	putKVKeyValue,
 	unexpectedKVKeyValueProps,
+	isValidKVNamespaceID,
 } from "./helpers";
 import type { ConfigPath } from "../index";
 import type { CommonYargsOptions } from "../yargs-types";
@@ -141,6 +142,12 @@ export const kvNamespace = (kvYargs: Argv<CommonYargsOptions>) => {
 				} catch (e) {
 					throw new CommandLineArgsError(
 						"Not able to delete namespace.\n" + ((e as Error).message ?? e)
+					);
+				}
+
+				if (!isValidKVNamespaceID(id)) {
+					throw new Error(
+						`"${id}" is not a valid KV namespace ID. Try running \`wrangler kv:namespace list\` to see a list of the KV namespaces on your account.`
 					);
 				}
 


### PR DESCRIPTION
What this PR solves / how to test:

Clarify the problem when trying to delete a KV namespace that has an invalid name.

Previously, there would be a bizarre authentication error when attempting to delete a KV namespace with a name like `my-namespaceඞ`. Now, wrangler will validate that an ID is valid before attempting to delete it.

Try running `wrangler kv:namespace delete --namespace-id test` -- you should get an error back that that's not a real namespace id. Compared to `wrangler kv:namespace delete --namespace-id aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`, which could theoretically be a valid namespace ID, and will return an actual API error.

Associated docs issues/PR:

- n/a

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Fixes #2288.
