### PR TITLE
Add wrangler-admins as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 # Global owners
 * @cloudflare/wrangler
+/packages/wrangler/CHANGELOG.md @cloudflare/wrangler-admins
 /packages/pages-shared/ @cloudflare/pages
 /packages/wrangler/pages/ @cloudflare/pages
 /packages/wrangler/src/pages/ @cloudflare/pages


### PR DESCRIPTION
Fixes: N/A

**What this PR solves / how to test:**
Adds the `@cloudflare/wrangler-admins` team as codeowner to the wrangler CHANGELOG file. The result is that wrangler-admins will be automatically set as requested reviewers for any Version Packages PRs.

**Associated docs issue(s)/PR(s):** N/A


**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
