### PR TITLE
fix: do not render "value of stdout.lastframe() is undefined" if the output is an empty string

### DIFF
--- a/.changeset/funny-spies-melt.md
+++ b/.changeset/funny-spies-melt.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: do not render "value of stdout.lastframe() is undefined" if the output is an empty string
+
+Fixes #2907

--- a/packages/wrangler/src/utils/render.ts
+++ b/packages/wrangler/src/utils/render.ts
@@ -83,7 +83,7 @@ export const render = (tree: ReactElement): Instance => {
 	});
 
 	return {
-		output: stdout.lastFrame() || LASTFRAME_UNDEFINED,
+		output: stdout.lastFrame() ?? LASTFRAME_UNDEFINED,
 		stdout,
 		stderr,
 		cleanup: instance.cleanup,


### PR DESCRIPTION
Fixes #2907

**What this PR solves / how to test:**

If the components passed to `renderToString()` resulted in an empty string, we were incorrectly converting that to a warning message. This message should only apply if there is a problem with rendering and it returns `undefined`.

To test run the following commands:

```bash
npx wrangler d1 create TEST_DB 
npx wrangler d1 execute TEST_DB --command "DROP TABLE IF EXISTS test_table"
```

You should not see the "value of stdout.lastframe() is undefined" message.


**Author has included the following, where applicable:**

- [ ] ~~Tests~~ D1 query execution is not possible to unit test - the WASM causes a segmentation fault in NodeJS.
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested
