### PR TITLE
Pages Functions Wasm cleanup

### DIFF
--- a/.changeset/fast-mayflies-kick.md
+++ b/.changeset/fast-mayflies-kick.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: Remove the `--experimental-worker-bundle` option from Pages Functions

--- a/.changeset/hot-berries-punch.md
+++ b/.changeset/hot-berries-punch.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: Add `--outdir` as an option when running `wrangler pages functions build`.
+
+This deprecates `--outfile` when building a Pages Plugin with `--plugin`.
+
+When building functions normally, `--outdir` may be used to produce a human-inspectable format of the `_worker.bundle` that is produced.

--- a/.changeset/lucky-ads-fry.md
+++ b/.changeset/lucky-ads-fry.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Enable bundling in Pages Functions by default.
+
+We now enable bundling by default for a `functions/` folder and for an `_worker.js` in Pages Functions. This allows you to use external modules such as Wasm. You can disable this behavior in Direct Upload projects by using the `--no-bundle` argument in `wrangler pages publish` and `wrangler pages dev`.

--- a/.gitignore
+++ b/.gitignore
@@ -180,7 +180,7 @@ dist
 wrangler-dist/
 miniflare-dist
 packages/wrangler/wrangler.toml
-packages/prerelease-registry/_worker.js
+packages/prerelease-registry/_worker.bundle
 packages/wranglerjs-compat-webpack-plugin/lib
 .wrangler-1-cache
 emitted-types/
@@ -189,5 +189,5 @@ _routes.generated.json
 # Vendored npm dependencies
 !vendor/*.tgz
 
-# IntelliJ 
+# IntelliJ
 .idea/

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,11 +6,11 @@ packages/wrangler/emitted-types/
 packages/wrangler/coverage/
 packages/wrangler/CHANGELOG.md
 packages/jest-environment-wrangler/CHANGELOG.md
-packages/prerelease-registry/_worker.js
+packages/prerelease-registry/dist/
 packages/jest-environment-wrangler/dist/
 packages/wranglerjs-compat-webpack-plugin/lib
 packages/wrangler-devtools/built-devtools
-fixtures/pages-plugin-example/index.js
+fixtures/pages-plugin-example/dist/
 fixtures/remix-pages-app/build/
 fixtures/remix-pages-app/public/build/
 fixtures/worker-app/dist/

--- a/fixtures/pages-functions-wasm-app/package.json
+++ b/fixtures/pages-functions-wasm-app/package.json
@@ -5,8 +5,8 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --experimental-worker-bundle=true --port 8776",
-		"publish": "npx wrangler pages publish public --experimental-worker-bundle=true",
+		"dev": "npx wrangler pages dev public --port 8776",
+		"publish": "npx wrangler pages publish public",
 		"test": "npx vitest",
 		"test:ci": "npx vitest"
 	},

--- a/fixtures/pages-functions-wasm-app/tests/index.test.ts
+++ b/fixtures/pages-functions-wasm-app/tests/index.test.ts
@@ -10,7 +10,7 @@ describe.concurrent("Pages Functions with wasm module imports", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0", "--experimental-worker-bundle=true"]
+			["--port=0"]
 		));
 	});
 
@@ -25,8 +25,8 @@ describe.concurrent("Pages Functions with wasm module imports", () => {
 	it("should resolve any wasm module imports and render /meaning-of-life", async ({
 		expect,
 	}) => {
-		let response = await fetch(`http://${ip}:${port}/meaning-of-life`);
-		let text = await response.text();
+		const response = await fetch(`http://${ip}:${port}/meaning-of-life`);
+		const text = await response.text();
 		expect(text).toEqual("Hello WASM World! The meaning of life is 21");
 	});
 });

--- a/fixtures/pages-plugin-example/functions/_middleware.ts
+++ b/fixtures/pages-plugin-example/functions/_middleware.ts
@@ -1,3 +1,12 @@
+import type { PluginArgs } from "..";
+
+type ExamplePagesPluginFunction<
+	Env = unknown,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	Params extends string = any,
+	Data extends Record<string, unknown> = Record<string, unknown>
+> = PagesPluginFunction<Env, Params, Data, PluginArgs>;
+
 class BodyHandler {
 	footerText: string;
 
@@ -11,12 +20,10 @@ class BodyHandler {
 	}
 }
 
-export const onRequest: PagesPluginFunction<
-	unknown,
-	never,
-	Record<string, unknown>,
-	{ footerText: string }
-> = async ({ next, pluginArgs }) => {
+export const onRequest: ExamplePagesPluginFunction = async ({
+	next,
+	pluginArgs,
+}) => {
 	const response = await next();
 
 	return new HTMLRewriter()

--- a/fixtures/pages-plugin-example/index.d.ts
+++ b/fixtures/pages-plugin-example/index.d.ts
@@ -1,0 +1,5 @@
+export type PluginArgs = {
+	footerText: string;
+};
+
+export default function (args: PluginArgs): PagesFunction;

--- a/fixtures/pages-plugin-example/package.json
+++ b/fixtures/pages-plugin-example/package.json
@@ -2,16 +2,16 @@
 	"name": "pages-plugin-example",
 	"version": "0.0.0",
 	"private": true,
-	"main": "index.js",
+	"main": "dist/index.js",
 	"types": "index.d.ts",
 	"files": [
-		"index.js",
+		"dist/",
 		"index.d.ts",
 		"tsconfig.json",
 		"public/"
 	],
 	"scripts": {
-		"build": "npx wrangler pages functions build --plugin --outfile=index.js",
+		"build": "npx wrangler pages functions build --plugin --outdir=dist",
 		"check:type": "tsc"
 	}
 }

--- a/fixtures/pages-plugin-example/tsconfig.json
+++ b/fixtures/pages-plugin-example/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["functions"],
+	"include": ["functions", "index.d.ts"],
 	"compilerOptions": {
 		"target": "ES2020",
 		"module": "CommonJS",

--- a/fixtures/pages-workerjs-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-app/tests/index.test.ts
@@ -5,11 +5,22 @@ import { describe, it } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe.concurrent("Pages _worker.js", () => {
-	it("should throw an error when the _worker.js file imports something", ({
+	it("should throw an error when the _worker.js file imports something and --bundle is false", ({
 		expect,
 	}) => {
 		expect(() =>
-			execSync("npm run dev", {
+			execSync("npm run dev -- --bundle=false", {
+				cwd: path.resolve(__dirname, ".."),
+				stdio: "ignore",
+			})
+		).toThrowError();
+	});
+
+	it("should throw an error when the _worker.js file imports something and --no-bundle is true", ({
+		expect,
+	}) => {
+		expect(() =>
+			execSync("npm run dev -- --no-bundle", {
 				cwd: path.resolve(__dirname, ".."),
 				stdio: "ignore",
 			})

--- a/fixtures/pages-workerjs-wasm-app/package.json
+++ b/fixtures/pages-workerjs-wasm-app/package.json
@@ -5,8 +5,8 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --bundle --port 8776",
-		"publish": "npx wrangler pages publish public --bundle",
+		"dev": "npx wrangler pages dev public --port 8776",
+		"publish": "npx wrangler pages publish public",
 		"test": "npx vitest",
 		"test:ci": "npx vitest"
 	},

--- a/fixtures/pages-workerjs-wasm-app/package.json
+++ b/fixtures/pages-workerjs-wasm-app/package.json
@@ -5,8 +5,8 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --port 8776",
-		"publish": "npx wrangler pages publish public --experimental-worker-bundle=true",
+		"dev": "npx wrangler pages dev public --bundle --port 8776",
+		"publish": "npx wrangler pages publish public --bundle",
 		"test": "npx vitest",
 		"test:ci": "npx vitest"
 	},

--- a/fixtures/pages-workerjs-wasm-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-wasm-app/tests/index.test.ts
@@ -10,7 +10,7 @@ describe.concurrent("Pages Advanced Mode with wasm module imports", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0", "--bundle"]
+			["--port=0"]
 		));
 	});
 

--- a/fixtures/pages-workerjs-wasm-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-wasm-app/tests/index.test.ts
@@ -10,7 +10,7 @@ describe.concurrent("Pages Advanced Mode with wasm module imports", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0", "--experimental-worker-bundle=true"]
+			["--port=0", "--bundle"]
 		));
 	});
 
@@ -25,8 +25,8 @@ describe.concurrent("Pages Advanced Mode with wasm module imports", () => {
 	it("should resolve any wasm module imports and render the correct response", async ({
 		expect,
 	}) => {
-		let response = await fetch(`http://${ip}:${port}/meaning-of-life`);
-		let text = await response.text();
+		const response = await fetch(`http://${ip}:${port}/meaning-of-life`);
+		const text = await response.text();
 		expect(text).toEqual(
 			"Hello _worker.js WASM World! The meaning of life is 21"
 		);

--- a/packages/prerelease-registry/package.json
+++ b/packages/prerelease-registry/package.json
@@ -2,14 +2,14 @@
 	"name": "@cloudflare/prerelease-registry",
 	"version": "0.0.1",
 	"private": true,
-	"main": "_worker.js",
+	"main": "dist/index.js",
 	"scripts": {
-		"build": "npx wrangler pages functions build --fallback-service='' ./functions/routes",
+		"build": "npx wrangler pages functions build --fallback-service='' ./functions/routes --outdir=dist",
 		"check:type": "tsc",
 		"prepublish": "npm run build",
-		"publish": "npx wrangler publish _worker.js",
+		"publish": "npx wrangler publish dist/index.js",
 		"prestart": "npm run build",
-		"start": "npx wrangler dev _worker.js"
+		"start": "npx wrangler dev dist/index.js"
 	},
 	"dependencies": {
 		"jszip": "^3.7.1"

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -172,7 +172,7 @@ export default {
 			workerBundleContents,
 			[
 				[/------formdata-undici-0.[0-9]*/g, "------formdata-undici-0.test"],
