### PR TITLE
Add a `--region` option to R2's bucket command

### DIFF
--- a/.changeset/large-carpets-jog.md
+++ b/.changeset/large-carpets-jog.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Added a `--region` option to the `wrangler r2` command to be able to supply a region hint when creating a bucket

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -31,11 +31,12 @@ export async function listR2Buckets(
  */
 export async function createR2Bucket(
 	accountId: string,
-	bucketName: string
+	bucketName: string,
+	locationHint?: string
 ): Promise<void> {
 	return await fetchResult<void>(`/accounts/${accountId}/r2/buckets`, {
 		method: "POST",
-		body: JSON.stringify({ name: bucketName }),
+		body: JSON.stringify({ name: bucketName, locationHint }),
 	});
 }
 

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -221,22 +221,30 @@ export function r2(r2Yargs: CommonYargsArgv) {
 				"create <name>",
 				"Create a new R2 bucket",
 				(yargs) => {
-					return yargs.positional("name", {
-						describe: "The name of the new bucket",
-						type: "string",
-						demandOption: true,
-					});
+					return yargs
+						.positional("name", {
+							describe: "The name of the new bucket",
+							type: "string",
+							demandOption: true,
+						})
+						.option("location", {
+							describe: "A hint to control where the bucket will be created",
+							alias: "l",
+							type: "string",
+							default: "auto",
+							choices: ["auto", "apac", "eeur", "enam", "weur", "wnam"],
+						});
 				},
 				async (args) => {
 					await printWranglerBanner();
 
 					const config = readConfig(args.config, args);
-
 					const accountId = await requireAuth(config);
 
 					logger.log(`Creating bucket ${args.name}.`);
-					await createR2Bucket(accountId, args.name);
+					await createR2Bucket(accountId, args.name, args.location);
 					logger.log(`Created bucket ${args.name}.`);
+
 					await metrics.sendMetricsEvent("create r2 bucket", {
 						sendMetrics: config.send_metrics,
 					});


### PR DESCRIPTION
What this PR solves / how to test:
We're planning on introducing region hints for bucket creation, so this lets users configure it from Wrangler

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
