### PR TITLE
docs(templates): add a service binding example to new-worker.ts

### DIFF
--- a/packages/wrangler/templates/new-worker.ts
+++ b/packages/wrangler/templates/new-worker.ts
@@ -17,6 +17,9 @@ export interface Env {
 	//
 	// Example binding to R2. Learn more at https://developers.cloudflare.com/workers/runtime-apis/r2/
 	// MY_BUCKET: R2Bucket;
+	//
+	// Example binding to a Service. Learn more at https://developers.cloudflare.com/workers/runtime-apis/service-bindings/
+	// MY_SERVICE: Fetcher;
 }
 
 export default {


### PR DESCRIPTION
What this PR solves / how to test:

with the release of service bindings, it's helpful to have an immediate idea of how service bindings work.  especially in typescript land, where the type is useful info.  in my case, i found `Fetcher` to be the most accurate type, but feel free to correct me if this is invalid.

Author has included the following, where applicable:

- [x] Tests (N/A)
- [x] Changeset (N/A)

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
