### PR TITLE
[Templates] Remove Beta Message D1

### DIFF
--- a/templates/worker-d1/README.md
+++ b/templates/worker-d1/README.md
@@ -2,8 +2,6 @@
 
 [![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-d1)
 
-> **Note: requires D1 Beta Access**
-
 This project is based off the Default Typescript Worker starter. To create a new project like this, run the following:
 
 ```sh


### PR DESCRIPTION
Some PR's were not merged before moving over the templates, this handles the https://github.com/cloudflare/templates/pull/160 which removes the Beta message from the D1 template
