### PR TITLE
[wrangler] use choices to pick the location hint

### DIFF
--- a/packages/wrangler/src/d1/create.tsx
+++ b/packages/wrangler/src/d1/create.tsx
@@ -19,8 +19,10 @@ export function Options(yargs: CommonYargsArgv) {
 			demandOption: true,
 		})
 		.option("primary-location-hint", {
-			describe: "A hint for the main location of the new DB",
+			describe:
+				"A hint for the main location of the new DB. Options:\nweur: Europe (west)\neeur: Europe (east)\napac: Asia Pacific\nwnam: North America (west)\nenam: North America (east) \n",
 			type: "string",
+			choices: ["weur", "eeur", "apac", "wnam", "enam"],
 		})
 		.epilogue(d1BetaWarning);
 }


### PR DESCRIPTION
`wrangler d1 create --help` prints:
```
Create D1 database

Positionals:
  name  The name of the new DB  [string] [required]

Flags:
  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
  -c, --config                    Path to .toml configuration file  [string]
  -e, --env                       Environment to use for operations and .env files  [string]
  -h, --help                      Show help  [boolean]
  -v, --version                   Show version number  [boolean]

Options:
      --primary-location-hint  A hint for the main location of the new DB. Options:
                               weur: Europe (west)
                               eeur: Europe (east)
                               apac: Asia Pacific
                               wnam: North America (west)
                               enam: North America (east)
  [string] [choices: "weur", "eeur", "apac", "wnam", "enam"]
```