### PR TITLE
templates(worker-rust): bump versions and fix lints

### DIFF
--- a/.changeset/mean-bananas-bake.md
+++ b/.changeset/mean-bananas-bake.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Bring `pages dev` logging in line with `dev` proper's
+
+`wrangler pages dev` now defaults to logging at the `log` level (rather than the previous `warn` level), and the `pages` prefix is removed.

--- a/.changeset/spicy-mangos-sip.md
+++ b/.changeset/spicy-mangos-sip.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix: Show correct link for how to create an API token in a non-interactive environment

--- a/.changeset/spotty-brooms-exercise.md
+++ b/.changeset/spotty-brooms-exercise.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/prerelease-registry": patch
+---
+
+feature: simple index page to prevent 522 error

--- a/packages/prerelease-registry/functions/routes/html.d.ts
+++ b/packages/prerelease-registry/functions/routes/html.d.ts
@@ -1,0 +1,4 @@
+declare module "*.html" {
+	const content: string;
+	export default content;
+}

--- a/packages/prerelease-registry/functions/routes/index.html
+++ b/packages/prerelease-registry/functions/routes/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Pre-Release Registry</title>
+		<link rel="icon" href="data:," />
+	</head>
+	<body>
+		<h1 style="text-align: center">This Page Intentionally Left Blank</h1>
+		<p style="text-align: center">
+			This site is only used for pre-releases of
+			<a href="https://github.com/cloudflare/workers-sdk">Workers-SDK</a>. You
+			should check it out!
+		</p>
+	</body>
+</html>

--- a/packages/prerelease-registry/functions/routes/index.ts
+++ b/packages/prerelease-registry/functions/routes/index.ts
@@ -1,0 +1,10 @@
+import index from "./index.html";
+
+export const onRequestGet: PagesFunction = async () => {
+	return new Response(index, {
+		headers: {
+			"Content-type": "text/html; charset=UTF-8",
+			"Cache-Control": `public, s-maxage=604800`,
+		},
+	});
+};

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -18,7 +18,7 @@ describe("execute", () => {
 		await expect(
 			runWrangler("d1 execute --command 'select 1;'")
 		).rejects.toThrowError(
-			`In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.`
+			`In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -750,6 +750,7 @@ describe("unchanged functionality when wrapping with middleware", () => {
 });
 
 describe("multiple middleware", () => {
+	runInTempDir();
 	it("should respond correctly with D1 databases, scheduled testing, and formatted dev errors", async () => {
 		// Kitchen sink test to check interaction between multiple middlewares
 		const scriptContent = `
@@ -769,7 +770,7 @@ describe("multiple middleware", () => {
 					const stmt = await env.DB.prepare("INSERT INTO test (id, value) VALUES (?, ?)");
 					await stmt.bind(1, "one").run();
 			  }
-			}	
+			}
 		`;
 		fs.writeFileSync("index.js", scriptContent);
 

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -326,7 +326,7 @@ describe("publish", () => {
 				await expect(runWrangler("publish index.js")).rejects.toThrowError();
 
 				expect(std.err).toMatchInlineSnapshot(`
-			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mIn a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mIn a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.[0m
 
 			          "
 		        `);

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -85,7 +85,7 @@ describe("User", () => {
 		await expect(
 			requireAuth({} as Config)
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."`
+			`"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."`
 		);
 	});
 

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -43,7 +43,6 @@ export interface UnstableDevOptions {
 		preview_bucket_name?: string;
 	}[];
 	logLevel?: "none" | "info" | "error" | "log" | "warn" | "debug"; // Specify logging level  [choices: "debug", "info", "log", "warn", "error", "none"] [default: "log"]
-	logPrefix?: string;
 	inspect?: boolean;
 	local?: boolean;
 	accountId?: string;

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -344,7 +344,6 @@ type StartDevOptions = DevArguments &
 		disableDevRegistry?: boolean;
 		enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
 		onReady?: (ip: string, port: number) => void;
-		logPrefix?: string;
 		showInteractiveDevSession?: boolean;
 	};
 
