### PR TITLE
[wrangler] chore: bump `miniflare@3` to `3.0.0-next.13`

### DIFF
--- a/.changeset/light-eels-accept.md
+++ b/.changeset/light-eels-accept.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+fix: disable persistence without `--persist` in `--experimental-local`
+
+This ensures `--experimental-local` doesn't persist data on the file-system, unless the `--persist` flag is set.
+Data is still always persisted between reloads.

--- a/.changeset/rare-rings-begin.md
+++ b/.changeset/rare-rings-begin.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+chore: upgrade `miniflare@3` to [`3.0.0-next.13`](https://github.com/cloudflare/miniflare/releases/tag/v3.0.0-next.13)
+
+Notably, this adds native support for Windows to `wrangler dev --experimental-local`, logging for incoming requests, and support for a bunch of newer R2 features.

--- a/.changeset/thirty-turtles-return.md
+++ b/.changeset/thirty-turtles-return.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: disable route validation when using `--experimental-local`
+
+This ensures `wrangler dev --experimental-local` doesn't require a login or an internet connection if a `route` is configured.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4243,9 +4243,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230221.0.tgz",
-			"integrity": "sha512-8yBpFqSO7Rw/Z/c/zmlO5KoGZDJ5ar8KH8xXyPMxUN6hqpKv9tg7tTJCi6rjRhSneonprKBtnnSShCUNeY4sMw==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230404.0.tgz",
+			"integrity": "sha512-W36JJLz3XLktBv+Huw37eZhiHvXp8XZ+1LsbUqU2O5Y0OXUzVhxhtdPSHgxvjfwo83zxnWuSS3uGKl6ex8Xm/Q==",
 			"cpu": [
 				"x64"
 			],
@@ -4259,9 +4259,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230221.0.tgz",
-			"integrity": "sha512-+Q/SFBqvMZOkC3McxaQkZENSFeQIwodIzMcy8uoa8nOLLBqCg2POmg9drTZBH51gzxCsgTeXi5dxxJl3yZdLkg==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230404.0.tgz",
+			"integrity": "sha512-cEpLgMwNmUpXVPjTJEd+WXgzSt9l4cTJpaNyEouAHrH99cStt21iIgkVctnef9bpPqzLoIZf2LUaPKu2H85/Ig==",
 			"cpu": [
 				"arm64"
 			],
@@ -4275,26 +4275,25 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230221.0.tgz",
-			"integrity": "sha512-9kR/PFdcudzyOwXpnC2LAXXwfsbby2YIPVzRQESGqXjWxls34dh4BlOgVTzccKPIDCg3luGgOj2x6fKbp8jbNw==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230404.0.tgz",
+			"integrity": "sha512-XMXUuZKTfWW60EKLYy0DJJSEKF8/q1EupYa2nldIp2i6gprhndXxOe3WR4inWB+XAMcppUXO0VgwAV6tTvgOvg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
 			"optional": true,
 			"os": [
-				"linux",
-				"win32"
+				"linux"
 			],
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230221.0.tgz",
-			"integrity": "sha512-HiGpjTdxFC+ZzLd7M3adgegqvljePuctdP7GDmGLBul3N3w5kfyy1j+vDw5Xq/FEvqLc7jhdS4S7/8eMfU2P+w==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230404.0.tgz",
+			"integrity": "sha512-4+mnzlnlYe66LusX0HeS5TNV4FN64QSMD/WuahbFPpxg41t/iBD4T8KrRYvz0PjIhNzt8wqxymHbL1Coo+La5Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -4302,6 +4301,22 @@
 			"optional": true,
 			"os": [
 				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230404.0.tgz",
+			"integrity": "sha512-LRuLa6dqYlFGSfeqYV+f0J2llUTQ5nuWDrp77pqSHgJlqFFEX2qlZ0wJIAxulvK5Vz/O05WvmpdV9HJwrlj3VQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
 			],
 			"engines": {
 				"node": ">=16"
@@ -7134,9 +7149,9 @@
 			}
 		},
 		"node_modules/@miniflare/tre": {
-			"version": "3.0.0-next.12",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.12.tgz",
-			"integrity": "sha512-jhlWVgsRjtlVY0y7TUaWOUKOaSehFUzPBwjAKNglJrbkfe118PKt39TjGsWq4D/zLX0vTCDAdrnf6Y7LgfCd8A==",
+			"version": "3.0.0-next.13",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.13.tgz",
+			"integrity": "sha512-FogtwZUmUqico28dTdrFd2BF2wyMMheUw3MI9MDSSYNqRUGiNw8cJopHRMjo7OoO3dq6F5D01HwqMMZvSA1ZFA==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -7151,10 +7166,10 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "^1.20230221.0",
+				"workerd": "^1.20230404.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
-				"zod": "^3.18.0"
+				"zod": "^3.20.6"
 			},
 			"engines": {
 				"node": ">=16.13"
@@ -43391,9 +43406,9 @@
 			"link": true
 		},
 		"node_modules/workerd": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230221.0.tgz",
