### PR TITLE
[wrangler]: Fix local mode force on pages dev

### DIFF
--- a/.changeset/cool-cobras-deliver.md
+++ b/.changeset/cool-cobras-deliver.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix: Pages Dev incorrectly allowing people to turn off local mode
+
+Local mode is not currently supported in Pages Dev, and errors when people attempt to use it. Previously, wrangler hid the "toggle local mode" button when using Pages dev, but this got broken somewhere along the line.

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -143,7 +143,6 @@ export async function unstable_dev(
 					enablePagesAssetsServiceBinding,
 					liveReload,
 					showInteractiveDevSession,
-					forceLocal,
 					onReady: (address, port) => {
 						readyPort = port;
 						readyAddress = address;
@@ -232,6 +231,7 @@ export async function unstable_dev(
 					experimentalLocal: experimentalLocal ?? false,
 					experimentalLocalRemoteKv: experimentalLocalRemoteKv ?? false,
 					enablePagesAssetsServiceBinding,
+					forceLocal,
 					liveReload,
 					onReady: (address, port) => {
 						readyPort = port;


### PR DESCRIPTION
Fixes N/A - Found [in the Discord](https://canary.discord.com/channels/595317990191398933/799437470004412476/1087684607698284554)

**What this PR solves / how to test:** Pages dev previously forced people to use local mode, however this got broken somewhere in the past. This pull fixes it, and prevents people from using remote mode once again

TLDR; Force local was incorrectly put in the `startApiDev` version of unstable_dev instead of the one that Pages uses

**Associated docs issue(s)/PR(s):**

- N/A

**Author has included the following, where applicable:**

- [ ] Tests (not sure how I can test the react element?)
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
