### PR TITLE
Add itty-router-openapi to prerelease allow list

### DIFF
--- a/packages/prerelease-registry/functions/utils/repoAllowlist.ts
+++ b/packages/prerelease-registry/functions/utils/repoAllowlist.ts
@@ -1,1 +1,1 @@
-export const repos = ["workers-sdk", "next-on-pages", "pages-plugins"];
+export const repos = ["workers-sdk", "next-on-pages", "pages-plugins", "itty-router-openapi"];

--- a/packages/prerelease-registry/functions/utils/repoAllowlist.ts
+++ b/packages/prerelease-registry/functions/utils/repoAllowlist.ts
@@ -1,1 +1,6 @@
-export const repos = ["workers-sdk", "next-on-pages", "pages-plugins", "itty-router-openapi"];
+export const repos = [
+	"workers-sdk",
+	"next-on-pages",
+	"pages-plugins",
+	"itty-router-openapi",
+];


### PR DESCRIPTION
This just addes the https://github.com/cloudflare/itty-router-openapi to the prerelease allow list

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
