### PR TITLE
Update devtools patches

### DIFF
--- a/packages/wrangler-devtools/patches/0001-Add-README-detailing-the-setup-process.patch
+++ b/packages/wrangler-devtools/patches/0001-Add-README-detailing-the-setup-process.patch
@@ -1,7 +1,7 @@
 From b2985a087935838fdf6a6f0dba21afed484849c7 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Wed, 11 Jan 2023 17:46:48 +0000
-Subject: [PATCH 01/13] Add README detailing the setup process
+Subject: [PATCH 01/14] Add README detailing the setup process
 
 ---
  README.md | 58 +++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/packages/wrangler-devtools/patches/0002-Support-viewing-files-over-the-network.patch
+++ b/packages/wrangler-devtools/patches/0002-Support-viewing-files-over-the-network.patch
@@ -1,7 +1,7 @@
 From cc7b688a2427d7506a2f4111887a5e243fb841d4 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 12 Jan 2023 15:33:43 +0000
-Subject: [PATCH 02/13] Support viewing files over the network
+Subject: [PATCH 02/14] Support viewing files over the network
 
 ---
  front_end/core/sdk/Target.ts             |  4 ++++

--- a/packages/wrangler-devtools/patches/0003-Show-fallback-image-on-Safari.patch
+++ b/packages/wrangler-devtools/patches/0003-Show-fallback-image-on-Safari.patch
@@ -1,7 +1,7 @@
 From a742a62c90c73c8c7e766eaaad9003200a447729 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Mon, 16 Jan 2023 16:51:11 +0000
-Subject: [PATCH 03/13] Show fallback image on Safari
+Subject: [PATCH 03/14] Show fallback image on Safari
 
 ---
  config/gni/devtools_grd_files.gni   |   1 +

--- a/packages/wrangler-devtools/patches/0004-Support-previewing-subrequest-responses.patch
+++ b/packages/wrangler-devtools/patches/0004-Support-previewing-subrequest-responses.patch
@@ -1,7 +1,7 @@
 From 6c4581cd2e985e8e94aa3c9091faec45743da6e4 Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Mon, 16 Jan 2023 14:26:52 +0000
-Subject: [PATCH 04/13] Support previewing subrequest responses
+Subject: [PATCH 04/14] Support previewing subrequest responses
 
 ---
  front_end/core/sdk/NetworkManager.ts   | 9 +++++++--

--- a/packages/wrangler-devtools/patches/0005-Better-Firefox-support-for-network-tab.patch
+++ b/packages/wrangler-devtools/patches/0005-Better-Firefox-support-for-network-tab.patch
@@ -1,7 +1,7 @@
 From b91cdddb4b2576149ba2c184f011073140f16e9b Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 19 Jan 2023 15:47:52 +0000
-Subject: [PATCH 05/13] Better Firefox support for network tab
+Subject: [PATCH 05/14] Better Firefox support for network tab
 
 ---
  front_end/entrypoints/js_app/js_app.ts               | 2 ++

--- a/packages/wrangler-devtools/patches/0006-DEVX-292-Remove-unsupported-network-UI.patch
+++ b/packages/wrangler-devtools/patches/0006-DEVX-292-Remove-unsupported-network-UI.patch
@@ -1,7 +1,7 @@
 From 1a267cd3d143892fb0886907a75e3eb295b5b150 Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Mon, 16 Jan 2023 15:43:50 +0000
-Subject: [PATCH 06/13] DEVX-292 Remove unsupported network UI
+Subject: [PATCH 06/14] DEVX-292 Remove unsupported network UI
 
 ---
  front_end/panels/network/NetworkPanel.ts | 35 ------------------------
@@ -48,7 +48,7 @@ index 304bb09af1..aaf80fbd50 100644
 @@ -411,28 +398,6 @@ export class NetworkPanel extends UI.Panel.Panel implements UI.ContextMenu.Provi
      this.panelToolbar.appendToolbarItem(new UI.Toolbar.ToolbarSettingCheckbox(
          this.preserveLogSetting, i18nString(UIStrings.doNotClearLogOnPageReload), i18nString(UIStrings.preserveLog)));
