### PR TITLE
Update prerelease registry page

### DIFF
--- a/packages/prerelease-registry/functions/routes/index.html
+++ b/packages/prerelease-registry/functions/routes/index.html
@@ -4,12 +4,60 @@
 		<title>Pre-Release Registry</title>
 		<link rel="icon" href="data:," />
 	</head>
+	<style>
+		body {
+			padding: 2rem;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+		}
+		ul {
+			margin: 0;
+			padding: 0;
+		}
+		li {
+			margin-block: 1rem;
+		}
+	</style>
 	<body>
-		<h1 style="text-align: center">This Page Intentionally Left Blank</h1>
-		<p style="text-align: center">
-			This site is only used for pre-releases of
-			<a href="https://github.com/cloudflare/workers-sdk">Workers-SDK</a>. You
-			should check it out!
+		<svg
+			width="72"
+			height="33"
+			viewBox="0 0 72 33"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				d="M49.1702 30.5941C49.6102 29.0854 49.4426 27.7023 48.7093 26.6755C48.0389 25.7326 46.9076 25.1878 45.5459 25.1249L19.7561 24.7896C19.5885 24.7896 19.4418 24.7058 19.358 24.5801C19.2742 24.4543 19.2533 24.2867 19.2952 24.1191C19.379 23.8676 19.6304 23.679 19.9027 23.658L45.923 23.3228C49.0026 23.1761 52.3547 20.6825 53.5279 17.623L55.0154 13.7464C55.0782 13.5788 55.0992 13.4111 55.0573 13.2435C53.3813 5.65781 46.6143 0 38.5275 0C31.0692 0 24.7423 4.81962 22.4796 11.5042C21.0131 10.4146 19.1485 9.82783 17.1373 10.0164C13.5548 10.3727 10.6846 13.2435 10.3285 16.8268C10.2447 17.7488 10.3075 18.6498 10.517 19.488C4.6719 19.6557 0 24.4334 0 30.3217C0 30.8456 0.0419005 31.3694 0.104751 31.8933C0.146652 32.1448 0.356153 32.3334 0.607556 32.3334H48.2065C48.4789 32.3334 48.7303 32.1448 48.8141 31.8724L49.1702 30.5941Z"
+				fill="#F38020"
+			/>
+			<path
+				d="M57.3828 14.0188C57.1524 14.0188 56.9009 14.0188 56.6705 14.0398C56.5029 14.0398 56.3562 14.1655 56.2934 14.3331L55.2878 17.8326C54.8478 19.3413 55.0154 20.7244 55.7487 21.7511C56.4191 22.6941 57.5504 23.2389 58.9122 23.3018L64.4011 23.6371C64.5687 23.6371 64.7154 23.7209 64.7992 23.8466C64.883 23.9724 64.904 24.161 64.8621 24.3076C64.7782 24.5591 64.5268 24.7477 64.2545 24.7686L58.5351 25.1039C55.4344 25.2506 52.1033 27.7442 50.9301 30.8036L50.5111 31.8723C50.4273 32.0819 50.574 32.2914 50.8044 32.2914H70.4558C70.6862 32.2914 70.8957 32.1448 70.9586 31.9143C71.2938 30.6989 71.4823 29.4206 71.4823 28.1005C71.4823 20.3472 65.1554 14.0188 57.3828 14.0188Z"
+				fill="#FAAE40"
+			/>
+		</svg>
+		<h1>Prerelease Registry</h1>
+		<p>
+			This page is intentionally left blank as this site is not supposed to be
+			accessed directly but its purpose is only for providing pre-releases for
+			the following Cloudflare github repositories:
 		</p>
+		<ul>
+			<li>
+				<a target="_blank" href="https://github.com/cloudflare/workers-sdk"
+					>workers-sdk</a
+				>
+			</li>
+			<li>
+				<a target="_blank" href="https://github.com/cloudflare/next-on-pages"
+					>next-on-pages</a
+				>
+			</li>
+			<li>
+				<a target="_blank" href="https://github.com/cloudflare/pages-plugins"
+					>pages-plugins</a
+				>
+			</li>
+		</ul>
 	</body>
 </html>


### PR DESCRIPTION
Updating the prerelease registry page to include also next-on-pages and pages-plugins (added in https://github.com/cloudflare/workers-sdk/pull/2731)

@GregBrimble 🙂 

Result:
![Screenshot 2023-03-07 at 17 59 35](https://user-images.githubusercontent.com/61631103/223509179-864ec1bc-559d-4175-9ed1-bcda6ffe288c.png)
