### PR TITLE
chore: upgrade to `@miniflare/tre@3.0.0-next.12`

### DIFF
--- a/.changeset/grumpy-pillows-cheat.md
+++ b/.changeset/grumpy-pillows-cheat.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+chore: upgrade `@miniflare/tre` to [`3.0.0-next.12`](https://github.com/cloudflare/miniflare/releases/tag/v3.0.0-next.12), incorporating changes from [`3.0.0-next.11`](https://github.com/cloudflare/miniflare/releases/tag/v3.0.0-next.11)
+
+Notably, this brings the following improvements to `wrangler dev --experimental-local`:
+
+- Adds support for Durable Objects and D1
+- Fixes an issue blocking clean exits and script reloads
+- Bumps to `better-sqlite3@8`, allowing installation on Node 19

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,31 +51,35 @@
 		},
 		"../miniflare3/packages/tre": {
 			"name": "@miniflare/tre",
-			"version": "3.0.0-next.3",
+			"version": "3.0.0-next.12",
 			"extraneous": true,
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^7.6.2",
+				"better-sqlite3": "^8.1.0",
 				"capnp-ts": "^0.7.0",
 				"exit-hook": "^2.2.1",
 				"get-port": "^5.1.1",
 				"glob-to-regexp": "^0.4.1",
 				"http-cache-semantics": "^4.1.0",
 				"kleur": "^4.1.5",
+				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
-				"undici": "^5.10.0",
-				"workerd": "^1.20221111.4",
+				"undici": "^5.13.0",
+				"workerd": "^1.20230221.0",
 				"ws": "^8.11.0",
+				"youch": "^3.2.2",
 				"zod": "^3.18.0"
 			},
 			"devDependencies": {
+				"@cloudflare/workers-types": "^4.20221111.1",
 				"@types/better-sqlite3": "^7.6.2",
 				"@types/debug": "^4.1.7",
 				"@types/estree": "^1.0.0",
 				"@types/glob-to-regexp": "^0.4.1",
 				"@types/http-cache-semantics": "^4.0.1",
+				"@types/source-map-support": "^0.5.6",
 				"@types/stoppable": "^1.1.1",
 				"@types/ws": "^8.5.3"
 			},
@@ -4218,9 +4222,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20221111.5.tgz",
-			"integrity": "sha512-Jl8uYpmpS1EO16JZEhCEemY5e1gHH2QxKP25HF6aoxvTwYytuTpjebMV7tAfdhe8U82tPnv57Or7mIdbXD7MAA==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230221.0.tgz",
+			"integrity": "sha512-8yBpFqSO7Rw/Z/c/zmlO5KoGZDJ5ar8KH8xXyPMxUN6hqpKv9tg7tTJCi6rjRhSneonprKBtnnSShCUNeY4sMw==",
 			"cpu": [
 				"x64"
 			],
@@ -4234,9 +4238,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20221111.5.tgz",
-			"integrity": "sha512-Zw/acmQvd5QPHI5q1+TdiPCHgkp0+sVCGChqVZfZfS+S1HJTwDDAGrugGPZqcYmUehVTYTLx5x8iVnFPFBQ4bw==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230221.0.tgz",
+			"integrity": "sha512-+Q/SFBqvMZOkC3McxaQkZENSFeQIwodIzMcy8uoa8nOLLBqCg2POmg9drTZBH51gzxCsgTeXi5dxxJl3yZdLkg==",
 			"cpu": [
 				"arm64"
 			],
@@ -4250,9 +4254,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20221111.5.tgz",
-			"integrity": "sha512-PRLYM2nsSyeNzxqOkByq7H4f3CtnA6PfivG8180OsCAiLfR1nmk9l4E6lYGBwmivL/R7cWu2y3a+hJUaFEdmqw==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230221.0.tgz",
+			"integrity": "sha512-9kR/PFdcudzyOwXpnC2LAXXwfsbby2YIPVzRQESGqXjWxls34dh4BlOgVTzccKPIDCg3luGgOj2x6fKbp8jbNw==",
 			"cpu": [
 				"x64"
 			],
@@ -4267,9 +4271,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20221111.5.tgz",
-			"integrity": "sha512-21IZ44ZnW6PvE6oT/UWstHazAF0nZOiprsbxu0NHnrLgsdSjSsKt7nWfLr/R/6DzKcYYdnQs8btgvKIvI8kChQ==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230221.0.tgz",
+			"integrity": "sha512-HiGpjTdxFC+ZzLd7M3adgegqvljePuctdP7GDmGLBul3N3w5kfyy1j+vDw5Xq/FEvqLc7jhdS4S7/8eMfU2P+w==",
 			"cpu": [
 				"arm64"
 			],
