### PR TITLE
Update devtools patches

### DIFF
--- a/packages/wrangler-devtools/patches/0001-Add-README-detailing-the-setup-process.patch
+++ b/packages/wrangler-devtools/patches/0001-Add-README-detailing-the-setup-process.patch
@@ -1,7 +1,7 @@
 From b2985a087935838fdf6a6f0dba21afed484849c7 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Wed, 11 Jan 2023 17:46:48 +0000
-Subject: [PATCH 01/12] Add README detailing the setup process
+Subject: [PATCH 01/13] Add README detailing the setup process
 
 ---
  README.md | 58 +++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/wrangler-devtools/patches/0002-Support-viewing-files-over-the-network.patch
+++ b/packages/wrangler-devtools/patches/0002-Support-viewing-files-over-the-network.patch
@@ -1,7 +1,7 @@
 From cc7b688a2427d7506a2f4111887a5e243fb841d4 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 12 Jan 2023 15:33:43 +0000
-Subject: [PATCH 02/12] Support viewing files over the network
+Subject: [PATCH 02/13] Support viewing files over the network
 
 ---
  front_end/core/sdk/Target.ts             |  4 ++++

--- a/packages/wrangler-devtools/patches/0003-Show-fallback-image-on-Safari.patch
+++ b/packages/wrangler-devtools/patches/0003-Show-fallback-image-on-Safari.patch
@@ -1,7 +1,7 @@
 From a742a62c90c73c8c7e766eaaad9003200a447729 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Mon, 16 Jan 2023 16:51:11 +0000
-Subject: [PATCH 03/12] Show fallback image on Safari
+Subject: [PATCH 03/13] Show fallback image on Safari
 
 ---
  config/gni/devtools_grd_files.gni   |   1 +

--- a/packages/wrangler-devtools/patches/0004-Support-previewing-subrequest-responses.patch
+++ b/packages/wrangler-devtools/patches/0004-Support-previewing-subrequest-responses.patch
@@ -1,7 +1,7 @@
 From 6c4581cd2e985e8e94aa3c9091faec45743da6e4 Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Mon, 16 Jan 2023 14:26:52 +0000
-Subject: [PATCH 04/12] Support previewing subrequest responses
+Subject: [PATCH 04/13] Support previewing subrequest responses
 
 ---
  front_end/core/sdk/NetworkManager.ts   | 9 +++++++--

--- a/packages/wrangler-devtools/patches/0005-Better-Firefox-support-for-network-tab.patch
+++ b/packages/wrangler-devtools/patches/0005-Better-Firefox-support-for-network-tab.patch
@@ -1,7 +1,7 @@
 From b91cdddb4b2576149ba2c184f011073140f16e9b Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 19 Jan 2023 15:47:52 +0000
-Subject: [PATCH 05/12] Better Firefox support for network tab
+Subject: [PATCH 05/13] Better Firefox support for network tab
 
 ---
  front_end/entrypoints/js_app/js_app.ts               | 2 ++

--- a/packages/wrangler-devtools/patches/0006-DEVX-292-Remove-unsupported-network-UI.patch
+++ b/packages/wrangler-devtools/patches/0006-DEVX-292-Remove-unsupported-network-UI.patch
@@ -1,7 +1,7 @@
 From 1a267cd3d143892fb0886907a75e3eb295b5b150 Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Mon, 16 Jan 2023 15:43:50 +0000
-Subject: [PATCH 06/12] DEVX-292 Remove unsupported network UI
+Subject: [PATCH 06/13] DEVX-292 Remove unsupported network UI
 
 ---
  front_end/panels/network/NetworkPanel.ts | 35 ------------------------
@@ -48,7 +48,7 @@ index 304bb09af1..aaf80fbd50 100644
 @@ -411,28 +398,6 @@ export class NetworkPanel extends UI.Panel.Panel implements UI.ContextMenu.Provi
      this.panelToolbar.appendToolbarItem(new UI.Toolbar.ToolbarSettingCheckbox(
          this.preserveLogSetting, i18nString(UIStrings.doNotClearLogOnPageReload), i18nString(UIStrings.preserveLog)));
