### PR TITLE
feat: Add D1 binding support to Email Workers

### DIFF
--- a/.changeset/spotty-walls-crash.md
+++ b/.changeset/spotty-walls-crash.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: Add D1 binding support to Email Workers
+
+This PR makes it possible to query D1 from an Email Worker, assuming a binding has been setup.
+
+As D1 is in alpha and not considered "production-ready", this changeset is a patch, rather than a minor bump to wrangler.

--- a/packages/wrangler/templates/d1-beta-facade.js
+++ b/packages/wrangler/templates/d1-beta-facade.js
@@ -237,5 +237,8 @@ var shim_default = {
 	async trace(traces, env, ctx) {
 		return worker.trace(traces, getMaskedEnv(env), ctx);
 	},
+	async email(message, env, ctx) {
+		return worker.email(message, getMaskedEnv(env), ctx);
+	},
 };
 export { shim_default as default };


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR makes it possible to query D1 from an Email Worker, assuming a binding has been setup.

As D1 is in alpha and not considered "production-ready", this changeset is a patch, rather than a minor bump to wrangler.


**Associated docs issues/PR:**

- N/A

**Author has included the following, where applicable:**

- [x] Changeset

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of a relevant changeset
- [ ] Manually pulled down the changes and spot-tested

Fixes #2876
