### PR TITLE
Fix "pages dev" --env param not being considered

### DIFF
--- a/.changeset/tasty-pens-join.md
+++ b/.changeset/tasty-pens-join.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix "pages dev" --env param not being considered

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -133,7 +133,6 @@ export function normalizeAndValidateConfig(
 	const envName = (args as { env: string | undefined }).env;
 
 	let activeEnv = topLevelEnv;
-
 	if (envName !== undefined) {
 		const envDiagnostics = new Diagnostics(
 			`"env.${envName}" environment configuration`

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -134,9 +134,7 @@ export function normalizeAndValidateConfig(
 
 	let activeEnv = topLevelEnv;
 
-	// When running `pages dev` there is no toml file (configPath) so we can skip these checks which validate
-	// the environment being defined in the toml file.
-	if (configPath !== undefined && envName !== undefined) {
+	if (envName !== undefined) {
 		const envDiagnostics = new Diagnostics(
 			`"env.${envName}" environment configuration`
 		);
@@ -165,25 +163,32 @@ export function normalizeAndValidateConfig(
 				isLegacyEnv,
 				rawConfig
 			);
-			const envNames = rawConfig.env
-				? `The available configured environment names are: ${JSON.stringify(
-						Object.keys(rawConfig.env)
-				  )}\n`
-				: "";
-			const message =
-				`No environment found in configuration with name "${envName}".\n` +
-				`Before using \`--env=${envName}\` there should be an equivalent environment section in the configuration.\n` +
-				`${envNames}\n` +
-				`Consider adding an environment configuration section to the wrangler.toml file:\n` +
-				"```\n[env." +
-				envName +
-				"]\n```\n";
 
-			if (envNames.length > 0) {
-				diagnostics.errors.push(message);
-			} else {
-				// Only warn (rather than error) if there are not actually any environments configured in wrangler.toml.
-				diagnostics.warnings.push(message);
+			// When running `pages dev` there is no toml file (configPath) so we don't warn the user about
+			// missing envs in the toml file
+			const shouldWarnAboutEnvsInConfig = configPath !== undefined;
+
+			if (shouldWarnAboutEnvsInConfig) {
+				const envNames = rawConfig.env
+					? `The available configured environment names are: ${JSON.stringify(
+							Object.keys(rawConfig.env)
+					  )}\n`
+					: "";
+				const message =
+					`No environment found in configuration with name "${envName}".\n` +
+					`Before using \`--env=${envName}\` there should be an equivalent environment section in the configuration.\n` +
+					`${envNames}\n` +
+					`Consider adding an environment configuration section to the wrangler.toml file:\n` +
+					"```\n[env." +
+					envName +
+					"]\n```\n";
+
+				if (envNames.length > 0) {
+					diagnostics.errors.push(message);
+				} else {
+					// Only warn (rather than error) if there are not actually any environments configured in wrangler.toml.
+					diagnostics.warnings.push(message);
+				}
 			}
 		}
 	}

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -133,7 +133,10 @@ export function normalizeAndValidateConfig(
 	const envName = (args as { env: string | undefined }).env;
 
 	let activeEnv = topLevelEnv;
-	if (envName !== undefined) {
+
+	// When running `pages dev` there is no toml file (configPath) so we can skip these checks which validate
+	// the environment being defined in the toml file.
+	if (configPath !== undefined && envName !== undefined) {
 		const envDiagnostics = new Diagnostics(
 			`"env.${envName}" environment configuration`
 		);

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -188,6 +188,7 @@ export const Handler = async ({
 	nodeCompat: legacyNodeCompat,
 	experimentalLocal,
 	config: config,
+	env: env,
 	_: [_pages, _dev, ...remaining],
 	logLevel,
 }: StrictYargsOptionsToInterface<typeof Options>) => {
@@ -498,6 +499,7 @@ export const Handler = async ({
 	}
 
 	const { stop, waitUntilExit } = await unstable_dev(entrypoint, {
+		env,
 		ip,
 		port,
 		inspectorPort,


### PR DESCRIPTION
When running `wrangler pages dev --env <myenv> ...`, the file .dev.vars.<myenv> is not being picked up.
After investigation, it looks like is because the env CLI argument was not being propagated downwards.

I didn't create a GH issue, due to this being a trivial fix.

**Author has included the following, where applicable:**

- [ ] Tests
- [X] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))