### PR TITLE
Have deployment view output in table

### DIFF
--- a/.changeset/brown-wasps-fail.md
+++ b/.changeset/brown-wasps-fail.md
@@ -14,27 +14,37 @@ in a developer's local setup.
 example of `view <deployment-id>` output:
 
 ```ts
-	{
-    Tag: '',
-    Number: 0,
-    'Metadata.author_id': 'Picard-Gamma-6-0-7-3',
-    'Metadata.author_email': 'picard@vinyard.com',
-    'Metadata.source': 'wrangler',
-    'Metadata.created_on': '2021-01-01T00:00:00.000000Z',
-    'Metadata.modified_on': '2021-01-01T00:00:00.000000Z',
-    'resources.script': {
-      etag: 'mock-e-tag',
-      handlers: [ 'fetch' ],
-      last_deployed_from: 'wrangler'
-    },
-    'resources.bindings': []
+Deployment ID: 07d7143d-0284-427e-ba22-2d5e6e91b479
+Created on:    2023-03-02T21:05:15.622446Z
+Author:        jspspike@gmail.com
+Source:        Upload from Wrangler 🤠
+------------------------------------------------------------
+Author ID:          e5a3ca86e08fb0940d3a05691310bb42
+Usage Model:        bundled
+Handlers:           fetch
+Compatibility Date: 2022-10-03
+--------------------------bindings--------------------------
+[[r2_buckets]]
+binding = "MY_BUCKET"
+bucket_name = "testr2"
+
+[[kv_namespaces]]
+id = "79300c6d17eb4180a07270f450efe53f"
+binding = "yeee"
+
+---------------------------script---------------------------
+
+// index.js
+var worker_default = {
+  fetch(request) {
+    const base = "https://example.com";
+    const statusCode = 301;
+    const destination = new URL(request.url, base);
+    return Response.redirect(destination.toString(), statusCode);
   }
-
-
-
-  export default {
-    async fetch(request) {
-      return new Response('Hello World from Deployment 1701-E');
-    },
-  };
+};
+export {
+  worker_default as default
+};
+//# sourceMappingURL=index.js.map
 ```

--- a/.changeset/brown-wasps-fail.md
+++ b/.changeset/brown-wasps-fail.md
@@ -4,7 +4,7 @@
 
 feature: add `deployment view` and `deployment rollbak` subcommands
 
-`deployment view <deployment-id>` will get the details of a deployment, including versioned script, bindings, and usage model information.
+`deployment view <deployment-id>` will get the details of a deployment, including bindings and usage model information. When using the `--content` option, the command will return the script content for that deployment.
 This information can be used to help debug bad deployments or get insights on changes between deployments.
 
 `deployment rollback [deployment-id]` will rollback to a specific deployment in the runtime. This will be useful in situations like recovering from a bad
@@ -31,20 +31,4 @@ bucket_name = "testr2"
 [[kv_namespaces]]
 id = "79300c6d17eb4180a07270f450efe53f"
 binding = "yeee"