-				[/bundledWorker-0.[0-9]*.mjs/g, "bundledWorker-0.test.mjs"],
+				[/functionsWorker-0.[0-9]*.js/g, "functionsWorker-0.test.js"],
 			]
 		);
 
@@ -180,9 +180,9 @@ export default {
 		"------formdata-undici-0.test
 		Content-Disposition: form-data; name=\\"metadata\\"
 
-		{\\"main_module\\":\\"bundledWorker-0.test.mjs\\"}
+		{\\"main_module\\":\\"functionsWorker-0.test.js\\"}
 		------formdata-undici-0.test
-		Content-Disposition: form-data; name=\\"bundledWorker-0.test.mjs\\"; filename=\\"bundledWorker-0.test.mjs\\"
+		Content-Disposition: form-data; name=\\"functionsWorker-0.test.js\\"; filename=\\"functionsWorker-0.test.js\\"
 		Content-Type: application/javascript+module
 
 		// ../utils/meaning-of-life.js
@@ -197,7 +197,6 @@ export default {
 		export {
 		  worker_default as default
 		};
-		//# sourceMappingURL=bundledWorker-0.test.mjs.map
 
 		------formdata-undici-0.test--"
 	`);
@@ -251,7 +250,7 @@ export default {
 			workerBundleContents,
 			[
 				[/------formdata-undici-0.[0-9]*/g, "------formdata-undici-0.test"],
-				[/bundledWorker-0.[0-9]*.mjs/g, "bundledWorker-0.test.mjs"],
+				[/functionsWorker-0.[0-9]*.js/g, "functionsWorker-0.test.js"],
 				[/[0-9a-z]*-greeting.wasm/g, "test-greeting.wasm"],
 				[/[0-9a-z]*-name.wasm/g, "test-name.wasm"],
 			]
@@ -262,7 +261,7 @@ export default {
 			`Content-Disposition: form-data; name="metadata"`
 		);
 		expect(workerBundleWithConstantData).toContain(
-			`{"main_module":"bundledWorker-0.test.mjs"}`
+			`{"main_module":"functionsWorker-0.test.js"}`
 		);
 
 		// check we appended the wasm modules
@@ -325,7 +324,7 @@ export default {
 			workerBundleContents,
 			[
 				[/------formdata-undici-0.[0-9]*/g, "------formdata-undici-0.test"],
-				[/bundledWorker-0.[0-9]*.mjs/g, "bundledWorker-0.test.mjs"],
+				[/functionsWorker-0.[0-9]*.js/g, "functionsWorker-0.test.js"],
 			]
 		);
 
@@ -333,9 +332,9 @@ export default {
 		"------formdata-undici-0.test
 		Content-Disposition: form-data; name=\\"metadata\\"
 
-		{\\"main_module\\":\\"bundledWorker-0.test.mjs\\"}
+		{\\"main_module\\":\\"functionsWorker-0.test.js\\"}
 		------formdata-undici-0.test
-		Content-Disposition: form-data; name=\\"bundledWorker-0.test.mjs\\"; filename=\\"bundledWorker-0.test.mjs\\"
+		Content-Disposition: form-data; name=\\"functionsWorker-0.test.js\\"; filename=\\"functionsWorker-0.test.js\\"
 		Content-Type: application/javascript+module
 
 		// _worker.js
@@ -347,7 +346,6 @@ export default {
 		export {
 		  worker_default as default
 		};
-		//# sourceMappingURL=bundledWorker-0.test.mjs.map
 
 		------formdata-undici-0.test--"
 	`);

--- a/packages/wrangler/src/__tests__/pages/publish.test.ts
+++ b/packages/wrangler/src/__tests__/pages/publish.test.ts
@@ -1116,10 +1116,10 @@ describe("deployment create", () => {
 					const body = await (req as RestRequestWithFormData).formData();
 					const manifest = JSON.parse(body.get("manifest") as string);
 
-					// for Functions projects, we auto-generate a `_worker.js`,
+					// for Functions projects, we auto-generate a `_worker.bundle`,
 					// `functions-filepath-routing-config.json`, and `_routes.json`
 					// file, based on the contents of `/functions`
-					const generatedWorkerJS = body.get("_worker.js") as string;
+					const generatedWorkerBundle = body.get("_worker.bundle") as string;
 					const generatedRoutesJSON = body.get("_routes.json") as string;
 					const generatedFilepathRoutingConfig = body.get(
 						"functions-filepath-routing-config.json"
@@ -1129,7 +1129,7 @@ describe("deployment create", () => {
 					expect([...body.keys()]).toEqual([
 						"manifest",
 						"functions-filepath-routing-config.json",
-						"_worker.js",
+						"_worker.bundle",
 						"_routes.json",
 					]);
 
@@ -1139,14 +1139,14 @@ describe("deployment create", () => {
 				                                  }
 			                            `);
 
-					// the contents of the generated `_worker.js` file is pretty massive, so I don't
+					// the contents of the generated `_worker.bundle` file is pretty massive, so I don't
 					// think snapshot testing makes much sense here. Plus, calling
 					// `.toMatchInlineSnapshot()` without any arguments, in order to generate that
 					// snapshot value, doesn't generate anything in this case (probably because the
-					// file contents is too big). So for now, let's test that _worker.js was indeed
+					// file contents is too big). So for now, let's test that _worker.bundle was indeed
 					// generated and that the file size is greater than zero
-					expect(generatedWorkerJS).not.toBeNull();
-					expect(generatedWorkerJS.length).toBeGreaterThan(0);
+					expect(generatedWorkerBundle).not.toBeNull();
+					expect(generatedWorkerBundle.length).toBeGreaterThan(0);
 
 					const maybeRoutesJSONSpec = JSON.parse(generatedRoutesJSON);
 					expect(isRoutesJSONSpec(maybeRoutesJSONSpec)).toBe(true);
@@ -1215,7 +1215,7 @@ describe("deployment create", () => {
 		    "✨ Compiled Worker successfully
 		    ✨ Success! Uploaded 1 files (TIMINGS)
 
-		    ✨ Uploading Functions
+		    ✨ Uploading Functions bundle
 		    ✨ Deployment complete! Take a peek over at https://abcxyz.foo.pages.dev/"
 	    `);
 
@@ -1301,11 +1301,11 @@ describe("deployment create", () => {
 					expect(req.params.accountId).toEqual("some-account-id");
 					const body = await (req as RestRequestWithFormData).formData();
 					const manifest = JSON.parse(body.get("manifest") as string);
-					const customWorkerJS = body.get("_worker.js");
+					const workerBundle = body.get("_worker.bundle");
 
 					// make sure this is all we uploaded
 					expect([...body.keys()].sort()).toEqual(
-						["manifest", "_worker.js"].sort()
+						["manifest", "_worker.bundle"].sort()
 					);
 
 					expect(manifest).toMatchInlineSnapshot(`
@@ -1314,8 +1314,8 @@ describe("deployment create", () => {
 				                                      }
 			                                `);
 
-					expect(workerHasD1Shim(customWorkerJS as string)).toBeTruthy();
-					expect(customWorkerJS).toContain(
+					expect(workerHasD1Shim(workerBundle as string)).toBeTruthy();
+					expect(workerBundle).toContain(
 						`console.log("SOMETHING FROM WITHIN THE WORKER");`
 					);
 
@@ -1365,7 +1365,7 @@ describe("deployment create", () => {
 		    "✨ Success! Uploaded 1 files (TIMINGS)
 
 		    ✨ Compiled Worker successfully
-		    ✨ Uploading _worker.js
+		    ✨ Uploading Worker bundle
 		    ✨ Deployment complete! Take a peek over at https://abcxyz.foo.pages.dev/"
 	  `);
 
@@ -1489,7 +1489,7 @@ describe("deployment create", () => {
 					expect(req.params.accountId).toEqual("some-account-id");
 					const body = await (req as RestRequestWithFormData).formData();
 					const manifest = JSON.parse(body.get("manifest") as string);
-					const generatedWorkerJS = body.get("_worker.js") as string;
+					const generatedWorkerBundle = body.get("_worker.bundle") as string;
 					const customRoutesJSON = body.get("_routes.json") as string;
 					const generatedFilepathRoutingConfig = body.get(
 						"functions-filepath-routing-config.json"
@@ -1500,7 +1500,7 @@ describe("deployment create", () => {
 						[
 							"manifest",
 							"functions-filepath-routing-config.json",
-							"_worker.js",
+							"_worker.bundle",
 							"_routes.json",
 						].sort()
 					);
@@ -1511,9 +1511,9 @@ describe("deployment create", () => {
 				                                }
 			                          `);
 
-					// file content of generated `_worker.js` is too massive to snapshot test
-					expect(generatedWorkerJS).not.toBeNull();
-					expect(generatedWorkerJS.length).toBeGreaterThan(0);
+					// file content of generated `_worker.bundle` is too massive to snapshot test
+					expect(generatedWorkerBundle).not.toBeNull();
+					expect(generatedWorkerBundle.length).toBeGreaterThan(0);
 
 					const customRoutes = JSON.parse(customRoutesJSON);
 					expect(customRoutes).toMatchObject({
@@ -1587,7 +1587,7 @@ describe("deployment create", () => {
 		    "✨ Compiled Worker successfully
 		    ✨ Success! Uploaded 1 files (TIMINGS)
 
-		    ✨ Uploading Functions
+		    ✨ Uploading Functions bundle
 		    ✨ Uploading _routes.json
 		    ✨ Deployment complete! Take a peek over at https://abcxyz.foo.pages.dev/"
 	    `);
@@ -1821,13 +1821,13 @@ and that at least one include rule is provided.
 					const body = await (req as RestRequestWithFormData).formData();
 
 					const manifest = JSON.parse(body.get("manifest") as string);
-					const customWorkerJS = body.get("_worker.js") as string;
+					const workerBundle = body.get("_worker.bundle") as string;
 					const customRoutesJSON = body.get("_routes.json") as string;
 
 					// make sure this is all we uploaded
 					expect([...body.keys()]).toEqual([
 						"manifest",
-						"_worker.js",
+						"_worker.bundle",
 						"_routes.json",
 					]);
 					expect(req.params.accountId).toEqual("some-account-id");
@@ -1837,15 +1837,41 @@ and that at least one include rule is provided.
 				            }
 			          `);
 
-					expect(customWorkerJS).toMatchInlineSnapshot(`
-				"
+					// some fields in workerBundle, such as the undici form boundary
+					// or the file hashes, are randomly generated. Let's replace these
+					// dynamic values with static ones so we can properly test the
+					// contents of `workerBundle`
+					// see https://jestjs.io/docs/snapshot-testing#property-matchers
+					let workerBundleWithConstantData = workerBundle.replace(
+						/------formdata-undici-0.[0-9]*/g,
+						"------formdata-undici-0.test"
+					);
+					workerBundleWithConstantData = workerBundleWithConstantData.replace(
+						/bundledWorker-0.[0-9]*.mjs/g,
+						"bundledWorker-0.test.mjs"
+					);
+
+					// we care about a couple of things here, like the presence of `metadata`,
+					// `bundledWorker`, the wasm import, etc., and since `workerBundle` is
+					// small enough, let's go ahead and snapshot test the whole thing
+					expect(workerBundleWithConstantData).toMatchInlineSnapshot(`
+				"------formdata-undici-0.test
+				Content-Disposition: form-data; name=\\"metadata\\"
+
+				{\\"main_module\\":\\"_worker.js\\"}
+				------formdata-undici-0.test
+				Content-Disposition: form-data; name=\\"_worker.js\\"; filename=\\"_worker.js\\"
+				Content-Type: application/javascript+module
+
+
 				      export default {
 				        async fetch(request, env) {
 				          const url = new URL(request.url);
 				          return url.pathname.startsWith('/api/') ? new Response('Ok') : env.ASSETS.fetch(request);
 				        }
 				      };
-				    "
+				    
+				------formdata-undici-0.test--"
 			`);
 
 					expect(JSON.parse(customRoutesJSON)).toMatchObject({
@@ -1894,7 +1920,7 @@ and that at least one include rule is provided.
 		    "✨ Success! Uploaded 1 files (TIMINGS)
 
 		    ✨ Compiled Worker successfully
-		    ✨ Uploading _worker.js
+		    ✨ Uploading Worker bundle
 		    ✨ Uploading _routes.json
 		    ✨ Deployment complete! Take a peek over at https://abcxyz.foo.pages.dev/"
 	  `);
@@ -2110,27 +2136,54 @@ and that at least one include rule is provided.
 				async (req, res, ctx) => {
 					const body = await (req as RestRequestWithFormData).formData();
 					const manifest = JSON.parse(body.get("manifest") as string);
-					const customWorkerJS = body.get("_worker.js");
+					const customWorkerBundle = body.get("_worker.bundle") as string;
 
 					expect(req.params.accountId).toEqual("some-account-id");
 					// make sure this is all we uploaded
 					expect([...body.keys()].sort()).toEqual(
-						["manifest", "_worker.js"].sort()
+						["manifest", "_worker.bundle"].sort()
 					);
 					expect(manifest).toMatchInlineSnapshot(`
 				Object {
 				  "/README.md": "13a03eaf24ae98378acd36ea00f77f2f",
 				}
 			`);
-					expect(customWorkerJS).toMatchInlineSnapshot(`
-				"
+
+					// some fields in workerBundle, such as the undici form boundary
+					// or the file hashes, are randomly generated. Let's replace these
+					// dynamic values with static ones so we can properly test the
+					// contents of `workerBundle`
+					// see https://jestjs.io/docs/snapshot-testing#property-matchers
+					let workerBundleWithConstantData = customWorkerBundle.replace(
+						/------formdata-undici-0.[0-9]*/g,
+						"------formdata-undici-0.test"
+					);
+					workerBundleWithConstantData = workerBundleWithConstantData.replace(
+						/bundledWorker-0.[0-9]*.mjs/g,
+						"bundledWorker-0.test.mjs"
+					);
+
+					// we care about a couple of things here, like the presence of `metadata`,
+					// `bundledWorker`, the wasm import, etc., and since `workerBundle` is
+					// small enough, let's go ahead and snapshot test the whole thing
+					expect(workerBundleWithConstantData).toMatchInlineSnapshot(`
+				"------formdata-undici-0.test
+				Content-Disposition: form-data; name=\\"metadata\\"
+
+				{\\"main_module\\":\\"_worker.js\\"}
+				------formdata-undici-0.test
+				Content-Disposition: form-data; name=\\"_worker.js\\"; filename=\\"_worker.js\\"
+				Content-Type: application/javascript+module
+
+
 				      export default {
 				        async fetch(request, env) {
 				          const url = new URL(request.url);
 				          return url.pathname.startsWith('/api/') ? new Response('Ok') : env.ASSETS.fetch(request);
 				        }
 				      };
-				    "
+				    
+				------formdata-undici-0.test--"
 			`);
 
 					return res.once(
@@ -2172,14 +2225,14 @@ and that at least one include rule is provided.
 		    "✨ Success! Uploaded 1 files (TIMINGS)
 
 		    ✨ Compiled Worker successfully
-		    ✨ Uploading _worker.js
+		    ✨ Uploading Worker bundle
 		    ✨ Deployment complete! Take a peek over at https://abcxyz.foo.pages.dev/"
 	  `);
 
 		expect(std.err).toMatchInlineSnapshot('""');
 	});
 
-	it("should bundle Functions and resolve its external module imports if the `--experimental-worker-bundle` flag is set", async () => {
+	it("should bundle Functions and resolve its external module imports", async () => {
 		// set up the directory of static files to upload.
 		mkdirSync("public");
 		writeFileSync("public/README.md", "This is a readme");
@@ -2364,9 +2417,7 @@ async function onRequest() {
 			)
 		);
 
-		await runWrangler(
-			"pages publish public --project-name=foo --experimental-worker-bundle=true"
-		);
+		await runWrangler("pages publish public --project-name=foo");
 
 		expect(std.out).toMatchInlineSnapshot(`
 		"✨ Compiled Worker successfully
@@ -2380,7 +2431,7 @@ async function onRequest() {
 		expect(std.err).toMatchInlineSnapshot('""');
 	});
 
-	it("should bundle _worker.js and resolve its external module imports if the `--experimental-worker-bundle` flag is set", async () => {
+	it("should bundle _worker.js and resolve its external module imports", async () => {
 		// set up the directory of static files to upload
 		mkdirSync("public");
 		writeFileSync("public/README.md", "This is a readme");
@@ -2570,9 +2621,7 @@ async function onRequest() {
 			)
 		);
 
-		await runWrangler(
-			"pages publish public --project-name=foo --experimental-worker-bundle=true"
-		);
+		await runWrangler("pages publish public --project-name=foo --bundle");
 
 		expect(std.out).toMatchInlineSnapshot(`
 		"✨ Success! Uploaded 1 files (TIMINGS)
@@ -2605,7 +2654,7 @@ async function onRequest() {
 			contents.includes("worker_default as default");
 
 		const simulateServer = (
-			generatedWorkerJsCheck: (workerJsContent: string) => void
+			generatedWorkerBundleCheck: (workerJsContent: string) => void
 		) => {
 			mockGetUploadTokenRequest(
 				"<<funfetti-auth-jwt>>",
@@ -2639,9 +2688,9 @@ async function onRequest() {
 					"*/accounts/:accountId/pages/projects/foo/deployments",
 					async (req, res, ctx) => {
 						const body = await (req as RestRequestWithFormData).formData();
-						const generatedWorkerJS = body.get("_worker.js") as string;
+						const generatedWorkerBundle = body.get("_worker.bundle") as string;
 
-						generatedWorkerJsCheck(generatedWorkerJS);
+						generatedWorkerBundleCheck(generatedWorkerBundle);
 
 						return res.once(
 							ctx.status(200),
@@ -2679,7 +2728,7 @@ async function onRequest() {
 				expect(workerIsBundled(generatedWorkerJS)).toBeFalsy()
 			);
 			await runWrangler("pages publish public --project-name=foo");
-			expect(std.out).toContain("✨ Uploading _worker.js");
+			expect(std.out).toContain("✨ Uploading Worker bundle");
 		});
 
 		it("should bundle the _worker.js when the `--no-bundle` is set to false", async () => {
@@ -2689,7 +2738,7 @@ async function onRequest() {
 			await runWrangler(
 				"pages publish public --no-bundle=false --project-name=foo"
 			);
-			expect(std.out).toContain("✨ Uploading _worker.js");
+			expect(std.out).toContain("✨ Uploading Worker bundle");
 		});
 
 		it("should bundle the _worker.js when the `--bundle` is set to true", async () => {
@@ -2699,7 +2748,7 @@ async function onRequest() {
 			await runWrangler(
 				"pages publish public --bundle=true --project-name=foo"
 			);
-			expect(std.out).toContain("✨ Uploading _worker.js");
+			expect(std.out).toContain("✨ Uploading Worker bundle");
 		});
 	});
 });

--- a/packages/wrangler/src/api/pages/publish.tsx
+++ b/packages/wrangler/src/api/pages/publish.tsx
@@ -69,14 +69,6 @@ interface PagesPublishOptions {
 	 */
 	bundle?: boolean;
 
-	/**
-	 * Whether to process non-JS module imports or not, such as
-	 * wasm/text/binary, when we run bundling on `functions` or
-	 * `_worker.js`
-	 * Default: false
-	 */
-	experimentalWorkerBundle?: boolean;
-
 	// TODO: Allow passing in the API key and plumb it through
 	// to the API calls so that the publish function does not
 	// rely on the `CLOUDFLARE_API_KEY` environment variable
@@ -98,7 +90,6 @@ export async function publish({
 	commitDirty,
 	functionsDirectory: customFunctionsDirectory,
 	bundle,
-	experimentalWorkerBundle,
 }: PagesPublishOptions) {
 	let _headers: string | undefined,
 		_redirects: string | undefined,
@@ -182,7 +173,6 @@ export async function publish({
 				local: false,
 				d1Databases,
 				nodejsCompat,
-				experimentalWorkerBundle,
 			});
 
 			builtFunctions = readFileSync(outfile, "utf-8");
@@ -253,10 +243,7 @@ export async function publish({
 	 * – this includes its routing and middleware characteristics.
 	 */
 	if (_workerJS) {
-		let workerFileContents = _workerJS;
-		const enableBundling = bundle || experimentalWorkerBundle;
-
-		if (enableBundling) {
+		if (bundle) {
 			const outfile = join(tmpdir(), `./bundledWorker-${Math.random()}.mjs`);
 			workerBundle = await buildRawWorker({
 				workerScriptPath,
@@ -268,30 +255,28 @@ export async function publish({
 				onEnd: () => {},
 				betaD1Shims: d1Databases,
 				nodejsCompat,
-				experimentalWorkerBundle,
 			});
-			workerFileContents = readFileSync(outfile, "utf8");
 		} else {
 			await checkRawWorker(workerScriptPath, () => {});
+			// TODO: Replace this with the cool new no-bundle stuff when that lands: https://github.com/cloudflare/workers-sdk/pull/2769
+			workerBundle = {
+				modules: [],
+				dependencies: {},
+				stop: undefined,
+				resolvedEntryPointPath: workerScriptPath,
+				bundleType: "esm",
+			};
 		}
 
-		if (experimentalWorkerBundle) {
-			const workerBundleContents = await createUploadWorkerBundleContents(
-				workerBundle as BundleResult
-			);
+		const workerBundleContents = await createUploadWorkerBundleContents(
+			workerBundle as BundleResult
+		);
 
-			formData.append(
-				"_worker.bundle",
-				new File([workerBundleContents], "_worker.bundle")
-			);
-			logger.log(`✨ Uploading Worker bundle`);
-		} else {
-			formData.append(
-				"_worker.js",
-				new File([workerFileContents], "_worker.js")
-			);
-			logger.log(`✨ Uploading _worker.js`);
-		}
+		formData.append(
+			"_worker.bundle",
+			new File([workerBundleContents], "_worker.bundle")
+		);
+		logger.log(`✨ Uploading Worker bundle`);
 
 		if (_routesCustom) {
 			// user provided a custom _routes.json file
@@ -317,21 +302,15 @@ export async function publish({
 	 * https://developers.cloudflare.com/pages/platform/functions/
 	 */
 	if (builtFunctions && !_workerJS) {
-		if (experimentalWorkerBundle) {
-			const workerBundleContents = await createUploadWorkerBundleContents(
-				workerBundle as BundleResult
-			);
+		const workerBundleContents = await createUploadWorkerBundleContents(
+			workerBundle as BundleResult
+		);
 
-			formData.append(
-				"_worker.bundle",
-				new File([workerBundleContents], "_worker.bundle")
-			);
-			logger.log(`✨ Uploading Functions bundle`);
-		} else {
-			// if Functions were build successfully, proceed to uploading the build file
-			formData.append("_worker.js", new File([builtFunctions], "_worker.js"));
-			logger.log(`✨ Uploading Functions`);
-		}
+		formData.append(
+			"_worker.bundle",
+			new File([workerBundleContents], "_worker.bundle")
+		);
+		logger.log(`✨ Uploading Functions bundle`);
 
 		if (_routesCustom) {
 			// user provided a custom _routes.json file

--- a/packages/wrangler/src/api/pages/publish.tsx
+++ b/packages/wrangler/src/api/pages/publish.tsx
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve as resolvePath } from "node:path";
+import { join, resolve as resolvePath } from "node:path";
 import { cwd } from "node:process";
 import { File, FormData } from "undici";
 import { fetchResult } from "../../cfetch";
@@ -156,7 +156,6 @@ export async function publish({
 	);
 
 	if (!_workerJS && existsSync(functionsDirectory)) {
-		const outfile = join(tmpdir(), `./functionsWorker-${Math.random()}.js`);
 		const outputConfigPath = join(
 			tmpdir(),
 			`functions-filepath-routing-config-${Math.random()}.json`
@@ -164,18 +163,20 @@ export async function publish({
 
 		try {
 			workerBundle = await buildFunctions({
-				outfile,
 				outputConfigPath,
 				functionsDirectory,
 				onEnd: () => {},
-				buildOutputDirectory: dirname(outfile),
+				buildOutputDirectory: directory,
 				routesOutputPath,
 				local: false,
 				d1Databases,
 				nodejsCompat,
 			});
 
-			builtFunctions = readFileSync(outfile, "utf-8");
+			builtFunctions = readFileSync(
+				workerBundle.resolvedEntryPointPath,
+				"utf-8"
+			);
 			filepathRoutingConfig = readFileSync(outputConfigPath, "utf-8");
 		} catch (e) {
 			if (e instanceof FunctionsNoRoutesError) {

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -107,6 +107,7 @@ export async function bundleWorker(
 		doBindings: DurableObjectBindings;
 		jsxFactory?: string;
 		jsxFragment?: string;
+		entryName?: string;
 		rules: Config["rules"];
 		watch?: esbuild.WatchMode | boolean;
 		tsconfig?: string;
@@ -137,6 +138,7 @@ export async function bundleWorker(
 		doBindings,
 		jsxFactory,
 		jsxFragment,
+		entryName,
 		rules,
 		watch,
 		tsconfig,
@@ -335,10 +337,12 @@ export async function bundleWorker(
 		bundle: true,
 		absWorkingDir: entry.directory,
 		outdir: destination,
+		entryNames: entryName,
 		...(isOutfile
 			? {
 					outdir: undefined,
 					outfile: destination,
+					entryNames: undefined,
 			  }
 			: {}),
 		inject,

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -8,6 +8,7 @@ import * as metrics from "../metrics";
 import { buildFunctions } from "./buildFunctions";
 import { isInPagesCI } from "./constants";
 import {
+	EXIT_CODE_FUNCTIONS_NOTHING_TO_BUILD_ERROR,
 	EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR,
 	FunctionsNoRoutesError,
 	getFunctionsNoRoutesWarning,
@@ -152,14 +153,17 @@ export const Handler = async ({
 	let bundle: BundleResult | undefined = undefined;
 
 	if (!foundWorkerScript && !existsSync(directory)) {
-		throw new FatalError(`Could not find anything to build.
+		throw new FatalError(
+			`Could not find anything to build.
 We first looked inside the build output directory (${basename(
-			resolvePath(buildOutputDirectory)
-		)}), then looked for the Functions directory (${basename(
-			directory
-		)}) but couldn't find anything to build.
+				resolvePath(buildOutputDirectory)
+			)}), then looked for the Functions directory (${basename(
+				directory
+			)}) but couldn't find anything to build.
 	➤ If you are trying to build _worker.js, please make sure you provide the [--build-output-directory] containing your static files.
-	➤ If you are trying to build Pages Functions, please make sure [--directory] points to the location of your Functions files.`);
+	➤ If you are trying to build Pages Functions, please make sure [--directory] points to the location of your Functions files.`,
+			EXIT_CODE_FUNCTIONS_NOTHING_TO_BUILD_ERROR
+		);
 	}
 
 	/**

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -165,7 +165,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 			}
 		}
 
-		if (outfile) {
+		if (outfile && outfile !== bundle.resolvedEntryPointPath) {
 			writeFileSync(
 				outfile,
 				`export { default } from './${relative(
@@ -314,7 +314,7 @@ const validateArgs = (args: PagesBuildArgs): ValidatedArgs => {
 		} else if (!args.outfile && !args.outdir) {
 			// Didn't specify `--outfile`, but didn't specify `--outdir` either. Implicit old behavior defaults. Encourage to migrate to `--outdir`.
 			args.outfile ??= "_worker.js";
-			args.outdir = dirname(resolvePath(args.outfile));
+			args.outdir = ".";
 
 			logger.warn(
 				"Creating a Pages Plugin without `--outdir` is now deprecated. Please add an `--outdir` argument."

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -1,6 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { basename, dirname, join, resolve as resolvePath } from "node:path";
+import { basename, dirname, relative, resolve as resolvePath } from "node:path";
 import { createUploadWorkerBundleContents } from "../api/pages/create-worker-bundle-contents";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
@@ -33,8 +32,11 @@ export function Options(yargs: CommonYargsArgv) {
 		.options({
 			outfile: {
 				type: "string",
-				default: "_worker.bundle",
 				description: "The location of the output Worker script",
+			},
+			outdir: {
+				type: "string",
+				description: "Output directory for the bundled Worker",
 			},
 			"output-config-path": {
 				type: "string",
@@ -104,95 +106,42 @@ export function Options(yargs: CommonYargsArgv) {
 		.epilogue(pagesBetaWarning);
 }
 
-export const Handler = async ({
-	directory,
-	outfile,
-	outputConfigPath,
-	outputRoutesPath: routesOutputPath,
-	minify,
-	sourcemap,
-	fallbackService,
-	watch,
-	plugin,
-	buildOutputDirectory,
-	nodeCompat: legacyNodeCompat,
-	compatibilityFlags,
-	bindings,
-}: PagesBuildArgs) => {
+export const Handler = async (args: PagesBuildArgs) => {
 	if (!isInPagesCI) {
 		// Beta message for `wrangler pages <commands>` usage
 		logger.log(pagesBetaWarning);
 	}
 
-	if (legacyNodeCompat) {
-		console.warn(
-			"Enabling Node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
-		);
-	}
-	const nodejsCompat = compatibilityFlags?.includes("nodejs_compat");
-	if (legacyNodeCompat && nodejsCompat) {
-		throw new Error(
-			"The `nodejs_compat` compatibility flag cannot be used in conjunction with the legacy `--node-compat` flag. If you want to use the Workers runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command."
-		);
-	}
+	const validatedArgs = validateArgs(args);
 
-	let d1Databases: string[] | undefined = undefined;
-	if (bindings) {
-		try {
-			const decodedBindings = JSON.parse(bindings);
-			d1Databases = Object.keys(decodedBindings?.d1_databases || {});
-		} catch {
-			throw new FatalError("Could not parse a valid set of 'bindings'.", 1);
-		}
-	}
-
-	buildOutputDirectory ??= dirname(outfile);
-
-	const workerScriptPath = resolvePath(buildOutputDirectory, "_worker.js");
-	const foundWorkerScript = existsSync(workerScriptPath);
 	let bundle: BundleResult | undefined = undefined;
 
-	if (!foundWorkerScript && !existsSync(directory)) {
-		throw new FatalError(
-			`Could not find anything to build.
-We first looked inside the build output directory (${basename(
-				resolvePath(buildOutputDirectory)
-			)}), then looked for the Functions directory (${basename(
-				directory
-			)}) but couldn't find anything to build.
-	➤ If you are trying to build _worker.js, please make sure you provide the [--build-output-directory] containing your static files.
-	➤ If you are trying to build Pages Functions, please make sure [--directory] points to the location of your Functions files.`,
-			EXIT_CODE_FUNCTIONS_NOTHING_TO_BUILD_ERROR
-		);
-	}
+	if (validatedArgs.plugin) {
+		const {
+			directory,
+			outfile,
+			outdir,
+			outputConfigPath,
+			outputRoutesPath: routesOutputPath,
+			minify,
+			sourcemap,
+			fallbackService,
+			watch,
+			plugin,
+			nodejsCompat,
+			legacyNodeCompat,
+		} = validatedArgs;
 
-	/**
-	 * prioritize building `_worker.js` over Pages Functions, if both exist
-	 * and if we were able to resolve _worker.js
-	 */
-	if (foundWorkerScript) {
-		/**
-		 * `buildRawWorker` builds `_worker.js`, but doesn't give us the bundle
-		 * we want to return, which includes the external dependencies (like wasm,
-		 * binary, text). Let's output that build result to memory and only write
-		 * to disk once we have the final bundle
-		 */
-		const workerOutfile = join(
-			tmpdir(),
-			`./bundledWorker-${Math.random()}.mjs`
-		);
-
-		bundle = await buildRawWorker({
-			workerScriptPath,
-			outfile: workerOutfile,
-			directory: buildOutputDirectory,
-			local: false,
-			sourcemap: true,
-			watch: false,
-			onEnd: () => {},
-			betaD1Shims: d1Databases,
-		});
-	} else {
+		if (!existsSync(directory)) {
+			throw new FatalError(
+				`Could not find anything to build.
+We looked for the Functions directory (${basename(
+					directory
+				)}) but couldn't find anything to build.
+	➤ Please make sure [directory] points to the location of your Functions files.`,
+				EXIT_CODE_FUNCTIONS_NOTHING_TO_BUILD_ERROR
+			);
+		}
 		try {
 			/**
 			 * `buildFunctions` builds `/functions`, but doesn't give us the bundle
@@ -200,12 +149,9 @@ We first looked inside the build output directory (${basename(
 			 * binary, text). Let's output that build result to memory and only write
 			 * to disk once we have the final bundle
 			 */
-			const functionsOutfile = plugin
-				? outfile
-				: join(tmpdir(), `./functionsWorker-${Math.random()}.js`);
-
 			bundle = await buildFunctions({
-				outfile: functionsOutfile,
+				outfile,
+				outdir,
 				outputConfigPath,
 				functionsDirectory: directory,
 				minify,
@@ -213,12 +159,10 @@ We first looked inside the build output directory (${basename(
 				fallbackService,
 				watch,
 				plugin,
-				buildOutputDirectory,
 				legacyNodeCompat,
 				nodejsCompat,
 				routesOutputPath,
 				local: false,
-				d1Databases,
 			});
 		} catch (e) {
 			if (e instanceof FunctionsNoRoutesError) {
@@ -230,19 +174,222 @@ We first looked inside the build output directory (${basename(
 				throw e;
 			}
 		}
-	}
 
-	if (!plugin) {
-		const workerBundleContents = await createUploadWorkerBundleContents(
-			bundle as BundleResult
-		);
-
-		mkdirSync(dirname(outfile), { recursive: true });
-		writeFileSync(
+		if (outfile) {
+			writeFileSync(
+				outfile,
+				`export { default } from './${relative(
+					dirname(outfile),
+					bundle.resolvedEntryPointPath
+				)}'`
+			);
+		}
+	} else {
+		const {
+			directory,
 			outfile,
-			Buffer.from(await workerBundleContents.arrayBuffer())
-		);
+			outdir,
+			outputConfigPath,
+			outputRoutesPath: routesOutputPath,
+			minify,
+			sourcemap,
+			fallbackService,
+			watch,
+			plugin,
+			buildOutputDirectory,
+			nodejsCompat,
+			legacyNodeCompat,
+			bindings,
+		} = validatedArgs;
+
+		let d1Databases: string[] | undefined = undefined;
+		if (bindings) {
+			try {
+				const decodedBindings = JSON.parse(bindings);
+				d1Databases = Object.keys(decodedBindings?.d1_databases || {});
+			} catch {
+				throw new FatalError("Could not parse a valid set of 'bindings'.", 1);
+			}
+		}
+
+		const workerScriptPath = resolvePath(buildOutputDirectory, "_worker.js");
+		const foundWorkerScript = existsSync(workerScriptPath);
+
+		if (!foundWorkerScript && !existsSync(directory)) {
+			throw new FatalError(
+				`Could not find anything to build.
+We first looked inside the build output directory (${basename(
+					resolvePath(buildOutputDirectory)
+				)}), then looked for the Functions directory (${basename(
+					directory
+				)}) but couldn't find anything to build.
+	➤ If you are trying to build _worker.js, please make sure you provide the [--build-output-directory] containing your static files.
+	➤ If you are trying to build Pages Functions, please make sure [directory] points to the location of your Functions files.`,
+				EXIT_CODE_FUNCTIONS_NOTHING_TO_BUILD_ERROR
+			);
+		}
+
+		/**
+		 * prioritize building `_worker.js` over Pages Functions, if both exist
+		 * and if we were able to resolve _worker.js
+		 */
+		if (foundWorkerScript) {
+			/**
+			 * `buildRawWorker` builds `_worker.js`, but doesn't give us the bundle
+			 * we want to return, which includes the external dependencies (like wasm,
+			 * binary, text). Let's output that build result to memory and only write
+			 * to disk once we have the final bundle
+			 */
+			bundle = await buildRawWorker({
+				workerScriptPath,
+				outdir,
+				directory: buildOutputDirectory,
+				local: false,
+				sourcemap,
+				watch,
+				betaD1Shims: d1Databases,
+			});
+		} else {
+			try {
+				/**
+				 * `buildFunctions` builds `/functions`, but doesn't give us the bundle
+				 * we want to return, which includes the external dependencies (like wasm,
+				 * binary, text). Let's output that build result to memory and only write
+				 * to disk once we have the final bundle
+				 */
+				bundle = await buildFunctions({
+					outdir,
+					outputConfigPath,
+					functionsDirectory: directory,
+					minify,
+					sourcemap,
+					fallbackService,
+					watch,
+					plugin,
+					buildOutputDirectory,
+					legacyNodeCompat,
+					nodejsCompat,
+					routesOutputPath,
+					local: false,
+					d1Databases,
+				});
+			} catch (e) {
+				if (e instanceof FunctionsNoRoutesError) {
+					throw new FatalError(
+						getFunctionsNoRoutesWarning(directory),
+						EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR
+					);
+				} else {
+					throw e;
+				}
+			}
+		}
+
+		if (outfile) {
+			const workerBundleContents = await createUploadWorkerBundleContents(
+				bundle as BundleResult
+			);
+
+			mkdirSync(dirname(outfile), { recursive: true });
+			writeFileSync(
+				outfile,
+				Buffer.from(await workerBundleContents.arrayBuffer())
+			);
+		}
 	}
 
 	await metrics.sendMetricsEvent("build pages functions");
+};
+
+type WorkerBundleArgs = Omit<PagesBuildArgs, "nodeCompat"> & {
+	plugin: false;
+	outfile: string;
+	buildOutputDirectory: string;
+	legacyNodeCompat: boolean;
+	nodejsCompat: boolean;
+};
+type PluginArgs = Omit<
+	PagesBuildArgs,
+	"buildOutputDirectory" | "bindings" | "nodeCompat"
+> & {
+	plugin: true;
+	outdir: string;
+	legacyNodeCompat: boolean;
+	nodejsCompat: boolean;
+};
+
+type ValidatedArgs = WorkerBundleArgs | PluginArgs;
+
+const validateArgs = (args: PagesBuildArgs): ValidatedArgs => {
+	if (args.outdir && args.outfile) {
+		throw new FatalError(
+			"Cannot specify both an `--outdir` and an `--outfile`.",
+			1
+		);
+	}
+
+	if (args.plugin) {
+		if (args.outfile) {
+			// Explicit old behavior. Encourage to migrate to `--outdir` instead.
+			logger.warn(
+				"Creating a Pages Plugin with `--outfile` is now deprecated. Please use `--outdir` instead."
+			);
+
+			args.outdir = dirname(resolvePath(args.outfile));
+		} else if (!args.outfile && !args.outdir) {
+			// Didn't specify `--outfile`, but didn't specify `--outdir` either. Implicit old behavior defaults. Encourage to migrate to `--outdir`.
+			args.outfile ??= "_worker.js";
+			args.outdir = dirname(resolvePath(args.outfile));
+
+			logger.warn(
+				"Creating a Pages Plugin without `--outdir` is now deprecated. Please add an `--outdir` argument."
+			);
+		}
+
+		if (args.bindings) {
+			throw new FatalError(
+				"The `--bindings` flag cannot be used when creating a Pages Plugin with `--plugin`.",
+				1
+			);
+		}
+
+		if (args.buildOutputDirectory) {
+			throw new FatalError(
+				"The `--build-output-directory` flag cannot be used when creating a Pages Plugin with `--plugin`.",
+				1
+			);
+		}
+	} else {
+		args.outfile ??= "_worker.bundle";
+		args.buildOutputDirectory ??= dirname(args.outfile);
+	}
+
+	if (args.buildOutputDirectory) {
+		args.buildOutputDirectory = resolvePath(args.buildOutputDirectory);
+	}
+	if (args.outdir) {
+		args.outdir = resolvePath(args.outdir);
+	}
+	if (args.outfile) {
+		args.outfile = resolvePath(args.outfile);
+	}
+
+	const { nodeCompat: legacyNodeCompat, ...argsExceptNodeCompat } = args;
+	if (legacyNodeCompat) {
+		console.warn(
+			"Enabling Node.js compatibility mode for builtins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
+		);
+	}
+	const nodejsCompat = !!args.compatibilityFlags?.includes("nodejs_compat");
+	if (legacyNodeCompat && nodejsCompat) {
+		throw new Error(
+			"The `nodejs_compat` compatibility flag cannot be used in conjunction with the legacy `--node-compat` flag. If you want to use the Workers runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command."
+		);
+	}
+
+	return {
+		...argsExceptNodeCompat,
+		nodejsCompat,
+		legacyNodeCompat,
+	} as ValidatedArgs;
 };

--- a/packages/wrangler/src/pages/buildFunctions.ts
+++ b/packages/wrangler/src/pages/buildFunctions.ts
@@ -1,6 +1,7 @@
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { FatalError } from "../errors";
 import { toUrlPath } from "../paths";
 import { FunctionsNoRoutesError } from "./errors";
 import { buildPlugin } from "./functions/buildPlugin";
@@ -20,6 +21,7 @@ import type { Config } from "./functions/routes";
 
 export async function buildFunctions({
 	outfile,
+	outdir,
 	outputConfigPath,
 	functionsDirectory,
 	minify = false,
@@ -37,6 +39,8 @@ export async function buildFunctions({
 }: Partial<
 	Pick<
 		PagesBuildArgs,
+		| "outfile"
+		| "outdir"
 		| "outputConfigPath"
 		| "minify"
 		| "sourcemap"
@@ -48,7 +52,6 @@ export async function buildFunctions({
 > & {
 	functionsDirectory: string;
 	onEnd?: () => void;
-	outfile: Required<PagesBuildArgs>["outfile"];
 	routesOutputPath?: PagesBuildArgs["outputRoutesPath"];
 	local: boolean;
 	d1Databases?: string[];
@@ -95,9 +98,16 @@ export async function buildFunctions({
 	let bundle: BundleResult;
 
 	if (plugin) {
+		if (outdir === undefined) {
+			throw new FatalError(
+				"Must specify an output directory when building a Plugin.",
+				1
+			);
+		}
+
 		bundle = await buildPlugin({
 			routesModule,
-			outfile,
+			outdir,
 			minify,
 			sourcemap,
 			watch,
@@ -105,12 +115,12 @@ export async function buildFunctions({
 			functionsDirectory: absoluteFunctionsDirectory,
 			local,
 			betaD1Shims: d1Databases,
-			onEnd,
 		});
 	} else {
 		bundle = await buildWorker({
 			routesModule,
 			outfile,
+			outdir,
 			minify,
 			sourcemap,
 			fallbackService,

--- a/packages/wrangler/src/pages/buildFunctions.ts
+++ b/packages/wrangler/src/pages/buildFunctions.ts
@@ -34,7 +34,6 @@ export async function buildFunctions({
 	nodejsCompat,
 	local,
 	d1Databases,
-	experimentalWorkerBundle = false,
 }: Partial<
 	Pick<
 		PagesBuildArgs,
@@ -53,7 +52,6 @@ export async function buildFunctions({
 	routesOutputPath?: PagesBuildArgs["outputRoutesPath"];
 	local: boolean;
 	d1Databases?: string[];
-	experimentalWorkerBundle?: boolean;
 	legacyNodeCompat?: boolean;
 	nodejsCompat?: boolean;
 }) {
@@ -124,7 +122,6 @@ export async function buildFunctions({
 			buildOutputDirectory,
 			legacyNodeCompat,
 			nodejsCompat,
-			experimentalWorkerBundle,
 		});
 	}
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -89,13 +89,6 @@ export function Options(yargs: CommonYargsArgv) {
 				default: true,
 				description: "Whether to run bundling on `_worker.js`",
 			},
-			"experimental-worker-bundle": {
-				type: "boolean",
-				default: false,
-				hidden: true,
-				description:
-					"Whether to process non-JS module imports or not, such as wasm/text/binary, when we run bundling on `functions` or `_worker.js`",
-			},
 			binding: {
 				type: "array",
 				description: "Bind variable/secret (KEY=VALUE)",
@@ -181,7 +174,6 @@ export const Handler = async ({
 	proxy: requestedProxyPort,
 	bundle,
 	noBundle,
-	experimentalWorkerBundle,
 	scriptPath: singleWorkerScriptPath,
 	binding: bindings = [],
 	kv: kvs = [],
@@ -280,7 +272,7 @@ export const Handler = async ({
 
 		// TODO: Here lies a known bug. If you specify both `--bundle` and `--no-bundle`, this behavior is undefined and you will get unexpected results.
 		// There is no sane way to get the true value out of yargs, so here we are.
-		const enableBundling = (bundle ?? !noBundle) || experimentalWorkerBundle;
+		const enableBundling = bundle ?? !noBundle;
 		if (enableBundling) {
 			// We want to actually run the `_worker.js` script through the bundler
 			// So update the final path to the script that will be uploaded and
@@ -297,7 +289,6 @@ export const Handler = async ({
 						sourcemap: true,
 						watch: true,
 						onEnd: () => scriptReadyResolve(),
-						experimentalWorkerBundle,
 					});
 				} catch (e: unknown) {
 					logger.warn("Failed to bundle _worker.js.", e);
@@ -343,7 +334,6 @@ export const Handler = async ({
 					legacyNodeCompat,
 					nodejsCompat,
 					local: true,
-					experimentalWorkerBundle,
 				});
 				await metrics.sendMetricsEvent("build pages functions");
 			};

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -86,7 +86,7 @@ export function Options(yargs: CommonYargsArgv) {
 			},
 			"no-bundle": {
 				type: "boolean",
-				default: true,
+				default: false,
 				description: "Whether to run bundling on `_worker.js`",
 			},
 			binding: {

--- a/packages/wrangler/src/pages/errors.ts
+++ b/packages/wrangler/src/pages/errors.ts
@@ -9,6 +9,7 @@ import { RoutesValidationError } from "./functions/routes-validation";
  * Exit code for `pages functions build` when no routes are found.
  */
 export const EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR = 156;
+export const EXIT_CODE_FUNCTIONS_NOTHING_TO_BUILD_ERROR = 157;
 
 /**
  * Pages error when no routes are found in the functions directory

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -92,7 +92,7 @@ export function buildPlugin({
 							const outdir = dirname(pluginBuild.initialOptions.outfile);
 
 							pluginBuild.onResolve(
-								{ filter: /.*\.(wasm|bin)/ },
+								{ filter: /.*\.(wasm|bin)$/ },
 								async (args) => {
 									return {
 										external: true,

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -101,7 +101,7 @@ export function buildPlugin({
 				},
 			],
 			serveAssetsFromWorker: false,
-			disableModuleCollection: true,
+			disableModuleCollection: false,
 			rules: [],
 			checkFetch: local,
 			targetConsumer: local ? "dev" : "publish",

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -1,5 +1,5 @@
 import { access, lstat } from "node:fs/promises";
-import { dirname, relative, resolve } from "node:path";
+import { relative, resolve } from "node:path";
 import { bundleWorker } from "../../bundle";
 import { getBasePath } from "../../paths";
 import { D1_BETA_PREFIX } from "../../worker";
@@ -8,12 +8,12 @@ import type { Options as WorkerOptions } from "./buildWorker";
 
 type Options = Omit<
 	WorkerOptions,
-	"fallbackService" | "buildOutputDirectory" | "nodejsCompat"
->;
+	"outfile" | "fallbackService" | "buildOutputDirectory" | "nodejsCompat"
+> & { outdir: string };
 
 export function buildPlugin({
 	routesModule,
-	outfile = "bundle.js",
+	outdir,
 	minify = false,
 	sourcemap = false,
 	watch = false,
@@ -29,9 +29,10 @@ export function buildPlugin({
 			directory: functionsDirectory,
 			format: "modules",
 		},
-		resolve(outfile),
+		resolve(outdir),
 		{
 			inject: [routesModule],
+			entryName: "index",
 			minify,
 			sourcemap,
 			watch,
@@ -50,37 +51,33 @@ export function buildPlugin({
 				{
 					name: "Assets",
 					setup(pluginBuild) {
-						if (pluginBuild.initialOptions.outfile) {
-							const outdir = dirname(pluginBuild.initialOptions.outfile);
+						pluginBuild.onResolve({ filter: /^assets:/ }, async (args) => {
+							const directory = resolve(
+								args.resolveDir,
+								args.path.slice("assets:".length)
+							);
 
-							pluginBuild.onResolve({ filter: /^assets:/ }, async (args) => {
-								const directory = resolve(
-									args.resolveDir,
-									args.path.slice("assets:".length)
-								);
+							const exists = await access(directory)
+								.then(() => true)
+								.catch(() => false);
 
-								const exists = await access(directory)
-									.then(() => true)
-									.catch(() => false);
+							const isDirectory =
+								exists && (await lstat(directory)).isDirectory();
 
-								const isDirectory =
-									exists && (await lstat(directory)).isDirectory();
+							if (!isDirectory) {
+								return {
+									errors: [
+										{
+											text: `'${directory}' does not exist or is not a directory.`,
+										},
+									],
+								};
+							}
 
-								if (!isDirectory) {
-									return {
-										errors: [
-											{
-												text: `'${directory}' does not exist or is not a directory.`,
-											},
-										],
-									};
-								}
+							const path = `assets:./${relative(outdir, directory)}`;
 
-								const path = `assets:./${relative(outdir, directory)}`;
-
-								return { path, external: true, namespace: "assets" };
-							});
-						}
+							return { path, external: true, namespace: "assets" };
+						});
 					},
 				},
 				// TODO: Replace this with a proper outdir solution for Plugins
@@ -88,26 +85,21 @@ export function buildPlugin({
 				{
 					name: "Mark externals",
 					setup(pluginBuild) {
-						if (pluginBuild.initialOptions.outfile) {
-							const outdir = dirname(pluginBuild.initialOptions.outfile);
-
-							pluginBuild.onResolve(
-								{ filter: /.*\.(wasm|bin)$/ },
-								async (args) => {
-									return {
-										external: true,
-										path: `./${relative(
-											outdir,
-											resolve(args.resolveDir, args.path)
-										)}`,
-									};
-								}
-							);
-						}
+						pluginBuild.onResolve(
+							{ filter: /.*\.(wasm|bin)$/ },
+							async (args) => {
+								return {
+									external: true,
+									path: `./${relative(
+										outdir,
+										resolve(args.resolveDir, args.path)
+									)}`,
+								};
+							}
+						);
 					},
 				},
 			],
-			isOutfile: true,
 			serveAssetsFromWorker: false,
 			disableModuleCollection: true,
 			rules: [],

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -83,6 +83,29 @@ export function buildPlugin({
 						}
 					},
 				},
+				// TODO: Replace this with a proper outdir solution for Plugins
+				// But for now, let's just mark all wasm/bin files as external
+				{
+					name: "Mark externals",
+					setup(pluginBuild) {
+						if (pluginBuild.initialOptions.outfile) {
+							const outdir = dirname(pluginBuild.initialOptions.outfile);
+
+							pluginBuild.onResolve(
+								{ filter: /.*\.(wasm|bin)/ },
+								async (args) => {
+									return {
+										external: true,
+										path: `./${relative(
+											outdir,
+											resolve(args.resolveDir, args.path)
+										)}`,
+									};
+								}
+							);
+						}
+					},
+				},
 			],
 			isOutfile: true,
 			serveAssetsFromWorker: false,

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -63,7 +63,7 @@ export function Options(yargs: CommonYargsArgv) {
 			},
 			"no-bundle": {
 				type: "boolean",
-				default: true,
+				default: false,
 				description: "Whether to run bundling on `_worker.js` before deploying",
 			},
 			config: {

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -66,13 +66,6 @@ export function Options(yargs: CommonYargsArgv) {
 				default: true,
 				description: "Whether to run bundling on `_worker.js` before deploying",
 			},
-			"experimental-worker-bundle": {
-				type: "boolean",
-				default: false,
-				hidden: true,
-				description:
-					"Whether to process non-JS module imports or not, such as wasm/text/binary, when we run bundling on `functions` or `_worker.js`",
-			},
 			config: {
 				describe: "Pages does not support wrangler.toml",
 				type: "string",
@@ -92,7 +85,6 @@ export const Handler = async ({
 	skipCaching,
 	bundle,
 	noBundle,
-	experimentalWorkerBundle,
 	config: wranglerConfig,
 }: PublishArgs) => {
 	if (wranglerConfig) {
@@ -261,7 +253,6 @@ export const Handler = async ({
 		// TODO: Here lies a known bug. If you specify both `--bundle` and `--no-bundle`, this behavior is undefined and you will get unexpected results.
 		// There is no sane way to get the true value out of yargs, so here we are.
 		bundle: bundle ?? !noBundle,
-		experimentalWorkerBundle,
 	});
 
 	saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {


### PR DESCRIPTION
What this PR solves / how to test:

This does two big things (and one little one):

- It removes the `--experimental-worker-bundle` option from Pages Functions. We now just always do this. It was temporarily added for us to test the new `_worker.bundle` upload format.
- It enables `--bundle` by default in `pages dev` and `pages publish`. This means that you're able to use Wasm etc. in `_worker.js` projects.
- Finally, it marks `.wasm` and `.bin` files as external when building a Plugin. We already do this with `assets:`, so there's prior art here, but this is ultimately only a stop-gap until we change the output format to an `--outdir` rather than an `--outfile` for Plugins. We'll follow up soon-ish with that.

Associated docs issues/PR:

- https://github.com/cloudflare/cloudflare-docs/pull/7886/files

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
