### PR TITLE
wrangler: add metadata to the unsafe binding

### DIFF
--- a/.changeset/selfish-files-pump.md
+++ b/.changeset/selfish-files-pump.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add new [unsafe.metadata] section to wrangler.toml allowing arbitary data to be added to the metadata section of the upload

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -65,7 +65,8 @@ describe("normalizeAndValidateConfig()", () => {
 				crons: [],
 			},
 			unsafe: {
-				bindings: [],
+				bindings: undefined,
+				metadata: undefined,
 			},
 			dispatch_namespaces: [],
 			mtls_certificates: [],
@@ -935,6 +936,7 @@ describe("normalizeAndValidateConfig()", () => {
 							extra: "UNSAFE_EXTRA_1",
 						},
 					],
+					metadata: undefined,
 				},
 				no_bundle: true,
 				minify: true,
@@ -2329,7 +2331,7 @@ describe("normalizeAndValidateConfig()", () => {
 		              `);
 			});
 
-			it("should error if unsafe.bindings is not defined", () => {
+			it("should not error if unsafe.bindings is not defined", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: {} } as unknown as RawConfig,
 					undefined,
@@ -2340,10 +2342,7 @@ describe("normalizeAndValidateConfig()", () => {
 			                  "Processing wrangler configuration:
 			                    - \\"unsafe\\" fields are experimental and may change or break at any time."
 		              `);
-				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-			                  "Processing wrangler configuration:
-			                    - The field \\"unsafe\\" is missing the required \\"bindings\\" property."
-		              `);
+				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
 			it("should error if unsafe.bindings is an object", () => {
@@ -2836,7 +2835,10 @@ describe("normalizeAndValidateConfig()", () => {
 			const r2_buckets: RawConfig["r2_buckets"] = [];
 			const analytics_engine_datasets: RawConfig["analytics_engine_datasets"] =
 				[];
-			const unsafe: RawConfig["unsafe"] = { bindings: [] };
+			const unsafe: RawConfig["unsafe"] = {
+				bindings: undefined,
+				metadata: undefined,
+			};
 			const rawConfig: RawConfig = {
 				define,
 				vars,
@@ -3784,7 +3786,7 @@ describe("normalizeAndValidateConfig()", () => {
 		        `);
 			});
 
