### PR TITLE
Feat(pages-shared): Validate `/* /index.html`

### DIFF
--- a/.changeset/tame-pumas-happen.md
+++ b/.changeset/tame-pumas-happen.md
@@ -2,4 +2,4 @@
 "@cloudflare/pages-shared": minor
 ---
 
-Feat(metadata-generator): Introduce validation for `/* /index.html 200` rules.
+Feat(metadata-generator): Introduce validation for `/* /index.html` rules.

--- a/.changeset/tame-pumas-happen.md
+++ b/.changeset/tame-pumas-happen.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/pages-shared": minor
+---
+
+Feat(metadata-generator): Introduce validation for `/* /index.html 200` rules.

--- a/packages/pages-shared/__tests__/metadata-generator/parseRedirects.invalid.test.ts
+++ b/packages/pages-shared/__tests__/metadata-generator/parseRedirects.invalid.test.ts
@@ -281,12 +281,35 @@ test("parseRedirects should reject '/* /index.html'", () => {
 / /index.html
 / /index
 /* /foo/index.html
+
+/* /foo
+/foo/* /bar 200
+/ /foo
 `;
 	const invalidRedirectError =
-		'This behaviour is default with Cloudflare Pages (when a 404.html isn\'t present) and will be ignored. Remove it from your _redirects to silence this warning.\nIf you wish to direct requests to a subfolder, for example, sending all requests to foo/index.html, you should use "/* /foo/".';
+		"Infinite loop detected in this rule and has been ignored. This will cause a redirect to strip `.html` or `/index` and end up triggering this rule again. Please fix or remove this rule to silence this warning.";
 	const result = parseRedirects(input);
 	expect(result).toEqual({
-		rules: [],
+		rules: [
+			{
+				from: "/*",
+				status: 302,
+				to: "/foo",
+				lineNumber: 8,
+			},
+			{
+				from: "/foo/*",
+				status: 200,
+				to: "/bar",
+				lineNumber: 9,
+			},
+			{
+				from: "/",
+				status: 302,
+				to: "/foo",
+				lineNumber: 10,
+			},
+		],
 		invalid: [
 			{
 				line: "/* /index.html 200",

--- a/packages/pages-shared/__tests__/metadata-generator/parseRedirects.invalid.test.ts
+++ b/packages/pages-shared/__tests__/metadata-generator/parseRedirects.invalid.test.ts
@@ -280,9 +280,10 @@ test("parseRedirects should reject '/* /index.html'", () => {
 /* /index 200
 / /index.html
 / /index
+/* /foo/index.html
 `;
 	const invalidRedirectError =
-		"This behaviour is default with Cloudflare Pages (when a 404.html isn't present) and will be ignored. Remove it from your _redirects to silence this warning.";
+		'This behaviour is default with Cloudflare Pages (when a 404.html isn\'t present) and will be ignored. Remove it from your _redirects to silence this warning.\nIf you wish to direct requests to a subfolder, for example, sending all requests to foo/index.html, you should use "/* /foo/".';
 	const result = parseRedirects(input);
 	expect(result).toEqual({
 		rules: [],
@@ -305,6 +306,11 @@ test("parseRedirects should reject '/* /index.html'", () => {
 			{
 				line: "/ /index",
 				lineNumber: 5,
+				message: invalidRedirectError,
+			},
+			{
+				line: "/* /foo/index.html",
+				lineNumber: 6,
 				message: invalidRedirectError,
 			},
 		],

--- a/packages/pages-shared/__tests__/metadata-generator/parseRedirects.invalid.test.ts
+++ b/packages/pages-shared/__tests__/metadata-generator/parseRedirects.invalid.test.ts
@@ -273,3 +273,40 @@ test("parseRedirects should reject non-relative URLs for proxying (200) redirect
 		],
 	});
 });
+
+test("parseRedirects should reject '/* /index.html'", () => {
+	const input = `
+/* /index.html 200
+/* /index 200
+/ /index.html
+/ /index
+`;
+	const invalidRedirectError =
+		"This behaviour is default with Cloudflare Pages (when a 404.html isn't present) and will be ignored. Remove it from your _redirects to silence this warning.";
+	const result = parseRedirects(input);
+	expect(result).toEqual({
+		rules: [],
+		invalid: [
+			{
+				line: "/* /index.html 200",
+				lineNumber: 2,
+				message: invalidRedirectError,
+			},
+			{
+				line: "/* /index 200",
+				lineNumber: 3,
+				message: invalidRedirectError,
+			},
+			{
+				line: "/ /index.html",
+				lineNumber: 4,
+				message: invalidRedirectError,
+			},
+			{
+				line: "/ /index",
+				lineNumber: 5,
+				message: invalidRedirectError,
+			},
+		],
+	});
+});

--- a/packages/pages-shared/__tests__/metadata-generator/parseRedirects.valid.test.ts
+++ b/packages/pages-shared/__tests__/metadata-generator/parseRedirects.valid.test.ts
@@ -138,3 +138,39 @@ test("parseRedirects should accept 200 (proxying) redirects", () => {
 		invalid: [],
 	});
 });
+
+test("parseRedirects should accept absolute URLs that end with index.html", () => {
+	const input = `
+	/foo https://bar.com/index.html 302
+`;
+	const result = parseRedirects(input);
+	expect(result).toEqual({
+		rules: [
+			{
+				from: "/foo",
+				status: 302,
+				to: "https://bar.com/index.html",
+				lineNumber: 2,
+			},
+		],
+		invalid: [],
+	});
+});
+
+test("parseRedirects should accept relative URLs that don't point to .html files", () => {
+	const input = `
+	/* /foo 200
+`;
+	const result = parseRedirects(input);
+	expect(result).toEqual({
+		rules: [
+			{
+				from: "/*",
+				status: 200,
+				to: "/foo",
+				lineNumber: 2,
+			},
+		],
+		invalid: [],
+	});
+});

--- a/packages/pages-shared/metadata-generator/parseRedirects.ts
+++ b/packages/pages-shared/metadata-generator/parseRedirects.ts
@@ -6,7 +6,7 @@ import {
 	SPLAT_REGEX,
 	PLACEHOLDER_REGEX,
 } from "./constants";
-import { validateUrl } from "./validateURL";
+import { validateUrl, urlHasHost } from "./validateURL";
 import type {
 	InvalidRedirectRule,
 	ParsedRedirects,
@@ -109,6 +109,19 @@ export function parseRedirects(input: string): ParsedRedirects {
 			continue;
 		}
 
+		// We want to always block the `/* /index.html` redirect - this will cause TOO_MANY_REDIRECTS errors as
+		// the asset server will redirect it back to `/`, removing the `/index.html`. This is the case for regular
+		// redirects, as well as proxied (200) rewrites. We only want to run this on relative urls
+		if (/\/\*?$/.test(from) && /\/index(.html)?$/.test(to) && !urlHasHost(to)) {
+			invalid.push({
+				line,
+				lineNumber: i + 1,
+				message:
+					"This behaviour is default with Cloudflare Pages (when a 404.html isn't present) and will be ignored. Remove it from your _redirects to silence this warning.",
+			});
+			continue;
+		}
+
 		if (seen_paths.has(from)) {
 			invalid.push({
 				line,
@@ -120,10 +133,7 @@ export function parseRedirects(input: string): ParsedRedirects {
 		seen_paths.add(from);
 
 		if (status === 200) {
-			// Error can only be that it's not relative - given validateUrl is called above without onlyRelative:true,
-			// so if it's present, we can error to the user that proxying only expects relative urls
-			const [proxyTo, error] = validateUrl(to, true, true, true);
-			if (error) {
+			if (urlHasHost(to)) {
 				invalid.push({
 					line,
 					lineNumber: i + 1,
@@ -131,8 +141,6 @@ export function parseRedirects(input: string): ParsedRedirects {
 				});
 				continue;
 			}
-			rules.push({ from, to: proxyTo as string, status, lineNumber: i + 1 });
-			continue;
 		}
 
 		rules.push({ from, to, status, lineNumber: i + 1 });

--- a/packages/pages-shared/metadata-generator/parseRedirects.ts
+++ b/packages/pages-shared/metadata-generator/parseRedirects.ts
@@ -117,7 +117,7 @@ export function parseRedirects(input: string): ParsedRedirects {
 				line,
 				lineNumber: i + 1,
 				message:
-					'This behaviour is default with Cloudflare Pages (when a 404.html isn\'t present) and will be ignored. Remove it from your _redirects to silence this warning.\nIf you wish to direct requests to a subfolder, for example, sending all requests to foo/index.html, you should use "/* /foo/".',
+					"Infinite loop detected in this rule and has been ignored. This will cause a redirect to strip `.html` or `/index` and end up triggering this rule again. Please fix or remove this rule to silence this warning.",
 			});
 			continue;
 		}

--- a/packages/pages-shared/metadata-generator/parseRedirects.ts
+++ b/packages/pages-shared/metadata-generator/parseRedirects.ts
@@ -117,7 +117,7 @@ export function parseRedirects(input: string): ParsedRedirects {
 				line,
 				lineNumber: i + 1,
 				message:
-					"This behaviour is default with Cloudflare Pages (when a 404.html isn't present) and will be ignored. Remove it from your _redirects to silence this warning.",
+					'This behaviour is default with Cloudflare Pages (when a 404.html isn\'t present) and will be ignored. Remove it from your _redirects to silence this warning.\nIf you wish to direct requests to a subfolder, for example, sending all requests to foo/index.html, you should use "/* /foo/".',
 			});
 			continue;
 		}

--- a/packages/pages-shared/metadata-generator/validateURL.ts
+++ b/packages/pages-shared/metadata-generator/validateURL.ts
@@ -55,3 +55,8 @@ export const validateUrl = (
 			: 'URLs should either be relative (e.g. begin with a forward-slash), or use HTTPS (e.g. begin with "https://").',
 	];
 };
+
+export function urlHasHost(token: string): boolean {
+	const host = URL_REGEX.exec(token);
+	return Boolean(host && host.groups && host.groups.host);
+}


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**
This PR implements validation to prevent people from having `/* /index.html 200` as a redirect rule in Pages, as this will cause an infinite amount of redirects when the API starts accepting 200 status codes in _redirects. This prevents breaking a number of projects that migrated from Netlify, etc. that are using this rule (for no reason - pages does the behaviour anyway)

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [x] Checked for inclusion of relevant tests
- [x] Checked for inclusion of a relevant changeset
- [x] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