@@ -7050,14 +7054,14 @@
 			}
 		},
 		"node_modules/@miniflare/tre": {
-			"version": "3.0.0-next.10",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.10.tgz",
-			"integrity": "sha512-zwuUzucjlYThqZd8jCBhZP6OvKHWLrpuhAhUsgVUcWutQ6VKPwzzgIArCgErmqaydLehWKCyyMqKRa2cwJ4Evw==",
+			"version": "3.0.0-next.12",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.12.tgz",
+			"integrity": "sha512-jhlWVgsRjtlVY0y7TUaWOUKOaSehFUzPBwjAKNglJrbkfe118PKt39TjGsWq4D/zLX0vTCDAdrnf6Y7LgfCd8A==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^7.6.2",
+				"better-sqlite3": "^8.1.0",
 				"capnp-ts": "^0.7.0",
 				"exit-hook": "^2.2.1",
 				"get-port": "^5.1.1",
@@ -7067,13 +7071,24 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "^1.20221111.5",
+				"workerd": "^1.20230221.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.18.0"
 			},
 			"engines": {
 				"node": ">=16.13"
+			}
+		},
+		"node_modules/@miniflare/tre/node_modules/better-sqlite3": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.1.0.tgz",
+			"integrity": "sha512-p1m09H+Oi8R9TPj810pdNswMFuVgRNgCJEWypp6jlkOgSwMIrNyuj3hW78xEuBRGok5RzeaUW8aBtTWF3l/TQA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"prebuild-install": "^7.1.0"
 			}
 		},
 		"node_modules/@miniflare/tre/node_modules/cookie": {
@@ -7098,16 +7113,16 @@
 			}
 		},
 		"node_modules/@miniflare/tre/node_modules/ws": {
-			"version": "8.11.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+			"integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
+				"utf-8-validate": ">=5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -7119,9 +7134,9 @@
 			}
 		},
 		"node_modules/@miniflare/tre/node_modules/youch": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.2.tgz",
-			"integrity": "sha512-+xhTK8sY9qV3nLbWVaOUFZPdlQ3wrMKiu3dKqKkAkLaYzzkYmpWY+v+eQIAfbPu7TZhS1G5FhEV++sl8fhuT4w==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
+			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
 			"dev": true,
 			"dependencies": {
 				"cookie": "^0.5.0",
@@ -12187,9 +12202,9 @@
 			}
 		},
 		"node_modules/capnp-ts/node_modules/tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
 			"dev": true
 		},
 		"node_modules/capture-exit": {
@@ -43697,9 +43712,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20221111.5.tgz",
-			"integrity": "sha512-cZVjhFaCYrNogLy52H20O2Y1Ld8orPRM5bt9fKCAwoGI0I2SZinPvcKb0QeK+EKrfQeWNcrd2MnEjP4sUDiWhA==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230221.0.tgz",
+			"integrity": "sha512-YMwTskgRys9xn/zZXAOd7vTjbnr/obh2rU7blIO+JY+LY5uZuH2AGi0chIXo7lGfLNlQ8HZqtFfurRzBhKbSHg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -43709,10 +43724,10 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20221111.5",
-				"@cloudflare/workerd-darwin-arm64": "1.20221111.5",
-				"@cloudflare/workerd-linux-64": "1.20221111.5",
-				"@cloudflare/workerd-linux-arm64": "1.20221111.5"
+				"@cloudflare/workerd-darwin-64": "1.20230221.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20230221.0",
+				"@cloudflare/workerd-linux-64": "1.20230221.0",
+				"@cloudflare/workerd-linux-arm64": "1.20230221.0"
 			}
 		},
 		"node_modules/workers-analytics-engine-template": {
@@ -44312,9 +44327,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.19.1",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
-			"integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+			"version": "3.20.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+			"integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
@@ -44782,7 +44797,7 @@
 				"@cloudflare/workers-types": "^4.20221111.1",
 				"@iarna/toml": "^3.0.0",
 				"@microsoft/api-extractor": "^7.28.3",
-				"@miniflare/tre": "^3.0.0-next.10",
+				"@miniflare/tre": "3.0.0-next.12",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",
@@ -58018,30 +58033,30 @@
 			}
 		},
 		"@cloudflare/workerd-darwin-64": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20221111.5.tgz",
