### PR TITLE
Add api, commands, and binding support for mTLS certificates

### DIFF
--- a/.changeset/clean-jokes-tan.md
+++ b/.changeset/clean-jokes-tan.md
@@ -1,0 +1,13 @@
+---
+"wrangler": minor
+---
+
+Add mtls-certificate commands and binding support
+
+Functionality implemented first as an api, which is used in the cli standard
+api commands
+
+Note that this adds a new OAuth scope, so OAuth users will need to log out and
+log back in to use the new 'mtls-certificate' commands
+However, publishing with mtls-certifcate bindings (bindings of type
+'mtls_certificate') will work without the scope.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -50,6 +50,7 @@ describe("wrangler", () => {
 			  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
 			  wrangler d1                          🗄  Interact with a D1 database
 			  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
+			  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
 			  wrangler login                       🔓 Login to Cloudflare
 			  wrangler logout                      🚪 Logout from Cloudflare
 			  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
@@ -99,6 +100,7 @@ describe("wrangler", () => {
 			  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
 			  wrangler d1                          🗄  Interact with a D1 database
 			  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
+			  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
 			  wrangler login                       🔓 Login to Cloudflare
 			  wrangler logout                      🚪 Logout from Cloudflare
 			  wrangler whoami                      🕵️  Retrieve your user info and test your auth config

--- a/packages/wrangler/src/__tests__/mtls-certificates.test.ts
+++ b/packages/wrangler/src/__tests__/mtls-certificates.test.ts
@@ -1,0 +1,585 @@
+import { writeFileSync } from "fs";
+import { rest } from "msw";
+import {
+	uploadMTlsCertificateFromFs,
+	uploadMTlsCertificate,
+	listMTlsCertificates,
+	deleteMTlsCertificate,
+	getMTlsCertificate,
+	getMTlsCertificateByName,
+} from "../api";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { mockConfirm } from "./helpers/mock-dialogs";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { msw } from "./helpers/msw";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+import type { MTlsCertificateResponse } from "../api/mtls-certificate";
+
+describe("wrangler", () => {
+	const accountId = "1a2b3c4d";
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+	const std = mockConsoleMethods();
+
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	function mockPostMTlsCertificate(
+		resp: Partial<MTlsCertificateResponse> = {}
+	) {
+		const config = { calls: 0 };
+		msw.use(
+			rest.post(
+				"*/accounts/:accountId/mtls_certificates",
+				async (request, response, context) => {
+					config.calls++;
+
+					const body = await request.json();
+					return response.once(
+						context.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								id: "1234",
+								name: body.name,
+								certificates: body.certificates,
+								issuer: "example.com...",
+								uploaded_on: now.toISOString(),
+								expires_on: oneYearLater.toISOString(),
+								...resp,
+							},
+						})
+					);
+				}
+			)
+		);
+		return config;
+	}
+
+	function mockGetMTlsCertificates(
+		certs: Partial<MTlsCertificateResponse>[] | undefined = undefined
+	) {
+		const config = { calls: 0 };
+		msw.use(
+			rest.get(
+				"*/accounts/:accountId/mtls_certificates",
+				async (request, response, context) => {
+					config.calls++;
+
+					return response.once(
+						context.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result:
+								typeof certs === "undefined"
+									? [
+											{
+												id: "1234",
+												name: "cert one",
+												certificates: "BEGIN CERTIFICATE...",
+												issuer: "example.com...",
+												uploaded_on: now.toISOString(),
+												expires_on: oneYearLater.toISOString(),
+											},
+											{
+												id: "5678",
+												name: "cert two",
+												certificates: "BEGIN CERTIFICATE...",
+												issuer: "example.com...",
+												uploaded_on: now.toISOString(),
+												expires_on: oneYearLater.toISOString(),
+											},
+									  ]
+									: certs,
+						})
+					);
+				}
+			)
+		);
+		return config;
+	}
+
+	function mockGetMTlsCertificate(resp: Partial<MTlsCertificateResponse> = {}) {
+		const config = { calls: 0 };
+		msw.use(
+			rest.get(
+				"*/accounts/:accountId/mtls_certificates/:certId",
+				async (request, response, context) => {
+					config.calls++;
+
+					return response.once(
+						context.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								id: "1234",
+								certificates: "BEGIN CERTIFICATE...",
+								issuer: "example.com...",
+								uploaded_on: now.toISOString(),
+								expires_on: oneYearLater.toISOString(),
+								...resp,
+							},
+						})
+					);
+				}
+			)
+		);
+		return config;
+	}
+
+	function mockDeleteMTlsCertificate() {
+		const config = { calls: 0 };
+		msw.use(
+			rest.delete(
+				"*/accounts/:accountId/mtls_certificates/:certId",
+				async (request, response, context) => {
+					config.calls++;
+
+					return response.once(
+						context.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: null,
+						})
+					);
+				}
+			)
+		);
+		return config;
+	}
+
+	const now = new Date();
+	const oneYearLater = new Date(now);
+	oneYearLater.setFullYear(now.getFullYear() + 1);
+
+	describe("mtls-certificates", () => {
+		describe("api", () => {
+			describe("uploadMTlsCertificate", () => {
+				it("should call mtls_certificates upload endpoint", async () => {
+					const mock = mockPostMTlsCertificate({
+						id: "1234",
+						issuer: "example.com...",
+						uploaded_on: now.toISOString(),
+						expires_on: oneYearLater.toISOString(),
+					});
+
+					const cert = await uploadMTlsCertificate(accountId, {
+						certificateChain: "BEGIN CERTIFICATE...",
+						privateKey: "BEGIN PRIVATE KEY...",
+						name: "my_cert",
+					});
+
+					expect(cert.id).toEqual("1234");
+					expect(cert.issuer).toEqual("example.com...");
+					expect(cert.expires_on).toEqual(oneYearLater.toISOString());
+
+					expect(mock.calls).toEqual(1);
+				});
+			});
+
+			describe("uploadMTlsCertificateFromFs", () => {
+				it("should fail to read cert and key files when missing", async () => {
+					await expect(
+						uploadMTlsCertificateFromFs(accountId, {
+							certificateChainFilename: "cert.pem",
+							privateKeyFilename: "key.pem",
+							name: "my_cert",
+						})
+					).rejects.toMatchInlineSnapshot(
+						`[ParseError: Could not read file: cert.pem]`
+					);
+				});
+
+				it("should read cert and key from disk and call mtls_certificates upload endpoint", async () => {
+					const mock = mockPostMTlsCertificate({
+						id: "1234",
+						issuer: "example.com...",
+					});
+
+					writeFileSync("cert.pem", "BEGIN CERTIFICATE...");
+					writeFileSync("key.pem", "BEGIN PRIVATE KEY...");
+
+					const cert = await uploadMTlsCertificateFromFs(accountId, {
+						certificateChainFilename: "cert.pem",
+						privateKeyFilename: "key.pem",
+						name: "my_cert",
+					});
+
+					expect(cert.id).toEqual("1234");
+					expect(cert.issuer).toEqual("example.com...");
+					expect(cert.expires_on).toEqual(oneYearLater.toISOString());
+
+					expect(mock.calls).toEqual(1);
+				});
+			});
+
+			describe("listMTlsCertificates", () => {
+				it("should call mtls_certificates list endpoint", async () => {
+					const mock = mockGetMTlsCertificates([
+						{
+							id: "1234",
+							name: "cert one",
+							certificates: "BEGIN CERTIFICATE...",
+							issuer: "example.com...",
+							uploaded_on: now.toISOString(),
+							expires_on: oneYearLater.toISOString(),
+						},
+						{
+							id: "5678",
+							name: "cert two",
+							certificates: "BEGIN CERTIFICATE...",
+							issuer: "example.com...",
+							uploaded_on: now.toISOString(),
+							expires_on: oneYearLater.toISOString(),
+						},
+					]);
+
+					const certs = await listMTlsCertificates(accountId, {});
+
+					expect(certs).toHaveLength(2);
+
+					expect(certs[0].id).toEqual("1234");
+					expect(certs[0].name).toEqual("cert one");
+
+					expect(certs[1].id).toEqual("5678");
+					expect(certs[1].name).toEqual("cert two");
+
+					expect(mock.calls).toEqual(1);
+				});
+			});
+
+			describe("getMTlsCertificate", () => {
+				it("calls get mtls_certificates endpoint", async () => {
+					const mock = mockGetMTlsCertificate({
+						id: "1234",
+						name: "cert one",
+						certificates: "BEGIN CERTIFICATE...",
+						issuer: "example.com...",
+						uploaded_on: now.toISOString(),
+						expires_on: oneYearLater.toISOString(),
+					});
+
+					const cert = await getMTlsCertificate(accountId, "1234");
+
+					expect(cert.id).toEqual("1234");
+					expect(cert.issuer).toEqual("example.com...");
+					expect(cert.expires_on).toEqual(oneYearLater.toISOString());
+
+					expect(mock.calls).toEqual(1);
+				});
+			});
+
+			describe("getMTlsCertificateByName", () => {
+				it("calls list mtls_certificates endpoint with name", async () => {
+					const mock = mockGetMTlsCertificates([
+						{
+							id: "1234",
+							name: "cert one",
+							certificates: "BEGIN CERTIFICATE...",
+							issuer: "example.com...",
+							uploaded_on: now.toISOString(),
+							expires_on: oneYearLater.toISOString(),
+						},
+					]);
+
+					const cert = await getMTlsCertificateByName(accountId, "cert one");
+
+					expect(cert.id).toEqual("1234");
+					expect(cert.issuer).toEqual("example.com...");
+					expect(cert.expires_on).toEqual(oneYearLater.toISOString());
+
+					expect(mock.calls).toEqual(1);
+				});
+
+				it("errors when a certificate cannot be found", async () => {
+					const mock = mockGetMTlsCertificates([]);
+
+					await expect(
+						getMTlsCertificateByName(accountId, "cert one")
+					).rejects.toMatchInlineSnapshot(
+						`[Error: certificate not found with name "cert one"]`
+					);
+
+					expect(mock.calls).toEqual(1);
+				});
+
+				it("errors when multiple certificates are found", async () => {
+					const mock = mockGetMTlsCertificates([
+						{
+							id: "1234",
+							name: "cert one",
+							certificates: "BEGIN CERTIFICATE...",
+							issuer: "example.com...",
+							uploaded_on: now.toISOString(),
+							expires_on: oneYearLater.toISOString(),
+						},
+						{
+							id: "5678",
+							name: "cert one",
+							certificates: "BEGIN CERTIFICATE...",
+							issuer: "example.com...",
+							uploaded_on: now.toISOString(),
+							expires_on: oneYearLater.toISOString(),
+						},
+					]);
+
+					await expect(
+						getMTlsCertificateByName(accountId, "cert one")
+					).rejects.toMatchInlineSnapshot(
+						`[Error: multiple certificates found with name "cert one"]`
+					);
+
+					expect(mock.calls).toEqual(1);
+				});
+			});
+
+			describe("deleteMTlsCertificate", () => {
+				test("calls delete mts_certificates endpoint", async () => {
+					const mock = mockDeleteMTlsCertificate();
+
+					await deleteMTlsCertificate(accountId, "1234");
+
+					expect(mock.calls).toEqual(1);
+				});
+			});
+		});
+
+		describe("commands", () => {
+			describe("help", () => {
+				it("should show the correct help text", async () => {
+					await runWrangler("mtls-certifiate --help");
+					expect(std.err).toMatchInlineSnapshot(`""`);
+					expect(std.out).toMatchInlineSnapshot(`
+				"wrangler
+
+				Commands:
+				  wrangler docs [command]              📚 Open wrangler's docs in your browser
+				  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
+				  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/templates
+				  wrangler dev [script]                👂 Start a local server for developing your worker
+				  wrangler publish [script]            🆙 Publish your Worker to Cloudflare.
+				  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
+				  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
+				  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
+				  wrangler secret:bulk <json>          🗄️  Bulk upload secrets for a Worker
+				  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
+				  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
+				  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
+				  wrangler pages                       ⚡️ Configure Cloudflare Pages
+				  wrangler queues                      🇶 Configure Workers Queues
+				  wrangler r2                          📦 Interact with an R2 store
+				  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
+				  wrangler d1                          🗄  Interact with a D1 database
+				  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
+				  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
+				  wrangler login                       🔓 Login to Cloudflare
+				  wrangler logout                      🚪 Logout from Cloudflare
+				  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
+				  wrangler types                       📝 Generate types from bindings & module rules in config
+				  wrangler deployments                 🚢 Displays the 10 most recent deployments for a worker
+
+				Flags:
+				  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+				  -c, --config                    Path to .toml configuration file  [string]
+				  -e, --env                       Environment to use for operations and .env files  [string]
+				  -h, --help                      Show help  [boolean]
+				  -v, --version                   Show version number  [boolean]"
+			`);
+				});
+			});
+
+			describe("upload", () => {
+				test("uploads certificate and key from file", async () => {
+					writeFileSync("cert.pem", "BEGIN CERTIFICATE...");
+					writeFileSync("key.pem", "BEGIN PRIVATE KEY...");
+
+					mockPostMTlsCertificate();
+
+					await runWrangler(
+						"mtls-certificate upload --cert cert.pem --key key.pem"
+					);
+
+					expect(std.err).toMatchInlineSnapshot(`""`);
+					expect(std.out).toEqual(
+						`Uploading mTLS Certificate...
+Success! Uploaded mTLS Certificate
+ID: 1234
+Issuer: example.com...
+Expires on ${oneYearLater.toLocaleDateString()}`
+					);
+				});
+
+				test("uploads certificate and key from file with name", async () => {
+					writeFileSync("cert.pem", "BEGIN CERTIFICATE...");
+					writeFileSync("key.pem", "BEGIN PRIVATE KEY...");
+
+					mockPostMTlsCertificate();
+
+					await runWrangler(
+						"mtls-certificate upload --cert cert.pem --key key.pem --name my-cert"
+					);
+
+					expect(std.err).toMatchInlineSnapshot(`""`);
+					expect(std.out).toEqual(
+						`Uploading mTLS Certificate my-cert...
+Success! Uploaded mTLS Certificate my-cert
+ID: 1234
+Issuer: example.com...
+Expires on ${oneYearLater.toLocaleDateString()}`
+					);
+				});
+			});
+
+			describe("list", () => {
+				it("should list certificates", async () => {
+					mockGetMTlsCertificates();
+
+					await runWrangler("mtls-certificate list");
+
+					expect(std.err).toMatchInlineSnapshot(`""`);
+					expect(std.out).toEqual(
+						`ID: 1234
+Name: cert one
+Issuer: example.com...
+Created on: ${now.toLocaleDateString()}
+Expires on: ${oneYearLater.toLocaleDateString()}
+
+
+ID: 5678
+Name: cert two
+Issuer: example.com...
+Created on: ${now.toLocaleDateString()}
+Expires on: ${oneYearLater.toLocaleDateString()}
+
+`
+					);
+				});
+			});
+
+			describe("delete", () => {
+				it("should require --id or --name", async () => {
+					await runWrangler("mtls-certificate delete");
+
+					expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mError: must provide --id or --name.[0m
+
+				"
+			`);
+					expect(std.out).toMatchInlineSnapshot(`""`);
+				});
+
+				it("should require not providing --id and --name", async () => {
+					await runWrangler("mtls-certificate delete --id 1234 --name mycert");
+
+					expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mError: can't provide both --id and --name.[0m
+
+				"
+			`);
+					expect(std.out).toMatchInlineSnapshot(`""`);
+				});
+
+				it("should delete certificate by id", async () => {
+					mockGetMTlsCertificate({ name: "my-cert" });
+					mockDeleteMTlsCertificate();
+
+					mockConfirm({
+						text: `Are you sure you want to delete certificate 1234 (my-cert)?`,
+						result: true,
+					});
+
+					await runWrangler("mtls-certificate delete --id 1234");
+
+					expect(std.err).toMatchInlineSnapshot(`""`);
+					expect(std.out).toMatchInlineSnapshot(
+						`"Deleted certificate 1234 (my-cert) successfully"`
+					);
+				});
+
+				it("should delete certificate by name", async () => {
+					mockGetMTlsCertificates([{ id: "1234", name: "my-cert" }]);
+					mockDeleteMTlsCertificate();
+
+					mockConfirm({
+						text: `Are you sure you want to delete certificate 1234 (my-cert)?`,
+						result: true,
+					});
+
+					await runWrangler("mtls-certificate delete --name my-cert");
+
+					expect(std.err).toMatchInlineSnapshot(`""`);
+					expect(std.out).toMatchInlineSnapshot(
+						`"Deleted certificate 1234 (my-cert) successfully"`
+					);
+				});
+
+				it("should not delete when certificate cannot be found by name", async () => {
+					mockGetMTlsCertificates([]);
+
+					await expect(
+						runWrangler("mtls-certificate delete --name my-cert")
+					).rejects.toMatchInlineSnapshot(
+						`[Error: certificate not found with name "my-cert"]`
+					);
+					expect(std.out).toMatchInlineSnapshot(`
+				"
+				[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
+			`);
+				});
+
+				it("should not delete when many certificates are found by name", async () => {
+					mockGetMTlsCertificates([
+						{
+							id: "1234",
+							name: "cert one",
+							certificates: "BEGIN CERTIFICATE...",
+							issuer: "example.com...",
+							uploaded_on: now.toISOString(),
+							expires_on: oneYearLater.toISOString(),
+						},
+						{
+							id: "5678",
+							name: "cert one",
+							certificates: "BEGIN CERTIFICATE...",
+							issuer: "example.com...",
+							uploaded_on: now.toISOString(),
+							expires_on: oneYearLater.toISOString(),
+						},
+					]);
+
+					await expect(
+						runWrangler("mtls-certificate delete --name my-cert")
+					).rejects.toMatchInlineSnapshot(
+						`[Error: multiple certificates found with name "my-cert"]`
+					);
+					expect(std.out).toMatchInlineSnapshot(`
+				"
+				[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
+			`);
+				});
+
+				it("should not delete when confirmation fails", async () => {
+					mockGetMTlsCertificate({ id: "1234" });
+
+					mockConfirm({
+						text: `Are you sure you want to delete certificate 1234?`,
+						result: false,
+					});
+
+					await runWrangler("mtls-certificate delete --id 1234");
+					expect(std.err).toMatchInlineSnapshot(`""`);
+					expect(std.out).toMatchInlineSnapshot(`"Not deleting"`);
+				});
+			});
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -137,7 +137,7 @@ describe("publish", () => {
 
 			expect(std.out).toMatchInlineSnapshot(`
 			"Attempting to login via OAuth...
-			Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+			Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 			Successfully logged in.
 			Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
@@ -177,7 +177,7 @@ describe("publish", () => {
 
 				expect(std.out).toMatchInlineSnapshot(`
 			"Attempting to login via OAuth...
-			Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+			Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 			Successfully logged in.
 			Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
@@ -7336,6 +7336,37 @@ export default{
 			).rejects.toMatchInlineSnapshot(
 				`[Error: Queue "queue1" does not exist. To create it, run: wrangler queues create queue1]`
 			);
+		});
+	});
+
+	describe("mtls_certificates", () => {
+		it("should upload mtls_certificate bindings", async () => {
+			writeWranglerToml({
+				mtls_certificates: [{ binding: "CERT_ONE", certificate_id: "1234" }],
+			});
+			await fs.promises.writeFile("index.js", `export default {};`);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedBindings: [
+					{
+						type: "mtls_certificate",
+						name: "CERT_ONE",
+						certificate_id: "1234",
+					},
+				],
+			});
+
+			await runWrangler("publish index.js");
+			expect(std.out).toMatchInlineSnapshot(`
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- mTLS Certificates:
+			  - CERT_ONE: 1234
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Deployment ID: Galaxy-Class"
+		`);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -60,7 +60,7 @@ describe("User", () => {
 			expect(counter).toBe(1);
 			expect(std.out).toMatchInlineSnapshot(`
 			"Attempting to login via OAuth...
-			Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+			Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 			Successfully logged in."
 		`);
 			expect(readAuthConfigFile()).toEqual<UserAuthConfig>({

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -1,3 +1,11 @@
 export { unstable_dev } from "./dev";
 export type { UnstableDevWorker, UnstableDevOptions } from "./dev";
 export { unstable_pages } from "./pages";
+export {
+	uploadMTlsCertificate,
+	uploadMTlsCertificateFromFs,
+	listMTlsCertificates,
+	getMTlsCertificate,
+	getMTlsCertificateByName,
+	deleteMTlsCertificate,
+} from "./mtls-certificate";

--- a/packages/wrangler/src/api/mtls-certificate.ts
+++ b/packages/wrangler/src/api/mtls-certificate.ts
@@ -1,0 +1,148 @@
+import { fetchResult } from "../cfetch";
+import { readFileSync } from "../parse";
+
+/**
+ * the representation of an mTLS certificate in the account certificate store
+ */
+export interface MTlsCertificateResponse {
+	id: string;
+	name?: string;
+	ca: boolean;
+	certificates: string;
+	expires_on: string;
+	issuer: string;
+	serial_number: string;
+	signature: string;
+	uploaded_on: string;
+}
+
+/**
+ * details for uploading an mTLS certificate from disk
+ */
+export interface MTlsCertificateUploadDetails {
+	certificateChainFilename: string;
+	privateKeyFilename: string;
+	name?: string;
+}
+
+/**
+ * details for uploading an mTLS certificate via the ssl api
+ */
+export interface MTlsCertificateBody {
+	certificateChain: string;
+	privateKey: string;
+	name?: string;
+}
+
+/**
+ * supported filters for listing mTLS certificates via the ssl api
+ */
+export interface MTlsCertificateListFilter {
+	name?: string;
+}
+
+/**
+ * indicates that looking up a certificate by name failed due to zero matching results
+ */
+export class ErrorMTlsCertificateNameNotFound extends Error {}
+
+/**
+ * indicates that looking up a certificate by name failed due to more than one matching results
+ */
+export class ErrorMTlsCertificateManyNamesMatch extends Error {}
+
+/**
+ * reads an mTLS certificate and private key pair from disk and uploads it to the account mTLS certificate store
+ */
+export async function uploadMTlsCertificateFromFs(
+	accountId: string,
+	details: MTlsCertificateUploadDetails
+): Promise<MTlsCertificateResponse> {
+	return await uploadMTlsCertificate(accountId, {
+		certificateChain: readFileSync(details.certificateChainFilename),
+		privateKey: readFileSync(details.privateKeyFilename),
+		name: details.name,
+	});
+}
+
+/**
+ *  uploads an mTLS certificate and private key pair to the account mTLS certificate store
+ */
+export async function uploadMTlsCertificate(
+	accountId: string,
+	body: MTlsCertificateBody
+): Promise<MTlsCertificateResponse> {
+	return await fetchResult(`/accounts/${accountId}/mtls_certificates`, {
+		method: "POST",
+		body: JSON.stringify({
+			name: body.name,
+			certificates: body.certificateChain,
+			private_key: body.privateKey,
+			ca: false,
+		}),
+	});
+}
+
+/**
+ *  fetches an mTLS certificate from the account mTLS certificate store by ID
+ */
+export async function getMTlsCertificate(
+	accountId: string,
+	id: string
+): Promise<MTlsCertificateResponse> {
+	return await fetchResult(
+		`/accounts/${accountId}/mtls_certificates/${id}`,
+		{}
+	);
+}
+
+/**
+ *  lists mTLS certificates for an account. filtering by name is supported
+ */
+export async function listMTlsCertificates(
+	accountId: string,
+	filter: MTlsCertificateListFilter
+): Promise<MTlsCertificateResponse[]> {
+	const params = new URLSearchParams();
+	params.append("ca", "false");
+	if (filter.name) {
+		params.append("name", filter.name);
+	}
+	return await fetchResult(
+		`/accounts/${accountId}/mtls_certificates`,
+		{},
+		params
+	);
+}
+
+/**
+ *  fetches an mTLS certificate from the account mTLS certificate store by name. will throw an error if no certificates are found, or multiple are found with that name
+ */
+export async function getMTlsCertificateByName(
+	accountId: string,
+	name: string
+): Promise<MTlsCertificateResponse> {
+	const certificates = await listMTlsCertificates(accountId, { name });
+	if (certificates.length === 0) {
+		throw new ErrorMTlsCertificateNameNotFound(
+			`certificate not found with name "${name}"`
+		);
+	}
+	if (certificates.length > 1) {
+		throw new ErrorMTlsCertificateManyNamesMatch(
+			`multiple certificates found with name "${name}"`
+		);
+	}
+	const certificate = certificates[0];
+	return certificate;
+}
+
+export async function deleteMTlsCertificate(
+	accountId: string,
+	certificateId: string
+) {
+	return await fetchResult(
+		`/accounts/${accountId}/mtls_certificates/${certificateId}`,
+		{ method: "DELETE" }
+	);
+}

--- a/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
+++ b/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
@@ -59,6 +59,7 @@ function createWorkerBundleFormData(workerBundle: BundleResult): FormData {
 			services: undefined,
 			analytics_engine_datasets: undefined,
 			dispatch_namespaces: undefined,
+			mtls_certificates: undefined,
 			logfwdr: undefined,
 			unsafe: undefined,
 		},

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -480,6 +480,13 @@ interface EnvironmentNonInheritable {
 			[key: string]: unknown;
 		}[];
 	};
+
+	mtls_certificates: {
+		/** The binding name used to refer to the certificate in the worker */
+		binding: string;
+		/** The uuid of the uploaded mTLS certificate */
+		certificate_id: string;
+	}[];
 }
 
 /**

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -108,6 +108,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 		vars,
 		wasm_modules,
 		dispatch_namespaces,
+		mtls_certificates,
 	} = bindings;
 
 	if (data_blobs !== undefined && Object.keys(data_blobs).length > 0) {
@@ -301,6 +302,18 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 				return {
 					key: binding,
 					value: namespace,
+				};
+			}),
+		});
+	}
+
+	if (mtls_certificates !== undefined && mtls_certificates.length > 0) {
+		output.push({
+			type: "mTLS Certificates",
+			entries: mtls_certificates.map(({ binding, certificate_id }) => {
+				return {
+					key: binding,
+					value: certificate_id,
 				};
 			}),
 		});

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1134,6 +1134,16 @@ function normalizeAndValidateEnvironment(
 			validateBindingArray(envName, validateWorkerNamespaceBinding),
 			[]
 		),
+		mtls_certificates: notInheritable(
+			diagnostics,
+			topLevelEnv,
+			rawConfig,
+			rawEnv,
+			envName,
+			"mtls_certificates",
+			validateBindingArray(envName, validateMTlsCertificateBinding),
+			[]
+		),
 		logfwdr: inheritable(
 			diagnostics,
 			topLevelEnv,
@@ -1590,6 +1600,7 @@ const validateUnsafeBinding: ValidatorFn = (diagnostics, field, value) => {
 			"r2_bucket",
 			"service",
 			"logfwdr",
+			"mtls_certificate",
 		];
 
 		if (safeBindings.includes(value.type)) {
@@ -2028,6 +2039,42 @@ const validateWorkerNamespaceBinding: ValidatorFn = (
 	if (!isRequiredProperty(value, "namespace", "string")) {
 		diagnostics.errors.push(
 			`"${field}" should have a string "namespace" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+	return isValid;
+};
+
+const validateMTlsCertificateBinding: ValidatorFn = (
+	diagnostics,
+	field,
+	value
+) => {
+	if (typeof value !== "object" || value === null) {
+		diagnostics.errors.push(
+			`"mtls_certificates" bindings should be objects, but got ${JSON.stringify(
+				value
+			)}`
+		);
+		return false;
+	}
+	let isValid = true;
+	if (!isRequiredProperty(value, "binding", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should have a string "binding" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
+	if (
+		!isRequiredProperty(value, "certificate_id", "string") ||
+		(value as { certificate_id: string }).certificate_id.length === 0
+	) {
+		diagnostics.errors.push(
+			`"${field}" bindings should have a string "certificate_id" field but got ${JSON.stringify(
 				value
 			)}.`
 		);

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -45,6 +45,7 @@ type WorkerMetadataBinding =
 	| { type: "service"; name: string; service: string; environment?: string }
 	| { type: "analytics_engine"; name: string; dataset?: string }
 	| { type: "dispatch_namespace"; name: string; namespace: string }
+	| { type: "mtls_certificate"; name: string; certificate_id: string }
 	| {
 			type: "logfwdr";
 			name: string;
@@ -163,6 +164,14 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 			name: binding,
 			type: "dispatch_namespace",
 			namespace,
+		});
+	});
+
+	bindings.mtls_certificates?.forEach(({ binding, certificate_id }) => {
+		metadataBindings.push({
+			name: binding,
+			type: "mtls_certificate",
+			certificate_id,
 		});
 	});
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -879,6 +879,7 @@ function getBindings(
 			...(args.r2 || []),
 		],
 		dispatch_namespaces: configParam.dispatch_namespaces,
+		mtls_certificates: configParam.mtls_certificates,
 		services: configParam.services,
 		analytics_engine_datasets: configParam.analytics_engine_datasets,
 		unsafe: configParam.unsafe?.bindings,

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -30,6 +30,7 @@ import { initHandler, initOptions } from "./init";
 import { kvNamespace, kvKey, kvBulk } from "./kv";
 import { logBuildFailure, logger } from "./logger";
 import * as metrics from "./metrics";
+import { mTlsCertificateCommands } from "./mtls-certificate/cli";
 import { pages } from "./pages";
 import { formatMessage, ParseError } from "./parse";
 import { publishOptions, publishHandler } from "./publish";
@@ -437,6 +438,15 @@ export function createCLIParser(argv: string[]) {
 		"📮 Interact and manage Pub/Sub Brokers",
 		(pubsubYargs) => {
 			return pubSubCommands(pubsubYargs, subHelp);
+		}
+	);
+
+	// mtls-certificate
+	wrangler.command(
+		"mtls-certificate",
+		"🪪 Manage certificates used for mTLS connections",
+		(mtlsYargs) => {
+			return mTlsCertificateCommands(mtlsYargs.command(subHelp));
 		}
 	);
 

--- a/packages/wrangler/src/mtls-certificate/cli.ts
+++ b/packages/wrangler/src/mtls-certificate/cli.ts
@@ -1,0 +1,155 @@
+import {
+	uploadMTlsCertificateFromFs,
+	listMTlsCertificates,
+	deleteMTlsCertificate,
+	getMTlsCertificate,
+	getMTlsCertificateByName,
+	type MTlsCertificateResponse,
+} from "../api/mtls-certificate";
+import { withConfig } from "../config";
+import { confirm } from "../dialogs";
+import { logger } from "../logger";
+import { requireAuth } from "../user";
+import type {
+	CommonYargsOptions,
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+import type { BuilderCallback } from "yargs";
+
+function uploadMTlsCertificateOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.option("cert", {
+			describe:
+				"The path to a certificate file (.pem) containing a chain of certificates to upload",
+			type: "string",
+			demandOption: true,
+		})
+		.option("key", {
+			describe:
+				"The path to a file containing the private key for your leaf certificate",
+			type: "string",
+			demandOption: true,
+		})
+		.option("name", {
+			describe: "The name for the certificate",
+			type: "string",
+		});
+}
+
+const uploadMTlsCertificateHandler = withConfig<
+	StrictYargsOptionsToInterface<typeof uploadMTlsCertificateOptions>
+>(async ({ config, cert, key, name }) => {
+	const accountId = await requireAuth(config);
+	logger.log(
+		name
+			? `Uploading mTLS Certificate ${name}...`
+			: `Uploading mTLS Certificate...`
+	);
+	const certResponse = await uploadMTlsCertificateFromFs(accountId, {
+		certificateChainFilename: cert,
+		privateKeyFilename: key,
+		name: name,
+	});
+	const expiresOn = new Date(certResponse.expires_on).toLocaleDateString();
+	logger.log(
+		name
+			? `Success! Uploaded mTLS Certificate ${name}`
+			: `Success! Uploaded mTLS Certificate`
+	);
+	logger.log(`ID: ${certResponse.id}`);
+	logger.log(`Issuer: ${certResponse.issuer}`);
+	logger.log(`Expires on ${expiresOn}`);
+});
+
+const listMTlsCertificatesHandler = withConfig(async ({ config }) => {
+	const accountId = await requireAuth(config);
+	const certificates = await listMTlsCertificates(accountId, {});
+	for (const certificate of certificates) {
+		logger.log(`ID: ${certificate.id}`);
+		if (certificate.name) {
+			logger.log(`Name: ${certificate.name}`);
+		}
+		logger.log(`Issuer: ${certificate.issuer}`);
+		logger.log(
+			`Created on: ${new Date(certificate.uploaded_on).toLocaleDateString()}`
+		);
+		logger.log(
+			`Expires on: ${new Date(certificate.expires_on).toLocaleDateString()}`
+		);
+		logger.log("\n");
+	}
+});
+
+function deleteMTlsCertificateOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.option("id", {
+			describe: "The id of the mTLS certificate to delete",
+			type: "string",
+		})
+		.option("name", {
+			describe: "The name of the mTLS certificate record to delete",
+			type: "string",
+		});
+}
+
+const deleteMTlsCertificateHandler = withConfig<
+	StrictYargsOptionsToInterface<typeof deleteMTlsCertificateOptions>
+>(async ({ config, id, name }) => {
+	const accountId = await requireAuth(config);
+	if (id && name) {
+		return logger.error(`Error: can't provide both --id and --name.`);
+	} else if (!id && !name) {
+		return logger.error(`Error: must provide --id or --name.`);
+	}
+	let certificate: MTlsCertificateResponse;
+	if (id) {
+		certificate = await getMTlsCertificate(accountId, id);
+	} else {
+		certificate = await getMTlsCertificateByName(accountId, name as string);
+	}
+
+	const response = await confirm(
+		certificate.name
+			? `Are you sure you want to delete certificate ${certificate.id} (${certificate.name})?`
+			: `Are you sure you want to delete certificate ${certificate.id}?`
+	);
+	if (!response) {
+		logger.log("Not deleting");
+		return;
+	}
+
+	await deleteMTlsCertificate(accountId, certificate.id);
+
+	logger.log(
+		certificate.name
+			? `Deleted certificate ${certificate.id} (${certificate.name}) successfully`
+			: `Deleted certificate ${certificate.id} successfully`
+	);
+});
+
+export const mTlsCertificateCommands: BuilderCallback<
+	CommonYargsOptions,
+	unknown
+> = (yargs) => {
+	yargs.command(
+		"upload",
+		"Upload an mTLS certificate",
+		uploadMTlsCertificateOptions,
+		uploadMTlsCertificateHandler
+	);
+
+	yargs.command(
+		"list",
+		"List uploaded mTLS certificates",
+		(a) => a,
+		listMTlsCertificatesHandler
+	);
+
+	yargs.command(
+		"delete",
+		"Delete an mTLS certificate",
+		deleteMTlsCertificateOptions,
+		deleteMTlsCertificateHandler
+	);
+};

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -551,6 +551,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			services: config.services,
 			analytics_engine_datasets: config.analytics_engine_datasets,
 			dispatch_namespaces: config.dispatch_namespaces,
+			mtls_certificates: config.mtls_certificates,
 			logfwdr: config.logfwdr,
 			unsafe: config.unsafe?.bindings,
 		};

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -111,6 +111,7 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 									text_blobs: {},
 									data_blobs: {},
 									dispatch_namespaces: [],
+									mtls_certificates: [],
 									logfwdr: { schema: undefined, bindings: [] },
 									unsafe: [],
 								},

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -346,6 +346,7 @@ const Scopes = {
 	"pages:write":
 		"See and change Cloudflare Pages projects, settings and deployments.",
 	"zone:read": "Grants read level access to account zone.",
+	"ssl_certs:write": "See and manage mTLS certificates for your account",
 } as const;
 
 /**

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -154,6 +154,11 @@ interface CfDispatchNamespace {
 	namespace: string;
 }
 
+interface CfMTlsCertificate {
+	binding: string;
+	certificate_id: string;
+}
+
 interface CfLogfwdr {
 	schema: string | undefined;
 	bindings: CfLogfwdrBinding[];
@@ -214,6 +219,7 @@ export interface CfWorkerInit {
 		services: CfService[] | undefined;
 		analytics_engine_datasets: CfAnalyticsEngineDataset[] | undefined;
 		dispatch_namespaces: CfDispatchNamespace[] | undefined;
+		mtls_certificates: CfMTlsCertificate[] | undefined;
 		logfwdr: CfLogfwdr | undefined;
 		unsafe: CfUnsafeBinding[] | undefined;
 	};


### PR DESCRIPTION
What this PR solves / how to test:

This pr does three things:
- adds an api for interacting with the SSL mTLS API (requires a new OAuth scope)
- uses the api for a new sub-command ('mtls-certificate') that allows uploading, listing, and deleting mTLS certificates
- supports new bindings (type: 'mtls_certificate') for worker uploads

NOTE: we are still waiting on the OAuth scope to be granted for Wrangler, so this shouldn't go just yet.

Associated docs issues/PR: https://github.com/cloudflare/cloudflare-docs/pull/7371

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
