### PR TITLE
Fix worker-build on Windows

### DIFF
--- a/templates/worker-rust/wrangler.toml
+++ b/templates/worker-rust/wrangler.toml
@@ -6,4 +6,4 @@ compatibility_date = "2022-01-20"
 WORKERS_RS_VERSION = "0.0.11"
 
 [build]
-command = "cargo install -q worker-build --version 0.0.7 && worker-build --release"
+command = "cargo install -q worker-build --version 0.0.8 && worker-build --release"


### PR DESCRIPTION
What this PR solves / how to test:
This PR increments the version of the worker-build command, since the version 0.0.7 resulted in errors when building on Windows.

Associated docs issues/PR:
https://github.com/cloudflare/workers-rs/issues/222

Author has included the following, where applicable:

- [ ] Tests
- [ ] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #2308