-			"integrity": "sha512-YMwTskgRys9xn/zZXAOd7vTjbnr/obh2rU7blIO+JY+LY5uZuH2AGi0chIXo7lGfLNlQ8HZqtFfurRzBhKbSHg==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230404.0.tgz",
+			"integrity": "sha512-tTiWZkJXetNmahmVZL1AcFH/U1cp9MMYRcQNBD1RjTSGh/v8VlKlEKTp4Ss6EdItvPNKQqsE7s/6y/TrblTI7g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -43403,10 +43418,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20230221.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230221.0",
-				"@cloudflare/workerd-linux-64": "1.20230221.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230221.0"
+				"@cloudflare/workerd-darwin-64": "1.20230404.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20230404.0",
+				"@cloudflare/workerd-linux-64": "1.20230404.0",
+				"@cloudflare/workerd-linux-arm64": "1.20230404.0",
+				"@cloudflare/workerd-windows-64": "1.20230404.0"
 			}
 		},
 		"node_modules/workers-analytics-engine-template": {
@@ -45462,7 +45478,7 @@
 				"@cloudflare/workers-types": "^4.20221111.1",
 				"@iarna/toml": "^3.0.0",
 				"@microsoft/api-extractor": "^7.28.3",
-				"@miniflare/tre": "3.0.0-next.12",
+				"@miniflare/tre": "3.0.0-next.13",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",
@@ -59429,30 +59445,37 @@
 			}
 		},
 		"@cloudflare/workerd-darwin-64": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230221.0.tgz",
