### PR TITLE
Make `WRANGLER_LOG` more lenient and fallback to `log`

### DIFF
--- a/.changeset/four-toes-lay.md
+++ b/.changeset/four-toes-lay.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: make `WRANGLER_LOG` case-insensitive, warn on unexpected values, and fallback to `log` if invalid
+
+Previously, levels set via the `WRANGLER_LOG` environment-variable were case-sensitive.
+If an unexpected level was set, Wrangler would fallback to `none`, hiding all logs.
+The fallback has now been switched to `log`, and lenient case-insensitive matching is used when setting the level.

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -26,15 +26,30 @@ const LOGGER_LEVEL_FORMAT_TYPE_MAP = {
 
 const getLogLevelFromEnv = getEnvironmentVariableFactory({
 	variableName: "WRANGLER_LOG",
-	defaultValue: () => "log",
 });
+
+function getLoggerLevel(): LoggerLevel {
+	const fromEnv = getLogLevelFromEnv()?.toLowerCase();
+	if (fromEnv !== undefined) {
+		if (fromEnv in LOGGER_LEVELS) return fromEnv as LoggerLevel;
+		const expected = Object.keys(LOGGER_LEVELS)
+			.map((level) => `"${level}"`)
+			.join(" | ");
+		console.warn(
+			`Unrecognised WRANGLER_LOG value ${JSON.stringify(
+				fromEnv
+			)}, expected ${expected}, defaulting to "log"...`
+		);
+	}
+	return "log";
+}
 
 export type TableRow<Keys extends string> = Record<Keys, string>;
 
 class Logger {
 	constructor() {}
 
-	loggerLevel: LoggerLevel = (getLogLevelFromEnv() as LoggerLevel) ?? "log";
+	loggerLevel = getLoggerLevel();
 	columns = process.stdout.columns;
 
 	debug = (...args: unknown[]) => this.doLog("debug", args);


### PR DESCRIPTION
#### What this PR solves / how to test:

Previously, levels set via the `WRANGLER_LOG` environment-variable were case-sensitive. If an unexpected level was set, Wrangler would fallback to `none`, hiding all logs. The fallback has now been switched to `log`, and lenient case-insensitive matching is used when setting the level. We now warn on unexpected levels too.

To test, try run `WRANGLER_LOG=<level> wrangler publish --dry-run`, replacing `<level>` with `DEBUG`, `unknown`, ...

#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [ ] Tests
- [x] Changeset

#### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes #2684