-			"integrity": "sha512-Jl8uYpmpS1EO16JZEhCEemY5e1gHH2QxKP25HF6aoxvTwYytuTpjebMV7tAfdhe8U82tPnv57Or7mIdbXD7MAA==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230221.0.tgz",
+			"integrity": "sha512-8yBpFqSO7Rw/Z/c/zmlO5KoGZDJ5ar8KH8xXyPMxUN6hqpKv9tg7tTJCi6rjRhSneonprKBtnnSShCUNeY4sMw==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20221111.5.tgz",
-			"integrity": "sha512-Zw/acmQvd5QPHI5q1+TdiPCHgkp0+sVCGChqVZfZfS+S1HJTwDDAGrugGPZqcYmUehVTYTLx5x8iVnFPFBQ4bw==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230221.0.tgz",
+			"integrity": "sha512-+Q/SFBqvMZOkC3McxaQkZENSFeQIwodIzMcy8uoa8nOLLBqCg2POmg9drTZBH51gzxCsgTeXi5dxxJl3yZdLkg==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-64": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20221111.5.tgz",
-			"integrity": "sha512-PRLYM2nsSyeNzxqOkByq7H4f3CtnA6PfivG8180OsCAiLfR1nmk9l4E6lYGBwmivL/R7cWu2y3a+hJUaFEdmqw==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230221.0.tgz",
+			"integrity": "sha512-9kR/PFdcudzyOwXpnC2LAXXwfsbby2YIPVzRQESGqXjWxls34dh4BlOgVTzccKPIDCg3luGgOj2x6fKbp8jbNw==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-arm64": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20221111.5.tgz",
-			"integrity": "sha512-21IZ44ZnW6PvE6oT/UWstHazAF0nZOiprsbxu0NHnrLgsdSjSsKt7nWfLr/R/6DzKcYYdnQs8btgvKIvI8kChQ==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230221.0.tgz",
+			"integrity": "sha512-HiGpjTdxFC+ZzLd7M3adgegqvljePuctdP7GDmGLBul3N3w5kfyy1j+vDw5Xq/FEvqLc7jhdS4S7/8eMfU2P+w==",
 			"dev": true,
 			"optional": true
 		},
@@ -59812,14 +59827,14 @@
 			}
 		},
 		"@miniflare/tre": {
-			"version": "3.0.0-next.10",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.10.tgz",
-			"integrity": "sha512-zwuUzucjlYThqZd8jCBhZP6OvKHWLrpuhAhUsgVUcWutQ6VKPwzzgIArCgErmqaydLehWKCyyMqKRa2cwJ4Evw==",
+			"version": "3.0.0-next.12",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.12.tgz",
+			"integrity": "sha512-jhlWVgsRjtlVY0y7TUaWOUKOaSehFUzPBwjAKNglJrbkfe118PKt39TjGsWq4D/zLX0vTCDAdrnf6Y7LgfCd8A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^7.6.2",
+				"better-sqlite3": "^8.1.0",
 				"capnp-ts": "^0.7.0",
 				"exit-hook": "^2.2.1",
 				"get-port": "^5.1.1",
@@ -59829,12 +59844,22 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "^1.20221111.5",
+				"workerd": "^1.20230221.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.18.0"
 			},
 			"dependencies": {
+				"better-sqlite3": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.1.0.tgz",
+					"integrity": "sha512-p1m09H+Oi8R9TPj810pdNswMFuVgRNgCJEWypp6jlkOgSwMIrNyuj3hW78xEuBRGok5RzeaUW8aBtTWF3l/TQA==",
+					"dev": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"prebuild-install": "^7.1.0"
+					}
+				},
 				"cookie": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
@@ -59848,16 +59873,16 @@
 					"dev": true
 				},
 				"ws": {
-					"version": "8.11.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-					"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+					"version": "8.12.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+					"integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
 					"dev": true,
 					"requires": {}
 				},
 				"youch": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.2.tgz",
-					"integrity": "sha512-+xhTK8sY9qV3nLbWVaOUFZPdlQ3wrMKiu3dKqKkAkLaYzzkYmpWY+v+eQIAfbPu7TZhS1G5FhEV++sl8fhuT4w==",
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
+					"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
 					"dev": true,
 					"requires": {
 						"cookie": "^0.5.0",
@@ -63677,9 +63702,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
 					"dev": true
 				}
 			}
