### PR TITLE
Writing `wrangler-error.log` on crashes to help debugging intermittent errors

### DIFF
--- a/.changeset/tiny-mugs-chew.md
+++ b/.changeset/tiny-mugs-chew.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Write a `wrangler-error.log` file in the current directory if Wrangler crashes, logging all messages that would have been output had WRANGLER_LOG=debug been set. Also added this file to the default .gitignore template.

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -1,7 +1,10 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
 import process from "process";
 import { hideBin } from "yargs/helpers";
 import { unstable_dev, unstable_pages } from "./api";
 import { FatalError } from "./errors";
+import { logger } from "./logger";
 import { main } from ".";
 
 import type { UnstableDevWorker, UnstableDevOptions } from "./api";
@@ -11,6 +14,10 @@ import type { UnstableDevWorker, UnstableDevOptions } from "./api";
  */
 if (typeof jest === "undefined" && require.main === module) {
 	main(hideBin(process.argv)).catch((e) => {
+		// Dump debug logs on crash
+		const errorLogPath = path.resolve("wrangler-error.log");
+		console.error(`Writing debug logs to ${errorLogPath}`);
+		writeFileSync(errorLogPath, logger.debugLogs.join("\n"));
 		// The logging of any error that was thrown from `main()` is handled in the `yargs.fail()` handler.
 		// Here we just want to ensure that the process exits with a non-zero code.
 		// We don't want to do this inside the `main()` function, since that would kill the process when running our tests.

--- a/packages/wrangler/templates/gitignore
+++ b/packages/wrangler/templates/gitignore
@@ -169,3 +169,4 @@ dist
 # wrangler project
 
 .dev.vars
+wrangler-error.log


### PR DESCRIPTION
What this PR solves / how to test: 

I find `WRANGLER_LOG=debug` too noisy to run all the time, but I'm seeing occasional API errors and trying to diagnose them. So, with this, if Wrangler crashes, you'll get a `wrangler-error.log` file output, which will capture everything that would have been logged with debug logging turned on from the start.

Turns out to pair really well with [`bat`](https://github.com/sharkdp/bat), makes the JSON dumps a lot more readable:

<img width="692" alt="image" src="https://user-images.githubusercontent.com/23264/218346430-bae33557-8e46-44dd-a48c-2e555a3d378c.png">

Associated docs issues/PR: (Replaces #2706)

Author has included the following, where applicable:

- [ ] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
