### PR TITLE
allow cloudflare-specific js module

### DIFF
--- a/.changeset/afraid-readers-warn.md
+++ b/.changeset/afraid-readers-warn.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: support external imports from `cloudflare:...` prefixed modules
+
+Going forward Workers will be providing built-in modules (similar to `node:...`) that can be imported using the `cloudflare:...` prefix. This change adds support to the Wrangler bundler to mark these imports as external.

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1341,6 +1341,32 @@ export default{
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
+		it("should allow cloudflare module import", async () => {
+			writeWranglerToml();
+			fs.writeFileSync(
+				"./index.js",
+				`
+import { EmailMessage } from "cloudflare:email";
+export default{
+  fetch(){
+    return new Response("all done");
+  }
+}
+`
+			);
+			mockUploadWorkerRequest();
+			mockSubDomainRequest();
+			await runWrangler("publish index.js");
+			expect(std.out).toMatchInlineSnapshot(`
+			"Total Upload: xx KiB / gzip: xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Deployment ID: Galaxy-Class"
+		`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
 		it("should be able to transpile entry-points in sub-directories (esm)", async () => {
 			writeWranglerToml();
 			writeWorkerSource({ basePath: "./src" });

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -94,6 +94,15 @@ const nodejsCompatPlugin: esbuild.Plugin = {
 	},
 };
 
+const cloudflareJsPlugin: esbuild.Plugin = {
+	name: "cloudflare javascript Plugin",
+	setup(pluginBuild) {
+		pluginBuild.onResolve({ filter: /^cloudflare:.*/ }, () => {
+			return { external: true };
+		});
+	},
+};
+
 /**
  * Generate a bundle for the worker identified by the arguments passed in.
  */
@@ -379,6 +388,7 @@ export async function bundleWorker(
 				? [NodeGlobalsPolyfills({ buffer: true }), NodeModulesPolyfills()]
 				: []),
 			...(nodejsCompat ? [nodejsCompatPlugin] : []),
+			...[cloudflareJsPlugin],
 			...(plugins || []),
 		],
 		...(jsxFactory && { jsxFactory }),


### PR DESCRIPTION
Mark cloudflare-specific js module as external so that scripts can be published that reference it.

**What this PR solves / how to test:**

`import { EmailMessage } from "cloudflare:email";`

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- ~~[ ] Checked for creation of associated docs updates~~ : no documentation needed for this just yet. I assume when the first official `cloudflare:..` prefixed modules are announced there will be docs associated with it.
- [x] Manually pulled down the changes and spot-tested
