### PR TITLE
feat: Add wasm support for `pages functions build`

### DIFF
--- a/.changeset/thirty-hornets-behave.md
+++ b/.changeset/thirty-hornets-behave.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+You can now import Wasm modules in Pages Functions and Pages Functions Advanced Mode (`_worker.js`).
+This change specifically enables `wasm` module imports in `wrangler pages functions build`.
+As a result, Pages users can now import their `wasm` modules within their Functions or
+`_worker.js` files, and `wrangler pages functions build` will correctly bundle everything
+and output the expected result file.

--- a/fixtures/pages-functions-wasm-app/tests/index.test.ts
+++ b/fixtures/pages-functions-wasm-app/tests/index.test.ts
@@ -22,7 +22,7 @@ describe.concurrent("Pages Functions with wasm module imports", () => {
 		expect(text).toContain("Hello from pages-functions-wasm-app!");
 	});
 
-	it("should resolve any wasm module imports and render the correct response", async ({
+	it("should resolve any wasm module imports and render /meaning-of-life", async ({
 		expect,
 	}) => {
 		let response = await fetch(`http://${ip}:${port}/meaning-of-life`);

--- a/packages/wrangler/src/__tests__/helpers/string-dynamic-values-matcher.ts
+++ b/packages/wrangler/src/__tests__/helpers/string-dynamic-values-matcher.ts
@@ -1,0 +1,28 @@
+export type PatternReplacementPair = [string | RegExp, string];
+
+/**
+ * Sometimes, we might need to test strings that contain dynamic |
+ * random | generated data (such as file hashes, IDs, etc.).
+ *
+ * This helper function replaces the dynamic parts of such strings with
+ * static values, thus enabling us to properly test the contents of the
+ * string.
+ *
+ * see https://jestjs.io/docs/snapshot-testing#property-matchers
+ */
+export function replaceRandomWithConstantData(
+	stringWithRandomData: string,
+	patternReplacementPairs: Array<PatternReplacementPair>
+) {
+	let stringWithConstantData = stringWithRandomData;
+
+	patternReplacementPairs.forEach(
+		(pair) =>
+			(stringWithConstantData = stringWithConstantData.replace(
+				pair[0], // pattern
+				pair[1] // replacement
+			))
+	);
+
+	return stringWithConstantData;
+}

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -1,0 +1,402 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { endEventLoop } from "../helpers/end-event-loop";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import { replaceRandomWithConstantData } from "../helpers/string-dynamic-values-matcher";
+
+describe("functions build", () => {
+	const std = mockConsoleMethods();
+
+	runInTempDir();
+
+	afterEach(async () => {
+		// Force a tick to ensure that all promises resolve
+		await endEventLoop();
+	});
+
+	it("should throw an error if no worker script and no Functions directory was found", async () => {
+		await expect(runWrangler("pages functions build")).rejects.toThrowError();
+		expect(std.err).toContain("Could not find anything to build.");
+	});
+
+	it("should build functions", async () => {
+		/* ---------------------------- */
+		/*       Set up Functions       */
+		/* ---------------------------- */
+		mkdirSync("functions");
+		writeFileSync(
+			"functions/hello.js",
+			`
+    export async function onRequest() {
+      return new Response("Hello from Pages Functions");
+    }
+    `
+		);
+
+		/* --------------------------------- */
+		/*     Run cmd & make assertions     */
+		/* --------------------------------- */
+		await runWrangler(`pages functions build`);
+
+		expect(existsSync("_worker.js")).toBe(true);
+		expect(std.out).toMatchInlineSnapshot(`
+		"🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
+		✨ Compiled Worker successfully"
+	`);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should include any external modules imported by functions in the output bundle when the [--experimental-worker-bundle] flag is set", async () => {
+		/* ---------------------------- */
+		/*       Set up wasm files      */
+		/* ---------------------------- */
+		mkdirSync("wasm");
+		writeFileSync("wasm/greeting.wasm", "Hello");
+		writeFileSync("wasm/name.wasm", "wasm Functions");
+
+		/* ---------------------------- */
+		/*       Set up Functions       */
+		/* ---------------------------- */
+		mkdirSync("functions");
+		writeFileSync(
+			"functions/hello.js",
+			`
+    import hello from "./../wasm/greeting.wasm";
+    import name from "./../wasm/name.wasm";
+
+    export async function onRequest() {
+      const greetingModule = await WebAssembly.instantiate(greeting);
+			const nameModule = await WebAssembly.instantiate(name);
+      return new Response(greetingModule.exports.hello + " " + nameModule.exports.name);
+    }
+    `
+		);
+
+		/* --------------------------------- */
+		/*     Run cmd & make assertions     */
+		/* --------------------------------- */
+		await runWrangler(
+			`pages functions build --outfile=_worker.bundle --experimental-worker-bundle=true`
+		);
+
+		expect(existsSync("_worker.bundle")).toBe(true);
+		expect(std.out).toMatchInlineSnapshot(`
+		"🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
+		✨ Compiled Worker successfully"
+	`);
+
+		// some values in workerBundleContents, such as the undici form boundary
+		// or the file hashes, are randomly generated. Let's replace them
+		// with static values so we can test the file contents
+		const workerBundleContents = readFileSync("_worker.bundle", "utf-8");
+		const workerBundleWithConstantData = replaceRandomWithConstantData(
+			workerBundleContents,
+			[
+				[/------formdata-undici-0.[0-9]*/g, "------formdata-undici-0.test"],
+				[/functionsWorker-0.[0-9]*.js/g, "functionsWorker-0.test.js"],
+				[/[0-9a-z]*-greeting.wasm/g, "test-greeting.wasm"],
+				[/[0-9a-z]*-name.wasm/g, "test-name.wasm"],
+			]
+		);
+
+		// check we appended the metadata
+		expect(workerBundleWithConstantData).toContain(
+			`Content-Disposition: form-data; name="metadata"`
+		);
+		expect(workerBundleWithConstantData).toContain(
+			`{"main_module":"functionsWorker-0.test.js"}`
+		);
+
+		// check we appended the compiled Worker
+		expect(workerBundleWithConstantData).toContain(
+			`Content-Disposition: form-data; name="functionsWorker-0.test.js"; filename="functionsWorker-0.test.js"`
+		);
+
+		// check we appended the wasm modules
+		expect(workerBundleWithConstantData).toContain(
+			`Content-Disposition: form-data; name="./test-greeting.wasm"; filename="./test-greeting.wasm"`
+		);
+		expect(workerBundleWithConstantData).toContain(
+			`Content-Disposition: form-data; name="./test-name.wasm"; filename="./test-name.wasm"`
+		);
+		expect(workerBundleWithConstantData).toContain(`Hello`);
+		expect(workerBundleWithConstantData).toContain(`wasm Functions`);
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should fail building if functions use external module imports, but the [--experimental-worker-bundle] flag is not set", async () => {
+		/* ---------------------------- */
+		/*       Set up wasm files      */
+		/* ---------------------------- */
+		mkdirSync("wasm");
+		writeFileSync("wasm/greeting.wasm", "Hello wasm Functions!");
+
+		/* ---------------------------- */
+		/*       Set up Functions       */
+		/* ---------------------------- */
+		mkdirSync("functions");
+		writeFileSync(
+			"functions/hello.js",
+			`
+    import hello from "./../wasm/greeting.wasm";
+
+    export async function onRequest() {
+      const module = await WebAssembly.instantiate(greeting);
+      return new Response(module.exports.hello);
+    }
+    `
+		);
+
+		/* --------------------------------- */
+		/*     Run cmd & make assertions     */
+		/* --------------------------------- */
+		await expect(runWrangler(`pages functions build`)).rejects.toThrowError();
+		expect(std.err).toContain(
+			`ERROR: No loader is configured for ".wasm" files: ../wasm/greeting.wasm`
+		);
+	});
+
+	it("should build _worker.js if the [--experimental-worker-bundle] flag is set", async () => {
+		/* ---------------------------- */
+		/*       Set up js files        */
+		/* ---------------------------- */
+		mkdirSync("utils");
+		writeFileSync(
+			"utils/meaning-of-life.js",
+			`
+export const MEANING_OF_LIFE = 21;
+`
+		);
+
+		/* ---------------------------- */
+		/*       Set up _worker.js      */
+		/* ---------------------------- */
+		mkdirSync("public");
+		writeFileSync(
+			"public/_worker.js",
+			`
+import { MEANING_OF_LIFE } from "./../utils/meaning-of-life.js";
+
+export default {
+  async fetch(request, env) {
+    return new Response("Hello from _worker.js. The meaning of life is " + MEANING_OF_LIFE);
+  },
+};`
+		);
+
+		/* --------------------------------- */
+		/*     Run cmd & make assertions     */
+		/* --------------------------------- */
+		await runWrangler(
+			`pages functions build --build-output-directory=public --outfile=_worker.bundle --experimental-worker-bundle=true`
+		);
+		expect(existsSync("_worker.bundle")).toBe(true);
+		expect(std.out).toMatchInlineSnapshot(`
+		"🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
+		✨ Compiled Worker successfully"
+	`);
+
+		// some values in workerBundleContents, such as the undici form boundary
+		// or the file hashes, are randomly generated. Let's replace them
+		// with static values so we can test the file contents
+		const workerBundleContents = readFileSync("_worker.bundle", "utf-8");
+		const workerBundleWithConstantData = replaceRandomWithConstantData(
+			workerBundleContents,
+			[
+				[/------formdata-undici-0.[0-9]*/g, "------formdata-undici-0.test"],
+				[/bundledWorker-0.[0-9]*.mjs/g, "bundledWorker-0.test.mjs"],
+			]
+		);
+
+		expect(workerBundleWithConstantData).toMatchInlineSnapshot(`
+		"------formdata-undici-0.test
+		Content-Disposition: form-data; name=\\"metadata\\"
+
+		{\\"main_module\\":\\"bundledWorker-0.test.mjs\\"}
+		------formdata-undici-0.test
+		Content-Disposition: form-data; name=\\"bundledWorker-0.test.mjs\\"; filename=\\"bundledWorker-0.test.mjs\\"
+		Content-Type: application/javascript+module
+
+		// ../utils/meaning-of-life.js
+		var MEANING_OF_LIFE = 21;
+
+		// _worker.js
+		var worker_default = {
+		  async fetch(request, env) {
+		    return new Response(\\"Hello from _worker.js. The meaning of life is \\" + MEANING_OF_LIFE);
+		  }
+		};
+		export {
+		  worker_default as default
+		};
+		//# sourceMappingURL=bundledWorker-0.test.mjs.map
+
+		------formdata-undici-0.test--"
+	`);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+
+		await expect(
+			runWrangler(`pages functions build --build-output-directory=public`)
+		).rejects.toThrowError();
+		expect(std.err).toMatch(
+			/ENOENT: no such file or directory, scandir '.*functions'/
+		);
+	});
+
+	it("should include all external modules imported by _worker.js in the output bundle, when bundling _worker.js", async () => {
+		/* ---------------------------- */
+		/*       Set up wasm files      */
+		/* ---------------------------- */
+		mkdirSync("wasm");
+		writeFileSync("wasm/greeting.wasm", "Hello");
+		writeFileSync("wasm/name.wasm", "wasm _worker.js");
+
+		/* ---------------------------- */
+		/*       Set up _worker.js      */
+		/* ---------------------------- */
+		mkdirSync("public");
+		writeFileSync(
+			"public/_worker.js",
+			`
+import greeting from "./../wasm/greeting.wasm";
+import name from "./../wasm/name.wasm";
+
+export default {
+  async fetch(request, env) {
+    const greetingModule = await WebAssembly.instantiate(greeting);
+    const nameModule = await WebAssembly.instantiate(name);
+    return new Response(greetingModule.exports.hello + " " + nameModule.exports.name + "!");
+  },
+};`
+		);
+
+		/* --------------------------------- */
+		/*     Run cmd & make assertions     */
+		/* --------------------------------- */
+		await runWrangler(
+			`pages functions build --build-output-directory=public --experimental-worker-bundle=true`
+		);
+
+		// built to _worker.js by default
+		expect(existsSync("_worker.js")).toBe(true);
+		expect(std.out).toMatchInlineSnapshot(`
+		"🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
+		✨ Compiled Worker successfully"
+	`);
+
+		// some values in workerBundleContents, such as the undici form boundary
+		// or the file hashes, are randomly generated. Let's replace them
+		// with static values so we can test the file contents
+		const workerBundleContents = readFileSync("_worker.js", "utf-8");
+		const workerBundleWithConstantData = replaceRandomWithConstantData(
+			workerBundleContents,
+			[
+				[/------formdata-undici-0.[0-9]*/g, "------formdata-undici-0.test"],
+				[/bundledWorker-0.[0-9]*.mjs/g, "bundledWorker-0.test.mjs"],
+				[/[0-9a-z]*-greeting.wasm/g, "test-greeting.wasm"],
+				[/[0-9a-z]*-name.wasm/g, "test-name.wasm"],
+			]
+		);
+
+		// check we appended the metadata
+		expect(workerBundleWithConstantData).toContain(
+			`Content-Disposition: form-data; name="metadata"`
+		);
+		expect(workerBundleWithConstantData).toContain(
+			`{"main_module":"bundledWorker-0.test.mjs"}`
+		);
+
+		// check we appended the wasm modules
+		expect(workerBundleWithConstantData).toContain(
+			`Content-Disposition: form-data; name="./test-greeting.wasm"; filename="./test-greeting.wasm"`
+		);
+		expect(workerBundleWithConstantData).toContain(
+			`Content-Disposition: form-data; name="./test-name.wasm"; filename="./test-name.wasm"`
+		);
+		expect(workerBundleWithConstantData).toContain(`Hello`);
+		expect(workerBundleWithConstantData).toContain(`wasm _worker.js`);
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should build _worker.js over /functions, if both are present and the [--experimental-worker-bundle] flag is set", async () => {
+		/* ---------------------------- */
+		/*       Set up _worker.js      */
+		/* ---------------------------- */
+		mkdirSync("public");
+		writeFileSync(
+			"public/_worker.js",
+			`
+export default {
+  async fetch(request, env) {
+    return new Response("Hello from _worker.js");
+  },
+};`
+		);
+
+		/* ---------------------------- */
+		/*       Set up Functions       */
+		/* ---------------------------- */
+		mkdirSync("functions");
+		writeFileSync(
+			"functions/hello.js",
+			`
+    export async function onRequest() {
+      return new Response("Hello from Pages Functions");
+    }
+    `
+		);
+
+		/* --------------------------------- */
+		/*     Run cmd & make assertions     */
+		/* --------------------------------- */
+		await runWrangler(
+			`pages functions build --outfile=public/_worker.bundle --experimental-worker-bundle=true`
+		);
+
+		expect(existsSync("public/_worker.bundle")).toBe(true);
+		expect(std.out).toMatchInlineSnapshot(`
+		"🚧 'wrangler pages <command>' is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
+		✨ Compiled Worker successfully"
+	`);
+
+		// some values in workerBundleContents, such as the undici form boundary
+		// or the file hashes, are randomly generated. Let's replace them
+		// with static values so we can test the file contents
+		const workerBundleContents = readFileSync("public/_worker.bundle", "utf-8");
+		const workerBundleWithConstantData = replaceRandomWithConstantData(
+			workerBundleContents,
+			[
+				[/------formdata-undici-0.[0-9]*/g, "------formdata-undici-0.test"],
+				[/bundledWorker-0.[0-9]*.mjs/g, "bundledWorker-0.test.mjs"],
+			]
+		);
+
+		expect(workerBundleWithConstantData).toMatchInlineSnapshot(`
+		"------formdata-undici-0.test
+		Content-Disposition: form-data; name=\\"metadata\\"
+
+		{\\"main_module\\":\\"bundledWorker-0.test.mjs\\"}
+		------formdata-undici-0.test
+		Content-Disposition: form-data; name=\\"bundledWorker-0.test.mjs\\"; filename=\\"bundledWorker-0.test.mjs\\"
+		Content-Type: application/javascript+module
+
+		// _worker.js
+		var worker_default = {
+		  async fetch(request, env) {
+		    return new Response(\\"Hello from _worker.js\\");
+		  }
+		};
+		export {
+		  worker_default as default
+		};
+		//# sourceMappingURL=bundledWorker-0.test.mjs.map
+
+		------formdata-undici-0.test--"
+	`);
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+});

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -6544,7 +6544,7 @@ addEventListener('fetch', event => {});`
 		`);
 		});
 
-		it("should copy any module imports related assets at --outdir if specified", async () => {
+		it("should copy any module imports related assets to --outdir if specified", async () => {
 			writeWranglerToml();
 			fs.writeFileSync(
 				"./index.js",


### PR DESCRIPTION
**What this PR solves**
Currently it is not possible to import `wasm` modules in either Pages
Functions or Pages Advanced Mode projects.

This commit caries out work to address the aforementioned issue by
enabling `wasm` module imports in `wrangler pages functions build`.
As a result, Pages users can now import their `wasm` modules withing
their Functions or `_worker.js` files, and `wrangler pages functions
build` will correctly bundle everything and output the expected result
file.

```
import hello from "./hello.wasm"

export async function onRequest() {
	const module = await WebAssembly.instantiate(hello);
	return new Response(module.exports.hello);
}
```

**How to test**
This feature is behind the `[--experimental-worker-bundle]` flag

`npx wrangler pages functions build <options> --experimental-worker-bundle=true`

**Associated docs issues/PR**
N/A

**Author has included the following, where applicable**

- [x] Tests
- [x] Changeset

**Reviewer has performed the following, where applicable**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
