### PR TITLE
WIP Refactor of bindings

### DIFF
--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -3026,9 +3026,6 @@ describe("normalizeAndValidateConfig()", () => {
 			    - \\"define\\" exists at the top level, but not on \\"env.ENV1\\".
 			      This is not what you probably want, since \\"define\\" is not inherited by environments.
 			      Please add \\"define\\" to \\"env.ENV1\\".
-			    - \\"durable_objects\\" exists at the top level, but not on \\"env.ENV1\\".
-			      This is not what you probably want, since \\"durable_objects\\" is not inherited by environments.
-			      Please add \\"durable_objects\\" to \\"env.ENV1\\".
 			    - \\"kv_namespaces\\" exists at the top level, but not on \\"env.ENV1\\".
 			      This is not what you probably want, since \\"kv_namespaces\\" is not inherited by environments.
 			      Please add \\"kv_namespaces\\" to \\"env.ENV1\\".
@@ -3040,7 +3037,10 @@ describe("normalizeAndValidateConfig()", () => {
 			      Please add \\"analytics_engine_datasets\\" to \\"env.ENV1\\".
 			    - \\"unsafe\\" exists at the top level, but not on \\"env.ENV1\\".
 			      This is not what you probably want, since \\"unsafe\\" is not inherited by environments.
-			      Please add \\"unsafe\\" to \\"env.ENV1\\"."
+			      Please add \\"unsafe\\" to \\"env.ENV1\\".
+			    - \\"durable_objects\\" exists at the top level, but not on \\"env.ENV1\\".
+			      This is not what you probably want, since \\"durable_objects\\" is not inherited by environments.
+			      Please add \\"durable_objects\\" to \\"env.ENV1\\"."
 		`);
 		});
 

--- a/packages/wrangler/src/bindings/binding-durable-object.ts
+++ b/packages/wrangler/src/bindings/binding-durable-object.ts
@@ -1,0 +1,121 @@
+import { isOptionalProperty, isRequiredProperty, notInheritable, validateBindingsProperty } from "../config/validation-helpers";
+import type { RawConfig, RawEnvironment } from "../config";
+import type { Diagnostics } from "../config/diagnostics";
+import type { ValidatorFn } from "../config/validation-helpers";
+import type { Environment } from "./../config/environment";
+
+// ===== Format read from config =====
+
+// Internal details
+
+export type DurableObjectFromConfig = {
+	/** The name of the binding used to refer to the Durable Object */
+	name: string;
+	/** The exported class name of the Durable Object */
+	class_name: string;
+	/** The script where the Durable Object is defined (if it's external to this worker) */
+	script_name?: string;
+	/** The service environment of the script_name to bind to */
+	environment?: string;
+}[];
+
+// Type added to Environment
+
+export interface BindingTypeDurableObject {
+	/**
+	 * A list of durable objects that your worker should be bound to.
+	 *
+	 * For more information about Durable Objects, see the documentation at
+	 * https://developers.cloudflare.com/workers/learning/using-durable-objects
+	 *
+	 * NOTE: This field is not automatically inherited from the top level environment,
+	 * and so must be specified in every named environment.
+	 *
+	 * @default `{bindings:[]}`
+	 * @nonInheritable
+	 */
+	durable_objects: {
+		bindings: DurableObjectFromConfig;
+	};
+}
+
+// ===== Format written to upload form ====
+
+export interface CfDurableObject {
+	name: string;
+	class_name: string;
+	script_name?: string;
+	environment?: string;
+}
+
+export function get_durable_object(
+	diagnostics: Diagnostics,
+	topLevelEnv: Environment | undefined,
+	rawConfig: RawConfig | undefined,
+	rawEnv: RawEnvironment,
+	envName: string,
+) {
+  return notInheritable(
+    diagnostics,
+    topLevelEnv,
+    rawConfig,
+    rawEnv,
+    envName,
+    "durable_objects",
+    validateBindingsProperty(envName, validateDurableObjectBinding),
+    {
+      bindings: [],
+    }
+  )
+}
+
+// ===== Validation function =====
+
+/**
+ * Check that the given field is a valid "durable_object" binding object.
+ */
+const validateDurableObjectBinding: ValidatorFn = (
+	diagnostics,
+	field,
+	value
+) => {
+	if (typeof value !== "object" || value === null) {
+		diagnostics.errors.push(
+			`Expected "${field}" to be an object but got ${JSON.stringify(value)}`
+		);
+		return false;
+	}
+
+	// Durable Object bindings must have a name and class_name, and optionally a script_name and an environment.
+	let isValid = true;
+	if (!isRequiredProperty(value, "name", "string")) {
+		diagnostics.errors.push(`binding should have a string "name" field.`);
+		isValid = false;
+	}
+	if (!isRequiredProperty(value, "class_name", "string")) {
+		diagnostics.errors.push(`binding should have a string "class_name" field.`);
+		isValid = false;
+	}
+	if (!isOptionalProperty(value, "script_name", "string")) {
+		diagnostics.errors.push(
+			`the field "script_name", when present, should be a string.`
+		);
+		isValid = false;
+	}
+	// environment requires a script_name
+	if (!isOptionalProperty(value, "environment", "string")) {
+		diagnostics.errors.push(
+			`the field "environment", when present, should be a string.`
+		);
+		isValid = false;
+	}
+
+	if ("environment" in value && !("script_name" in value)) {
+		diagnostics.errors.push(
+			`binding should have a "script_name" field if "environment" is present.`
+		);
+		isValid = false;
+	}
+
+	return isValid;
+};

--- a/packages/wrangler/src/bindings/bindings.ts
+++ b/packages/wrangler/src/bindings/bindings.ts
@@ -1,0 +1,20 @@
+import { Environment } from "../config/environment";
+import { RawConfig, RawEnvironment } from "../config";
+import { Diagnostics } from "../config/diagnostics";
+import type {DurableObjectFromConfig, BindingTypeDurableObject, CfDurableObject } from "./binding-durable-object"
+import {get_durable_object } from "./binding-durable-object"
+export type { DurableObjectFromConfig, BindingTypeDurableObject, CfDurableObject }
+
+export type BindingTypesNonInheritable = BindingTypeDurableObject;
+
+export function get_env_bindings_array(
+	diagnostics: Diagnostics,
+	topLevelEnv: Environment | undefined,
+	rawConfig: RawConfig | undefined,
+	rawEnv: RawEnvironment,
+	envName: string,
+){
+  return {
+    durable_objects: get_durable_object(diagnostics, topLevelEnv, rawConfig, rawEnv, envName),
+  }
+}

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -9,7 +9,7 @@ import tmp from "tmp-promise";
 import createModuleCollector from "./module-collection";
 import { getBasePath, toUrlPath } from "./paths";
 import type { Config } from "./config";
-import type { DurableObjectBindings } from "./config/environment";
+import type { DurableObjectFromConfig } from "./bindings/bindings";
 import type { WorkerRegistry } from "./dev-registry";
 import type { Entry } from "./entry";
 import type { CfModule } from "./worker";
@@ -120,7 +120,7 @@ export async function bundleWorker(
 		serveAssetsFromWorker: boolean;
 		assets?: StaticAssetsConfig;
 		betaD1Shims?: string[];
-		doBindings: DurableObjectBindings;
+		doBindings: DurableObjectFromConfig;
 		jsxFactory?: string;
 		jsxFragment?: string;
 		entryName?: string;
@@ -835,7 +835,7 @@ async function applyD1BetaFacade(
 	tmpDirPath: string,
 	betaD1Shims: string[],
 	miniflare2: boolean,
-	doBindings: DurableObjectBindings
+	doBindings: DurableObjectFromConfig
 ): Promise<Entry> {
 	let entrypointPath = path.resolve(
 		getBasePath(),

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -26,6 +26,8 @@ export type Route =
 	| ZoneNameRoute
 	| CustomDomainRoute;
 
+import { BindingTypesNonInheritable } from "./../bindings/bindings"
+
 /**
  * The `EnvironmentInheritable` interface declares all the configuration fields for an environment
  * that can be inherited (and overridden) from the top-level environment.
@@ -267,17 +269,6 @@ interface EnvironmentInheritable {
 	logpush: boolean | undefined;
 }
 
-export type DurableObjectBindings = {
-	/** The name of the binding used to refer to the Durable Object */
-	name: string;
-	/** The exported class name of the Durable Object */
-	class_name: string;
-	/** The script where the Durable Object is defined (if it's external to this worker) */
-	script_name?: string;
-	/** The service environment of the script_name to bind to */
-	environment?: string;
-}[];
-
 /**
  * The `EnvironmentNonInheritable` interface declares all the configuration fields for an environment
  * that cannot be inherited from the top-level environment, and must be defined specifically.
@@ -285,7 +276,7 @@ export type DurableObjectBindings = {
  * If any of these fields are defined at the top-level then they should also be specifically defined
  * for each named environment.
  */
-interface EnvironmentNonInheritable {
+interface EnvironmentNonInheritable extends BindingTypesNonInheritable {
 	/**
 	 * A map of values to substitute when deploying your worker.
 	 *
@@ -306,22 +297,6 @@ interface EnvironmentNonInheritable {
 	 * @nonInheritable
 	 */
 	vars: { [key: string]: unknown };
-
-	/**
-	 * A list of durable objects that your worker should be bound to.
-	 *
-	 * For more information about Durable Objects, see the documentation at
-	 * https://developers.cloudflare.com/workers/learning/using-durable-objects
-	 *
-	 * NOTE: This field is not automatically inherited from the top level environment,
-	 * and so must be specified in every named environment.
-	 *
-	 * @default `{bindings:[]}`
-	 * @nonInheritable
-	 */
-	durable_objects: {
-		bindings: DurableObjectBindings;
-	};
 
 	/**
 	 * These specify any Workers KV Namespaces you want to

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -31,13 +31,13 @@ import type {
 	CfWasmModuleBindings,
 	CfTextBlobBindings,
 	CfDataBlobBindings,
-	CfDurableObject,
 	CfKvNamespace,
 	CfR2Bucket,
 	CfVars,
 	CfQueue,
 	CfD1Database,
 } from "../worker";
+import type { CfDurableObject } from "./../bindings/bindings"
 import type { EsbuildBundle } from "./use-esbuild";
 import type {
 	Miniflare as Miniflare3Type,

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -27,7 +27,7 @@ import { startRemoteServer } from "./remote";
 import { validateDevProps } from "./validate-dev-props";
 
 import type { Config } from "../config";
-import type { DurableObjectBindings } from "../config/environment";
+import type { DurableObjectFromConfig } from "../bindings/bindings";
 import type { WorkerRegistry } from "../dev-registry";
 import type { Entry } from "../entry";
 import type { DevProps, DirectorySyncResult } from "./dev";
@@ -243,7 +243,7 @@ async function runEsbuild({
 	testScheduled?: boolean;
 	local: boolean;
 	experimentalLocal: boolean | undefined;
-	doBindings: DurableObjectBindings;
+	doBindings: DurableObjectFromConfig;
 }): Promise<EsbuildBundle | undefined> {
 	if (!destination) return;
 

--- a/packages/wrangler/src/entry.ts
+++ b/packages/wrangler/src/entry.ts
@@ -7,7 +7,7 @@ import { COMMON_ESBUILD_OPTIONS } from "./bundle";
 import { logger } from "./logger";
 import { getBasePath } from "./paths";
 import type { Config } from "./config";
-import type { DurableObjectBindings } from "./config/environment";
+import type { DurableObjectFromConfig } from "./bindings/bindings";
 import type { CfScriptFormat } from "./worker";
 import type { Metafile } from "esbuild";
 
@@ -251,11 +251,11 @@ export function fileExists(filePath: string): boolean {
  * those that are defined locally and those that refer to a durable object defined in another script.
  */
 function partitionDurableObjectBindings(config: Config): {
-	localBindings: DurableObjectBindings;
-	remoteBindings: DurableObjectBindings;
+	localBindings: DurableObjectFromConfig;
+	remoteBindings: DurableObjectFromConfig;
 } {
-	const localBindings: DurableObjectBindings = [];
-	const remoteBindings: DurableObjectBindings = [];
+	const localBindings: DurableObjectFromConfig = [];
+	const remoteBindings: DurableObjectFromConfig = [];
 	for (const binding of config.durable_objects.bindings) {
 		if (binding.script_name === undefined) {
 			localBindings.push(binding);
@@ -272,7 +272,7 @@ function partitionDurableObjectBindings(config: Config): {
  * externally defined Durable Object.
  */
 function generateAddScriptNameExamples(
-	localBindings: DurableObjectBindings
+	localBindings: DurableObjectFromConfig
 ): string {
 	function exampleScriptName(binding_name: string): string {
 		return `${binding_name.toLowerCase().replaceAll("_", "-")}-worker`;

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -1,3 +1,4 @@
+import type { CfDurableObject } from "./bindings/bindings";
 import type { Environment } from "./config";
 import type { Route } from "./config/environment";
 import type { ApiCredentials } from "./user";
@@ -110,16 +111,6 @@ export interface CfTextBlobBindings {
 
 export interface CfDataBlobBindings {
 	[key: string]: string;
-}
-
-/**
- * A Durable Object.
- */
-export interface CfDurableObject {
-	name: string;
-	class_name: string;
-	script_name?: string;
-	environment?: string;
 }
 
 export interface CfQueue {


### PR DESCRIPTION
This PR is to discuss the refactoring bindings.

Currently data structures and functionality for bindings are in many files.  Adding a new binding, or extending an existing one, is difficult because you have to track down everywhere you need to change, and also figure out which data structures are for reading the existing bindings from wrangler.toml and which are for uploading with the worker (and where/how the conversion happens).

My suggestion is that we extract each binding into its own file with four broad sections:
- Data structure for reading from config
- Data structure for writing into the upload form
- Conversion function
- Validation function

bindings/bindings.ts becomes a single registry that glues the bindings together.

To add a new binding you would:
- Create your new binding file: bindings/my-binding.ts
- Add the type to BindingTypesNonInheritable
- Add an entry to get_env_bindings_array

I suspect we need to extract a couple of other things, ideally I want to eliminate anyone having to reference a concrete binding type anywhere in the code except in bindings/*.ts.  So we need to do some abstraction in worker.ts and create-worker-upload-form.ts.

This PR just extracts one binding for now, durable_object.  If there is interest in this approach I will continue with durable_object and convert another binding too.
