### PR TITLE
Use correct host in exchange

### DIFF
--- a/.changeset/happy-grapes-check.md
+++ b/.changeset/happy-grapes-check.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Previously, wrangler dev would not work if the root of your zone wasn't behind Cloudflare. This behaviour has changed so that now only the route which your Worker is exposed on has to be behind Cloudflare.

--- a/packages/wrangler/src/create-worker-preview.ts
+++ b/packages/wrangler/src/create-worker-preview.ts
@@ -130,18 +130,20 @@ export async function createPreviewSession(
 		? `/zones/${ctx.zone}/workers/edge-preview`
 		: `/accounts/${accountId}/workers/subdomain/edge-preview`;
 
-	let { exchange_url } = await fetchResult<{ exchange_url: string }>(
+	const { exchange_url } = await fetchResult<{ exchange_url: string }>(
 		initUrl,
 		undefined,
 		undefined,
 		abortSignal
 	);
 
-	exchange_url = switchHost(exchange_url, ctx.host).toString();
+	const switchedExchangeUrl = switchHost(exchange_url, ctx.host).toString();
 
-	logger.debug(`-- START EXCHANGE API REQUEST: GET ${exchange_url}`);
+	logger.debug(`-- START EXCHANGE API REQUEST: GET ${switchedExchangeUrl}`);
 	logger.debug("-- END EXCHANGE API REQUEST");
-	const exchangeResponse = await fetch(exchange_url, { signal: abortSignal });
+	const exchangeResponse = await fetch(switchedExchangeUrl, {
+		signal: abortSignal,
+	});
 	const bodyText = await exchangeResponse.text();
 	logger.debug(
 		"-- START EXCHANGE API RESPONSE:",


### PR DESCRIPTION
What this PR solves / how to test:

URLs from the Cloudflare API are usually relative to the zone. Sometimes the base zone will be grey-clouded, and so the host must be swapped out for the worker route host, which is more likely to be orange-clouded.

Associated docs issues/PR:

- Bugfix, so no docs changes needed

Author has included the following, where applicable:

- [ ] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #2018, #2602, #2581
