### PR TITLE
feat(api): Exposes the `createPagesTail` function in the unstable_pages

### DIFF
--- a/.changeset/giant-schools-double.md
+++ b/.changeset/giant-schools-double.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Exposes the `createPagesTail` function in the unstable_pages API.

--- a/packages/wrangler/src/api/pages/index.ts
+++ b/packages/wrangler/src/api/pages/index.ts
@@ -1,5 +1,7 @@
+import { createPagesTail } from "../../tail/createTail";
 import { publish } from "./publish";
 
 export const unstable_pages = {
 	publish,
+	createPagesTail,
 };


### PR DESCRIPTION
What this PR solves / how to test:

This change exposes the `createPagesTail` function in the `unstable_pages` API. 

Associated docs issues/PR:

- N/A

Author has included the following, where applicable:

- [x] ~~Tests~~
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
