### PR TITLE
[D1] refactor migrations for preview

### DIFF
--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -156,9 +156,9 @@ export async function executeSql({
 	name: string;
 	shouldPrompt: boolean | undefined;
 	persistTo: string | undefined;
-	file?: string;
-	command?: string;
-	json?: boolean;
+	file: string | undefined;
+	command: string | undefined;
+	json: boolean | undefined;
 }) {
 	const sql = file ? readFileSync(file) : command;
 	if (!sql) throw new Error(`Error: must provide --command or --file.`);
@@ -207,7 +207,7 @@ async function executeLocally({
 	shouldPrompt: boolean | undefined;
 	queries: string[];
 	persistTo: string | undefined;
-	json?: boolean;
+	json: boolean | undefined;
 }) {
 	const localDB = getDatabaseInfoFromConfig(config, name);
 	if (!localDB) {
@@ -262,7 +262,7 @@ async function executeRemotely({
 	name: string;
 	shouldPrompt: boolean | undefined;
 	batches: string[];
-	json?: boolean;
+	json: boolean | undefined;
 }) {
 	const multiple_batches = batches.length > 1;
 	// in JSON mode, we don't want a prompt here

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -151,11 +151,11 @@ export async function executeSql({
 	command,
 	json,
 }: {
-	local: undefined | boolean;
+	local: boolean | undefined;
 	config: ConfigFields<DevConfig> & Environment;
 	name: string;
 	shouldPrompt: boolean | undefined;
-	persistTo: undefined | string;
+	persistTo: string | undefined;
 	file?: string;
 	command?: string;
 	json?: boolean;

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -140,6 +140,8 @@ Your database may not be available to serve requests during the migration, conti
 					shouldPrompt: isInteractive() && !CI.isCI(),
 					persistTo,
 					command: query,
+					file: undefined,
+					json: undefined,
 				});
 
 				if (response === null) {

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -133,15 +133,14 @@ Your database may not be available to serve requests during the migration, conti
 			let success = true;
 			let errorNotes: Array<string> = [];
 			try {
-				const response = await executeSql(
+				const response = await executeSql({
 					local,
 					config,
-					database,
-					isInteractive() && !CI.isCI(),
+					name: database,
+					shouldPrompt: isInteractive() && !CI.isCI(),
 					persistTo,
-					undefined,
-					query
-				);
+					command: query,
+				});
 
 				if (response === null) {
 					// TODO:  return error

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -82,6 +82,8 @@ const listAppliedMigrations = async (
 		command: `SELECT *
 		FROM ${migrationsTableName}
 		ORDER BY id`,
+		file: undefined,
+		json: undefined,
 	});
 
 	if (!response || response[0].results.length === 0) return [];
@@ -139,5 +141,7 @@ export const initMigrationsTable = async (
 								applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 						);
 				`,
+		file: undefined,
+		json: undefined,
 	});
 };

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -73,19 +73,16 @@ const listAppliedMigrations = async (
 	name: string,
 	persistTo: undefined | string
 ): Promise<Migration[]> => {
-	const Query = `SELECT *
-									 FROM ${migrationsTableName}
-									 ORDER BY id`;
-
-	const response: QueryResult[] | null = await executeSql(
+	const response: QueryResult[] | null = await executeSql({
 		local,
 		config,
 		name,
-		isInteractive() && !CI.isCI(),
+		shouldPrompt: isInteractive() && !CI.isCI(),
 		persistTo,
-		undefined,
-		Query
-	);
+		command: `SELECT *
+		FROM ${migrationsTableName}
+		ORDER BY id`,
+	});
 
 	if (!response || response[0].results.length === 0) return [];
 
@@ -128,20 +125,19 @@ export const initMigrationsTable = async (
 	name: string,
 	persistTo: undefined | string
 ) => {
-	return executeSql(
+	return executeSql({
 		local,
 		config,
 		name,
-		isInteractive() && !CI.isCI(),
+		shouldPrompt: isInteractive() && !CI.isCI(),
 		persistTo,
-		undefined,
-		`
+		command: `
 						CREATE TABLE IF NOT EXISTS ${migrationsTableName}
 						(
 								id         INTEGER PRIMARY KEY AUTOINCREMENT,
 								name       TEXT UNIQUE,
 								applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 						);
-				`
-	);
+				`,
+	});
 };

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -37,10 +37,10 @@ export async function getMigrationsPath(
 export async function getUnappliedMigrations(
 	migrationsTableName: string,
 	migrationsPath: string,
-	local: undefined | boolean,
+	local: boolean | undefined,
 	config: ConfigFields<DevConfig> & Environment,
 	name: string,
-	persistTo: undefined | string
+	persistTo: string | undefined
 ): Promise<Array<string>> {
 	const appliedMigrations = (
 		await listAppliedMigrations(
@@ -68,10 +68,10 @@ export async function getUnappliedMigrations(
 
 const listAppliedMigrations = async (
 	migrationsTableName: string,
-	local: undefined | boolean,
+	local: boolean | undefined,
 	config: ConfigFields<DevConfig> & Environment,
 	name: string,
-	persistTo: undefined | string
+	persistTo: string | undefined
 ): Promise<Migration[]> => {
 	const response: QueryResult[] | null = await executeSql({
 		local,
@@ -120,10 +120,10 @@ export function getNextMigrationNumber(migrationsPath: string): number {
 
 export const initMigrationsTable = async (
 	migrationsTableName: string,
-	local: undefined | boolean,
+	local: boolean | undefined,
 	config: ConfigFields<DevConfig> & Environment,
 	name: string,
-	persistTo: undefined | string
+	persistTo: string | undefined
 ) => {
 	return executeSql({
 		local,

--- a/packages/wrangler/src/d1/types.ts
+++ b/packages/wrangler/src/d1/types.ts
@@ -1,5 +1,6 @@
 export type Database = {
 	uuid: string;
+	previewDatabaseUuid?: string;
 	name: string;
 	binding: string;
 	internal_env?: string;

--- a/packages/wrangler/src/d1/utils.ts
+++ b/packages/wrangler/src/d1/utils.ts
@@ -14,6 +14,7 @@ export function getDatabaseInfoFromConfig(
 		) {
 			return {
 				uuid: d1Database.database_id,
+				previewDatabaseUuid: d1Database.preview_database_id,
 				binding: d1Database.binding,
 				name: d1Database.database_name,
 				migrationsTableName:


### PR DESCRIPTION
- Added `previewDatabaseUuid` to our types
- the executeSql API now takes an object so it's less annoying to use
- Intentionally no changeset, just a quick refactor