### PR TITLE
fix: Pages direct upload failing with expired JWT error

### DIFF
--- a/.changeset/dull-pans-happen.md
+++ b/.changeset/dull-pans-happen.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Fixes large Pages projects failing to complete direct upload due to expiring JWTs
+
+For projects which are slow to upload - either because of client bandwidth or large numbers of files and sizes - It's possible for the JWT to expire multiple times. Since our network request concurrency is set to 3, it's possible that each time the JWT expires we get 3 failed attempts. This can quickly exhaust our upload attempt count and cause the entire process to bail.
+
+This change makes it such that jwt refreshes do not count as a failed upload attempt.

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -317,12 +317,15 @@ export const upload = async (
 					console.debug("failed:", e, "retrying...");
 					// Exponential backoff, 1 second first time, then 2 second, then 4 second etc.
 					await new Promise((resolvePromise) =>
-						setTimeout(resolvePromise, Math.pow(2, attempts++) * 1000)
+						setTimeout(resolvePromise, Math.pow(2, attempts) * 1000)
 					);
 
 					if ((e as { code: number }).code === 8000013 || isJwtExpired(jwt)) {
 						// Looks like the JWT expired, fetch another one
 						jwt = await fetchJwt();
+					} else {
+						// Only count as a failed attempt if the error _wasn't_ an expired JWT
+						attempts++;
 					}
 					return doUpload();
 				} else {


### PR DESCRIPTION
For projects which are slow to upload - either because of client bandwidth or large numbers of files and sizes - It's possible for the JWT to expire multiple times. Since our network request concurrency is set to 3, it's possible that each time the JWT expires we get 3 failed attempts. This can quickly exhaust our upload attempt count (5) and cause the entire process to bail.

This change makes it such that jwt refreshes do not count as a failed upload attempt.

Author has included the following, where applicable:

- [ ] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested
