### PR TITLE
[wrangler] teach wrangler to search docs

### DIFF
--- a/.changeset/six-toes-yawn.md
+++ b/.changeset/six-toes-yawn.md
@@ -1,0 +1,15 @@
+---
+"wrangler": minor
+---
+
+feat: teach `wrangler docs` to use algolia search index
+
+This PR lets you search Cloudflare's entire docs via `wrangler docs [search term here]`.
+
+By default, if the search fails to find what you're looking for, you'll get an error like this:
+
+```
+✘ [ERROR] Could not find docs for: <search term goes here>. Please try again with another search term.
+```
+
+If you provide the `--yes` or `-y` flag, wrangler will open the docs to https://developers.cloudflare.com/workers/wrangler/commands/, even if the search fails.

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -37,6 +37,8 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: "production"
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
 
       - name: Pack wrangler
         run: npm pack

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -87,6 +87,8 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: "production"
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
 
       - name: Build & Publish Prerelease Registry
         run: npm run publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
           NODE_ENV: "production"
           # This is the "production" key for sparrow analytics.
           # Include this here because this step will rebuild Wrangler and needs to have this available

--- a/packages/wrangler/scripts/bundle.ts
+++ b/packages/wrangler/scripts/bundle.ts
@@ -56,6 +56,12 @@ async function buildMain(flags: BuildFlags = {}) {
 			...(process.env.SPARROW_SOURCE_KEY
 				? { SPARROW_SOURCE_KEY: `"${process.env.SPARROW_SOURCE_KEY}"` }
 				: {}),
+			...(process.env.ALGOLIA_APP_ID
+				? { ALGOLIA_APP_ID: `"${process.env.ALGOLIA_APP_ID}"` }
+				: {}),
+			...(process.env.ALGOLIA_PUBLIC_KEY
+				? { ALGOLIA_PUBLIC_KEY: `"${process.env.ALGOLIA_PUBLIC_KEY}"` }
+				: {}),
 		},
 		watch: flags.watch ? watchLogger("./wrangler-dist") : false,
 	});

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -32,7 +32,7 @@ describe("wrangler", () => {
 			"wrangler
 
 			Commands:
-			  wrangler docs [command]              📚 Open wrangler's docs in your browser
+			  wrangler docs [command..]            📚 Open wrangler's docs in your browser
 			  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
 			  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/templates
 			  wrangler dev [script]                👂 Start a local server for developing your worker
@@ -85,7 +85,7 @@ describe("wrangler", () => {
 			wrangler
 
 			Commands:
-			  wrangler docs [command]              📚 Open wrangler's docs in your browser
+			  wrangler docs [command..]            📚 Open wrangler's docs in your browser
 			  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
 			  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/templates
 			  wrangler dev [script]                👂 Start a local server for developing your worker

--- a/packages/wrangler/src/__tests__/mtls-certificates.test.ts
+++ b/packages/wrangler/src/__tests__/mtls-certificates.test.ts
@@ -362,7 +362,7 @@ describe("wrangler", () => {
 				"wrangler
 
 				Commands:
-				  wrangler docs [command]              📚 Open wrangler's docs in your browser
+				  wrangler docs [command..]            📚 Open wrangler's docs in your browser
 				  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
 				  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/templates
 				  wrangler dev [script]                👂 Start a local server for developing your worker

--- a/packages/wrangler/src/docs/helpers.ts
+++ b/packages/wrangler/src/docs/helpers.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert";
+import { fetch } from "undici";
+import { logger } from "../logger";
+
+// The ALGOLIA_APP_ID and ALGOLIA_PUBLIC_KEY are provided at esbuild time as a `define` for production and beta releases.
+// Otherwise it is left undefined, which disables search.
+declare const ALGOLIA_APP_ID: string;
+declare const ALGOLIA_PUBLIC_KEY: string;
+
+export async function runSearch(searchTerm: string) {
+	const id = ALGOLIA_APP_ID;
+	const index = "developers-cloudflare2";
+	const key = ALGOLIA_PUBLIC_KEY;
+	const params = new URLSearchParams({
+		query: searchTerm,
+		hitsPerPage: "1",
+		getRankingInfo: "0",
+	});
+
+	assert(id, "Missing Algolia App ID");
+	assert(key, "Missing Algolia Key");
+
+	const searchResp = await fetch(
+		`https://${id}-dsn.algolia.net/1/indexes/${index}/query`,
+		{
+			method: "POST",
+			body: JSON.stringify({
+				params: params.toString(),
+			}),
+			headers: {
+				"X-Algolia-API-Key": key,
+				"X-Algolia-Application-Id": id,
+			},
+		}
+	);
+	if (!searchResp.ok) {
+		logger.error(`Could not search the docs. Please try again later.`);
+		return;
+	}
+	const searchData = (await searchResp.json()) as { hits: { url: string }[] };
+	logger.debug("searchData: ", searchData);
+	if (searchData.hits[0]) {
+		return searchData.hits[0].url;
+	} else {
+		logger.error(
+			`Could not find docs for: ${searchTerm}. Please try again with another search term.`
+		);
+		return;
+	}
+}

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -271,7 +271,7 @@ export function createCLIParser(argv: string[]) {
 
 	// docs
 	wrangler.command(
-		"docs [command]",
+		"docs [command..]",
 		"📚 Open wrangler's docs in your browser",
 		docsOptions,
 		docsHandler


### PR DESCRIPTION
I basically taught wrangler how to do a "I'm feeling lucky" search

How it works:
- The wrangler user enters `wrangler docs <command>`
- wrangler sends an API request to Algolia's index of https://developers.cloudflare.com/workers/wrangler/
- wrangler sends the user to the first URL in the index that matches the search term

Here's what it looks like in action:

https://user-images.githubusercontent.com/3822106/207370613-eacccce9-ddea-4c9b-82d1-de476ff52fa2.mov



@rita3ko FYI