-
+ 
 -    this.panelToolbar.appendSeparator();
 -    const disableCacheCheckbox = new UI.Toolbar.ToolbarSettingCheckbox(
 -        Common.Settings.Settings.instance().moduleSetting('cacheDisabled'),
@@ -74,6 +74,6 @@ index 304bb09af1..aaf80fbd50 100644
      this.rightToolbar.appendToolbarItem(new UI.Toolbar.ToolbarItem(this.progressBarContainer));
      this.rightToolbar.appendSeparator();
      this.rightToolbar.appendToolbarItem(new UI.Toolbar.ToolbarSettingToggle(
---
+-- 
 2.37.1 (Apple Git-137.1)
 

--- a/packages/wrangler-devtools/patches/0007-Remove-unsupported-profiler-UI.patch
+++ b/packages/wrangler-devtools/patches/0007-Remove-unsupported-profiler-UI.patch
@@ -1,7 +1,7 @@
 From 7312af32a23a62acc2f5661187ef90b01381c0de Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Mon, 16 Jan 2023 16:32:45 +0000
-Subject: [PATCH 07/13] Remove unsupported profiler UI
+Subject: [PATCH 07/14] Remove unsupported profiler UI
 
 ---
  front_end/panels/profiler/HeapProfilerPanel.ts | 2 +-

--- a/packages/wrangler-devtools/patches/0008-Show-an-overlay-on-the-memory-tab-in-Firefox.patch
+++ b/packages/wrangler-devtools/patches/0008-Show-an-overlay-on-the-memory-tab-in-Firefox.patch
@@ -1,7 +1,7 @@
 From 70e79d4a4e1821021d0df627a23d62ede6c558ba Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 19 Jan 2023 18:49:47 +0000
-Subject: [PATCH 08/13] Show an overlay on the memory tab in Firefox
+Subject: [PATCH 08/14] Show an overlay on the memory tab in Firefox
 
 ---
  front_end/entrypoint_template.html          | 18 ++++++++++++++++--

--- a/packages/wrangler-devtools/patches/0009-Support-theme-url-parameter-for-forcing-the-theme-fr.patch
+++ b/packages/wrangler-devtools/patches/0009-Support-theme-url-parameter-for-forcing-the-theme-fr.patch
@@ -1,7 +1,7 @@
 From 0edd0dbfe2704ef6bc527cbfa68dd35989d95cc5 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Fri, 20 Jan 2023 19:19:37 +0000
-Subject: [PATCH 09/13] Support theme= url parameter for forcing the theme from
+Subject: [PATCH 09/14] Support theme= url parameter for forcing the theme from
  outside
 
 ---

--- a/packages/wrangler-devtools/patches/0010-Basic-support-for-text-colour-in-dark-mode-in-browse.patch
+++ b/packages/wrangler-devtools/patches/0010-Basic-support-for-text-colour-in-dark-mode-in-browse.patch
@@ -1,7 +1,7 @@
 From 9d34de7c9010659ece1be008ee852a21e06bff55 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Mon, 23 Jan 2023 15:12:38 +0000
-Subject: [PATCH 10/13] Basic support for text colour in dark mode in browsers
+Subject: [PATCH 10/14] Basic support for text colour in dark mode in browsers
  that don't implement :host-context
 
 ---

--- a/packages/wrangler-devtools/patches/0011-Fallback-to-location-for-domain.patch
+++ b/packages/wrangler-devtools/patches/0011-Fallback-to-location-for-domain.patch
@@ -1,7 +1,7 @@
 From 0091abac4c9631649485198cc36b49ebd4fd40dd Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 26 Jan 2023 15:27:04 +0000
-Subject: [PATCH 11/13] Fallback to location for domain
+Subject: [PATCH 11/14] Fallback to location for domain
 
 ---
  front_end/panels/sources/NavigatorView.ts | 3 ++-

--- a/packages/wrangler-devtools/patches/0012-Hide-unsupported-settings-UI.patch
+++ b/packages/wrangler-devtools/patches/0012-Hide-unsupported-settings-UI.patch
@@ -1,7 +1,7 @@
 From deeac26dadb8f2d7f5653c1994eed41f9e220af2 Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Thu, 26 Jan 2023 15:30:34 +0000
-Subject: [PATCH 12/13] Hide unsupported settings UI
+Subject: [PATCH 12/14] Hide unsupported settings UI
 
 - Show CORS errors in console setting
 - Show XHR requests in console setting

--- a/packages/wrangler-devtools/patches/0013-DEVX-380-Hide-debugger-sidebar-and-disable-breakpoin.patch
+++ b/packages/wrangler-devtools/patches/0013-DEVX-380-Hide-debugger-sidebar-and-disable-breakpoin.patch
@@ -1,7 +1,7 @@
 From cde74d1233f0e89563cfe4d458af197f21c22f18 Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Wed, 15 Feb 2023 15:07:45 +0000
-Subject: [PATCH 13/13] DEVX-380 Hide debugger sidebar and disable breakpoints
+Subject: [PATCH 13/14] DEVX-380 Hide debugger sidebar and disable breakpoints
 
 - Hides debugger sidebar
 - Removes toggle debugger sidebar command

--- a/packages/wrangler-devtools/patches/0014-Add-ping-to-improve-connection-stability.patch
+++ b/packages/wrangler-devtools/patches/0014-Add-ping-to-improve-connection-stability.patch
@@ -1,0 +1,46 @@
+From b6b9e129a3f09863a82d4e0af0cfd234fd0b8f1d Mon Sep 17 00:00:00 2001
+From: Samuel Macleod <smacleod@cloudflare.com>
+Date: Fri, 31 Mar 2023 23:20:07 +0100
+Subject: [PATCH 14/14] Add ping to improve connection stability
+
+---
+ front_end/core/sdk/Connections.ts | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/front_end/core/sdk/Connections.ts b/front_end/core/sdk/Connections.ts
+index f8ac89d283..cb963a973c 100644
+--- a/front_end/core/sdk/Connections.ts
++++ b/front_end/core/sdk/Connections.ts
+@@ -83,6 +83,7 @@ export class WebSocketConnection implements ProtocolClient.InspectorBackend.Conn
+   #onWebSocketDisconnect: (() => void)|null;
+   #connected: boolean;
+   #messages: string[];
++  #pingInterval: ReturnType<typeof setInterval>;
+   constructor(url: Platform.DevToolsPath.UrlString, onWebSocketDisconnect: () => void) {
+     this.#socket = new WebSocket(url);
+     this.#socket.onerror = this.onError.bind(this);
+@@ -99,6 +100,13 @@ export class WebSocketConnection implements ProtocolClient.InspectorBackend.Conn
+     this.#onWebSocketDisconnect = onWebSocketDisconnect;
+     this.#connected = false;
+     this.#messages = [];
++    let highPingId = 100_000;
++    this.#pingInterval = setInterval(() => {
++      this.sendRawMessage(JSON.stringify({
++        method: "Runtime.getIsolateId",
++        id: highPingId++,
++      }));
++    }, 10_000);
+   }
+ 
+   setOnMessage(onMessage: (arg0: (Object|string)) => void): void {
+@@ -151,6 +159,7 @@ export class WebSocketConnection implements ProtocolClient.InspectorBackend.Conn
+       this.#socket = null;
+     }
+     this.#onWebSocketDisconnect = null;
++    clearInterval(this.#pingInterval)
+   }
+ 
+   sendRawMessage(message: string): void {
+-- 
+2.37.1 (Apple Git-137.1)
+


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-386

**What this PR solves / how to test:**

This PR adds an extra patch to Devtools which pings `workerd` every 10 seconds to avoid WebSocket timeout and keep the connection open. It can be tested by using the preview build of devtools which this PR will generate, and verifying that connecting it to `workerd` doesn't disconnect after 1 minute.

**Author has included the following, where applicable:**

- ~[ ] Tests~
- ~[ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