-			it("should error if unsafe.bindings is not defined", () => {
+			it("should not error if unsafe.bindings is undefined", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { unsafe: {} } } } as unknown as RawConfig,
 					undefined,
@@ -3797,12 +3799,7 @@ describe("normalizeAndValidateConfig()", () => {
 			            - \\"env.ENV1\\" environment configuration
 			              - \\"unsafe\\" fields are experimental and may change or break at any time."
 		        `);
-				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-
-			            - \\"env.ENV1\\" environment configuration
-			              - The field \\"env.ENV1.unsafe\\" is missing the required \\"bindings\\" property."
-		        `);
+				expect(diagnostics.hasErrors()).toBe(false);
 			});
 
 			it("should error if unsafe.bindings is an object", () => {

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -2331,9 +2331,40 @@ describe("normalizeAndValidateConfig()", () => {
 		              `);
 			});
 
-			it("should not error if unsafe.bindings is not defined", () => {
+			it("should error if neither unsafe.bindings nor unsafe.metadata are defined", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ unsafe: {} } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - \\"unsafe\\" fields are experimental and may change or break at any time."
+		              `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			"Processing wrangler configuration:
+			  - The field \\"unsafe\\" should contain at least one of \\"bindings\\" or \\"metadata\\" properties but got {}."
+		`);
+			});
+
+			it("should not error if at least unsafe.bindings is defined", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ unsafe: { bindings: [] } } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - \\"unsafe\\" fields are experimental and may change or break at any time."
+		              `);
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
+			it("should not error if at least unsafe.metadata is defined", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ unsafe: { metadata: {} } } as unknown as RawConfig,
 					undefined,
 					{ env: undefined }
 				);
@@ -2451,6 +2482,74 @@ describe("normalizeAndValidateConfig()", () => {
 			              - binding should have a string \\"name\\" field.
 			              - binding should have a string \\"type\\" field."
 		        `);
+			});
+
+			it("should error if unsafe.metadata is an array", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ unsafe: { metadata: [] } } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - \\"unsafe\\" fields are experimental and may change or break at any time."
+		              `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			"Processing wrangler configuration:
+			  - The field \\"unsafe.metadata\\" should be an object but got []."
+		`);
+			});
+
+			it("should error if unsafe.metadata is a string", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ unsafe: { metadata: "BAD" } } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - \\"unsafe\\" fields are experimental and may change or break at any time."
+		              `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - The field \\"unsafe.metadata\\" should be an object but got \\"BAD\\"."
+		              `);
+			});
+
+			it("should error if unsafe.metadata is a number", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ unsafe: { metadata: 999 } } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - \\"unsafe\\" fields are experimental and may change or break at any time."
+		              `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - The field \\"unsafe.metadata\\" should be an object but got 999."
+		              `);
+			});
+
+			it("should error if unsafe.metadata is null", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{ unsafe: { metadata: null } } as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - \\"unsafe\\" fields are experimental and may change or break at any time."
+		              `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			                  "Processing wrangler configuration:
+			                    - The field \\"unsafe.metadata\\" should be an object but got null."
+		              `);
 			});
 		});
 
@@ -3786,9 +3885,50 @@ describe("normalizeAndValidateConfig()", () => {
 		        `);
 			});
 
-			it("should not error if unsafe.bindings is undefined", () => {
+			it("should error if neither unsafe.bindings nor unsafe.metadata are defined", () => {
 				const { diagnostics } = normalizeAndValidateConfig(
 					{ env: { ENV1: { unsafe: {} } } } as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - \\"unsafe\\" fields are experimental and may change or break at any time."
+		        `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			"Processing wrangler configuration:
+
+			  - \\"env.ENV1\\" environment configuration
+			    - The field \\"env.ENV1.unsafe\\" should contain at least one of \\"bindings\\" or \\"metadata\\" properties but got {}."
+		`);
+			});
+
+			it("should not error if at least unsafe.bindings is undefined", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						env: { ENV1: { unsafe: { bindings: [] } } },
+					} as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - \\"unsafe\\" fields are experimental and may change or break at any time."
+		        `);
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
+
+			it("should not error if at least unsafe.metadata is undefined", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						env: { ENV1: { unsafe: { metadata: {} } } },
+					} as unknown as RawConfig,
 					undefined,
 					{ env: "ENV1" }
 				);
@@ -3940,6 +4080,98 @@ describe("normalizeAndValidateConfig()", () => {
 			                - binding should have a string \\"name\\" field.
 			                - binding should have a string \\"type\\" field."
 		        `);
+			});
+
+			it("should error if unsafe.metadata is an array", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						env: { ENV1: { unsafe: { metadata: [] } } },
+					} as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - \\"unsafe\\" fields are experimental and may change or break at any time."
+		        `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - The field \\"env.ENV1.unsafe.metadata\\" should be an object but got []."
+		        `);
+			});
+
+			it("should error if unsafe.metadata is a string", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						env: { ENV1: { unsafe: { metadata: "BAD" } } },
+					} as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - \\"unsafe\\" fields are experimental and may change or break at any time."
+		        `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			"Processing wrangler configuration:
+
+			  - \\"env.ENV1\\" environment configuration
+			    - The field \\"env.ENV1.unsafe.metadata\\" should be an object but got \\"BAD\\"."
+		`);
+			});
+
+			it("should error if unsafe.metadata is a number", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						env: { ENV1: { unsafe: { metadata: 999 } } },
+					} as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - \\"unsafe\\" fields are experimental and may change or break at any time."
+		        `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			"Processing wrangler configuration:
+
+			  - \\"env.ENV1\\" environment configuration
+			    - The field \\"env.ENV1.unsafe.metadata\\" should be an object but got 999."
+		`);
+			});
+
+			it("should error if unsafe.metadata is null", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						env: { ENV1: { unsafe: { metadata: null } } },
+					} as unknown as RawConfig,
+					undefined,
+					{ env: "ENV1" }
+				);
+
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+			          "Processing wrangler configuration:
+
+			            - \\"env.ENV1\\" environment configuration
+			              - \\"unsafe\\" fields are experimental and may change or break at any time."
+		        `);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			"Processing wrangler configuration:
+
+			  - \\"env.ENV1\\" environment configuration
+			    - The field \\"env.ENV1.unsafe.metadata\\" should be an object but got null."
+		`);
 			});
 		});
 

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -2719,17 +2719,18 @@ describe("init", () => {
 			DATA_BLOB_ONE = \\"DATA_BLOB_ONE\\"
 			DATA_BLOB_TWO = \\"DATA_BLOB_TWO\\"
 
-			[[unsafe.bindings]]
-			type = \\"some unsafe thing\\"
-			name = \\"UNSAFE_BINDING_ONE\\"
+			[unsafe]
+			  [[unsafe.bindings]]
+			  type = \\"some unsafe thing\\"
+			  name = \\"UNSAFE_BINDING_ONE\\"
 
 			[unsafe.bindings.data.some]
 			unsafe = \\"thing\\"
 
-			[[unsafe.bindings]]
-			type = \\"another unsafe thing\\"
-			name = \\"UNSAFE_BINDING_TWO\\"
-			data = 1_337
+			  [[unsafe.bindings]]
+			  type = \\"another unsafe thing\\"
+			  name = \\"UNSAFE_BINDING_TWO\\"
+			  data = 1_337
 			"
 		`);
 			expect(std.out).toContain("cd isolinear-optical-chip");

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -4559,6 +4559,10 @@ addEventListener('fetch', event => {});`
 							data: 1337,
 						},
 					],
