### PR TITLE
boolean fixup

### DIFF
--- a/packages/wrangler-devtools/package.json
+++ b/packages/wrangler-devtools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@cloudflare/wrangler-devtools",
 	"version": "0.0.0",
-	"private": "true",
+	"private": true,
 	"description": "Chrome Devtools hosted for easy use with Wrangler",
 	"homepage": "https://github.com/cloudflare/workers-sdk#readme",
 	"bugs": {


### PR DESCRIPTION
In the package.json for wrangler-devtools the private field was set to string rather than a boolean, boolean will be expected for certain tools and systems.

