### PR TITLE
Added inspect option to Pages dev and make sure we always log MF errors

### DIFF
--- a/.changeset/real-nails-fail.md
+++ b/.changeset/real-nails-fail.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Added `--inspect` option to Pages dev, this can be used to disable the Node.js inspector which backs dev tools.
+Made sure to surface Miniflare errors incase it starts to fail.
+Changed the default log level for Pages dev to `info` from `error`.

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -200,6 +200,9 @@ async function main() {
 			);
 	} catch (e) {
 		mf?.log.error(e as Error);
+		if (!mf) {
+			console.error(e)
+		}
 		process.exitCode = 1;
 		// Unmount any mounted workers
 		await mf?.dispose();

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -65,6 +65,11 @@ export function Options(yargs: CommonYargsArgv) {
 				default: 8788,
 				description: "The port to listen on (serve from)",
 			},
+			inspect: {
+				type: "boolean",
+				describe: "Enable or disable the inspector (devtools)",
+				default: true,
+			},
 			"inspector-port": {
 				type: "number",
 				describe: "Port for devtools to connect to",
@@ -177,6 +182,7 @@ export const Handler = async ({
 	compatibilityFlags,
 	ip,
 	port,
+	inspect,
 	inspectorPort,
 	proxy: requestedProxyPort,
 	bundle,
@@ -537,9 +543,9 @@ export const Handler = async ({
 		}),
 		persist,
 		persistTo,
-		inspect: undefined,
+		inspect,
 		logPrefix: "pages",
-		logLevel: logLevel ?? "warn",
+		logLevel: logLevel ?? "info",
 		experimental: {
 			d1Databases: d1s.map((binding) => ({
 				binding: binding.toString(),


### PR DESCRIPTION
What this PR solves / how to test:

I was getting really weird errors which led me down an absolute rabbit hole of debugging. While debugging, I realised a bunch of small things:
The initial error was the Node debugger just not properly attaching, this led me to try to disable it and realising I couldn't. This feels weird to me so added an option to disable it for Pages dev.
Next, I was getting a Miniflare error (it exited with code 1 during start) and no error was being printed. So, even if no MF logging is available, we fallback to good old console.error (console vs logger because we could hide this error and we shouldn't)
While looking through all this I realised the "Starting a local server..." message wasn't being printed, this made it look like it was hanging much earlier than it actually was. Turns out, Pages dev has not been printing info messages. Also seemed weird to me, so changed the default to info.

Changing the log level also surfaces the `--experimental-local` option which appears to be broken right now for Pages dev, I haven't looked into this yet but worth noting.

Associated docs issues/PR:

N/A

Author has included the following, where applicable:

- [ ] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
