### PR TITLE
[wrangler] Add better printing for complex unsafe metadata

### DIFF
--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -5578,8 +5578,8 @@ addEventListener('fetch', event => {});`
 			  - WASM_MODULE_ONE: some_wasm.wasm
 			  - WASM_MODULE_TWO: more_wasm.wasm
 			- Unsafe Metadata:
-			  - extra_data: interesting value
-			  - more_data: dubious value
+			  - extra_data: \\"interesting value\\"
+			  - more_data: \\"dubious value\\"
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -6963,6 +6963,46 @@ addEventListener('fetch', event => {});`
 
 		describe("[unsafe]", () => {
 			describe("[unsafe.bindings]", () => {
+				it("should stringify object in unsafe metadata", async () => {
+					writeWranglerToml({
+						unsafe: {
+							metadata: {
+								stringify: true,
+								something: "else",
+								undefined: undefined,
+								null: null,
+								nested: {
+									stuff: "here",
+								},
+							},
+						},
+					});
+					writeWorkerSource();
+					mockSubDomainRequest();
+					mockUploadWorkerRequest({
+						expectedUnsafeMetaData: {
+							stringify: true,
+							something: "else",
+							nested: {
+								stuff: "here",
+							},
+						},
+					});
+					await runWrangler("deploy index.js");
+					expect(std.out).toMatchInlineSnapshot(`
+				"Total Upload: xx KiB / gzip: xx KiB
+				Your worker has access to the following bindings:
+				- Unsafe Metadata:
+				  - stringify: true
+				  - something: \\"else\\"
+				  - nested: {\\"stuff\\":\\"here\\"}
+				Uploaded test-name (TIMINGS)
+				Published test-name (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Deployment ID: Galaxy-Class"
+			`);
+				});
+
 				it("should warn if using unsafe bindings", async () => {
 					writeWranglerToml({
 						unsafe: {

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -22,7 +22,7 @@ export function mockUploadWorkerRequest(
 		expectedCompatibilityFlags?: string[];
 		expectedMigrations?: CfWorkerInit["migrations"];
 		expectedTailConsumers?: CfWorkerInit["tail_consumers"];
-		expectedUnsafeMetaData?: Record<string, string>;
+		expectedUnsafeMetaData?: Record<string, unknown>;
 		expectedCapnpSchema?: string;
 		expectedLimits?: CfWorkerInit["limits"];
 		env?: string;

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -606,7 +606,7 @@ interface EnvironmentNonInheritable {
 		 * here will always be applied to metadata last, so can add new or override existing fields.
 		 */
 		metadata?: {
-			[key: string]: string;
+			[key: string]: unknown;
 		};
 
 		/**

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -401,7 +401,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 			type: "Unsafe Metadata",
 			entries: Object.entries(unsafe.metadata).map(([key, value]) => ({
 				key,
-				value: `${value}`,
+				value: `${typeof value === "object" ? JSON.stringify(value) : value}`,
 			})),
 		});
 	}

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -401,7 +401,7 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 			type: "Unsafe Metadata",
 			entries: Object.entries(unsafe.metadata).map(([key, value]) => ({
 				key,
-				value: `${typeof value === "object" ? JSON.stringify(value) : value}`,
+				value: JSON.stringify(value),
 			})),
 		});
 	}


### PR DESCRIPTION
What this PR solves / how to test:

Currently the following:

```toml
[unsafe.metadata]
myprop = { something = "whatever" }
```

Will print:

```
Your worker has access to the following bindings:
- Unsafe Metadata:
  - myprop: [object Object]
```

After this PR it will print:

```
Your worker has access to the following bindings:
- Unsafe Metadata:
  - myprop: {"something": "whatever"}
```

Alternatives include:
- just `JSON.stringify` everything, including primitives
- create a more complex formatter that nests nicely, etc (not sure what unsafe bindings do here)

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [ ] Tests
- [ ] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