+					metadata: {
+						extra_data: "interesting value",
+						more_data: "dubious value",
+					},
 				},
 				vars: {
 					ENV_VAR_ONE: 123,
@@ -4603,6 +4607,10 @@ addEventListener('fetch', event => {});`
 
 			mockUploadWorkerRequest({
 				expectedType: "sw",
+				expectedUnsafeMetaData: {
+					extra_data: "interesting value",
+					more_data: "dubious value",
+				},
 				expectedBindings: [
 					{ json: 123, name: "ENV_VAR_ONE", type: "json" },
 					{
@@ -4726,6 +4734,9 @@ addEventListener('fetch', event => {});`
 			- Wasm Modules:
 			  - WASM_MODULE_ONE: some_wasm.wasm
 			  - WASM_MODULE_TWO: more_wasm.wasm
+			- Unsafe Metadata:
+			  - extra_data: interesting value
+			  - more_data: dubious value
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -4794,6 +4805,7 @@ addEventListener('fetch', event => {});`
 							data: 1337,
 						},
 					],
+					metadata: undefined,
 				},
 				vars: {
 					ENV_VAR_ONE: 123,
@@ -4907,6 +4919,7 @@ addEventListener('fetch', event => {});`
 							data: 1337,
 						},
 					],
+					metadata: undefined,
 				},
 				// text_blobs, vars, wasm_modules and data_blobs are fine because they're object literals,
 				// and by definition cannot have two keys of the same name
@@ -5055,6 +5068,7 @@ addEventListener('fetch', event => {});`
 							data: null,
 						},
 					],
+					metadata: undefined,
 				},
 				vars: {
 					ENV_VAR_ONE: 123,
@@ -5992,6 +6006,7 @@ addEventListener('fetch', event => {});`
 								param: "binding-param",
 							},
 						],
+						metadata: undefined,
 					},
 				});
 				writeWorkerSource();
