### PR TITLE
Wrangler api querystring

### DIFF
--- a/.changeset/dry-eyes-walk.md
+++ b/.changeset/dry-eyes-walk.md
@@ -1,0 +1,25 @@
+---
+"wrangler": patch
+---
+
+fix: Respect querystring params when calling `.fetch` on a worker instantiated with `unstable_dev`
+
+Previously, querystring params would be stripped, causing issues for test cases that depended on them. For example, given the following worker script:
+```js
+export default {
+  fetch(req) {
+    const url = new URL(req.url);
+    const name = url.searchParams.get('name');
+    return new Response('Hello, ' + name);
+  }
+}
+```
+
+would fail the following test case:
+```js
+const worker = await unstable_dev('script.js');
+const res = await worker.fetch('http://worker?name=Walshy');
+const text = await res.text();
+// Following fails, as returned text is 'Hello, null'
+expect(text).toBe('Hello, Walshy');
+```

--- a/packages/wrangler/src/__tests__/api.test.ts
+++ b/packages/wrangler/src/__tests__/api.test.ts
@@ -5,7 +5,7 @@ describe("parseRequestInput for fetch on unstable dev", () => {
 	it("should allow no input to be passed in", () => {
 		const [input, _] = parseRequestInput("0.0.0.0", 8080);
 
-		expect(input).toMatchInlineSnapshot(`"http://0.0.0.0:8080"`);
+		expect(input).toMatchInlineSnapshot(`"http://0.0.0.0:8080/"`);
 	});
 
 	it("should allow string of pathname to be passed in", () => {
@@ -14,14 +14,24 @@ describe("parseRequestInput for fetch on unstable dev", () => {
 		expect(input).toMatchInlineSnapshot(`"http://0.0.0.0:8080/test"`);
 	});
 
+	it("should allow string of pathname and querystring to be passed in", () => {
+		const [input, _] = parseRequestInput("0.0.0.0", 8080, "/test?q=testparam");
+
+		expect(input).toMatchInlineSnapshot(
+			`"http://0.0.0.0:8080/test?q=testparam"`
+		);
+	});
+
 	it("should allow full url to be passed in as string and stripped", () => {
 		const [input, _] = parseRequestInput(
 			"0.0.0.0",
 			8080,
-			"http://cloudflare.com/test"
+			"http://cloudflare.com/test?q=testparam"
 		);
 
-		expect(input).toMatchInlineSnapshot(`"http://0.0.0.0:8080/test"`);
+		expect(input).toMatchInlineSnapshot(
+			`"http://0.0.0.0:8080/test?q=testparam"`
+		);
 	});
 
 	it("should allow URL object without pathname to be passed in and stripped", () => {
@@ -44,18 +54,30 @@ describe("parseRequestInput for fetch on unstable dev", () => {
 		expect(input).toMatchInlineSnapshot(`"http://0.0.0.0:8080/test"`);
 	});
 
+	it("should allow URL object with pathname and querystring to be passed in and stripped", () => {
+		const [input, _] = parseRequestInput(
+			"0.0.0.0",
+			8080,
+			new URL("http://cloudflare.com/test?q=testparam")
+		);
+
+		expect(input).toMatchInlineSnapshot(
+			`"http://0.0.0.0:8080/test?q=testparam"`
+		);
+	});
+
 	it("should allow request object to be passed in", () => {
 		const [input, init] = parseRequestInput(
 			"0.0.0.0",
 			8080,
-			new Request("http://cloudflare.com/test", { method: "POST" })
+			new Request("http://cloudflare.com/test?q=testparam", { method: "POST" })
 		);
 
 		expect(init).toBeUndefined();
 		expect(input).toBeInstanceOf(Request);
 		// We don't expect the request to be modified
 		expect((input as Request).url).toMatchInlineSnapshot(
-			`"http://cloudflare.com/test"`
+			`"http://cloudflare.com/test?q=testparam"`
 		);
 		expect((input as Request).method).toMatchInlineSnapshot(`"POST"`);
 	});

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -307,21 +307,16 @@ export function parseRequestInput(
 ): [RequestInfo, RequestInit | undefined] {
 	if (input instanceof Request) {
 		return [input, undefined];
-	} else if (input instanceof URL) {
-		input = `${protocol}://${readyAddress}:${readyPort}${input.pathname}`;
-	} else if (typeof input === "string") {
-		try {
-			// Want to strip the URL to only get the pathname, but the user could pass in only the pathname
-			// Will error if we try and pass "/something" into new URL("/something")
-			input = `${protocol}://${readyAddress}:${readyPort}${
-				new URL(input).pathname
-			}`;
-		} catch {
-			input = `${protocol}://${readyAddress}:${readyPort}${input}`;
-		}
-	} else {
-		input = `${protocol}://${readyAddress}:${readyPort}`;
 	}
-
-	return [input, init];
+	if (!input) {
+		input = "/";
+	}
+	const url =
+		typeof input === "string"
+			? new URL(input, `${protocol}://${readyAddress}:${readyPort}`)
+			: input;
+	url.protocol = protocol;
+	url.hostname = readyAddress;
+	url.port = readyPort.toString();
+	return [url, init];
 }


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/2641

**What this PR solves / how to test:**

Respects querystring params passed to `.fetch` exposed by `unstable_dev`.

**Associated docs issue(s)/PR(s):**

- https://github.com/cloudflare/workers-sdk/issues/2641

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