@@ -91935,15 +91960,15 @@
 			}
 		},
 		"workerd": {
-			"version": "1.20221111.5",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20221111.5.tgz",
-			"integrity": "sha512-cZVjhFaCYrNogLy52H20O2Y1Ld8orPRM5bt9fKCAwoGI0I2SZinPvcKb0QeK+EKrfQeWNcrd2MnEjP4sUDiWhA==",
+			"version": "1.20230221.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230221.0.tgz",
+			"integrity": "sha512-YMwTskgRys9xn/zZXAOd7vTjbnr/obh2rU7blIO+JY+LY5uZuH2AGi0chIXo7lGfLNlQ8HZqtFfurRzBhKbSHg==",
 			"dev": true,
 			"requires": {
-				"@cloudflare/workerd-darwin-64": "1.20221111.5",
-				"@cloudflare/workerd-darwin-arm64": "1.20221111.5",
-				"@cloudflare/workerd-linux-64": "1.20221111.5",
-				"@cloudflare/workerd-linux-arm64": "1.20221111.5"
+				"@cloudflare/workerd-darwin-64": "1.20230221.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20230221.0",
+				"@cloudflare/workerd-linux-64": "1.20230221.0",
+				"@cloudflare/workerd-linux-arm64": "1.20230221.0"
 			}
 		},
 		"workers-analytics-engine-template": {
@@ -92164,7 +92189,7 @@
 				"@miniflare/core": "2.12.1",
 				"@miniflare/d1": "2.12.1",
 				"@miniflare/durable-objects": "2.12.1",
-				"@miniflare/tre": "^3.0.0-next.10",
+				"@miniflare/tre": "3.0.0-next.12",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",
@@ -93409,9 +93434,9 @@
 			}
 		},
 		"zod": {
-			"version": "3.19.1",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
-			"integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+			"version": "3.20.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+			"integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
 			"dev": true
 		},
 		"zwitch": {

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -118,7 +118,7 @@
 		"@cloudflare/workers-types": "^4.20221111.1",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
-		"@miniflare/tre": "^3.0.0-next.10",
+		"@miniflare/tre": "3.0.0-next.12",
 		"@types/better-sqlite3": "^7.6.0",
 		"@types/busboy": "^1.5.0",
 		"@types/command-exists": "^1.2.0",

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -288,7 +288,7 @@ export async function bundleWorker(
 					currentEntry,
 					tmpDir.path,
 					betaD1Shims,
-					local,
+					local && !experimentalLocal,
 					doBindings
 				);
 			}),
