### PR TITLE
[wrangler] fix: prereleases don't get vars injected at build time

### DIFF
--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -37,6 +37,10 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          NODE_ENV: "production"
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
 
       - name: Check for errors
         run: npm run check


### PR DESCRIPTION
Upon merging https://github.com/cloudflare/workers-sdk/pull/3004, I realised our prereleases were missing this bit to inject environment variables into the bundle.