### PR TITLE
Fix `--experimental-local` with `wrangler pages dev`

### DIFF
--- a/.changeset/shaggy-horses-matter.md
+++ b/.changeset/shaggy-horses-matter.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: `--experimental-local` with `wrangler pages dev`
+
+We previously had a bug which logged an error (`local worker: TypeError: generateASSETSBinding2 is not a function`). This has now been fixed.

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -850,7 +850,7 @@ export async function transformMf2OptionsToMf3Options({
 		// relies on the fact that `require` is untyped.
 		//
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		const generateASSETSBinding = require("../miniflare-cli/assets");
+		const generateASSETSBinding = require("../miniflare-cli/assets").default;
 		options.serviceBindings = {
 			...options.serviceBindings,
 			ASSETS: (await generateASSETSBinding({


### PR DESCRIPTION
What this PR solves / how to test:

`wrangler pages dev --experimental-local` will no longer fail with an error like `local worker: TypeError: generateASSETSBinding2 is not a function`.

Author has included the following, where applicable:

- [ ] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
