### PR TITLE
Feat(pages) `pages deploy` redirects/headers warnings

### DIFF
--- a/.changeset/kind-singers-grab.md
+++ b/.changeset/kind-singers-grab.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Feat: Add logs & warnings for redirects and headers files on `wrangler pages deploy`
+
+People using `pages deploy` will now receive warnings for invalid headers & redirect rules, as well as being notified of the valid rules being parsed.


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:** 
This PR adds support for `wrangler pages deploy` providing warnings for any invalid redirect rules, which is currently done for `pages dev` and Pages' CI. 

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests (there's currently no testing around _redirects and _headers for pages publish, so I'm struggling a little)
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested

## A warning before merging
The pages CI is a consumer of this API, and so it having this without modifying that would result in all of these logs being duplicated
