### PR TITLE
Update `worker-typescript` template -- fix fetch() and update experimental syntax

### DIFF
--- a/templates/worker-typescript/src/index.test.ts
+++ b/templates/worker-typescript/src/index.test.ts
@@ -16,7 +16,7 @@ describe('Worker', () => {
 	});
 
 	it('should return 200 response', async () => {
-		const resp = await worker.fetch('/', {method: 'GET'});
+		const resp = await worker.fetch('/', { method: 'GET' });
 		expect(resp.status).toBe(200);
 
 		const text = await resp.text();

--- a/templates/worker-typescript/src/index.test.ts
+++ b/templates/worker-typescript/src/index.test.ts
@@ -6,7 +6,9 @@ describe('Worker', () => {
 	let worker: UnstableDevWorker;
 
 	beforeAll(async () => {
-		worker = await unstable_dev('src/index.ts', {}, { disableExperimentalWarning: true });
+		worker = await unstable_dev('src/index.ts', {
+			experimental: { disableExperimentalWarning: true },
+		});
 	});
 
 	afterAll(async () => {
@@ -14,8 +16,7 @@ describe('Worker', () => {
 	});
 
 	it('should return 200 response', async () => {
-		const req = new Request('http://falcon', { method: 'GET' });
-		const resp = await worker.fetch(req);
+		const resp = await worker.fetch('/', {method: 'GET'});
 		expect(resp.status).toBe(200);
 
 		const text = await resp.text();


### PR DESCRIPTION
## What this PR solves

**The `worker-typescript` code example was out-of-date.** Here are the two fixes:

- [x] Updated experimental option to latest recommended format
- [x] Update `fetch()` which no longer accepts Request (and was showing a typescript warning)

---

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
