### PR TITLE
Preserve entrypoint filename when building a Worker with --outdir

### DIFF
--- a/.changeset/lucky-peas-compete.md
+++ b/.changeset/lucky-peas-compete.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Preserve the entrypoint filename when running `wrangler publish --outdir <dir>`.
+
+Previously, this entrypoint filename would sometimes be overwritten with some internal filenames. It should now be based off of the entrypoint your provide for your Worker.

--- a/.changeset/lucky-peas-compete.md
+++ b/.changeset/lucky-peas-compete.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-Preserve the entrypoint filename when running `wrangler publish --outdir <dir>`.
+fix: preserve the entrypoint filename when running `wrangler publish --outdir <dir>`.
 
-Previously, this entrypoint filename would sometimes be overwritten with some internal filenames. It should now be based off of the entrypoint your provide for your Worker.
+Previously, this entrypoint filename would sometimes be overwritten with some internal filenames. It should now be based off of the entrypoint you provide for your Worker.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1649,7 +1649,7 @@ addEventListener('fetch', event => {});`
 			};
 			writeAssets(assets);
 			mockUploadWorkerRequest({
-				expectedMainModule: "serve-static-assets.entry.js",
+				expectedMainModule: "no-op-worker.js",
 			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);
@@ -1740,7 +1740,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			writeAssets(assets);
 			mockUploadWorkerRequest({
-				expectedMainModule: "serve-static-assets.entry.js",
+				expectedMainModule: "index.js",
 			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);
@@ -1925,7 +1925,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			writeAssets(assets);
 			mockUploadWorkerRequest({
-				expectedMainModule: "serve-static-assets.entry.js",
+				expectedMainModule: "index.js",
 			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);
@@ -1972,7 +1972,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			writeAssets(assets);
 			mockUploadWorkerRequest({
-				expectedMainModule: "serve-static-assets.entry.js",
+				expectedMainModule: "index.js",
 			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);
@@ -3015,7 +3015,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			writeAssets(assets, "my-assets");
 			mockUploadWorkerRequest({
-				expectedMainModule: "serve-static-assets.entry.js",
+				expectedMainModule: "index.js",
 			});
 			mockSubDomainRequest();
 			mockListKVNamespacesRequest(kvNamespace);
@@ -5846,7 +5846,7 @@ addEventListener('fetch', event => {});`
 
 			"
 		`);
-				const output = fs.readFileSync("tmp/d1-beta-facade.entry.js", "utf-8");
+				const output = fs.readFileSync("tmp/index.js", "utf-8");
 				expect(output).toContain(
 					`var ExampleDurableObject2 = maskDurableObjectDefinition(ExampleDurableObject);`
 				);
@@ -6575,6 +6575,47 @@ addEventListener('fetch', event => {});`
 			  https://test-name.test-sub-domain.workers.dev
 			Current Deployment ID: Galaxy-Class",
 			  "warn": "",
+			}
+		`);
+		});
+
+		it("should preserve the entry point file name, even when using a facade", async () => {
+			writeWranglerToml();
+			writeWorkerSource();
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+			const assets = [
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "file-2.txt", content: "Content of file-2" },
+			];
+			const kvNamespace = {
+				title: "__test-name-workers_sites_assets",
+				id: "__test-name-workers_sites_assets-id",
+			};
+			writeAssets(assets);
+			mockListKVNamespacesRequest(kvNamespace);
+			mockKeyListRequest(kvNamespace.id, []);
+			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
+			await runWrangler("publish index.js --outdir some-dir --assets assets");
+			expect(fs.existsSync("some-dir/index.js")).toBe(true);
+			expect(fs.existsSync("some-dir/index.js.map")).toBe(true);
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "out": "Reading file-1.txt...
+			Uploading as file-1.2ca234f380.txt...
+			Reading file-2.txt...
+			Uploading as file-2.5938485188.txt...
+			↗️  Done syncing assets
+			Total Upload: xx KiB / gzip: xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Deployment ID: Galaxy-Class",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+
+			",
 			}
 		`);
 		});

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -337,7 +337,7 @@ export async function bundleWorker(
 		bundle: true,
 		absWorkingDir: entry.directory,
 		outdir: destination,
-		entryNames: entryName,
+		entryNames: entryName || path.parse(entry.file).name,
 		...(isOutfile
 			? {
 					outdir: undefined,


### PR DESCRIPTION
What this PR solves / how to test:

`npx wrangler publish --dry-run --outdir dist --assets public src/foo.ts` should produce a `dist/foo.js` rather than `dist/<internal-facade-name>.js`

Associated docs issues/PR:

- Fixes #2835

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
