### PR TITLE
[wrangler] Log `Error#cause` and `DOMException` reasons when running `wrangler dev`

### DIFF
--- a/.changeset/fast-rats-turn.md
+++ b/.changeset/fast-rats-turn.md
@@ -1,0 +1,14 @@
+---
+"wrangler": minor
+---
+
+feat: log error causes when running `wrangler dev`
+
+Previously, the `cause` property of errors was ignored when logging.
+This is used by D1 to include context on why an operation failed.
+Because we weren't logging this, D1 failures would always show up as
+`D1_ERROR`, with no additional context, making debugging difficult.
+
+We now attempt to source-map and log these. Due to a known issue, the
+cause is sometimes not returned on the first request after a script reload.
+We also now log the reason for `DOMException`s.

--- a/packages/wrangler/src/callsite.ts
+++ b/packages/wrangler/src/callsite.ts
@@ -1,0 +1,160 @@
+// Lifted from `node-stack-trace`:
+// https://github.com/felixge/node-stack-trace/blob/4c41a4526e74470179b3b6dd5d75191ca8c56c17/index.js
+// Ideally, we'd just use this package as-is, but it has a strict
+// `engines.node == 16` constraint in its `package.json`. There's a PR open to
+// fix this (https://github.com/felixge/node-stack-trace/pull/39), but it's been
+// open for a while. As soon as it's merged, we should just depend on it.
+
+/*!
+ * Copyright (c) 2011 Felix Geisendörfer (felix@debuggable.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+export function parseStack(stack: string): CallSite[] {
+	return stack
+		.split("\n")
+		.slice(1)
+		.map(parseCallSite)
+		.filter((site): site is CallSite => site !== undefined);
+}
+
+function parseCallSite(line: string): CallSite | undefined {
+	const lineMatch = line.match(
+		/at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/
+	);
+	if (!lineMatch) {
+		return;
+	}
+
+	let object = null;
+	let method = null;
+	let functionName = null;
+	let typeName = null;
+	let methodName = null;
+	const isNative = lineMatch[5] === "native";
+
+	if (lineMatch[1]) {
+		functionName = lineMatch[1];
+		let methodStart = functionName.lastIndexOf(".");
+		if (functionName[methodStart - 1] == ".") methodStart--;
+		if (methodStart > 0) {
+			object = functionName.substring(0, methodStart);
+			method = functionName.substring(methodStart + 1);
+			const objectEnd = object.indexOf(".Module");
+			if (objectEnd > 0) {
+				functionName = functionName.substring(objectEnd + 1);
+				object = object.substring(0, objectEnd);
+			}
+		}
+	}
+
+	if (method) {
+		typeName = object;
+		methodName = method;
+	}
+
+	if (method === "<anonymous>") {
+		methodName = null;
+		functionName = null;
+	}
+
+	return new CallSite({
+		typeName,
+		functionName,
+		methodName,
+		fileName: lineMatch[2] || null,
+		lineNumber: parseInt(lineMatch[3]) || null,
+		columnNumber: parseInt(lineMatch[4]) || null,
+		native: isNative,
+	});
+}
+
+export interface CallSiteOptions {
+	typeName: string | null;
+	functionName: string | null;
+	methodName: string | null;
+	fileName: string | null;
+	lineNumber: number | null;
+	columnNumber: number | null;
+	native: boolean;
+}
+
+// https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+// This class supports the subset of options implemented by `node-stack-trace`:
+// https://github.com/felixge/node-stack-trace/blob/4c41a4526e74470179b3b6dd5d75191ca8c56c17/index.js
+export class CallSite implements NodeJS.CallSite {
+	constructor(private readonly opts: CallSiteOptions) {}
+
+	getThis(): unknown {
+		return null;
+	}
+	getTypeName(): string | null {
+		return this.opts.typeName;
+	}
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	getFunction(): Function | undefined {
+		return undefined;
+	}
+	getFunctionName(): string | null {
+		return this.opts.functionName;
+	}
+	getMethodName(): string | null {
+		return this.opts.methodName;
+	}
+	getFileName(): string | null {
+		return this.opts.fileName;
+	}
+	getScriptNameOrSourceURL(): string | null {
+		return this.opts.fileName;
+	}
+	getLineNumber(): number | null {
+		return this.opts.lineNumber;
+	}
+	getColumnNumber(): number | null {
+		return this.opts.columnNumber;
+	}
+	getEvalOrigin(): string | undefined {
+		return undefined;
+	}
+	isToplevel(): boolean {
+		return false;
+	}
+	isEval(): boolean {
+		return false;
+	}
+	isNative(): boolean {
+		return this.opts.native;
+	}
+	isConstructor(): boolean {
+		return false;
+	}
+	isAsync(): boolean {
+		return false;
+	}
+	isPromiseAll(): boolean {
+		return false;
+	}
+	isPromiseAny(): boolean {
+		return false;
+	}
+	getPromiseIndex(): number | null {
+		return null;
+	}
+}


### PR DESCRIPTION
#### What this PR solves:

Previously, the `cause` property of errors was ignored when logging. This is used by D1 to include context on why an operation failed. Because we weren't logging this, D1 failures would always show up as `D1_ERROR`, with no additional context, making debugging difficult.

This change attempts to extract `cause` from the object preview sent back from the inspector with the rest of exception details. Unfortunately, the stack trace we get back is an unstructured string, so we need to parse it into an array of call sites before we can source-map. The stack trace may be truncated as this is only a preview. In this case, we just log the truncation. We could send a request to the inspector to get the full stack in this case if we
wanted. Additionally, the cause is sometimes not returned on the first request. This is the same bug that causes objects entries not to be displayed when `console.log`ging on first request too.

`DOMException`s are special, the actually useful stack trace is hidden behind the `stack` getter, and not included in the preview. `DOMException`s are quite common (e.g. invalid base64 in `atob()`, invalid algorithm name when using WebCrypto, ...). Currently, these errors are just logged as `DOMException`, which isn't helpful for debugging. With this change, the actual reason is logged, along with the source-mapped location. Note this requires us sending requests to the inspector, and waiting for the response. To avoid ID collisions with DevTools frontend's own RPC requests, we use negative integer IDs, which are allowed by `workerd`.

#### How to test

Run `wrangler dev worker.js` with the following:

```js
export default {
  async fetch(request, env, ctx) {
    throw new Error("thing", {
      cause: new TypeError("cause"),
    });
  },
};
```

Visit the Worker in your browser and look at the console. You may need to refresh the page again, but you should see the cause. Replace the `fetch` handler body with some other examples that throw `DOMExceptions`, e.g. `atob("🙃");` or `await crypto.subtle.digest("🇲🇩5", new Uint8Array());`.

Best reviewed commit-by-commit. 🙂 

#### Associated docs issues/PR:

N/A

#### Author has included the following, where applicable:

- [ ] Tests
- [x] Changeset

#### Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
