### PR TITLE
Fixes `wrangler pages publish` not uploading static file imports in Functions

### DIFF
--- a/.changeset/unlucky-carpets-wave.md
+++ b/.changeset/unlucky-carpets-wave.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+Fixes `wrangler pages publish` not uploading static file imports from Functions.
+
+Previously, when a user ran `wrangler pages publish public/` and also had a Function which imported static assets:
+
+```tsx
+import filePath from "assets:../static/foo.txt";
+```
+
+The contents of the imported files would never make it to the deployment. This change updates the `buildOutputDirectory` option passed into `buildFunctions` from the `publish` API such that the `buildOutputDirectory` becomes whatever was passed into `wrangler pages publish <dir>`

--- a/packages/wrangler/src/api/pages/publish.tsx
+++ b/packages/wrangler/src/api/pages/publish.tsx
@@ -159,7 +159,7 @@ export async function publish({
 				outputConfigPath,
 				functionsDirectory,
 				onEnd: () => {},
-				buildOutputDirectory: dirname(outfile),
+				buildOutputDirectory: directory,
 				routesOutputPath,
 				local: false,
 				d1Databases,


### PR DESCRIPTION
Previously, when a user ran `wrangler pages publish public/` and also had a Function which imported static assets:

```tsx
import filePath from 'assets:../static/foo.txt'
```

The contents of the imported files would never make it to the deployment. This change updates the `buildOutputDirectory` option passed into `buildFunctions` from the `publish` API such that the `buildOutputDirectory` becomes whatever was passed into `wrangler pages publish <dir>`

What this PR solves / how to test:

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [ ] Tests
- [ ] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