@@ -816,7 +816,7 @@ async function applyD1BetaFacade(
 	entry: Entry,
 	tmpDirPath: string,
 	betaD1Shims: string[],
-	local: boolean,
+	miniflare2: boolean,
 	doBindings: DurableObjectBindings
 ): Promise<Entry> {
 	let entrypointPath = path.resolve(
@@ -867,7 +867,7 @@ async function applyD1BetaFacade(
 		],
 		define: {
 			__D1_IMPORTS__: JSON.stringify(betaD1Shims),
-			__LOCAL_MODE__: JSON.stringify(local),
+			__LOCAL_MODE__: JSON.stringify(miniflare2),
 		},
 		outfile: targetPath,
 	});

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -231,6 +231,7 @@ function useLocalWorker({
 					enablePagesAssetsServiceBinding,
 					kvNamespaces: bindings?.kv_namespaces,
 					r2Buckets: bindings?.r2_buckets,
+					d1Databases: bindings?.d1_databases,
 					authenticatedAccountId: accountId,
 					kvRemote: experimentalLocalRemoteKv,
 					inspectorPort: runtimeInspectorPort,
@@ -776,6 +777,7 @@ export interface SetupMiniflare3Options {
 	// we need actual namespace IDs to connect to.
 	kvNamespaces: CfKvNamespace[] | undefined;
 	r2Buckets: CfR2Bucket[] | undefined;
+	d1Databases: CfD1Database[] | undefined;
 
 	// Account ID to use for authenticated Cloudflare fetch. If true, prompt
 	// user for ID if multiple available.
@@ -809,6 +811,7 @@ export async function transformMf2OptionsToMf3Options({
 	enablePagesAssetsServiceBinding,
 	kvNamespaces,
 	r2Buckets,
+	d1Databases,
 	authenticatedAccountId,
 	kvRemote,
 	inspectorPort,
@@ -835,6 +838,12 @@ export async function transformMf2OptionsToMf3Options({
 		),
 		r2Buckets: Object.fromEntries(
 			r2Buckets?.map(({ binding, bucket_name }) => [binding, bucket_name]) ?? []
+		),
+		d1Databases: Object.fromEntries(
+			d1Databases?.map(({ binding, database_id, preview_database_id }) => [
+				binding,
+				preview_database_id ?? database_id,
+			]) ?? []
 		),
 		inspectorPort,
 		verbose: true,
@@ -918,5 +927,5 @@ export async function getMiniflare3(): Promise<
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 	typeof import("@miniflare/tre")
 > {
-	return (miniflare3Module ??= await npxImport("@miniflare/tre@3.0.0-next.10"));
+	return (miniflare3Module ??= await npxImport("@miniflare/tre@3.0.0-next.12"));
 }

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -416,6 +416,7 @@ export async function startLocalServer({
 				log,
 				kvNamespaces: bindings?.kv_namespaces,
 				r2Buckets: bindings?.r2_buckets,
+				d1Databases: bindings?.d1_databases,
 				authenticatedAccountId: accountId,
 				kvRemote: experimentalLocalRemoteKv,
 				inspectorPort,

--- a/packages/wrangler/templates/d1-beta-facade.js
+++ b/packages/wrangler/templates/d1-beta-facade.js
@@ -11,7 +11,7 @@ var D1Database = class {
 		return new D1PreparedStatement(this, query);
 	}
 	async dump() {
-		const response = await this.binding.fetch("/dump", {
+		const response = await this.binding.fetch("http://d1/dump", {
 			method: "POST",
 			headers: {
 				"content-type": "application/json",
@@ -79,7 +79,7 @@ var D1Database = class {
 						params,
 				  }
 		);
-		const response = await this.binding.fetch(endpoint, {
+		const response = await this.binding.fetch(new URL(endpoint, "http://d1"), {
 			method: "POST",
 			headers: {
 				"content-type": "application/json",

--- a/packages/wrangler/templates/middleware/middleware-miniflare3-json-error.ts
+++ b/packages/wrangler/templates/middleware/middleware-miniflare3-json-error.ts
@@ -1,15 +1,27 @@
 import type { Middleware } from "./common";
 
+interface JsonError {
+	message?: string;
+	name?: string;
+	stack?: string;
+	cause?: JsonError;
+}
+
+function reduceError(e: any): JsonError {
+	return {
+		name: e?.name,
+		message: e?.message ?? String(e),
+		stack: e?.stack,
+		cause: e?.cause === undefined ? undefined : reduceError(e.cause),
+	};
+}
+
 // See comment in `bundle.ts` for details on why this is needed
 const jsonError: Middleware = async (request, env, _ctx, middlewareCtx) => {
 	try {
 		return await middlewareCtx.next(request, env);
 	} catch (e: any) {
-		const error = {
-			name: e?.name,
-			message: e?.message ?? String(e),
-			stack: e?.stack,
-		};
+		const error = reduceError(e);
 		return Response.json(error, {
 			status: 500,
 			headers: { "MF-Experimental-Error-Stack": "true" },


### PR DESCRIPTION
#### What this PR solves / how to test:

This PR upgrades `@miniflare/tre` (Miniflare 3) to [`3.0.0-next.12`](https://github.com/cloudflare/miniflare/releases/tag/v3.0.0-next.12), incorporating changes from [`3.0.0-next.11`](https://github.com/cloudflare/miniflare/releases/tag/v3.0.0-next.11).

Notably, this brings the following improvements to `wrangler dev --experimental-local`:

- **Adds support for Durable Objects:** technically `workerd`/Miniflare 3 already supported Durable Objects, but Miniflare 3 didn't implement the `durableObjectsPersist` option required by Wrangler (#2403, #2458)
- **Adds support for D1:** this requires a few minor changes to the D1 facade, as `workerd` requires full URLs when `fetch`ing with service bindings (#2667)
- **Fixes an issue blocking clean exits and script reloads:** using `SIGINT` instead of `SIGTERM` when terminating `workerd` force closes HTTP connections, see cloudflare/workerd#244
- **Bumps to `better-sqlite3@8`:** allows installation on Node 19 (#2318)

#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [ ] ~~Tests~~ (passing existing tests)
- [x] Changeset

#### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #2318
Fixes #2403
Fixes #2458
Fixes #2667
