### PR TITLE
[wrangler] Display cause when local D1 migrations fail to apply

### DIFF
--- a/.changeset/many-pens-unite.md
+++ b/.changeset/many-pens-unite.md
@@ -1,0 +1,27 @@
+---
+"wrangler": patch
+---
+
+fix: display cause when local D1 migrations fail to apply
+
+Previously, if `wrangler d1 migrations apply --local` failed, you'd see something like:
+
+```
+❌ Migration 0000_migration.sql failed with following Errors
+┌──────────┐
+│ Error    │
+├──────────┤
+│ D1_ERROR │
+└──────────┘
+```
+
+We'll now show the SQLite error that caused the failure:
+
+```
+❌ Migration 0000_migration.sql failed with following Errors
+┌───────────────────────────────────────────────┐
+│ Error                                         │
+├───────────────────────────────────────────────┤
+│ Error: SqliteError: unknown database "public" │
+└───────────────────────────────────────────────┘
+```

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -169,10 +169,11 @@ Your database may not be available to serve requests during the migration, conti
 				}
 			} catch (e) {
 				const err = e as ParseError;
+				const maybeCause = (err.cause ?? err) as Error;
 
 				success = false;
 				errorNotes = err.notes?.map((msg) => msg.text) ?? [
-					err.message ?? err.toString(),
+					maybeCause?.message ?? maybeCause.toString(),
 				];
 			}
 


### PR DESCRIPTION
#### What this PR solves / how to test:

Previously, if `wrangler d1 migrations apply --local` failed, you'd see something like:

```
❌ Migration 0000_migration.sql failed with following Errors
┌──────────┐
│ Error    │
├──────────┤
│ D1_ERROR │
└──────────┘
```

We'll now show the SQLite error that caused the failure:

```
❌ Migration 0000_migration.sql failed with following Errors
┌───────────────────────────────────────────────┐
│ Error                                         │
├───────────────────────────────────────────────┤
│ Error: SqliteError: unknown database "public" │
└───────────────────────────────────────────────┘
```


#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [ ] ~~Tests~~ (we don't have any tests for `d1 migrations apply` yet, I did try to write some, but hit https://github.com/cloudflare/miniflare/issues/529, will get that fixed and try add some tests in another PR)
- [x] Changeset

#### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #2772
