### PR TITLE
fix API token guide link

### DIFF
--- a/.changeset/spicy-mangos-sip.md
+++ b/.changeset/spicy-mangos-sip.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix: Show correct link for how to create an API token in a non-interactive environment

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -18,7 +18,7 @@ describe("execute", () => {
 		await expect(
 			runWrangler("d1 execute --command 'select 1;'")
 		).rejects.toThrowError(
-			`In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.`
+			`In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -326,7 +326,7 @@ describe("publish", () => {
 				await expect(runWrangler("publish index.js")).rejects.toThrowError();
 
 				expect(std.err).toMatchInlineSnapshot(`
-			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mIn a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.[0m
+			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mIn a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.[0m
 
 			          "
 		        `);

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -85,7 +85,7 @@ describe("User", () => {
 		await expect(
 			requireAuth({} as Config)
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."`
+			`"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."`
 		);
 	});
 

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1153,7 +1153,7 @@ export async function requireAuth(config: {
 	if (!loggedIn) {
 		if (!isInteractive() || CI.isCI()) {
 			throw new Error(
-				"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/api/tokens/create/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."
+				"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN."
 			);
 		} else {
 			// didn't login, let's just quit


### PR DESCRIPTION
What this PR solves / how to test:

The previous link for Creating an API token in a non-interactive environment 404'd, and didn't show the user any useful information. This points the link to the correct one in the docs

Associated docs issues/PR:

- N/A

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested