### PR TITLE
[quick-edit] Typescript support through JSDoc 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,4 +196,4 @@ packages/quick-edit/web
 
 # VSCode Theme
 *.vsix
-./vendor/vscode
+vendor/vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -15607,8 +15607,12 @@
 			}
 		},
 		"node_modules/esbuild-register": {
-			"version": "3.3.2",
-			"license": "MIT",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.4.2.tgz",
+			"integrity": "sha512-kG/XyTDyz6+YDuyfB9ZoSIOOmgyFCH+xPRtsCa8W85HLRV5Csp+o3jWVbOSHgSLfyLc5DmP+KFDNwty4mEjC+Q==",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
 			"peerDependencies": {
 				"esbuild": ">=0.12 <1"
 			}
@@ -44557,12 +44561,20 @@
 		"packages/quick-edit-extension": {
 			"version": "0.0.1",
 			"devDependencies": {
-				"esbuild": "^0.17.11",
+				"@cloudflare/workers-types": "^4.20230404.0",
+				"esbuild": "0.16.3",
+				"esbuild-register": "^3.4.2",
 				"typescript": "^4.9.5"
 			},
 			"engines": {
 				"vscode": "^1.76.0"
 			}
+		},
+		"packages/quick-edit-extension/node_modules/@cloudflare/workers-types": {
+			"version": "4.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230404.0.tgz",
+			"integrity": "sha512-fG3oaJX1icfsGV74nhx1+AC6opvZsGqnpx6FvrcVqQaBmCNkjKNqDRFrpasXWFiOIvysBXHKQAzsAJkBZgnM+A==",
+			"dev": true
 		},
 		"packages/quick-edit-extension/node_modules/@esbuild/android-arm": {
 			"version": "0.17.15",
@@ -67822,8 +67834,12 @@
 			"optional": true
 		},
 		"esbuild-register": {
-			"version": "3.3.2",
-			"requires": {}
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.4.2.tgz",
+			"integrity": "sha512-kG/XyTDyz6+YDuyfB9ZoSIOOmgyFCH+xPRtsCa8W85HLRV5Csp+o3jWVbOSHgSLfyLc5DmP+KFDNwty4mEjC+Q==",
+			"requires": {
+				"debug": "^4.3.4"
+			}
 		},
 		"esbuild-sunos-64": {
 			"version": "0.15.12",
@@ -84616,10 +84632,18 @@
 		"quick-edit-extension": {
 			"version": "file:packages/quick-edit-extension",
 			"requires": {
-				"esbuild": "^0.17.11",
+				"@cloudflare/workers-types": "^4.20230404.0",
+				"esbuild": "0.16.3",
+				"esbuild-register": "^3.4.2",
 				"typescript": "^4.9.5"
 			},
 			"dependencies": {
+				"@cloudflare/workers-types": {
+					"version": "4.20230404.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230404.0.tgz",
+					"integrity": "sha512-fG3oaJX1icfsGV74nhx1+AC6opvZsGqnpx6FvrcVqQaBmCNkjKNqDRFrpasXWFiOIvysBXHKQAzsAJkBZgnM+A==",
+					"dev": true
+				},
 				"@esbuild/android-arm": {
 					"version": "0.17.15",
 					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.15.tgz",
@@ -84775,8 +84799,7 @@
 					"optional": true
 				},
 				"esbuild": {
-					"version": "0.17.15",
-					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.15.tgz",
+					"version": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.15.tgz",
 					"integrity": "sha512-LBUV2VsUIc/iD9ME75qhT4aJj0r75abCVS0jakhFzOtR7TQsqQA5w0tZ+KTKnwl3kXE0MhskNdHDh/I5aCR1Zw==",
 					"dev": true,
 					"requires": {

--- a/packages/quick-edit-extension/package.json
+++ b/packages/quick-edit-extension/package.json
@@ -10,7 +10,7 @@
 	"publisher": "cloudflare",
 	"browser": "./dist/extension.js",
 	"scripts": {
-		"package-web": "esbuild --bundle --external:vscode --format=cjs src/extension.ts --outfile=dist/extension.js",
+		"package-web": "node -r esbuild-register scripts/bundle.ts",
 		"vscode:prepublish": "npm run package-web",
 		"watch-web": "npm run package-web -- --watch"
 	},
@@ -40,7 +40,9 @@
 		"onFileSystem:cfs"
 	],
 	"devDependencies": {
-		"esbuild": "^0.17.11",
+		"@cloudflare/workers-types": "^4.20230404.0",
+		"esbuild": "0.16.3",
+		"esbuild-register": "^3.4.2",
 		"typescript": "^4.9.5"
 	},
 	"engines": {

--- a/packages/quick-edit-extension/scripts/bundle.ts
+++ b/packages/quick-edit-extension/scripts/bundle.ts
@@ -1,0 +1,61 @@
+import { readFile } from "fs/promises";
+import * as esbuild from "esbuild";
+
+type BuildFlags = {
+	watch?: boolean;
+};
+
+async function buildMain(flags: BuildFlags = {}) {
+	const options: esbuild.BuildOptions = {
+		entryPoints: ["./src/extension.ts"],
+		bundle: true,
+		outfile: "./dist/extension.js",
+		format: "cjs",
+		external: ["vscode"],
+		logLevel: "info",
+		plugins: [
+			{
+				name: "workers-types",
+				setup(build) {
+					build.onResolve({ filter: /^raw:.*/ }, async (args) => {
+						const result = await build.resolve(args.path.slice(4), {
+							kind: "import-statement",
+							resolveDir: args.resolveDir,
+						});
+						return {
+							path: result.path,
+							namespace: "raw-file",
+						};
+					});
+
+					build.onLoad(
+						{ filter: /.*/, namespace: "raw-file" },
+						async (args) => {
+							const contents = await readFile(args.path);
+							return { contents, loader: "text" };
+						}
+					);
+				},
+			},
+		],
+	};
+	if (flags.watch) {
+		const ctx = await esbuild.context(options);
+		await ctx.watch();
+	} else {
+		await esbuild.build(options);
+	}
+}
+
+async function run() {
+	await buildMain();
+	if (process.argv.includes("--watch")) {
+		console.log("Built. Watching for changes...");
+		await Promise.all([buildMain({ watch: true })]);
+	}
+}
+
+run().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/packages/quick-edit-extension/scripts/tsconfig.json
+++ b/packages/quick-edit-extension/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"module": "CommonJS",
+		"types": ["node"]
+	},
+	"include": ["bundle.ts"],
+	"exclude": []
+}

--- a/packages/quick-edit-extension/src/raw.d.ts
+++ b/packages/quick-edit-extension/src/raw.d.ts
@@ -1,0 +1,4 @@
+declare module "raw:*" {
+	const value: string;
+	export default value;
+}

--- a/packages/quick-edit-extension/tsconfig.json
+++ b/packages/quick-edit-extension/tsconfig.json
@@ -7,5 +7,6 @@
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true
-	}
+	},
+	"exclude": ["scripts"]
 }

--- a/packages/quick-edit/patches/0001-Add-Custom-workbench-for-Cloudflare.patch
+++ b/packages/quick-edit/patches/0001-Add-Custom-workbench-for-Cloudflare.patch
@@ -1,7 +1,7 @@
-From 1d978b85556fde86dfec9ed1455e35c9b587ba95 Mon Sep 17 00:00:00 2001
+From 6849aafb8c1311b367431cbf6054a531abed2134 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Mon, 3 Apr 2023 11:18:10 +0100
-Subject: [PATCH 01/10] Add Custom workbench for Cloudflare
+Subject: [PATCH 01/11] Add Custom workbench for Cloudflare
 
 ---
  src/vs/code/browser/workbench/workbench.ts | 522 +++------------------

--- a/packages/quick-edit/patches/0002-Remove-Themes-from-Setting-SubMenu.patch
+++ b/packages/quick-edit/patches/0002-Remove-Themes-from-Setting-SubMenu.patch
@@ -1,7 +1,7 @@
-From 69a4c2e499a1e9ba99c2ea819b41af7abfb4053e Mon Sep 17 00:00:00 2001
+From 6c409326aafb7a6ad7a755f642468e15f05dd4f2 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:11:08 -0500
-Subject: [PATCH 02/10] Remove Themes from Setting SubMenu
+Subject: [PATCH 02/11] Remove Themes from Setting SubMenu
 
 ---
  .../themes/browser/themes.contribution.ts     | 76 +++++++++----------

--- a/packages/quick-edit/patches/0003-Removed-Menu.patch
+++ b/packages/quick-edit/patches/0003-Removed-Menu.patch
@@ -1,7 +1,7 @@
-From ca3fff3caa78e54bee3503f985dd84800632239b Mon Sep 17 00:00:00 2001
+From d779d203de3f456a7b3c7f1674ec67403e40cfa2 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Tue, 28 Mar 2023 14:41:00 -0500
-Subject: [PATCH 03/10] Removed Menu
+Subject: [PATCH 03/11] Removed Menu
 
 ---
  .../browser/parts/titlebar/menubarControl.ts  | 94 +++++++++----------

--- a/packages/quick-edit/patches/0004-Remove-Profile-from-Setting-SubMenu.patch
+++ b/packages/quick-edit/patches/0004-Remove-Profile-from-Setting-SubMenu.patch
@@ -1,7 +1,7 @@
-From 6434055430af0c2789affd2296900fefc0765d2c Mon Sep 17 00:00:00 2001
+From a0f0970d77717bb6715de290e08720f50693a39c Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:11:28 -0500
-Subject: [PATCH 04/10] Remove Profile from Setting SubMenu
+Subject: [PATCH 04/11] Remove Profile from Setting SubMenu
 
 ---
  .../browser/userDataProfile.ts                | 46 +++++++++----------

--- a/packages/quick-edit/patches/0005-Remove-Account-Extension.patch
+++ b/packages/quick-edit/patches/0005-Remove-Account-Extension.patch
@@ -1,7 +1,7 @@
-From 123d396902358d75908af3a360c75950763b413f Mon Sep 17 00:00:00 2001
+From a532ef3f3e5630c3c139ef377eec4d2d9d65a0fb Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Tue, 28 Mar 2023 14:53:02 -0500
-Subject: [PATCH 05/10] Remove Account & Extension
+Subject: [PATCH 05/11] Remove Account & Extension
 
 ---
  .../parts/activitybar/activitybarPart.ts      | 26 +++++++++----------

--- a/packages/quick-edit/patches/0006-Remove-Debug-Icon-other-default-views.patch
+++ b/packages/quick-edit/patches/0006-Remove-Debug-Icon-other-default-views.patch
@@ -1,7 +1,7 @@
-From e49ad7c980d22439853c75c7e2c1c55a007c556f Mon Sep 17 00:00:00 2001
+From 098049536be307fae8309d0f48e1ff92c19c1abd Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:08:40 -0500
-Subject: [PATCH 06/10] Remove Debug Icon & other default views
+Subject: [PATCH 06/11] Remove Debug Icon & other default views
 
 ---
  .../debug/browser/debug.contribution.ts       | 46 +++++++++----------

--- a/packages/quick-edit/patches/0007-Remove-Source-Control.patch
+++ b/packages/quick-edit/patches/0007-Remove-Source-Control.patch
@@ -1,7 +1,7 @@
-From bdc5b0d280c565e2ac586f83ac1f8ad67bcd2770 Mon Sep 17 00:00:00 2001
+From 2138039ca5b9a35f1abefb723118c89758179ebf Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Tue, 28 Mar 2023 14:42:09 -0500
-Subject: [PATCH 07/10] Remove Source Control
+Subject: [PATCH 07/11] Remove Source Control
 
 ---
  .../contrib/scm/browser/scm.contribution.ts   | 100 +++++++++---------

--- a/packages/quick-edit/patches/0008-Remove-Custom-Menu-hamburger.patch
+++ b/packages/quick-edit/patches/0008-Remove-Custom-Menu-hamburger.patch
@@ -1,7 +1,7 @@
-From 4ff93c1ca04ac255866ccb3688177d31a13af590 Mon Sep 17 00:00:00 2001
+From 3b5d5f2f949840d45d8ff29db9d219dc3b6d22c6 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:07:44 -0500
-Subject: [PATCH 08/10] Remove 'Custom' Menu (hamburger)
+Subject: [PATCH 08/11] Remove 'Custom' Menu (hamburger)
 
 ---
  .../parts/activitybar/activitybarPart.ts      |   6 +-

--- a/packages/quick-edit/patches/0009-Remove-Extensions-Icon-Quick-Access.patch
+++ b/packages/quick-edit/patches/0009-Remove-Extensions-Icon-Quick-Access.patch
@@ -1,7 +1,7 @@
-From befb9a90cb5c6c5c6dc8498a8b7a146f6508a4f8 Mon Sep 17 00:00:00 2001
+From bc4b9b6591ec7f0c569f4e1f0dd05afdec43c611 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:10:30 -0500
-Subject: [PATCH 09/10] Remove Extensions Icon & Quick Access
+Subject: [PATCH 09/11] Remove Extensions Icon & Quick Access
 
 ---
  .../browser/extensions.contribution.ts        | 98 +++++++++----------

--- a/packages/quick-edit/patches/0010-Remove-dead-code.patch
+++ b/packages/quick-edit/patches/0010-Remove-dead-code.patch
@@ -1,7 +1,7 @@
-From 123c969a5704c42673f6311d8fc6c3e7213cf85c Mon Sep 17 00:00:00 2001
+From 1f225f5e42b0b8e0d0e0fa44205a2391b034b9ba Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Wed, 12 Apr 2023 18:46:53 +0100
-Subject: [PATCH 10/10] Remove dead code
+Subject: [PATCH 10/11] Remove dead code
 
 ---
  .../parts/activitybar/activitybarPart.ts      |  16 +-

--- a/packages/quick-edit/patches/0011-Support-project-wide-typescript-on-web.patch
+++ b/packages/quick-edit/patches/0011-Support-project-wide-typescript-on-web.patch
@@ -1,0 +1,774 @@
+From ac6293cf9414937b3098cb82ef158c71a3342fa9 Mon Sep 17 00:00:00 2001
+From: Workers DevProd <workers-devprod@cloudflare.com>
+Date: Fri, 14 Apr 2023 01:54:40 +0100
+Subject: [PATCH 11/11] Support project-wide typescript on web
+
+---
+ .../typescript-language-features/package.json |   2 +-
+ .../src/extension.browser.ts                  |   4 -
+ .../src/tsServer/serverProcess.browser.ts     |  66 ++-
+ .../src/typescriptServiceClient.ts            |   4 +-
+ .../web/cfs-simple.ts                         | 425 ++++++++++++++++++
+ .../web/webServer.ts                          |  85 +++-
+ 6 files changed, 547 insertions(+), 39 deletions(-)
+ create mode 100644 extensions/typescript-language-features/web/cfs-simple.ts
+
+diff --git a/extensions/typescript-language-features/package.json b/extensions/typescript-language-features/package.json
+index 30ccbd8..62f99a2 100644
+--- a/extensions/typescript-language-features/package.json
++++ b/extensions/typescript-language-features/package.json
+@@ -906,7 +906,7 @@
+             "%typescript.preferences.importModuleSpecifierEnding.index%",
+             "%typescript.preferences.importModuleSpecifierEnding.js%"
+           ],
+-          "default": "auto",
++          "default": "js",
+           "description": "%typescript.preferences.importModuleSpecifierEnding%",
+           "scope": "language-overridable"
+         },
+diff --git a/extensions/typescript-language-features/src/extension.browser.ts b/extensions/typescript-language-features/src/extension.browser.ts
+index 517c6f8..b8bd688 100644
+--- a/extensions/typescript-language-features/src/extension.browser.ts
++++ b/extensions/typescript-language-features/src/extension.browser.ts
+@@ -21,7 +21,6 @@ import { TypeScriptServiceConfiguration } from './utils/configuration';
+ import { BrowserServiceConfigurationProvider } from './utils/configuration.browser';
+ import { Logger } from './utils/logger';
+ import { getPackageInfo } from './utils/packageInfo';
+-import { isWebAndHasSharedArrayBuffers } from './utils/platform';
+ import { PluginManager } from './utils/plugins';
+ 
+ class StaticVersionProvider implements ITypeScriptVersionProvider {
+@@ -103,9 +102,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
+ }
+ 
+ async function preload(logger: Logger): Promise<void> {
+-	if (!isWebAndHasSharedArrayBuffers()) {
+-		return;
+-	}
+ 
+ 	const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri;
+ 	if (!workspaceUri || workspaceUri.scheme !== 'vscode-vfs' || workspaceUri.authority !== 'github') {
+diff --git a/extensions/typescript-language-features/src/tsServer/serverProcess.browser.ts b/extensions/typescript-language-features/src/tsServer/serverProcess.browser.ts
+index c5c2af3..da19f31 100644
+--- a/extensions/typescript-language-features/src/tsServer/serverProcess.browser.ts
++++ b/extensions/typescript-language-features/src/tsServer/serverProcess.browser.ts
+@@ -105,11 +105,34 @@ class WorkerServerProcess implements TsServerProcess {
+ 				}
+ 				case 'watchDirectory':
+ 				case 'watchFile': {
+-					this.watches.create(event.data.id, vscode.Uri.from(event.data.uri), /*watchParentDirs*/ true, !!event.data.recursive, {
+-						change: uri => this.watcher.postMessage({ type: 'watch', event: 'change', uri }),
+-						create: uri => this.watcher.postMessage({ type: 'watch', event: 'create', uri }),
+-						delete: uri => this.watcher.postMessage({ type: 'watch', event: 'delete', uri }),
+-					});
++					this.watches.create(
++						event.data.id,
++						vscode.Uri.from(event.data.uri),
++						/*watchParentDirs*/ true,
++						!!event.data.recursive,
++						{
++							change: async (uri) =>
++								this.watcher.postMessage({
++									type: 'watch',
++									event: 'change',
++									uri,
++									file: await vscode.workspace.fs.readFile(uri),
++								}),
++							create: async (uri) =>
++								this.watcher.postMessage({
++									type: 'watch',
++									event: 'create',
++									uri,
++									file: await vscode.workspace.fs.readFile(uri),
++								}),
++							delete: (uri) =>
++								this.watcher.postMessage({
++									type: 'watch',
++									event: 'delete',
++									uri,
++								}),
++						}
++					);
+ 					break;
+ 				}
+ 				default:
+@@ -134,9 +157,36 @@ class WorkerServerProcess implements TsServerProcess {
+ 			}
+ 		};
+ 
+-		this.worker.postMessage(
+-			{ args, extensionUri },
+-			[syncChannel.port1, tsserverChannel.port1, watcherChannel.port1]
++		async function addFilesFromDir(
++			root: vscode.Uri
++		): Promise<[vscode.Uri, Uint8Array][]> {
++			const files = await vscode.workspace.fs.readDirectory(root);
++			const storedFiles: [vscode.Uri, Uint8Array][] = [];
++
++			for (const [name, type] of files) {
++				if (type === vscode.FileType.File) {
++					storedFiles.push([
++						vscode.Uri.parse('cfs:' + root.path + `/${name}`),
++						await vscode.workspace.fs.readFile(
++							vscode.Uri.parse('cfs:' + root.path + `/${name}`)
++						),
++					]);
++				} else {
++					storedFiles.push(
++						...(await addFilesFromDir(
++							vscode.Uri.parse('cfs:' + root.path + `/${name}`)
++						))
++					);
++				}
++			}
++			return storedFiles;
++		}
++		addFilesFromDir(vscode.Uri.parse('cfs:/')).then((storedFiles) =>
++			this.worker.postMessage({ args, extensionUri, storedFiles }, [
++				syncChannel.port1,
++				tsserverChannel.port1,
++				watcherChannel.port1,
++			])
+ 		);
+ 
+ 		const connection = new ServiceConnection<Requests>(syncChannel.port2);
+diff --git a/extensions/typescript-language-features/src/typescriptServiceClient.ts b/extensions/typescript-language-features/src/typescriptServiceClient.ts
+index 737f452..25bce58 100644
+--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
++++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
+@@ -23,7 +23,7 @@ import { ServiceConfigurationProvider, SyntaxServerConfiguration, TsServerLogLev
+ import { Disposable } from './utils/dispose';
+ import * as fileSchemes from './utils/fileSchemes';
+ import { Logger } from './utils/logger';
+-import { isWeb, isWebAndHasSharedArrayBuffers } from './utils/platform';
++import { isWeb } from './utils/platform';
+ import { TypeScriptPluginPathsProvider } from './utils/pluginPathsProvider';
+ import { PluginManager, TypeScriptServerPlugin } from './utils/plugins';
+ import { TelemetryProperties, TelemetryReporter, VSCodeTelemetryReporter } from './utils/telemetry';
+@@ -259,7 +259,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
+ 	readonly onDidChangeCapabilities = this._onDidChangeCapabilities.event;
+ 
+ 	private isProjectWideIntellisenseOnWebEnabled(): boolean {
+-		return isWebAndHasSharedArrayBuffers() && this._configuration.enableProjectWideIntellisenseOnWeb;
++		return true;
+ 	}
+ 
+ 	private cancelInflightRequestsForResource(resource: vscode.Uri): void {
+diff --git a/extensions/typescript-language-features/web/cfs-simple.ts b/extensions/typescript-language-features/web/cfs-simple.ts
+new file mode 100644
+index 0000000..0ba6abf
+--- /dev/null
++++ b/extensions/typescript-language-features/web/cfs-simple.ts
+@@ -0,0 +1,425 @@
++/*---------------------------------------------------------------------------------------------
++ *  Copyright (c) Microsoft Corporation. All rights reserved.
++ *  Licensed under the MIT License. See License.txt in the project root for license information.
++ *--------------------------------------------------------------------------------------------*/
++import { URI } from 'vscode-uri';
++enum FilePermission {
++	/**
++	 * The file is readonly.
++	 *
++	 * *Note:* All `FileStat` from a `FileSystemProvider` that is registered with
++	 * the option `isReadonly: true` will be implicitly handled as if `FilePermission.Readonly`
++	 * is set. As a consequence, it is not possible to have a readonly file system provider
++	 * registered where some `FileStat` are not readonly.
++	 */
++	Readonly = 1,
++}
++interface FileStat {
++	/**
++	 * The type of the file, e.g. is a regular file, a directory, or symbolic link
++	 * to a file.
++	 *
++	 * *Note:* This value might be a bitmask, e.g. `FileType.File | FileType.SymbolicLink`.
++	 */
++	type: FileType;
++	/**
++	 * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
++	 */
++	ctime: number;
++	/**
++	 * The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
++	 *
++	 * *Note:* If the file changed, it is important to provide an updated `mtime` that advanced
++	 * from the previous value. Otherwise there may be optimizations in place that will not show
++	 * the updated file contents in an editor for example.
++	 */
++	mtime: number;
++	/**
++	 * The size in bytes.
++	 *
++	 * *Note:* If the file changed, it is important to provide an updated `size`. Otherwise there
++	 * may be optimizations in place that will not show the updated file contents in an editor for
++	 * example.
++	 */
++	size: number;
++	/**
++	 * The permissions of the file, e.g. whether the file is readonly.
++	 *
++	 * *Note:* This value might be a bitmask, e.g. `FilePermission.Readonly | FilePermission.Other`.
++	 */
++	permissions?: FilePermission;
++}
++enum FileSystemProviderErrorCode {
++	FileExists = 'EntryExists',
++	FileNotFound = 'EntryNotFound',
++	FileNotADirectory = 'EntryNotADirectory',
++	FileIsADirectory = 'EntryIsADirectory',
++	FileExceedsMemoryLimit = 'EntryExceedsMemoryLimit',
++	FileTooLarge = 'EntryTooLarge',
++	FileWriteLocked = 'EntryWriteLocked',
++	NoPermissions = 'NoPermissions',
++	Unavailable = 'Unavailable',
++	Unknown = 'Unknown',
++}
++class FileSystemError extends Error {
++	static FileExists(messageOrUri?: string | URI): FileSystemError {
++		return new FileSystemError(
++			messageOrUri,
++			FileSystemProviderErrorCode.FileExists,
++			FileSystemError.FileExists
++		);
++	}
++	static FileNotFound(messageOrUri?: string | URI): FileSystemError {
++		return new FileSystemError(
++			messageOrUri,
++			FileSystemProviderErrorCode.FileNotFound,
++			FileSystemError.FileNotFound
++		);
++	}
++	static FileNotADirectory(messageOrUri?: string | URI): FileSystemError {
++		return new FileSystemError(
++			messageOrUri,
++			FileSystemProviderErrorCode.FileNotADirectory,
++			FileSystemError.FileNotADirectory
++		);
++	}
++	static FileIsADirectory(messageOrUri?: string | URI): FileSystemError {
++		return new FileSystemError(
++			messageOrUri,
++			FileSystemProviderErrorCode.FileIsADirectory,
++			FileSystemError.FileIsADirectory
++		);
++	}
++	static NoPermissions(messageOrUri?: string | URI): FileSystemError {
++		return new FileSystemError(
++			messageOrUri,
++			FileSystemProviderErrorCode.NoPermissions,
++			FileSystemError.NoPermissions
++		);
++	}
++	static Unavailable(messageOrUri?: string | URI): FileSystemError {
++		return new FileSystemError(
++			messageOrUri,
++			FileSystemProviderErrorCode.Unavailable,
++			FileSystemError.Unavailable
++		);
++	}
++
++	readonly code: string;
++
++	constructor(
++		uriOrMessage?: string | URI,
++		code: FileSystemProviderErrorCode = FileSystemProviderErrorCode.Unknown,
++		terminator?: Function
++	) {
++		super(
++			code +
++			(URI.isUri(uriOrMessage) ? uriOrMessage.toString(true) : uriOrMessage)
++		);
++
++		this.code = code;
++
++		// workaround when extending builtin objects and when compiling to ES5, see:
++		// https://github.com/microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
++		Object.setPrototypeOf(this, FileSystemError.prototype);
++
++		if (
++			typeof Error.captureStackTrace === 'function' &&
++			typeof terminator === 'function'
++		) {
++			// nice stack traces
++			Error.captureStackTrace(this, terminator);
++		}
++	}
++}
++export enum FileType {
++	/**
++	 * The file type is unknown.
++	 */
++	Unknown = 0,
++	/**
++	 * A regular file.
++	 */
++	File = 1,
++	/**
++	 * A directory.
++	 */
++	Directory = 2,
++	/**
++	 * A symbolic link to a file.
++	 */
++	SymbolicLink = 64,
++}
++
++export class File implements FileStat {
++	type: FileType;
++	ctime: number;
++	mtime: number;
++	size: number;
++
++	name: string;
++	data?: Uint8Array;
++	permissions?: FilePermission;
++
++	constructor(public uri: URI, name: string) {
++		this.type = FileType.File;
++		this.ctime = Date.now();
++		this.mtime = Date.now();
++		this.size = 0;
++		this.name = name;
++	}
++
++	public setReadOnly() {
++		this.permissions = FilePermission.Readonly;
++	}
++}
++
++export class Directory implements FileStat {
++	type: FileType;
++	ctime: number;
++	mtime: number;
++	size: number;
++
++	name: string;
++	entries: Map<string, File | Directory>;
++
++	constructor(public uri: URI, name: string) {
++		this.type = FileType.Directory;
++		this.ctime = Date.now();
++		this.mtime = Date.now();
++		this.size = 0;
++		this.name = name;
++		this.entries = new Map();
++	}
++}
++
++export type Entry = File | Directory;
++function stripSlashPrefix(path: string) {
++	return path[0] === '/' ? path.slice(1) : path;
++}
++export class CFS {
++	static scheme = 'cfs';
++	private readonly rootFolder = 'cfs:';
++
++	constructor() { }
++
++	root = new Directory(URI.parse('cfs:/'), '');
++
++	async seed(files: [URI, Uint8Array][]) {
++		for (const [path, contents] of files) {
++			const pathSegments = stripSlashPrefix(path.path).split('/');
++			console.log('SEED', path, pathSegments);
++			if (pathSegments.length > 1) {
++				let created = this.rootFolder;
++				for (const pathPart of pathSegments.slice(0, -1)) {
++					created = created + `/${pathPart}`;
++					console.log('SEED', created);
++
++					try {
++						await this.readDirectory(URI.parse(created));
++					} catch {
++						await this.createDirectory(URI.parse(created));
++					}
++				}
++			}
++			await this.writeFile(path, contents, {
++				create: true,
++				overwrite: true,
++			});
++		}
++	}
++
++	stat(uri: URI): FileStat {
++		console.log('TSSERVER CFS stat', uri);
++		return this._lookup(uri, false);
++	}
++
++	readDirectory(uri: URI): [string, FileType][] {
++		const entry = this._lookupAsDirectory(uri, false);
++		const result: [string, FileType][] = [];
++		for (const [name, child] of entry.entries) {
++			result.push([name, child.type]);
++		}
++		return result;
++	}
++
++	readFile(uri: URI): Uint8Array {
++		const data = this._lookupAsFile(uri, false).data;
++		if (data) {
++			return data;
++		}
++		throw FileSystemError.FileNotFound();
++	}
++
++	writeFile(
++		uri: URI,
++		content: Uint8Array,
++		options: {
++			create: boolean;
++			overwrite: boolean;
++		}
++	): void {
++		const basename = this._basename(uri.path);
++		const parent = this._lookupParentDirectory(uri);
++		let entry = parent.entries.get(basename);
++		if (entry instanceof Directory) {
++			throw FileSystemError.FileIsADirectory(uri);
++		}
++		if (!entry && !options.create) {
++			throw FileSystemError.FileNotFound(uri);
++		}
++		if (entry && options.create && !options.overwrite) {
++			throw FileSystemError.FileExists(uri);
++		}
++		if (!entry) {
++			entry = new File(uri, basename);
++			parent.entries.set(basename, entry);
++		}
++		entry.mtime = Date.now();
++		entry.size = content.byteLength;
++		entry.data = content;
++	}
++
++	rename(oldURI: URI, newURI: URI, options: { overwrite: boolean }): void {
++		if (!options.overwrite && this._lookup(newURI, true)) {
++			throw FileSystemError.FileExists(newURI);
++		}
++
++		const entry = this._lookup(oldURI, false);
++		const oldParent = this._lookupParentDirectory(oldURI);
++
++		const newParent = this._lookupParentDirectory(newURI);
++		const newName = this._basename(newURI.path);
++
++		oldParent.entries.delete(entry.name);
++		entry.name = newName;
++		newParent.entries.set(newName, entry);
++	}
++
++	delete(uri: URI): void {
++		const dirname = uri.with({ path: this._dirname(uri.path) });
++		const basename = this._basename(uri.path);
++		const parent = this._lookupAsDirectory(dirname, false);
++		if (!parent.entries.has(basename)) {
++			throw FileSystemError.FileNotFound(uri);
++		}
++		const entry = parent.entries.get(basename);
++		// Recursively delete all children
++		if (entry instanceof Directory) {
++			for (const child of entry.entries.values()) {
++				this.delete(child.uri);
++			}
++		}
++
++		parent.entries.delete(basename);
++		parent.mtime = Date.now();
++		parent.size -= 1;
++	}
++
++	createDirectory(uri: URI): void {
++		const basename = this._basename(uri.path);
++		const dirname = uri.with({ path: this._dirname(uri.path) });
++		const parent = this._lookupAsDirectory(dirname, false);
++
++		const entry = new Directory(uri, basename);
++		parent.entries.set(entry.name, entry);
++		parent.mtime = Date.now();
++		parent.size += 1;
++	}
++
++	// --- lookup
++
++	private _lookup(uri: URI, silent: false): Entry;
++	private _lookup(uri: URI, silent: boolean): Entry | undefined;
++	private _lookup(uri: URI, silent: boolean): Entry | undefined {
++		const parts = uri.path.split('/');
++		let entry: Entry = this.root;
++		for (const part of parts) {
++			if (!part) {
++				continue;
++			}
++			let child: Entry | undefined;
++			if (entry instanceof Directory) {
++				child = entry.entries.get(part);
++			}
++			if (!child) {
++				if (!silent) {
++					throw FileSystemError.FileNotFound(uri);
++				} else {
++					return undefined;
++				}
++			}
++			entry = child;
++		}
++		return entry;
++	}
++
++	private _lookupAsDirectory(uri: URI, silent: boolean): Directory {
++		const entry = this._lookup(uri, silent);
++		if (entry instanceof Directory) {
++			return entry;
++		}
++		throw FileSystemError.FileNotADirectory(uri);
++	}
++
++	private _lookupAsFile(uri: URI, silent: boolean): File {
++		const entry = this._lookup(uri, silent);
++		if (entry instanceof File) {
++			return entry;
++		}
++		throw FileSystemError.FileIsADirectory(uri);
++	}
++
++	private _lookupParentDirectory(uri: URI): Directory {
++		const dirname = uri.with({ path: this._dirname(uri.path) });
++		return this._lookupAsDirectory(dirname, false);
++	}
++
++	private _basename(path: string): string {
++		path = this._rtrim(path, '/');
++		if (!path) {
++			return '';
++		}
++
++		return path.substr(path.lastIndexOf('/') + 1);
++	}
++
++	private _dirname(path: string): string {
++		path = this._rtrim(path, '/');
++		if (!path) {
++			return '/';
++		}
++
++		return path.substr(0, path.lastIndexOf('/'));
++	}
++
++	private _rtrim(haystack: string, needle: string): string {
++		if (!haystack || !needle) {
++			return haystack;
++		}
++
++		const needleLen = needle.length,
++			haystackLen = haystack.length;
++
++		if (needleLen === 0 || haystackLen === 0) {
++			return haystack;
++		}
++
++		let offset = haystackLen,
++			idx = -1;
++
++		// eslint-disable-next-line
++		while (true) {
++			idx = haystack.lastIndexOf(needle, offset - 1);
++			if (idx === -1 || idx + needleLen !== offset) {
++				break;
++			}
++			if (idx === 0) {
++				return '';
++			}
++			offset = idx;
++		}
++
++		return haystack.substring(0, offset);
++	}
++}
+diff --git a/extensions/typescript-language-features/web/webServer.ts b/extensions/typescript-language-features/web/webServer.ts
+index 1db00fe..da46091 100644
+--- a/extensions/typescript-language-features/web/webServer.ts
++++ b/extensions/typescript-language-features/web/webServer.ts
+@@ -6,10 +6,14 @@
+ /// <reference lib='webworker' />
+ 
+ import * as ts from 'typescript/lib/tsserverlibrary';
+-import { ApiClient, FileType, Requests } from '@vscode/sync-api-client';
+-import { ClientConnection } from '@vscode/sync-api-common/browser';
+ import { URI } from 'vscode-uri';
+ 
++// Keep an in-memory representation of the current Worker script.
++// This is in-memory within this (Web) Worker to avoid a dependency on SharedArrayBuffer
++// The contents are updated on a slight lag from VSCode filesystem events
++import { CFS, FileType } from './cfs-simple';
++const cfs = new CFS();
++
+ // GLOBALS
+ const watchFiles: Map<string, { path: string; callback: ts.FileWatcherCallback; pollingInterval?: number; options?: ts.WatchOptions }> = new Map();
+ const watchDirectories: Map<string, { path: string; callback: ts.DirectoryWatcherCallback; recursive?: boolean; options?: ts.WatchOptions }> = new Map();
+@@ -44,7 +48,8 @@ function fromResource(extensionUri: URI, uri: URI) {
+ 		&& uri.path.endsWith('.d.ts')) {
+ 		return uri.path;
+ 	}
+-	return `/${uri.scheme}/${uri.authority}${uri.path}`;
++	// Use `ts-nul-authority` when the authority is an empty string. All CFS file have an empty authority
++	return `/${uri.scheme}/${uri.authority === '' ? 'ts-nul-authority' : uri.authority}${uri.path}`;
+ }
+ function updateWatch(event: 'create' | 'change' | 'delete', uri: URI, extensionUri: URI) {
+ 	const kind = event === 'create' ? ts.FileWatcherEventKind.Created
+@@ -68,9 +73,9 @@ function updateWatch(event: 'create' | 'change' | 'delete', uri: URI, extensionU
+ 
+ type ServerHostWithImport = ts.server.ServerHost & { importPlugin(root: string, moduleName: string): Promise<ts.server.ModuleImportResult> };
+ 
+-function createServerHost(extensionUri: URI, logger: ts.server.Logger, apiClient: ApiClient | undefined, args: string[], fsWatcher: MessagePort): ServerHostWithImport {
++function createServerHost(extensionUri: URI, logger: ts.server.Logger, args: string[], fsWatcher: MessagePort): ServerHostWithImport {
+ 	const currentDirectory = '/';
+-	const fs = apiClient?.vscode.workspace.fileSystem;
++	const fs = cfs;
+ 	let watchId = 0;
+ 
+ 	// Legacy web
+@@ -170,7 +175,7 @@ function createServerHost(extensionUri: URI, logger: ts.server.Logger, apiClient
+ 		newLine: '\n',
+ 		useCaseSensitiveFileNames: true,
+ 		write: s => {
+-			apiClient?.vscode.terminal.write(s);
++			logNormal(s);
+ 		},
+ 		writeOutputIsTTY() {
+ 			return true;
+@@ -178,7 +183,9 @@ function createServerHost(extensionUri: URI, logger: ts.server.Logger, apiClient
+ 		readFile(path) {
+ 			logVerbose('fs.readFile', { path });
+ 
+-			if (!fs) {
++			// Load http resources bypassing CFS. This is pretty much just Typescript lib files
++			const resource = toResource(path);
++			if (!fs || resource.scheme.startsWith('http')) {
+ 				const webPath = getWebPath(path);
+ 				if (webPath) {
+ 					const request = new XMLHttpRequest();
+@@ -192,7 +199,7 @@ function createServerHost(extensionUri: URI, logger: ts.server.Logger, apiClient
+ 
+ 			try {
+ 				// We need to slice the bytes since we can't pass a shared array to text decoder
+-				const contents = fs.readFile(toResource(path)).slice();
++				const contents = fs.readFile(resource);
+ 				return textDecoder.decode(contents);
+ 			} catch (error) {
+ 				logNormal('Error fs.readFile', { path, error: error + '' });
+@@ -225,7 +232,10 @@ function createServerHost(extensionUri: URI, logger: ts.server.Logger, apiClient
+ 			}
+ 
+ 			try {
+-				fs.writeFile(toResource(path), textEncoder.encode(data));
++				fs.writeFile(toResource(path), textEncoder.encode(data), {
++					create: true,
++					overwrite: true,
++				});
+ 			} catch (error) {
+ 				logNormal('Error fs.writeFile', { path, error: error + '' });
+ 			}
+@@ -235,8 +245,9 @@ function createServerHost(extensionUri: URI, logger: ts.server.Logger, apiClient
+ 		},
+ 		fileExists(path: string): boolean {
+ 			logVerbose('fs.fileExists', { path });
++			const resource = toResource(path);
+ 
+-			if (!fs) {
++			if (!fs || resource.scheme.startsWith('http')) {
+ 				const webPath = getWebPath(path);
+ 				if (!webPath) {
+ 					return false;
+@@ -249,7 +260,7 @@ function createServerHost(extensionUri: URI, logger: ts.server.Logger, apiClient
+ 			}
+ 
+ 			try {
+-				return fs.stat(toResource(path)).type === FileType.File;
++				return fs.stat(resource).type === FileType.File;
+ 			} catch (error) {
+ 				logNormal('Error fs.fileExists', { path, error: error + '' });
+ 				return false;
+@@ -480,7 +491,6 @@ interface StartSessionOptions {
+ }
+ 
+ class WorkerSession extends ts.server.Session<{}> {
+-
+ 	readonly wasmCancellationToken: WasmCancellationToken;
+ 	readonly listener: (message: any) => void;
+ 
+@@ -642,16 +652,12 @@ async function initializeSession(args: string[], extensionUri: URI, ports: { tss
+ 		serverMode
+ 	};
+ 
+-	let sys: ServerHostWithImport;
+-	if (hasArgument(args, '--enableProjectWideIntelliSenseOnWeb')) {
+-		const connection = new ClientConnection<Requests>(ports.sync);
+-		await connection.serviceReady();
+-
+-		sys = createServerHost(extensionUri, logger, new ApiClient(connection), args, ports.watcher);
+-	} else {
+-		sys = createServerHost(extensionUri, logger, undefined, args, ports.watcher);
+-
+-	}
++	const sys: ServerHostWithImport = createServerHost(
++		extensionUri,
++		logger,
++		args,
++		ports.watcher
++	);
+ 
+ 	setSys(sys);
+ 	session = new WorkerSession(sys, options, ports.tsserver, logger, hrtime);
+@@ -671,6 +677,12 @@ let hasInitialized = false;
+ const listener = async (e: any) => {
+ 	if (!hasInitialized) {
+ 		hasInitialized = true;
++		await cfs.seed(
++			(e.data.storedFiles as [Parameters<typeof URI.from>[0], Uint8Array][]).map(([uri, contents]) => [
++				URI.from(uri),
++				contents,
++			])
++		);
+ 		if ('args' in e.data) {
+ 			const args = e.data.args;
+ 
+@@ -693,8 +705,33 @@ const listener = async (e: any) => {
+ 
+ 			const [sync, tsserver, watcher] = e.ports as MessagePort[];
+ 			const extensionUri = URI.from(e.data.extensionUri);
+-			watcher.onmessage = (e: any) => updateWatch(e.data.event, URI.from(e.data.uri), extensionUri);
+-			await initializeSession(args, extensionUri, { sync, tsserver, watcher }, logger);
++			watcher.onmessage = async (e: any) => {
++				try {
++					switch (e.data.event) {
++						case 'create':
++							await cfs.seed([[URI.from(e.data.uri), e.data.file]]);
++							break;
++						case 'change':
++							await cfs.writeFile(URI.from(e.data.uri), e.data.file, {
++								create: true,
++								overwrite: true,
++							});
++							break;
++						case 'delete':
++							await cfs.delete(URI.from(e.data.uri));
++							break;
++					}
++				} catch (e) {
++					console.error(e);
++				}
++				updateWatch(e.data.event, URI.from(e.data.uri), extensionUri);
++			};
++			await initializeSession(
++				args,
++				extensionUri,
++				{ sync, tsserver, watcher },
++				logger
++			);
+ 		} else {
+ 			console.error('unexpected message in place of initial message: ' + JSON.stringify(e.data));
+ 		}
+-- 
+2.39.2 (Apple Git-143)
+


### PR DESCRIPTION
**What this PR solves / how to test:**
- Adds support for Typescript checking, via JSDoc annotations
- In particular, this patches the VSCode typescript extension to work without `SharedArrayBuffer`, and loads two read-only files into Worker workspaces, `jsconfig.json` and `workers-types.d.ts`

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