-
----------------------------script---------------------------
-
-// index.js
-var worker_default = {
-  fetch(request) {
-    const base = "https://example.com";
-    const statusCode = 301;
-    const destination = new URL(request.url, base);
-    return Response.redirect(destination.toString(), statusCode);
-  }
-};
-export {
-  worker_default as default
-};
-//# sourceMappingURL=index.js.map
 ```

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -148,8 +148,17 @@ describe("deployments", () => {
 			Usage Model:        bundled
 			Handlers:           fetch
 			--------------------------bindings--------------------------
+			None
+			"
+		`);
+			});
+			it("should log deployment script", async () => {
+				writeWranglerToml();
 
-			---------------------------script---------------------------
+				await runWrangler("deployments view 1701-E --content");
+
+				expect(std.out).toMatchInlineSnapshot(`
+			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
 
 						export default {
@@ -157,6 +166,32 @@ describe("deployments", () => {
 								return new Response('Hello World from Deployment 1701-E');
 							},
 						};"
+		`);
+			});
+
+			it("should log deployment details with bindings", async () => {
+				writeWranglerToml();
+
+				await runWrangler("deployments view bindings-tag");
+
+				expect(std.out).toMatchInlineSnapshot(`
+			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
+
+
+			Deployment ID: undefined
+			Created on:    2021-01-01T00:00:00.000000Z
+			Author:        Jean-Luc-Picard@federation.org
+			Source:        Wrangler 🤠
+			------------------------------------------------------------
+			Author ID:          Picard-Gamma-6-0-7-3
+			Usage Model:        bundled
+			Handlers:           fetch
+			--------------------------bindings--------------------------
+			[[r2_buckets]]
+			binding = \\"MY_BUCKET\\"
+			bucket_name = \\"testr2\\"
+
+			"
 		`);
 			});
 		});

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -69,23 +69,23 @@ describe("deployments", () => {
 		Deployment ID: Constitution-Class
 		Created on:    2021-01-01T00:00:00.000000Z
 		Author:        Jean-Luc-Picard@federation.org
-		Source:       Upload from Wrangler 🤠
+		Source:        Upload from Wrangler 🤠
 
 		Deployment ID: Intrepid-Class
 		Created on:    2021-02-02T00:00:00.000000Z
 		Author:        Kathryn-Janeway@federation.org
-		Source:       Rollback from Wrangler 🤠
+		Source:        Rollback from Wrangler 🤠
 		Rollback from: MOCK-DEPLOYMENT-ID-1111
 
 		Deployment ID: 3mEgaU1T-Intrepid-someThing
 		Created on:    2021-02-03T00:00:00.000000Z
 		Author:        Kathryn-Janeway@federation.org
-		Source:       Wrangler 🤠
+		Source:        Wrangler 🤠
 
 		Deployment ID: Galaxy-Class
 		Created on:    2021-01-04T00:00:00.000000Z
 		Author:        Jean-Luc-Picard@federation.org
-		Source:       Rollback from Wrangler 🤠
+		Source:        Rollback from Wrangler 🤠
 		Rollback from: MOCK-DEPLOYMENT-ID-2222
 		🟩 Active"
 	`);
@@ -100,23 +100,23 @@ describe("deployments", () => {
 		Deployment ID: Constitution-Class
 		Created on:    2021-01-01T00:00:00.000000Z
 		Author:        Jean-Luc-Picard@federation.org
-		Source:       Upload from Wrangler 🤠
+		Source:        Upload from Wrangler 🤠
 
 		Deployment ID: Intrepid-Class
 		Created on:    2021-02-02T00:00:00.000000Z
 		Author:        Kathryn-Janeway@federation.org
-		Source:       Rollback from Wrangler 🤠
+		Source:        Rollback from Wrangler 🤠
 		Rollback from: MOCK-DEPLOYMENT-ID-1111
 
 		Deployment ID: 3mEgaU1T-Intrepid-someThing
 		Created on:    2021-02-03T00:00:00.000000Z
 		Author:        Kathryn-Janeway@federation.org
-		Source:       Wrangler 🤠
+		Source:        Wrangler 🤠
 
 		Deployment ID: Galaxy-Class
 		Created on:    2021-01-04T00:00:00.000000Z
 		Author:        Jean-Luc-Picard@federation.org
-		Source:       Rollback from Wrangler 🤠
+		Source:        Rollback from Wrangler 🤠
 		Rollback from: MOCK-DEPLOYMENT-ID-2222
 		🟩 Active"
 	`);
@@ -138,21 +138,19 @@ describe("deployments", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
-			{
-			  Tag: '',
-			  Number: 0,
-			  'Metadata.author_id': 'Picard-Gamma-6-0-7-3',
-			  'Metadata.author_email': 'Jean-Luc-Picard@federation.org',
-			  'Metadata.source': 'wrangler',
-			  'Metadata.created_on': '2021-01-01T00:00:00.000000Z',
-			  'Metadata.modified_on': '2021-01-01T00:00:00.000000Z',
-			  'resources.script': {
-			    etag: 'mock-e-tag',
-			    handlers: [ 'fetch' ],
-			    last_deployed_from: 'wrangler'
-			  },
-			  'resources.bindings': []
-			}
+
+			Deployment ID: undefined
+			Created on:    2021-01-01T00:00:00.000000Z
+			Author:        Jean-Luc-Picard@federation.org
+			Source:        Wrangler 🤠
+			------------------------------------------------------------
+			Author ID:          Picard-Gamma-6-0-7-3
+			Usage Model:        bundled
+			Handlers:           fetch
+			--------------------------bindings--------------------------
+
+			---------------------------script---------------------------
+
 
 						export default {
 							async fetch(request) {

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
@@ -103,7 +103,7 @@ export const mswSuccessDeploymentDetails = [
 					createFetchResult({
 						Tag: "",
 						Number: 0,
-						Metadata: {
+						metadata: {
 							author_id: "Picard-Gamma-6-0-7-3",
 							author_email: "Jean-Luc-Picard@federation.org",
 							source: "wrangler",
@@ -115,6 +115,9 @@ export const mswSuccessDeploymentDetails = [
 								etag: "mock-e-tag",
 								handlers: ["fetch"],
 								last_deployed_from: "wrangler",
+							},
+							script_runtime: {
+								usage_model: "bundled",
 							},
 							bindings: [],
 						},

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
@@ -97,7 +97,17 @@ export const mswSuccessDeploymentScriptMetadata = [
 export const mswSuccessDeploymentDetails = [
 	rest.get(
 		"*/accounts/:accountId/workers/deployments/by-script/:scriptTag/detail/:deploymentId",
-		(_, res, ctx) => {
+		(req, res, ctx) => {
+			let bindings: object[] = [];
+			if (req.url.toString().includes("bindings-tag")) {
+				bindings = [
+					{
+						bucket_name: "testr2",
+						name: "MY_BUCKET",
+						type: "r2_bucket",
+					},
+				];
+			}
 			return res.once(
 				ctx.json(
 					createFetchResult({
@@ -119,7 +129,7 @@ export const mswSuccessDeploymentDetails = [
 							script_runtime: {
 								usage_model: "bundled",
 							},
-							bindings: [],
+							bindings: bindings,
 						},
 					})
 				)

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -23,7 +23,7 @@ export function toMimeType(type: CfModuleType): string {
 	}
 }
 
-type WorkerMetadataBinding =
+export type WorkerMetadataBinding =
 	// If you add any new binding types here, also add it to safeBindings
 	// under validateUnsafeBinding in config/validation.ts
 	| { type: "plain_text"; name: string; text: string }

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -625,6 +625,11 @@ export function createCLIParser(argv: string[]) {
 								type: "string",
 								demandOption: true,
 							})
+							.option("content", {
+								describe: "Show script content for given deployment ID",
+								type: "boolean",
+								default: false,
+							})
 							.option("yes", {
 								alias: "y",
 								describe: "Skip confirmation prompt",
@@ -639,7 +644,8 @@ export function createCLIParser(argv: string[]) {
 							accountId,
 							scriptName,
 							config,
-							viewYargs.deploymentId
+							viewYargs.deploymentId,
+							viewYargs.content
 						);
 					}
 				)

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -19,7 +19,10 @@ import { CommandLineArgsError, printWranglerBanner } from "./index";
 
 import type { RawConfig } from "./config";
 import type { Route, SimpleRoute } from "./config/environment";
-import type { WorkerMetadata } from "./create-worker-upload-form";
+import type {
+	WorkerMetadata,
+	WorkerMetadataBinding,
+} from "./create-worker-upload-form";
 import type { PackageManager } from "./package-manager";
 import type { PackageJSON } from "./parse";
 import type {
@@ -838,140 +841,7 @@ async function getWorkerConfig(
 			);
 		});
 
-	const mappedBindings = bindings
-		.filter((binding) => (binding.type as string) !== "secret_text")
-		// Combine the same types into {[type]: [binding]}
-		.reduce((configObj, binding) => {
-			// Some types have different names in wrangler.toml
-			// I want the type safety of the binding being destructured after the case narrowing the union but type is unused
-
-			switch (binding.type) {
-				case "plain_text":
-					{
-						configObj.vars = {
-							...(configObj.vars ?? {}),
-							[binding.name]: binding.text,
-						};
-					}
-					break;
-				case "json":
-					{
-						configObj.vars = {
-							...(configObj.vars ?? {}),
-							name: binding.name,
-							json: binding.json,
-						};
-					}
-					break;
-				case "kv_namespace":
-					{
-						configObj.kv_namespaces = [
-							...(configObj.kv_namespaces ?? []),
-							{ id: binding.namespace_id, binding: binding.name },
-						];
-					}
-					break;
-				case "durable_object_namespace":
-					{
-						configObj.durable_objects = {
-							bindings: [
-								...(configObj.durable_objects?.bindings ?? []),
-								{
-									name: binding.name,
-									class_name: binding.class_name,
-									script_name: binding.script_name,
-									environment: binding.environment,
-								},
-							],
-						};
-					}
-					break;
-				case "r2_bucket":
-					{
-						configObj.r2_buckets = [
-							...(configObj.r2_buckets ?? []),
-							{ binding: binding.name, bucket_name: binding.bucket_name },
-						];
-					}
-					break;
-				case "service":
-					{
-						configObj.services = [
-							...(configObj.services ?? []),
-							{
-								binding: binding.name,
-								service: binding.service,
-								environment: binding.environment,
-							},
-						];
-					}
-					break;
-				case "analytics_engine":
-					{
-						configObj.analytics_engine_datasets = [
-							...(configObj.analytics_engine_datasets ?? []),
-							{ binding: binding.name, dataset: binding.dataset },
-						];
-					}
-					break;
-				case "dispatch_namespace":
-					{
-						configObj.dispatch_namespaces = [
-							...(configObj.dispatch_namespaces ?? []),
-							{ binding: binding.name, namespace: binding.namespace },
-						];
-					}
-					break;
-				case "logfwdr":
-					{
-						configObj.logfwdr = {
-							// TODO: Messaging about adding schema file path
-							schema: "",
-							bindings: [
-								...(configObj.logfwdr?.bindings ?? []),
-								{ name: binding.name, destination: binding.destination },
-							],
-						};
-					}
-					break;
-				case "wasm_module":
-					{
-						configObj.wasm_modules = {
-							...(configObj.wasm_modules ?? {}),
-							[binding.name]: binding.part,
-						};
-					}
-					break;
-				case "text_blob":
-					{
-						configObj.text_blobs = {
-							...(configObj.text_blobs ?? {}),
-							[binding.name]: binding.part,
-						};
-					}
-					break;
-				case "data_blob":
-					{
-						configObj.data_blobs = {
-							...(configObj.data_blobs ?? {}),
-							[binding.name]: binding.part,
-						};
-					}
-					break;
-				default: {
-					// If we don't know what the type is, its an unsafe binding
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					if (!(binding as any)?.type) break;
-					configObj.unsafe = {
-						bindings: [...(configObj.unsafe?.bindings ?? []), binding],
-						metadata: configObj.unsafe?.metadata ?? undefined,
-					};
-				}
-			}
-
-			return configObj;
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		}, {} as RawConfig);
+	const mappedBindings = mapBindings(bindings);
 
 	const durableObjectClassNames = bindings
 		.filter((binding) => binding.type === "durable_object_namespace")
@@ -1020,4 +890,143 @@ async function getWorkerConfig(
 			}, {} as RawConfig["env"]),
 		...mappedBindings,
 	};
+}
+
+export function mapBindings(bindings: WorkerMetadataBinding[]): RawConfig {
+	return (
+		bindings
+			.filter((binding) => (binding.type as string) !== "secret_text")
+			// Combine the same types into {[type]: [binding]}
+			.reduce((configObj, binding) => {
+				// Some types have different names in wrangler.toml
+				// I want the type safety of the binding being destructured after the case narrowing the union but type is unused
+
+				switch (binding.type) {
+					case "plain_text":
+						{
+							configObj.vars = {
+								...(configObj.vars ?? {}),
+								[binding.name]: binding.text,
+							};
+						}
+						break;
+					case "json":
+						{
+							configObj.vars = {
+								...(configObj.vars ?? {}),
+								name: binding.name,
+								json: binding.json,
+							};
+						}
+						break;
+					case "kv_namespace":
+						{
+							configObj.kv_namespaces = [
+								...(configObj.kv_namespaces ?? []),
+								{ id: binding.namespace_id, binding: binding.name },
+							];
+						}
+						break;
+					case "durable_object_namespace":
+						{
+							configObj.durable_objects = {
+								bindings: [
+									...(configObj.durable_objects?.bindings ?? []),
+									{
+										name: binding.name,
+										class_name: binding.class_name,
+										script_name: binding.script_name,
+										environment: binding.environment,
+									},
+								],
+							};
+						}
+						break;
+					case "r2_bucket":
+						{
+							configObj.r2_buckets = [
+								...(configObj.r2_buckets ?? []),
+								{ binding: binding.name, bucket_name: binding.bucket_name },
+							];
+						}
+						break;
+					case "service":
+						{
+							configObj.services = [
+								...(configObj.services ?? []),
+								{
+									binding: binding.name,
+									service: binding.service,
+									environment: binding.environment,
+								},
+							];
+						}
+						break;
+					case "analytics_engine":
+						{
+							configObj.analytics_engine_datasets = [
+								...(configObj.analytics_engine_datasets ?? []),
+								{ binding: binding.name, dataset: binding.dataset },
+							];
+						}
+						break;
+					case "dispatch_namespace":
+						{
+							configObj.dispatch_namespaces = [
+								...(configObj.dispatch_namespaces ?? []),
+								{ binding: binding.name, namespace: binding.namespace },
+							];
+						}
+						break;
+					case "logfwdr":
+						{
+							configObj.logfwdr = {
+								// TODO: Messaging about adding schema file path
+								schema: "",
+								bindings: [
+									...(configObj.logfwdr?.bindings ?? []),
+									{ name: binding.name, destination: binding.destination },
+								],
+							};
+						}
+						break;
+					case "wasm_module":
+						{
+							configObj.wasm_modules = {
+								...(configObj.wasm_modules ?? {}),
+								[binding.name]: binding.part,
+							};
+						}
+						break;
+					case "text_blob":
+						{
+							configObj.text_blobs = {
+								...(configObj.text_blobs ?? {}),
+								[binding.name]: binding.part,
+							};
+						}
+						break;
+					case "data_blob":
+						{
+							configObj.data_blobs = {
+								...(configObj.data_blobs ?? {}),
+								[binding.name]: binding.part,
+							};
+						}
+						break;
+					default: {
+						// If we don't know what the type is, its an unsafe binding
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						if (!(binding as any)?.type) break;
+						configObj.unsafe = {
+							bindings: [...(configObj.unsafe?.bindings ?? []), binding],
+							metadata: configObj.unsafe?.metadata ?? undefined,
+						};
+					}
+				}
+
+				return configObj;
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			}, {} as RawConfig)
+	);
 }


### PR DESCRIPTION
Have new view for `wrangler deployment view` command
Example output
```
 ⛅️ wrangler 2.12.0
--------------------
🚧`wrangler deployments` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose


Deployment ID: 07d7143d-0284-427e-ba22-2d5e6e91b479
Created on:    2023-03-02T21:05:15.622446Z
Author:        jspspike@gmail.com
Source:        Upload from Wrangler 🤠
------------------------------------------------------------
Author ID:          e5a3ca86e08fb0940d3a05691310bb42
Usage Model:        bundled
Handlers:           fetch
Compatibility Date: 2022-10-03
--------------------------bindings--------------------------
[[r2_buckets]]
binding = "MY_BUCKET"
bucket_name = "testr2"

[[kv_namespaces]]
id = "79300c6d17eb4180a07270f450efe53f"
binding = "yeee"

---------------------------script---------------------------

(() => {
  // index.js
  addEventListener("fetch", (event) => {
    event.respondWith(handleRequest(event.request));
  });
  async function handleRequest(request) {
    return new Response(JSON.stringify("Hello r2"), {
      headers: { "content-type": "text/plain" }
    });
  }
})();
//# sourceMappingURL=index.js.map
```

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
