### PR TITLE
[wrangler] Remove ambient `vitest` types from generated `tsconfig.json`s

### DIFF
--- a/.changeset/eight-eagles-juggle.md
+++ b/.changeset/eight-eagles-juggle.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+fix: remove `vitest` from `wrangler init`'s generated `tsconfig.json` `types` array
+
+Previously, `wrangler init` generated a `tsconfig.json` with `"types": ["@cloudflare/workers-types", "vitest"]`, even if Vitest tests weren't generated.
+Unlike Jest, Vitest [doesn't provide global APIs by default](https://vitest.dev/config/#globals), so there's no need for ambient types.

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -1392,7 +1392,7 @@ describe("init", () => {
 						contents: {
 							config: {
 								compilerOptions: expect.objectContaining({
-									types: ["@cloudflare/workers-types", "vitest"],
+									types: ["@cloudflare/workers-types"],
 								}),
 							},
 							error: undefined,

--- a/packages/wrangler/templates/tsconfig.init.json
+++ b/packages/wrangler/templates/tsconfig.init.json
@@ -34,8 +34,7 @@
 		// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
 		// "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
 		"types": [
-			"@cloudflare/workers-types",
-			"vitest"
+			"@cloudflare/workers-types"
 		] /* Specify type package names to be included without being referenced in a source file. */,
 		// "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
 		"resolveJsonModule": true /* Enable importing .json files */,


### PR DESCRIPTION
#### What this PR solves / how to test:

Previously, `wrangler init` generated a `tsconfig.json` with `"types": [..., "vitest"]`, even if Vitest tests weren't generated. Unlike Jest, Vitest doesn't provide global APIs by default (https://vitest.dev/config/#globals), so there's no need for ambient types. Because these ambient types don't actually exist, this was causing issues during type checking.

#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

#### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes https://github.com/cloudflare/workers-sdk/issues/2773.
