### PR TITLE
Add duplex to r2 put

### DIFF
--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -113,6 +113,7 @@ export async function putR2Object(
 			body: object,
 			headers,
 			method: "PUT",
+			duplex: "half",
 		}
 	);
 }


### PR DESCRIPTION
What this PR solves / how to test:

Adds `duplex: half` to r2 object put to workaround an undici change.

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [ ] Tests
- [ ] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #2784
