### PR TITLE
test(wrangler): ensure that middleware test does not write to the source directory

### DIFF
--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -750,6 +750,7 @@ describe("unchanged functionality when wrapping with middleware", () => {
 });
 
 describe("multiple middleware", () => {
+	runInTempDir();
 	it("should respond correctly with D1 databases, scheduled testing, and formatted dev errors", async () => {
 		// Kitchen sink test to check interaction between multiple middlewares
 		const scriptContent = `
@@ -769,7 +770,7 @@ describe("multiple middleware", () => {
 					const stmt = await env.DB.prepare("INSERT INTO test (id, value) VALUES (?, ?)");
 					await stmt.bind(1, "one").run();
 			  }
-			}	
+			}
 		`;
 		fs.writeFileSync("index.js", scriptContent);
 


### PR DESCRIPTION
Super simple fix. Otherwise, you'll notice, that an `index.js` appears in the wrangler package every time you run tests.