-			"integrity": "sha512-8yBpFqSO7Rw/Z/c/zmlO5KoGZDJ5ar8KH8xXyPMxUN6hqpKv9tg7tTJCi6rjRhSneonprKBtnnSShCUNeY4sMw==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230404.0.tgz",
+			"integrity": "sha512-W36JJLz3XLktBv+Huw37eZhiHvXp8XZ+1LsbUqU2O5Y0OXUzVhxhtdPSHgxvjfwo83zxnWuSS3uGKl6ex8Xm/Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230221.0.tgz",
-			"integrity": "sha512-+Q/SFBqvMZOkC3McxaQkZENSFeQIwodIzMcy8uoa8nOLLBqCg2POmg9drTZBH51gzxCsgTeXi5dxxJl3yZdLkg==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230404.0.tgz",
+			"integrity": "sha512-cEpLgMwNmUpXVPjTJEd+WXgzSt9l4cTJpaNyEouAHrH99cStt21iIgkVctnef9bpPqzLoIZf2LUaPKu2H85/Ig==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-64": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230221.0.tgz",
-			"integrity": "sha512-9kR/PFdcudzyOwXpnC2LAXXwfsbby2YIPVzRQESGqXjWxls34dh4BlOgVTzccKPIDCg3luGgOj2x6fKbp8jbNw==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230404.0.tgz",
+			"integrity": "sha512-XMXUuZKTfWW60EKLYy0DJJSEKF8/q1EupYa2nldIp2i6gprhndXxOe3WR4inWB+XAMcppUXO0VgwAV6tTvgOvg==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230221.0.tgz",
-			"integrity": "sha512-HiGpjTdxFC+ZzLd7M3adgegqvljePuctdP7GDmGLBul3N3w5kfyy1j+vDw5Xq/FEvqLc7jhdS4S7/8eMfU2P+w==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230404.0.tgz",
+			"integrity": "sha512-4+mnzlnlYe66LusX0HeS5TNV4FN64QSMD/WuahbFPpxg41t/iBD4T8KrRYvz0PjIhNzt8wqxymHbL1Coo+La5Q==",
+			"dev": true,
+			"optional": true
+		},
+		"@cloudflare/workerd-windows-64": {
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230404.0.tgz",
+			"integrity": "sha512-LRuLa6dqYlFGSfeqYV+f0J2llUTQ5nuWDrp77pqSHgJlqFFEX2qlZ0wJIAxulvK5Vz/O05WvmpdV9HJwrlj3VQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -61274,9 +61297,9 @@
 			}
 		},
 		"@miniflare/tre": {
-			"version": "3.0.0-next.12",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.12.tgz",
-			"integrity": "sha512-jhlWVgsRjtlVY0y7TUaWOUKOaSehFUzPBwjAKNglJrbkfe118PKt39TjGsWq4D/zLX0vTCDAdrnf6Y7LgfCd8A==",
+			"version": "3.0.0-next.13",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.13.tgz",
+			"integrity": "sha512-FogtwZUmUqico28dTdrFd2BF2wyMMheUw3MI9MDSSYNqRUGiNw8cJopHRMjo7OoO3dq6F5D01HwqMMZvSA1ZFA==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
@@ -61291,10 +61314,10 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "^1.20230221.0",
+				"workerd": "^1.20230404.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
-				"zod": "^3.18.0"
+				"zod": "^3.20.6"
 			},
 			"dependencies": {
 				"better-sqlite3": {
@@ -93802,15 +93825,16 @@
 			}
 		},
 		"workerd": {
-			"version": "1.20230221.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230221.0.tgz",
-			"integrity": "sha512-YMwTskgRys9xn/zZXAOd7vTjbnr/obh2rU7blIO+JY+LY5uZuH2AGi0chIXo7lGfLNlQ8HZqtFfurRzBhKbSHg==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230404.0.tgz",
+			"integrity": "sha512-tTiWZkJXetNmahmVZL1AcFH/U1cp9MMYRcQNBD1RjTSGh/v8VlKlEKTp4Ss6EdItvPNKQqsE7s/6y/TrblTI7g==",
 			"dev": true,
 			"requires": {
-				"@cloudflare/workerd-darwin-64": "1.20230221.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230221.0",
-				"@cloudflare/workerd-linux-64": "1.20230221.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230221.0"
+				"@cloudflare/workerd-darwin-64": "1.20230404.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20230404.0",
+				"@cloudflare/workerd-linux-64": "1.20230404.0",
+				"@cloudflare/workerd-linux-arm64": "1.20230404.0",
+				"@cloudflare/workerd-windows-64": "1.20230404.0"
 			}
 		},
 		"workers-analytics-engine-template": {
@@ -94031,7 +94055,7 @@
 				"@miniflare/core": "2.13.0",
 				"@miniflare/d1": "2.13.0",
 				"@miniflare/durable-objects": "2.13.0",
-				"@miniflare/tre": "3.0.0-next.12",
+				"@miniflare/tre": "3.0.0-next.13",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -120,7 +120,7 @@
 		"@cloudflare/workers-types": "^4.20221111.1",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
-		"@miniflare/tre": "3.0.0-next.12",
+		"@miniflare/tre": "3.0.0-next.13",
 		"@types/better-sqlite3": "^7.6.0",
 		"@types/busboy": "^1.5.0",
 		"@types/command-exists": "^1.2.0",

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -7,7 +7,7 @@ import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
 import * as esbuild from "esbuild";
 import tmp from "tmp-promise";
 import createModuleCollector from "./module-collection";
-import { getBasePath, toUrlPath } from "./paths";
+import { getBasePath } from "./paths";
 import type { Config } from "./config";
 import type { DurableObjectBindings } from "./config/environment";
 import type { WorkerRegistry } from "./dev-registry";
@@ -599,7 +599,7 @@ async function applyMiddlewareLoaderFacade(
 					...Object.fromEntries(
 						middleware.map((val, index) => [
 							middlewareIdentifiers[index],
-							toUrlPath(path.resolve(getBasePath(), val.path)),
+							path.resolve(getBasePath(), val.path),
 						])
 					),
 				}),

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -661,7 +661,7 @@ async function getZoneIdHostAndRoutes(args: StartDevOptions, config: Config) {
 		args.local = true;
 	}
 
-	if (!args.local) {
+	if (!args.local && !args.experimentalLocal) {
 		if (host) {
 			zoneId = await getZoneIdFromHost(host);
 		}

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -858,7 +858,7 @@ export async function transformMf2OptionsToMf3Options({
 		d1Persist: transformMf2PersistToMf3(miniflare2Options.d1Persist),
 
 		inspectorPort,
-		verbose: true,
+		verbose: logger.loggerLevel === "debug",
 		cloudflareFetch,
 		log,
 	};


### PR DESCRIPTION
Fixes #2881.
Fixes #2987.
Fixes #2995.

**What this PR solves / how to test:**

This PR upgrades `wrangler`'s Miniflare 3 version to `3.0.0-next.13`. Find the full changelog here: https://github.com/cloudflare/miniflare/releases/tag/v3.0.0-next.13. Notably this includes native Windows support for `--experimental-local`. 🎉 

I've also thrown in a couple other minor `--experimental-local` fixes. See comment descriptions and the issues they close for details. 🙂 

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ]  ~~Tests~~ (passes existing tests locally)
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