@@ -467,7 +466,6 @@ export async function startDev(args: StartDevOptions) {
 					bindings={bindings}
 					crons={configParam.triggers.crons}
 					queueConsumers={configParam.queues.consumers}
-					logPrefix={args.logPrefix}
 					onReady={args.onReady}
 					inspect={args.inspect ?? true}
 					showInteractiveDevSession={args.showInteractiveDevSession}
@@ -600,7 +598,6 @@ export async function startApiDev(args: StartDevOptions) {
 			bindings: bindings,
 			crons: configParam.triggers.crons,
 			queueConsumers: configParam.queues.consumers,
-			logPrefix: args.logPrefix,
 			onReady: args.onReady,
 			inspect: args.inspect ?? true,
 			showInteractiveDevSession: args.showInteractiveDevSession,

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -147,7 +147,6 @@ export type DevProps = {
 	host: string | undefined;
 	routes: Route[] | undefined;
 	inspect: boolean;
-	logPrefix?: string;
 	onReady: ((ip: string, port: number) => void) | undefined;
 	showInteractiveDevSession: boolean | undefined;
 	forceLocal: boolean | undefined;
@@ -343,7 +342,6 @@ function DevSession(props: DevSessionProps) {
 			queueConsumers={props.queueConsumers}
 			localProtocol={props.localProtocol}
 			localUpstream={props.localUpstream}
-			logPrefix={props.logPrefix}
 			inspect={props.inspect}
 			onReady={announceAndOnReady}
 			enablePagesAssetsServiceBinding={props.enablePagesAssetsServiceBinding}

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -70,7 +70,6 @@ export interface LocalProps {
 	localUpstream: string | undefined;
 	inspect: boolean;
 	onReady: ((ip: string, port: number) => void) | undefined;
-	logPrefix?: string;
 	enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
 	testScheduled?: boolean;
 	experimentalLocal: boolean | undefined;
@@ -121,7 +120,6 @@ function useLocalWorker({
 	localUpstream,
 	inspect,
 	onReady,
-	logPrefix,
 	enablePagesAssetsServiceBinding,
 	experimentalLocal,
 	accountId,
@@ -216,13 +214,12 @@ function useLocalWorker({
 				dataBlobBindings,
 				crons,
 				upstream,
-				logPrefix,
 				workerDefinitions,
 				enablePagesAssetsServiceBinding,
 			});
 
 			if (experimentalLocal) {
-				const log = await buildMiniflare3Logger(logPrefix);
+				const log = await buildMiniflare3Logger();
 				const mf3Options = await transformMf2OptionsToMf3Options({
 					miniflare2Options: options,
 					format,
@@ -438,7 +435,6 @@ function useLocalWorker({
 		localProtocol,
 		localUpstream,
 		inspect,
-		logPrefix,
 		onReady,
 		enablePagesAssetsServiceBinding,
 		experimentalLocal,
@@ -577,7 +573,6 @@ interface SetupMiniflareOptionsProps {
 	dataBlobBindings: Record<string, string>;
 	crons: Config["triggers"]["crons"];
 	upstream: string | undefined;
-	logPrefix: string | undefined;
 	workerDefinitions: WorkerRegistry | undefined;
 	enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
 }
@@ -609,7 +604,6 @@ export function setupMiniflareOptions({
 	dataBlobBindings,
 	crons,
 	upstream,
-	logPrefix,
 	workerDefinitions,
 	enablePagesAssetsServiceBinding,
 }: SetupMiniflareOptionsProps): {
@@ -722,7 +716,6 @@ export function setupMiniflareOptions({
 		crons,
 		upstream,
 		logLevel: logger.loggerLevel,
-		logOptions: logPrefix ? { prefix: logPrefix } : undefined,
 		enablePagesAssetsServiceBinding,
 	};
 	// The path to the Miniflare CLI assumes that this file is being run from
@@ -789,18 +782,14 @@ export interface SetupMiniflare3Options {
 	inspectorPort: number;
 }
 
-export async function buildMiniflare3Logger(
-	logPrefix?: string
-): Promise<Miniflare3LogType> {
+export async function buildMiniflare3Logger(): Promise<Miniflare3LogType> {
 	const { Log, NoOpLog, LogLevel } = await getMiniflare3();
 
 	let level = logger.loggerLevel.toUpperCase() as Uppercase<LoggerLevel>;
 	if (level === "LOG") level = "INFO";
 	const logLevel = LogLevel[level];
 
-	return logLevel === LogLevel.NONE
-		? new NoOpLog()
-		: new Log(logLevel, { prefix: logPrefix });
+	return logLevel === LogLevel.NONE ? new NoOpLog() : new Log(logLevel);
 }
 
 export async function transformMf2OptionsToMf3Options({

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -132,7 +132,6 @@ export async function startDevServer(
 				queueConsumers: props.queueConsumers,
 				localProtocol: props.localProtocol,
 				localUpstream: props.localUpstream,
-				logPrefix: props.logPrefix,
 				inspect: props.inspect,
 				onReady: props.onReady,
 				enablePagesAssetsServiceBinding: props.enablePagesAssetsServiceBinding,
@@ -322,7 +321,6 @@ export async function startLocalServer({
 	localUpstream,
 	inspect,
 	onReady,
-	logPrefix,
 	enablePagesAssetsServiceBinding,
 	experimentalLocal,
 	accountId,
@@ -402,13 +400,12 @@ export async function startLocalServer({
 			dataBlobBindings,
 			crons,
 			upstream,
-			logPrefix,
 			workerDefinitions,
 			enablePagesAssetsServiceBinding,
 		});
 
 		if (experimentalLocal) {
-			const log = await buildMiniflare3Logger(logPrefix);
+			const log = await buildMiniflare3Logger();
 			const mf3Options = await transformMf2OptionsToMf3Options({
 				miniflare2Options: options,
 				format,

--- a/packages/wrangler/src/miniflare-cli/index.ts
+++ b/packages/wrangler/src/miniflare-cli/index.ts
@@ -47,7 +47,7 @@ async function main() {
 	config.log =
 		logLevel === MiniflareLogLevel.NONE
 			? new MiniflareNoOpLog()
-			: new MiniflareLog(logLevel, config.logOptions);
+			: new MiniflareLog(logLevel);
 
 	if (logLevel === MiniflareLogLevel.DEBUG) {
 		console.log("MINIFLARE OPTIONS:\n", JSON.stringify(config, null, 2));

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -551,8 +551,7 @@ export const Handler = async ({
 		persist,
 		persistTo,
 		inspect: undefined,
-		logPrefix: "pages",
-		logLevel: logLevel ?? "warn",
+		logLevel,
 		experimental: {
 			d1Databases: d1s.map((binding) => ({
 				binding: binding.toString(),

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1153,7 +1153,7 @@ export async function requireAuth(config: {
 	if (!loggedIn) {
 		if (!isInteractive() || CI.isCI()) {
 			throw new Error(
-				"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."
+				"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."
 			);
 		} else {
 			// didn't login, let's just quit

--- a/templates/worker-rust/Cargo.toml
+++ b/templates/worker-rust/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-cfg-if = "0.1.2"
-worker = "0.0.11"
+cfg-if = "1.0.0"
+worker = "0.0.13"
 serde_json = "1.0.67"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/templates/worker-rust/Cargo.toml
+++ b/templates/worker-rust/Cargo.toml
@@ -11,7 +11,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 cfg-if = "1.0.0"
-worker = "0.0.13"
+worker = "0.0.14"
 serde_json = "1.0.67"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/templates/worker-rust/src/lib.rs
+++ b/templates/worker-rust/src/lib.rs
@@ -14,7 +14,7 @@ fn log_request(req: &Request) {
 }
 
 #[event(fetch)]
-pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Response> {
+pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     log_request(&req);
 
     // Optionally, get more helpful error messages written to the console in the case of a panic.
@@ -33,14 +33,14 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         .post_async("/form/:field", |mut req, ctx| async move {
             if let Some(name) = ctx.param("field") {
                 let form = req.form_data().await?;
-                match form.get(name) {
+                return match form.get(name) {
                     Some(FormEntry::Field(value)) => {
-                        return Response::from_json(&json!({ name: value }))
+                        Response::from_json(&json!({ name: value }))
                     }
                     Some(FormEntry::File(_)) => {
-                        return Response::error("`field` param in form shouldn't be a File", 422);
+                        Response::error("`field` param in form shouldn't be a File", 422)
                     }
-                    None => return Response::error("Bad Request", 400),
+                    None => Response::error("Bad Request", 400),
                 }
             }
 

--- a/templates/worker-rust/wrangler.toml
+++ b/templates/worker-rust/wrangler.toml
@@ -6,4 +6,4 @@ compatibility_date = "2022-01-20"
 WORKERS_RS_VERSION = "0.0.11"
 
 [build]
-command = "cargo install -q worker-build --version 0.0.7 && worker-build --release"
+command = "cargo install -q worker-build --version 0.0.9 && worker-build --release"


### PR DESCRIPTION
What this PR solves / how to test: Current `worker-rust` template doesn't work due to outdated crate versions (`worker-build`).

Also bumps other dependencies & fixes lints.

Associated docs issues/PR:

- https://github.com/cloudflare/workers-rs/issues/282
- https://github.com/cloudflare/workers-sdk/issues/2751

