### PR TITLE
fix: make it possible to run SQL against preview databases

### DIFF
--- a/.changeset/plenty-clouds-dance.md
+++ b/.changeset/plenty-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: make it possible to run SQL against preview databases

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -1,0 +1,64 @@
+import { useMockIsTTY } from "../helpers/mock-istty";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import writeWranglerToml from "../helpers/write-wrangler-toml";
+
+describe("execute", () => {
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+
+	it("should require login when running against prod", async () => {
+		setIsTTY(false);
+		writeWranglerToml({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+
+		await expect(
+			runWrangler("d1 execute --command 'select 1;'")
+		).rejects.toThrowError(
+			`In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.`
+		);
+	});
+
+	it("should expect either --command or --file", async () => {
+		setIsTTY(false);
+		writeWranglerToml({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+
+		await expect(runWrangler("d1 execute db")).rejects.toThrowError(
+			`Error: must provide --command or --file`
+		);
+	});
+
+	it("should reject the use of --preview with --local", async () => {
+		setIsTTY(false);
+		writeWranglerToml({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+
+		await expect(
+			runWrangler(`d1 execute db --command "select;" --local --preview`)
+		).rejects.toThrowError(`Error: can't use --preview with --local`);
+	});
+
+	it("should expect --local when using --persist-to", async () => {
+		setIsTTY(false);
+		writeWranglerToml({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+		await runWrangler("d1 migrations create db test");
+
+		await expect(
+			runWrangler("d1 migrations apply --local db --preview")
+		).rejects.toThrowError(`Error: can't use --preview with --local`);
+	});
+});

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -61,6 +61,20 @@ describe("migrate", () => {
 				`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
 			);
 		});
+
+		it("should reject the use of --preview with --local", async () => {
+			setIsTTY(false);
+			writeWranglerToml({
+				d1_databases: [
+					{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+				],
+			});
+			await runWrangler("d1 migrations create db test");
+
+			await expect(
+				runWrangler("d1 migrations apply --local db --preview")
+			).rejects.toThrowError(`Error: can't use --preview with --local`);
+		});
 	});
 
 	describe("list", () => {

--- a/packages/wrangler/src/d1/migrations/create.tsx
+++ b/packages/wrangler/src/d1/migrations/create.tsx
@@ -39,11 +39,11 @@ export const CreateHandler = withConfig<CreateHandlerOptions>(
 			return;
 		}
 
-		const migrationsPath = await getMigrationsPath(
-			path.dirname(config.configPath),
-			databaseInfo.migrationsFolderPath,
-			true
-		);
+		const migrationsPath = await getMigrationsPath({
+			projectPath: path.dirname(config.configPath),
+			migrationsFolderPath: databaseInfo.migrationsFolderPath,
+			createIfMissing: true,
+		});
 		const nextMigrationNumber = pad(getNextMigrationNumber(migrationsPath), 4);
 		const migrationName = message.replaceAll(" ", "_");
 

--- a/packages/wrangler/src/d1/migrations/create.tsx
+++ b/packages/wrangler/src/d1/migrations/create.tsx
@@ -4,7 +4,7 @@ import { Box, render, Text } from "ink";
 import React from "react";
 import { withConfig } from "../../config";
 import { logger } from "../../logger";
-import { requireAuth } from "../../user";
+import { DEFAULT_MIGRATION_PATH } from "../constants";
 import { Database } from "../options";
 import { d1BetaWarning, getDatabaseInfoFromConfig } from "../utils";
 import { getMigrationsPath, getNextMigrationNumber } from "./helpers";
@@ -25,7 +25,6 @@ type CreateHandlerOptions = StrictYargsOptionsToInterface<typeof CreateOptions>;
 
 export const CreateHandler = withConfig<CreateHandlerOptions>(
 	async ({ config, database, message }): Promise<void> => {
-		await requireAuth({});
 		logger.log(d1BetaWarning);
 
 		const databaseInfo = getDatabaseInfoFromConfig(config, database);
@@ -41,7 +40,8 @@ export const CreateHandler = withConfig<CreateHandlerOptions>(
 
 		const migrationsPath = await getMigrationsPath({
 			projectPath: path.dirname(config.configPath),
-			migrationsFolderPath: databaseInfo.migrationsFolderPath,
+			migrationsFolderPath:
+				databaseInfo.migrationsFolderPath ?? DEFAULT_MIGRATION_PATH,
 			createIfMissing: true,
 		});
 		const nextMigrationNumber = pad(getNextMigrationNumber(migrationsPath), 4);

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -10,11 +10,15 @@ import type { ConfigFields, DevConfig, Environment } from "../../config";
 import type { QueryResult } from "../execute";
 import type { Migration } from "../types";
 
-export async function getMigrationsPath(
-	projectPath: string,
-	migrationsFolderPath: string,
-	createIfMissing: boolean
-): Promise<string> {
+export async function getMigrationsPath({
+	projectPath,
+	migrationsFolderPath,
+	createIfMissing,
+}: {
+	projectPath: string;
+	migrationsFolderPath: string;
+	createIfMissing: boolean;
+}): Promise<string> {
 	const dir = path.resolve(projectPath, migrationsFolderPath);
 	if (fs.existsSync(dir)) return dir;
 
@@ -34,21 +38,31 @@ export async function getMigrationsPath(
 	throw new Error(`No migrations present at ${dir}.`);
 }
 
-export async function getUnappliedMigrations(
-	migrationsTableName: string,
-	migrationsPath: string,
-	local: boolean | undefined,
-	config: ConfigFields<DevConfig> & Environment,
-	name: string,
-	persistTo: string | undefined
-): Promise<Array<string>> {
+export async function getUnappliedMigrations({
+	migrationsTableName,
+	migrationsPath,
+	local,
+	config,
+	name,
+	persistTo,
+	preview,
+}: {
+	migrationsTableName: string;
+	migrationsPath: string;
+	local: boolean | undefined;
+	config: ConfigFields<DevConfig> & Environment;
+	name: string;
+	persistTo: string | undefined;
+	preview: boolean | undefined;
+}): Promise<Array<string>> {
 	const appliedMigrations = (
 		await listAppliedMigrations(
 			migrationsTableName,
 			local,
 			config,
 			name,
-			persistTo
+			persistTo,
+			preview
 		)
 	).map((migration) => {
 		return migration.name;
@@ -71,7 +85,8 @@ const listAppliedMigrations = async (
 	local: boolean | undefined,
 	config: ConfigFields<DevConfig> & Environment,
 	name: string,
-	persistTo: string | undefined
+	persistTo: string | undefined,
+	preview: boolean | undefined
 ): Promise<Migration[]> => {
 	const response: QueryResult[] | null = await executeSql({
 		local,
@@ -84,6 +99,7 @@ const listAppliedMigrations = async (
 		ORDER BY id`,
 		file: undefined,
 		json: undefined,
+		preview,
 	});
 
 	if (!response || response[0].results.length === 0) return [];
@@ -120,13 +136,21 @@ export function getNextMigrationNumber(migrationsPath: string): number {
 	return highestMigrationNumber + 1;
 }
 
-export const initMigrationsTable = async (
-	migrationsTableName: string,
-	local: boolean | undefined,
-	config: ConfigFields<DevConfig> & Environment,
-	name: string,
-	persistTo: string | undefined
-) => {
+export const initMigrationsTable = async ({
+	migrationsTableName,
+	local,
+	config,
+	name,
+	persistTo,
+	preview,
+}: {
+	migrationsTableName: string;
+	local: boolean | undefined;
+	config: ConfigFields<DevConfig> & Environment;
+	name: string;
+	persistTo: string | undefined;
+	preview: boolean | undefined;
+}) => {
 	return executeSql({
 		local,
 		config,
@@ -143,5 +167,6 @@ export const initMigrationsTable = async (
 				`,
 		file: undefined,
 		json: undefined,
+		preview,
 	});
 };

--- a/packages/wrangler/src/d1/migrations/options.ts
+++ b/packages/wrangler/src/d1/migrations/options.ts
@@ -1,12 +1,17 @@
 import { Database } from "../options";
 import type { CommonYargsArgv } from "../../yargs-types";
 
-export function DatabaseWithLocal(yargs: CommonYargsArgv) {
+export function MigrationOptions(yargs: CommonYargsArgv) {
 	return Database(yargs)
 		.option("local", {
 			describe:
 				"Execute commands/files against a local DB for use with wrangler dev --local",
 			type: "boolean",
+		})
+		.option("preview", {
+			describe: "Execute commands/files against a preview D1 DB",
+			type: "boolean",
+			default: false,
 		})
 		.option("persist-to", {
 			describe:


### PR DESCRIPTION
What this PR solves / how to test:
- `npx wrangler init test-db`
- `npx wrangler d1 create test1`
- `npx wrangler d1 create test2`
- add the db named test2 to test1's definition as `preview_database_id`
- run `wrangler d1 execute test1 --preview --command "SELECT * from Customers"` or add migrations and run them

We don't know if we actually want to go down this path long-term with preview databases. It could be easier to clone&delete off a prod db instead, but we've already got people with preview dbs, so may as well support them properly.

Associated docs issues/PR:

- TODO once we decide whether we'll be taking preview databases down this path long term

Author has included the following, where applicable:

- [ ] Tests
- [ ] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Closes https://github.com/cloudflare/workers-sdk/issues/2446
