### PR TITLE
fix: don't force people to use preview_database_id

### DIFF
--- a/.changeset/fluffy-beans-hide.md
+++ b/.changeset/fluffy-beans-hide.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-fix: don't throw an error when using preview_database_id, warn instead
+fix: don't throw an error when omitting preview_database_id, warn instead

--- a/.changeset/fluffy-beans-hide.md
+++ b/.changeset/fluffy-beans-hide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: don't throw an error when using preview_database_id, warn instead

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -895,7 +895,7 @@ function getBindings(
 				// if you have a preview_database_id, we'll use it, but we shouldn't force people to use it.
 				if (!d1Db.preview_database_id) {
 					logger.log(
-						`💡 Recommendation: for development, use a preview D1 database rather than the one you'd use in production.\n💡 Create a new D1 database with "wrangler d1 create <name>" and add its id as preview_database_id to the d1_database "${d1Db.binding}" in your wrangler.toml`
+						`--------------------\n💡 Recommendation: for development, use a preview D1 database rather than the one you'd use in production.\n💡 Create a new D1 database with "wrangler d1 create <name>" and add its id as preview_database_id to the d1_database "${d1Db.binding}" in your wrangler.toml\n--------------------\n`
 					);
 				}
 				return {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -892,15 +892,17 @@ function getBindings(
 						database_id: "local",
 					};
 				}
+				// if you have a preview_database_id, we'll use it, but we shouldn't force people to use it.
 				if (!d1Db.preview_database_id) {
-					throw new Error(
-						`In development, you should use a separate D1 database than the one you'd use in production. Please create a new D1 database with "wrangler d1 create <name>" and add its id as preview_database_id to the d1_database "${d1Db.binding}" in your wrangler.toml`
+					logger.log(
+						`For development, we recommend you use a preview D1 database, rather than the one you'd use in production.\nCreate a new D1 database with "wrangler d1 create <name>" and add its id as preview_database_id to the d1_database "${d1Db.binding}" in your wrangler.toml`
 					);
 				}
-
 				return {
 					...d1Db,
-					database_id: d1Db.preview_database_id,
+					database_id: d1Db.preview_database_id
+						? d1Db.preview_database_id
+						: d1Db.database_id,
 				};
 			}),
 			...(args.d1Databases || []),

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -895,7 +895,7 @@ function getBindings(
 				// if you have a preview_database_id, we'll use it, but we shouldn't force people to use it.
 				if (!d1Db.preview_database_id) {
 					logger.log(
-						`For development, we recommend you use a preview D1 database, rather than the one you'd use in production.\nCreate a new D1 database with "wrangler d1 create <name>" and add its id as preview_database_id to the d1_database "${d1Db.binding}" in your wrangler.toml`
+						`💡 Recommendation: for development, use a preview D1 database rather than the one you'd use in production.\n💡 Create a new D1 database with "wrangler d1 create <name>" and add its id as preview_database_id to the d1_database "${d1Db.binding}" in your wrangler.toml`
 					);
 				}
 				return {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -893,7 +893,7 @@ function getBindings(
 					};
 				}
 				// if you have a preview_database_id, we'll use it, but we shouldn't force people to use it.
-				if (!d1Db.preview_database_id) {
+				if (!d1Db.preview_database_id && !process.env.NO_D1_WARNING) {
 					logger.log(
 						`--------------------\n💡 Recommendation: for development, use a preview D1 database rather than the one you'd use in production.\n💡 Create a new D1 database with "wrangler d1 create <name>" and add its id as preview_database_id to the d1_database "${d1Db.binding}" in your wrangler.toml\n--------------------\n`
 					);

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -249,20 +249,6 @@ function DevSession(props: DevSessionProps) {
 		() => props.bindings.d1_databases?.map((db) => db.binding),
 		[props.bindings.d1_databases]
 	);
-	const everyD1BindingHasPreview = props.bindings.d1_databases?.every(
-		(binding) => binding.preview_database_id
-	);
-	if (
-		betaD1Shims &&
-		betaD1Shims.length > 0 &&
-		!(props.local || everyD1BindingHasPreview)
-	) {
-		handleError(
-			new Error(
-				"D1 bindings require dev --local or preview_database_id for now"
-			)
-		);
-	}
 
 	// If we are using d1 bindings, and are not bundling the worker
 	// we should error here as the d1 shim won't be added


### PR DESCRIPTION
**What this PR solves / how to test:**

Removes the annoying error when folks don't have a preview_database_id. We should trust users to know what they're doing.

**Associated docs issues/PR:**

N/A

**Author has included the following, where applicable:**


- [x] Changeset

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested


