### PR TITLE
Allow Sources reload

### DIFF
--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -151,6 +151,12 @@ export default function useInspector(props: InspectorProps) {
 			);
 			ws.close(1013, "Too many clients; only one can be connected at a time");
 		} else {
+			remoteWebSocket?.send(
+				JSON.stringify({
+					id: 100_000,
+					method: "Debugger.disable",
+				})
+			);
 			// As promised, save the created websocket in a state hook
 			setLocalWebSocket(ws);
 

--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -151,9 +151,15 @@ export default function useInspector(props: InspectorProps) {
 			);
 			ws.close(1013, "Too many clients; only one can be connected at a time");
 		} else {
+			// Since Wrangler proxies the inspector, reloading Chrome DevTools won't trigger debugger initialisation events (because it's connecting to an extant session).
+			// This sends a `Debugger.disable` message to the remote when a new WebSocket connection is initialised,
+			// with the assumption that the new connection will shortly send a `Debugger.enable` event and trigger re-initialisation.
+			// The key initialisation messages that are needed are the `Debugger.scriptParsed events`.
 			remoteWebSocket?.send(
 				JSON.stringify({
-					id: 100_000,
+					// This number is arbitrary, and is chosen to be high so as not to conflict with messages that DevTools might actually send.
+					// For completeness, these options don't work: 0, -1, or Number.MAX_SAFE_INTEGER
+					id: 100_000_000,
 					method: "Debugger.disable",
 				})
 			);


### PR DESCRIPTION
What this PR solves / how to test:

Since Wrangler proxies the inspector, reloading the page open to Chrome DevTools won't trigger debugger initialisation events (because it's connecting to an extant session). This PR sends a `Debugger.disable` message to the remote when a new WebSocket connection is initialised, with the assumption that the new connection will shortly send a `Debugger.enable` event and trigger re-initialisation. The key initialisation messages that are needed are the `Debugger.scriptParsed` events, which I've verified are sent.

**How to test:**
- Run `wrangler dev` on a test worker
- Press `[d]`, which will open the inspector
- Replace the inspector domain with `devtools.devprod.cloudflare.dev`
- Verify that the Sources/Network/console tabs work after reloading the page
- Verify that Wrangler still prints your worker logs
- Verify the above with `wrangler dev --experimental-local`

Associated docs issues/PR:

- [Internal ticket](https://jira.cfdata.org/browse/DEVX-382)

Author has included the following, where applicable:

- ~[ ] Tests~
- ~[ ] Changeset~

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested