### PR TITLE
Add support for Queue Consumer concurrency

### DIFF
--- a/.changeset/wild-pandas-destroy.md
+++ b/.changeset/wild-pandas-destroy.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add support for Queue Consumer concurrency

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -1791,6 +1791,8 @@ describe("normalizeAndValidateConfig()", () => {
 									max_batch_timeout: null,
 									max_retries: "hello",
 									dead_letter_queue: 5,
+									concurrency_enabled: true,
+									max_concurrency: 1,
 								},
 							],
 						},
@@ -1812,14 +1814,15 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-					"Processing wrangler configuration:
-					  - \\"queues.consumers[0]\\" should have a string \\"queue\\" field but got {}.
-					  - \\"queues.consumers[1]\\" should have a string \\"queue\\" field but got {\\"queue\\":22}.
-					  - \\"queues.consumers[3]\\" should, optionally, have a number \\"max_batch_size\\" field but got {\\"queue\\":\\"myQueue\\",\\"max_batch_size\\":\\"3\\",\\"max_batch_timeout\\":null,\\"max_retries\\":\\"hello\\",\\"dead_letter_queue\\":5}.
-					  - \\"queues.consumers[3]\\" should, optionally, have a number \\"max_batch_timeout\\" field but got {\\"queue\\":\\"myQueue\\",\\"max_batch_size\\":\\"3\\",\\"max_batch_timeout\\":null,\\"max_retries\\":\\"hello\\",\\"dead_letter_queue\\":5}.
-					  - \\"queues.consumers[3]\\" should, optionally, have a number \\"max_retries\\" field but got {\\"queue\\":\\"myQueue\\",\\"max_batch_size\\":\\"3\\",\\"max_batch_timeout\\":null,\\"max_retries\\":\\"hello\\",\\"dead_letter_queue\\":5}.
-					  - \\"queues.consumers[3]\\" should, optionally, have a string \\"dead_letter_queue\\" field but got {\\"queue\\":\\"myQueue\\",\\"max_batch_size\\":\\"3\\",\\"max_batch_timeout\\":null,\\"max_retries\\":\\"hello\\",\\"dead_letter_queue\\":5}."
-				`);
+			"Processing wrangler configuration:
+			  - \\"queues.consumers[0]\\" should have a string \\"queue\\" field but got {}.
+			  - \\"queues.consumers[1]\\" should have a string \\"queue\\" field but got {\\"queue\\":22}.
+			  - \\"queues.consumers[3]\\" should, optionally, have a number \\"max_batch_size\\" field but got {\\"queue\\":\\"myQueue\\",\\"max_batch_size\\":\\"3\\",\\"max_batch_timeout\\":null,\\"max_retries\\":\\"hello\\",\\"dead_letter_queue\\":5,\\"concurrency_enabled\\":true,\\"max_concurrency\\":1}.
+			  - \\"queues.consumers[3]\\" should, optionally, have a number \\"max_batch_timeout\\" field but got {\\"queue\\":\\"myQueue\\",\\"max_batch_size\\":\\"3\\",\\"max_batch_timeout\\":null,\\"max_retries\\":\\"hello\\",\\"dead_letter_queue\\":5,\\"concurrency_enabled\\":true,\\"max_concurrency\\":1}.
+			  - \\"queues.consumers[3]\\" should, optionally, have a number \\"max_retries\\" field but got {\\"queue\\":\\"myQueue\\",\\"max_batch_size\\":\\"3\\",\\"max_batch_timeout\\":null,\\"max_retries\\":\\"hello\\",\\"dead_letter_queue\\":5,\\"concurrency_enabled\\":true,\\"max_concurrency\\":1}.
+			  - \\"queues.consumers[3]\\" should, optionally, have a string \\"dead_letter_queue\\" field but got {\\"queue\\":\\"myQueue\\",\\"max_batch_size\\":\\"3\\",\\"max_batch_timeout\\":null,\\"max_retries\\":\\"hello\\",\\"dead_letter_queue\\":5,\\"concurrency_enabled\\":true,\\"max_concurrency\\":1}.
+			  - \\"queues.consumers[3]\\" cannot have \\"concurrency_enabled\\" and \\"max_concurrency\\" both defined."
+		`);
 			});
 		});
 

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -7372,6 +7372,7 @@ export default{
 							max_batch_size: 5,
 							max_batch_timeout: 3,
 							max_retries: 10,
+							concurrency_enabled: true,
 						},
 					],
 				},
@@ -7386,6 +7387,8 @@ export default{
 					batch_size: 5,
 					max_retries: 10,
 					max_wait_time_ms: 3000,
+					concurrency_enabled: true,
+					max_concurrency: 5,
 				},
 			});
 			await runWrangler("publish index.js");

--- a/packages/wrangler/src/__tests__/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues.test.ts
@@ -348,10 +348,12 @@ describe("wrangler", () => {
 				  -v, --version                   Show version number  [boolean]
 
 				Options:
-				      --batch-size         Maximum number of messages per batch  [number]
-				      --batch-timeout      Maximum number of seconds to wait to fill a batch with messages  [number]
-				      --message-retries    Maximum number of retries for each message  [number]
-				      --dead-letter-queue  Queue to send messages that failed to be consumed  [string]"
+				      --batch-size           Maximum number of messages per batch  [number]
+				      --batch-timeout        Maximum number of seconds to wait to fill a batch with messages  [number]
+				      --message-retries      Maximum number of retries for each message  [number]
+				      --dead-letter-queue    Queue to send messages that failed to be consumed  [string]
+				      --concurrency-enabled  Whether the Queue broker will make concurrent consumer invocations  [boolean]
+				      --max-concurrency      The maximum number of concurrent consumer Worker executions  [number]"
 			`);
 				});
 
@@ -363,6 +365,8 @@ describe("wrangler", () => {
 							batch_size: undefined,
 							max_retries: undefined,
 							max_wait_time_ms: undefined,
+							concurrency_enabled: undefined,
+							max_concurrency: undefined,
 						},
 						dead_letter_queue: undefined,
 					};
@@ -382,13 +386,15 @@ describe("wrangler", () => {
 							batch_size: 20,
 							max_retries: 3,
 							max_wait_time_ms: 10 * 1000,
+							concurrency_enabled: true,
+							max_concurrency: 5,
 						},
 						dead_letter_queue: "myDLQ",
 					};
 					mockPostRequest("testQueue", expectedBody);
 
 					await runWrangler(
-						"queues consumer add testQueue testScript --env myEnv --batch-size 20 --batch-timeout 10 --message-retries 3 --dead-letter-queue myDLQ"
+						"queues consumer add testQueue testScript --env myEnv --batch-size 20 --batch-timeout 10 --message-retries 3 --concurrency-enabled true --dead-letter-queue myDLQ"
 					);
 					expect(std.out).toMatchInlineSnapshot(`
 						"Adding consumer to queue testQueue.

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -374,6 +374,12 @@ interface EnvironmentNonInheritable {
 
 			/** The queue to send messages that failed to be consumed. */
 			dead_letter_queue?: string;
+
+			/** Whether the Queue broker will make concurrent consumer invocations */
+			concurrency_enabled?: boolean;
+
+			/** The maximum number of concurrent consumer Worker executions */
+			max_concurrency?: number;
 		}[];
 	};
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2215,6 +2215,8 @@ const validateConsumer: ValidatorFn = (diagnostics, field, value, _config) => {
 			"max_batch_timeout",
 			"max_retries",
 			"dead_letter_queue",
+			"concurrency_enabled",
+			"max_concurrency",
 		])
 	) {
 		isValid = false;
@@ -2230,12 +2232,14 @@ const validateConsumer: ValidatorFn = (diagnostics, field, value, _config) => {
 
 	const options: {
 		key: string;
-		type: "number" | "string";
+		type: "number" | "string" | "boolean";
 	}[] = [
 		{ key: "max_batch_size", type: "number" },
 		{ key: "max_batch_timeout", type: "number" },
 		{ key: "max_retries", type: "number" },
 		{ key: "dead_letter_queue", type: "string" },
+		{ key: "concurrency_enabled", type: "boolean" },
+		{ key: "max_concurrency", type: "number" },
 	];
 	for (const optionalOpt of options) {
 		if (!isOptionalProperty(value, optionalOpt.key, optionalOpt.type)) {
@@ -2246,6 +2250,16 @@ const validateConsumer: ValidatorFn = (diagnostics, field, value, _config) => {
 			);
 			isValid = false;
 		}
+	}
+
+	if (
+		hasProperty(value, "concurrency_enabled") &&
+		hasProperty(value, "max_concurrency")
+	) {
+		diagnostics.errors.push(
+			`"${field}" cannot have "concurrency_enabled" and "max_concurrency" both defined.`
+		);
+		isValid = false;
 	}
 
 	return isValid;

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -637,6 +637,7 @@ export function setupMiniflareOptions({
 			const waitMs = consumer.max_batch_timeout
 				? 1000 * consumer.max_batch_timeout
 				: undefined;
+			// TODO: Pass concurrency configuration to miniflare
 			return {
 				queueName: consumer.queue,
 				maxBatchSize: consumer.max_batch_size,

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -1052,6 +1052,9 @@ async function ensureQueuesExist(config: Config) {
 function updateQueueConsumers(config: Config): Promise<string[]>[] {
 	const consumers = config.queues.consumers || [];
 	return consumers.map((consumer) => {
+		const maxConcurrency = consumer.concurrency_enabled
+			? 5
+			: consumer.max_concurrency ?? 1;
 		const body: PutConsumerBody = {
 			dead_letter_queue: consumer.dead_letter_queue,
 			settings: {
@@ -1060,6 +1063,8 @@ function updateQueueConsumers(config: Config): Promise<string[]>[] {
 				max_wait_time_ms: consumer.max_batch_timeout
 					? 1000 * consumer.max_batch_timeout
 					: undefined,
+				concurrency_enabled: maxConcurrency > 1,
+				max_concurrency: maxConcurrency,
 			},
 		};
 

--- a/packages/wrangler/src/queues/client.ts
+++ b/packages/wrangler/src/queues/client.ts
@@ -90,6 +90,8 @@ export interface ConsumerSettings {
 	batch_size?: number;
 	max_retries?: number;
 	max_wait_time_ms?: number;
+	concurrency_enabled?: boolean;
+	max_concurrency?: number;
 }
 
 export interface ConsumerResponse extends PostConsumerBody {


### PR DESCRIPTION
What this PR solves / how to test:

This PR adds support for new Queues Consumer configuration options: `concurrency_enabled` and `max_concurrency`.

Associated docs issues/PR:

- Forthcoming

Author has included the following, where applicable:

- [x] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
