### PR TITLE
Include an empty __STATIC_CONTENT_MANIFEST if not defined.

### DIFF
--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -563,13 +563,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			},
 		};
 
-		if (assets.manifest) {
-			modules.push({
-				name: "__STATIC_CONTENT_MANIFEST",
-				content: JSON.stringify(assets.manifest),
-				type: "text",
-			});
-		}
+		modules.push({
+			name: "__STATIC_CONTENT_MANIFEST",
+			content: JSON.stringify(assets.manifest) || "{}",
+			type: "text",
+		});
 
 		// The upload API only accepts an empty string or no specified placement for the "off" mode.
 		const placement: CfPlacement | undefined =


### PR DESCRIPTION
Helps to # https://github.com/cloudflare/workers-rs/issues/54

**What this PR solves / how to test:**

This change inserts an empty manifest if no assets are uploaded. The reason behind the change is that it allows workers-rs (rust) read **unconditionally** the manifest. 

When no manifest exists, the rust code must detect this reading wrangler.toml. However, one can simply assumed that the manifest always exists, but it's empty when no assets are submitted.

**Associated docs issue(s)/PR(s):**

This PR is a dependency of https://github.com/cloudflare/workers-rs/pull/308
