### PR TITLE
[Wrangler] Add ESLint no .only

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
 		"eslint-plugin-react-hooks",
 		"import",
 		"unused-imports",
+		"no-only-tests",
 	],
 	overrides: [
 		{
@@ -47,6 +48,7 @@ module.exports = {
 				"no-empty": "off",
 				"no-empty-function": "off",
 				"no-mixed-spaces-and-tabs": ["error", "smart-tabs"],
+				"no-only-tests/no-only-tests": "error",
 				"no-shadow": "error",
 				"require-yield": "off",
 				"@typescript-eslint/consistent-type-imports": ["error"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
 			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20221111.1",
+				"eslint-plugin-no-only-tests": "^3.1.0",
 				"patch-package": "^6.5.1"
 			},
 			"engines": {
@@ -16886,6 +16887,15 @@
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/eslint-plugin-no-only-tests": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+			"integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+			"dev": true,
+			"engines": {
+				"node": ">=5.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-node": {
@@ -66963,6 +66973,12 @@
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
+		},
+		"eslint-plugin-no-only-tests": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz",
+			"integrity": "sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==",
+			"dev": true
 		},
 		"eslint-plugin-node": {
 			"version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20221111.1",
+		"eslint-plugin-no-only-tests": "^3.1.0",
 		"patch-package": "^6.5.1"
 	},
 	"engines": {


### PR DESCRIPTION
To prevent .only in tests from getting into main, added an ESLint rule that will error on them, CI will no longer pass if .only is present in any tests
