### PR TITLE
Remove circular dependency when applying modules middleware loader

### DIFF
--- a/.changeset/clever-doors-sip.md
+++ b/.changeset/clever-doors-sip.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix internal middleware system to allow D1 databases and `--test-scheduled` to be used together

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -748,3 +748,68 @@ describe("unchanged functionality when wrapping with middleware", () => {
 		});
 	});
 });
+
+describe("multiple middleware", () => {
+	it("should respond correctly with D1 databases, scheduled testing, and formatted dev errors", async () => {
+		// Kitchen sink test to check interaction between multiple middlewares
+		const scriptContent = `
+			export default {
+				async fetch(request, env, ctx) {
+					const { pathname } = new URL(request.url);
+					if (pathname === "/setup") {
+						await env.DB.exec("CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, value TEXT);");
+						return new Response(null, { status: 204 });
+					} else if (pathname === "/query") {
+      			const rows = await env.DB.prepare("SELECT * FROM test;").all();
+      			return Response.json(rows.results);
+					}
+					throw new Error("Not found!");
+			  },
+			  async scheduled(controller, env, ctx) {
+					const stmt = await env.DB.prepare("INSERT INTO test (id, value) VALUES (?, ?)");
+					await stmt.bind(1, "one").run();
+			  }
+			}	
+		`;
+		fs.writeFileSync("index.js", scriptContent);
+
+		const originalFormatErrors = process.env.FORMAT_WRANGLER_ERRORS;
+		process.env.FORMAT_WRANGLER_ERRORS = "true";
+
+		const worker = await unstable_dev("index.js", {
+			experimental: {
+				disableExperimentalWarning: true,
+				disableDevRegistry: true,
+				testScheduled: true,
+				d1Databases: [
+					{
+						binding: "DB",
+						database_name: "db",
+						database_id: "00000000-0000-0000-0000-000000000000",
+					},
+				],
+			},
+		});
+
+		try {
+			let res = await worker.fetch("http://localhost/setup");
+			expect(res.status).toBe(204);
+
+			res = await worker.fetch("http://localhost/__scheduled");
+			expect(res.status).toBe(200);
+			expect(await res.text()).toBe("Ran scheduled event");
+
+			res = await worker.fetch("http://localhost/query");
+			expect(res.status).toBe(200);
+			expect(await res.json()).toEqual([{ id: 1, value: "one" }]);
+
+			res = await worker.fetch("http://localhost/bad");
+			expect(res.status).toBe(500);
+			expect(res.headers.get("Content-Type")).toBe("text/html");
+			expect(await res.text()).toContain("Error: Not found!");
+		} finally {
+			process.env.FORMAT_WRANGLER_ERRORS = originalFormatErrors;
+			await worker.stop();
+		}
+	});
+});

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -574,9 +574,10 @@ async function applyMiddlewareLoaderFacade(
 			],
 			outfile: targetPathInsertion,
 		});
-
-		let targetPathLoader = path.join(tmpDirPath, path.basename(entry.file));
-		if (path.extname(entry.file) === "") targetPathLoader += ".js";
+		const targetPathLoader = path.join(
+			tmpDirPath,
+			"middleware-loader.entry.js"
+		);
 		const loaderPath = path.resolve(
 			getBasePath(),
 			"templates/middleware/loader-modules.ts"

--- a/packages/wrangler/templates/format-dev-errors.ts
+++ b/packages/wrangler/templates/format-dev-errors.ts
@@ -3,6 +3,7 @@ import worker from "__ENTRY_POINT__";
 export * from "__ENTRY_POINT__";
 
 export default <ExportedHandler>{
+	...worker,
 	async fetch(req, env, ctx) {
 		if (worker.fetch === undefined) {
 			throw new TypeError("Entry point missing `fetch` handler");

--- a/packages/wrangler/templates/serve-static-assets.ts
+++ b/packages/wrangler/templates/serve-static-assets.ts
@@ -20,6 +20,7 @@ declare global {
 }
 
 export default <ExportedHandler<{ __STATIC_CONTENT: KVNamespace }>>{
+	...worker,
 	async fetch(request, env, ctx) {
 		let options: Partial<Options> = {
 			ASSET_MANIFEST,

--- a/packages/wrangler/templates/service-bindings-module-facade.js
+++ b/packages/wrangler/templates/service-bindings-module-facade.js
@@ -4,6 +4,7 @@ const Workers = __WORKERS__;
 export * from "__ENTRY_POINT__";
 
 export default {
+	...worker,
 	async fetch(req, env, ctx) {
 		const facadeEnv = { ...env };
 		// For every Worker definition that's available,


### PR DESCRIPTION
#### What this PR solves:

(When I say middleware loader here, I mean the thing that powers `--test-scheduled`, not Wrangler's facade mechanism which D1 uses)

For modules mode, the middleware loader is split into two esbuild stages. The first "insertion" stage generates a file that imports the current entrypoint (either the user's worker or output of another facade, e.g. D1) and all the selected middleware. The second "loader" stage re-exports this output using
https://github.com/cloudflare/workers-sdk/blob/ff35b9d1f589e2d07e0d1935a1c53b90de01588a/packages/wrangler/templates/middleware/loader-modules.ts. Note all imports are marked as external in these stages, so no bundling occurs. Once all Wrangler facades are applied (not just the middleware loader), we run esbuild a final time to produce a Worker bundle.

Prior to this change, the second "loader" stage would output to the same location as the input to the first "insertion" stage, meaning we ended up with a circular import:

```ts
// entry.js
export default {
  fetch() {
    return new Response();
  }
}
```

--- middleware "insertion" stage --->


```ts
// middleware-insertion.entry.js
import worker from "./entry.js";
import __MIDDLEWARE_0__ from ".../middleware-scheduled.ts";
export * from "./entry.js";
export default {
  ...worker,
  middleware: [__MIDDLEWARE_0__]
};
```

--- middleware "loader" stage --->

```ts
// entry.js (note we output to entry.js, not a new file)
import { __facade_invoke__ } from ".../middleware/common.ts"; // middleware runtime
import worker from "./middleware-insertion.entry.js";
export * from "./middleware-insertion.entry.js";
export default {
  fetch() {
    // Dispatch through middlewares, to original entry point
    return __facade_invoke__(...);
  }
}
```

```
      --- imports ---> 
`entry.js`       `middleware-insertion.entry.js`
      <--- imports ---
```

This PR updates the "loader" stage to output to a new file, preventing the circular dependency. With this change we now have...

```
`middleware-loader.entry.js` --- imports ---> `middleware-insertion.entry.js` --- imports ---> `entry.js`
```

####  How to test:

Test by creating a Worker with a D1 database and `scheduled` handler. Try run `wrangler dev --test-scheduled`. Prior to this change, this will crash. After this change, `wrangler dev` should start, and visiting `/__scheduled` in the browser should run the `scheduled` handler.

#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

#### Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested

Alternative to #2682

Fixes #2666
Fixes #2054
