### PR TITLE
ci: fix the release github workflow

### DIFF
--- a/.github/changeset-version.js
+++ b/.github/changeset-version.js
@@ -6,4 +6,13 @@ const { execSync } = require("node:child_process");
 // This is a workaround until this is handled automatically by `changeset version`.
 // See https://github.com/changesets/changesets/issues/421.
 execSync("npx changeset version");
-execSync("npm install --package-lock-only");
+
+// HACK: run a newer version of npm that can update package-lock.json using local dependencies.
+// See https://github.com/npm/cli/issues/4379 and https://github.com/npm/cli/pull/4371.
+// The error looks like: `No matching version found for wrangler@^2.15.0.`
+if (!process.version.startsWith("v16")) {
+	throw new Error(
+		"You have updated node version and so you must now remove the hack below!"
+	);
+}
+execSync("npx -y npm@8.5.0 install --package-lock-only");


### PR DESCRIPTION
This workflow was failing whenever there was a minor release to wrangler and a patch release to a package that depended upon wrangler. It was caused by a bug in npm that was resolved in v8.5.0. See https://github.com/npm/cli/issues/4379 and https://github.com/npm/cli/pull/4371. The error looks like: `No matching version found for wrangler@^2.15.0.`

