### PR TITLE
feat: Add wasm support in `wrangler pages publish`

### DIFF
--- a/.changeset/beige-bikes-perform.md
+++ b/.changeset/beige-bikes-perform.md
@@ -1,0 +1,14 @@
+---
+"wrangler": patch
+---
+
+Add wasm support in `wrangler pages publish`
+
+Currently it is not possible to import `wasm` modules in either Pages
+Functions or Pages Advanced Mode projects.
+
+This commit caries out work to address the aforementioned issue by
+enabling `wasm` module imports in `wrangler pages publish`. As a result,
+Pages users can now import their `wasm` modules withing their Functions
+or `_worker.js` files, and `wrangler pages publish` will correctly
+bundle everything and serve these "external" modules.

--- a/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
+++ b/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { Response } from "undici";
+import { createWorkerUploadForm } from "../../create-worker-upload-form";
+import type { BundleResult } from "../../bundle";
+import type { CfWorkerInit } from "../../worker";
+import type { Blob } from "node:buffer";
+import type { FormData } from "undici";
+
+/**
+ * Takes a Worker bundle - `BundleResult` - and generates the _worker.bundle
+ * contents
+ */
+export async function createUploadWorkerBundleContents(
+	workerBundle: BundleResult
+): Promise<Blob> {
+	const workerBundleFormData = createWorkerBundleFormData(workerBundle);
+	const metadata = JSON.parse(workerBundleFormData.get("metadata") as string);
+
+	/**
+	 * Pages doesn't need the metadata bindings returned by
+	 * `createWorkerBundleFormData`. Let's strip them out and return only
+	 * the contents we need
+	 */
+	workerBundleFormData.set(
+		"metadata",
+		JSON.stringify({ main_module: metadata.main_module })
+	);
+
+	return await new Response(workerBundleFormData).blob();
+}
+
+/**
+ * Creates a `FormData` upload from a `BundleResult`
+ */
+function createWorkerBundleFormData(workerBundle: BundleResult): FormData {
+	const mainModule = {
+		name: path.basename(workerBundle.resolvedEntryPointPath),
+		content: readFileSync(workerBundle.resolvedEntryPointPath, {
+			encoding: "utf-8",
+		}),
+		type: workerBundle.bundleType || "esm",
+	};
+
+	const worker: CfWorkerInit = {
+		name: mainModule.name,
+		main: mainModule,
+		modules: workerBundle.modules,
+		bindings: {
+			vars: undefined,
+			kv_namespaces: undefined,
+			wasm_modules: undefined,
+			text_blobs: undefined,
+			data_blobs: undefined,
+			durable_objects: undefined,
+			queues: undefined,
+			r2_buckets: undefined,
+			d1_databases: undefined,
+			services: undefined,
+			analytics_engine_datasets: undefined,
+			dispatch_namespaces: undefined,
+			logfwdr: undefined,
+			unsafe: undefined,
+		},
+		migrations: undefined,
+		compatibility_date: undefined,
+		compatibility_flags: undefined,
+		usage_model: undefined,
+		keepVars: undefined,
+		logpush: undefined,
+	};
+
+	return createWorkerUploadForm(worker);
+}

--- a/packages/wrangler/src/pages/buildFunctions.ts
+++ b/packages/wrangler/src/pages/buildFunctions.ts
@@ -9,6 +9,7 @@ import { generateConfigFromFileTree } from "./functions/filepath-routing";
 import { writeRoutesModule } from "./functions/routes";
 import { convertRoutesToRoutesJSONSpec } from "./functions/routes-transformation";
 import { RUNNING_BUILDERS } from "./utils";
+import type { BundleResult } from "../bundle";
 import type { PagesBuildArgs } from "./build";
 import type { Config } from "./functions/routes";
 
@@ -91,39 +92,39 @@ export async function buildFunctions({
 	});
 
 	const absoluteFunctionsDirectory = resolve(functionsDirectory);
