### PR TITLE
Feat(unstable_dev): Add option to enable update check

### DIFF
--- a/.changeset/cyan-books-act.md
+++ b/.changeset/cyan-books-act.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Feat(unstable_dev): Provide an option for unstable_dev to perform the check that prompts users to update wrangler

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -59,6 +59,7 @@ export interface UnstableDevOptions {
 		testMode?: boolean; // This option shouldn't be used - We plan on removing it eventually
 		testScheduled?: boolean; // Test scheduled events by visiting /__scheduled in browser
 		watch?: boolean; // unstable_dev doesn't support watch-mode yet in testMode
+		doUpdateCheck?: boolean;
 	};
 }
 
@@ -85,6 +86,7 @@ export async function unstable_dev(
 		disableExperimentalWarning: false,
 		showInteractiveDevSession: false,
 		testMode: true,
+		doUpdateCheck: false,
 		// Override all options, including overwriting with "undefined"
 		...options?.experimental,
 	};
@@ -99,6 +101,7 @@ export async function unstable_dev(
 		showInteractiveDevSession,
 		testMode,
 		testScheduled,
+		doUpdateCheck,
 		// 2. options for alpha/beta products/libs
 		d1Databases,
 		experimentalLocal,
@@ -183,6 +186,7 @@ export async function unstable_dev(
 					experimentalEnableLocalPersistence: undefined,
 					legacyEnv: undefined,
 					public: undefined,
+					doUpdateCheck, // whether to prompt the user to update wrangler
 					...options,
 				});
 			}).then((devServer) => {
@@ -273,6 +277,7 @@ export async function unstable_dev(
 					experimentalEnableLocalPersistence: undefined,
 					legacyEnv: undefined,
 					public: undefined,
+					doUpdateCheck, // whether to prompt the user to update wrangler
 					...options,
 				});
 			}).then((devServer) => {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -345,6 +345,7 @@ type StartDevOptions = DevArguments &
 		enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
 		onReady?: (ip: string, port: number) => void;
 		showInteractiveDevSession?: boolean;
+		doUpdateCheck?: boolean;
 	};
 
 export async function startDev(args: StartDevOptions) {
@@ -354,7 +355,7 @@ export async function startDev(args: StartDevOptions) {
 		if (args.logLevel) {
 			logger.loggerLevel = args.logLevel;
 		}
-		await printWranglerBanner();
+		await printWranglerBanner(args.doUpdateCheck);
 
 		if (args.local && process.platform !== "win32") {
 			logger.info(
@@ -515,7 +516,7 @@ export async function startApiDev(args: StartDevOptions) {
 	if (args.logLevel) {
 		logger.loggerLevel = args.logLevel;
 	}
-	await printWranglerBanner();
+	await printWranglerBanner(args.doUpdateCheck);
 
 	const configPath =
 		args.config || (args.script && findWranglerToml(path.dirname(args.script)));

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -91,13 +91,16 @@ ${TOML.stringify({ rules: config.build.upload.rules })}`
 	return rules;
 }
 
-export async function printWranglerBanner() {
+export async function printWranglerBanner(doUpdateCheck = true) {
 	// Let's not print this in tests
 	if (typeof jest !== "undefined") {
 		return;
 	}
 
-	const text = ` ⛅️ wrangler ${wranglerVersion} ${await updateCheck()}`;
+	let text = ` ⛅️ wrangler ${wranglerVersion}`;
+	if (doUpdateCheck) {
+		text += ` ${await updateCheck()}`;
+	}
 
 	logger.log(
 		text +

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -559,6 +559,7 @@ export const Handler = async ({
 			showInteractiveDevSession: undefined,
 			testMode: false,
 			watch: true,
+			doUpdateCheck: true,
 		},
 	});
 	await metrics.sendMetricsEvent("run pages dev");


### PR DESCRIPTION
Fixes #2956.

**What this PR solves / how to test:**

Wrangler makes a HTTP request to the NPM registry, checking for updates to inform end users. While this makes sense in regular commands, it (generally) has little place in it's API, particularly when this is primarily used for tests. 

This pull request adds an experimental option which **disables** the update check, and optionally allows users to enable it. (There are cases for this, such as `pages dev`)

**Associated docs issue(s)/PR(s):**

- N/A

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
