### PR TITLE
[wrangler] Fix compile loop with `_worker.js` and `wrangler pages dev`

### DIFF
--- a/.changeset/heavy-rockets-destroy.md
+++ b/.changeset/heavy-rockets-destroy.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Prevent compile loop when using `_worker.js` and `wrangler pages dev`

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -297,7 +297,7 @@ export const Handler = async ({
 		}
 
 		await runBuild();
-		watch([scriptPath], {
+		watch([workerScriptPath], {
 			persistent: true,
 			ignoreInitial: true,
 		}).on("all", async () => {


### PR DESCRIPTION
What this PR solves / how to test:

- Run `npm run dev` in `fixtures/pages-workerjs-app`
- Note the _lack_ of compile loop :)

Associated docs issues/PR:

- [insert associated docs issue(s)/PR(s)]

Author has included the following, where applicable:

- [ ] Tests
- [x] Changeset

Reviewer has performed the following, where applicable:

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

Fixes # [insert issue number].