+	let bundle: BundleResult;
 
 	if (plugin) {
-		RUNNING_BUILDERS.push(
-			await buildPlugin({
-				routesModule,
-				outfile,
-				minify,
-				sourcemap,
-				watch,
-				nodeCompat,
-				functionsDirectory: absoluteFunctionsDirectory,
-				local,
-				betaD1Shims: d1Databases,
-				onEnd,
-			})
-		);
+		bundle = await buildPlugin({
+			routesModule,
+			outfile,
+			minify,
+			sourcemap,
+			watch,
+			nodeCompat,
+			functionsDirectory: absoluteFunctionsDirectory,
+			local,
+			betaD1Shims: d1Databases,
+			onEnd,
+		});
 	} else {
-		RUNNING_BUILDERS.push(
-			await buildWorker({
-				routesModule,
-				outfile,
-				minify,
-				sourcemap,
-				fallbackService,
-				watch,
-				functionsDirectory: absoluteFunctionsDirectory,
-				local,
-				betaD1Shims: d1Databases,
-				onEnd,
-				buildOutputDirectory,
-				nodeCompat,
-				experimentalWorkerBundle,
-			})
-		);
+		bundle = await buildWorker({
+			routesModule,
+			outfile,
+			minify,
+			sourcemap,
+			fallbackService,
+			watch,
+			functionsDirectory: absoluteFunctionsDirectory,
+			local,
+			betaD1Shims: d1Databases,
+			onEnd,
+			buildOutputDirectory,
+			nodeCompat,
+			experimentalWorkerBundle,
+		});
 	}
+
+	RUNNING_BUILDERS.push(bundle);
+	return bundle;
 }

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -66,6 +66,13 @@ export function Options(yargs: CommonYargsArgv) {
 				default: true,
 				description: "Whether to run bundling on `_worker.js` before deploying",
 			},
+			"experimental-worker-bundle": {
+				type: "boolean",
+				default: false,
+				hidden: true,
+				description:
+					"Whether to process non-JS module imports or not, such as wasm/text/binary, when we run bundling on `functions` or `_worker.js`",
+			},
 			config: {
 				describe: "Pages does not support wrangler.toml",
 				type: "string",
@@ -85,6 +92,7 @@ export const Handler = async ({
 	skipCaching,
 	bundle,
 	noBundle,
+	experimentalWorkerBundle,
 	config: wranglerConfig,
 }: PublishArgs) => {
 	if (wranglerConfig) {
@@ -253,6 +261,7 @@ export const Handler = async ({
 		// TODO: Here lies a known bug. If you specify both `--bundle` and `--no-bundle`, this behavior is undefined and you will get unexpected results.
 		// There is no sane way to get the true value out of yargs, so here we are.
 		bundle: bundle ?? !noBundle,
+		experimentalWorkerBundle,
 	});
 
 	saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {


### PR DESCRIPTION
**What this PR solves:**
Currently it is not possible to import `wasm` modules in either Pages
Functions or Pages Advanced Mode projects.

This commit caries out work to address the aforementioned issue by
enabling `wasm` module imports in `wrangler pages publish`. As a result,
Pages users can now import their `wasm` modules withing their Functions
or `_worker.js` files, and `wrangler pages publish` will correctly
bundle everything and serve these "external" modules.

```
import hello from "./hello.wasm"

export async function onRequest() {
	const module = await WebAssembly.instantiate(hello);
	return new Response(module.exports.hello);
}
```

**How to test:**
Use the fixtures projects provided in this PR

- `pages-functions-wasm-app`

```
# build wrangler
npm run build

# cd into the fixture folder
cd fixtures/pages-functions-wasm-app

# publish project
npx wrangler pages publish public --experimental-worker-bundle=true
```

- `pages-workerjs-wasm-app`

```
# build wrangler
npm run build

# cd into the fixture folder
cd fixtures/pages-workerjs-wasm-app

# publish project
npx wrangler pages publish public --experimental-worker-bundle=true
```

Associated docs issues/PR:
N/A

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
