### PR TITLE
Switch to new Devtools

### DIFF
--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -745,7 +745,7 @@ function logConsoleMessage(evt: Protocol.Runtime.ConsoleAPICalledEvent): void {
  * Opens the chrome debugger
  */
 export const openInspector = async (inspectorPort: number) => {
-	const url = `https://built-devtools.pages.dev/js_app?experiments=true&v8only=true&ws=localhost:${inspectorPort}/ws`;
+	const url = `https://devtools.devprod.cloudflare.dev/js_app?theme=systemPreferred&ws=localhost:${inspectorPort}/ws`;
 	const errorMessage =
 		"Failed to open inspector.\nInspector depends on having a Chromium-based browser installed, maybe you need to install one?";
 
@@ -770,6 +770,9 @@ export const openInspector = async (inspectorPort: number) => {
 			},
 			{
 				name: open.apps.edge,
+			},
+			{
+				name: open.apps.firefox,
 			},
 		],
 	});


### PR DESCRIPTION
What this PR solves / how to test:

This updates Wrangler to point to our new fork of Chrome DevTools.

How to test:
- Run `wrangler dev` on a worker
- Press D
- Verify debugging functionality works as expected

Author has included the following, where applicable:

- ~[ ] Tests~
- ~[ ] Changeset~

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
