### PR TITLE
Disable format conversion when detecting format

### DIFF
--- a/.changeset/nervous-scissors-roll.md
+++ b/.changeset/nervous-scissors-roll.md
@@ -2,4 +2,10 @@
 "wrangler": patch
 ---
 
-Fix automatic detection of Worker format when using `typeof module`
+fix: correctly detect `service-worker` format when using `typeof module`
+
+Wrangler automatically detects whether your code is a `modules` or `service-worker` format Worker based on the presence of a `default` `export`. This check currently works by building your entrypoint with `esbuild` and looking at the output metafile.
+
+Previously, we were passing `format: "esm"` to `esbuild` when performing this check, which enables _format conversion_. This may introduce `export default` into the built code, even if it wasn't there to start with, resulting in incorrect format detections.
+
+This change removes `format: "esm"` which disables format conversion when bundling is disabled. See https://esbuild.github.io/api/#format for more details.

--- a/.changeset/nervous-scissors-roll.md
+++ b/.changeset/nervous-scissors-roll.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix automatic detection of Worker format when using `typeof module`

--- a/packages/wrangler/src/__tests__/guess-worker-format.test.ts
+++ b/packages/wrangler/src/__tests__/guess-worker-format.test.ts
@@ -32,8 +32,33 @@ describe("guess worker format", () => {
 		expect(guess).toBe("service-worker");
 	});
 
-	it('should detect a "server-worker" worker using `typeof module`', async () => {
+	it('should detect a "service-worker" worker using `typeof module`', async () => {
 		await writeFile("./index.ts", "typeof module");
+		const guess = await guessWorkerFormat(
+			path.join(process.cwd(), "./index.ts"),
+			process.cwd(),
+			undefined
+		);
+		expect(guess).toBe("service-worker");
+	});
+
+	it('should detect a "service-worker" worker using imports', async () => {
+		await writeFile(
+			"./dep.ts",
+			`
+			const value = 'thing';
+			export default value;
+			`
+		);
+		await writeFile(
+			"./index.ts",
+			`
+			import value from './dep.ts';
+			addEventListener('fetch', (event) => {
+				event.respondWith(new Response(value));
+			});
+			`
+		);
 		const guess = await guessWorkerFormat(
 			path.join(process.cwd(), "./index.ts"),
 			process.cwd(),

--- a/packages/wrangler/src/__tests__/guess-worker-format.test.ts
+++ b/packages/wrangler/src/__tests__/guess-worker-format.test.ts
@@ -32,6 +32,16 @@ describe("guess worker format", () => {
 		expect(guess).toBe("service-worker");
 	});
 
+	it('should detect a "server-worker" worker using `typeof module`', async () => {
+		await writeFile("./index.ts", "typeof module");
+		const guess = await guessWorkerFormat(
+			path.join(process.cwd(), "./index.ts"),
+			process.cwd(),
+			undefined
+		);
+		expect(guess).toBe("service-worker");
+	});
+
 	it("should throw an error when the hint doesn't match the guess (modules - service-worker)", async () => {
 		await writeFile("./index.ts", "export default {};");
 		await expect(

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -151,7 +151,6 @@ export default async function guessWorkerFormat(
 		absWorkingDir: entryWorkingDirectory,
 		metafile: true,
 		bundle: false,
-		format: "esm",
 		target: "es2022",
 		write: false,
 		loader: {


### PR DESCRIPTION
#### What this PR solves

Wrangler automatically detects whether your code is a `modules` or `service-worker` format Worker based on the presence of a `default` `export`. This check currently works by building your entrypoint with `esbuild` and looking at the output metafile.

Previously, we were passing `format: "esm"` to `esbuild` when performing this check, which enables *format conversion*. This may introduce `export default` into the built code, even if it wasn't there to start with, resulting in incorrect format detections.

This change removes `format: "esm"` which disables format conversion when bundling is disabled: https://esbuild.github.io/api/#format.

We may want to use a package like [`es-module-lexer`](https://npmjs.com/package/es-module-lexer) in the future, but this issue is affecting users, and this is probably the simplest fix.

#### How to test:

Run `wrangler dev worker.js` with the following:

```js
addEventListener("fetch", (event) => {
  event.respondWith(new Response(typeof module));
});
```

Before this PR, you'd see `When using module syntax, the 'fetch' event handler should be declared as an exported function on the root module as opposed to using the global addEventListener().` in the console, indicating Wrangler thought this was a `modules`-format Worker, and uploaded it as such. Attempting to access this in the browser results in `Uncaught Error: Handler does not export a fetch() function.`.

After this PR, the Worker should be deployed as a `service-worker`, and attempting to access it in the browser will result in a 200 OK response.

#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #1668
Supersedes #2396
Supersedes #2737