### PR TITLE
feat: introduce exclude option to pages upload

### DIFF
--- a/.changeset/pink-icons-vanish.md
+++ b/.changeset/pink-icons-vanish.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: introduce exclude option for wrangler pages deployment create command

--- a/packages/wrangler/src/api/pages/publish.tsx
+++ b/packages/wrangler/src/api/pages/publish.tsx
@@ -72,6 +72,11 @@ interface PagesPublishOptions {
 	// TODO: Allow passing in the API key and plumb it through
 	// to the API calls so that the publish function does not
 	// rely on the `CLOUDFLARE_API_KEY` environment variable
+
+	/**
+	 * Patterns to exclude from static assets to publish to Pages
+	 */
+	exclude?: string[];
 }
 
 /**
@@ -81,6 +86,7 @@ interface PagesPublishOptions {
  */
 export async function publish({
 	directory,
+	exclude,
 	accountId,
 	projectName,
 	branch,
@@ -191,6 +197,7 @@ export async function publish({
 
 	const manifest = await upload({
 		directory,
+		exclude,
 		accountId,
 		projectName,
 		skipCaching: skipCaching ?? false,

--- a/packages/wrangler/src/pages/publish.tsx
+++ b/packages/wrangler/src/pages/publish.tsx
@@ -71,12 +71,18 @@ export function Options(yargs: CommonYargsArgv) {
 				type: "string",
 				hidden: true,
 			},
+			exclude: {
+				type: "array",
+				default: [],
+				description: "Exclude assets by patterns",
+			}
 		})
 		.epilogue(pagesBetaWarning);
 }
 
 export const Handler = async ({
 	directory,
+	exclude,
 	projectName,
 	branch,
 	commitHash,
@@ -243,6 +249,7 @@ export const Handler = async ({
 
 	const deploymentResponse = await publish({
 		directory,
+		exclude,
 		accountId,
 		projectName,
 		branch,


### PR DESCRIPTION
**What this PR solves / how to test:**

It solves me to exclude sourcemaps and other unnecessary files of uploading to cloudflare pages using wrangler cli.
It implements array option `--exclude` for `wrangler pages deployment create` command.
It uses existing APIs and node modules and brings no breaking changes.

This PR is quite urgent to be merged, overwise I have to make my own packaged fork :(

**Author has included the following, where applicable:**

- [x] Tests (automated options tests)
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [x] Manually pulled down the changes and spot-tested