@@ -6036,6 +6051,7 @@ addEventListener('fetch', event => {});`
 								text: "text",
 							},
 						],
+						metadata: undefined,
 					},
 				});
 				writeWorkerSource();
@@ -7547,6 +7563,7 @@ function mockUploadWorkerRequest(
 		expectedCompatibilityDate?: string;
 		expectedCompatibilityFlags?: string[];
 		expectedMigrations?: CfWorkerInit["migrations"];
+		expectedUnsafeMetaData?: Record<string, string>;
 		env?: string;
 		legacyEnv?: boolean;
 		sendScriptIds?: boolean;
@@ -7566,6 +7583,7 @@ function mockUploadWorkerRequest(
 		env = undefined,
 		legacyEnv = false,
 		expectedMigrations,
+		expectedUnsafeMetaData,
 		sendScriptIds,
 		keepVars,
 	} = options;
@@ -7634,6 +7652,11 @@ function mockUploadWorkerRequest(
 		}
 		if ("expectedMigrations" in options) {
 			expect(metadata.migrations).toEqual(expectedMigrations);
+		}
+		if (expectedUnsafeMetaData !== undefined) {
+			Object.keys(expectedUnsafeMetaData).forEach((key) => {
+				expect(metadata[key]).toEqual(expectedUnsafeMetaData[key]);
+			});
 		}
 		for (const [name, content] of Object.entries(expectedModules)) {
 			expect(formBody.get(name)).toEqual(content);

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -76,6 +76,7 @@ const bindingsConfigMock: Partial<Config> = {
 	wasm_modules: { MODULE1: "module1.wasm", MODULE2: "module2.wasm" },
 	unsafe: {
 		bindings: [{ name: "testing_unsafe", type: "plain_text" }],
+		metadata: { some_key: "some_value" },
 	},
 	rules: [
 		{

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -474,11 +474,25 @@ interface EnvironmentNonInheritable {
 		 *
 		 * @default []
 		 */
-		bindings: {
-			name: string;
-			type: string;
-			[key: string]: unknown;
-		}[];
+		bindings:
+			| {
+					name: string;
+					type: string;
+					[key: string]: unknown;
+			  }[]
+			| undefined;
+
+		metadata:
+			| {
+					/**
+					 * Arbitary key/value pairs that will be included in the uploaded metadata.  Values specified
+					 * here will always be applied to metadata last, so can add new or override existing fields.
+					 *
+					 * @default undefined
+					 */
+					[key: string]: string;
+			  }
+			| undefined;
 	};
 
 	mtls_certificates: {

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -463,7 +463,6 @@ interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `{ bindings: [] }`
 	 * @nonInheritable
 	 */
 	unsafe: {
@@ -471,28 +470,20 @@ interface EnvironmentNonInheritable {
 		 * A set of bindings that should be put into a Worker's upload metadata without changes. These
 		 * can be used to implement bindings for features that haven't released and aren't supported
 		 * directly by wrangler or miniflare.
-		 *
-		 * @default []
 		 */
-		bindings:
-			| {
-					name: string;
-					type: string;
-					[key: string]: unknown;
-			  }[]
-			| undefined;
+		bindings?: {
+			name: string;
+			type: string;
+			[key: string]: unknown;
+		}[];
 
-		metadata:
-			| {
-					/**
-					 * Arbitary key/value pairs that will be included in the uploaded metadata.  Values specified
-					 * here will always be applied to metadata last, so can add new or override existing fields.
-					 *
-					 * @default undefined
-					 */
-					[key: string]: string;
-			  }
-			| undefined;
+		/**
+		 * Arbitrary key/value pairs that will be included in the uploaded metadata.  Values specified
+		 * here will always be applied to metadata last, so can add new or override existing fields.
+		 */
+		metadata?: {
+			[key: string]: string;
+		};
 	};
 
 	mtls_certificates: {

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -255,10 +255,10 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 		});
 	}
 
-	if (unsafe !== undefined && unsafe.length > 0) {
+	if (unsafe?.bindings !== undefined && unsafe.bindings.length > 0) {
 		output.push({
 			type: "Unsafe",
-			entries: unsafe.map(({ name, type }) => ({
+			entries: unsafe.bindings.map(({ name, type }) => ({
 				key: type,
 				value: name,
 			})),
@@ -316,6 +316,16 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 					value: certificate_id,
 				};
 			}),
+		});
+	}
+
+	if (unsafe?.metadata !== undefined) {
+		output.push({
+			type: "Unsafe Metadata",
+			entries: Object.entries(unsafe.metadata).map(([key, value]) => ({
+				key,
+				value: `${value}`,
+			})),
 		});
 	}
 

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -550,7 +550,7 @@ export const getBindingNames = (value: unknown): string[] => {
 	} else if (isNamespaceList(value)) {
 		return value.map(({ binding }) => binding);
 	} else if (isRecord(value)) {
-		return Object.keys(value);
+		return Object.keys(value).filter((k) => k !== "bindings");
 	} else {
 		return [];
 	}

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -550,7 +550,7 @@ export const getBindingNames = (value: unknown): string[] => {
 	} else if (isNamespaceList(value)) {
 		return value.map(({ binding }) => binding);
 	} else if (isRecord(value)) {
-		return Object.keys(value).filter((k) => k !== "bindings");
+		return Object.keys(value).filter((k) => value[k] !== undefined);
 	} else {
 		return [];
 	}

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1508,28 +1508,42 @@ const validateUnsafeSettings =
 			return false;
 		}
 
-		// Within the unsafe settings there are multiple fields
-		// Each is optional, so just validate any that do appear
+		// At least one of bindings and metadata must exist
+		if (!hasProperty(value, "bindings") && !hasProperty(value, "metadata")) {
+			diagnostics.errors.push(
+				`The field "${fieldPath}" should contain at least one of "bindings" or "metadata" properties but got ${JSON.stringify(
+					value
+				)}.`
+			);
+			return false;
+		}
 
 		// unsafe.bindings
-		//diagnostics.errors.push(JSON.stringify(value));
-		if (hasProperty(value, "bindings")) {
-			if (value.bindings !== undefined) {
-				const validateBindingsFn = validateBindingsProperty(
-					envName,
-					validateUnsafeBinding
-				);
-				const valid = validateBindingsFn(diagnostics, field, value, config);
-				if (!valid) {
-					return false;
-				}
+		if (hasProperty(value, "bindings") && value.bindings !== undefined) {
+			const validateBindingsFn = validateBindingsProperty(
+				envName,
+				validateUnsafeBinding
+			);
+			const valid = validateBindingsFn(diagnostics, field, value, config);
+			if (!valid) {
+				return false;
 			}
 		}
 
 		// unsafe.metadata
-		if ("metadata" in value) {
-			// This is an object with some number of properties
-			// There isn't any further useful validation we can do here
+		if (
+			hasProperty(value, "metadata") &&
+			value.metadata !== undefined &&
+			(typeof value.metadata !== "object" ||
+				value.metadata === null ||
+				Array.isArray(value.metadata))
+		) {
+			diagnostics.errors.push(
+				`The field "${fieldPath}.metadata" should be an object but got ${JSON.stringify(
+					value.metadata
+				)}.`
+			);
+			return false;
 		}
 
 		return true;

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1163,10 +1163,7 @@ function normalizeAndValidateEnvironment(
 			envName,
 			"unsafe",
 			validateUnsafeSettings(envName),
-			{
-				bindings: undefined,
-				metadata: undefined,
-			}
+			{}
 		),
 		zone_id: rawEnv.zone_id,
 		no_bundle: inheritable(

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -896,7 +896,10 @@ function getBindings(
 		mtls_certificates: configParam.mtls_certificates,
 		services: configParam.services,
 		analytics_engine_datasets: configParam.analytics_engine_datasets,
-		unsafe: configParam.unsafe,
+		unsafe: {
+			bindings: configParam.unsafe.bindings,
+			metadata: configParam.unsafe.metadata,
+		},
 		logfwdr: configParam.logfwdr,
 		d1_databases: identifyD1BindingsAsBeta([
 			...(configParam.d1_databases ?? []).map((d1Db) => {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -896,7 +896,7 @@ function getBindings(
 		mtls_certificates: configParam.mtls_certificates,
 		services: configParam.services,
 		analytics_engine_datasets: configParam.analytics_engine_datasets,
-		unsafe: configParam.unsafe?.bindings,
+		unsafe: configParam.unsafe,
 		logfwdr: configParam.logfwdr,
 		d1_databases: identifyD1BindingsAsBeta([
 			...(configParam.d1_databases ?? []).map((d1Db) => {

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -567,7 +567,7 @@ export function createCLIParser(argv: string[]) {
 				analytics_engine_datasets: config.analytics_engine_datasets,
 				dispatch_namespaces: config.dispatch_namespaces,
 				logfwdr: config.logfwdr,
-				unsafe: { bindings: config.unsafe?.bindings },
+				unsafe: config.unsafe,
 				rules: config.rules,
 				queues: config.queues,
 			};

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -964,6 +964,7 @@ async function getWorkerConfig(
 					if (!(binding as any)?.type) break;
 					configObj.unsafe = {
 						bindings: [...(configObj.unsafe?.bindings ?? []), binding],
+						metadata: configObj.unsafe?.metadata ?? undefined,
 					};
 				}
 			}

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -562,7 +562,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			dispatch_namespaces: config.dispatch_namespaces,
 			mtls_certificates: config.mtls_certificates,
 			logfwdr: config.logfwdr,
-			unsafe: config.unsafe,
+			unsafe: {
+				bindings: config.unsafe.bindings,
+				metadata: config.unsafe.metadata,
+			},
 		};
 
 		if (assets.manifest) {

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -562,7 +562,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			dispatch_namespaces: config.dispatch_namespaces,
 			mtls_certificates: config.mtls_certificates,
 			logfwdr: config.logfwdr,
-			unsafe: config.unsafe?.bindings,
+			unsafe: config.unsafe,
 		};
 
 		if (assets.manifest) {

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -113,7 +113,7 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 									dispatch_namespaces: [],
 									mtls_certificates: [],
 									logfwdr: { schema: undefined, bindings: [] },
-									unsafe: [],
+									unsafe: { bindings: undefined, metadata: undefined },
 								},
 								modules: [],
 								migrations: undefined,

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -89,7 +89,7 @@ export async function generateTypes(
 		}
 	}
 
-	if (configToDTS.unsafe) {
+	if (configToDTS.unsafe?.bindings) {
 		for (const unsafe of configToDTS.unsafe.bindings) {
 			envTypeStructure.push(`${unsafe.name}: any;`);
 		}

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -174,6 +174,13 @@ interface CfUnsafeBinding {
 	type: string;
 }
 
+type CfUnsafeMetadata = Record<string, unknown>;
+
+interface CfUnsafe {
+	bindings: CfUnsafeBinding[] | undefined;
+	metadata: CfUnsafeMetadata | undefined;
+}
+
 export interface CfDurableObjectMigrations {
 	old_tag?: string;
 	new_tag: string;
@@ -221,7 +228,7 @@ export interface CfWorkerInit {
 		dispatch_namespaces: CfDispatchNamespace[] | undefined;
 		mtls_certificates: CfMTlsCertificate[] | undefined;
 		logfwdr: CfLogfwdr | undefined;
-		unsafe: CfUnsafeBinding[] | undefined;
+		unsafe: CfUnsafe | undefined;
 	};
 	migrations: CfDurableObjectMigrations | undefined;
 	compatibility_date: string | undefined;


### PR DESCRIPTION
This allows you to add arbitary fields to the metadata uploaded with a worker.

[unsafe.metadata]
some_key = some_value

What this PR solves / how to test:

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