- 
+
 -    this.panelToolbar.appendSeparator();
 -    const disableCacheCheckbox = new UI.Toolbar.ToolbarSettingCheckbox(
 -        Common.Settings.Settings.instance().moduleSetting('cacheDisabled'),
@@ -74,6 +74,6 @@ index 304bb09af1..aaf80fbd50 100644
      this.rightToolbar.appendToolbarItem(new UI.Toolbar.ToolbarItem(this.progressBarContainer));
      this.rightToolbar.appendSeparator();
      this.rightToolbar.appendToolbarItem(new UI.Toolbar.ToolbarSettingToggle(
--- 
+--
 2.37.1 (Apple Git-137.1)
 

--- a/packages/wrangler-devtools/patches/0007-Remove-unsupported-profiler-UI.patch
+++ b/packages/wrangler-devtools/patches/0007-Remove-unsupported-profiler-UI.patch
@@ -1,7 +1,7 @@
 From 7312af32a23a62acc2f5661187ef90b01381c0de Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Mon, 16 Jan 2023 16:32:45 +0000
-Subject: [PATCH 07/12] Remove unsupported profiler UI
+Subject: [PATCH 07/13] Remove unsupported profiler UI
 
 ---
  front_end/panels/profiler/HeapProfilerPanel.ts | 2 +-

--- a/packages/wrangler-devtools/patches/0008-Show-an-overlay-on-the-memory-tab-in-Firefox.patch
+++ b/packages/wrangler-devtools/patches/0008-Show-an-overlay-on-the-memory-tab-in-Firefox.patch
@@ -1,7 +1,7 @@
 From 70e79d4a4e1821021d0df627a23d62ede6c558ba Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 19 Jan 2023 18:49:47 +0000
-Subject: [PATCH 08/12] Show an overlay on the memory tab in Firefox
+Subject: [PATCH 08/13] Show an overlay on the memory tab in Firefox
 
 ---
  front_end/entrypoint_template.html          | 18 ++++++++++++++++--

--- a/packages/wrangler-devtools/patches/0009-Support-theme-url-parameter-for-forcing-the-theme-fr.patch
+++ b/packages/wrangler-devtools/patches/0009-Support-theme-url-parameter-for-forcing-the-theme-fr.patch
@@ -1,7 +1,7 @@
 From 0edd0dbfe2704ef6bc527cbfa68dd35989d95cc5 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Fri, 20 Jan 2023 19:19:37 +0000
-Subject: [PATCH 09/12] Support theme= url parameter for forcing the theme from
+Subject: [PATCH 09/13] Support theme= url parameter for forcing the theme from
  outside
 
 ---

--- a/packages/wrangler-devtools/patches/0010-Basic-support-for-text-colour-in-dark-mode-in-browse.patch
+++ b/packages/wrangler-devtools/patches/0010-Basic-support-for-text-colour-in-dark-mode-in-browse.patch
@@ -1,7 +1,7 @@
 From 9d34de7c9010659ece1be008ee852a21e06bff55 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Mon, 23 Jan 2023 15:12:38 +0000
-Subject: [PATCH 10/12] Basic support for text colour in dark mode in browsers
+Subject: [PATCH 10/13] Basic support for text colour in dark mode in browsers
  that don't implement :host-context
 
 ---

--- a/packages/wrangler-devtools/patches/0011-Fallback-to-location-for-domain.patch
+++ b/packages/wrangler-devtools/patches/0011-Fallback-to-location-for-domain.patch
@@ -1,7 +1,7 @@
 From 0091abac4c9631649485198cc36b49ebd4fd40dd Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 26 Jan 2023 15:27:04 +0000
-Subject: [PATCH 11/12] Fallback to location for domain
+Subject: [PATCH 11/13] Fallback to location for domain
 
 ---
  front_end/panels/sources/NavigatorView.ts | 3 ++-

--- a/packages/wrangler-devtools/patches/0012-Hide-unsupported-settings-UI.patch
+++ b/packages/wrangler-devtools/patches/0012-Hide-unsupported-settings-UI.patch
@@ -1,7 +1,7 @@
 From deeac26dadb8f2d7f5653c1994eed41f9e220af2 Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Thu, 26 Jan 2023 15:30:34 +0000
-Subject: [PATCH 12/12] Hide unsupported settings UI
+Subject: [PATCH 12/13] Hide unsupported settings UI
 
 - Show CORS errors in console setting
 - Show XHR requests in console setting

--- a/packages/wrangler-devtools/patches/0013-DEVX-380-Hide-debugger-sidebar-and-disable-breakpoin.patch
+++ b/packages/wrangler-devtools/patches/0013-DEVX-380-Hide-debugger-sidebar-and-disable-breakpoin.patch
@@ -1,0 +1,91 @@
+From cde74d1233f0e89563cfe4d458af197f21c22f18 Mon Sep 17 00:00:00 2001
+From: bcoll <bcoll@cloudflare.com>
+Date: Wed, 15 Feb 2023 15:07:45 +0000
+Subject: [PATCH 13/13] DEVX-380 Hide debugger sidebar and disable breakpoints
+
+- Hides debugger sidebar
+- Removes toggle debugger sidebar command
+- Disables breakpoint creation
+---
+ front_end/panels/sources/DebuggerPlugin.ts |  5 -----
+ front_end/panels/sources/SourcesPanel.ts   |  6 +-----
+ front_end/panels/sources/sources-meta.ts   | 23 ----------------------
+ 3 files changed, 1 insertion(+), 33 deletions(-)
+
+diff --git a/front_end/panels/sources/DebuggerPlugin.ts b/front_end/panels/sources/DebuggerPlugin.ts
+index 81f01d388f..6871a61d55 100644
+--- a/front_end/panels/sources/DebuggerPlugin.ts
++++ b/front_end/panels/sources/DebuggerPlugin.ts
+@@ -228,11 +228,6 @@ export class DebuggerPlugin extends Plugin {
+     this.scriptsPanel = SourcesPanel.instance();
+     this.breakpointManager = Bindings.BreakpointManager.BreakpointManager.instance();
+ 
+-    this.breakpointManager.addEventListener(
+-        Bindings.BreakpointManager.Events.BreakpointAdded, this.breakpointChange, this);
+-    this.breakpointManager.addEventListener(
+-        Bindings.BreakpointManager.Events.BreakpointRemoved, this.breakpointChange, this);
+-
+     this.uiSourceCode.addEventListener(Workspace.UISourceCode.Events.WorkingCopyChanged, this.workingCopyChanged, this);
+     this.uiSourceCode.addEventListener(
+         Workspace.UISourceCode.Events.WorkingCopyCommitted, this.workingCopyCommitted, this);
+diff --git a/front_end/panels/sources/SourcesPanel.ts b/front_end/panels/sources/SourcesPanel.ts
+index 72287c6b5d..1e094864ea 100644
+--- a/front_end/panels/sources/SourcesPanel.ts
++++ b/front_end/panels/sources/SourcesPanel.ts
+@@ -248,6 +248,7 @@ export class SourcesPanel extends UI.Panel.Panel implements UI.ContextMenu.Provi
+         new UI.SplitWidget.SplitWidget(true, true, 'sourcesPanelSplitViewState', initialDebugSidebarWidth);
+     this.splitWidget.enableShowModeSaving();
+     this.splitWidget.show(this.element);
++    this.splitWidget.hideSidebar(false);
+ 
+     // Create scripts navigator
+     const initialNavigatorWidth = 225;
+@@ -355,11 +356,6 @@ export class SourcesPanel extends UI.Panel.Panel implements UI.ContextMenu.Provi
+     }
+     if (!isInWrapper) {
+       panel.sourcesViewInternal.leftToolbar().appendToolbarItem(panel.toggleNavigatorSidebarButton);
+-      if (panel.splitWidget.isVertical()) {
+-        panel.sourcesViewInternal.rightToolbar().appendToolbarItem(panel.toggleDebuggerSidebarButton);
+-      } else {
+-        panel.sourcesViewInternal.bottomToolbar().appendToolbarItem(panel.toggleDebuggerSidebarButton);
+-      }
+     }
+   }
+ 
+diff --git a/front_end/panels/sources/sources-meta.ts b/front_end/panels/sources/sources-meta.ts
+index c5e95ab535..9c53bca1b3 100644
+--- a/front_end/panels/sources/sources-meta.ts
++++ b/front_end/panels/sources/sources-meta.ts
+@@ -1375,29 +1375,6 @@ UI.ActionRegistration.registerActionExtension({
+   ],
+ });
+ 
+-UI.ActionRegistration.registerActionExtension({
+-  actionId: 'sources.toggle-debugger-sidebar',
+-  category: UI.ActionRegistration.ActionCategory.SOURCES,
+-  title: i18nLazyString(UIStrings.toggleDebuggerSidebar),
+-  async loadActionDelegate() {
+-    const Sources = await loadSourcesModule();
+-    return Sources.SourcesPanel.ActionDelegate.instance();
+-  },
+-  contextTypes() {
+-    return maybeRetrieveContextTypes(Sources => [Sources.SourcesView.SourcesView]);
+-  },
+-  bindings: [
+-    {
+-      platform: UI.ActionRegistration.Platforms.WindowsLinux,
+-      shortcut: 'Ctrl+Shift+h',
+-    },
+-    {
+-      platform: UI.ActionRegistration.Platforms.Mac,
+-      shortcut: 'Meta+Shift+h',
+-    },
+-  ],
+-});
+-
+ Common.Settings.registerSettingExtension({
+   settingName: 'navigatorGroupByFolder',
+   settingType: Common.Settings.SettingType.BOOLEAN,
+-- 
+2.37.1 (Apple Git-137.1)
+


### PR DESCRIPTION
What this PR solves / how to test:

Adds a patch to DevTools that hides the breakpoint debugging panel, since it's not supported by the runtime.

Associated docs issues/PR:

- [Internal ticket](https://jira.cfdata.org/browse/DEVX-380)

Author has included the following, where applicable:

- ~[ ] Tests~
  - Manually tested
- [ ] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
