### PR TITLE
[wip] support --json flag for pages publish

### DIFF
--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -37,6 +37,14 @@ class Logger {
 	loggerLevel: LoggerLevel = (getLogLevelFromEnv() as LoggerLevel) ?? "log";
 	columns = process.stdout.columns;
 
+	disableStdOut() {
+		this.stdOutDisabled = true;
+	}
+
+	enableStdOut() {
+		this.stdOutDisabled = false;
+	}
+
 	debug = (...args: unknown[]) => this.doLog("debug", args);
 	info = (...args: unknown[]) => this.doLog("info", args);
 	log = (...args: unknown[]) => this.doLog("log", args);
@@ -52,8 +60,17 @@ class Logger {
 		return this.doLog("log", [t.toString()]);
 	}
 
+	private stdOutDisabled = false;
+
 	private doLog(messageLevel: Exclude<LoggerLevel, "none">, args: unknown[]) {
 		if (LOGGER_LEVELS[this.loggerLevel] >= LOGGER_LEVELS[messageLevel]) {
+			if (
+				this.stdOutDisabled &&
+				LOGGER_LEVELS[messageLevel] <= LOGGER_LEVELS.log
+			) {
+				// switch to warn which is stderr
+				messageLevel = "warn";
+			}
 			console[messageLevel](this.formatMessage(messageLevel, format(...args)));
 		}
 	}

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -71,6 +71,11 @@ export function Options(yargs: CommonYargsArgv) {
 				type: "string",
 				hidden: true,
 			},
+			json: {
+				describe: "output clean JSON on stdout",
+				type: "boolean",
+				default: false,
+			},
 		})
 		.epilogue(pagesBetaWarning);
 }
@@ -86,7 +91,10 @@ export const Handler = async ({
 	bundle,
 	noBundle,
 	config: wranglerConfig,
+	json,
 }: PublishArgs) => {
+	if (json) logger.disableStdOut();
+
 	if (wranglerConfig) {
 		throw new FatalError("Pages does not support wrangler.toml", 1);
 	}
@@ -263,5 +271,10 @@ export const Handler = async ({
 	logger.log(
 		`✨ Deployment complete! Take a peek over at ${deploymentResponse.url}`
 	);
+
+	if (json) {
+		console.log(JSON.stringify({ url: deploymentResponse.url }, null, 2));
+	}
+
 	await metrics.sendMetricsEvent("create pages deployment");
 };


### PR DESCRIPTION
Fixes #2437

**What this PR solves / how to test:**

Adds a `--json` flag to pages publish command, that outputs the URL to the deployment.

This is still WIP but would be great to get some feedback on the approach here. The idea is to put the logger into a mode where it will not use stdout, and then any log messages that would have gone to stdout will be redirected to stderr instead, just leaving stdout for the json.

- I wonder if the logger should become instance based and passed through to things that need it?
- Or should we have a global `--json` flag that constructs the logger in a mode with stdout disabled to prevent any chance of something getting through before it's configured?
- Should we stop using stdout and reserve that just for machine readable messages?

I noticed there's one other place already that already respects a `--json` flag in the cli.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
