### PR TITLE
🧹 chore: move links to old templates repo to point here

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -26,10 +26,10 @@ There are a few ways to quickly jumpstart your next project using one of the tem
 
    ```sh
    # full repository clone
-   $ git clone --depth 1 https://github.com/cloudflare/templates
+   $ git clone --depth 1 https://github.com/cloudflare/worker-sdk
 
    # copy the "worker-typescript" example to "my-project" directory
-   $ cp -rf templates/worker-typescript my-project
+   $ cp -rf workers-sdk/templates/worker-typescript my-project
 
    # setup & begin development
    $ cd my-project && npm install && npm run dev

--- a/templates/README.md
+++ b/templates/README.md
@@ -26,7 +26,7 @@ There are a few ways to quickly jumpstart your next project using one of the tem
 
    ```sh
    # full repository clone
-   $ git clone --depth 1 https://github.com/cloudflare/worker-sdk
+   $ git clone --depth 1 https://github.com/cloudflare/workers-sdk
 
    # copy the "worker-typescript" example to "my-project" directory
    $ cp -rf workers-sdk/templates/worker-typescript my-project

--- a/templates/examples/cryptocurrency-slack-bot/index.js
+++ b/templates/examples/cryptocurrency-slack-bot/index.js
@@ -6,7 +6,7 @@ addEventListener("fetch", (event) => {
 // Keep this value secret.
 let SLACK_TOKEN = "PUTYOURTOKENHERE";
 let BOT_NAME = "Crypto-bot 🤖";
-let REPO_URL = "https://github.com/cloudflare/templates";
+let REPO_URL = "https://github.com/cloudflare/workers-sdk/tree/main/templates/examples/cryptocurrency-slack-bot";
 
 let jsonHeaders = new Headers([["Content-Type", "application/json"]]);
 

--- a/templates/examples/cryptocurrency-slack-bot/index.js
+++ b/templates/examples/cryptocurrency-slack-bot/index.js
@@ -6,7 +6,8 @@ addEventListener("fetch", (event) => {
 // Keep this value secret.
 let SLACK_TOKEN = "PUTYOURTOKENHERE";
 let BOT_NAME = "Crypto-bot 🤖";
-let REPO_URL = "https://github.com/cloudflare/workers-sdk/tree/main/templates/examples/cryptocurrency-slack-bot";
+let REPO_URL =
+	"https://github.com/cloudflare/workers-sdk/tree/main/templates/examples/cryptocurrency-slack-bot";
 
 let jsonHeaders = new Headers([["Content-Type", "application/json"]]);
 

--- a/templates/experimental/worker-cobol/README.md
+++ b/templates/experimental/worker-cobol/README.md
@@ -1,6 +1,6 @@
 # Template: worker-cobol
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-cobol)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/experimental/worker-cobol)
 
 A Cloudflare worker that runs COBOL.
 

--- a/templates/experimental/worker-cobol/README.md
+++ b/templates/experimental/worker-cobol/README.md
@@ -1,6 +1,6 @@
 # Template: worker-cobol
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/experimental/worker-cobol)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/experimental/worker-cobol)
 
 A Cloudflare worker that runs COBOL.
 

--- a/templates/experimental/worker-emscripten/README.md
+++ b/templates/experimental/worker-emscripten/README.md
@@ -1,6 +1,6 @@
 # Template: worker-emscripten
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-emscripten)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/experimental/worker-emscripten)
 
 A template for kick starting a Cloudflare worker project with emscripten
 

--- a/templates/experimental/worker-emscripten/README.md
+++ b/templates/experimental/worker-emscripten/README.md
@@ -1,6 +1,6 @@
 # Template: worker-emscripten
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/experimental/worker-emscripten)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/experimental/worker-emscripten)
 
 A template for kick starting a Cloudflare worker project with emscripten
 

--- a/templates/experimental/worker-rust/README.md
+++ b/templates/experimental/worker-rust/README.md
@@ -1,6 +1,6 @@
 # Template: worker-rust
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-rust)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/experimental/worker-rust)
 
 A template for kick starting a Cloudflare worker project using [`workers-rs`](https://github.com/cloudflare/workers-rs).
 

--- a/templates/experimental/worker-rust/README.md
+++ b/templates/experimental/worker-rust/README.md
@@ -1,6 +1,6 @@
 # Template: worker-rust
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/experimental/worker-rust)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/experimental/worker-rust)
 
 A template for kick starting a Cloudflare worker project using [`workers-rs`](https://github.com/cloudflare/workers-rs).
 

--- a/templates/pages-example-forum-app/README.md
+++ b/templates/pages-example-forum-app/README.md
@@ -1,6 +1,6 @@
 # Forum application built with Pages Functions, Workers KV and Durable Objects
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-example-forum-app)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-example-forum-app)
 
 ## Overview
 

--- a/templates/pages-example-forum-app/README.md
+++ b/templates/pages-example-forum-app/README.md
@@ -1,6 +1,6 @@
 # Forum application built with Pages Functions, Workers KV and Durable Objects
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/pages-example-forum-app)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-example-forum-app)
 
 ## Overview
 

--- a/templates/pages-functions-cors/README.md
+++ b/templates/pages-functions-cors/README.md
@@ -1,6 +1,6 @@
 # Template: pages-functions-cors
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/pages-functions-cors)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-functions-cors)
 
 A template for Pages Functions appending CORS headers.
 

--- a/templates/pages-functions-cors/README.md
+++ b/templates/pages-functions-cors/README.md
@@ -1,6 +1,6 @@
 # Template: pages-functions-cors
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-functions-cors)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-functions-cors)
 
 A template for Pages Functions appending CORS headers.
 

--- a/templates/pages-image-sharing/README.md
+++ b/templates/pages-image-sharing/README.md
@@ -1,5 +1,5 @@
 # Image sharing platform build with Cloudflare Pages
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/pages-image-sharing)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-image-sharing)
 
 This example application showcases Cloudflare Pages functions powered by Cloudflare Workers

--- a/templates/pages-image-sharing/README.md
+++ b/templates/pages-image-sharing/README.md
@@ -1,5 +1,5 @@
 # Image sharing platform build with Cloudflare Pages
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-image-sharing)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-image-sharing)
 
 This example application showcases Cloudflare Pages functions powered by Cloudflare Workers

--- a/templates/pages-plugin-static-forms/README.md
+++ b/templates/pages-plugin-static-forms/README.md
@@ -1,6 +1,6 @@
 # Template: pages-functions-static-form
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-plugin-static-forms)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-plugin-static-forms)
 
 A template for Pages using static-forms plugin.
 

--- a/templates/pages-plugin-static-forms/README.md
+++ b/templates/pages-plugin-static-forms/README.md
@@ -1,6 +1,6 @@
 # Template: pages-functions-static-form
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/pages-functions-static-form)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-plugin-static-forms)
 
 A template for Pages using static-forms plugin.
 

--- a/templates/stream/auth/stripe/README.md
+++ b/templates/stream/auth/stripe/README.md
@@ -1,6 +1,6 @@
 # Cloudflare Stream + Stripe
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/auth/stripe)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/auth/stripe)
 
 Host and monetize **paid** video content (live or on-demand) that you fully control, on your own website, using [Cloudflare Stream](https://www.cloudflare.com/products/cloudflare-stream/), [Cloudflare Pages](https://pages.cloudflare.com/), and [Stripe Checkout](https://stripe.com/payments/checkout).
 

--- a/templates/stream/auth/stripe/README.md
+++ b/templates/stream/auth/stripe/README.md
@@ -1,6 +1,6 @@
 # Cloudflare Stream + Stripe
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/auth/stripe)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/auth/stripe)
 
 Host and monetize **paid** video content (live or on-demand) that you fully control, on your own website, using [Cloudflare Stream](https://www.cloudflare.com/products/cloudflare-stream/), [Cloudflare Pages](https://pages.cloudflare.com/), and [Stripe Checkout](https://stripe.com/payments/checkout).
 

--- a/templates/stream/playback/dash-js/README.md
+++ b/templates/stream/playback/dash-js/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream + dash.js playback
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/playback/dash-js)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/dash-js)
 
 Example of video playback with Cloudflare Stream and dash.js

--- a/templates/stream/playback/dash-js/README.md
+++ b/templates/stream/playback/dash-js/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream + dash.js playback
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/dash-js)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/dash-js)
 
 Example of video playback with Cloudflare Stream and dash.js

--- a/templates/stream/playback/hls-js/README.md
+++ b/templates/stream/playback/hls-js/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream + hls.js playback
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/hls-js)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/hls-js)
 
 Example of video playback with Cloudflare Stream and hls.js

--- a/templates/stream/playback/hls-js/README.md
+++ b/templates/stream/playback/hls-js/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream + hls.js playback
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/playback/hls-js)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/hls-js)
 
 Example of video playback with Cloudflare Stream and hls.js

--- a/templates/stream/playback/shaka-player/README.md
+++ b/templates/stream/playback/shaka-player/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream + Shaka Player
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/shaka-player)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/shaka-player)
 
 Example of video playback with Shaka Player and Cloudflare Stream

--- a/templates/stream/playback/shaka-player/README.md
+++ b/templates/stream/playback/shaka-player/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream + Shaka Player
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/playback/shaka-player)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/shaka-player)
 
 Example of video playback with Shaka Player and Cloudflare Stream

--- a/templates/stream/playback/stream-player/README.md
+++ b/templates/stream/playback/stream-player/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream Player
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/stream-player)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/stream-player)
 
 Example of video playback with the Cloudflare Stream Player

--- a/templates/stream/playback/stream-player/README.md
+++ b/templates/stream/playback/stream-player/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream Player
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/playback/stream-player)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/stream-player)
 
 Example of video playback with the Cloudflare Stream Player

--- a/templates/stream/playback/video-js/README.md
+++ b/templates/stream/playback/video-js/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream + Video.js Playback
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/video-js)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/video-js)
 
 Example of Video.js playback with Cloudflare Stream

--- a/templates/stream/playback/video-js/README.md
+++ b/templates/stream/playback/video-js/README.md
@@ -1,5 +1,5 @@
 # Template: Cloudflare Stream + Video.js Playback
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/playback/video-js)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/video-js)
 
 Example of Video.js playback with Cloudflare Stream

--- a/templates/stream/playback/vidstack/README.md
+++ b/templates/stream/playback/vidstack/README.md
@@ -1,6 +1,6 @@
 # Template: Cloudflare Stream + Vidstack
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/playback/vidstack)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/vidstack)
 
 A very simple CDN example of HLS playback with Cloudflare Stream and Vidstack. You can find more
 installation options and examples at:

--- a/templates/stream/playback/vidstack/README.md
+++ b/templates/stream/playback/vidstack/README.md
@@ -1,6 +1,6 @@
 # Template: Cloudflare Stream + Vidstack
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/vidstack)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/vidstack)
 
 A very simple CDN example of HLS playback with Cloudflare Stream and Vidstack. You can find more
 installation options and examples at:

--- a/templates/stream/upload/direct-creator-uploads-tus/README.md
+++ b/templates/stream/upload/direct-creator-uploads-tus/README.md
@@ -1,6 +1,6 @@
 # Template: Direct Creator Uploads to Cloudflare Stream, using TUS
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/upload/direct-creator-uploads-tus)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads-tus)
 
 Example of (Direct Creator Uploads)[https://developers.cloudflare.com/stream/uploading-videos/direct-creator-uploads/] to Cloudflare Stream, using the TUS protocol.
 

--- a/templates/stream/upload/direct-creator-uploads-tus/README.md
+++ b/templates/stream/upload/direct-creator-uploads-tus/README.md
@@ -1,6 +1,6 @@
 # Template: Direct Creator Uploads to Cloudflare Stream, using TUS
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads-tus)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads-tus)
 
 Example of (Direct Creator Uploads)[https://developers.cloudflare.com/stream/uploading-videos/direct-creator-uploads/] to Cloudflare Stream, using the TUS protocol.
 

--- a/templates/stream/upload/direct-creator-uploads/README.md
+++ b/templates/stream/upload/direct-creator-uploads/README.md
@@ -1,6 +1,6 @@
 # Template: Direct Creator Uploads to Cloudflare Stream
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads)
 
 Example of (Direct Creator Uploads)[https://developers.cloudflare.com/stream/uploading-videos/direct-creator-uploads/] to Cloudflare Stream
 

--- a/templates/stream/upload/direct-creator-uploads/README.md
+++ b/templates/stream/upload/direct-creator-uploads/README.md
@@ -1,6 +1,6 @@
 # Template: Direct Creator Uploads to Cloudflare Stream
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/upload/direct-creator-uploads)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads)
 
 Example of (Direct Creator Uploads)[https://developers.cloudflare.com/stream/uploading-videos/direct-creator-uploads/] to Cloudflare Stream
 

--- a/templates/stream/webrtc/README.md
+++ b/templates/stream/webrtc/README.md
@@ -1,6 +1,6 @@
 # Stream and playback live video over WebRTC with Cloudflare Stream
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/webrtc)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/webrtc)
 
 Follow [this guide](https://developers.cloudflare.com/stream/webrtc-beta) to get started.
 

--- a/templates/stream/webrtc/README.md
+++ b/templates/stream/webrtc/README.md
@@ -1,6 +1,6 @@
 # Stream and playback live video over WebRTC with Cloudflare Stream
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/stream/webrtc)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/webrtc)
 
 Follow [this guide](https://developers.cloudflare.com/stream/webrtc-beta) to get started.
 

--- a/templates/worker-aws/README.md
+++ b/templates/worker-aws/README.md
@@ -1,6 +1,6 @@
 # Template: worker-aws
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-aws)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-aws)
 
 This is a template for using Amazon Web Services such as DynamoDB and SQS from a Cloudflare Worker.
 

--- a/templates/worker-aws/README.md
+++ b/templates/worker-aws/README.md
@@ -1,6 +1,6 @@
 # Template: worker-aws
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-aws)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-aws)
 
 This is a template for using Amazon Web Services such as DynamoDB and SQS from a Cloudflare Worker.
 

--- a/templates/worker-d1-api/README.md
+++ b/templates/worker-d1-api/README.md
@@ -2,8 +2,6 @@
 
 [![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api)
 
-> **Note: requires D1 Beta Access**
-
 This project is based off the Default Typescript Worker starter. To create a new project like this, run the following:
 
 ```sh

--- a/templates/worker-d1-api/README.md
+++ b/templates/worker-d1-api/README.md
@@ -1,6 +1,8 @@
 # Template: worker-d1-api
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-d1-api)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api)
+
+> **Note: requires D1 Beta Access**
 
 This project is based off the Default Typescript Worker starter. To create a new project like this, run the following:
 

--- a/templates/worker-d1-api/README.md
+++ b/templates/worker-d1-api/README.md
@@ -1,6 +1,6 @@
 # Template: worker-d1-api
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1-api)
 
 > **Note: requires D1 Beta Access**
 

--- a/templates/worker-d1/README.md
+++ b/templates/worker-d1/README.md
@@ -1,6 +1,6 @@
 # Template: worker-d1
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-d1)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1)
 
 This project is based off the Default Typescript Worker starter. To create a new project like this, run the following:
 

--- a/templates/worker-d1/README.md
+++ b/templates/worker-d1/README.md
@@ -1,6 +1,6 @@
 # Template: worker-d1
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1)
 
 This project is based off the Default Typescript Worker starter. To create a new project like this, run the following:
 

--- a/templates/worker-durable-objects/README.md
+++ b/templates/worker-durable-objects/README.md
@@ -1,6 +1,6 @@
 # Template: worker-durable-objects
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-durable-objects)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-durable-objects)
 
 ## Note: You must use [wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update) 1.19.3 or newer to use this template.
 

--- a/templates/worker-durable-objects/README.md
+++ b/templates/worker-durable-objects/README.md
@@ -1,6 +1,6 @@
 # Template: worker-durable-objects
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-durable-objects)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-durable-objects)
 
 ## Note: You must use [wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update) 1.19.3 or newer to use this template.
 

--- a/templates/worker-example-request-scheduler/README.md
+++ b/templates/worker-example-request-scheduler/README.md
@@ -1,6 +1,6 @@
 # Template: worker-example-request-scheduler
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-example-request-scheduler)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-request-scheduler)
 
 A example for building a scalable request scheduler.
 

--- a/templates/worker-example-request-scheduler/README.md
+++ b/templates/worker-example-request-scheduler/README.md
@@ -1,6 +1,6 @@
 # Template: worker-example-request-scheduler
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-request-scheduler)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-request-scheduler)
 
 A example for building a scalable request scheduler.
 

--- a/templates/worker-example-wordle/README.md
+++ b/templates/worker-example-wordle/README.md
@@ -1,6 +1,6 @@
 # Template: worker-example-wordle
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-example-wordle)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-wordle)
 
 A template for kickstarting a multiplayer clone of the [Wordle](https://www.nytimes.com/games/wordle/index.html) game.
 

--- a/templates/worker-example-wordle/README.md
+++ b/templates/worker-example-wordle/README.md
@@ -1,6 +1,6 @@
 # Template: worker-example-wordle
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-wordle)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-wordle)
 
 A template for kickstarting a multiplayer clone of the [Wordle](https://www.nytimes.com/games/wordle/index.html) game.
 

--- a/templates/worker-mysql/README.md
+++ b/templates/worker-mysql/README.md
@@ -1,6 +1,6 @@
 # Template: worker-mysql
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-mysql)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-mysql)
 
 This repo contains example code and a MySQL driver that can be used in any Workers project. If you are interested in using the driver _outside_ of this template, copy the `driver/mysql` module into your project's `node_modules` or directly alongside your source.
 

--- a/templates/worker-mysql/README.md
+++ b/templates/worker-mysql/README.md
@@ -1,6 +1,6 @@
 # Template: worker-mysql
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-mysql)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-mysql)
 
 This repo contains example code and a MySQL driver that can be used in any Workers project. If you are interested in using the driver _outside_ of this template, copy the `driver/mysql` module into your project's `node_modules` or directly alongside your source.
 

--- a/templates/worker-openapi/README.md
+++ b/templates/worker-openapi/README.md
@@ -1,6 +1,6 @@
 ## Template: worker-openapi
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-openapi)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-openapi)
 
 This template demonstrates using the [`itty-router-openapi`](https://github.com/cloudflare/itty-router-openapi) package to add openapi 3 schema generation and validation.
 

--- a/templates/worker-openapi/README.md
+++ b/templates/worker-openapi/README.md
@@ -1,6 +1,6 @@
 ## Template: worker-openapi
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-openapi)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-openapi)
 
 This template demonstrates using the [`itty-router-openapi`](https://github.com/cloudflare/itty-router-openapi) package to add openapi 3 schema generation and validation.
 

--- a/templates/worker-postgres/README.md
+++ b/templates/worker-postgres/README.md
@@ -1,6 +1,6 @@
 # Template: worker-postgres
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-postgres)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-postgres)
 
 This repo contains example code and a PostgreSQL driver that can be used in any Workers project. If you are interested in using the driver _outside_ of this template, copy the `driver/postgres` module into your project's `node_modules` or directly alongside your source.
 

--- a/templates/worker-postgres/README.md
+++ b/templates/worker-postgres/README.md
@@ -1,6 +1,6 @@
 # Template: worker-postgres
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-postgres)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-postgres)
 
 This repo contains example code and a PostgreSQL driver that can be used in any Workers project. If you are interested in using the driver _outside_ of this template, copy the `driver/postgres` module into your project's `node_modules` or directly alongside your source.
 

--- a/templates/worker-prospector/readme.md
+++ b/templates/worker-prospector/readme.md
@@ -1,6 +1,6 @@
 # ⛏️ Prospector
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-prospector)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-prospector)
 
 An open-source template built for internal use by Cloudflare's SEO experts to parse and notify on new website content. Using D1, Queues, and Workers, this template will show you how to connect multiple Cloudflare products together to build a fully-featured application.
 

--- a/templates/worker-prospector/readme.md
+++ b/templates/worker-prospector/readme.md
@@ -1,12 +1,12 @@
 # ⛏️ Prospector
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-prospector)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-prospector)
 
 An open-source template built for internal use by Cloudflare's SEO experts to parse and notify on new website content. Using D1, Queues, and Workers, this template will show you how to connect multiple Cloudflare products together to build a fully-featured application.
 
 ## Deployment
 
-Clone the repository from the `cloudflare/tmemplates` repository:
+Clone the repository from the `cloudflare/workers-sdk` repository:
 
 ```bash
 $ npx wrangler generate my-project prospector

--- a/templates/worker-r2/README.md
+++ b/templates/worker-r2/README.md
@@ -1,6 +1,6 @@
 # Template: worker-r2
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-r2)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-r2)
 
 A template for interfacing with an R2 bucket from within a Cloudflare Worker.
 

--- a/templates/worker-r2/README.md
+++ b/templates/worker-r2/README.md
@@ -1,6 +1,6 @@
 # Template: worker-r2
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-r2)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-r2)
 
 A template for interfacing with an R2 bucket from within a Cloudflare Worker.
 

--- a/templates/worker-router/README.md
+++ b/templates/worker-router/README.md
@@ -1,6 +1,6 @@
 ## Template: worker-router
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-router)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-router)
 
 This template demonstrates using the [`itty-router`](https://github.com/kwhitley/itty-router) package to add routing to your Cloudflare Workers.
 

--- a/templates/worker-router/README.md
+++ b/templates/worker-router/README.md
@@ -1,6 +1,6 @@
 ## Template: worker-router
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-router)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-router)
 
 This template demonstrates using the [`itty-router`](https://github.com/kwhitley/itty-router) package to add routing to your Cloudflare Workers.
 

--- a/templates/worker-sites-react/README.md
+++ b/templates/worker-sites-react/README.md
@@ -1,6 +1,6 @@
 # Template: worker-sites-react
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites-react)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites-react)
 
 This project is a React application generated with [create-react-app](https://github.com/facebook/create-react-app), and deployed with [Workers Sites](https://developers.cloudflare.com/workers/sites).
 

--- a/templates/worker-sites-react/README.md
+++ b/templates/worker-sites-react/README.md
@@ -1,6 +1,6 @@
 # Template: worker-sites-react
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-sites-react)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites-react)
 
 This project is a React application generated with [create-react-app](https://github.com/facebook/create-react-app), and deployed with [Workers Sites](https://developers.cloudflare.com/workers/sites).
 

--- a/templates/worker-sites/README.md
+++ b/templates/worker-sites/README.md
@@ -1,6 +1,6 @@
 # Template: worker-sites
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-sites)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites)
 
 A bare minimum template of deploying a [Workers Site](https://developers.cloudflare.com/workers/platform/sites/) application.
 

--- a/templates/worker-sites/README.md
+++ b/templates/worker-sites/README.md
@@ -1,6 +1,6 @@
 # Template: worker-sites
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-sites)
 
 A bare minimum template of deploying a [Workers Site](https://developers.cloudflare.com/workers/platform/sites/) application.
 

--- a/templates/worker-speedtest/README.md
+++ b/templates/worker-speedtest/README.md
@@ -1,6 +1,6 @@
 # Template: worker-speedtest
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-speedtest)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-speedtest)
 
 Worker for measuring download / upload connection speed from the client side, using the [Performance Timing API](https://w3c.github.io/perf-timing-primer/).
 

--- a/templates/worker-speedtest/README.md
+++ b/templates/worker-speedtest/README.md
@@ -1,6 +1,6 @@
 # Template: worker-speedtest
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-speedtest)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-speedtest)
 
 Worker for measuring download / upload connection speed from the client side, using the [Performance Timing API](https://w3c.github.io/perf-timing-primer/).
 

--- a/templates/worker-typescript/README.md
+++ b/templates/worker-typescript/README.md
@@ -1,6 +1,6 @@
 # Template: worker-typescript
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-typescript)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript)
 
 A batteries included template for kick starting a TypeScript Cloudflare worker project.
 

--- a/templates/worker-typescript/README.md
+++ b/templates/worker-typescript/README.md
@@ -1,6 +1,6 @@
 # Template: worker-typescript
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript)
 
 A batteries included template for kick starting a TypeScript Cloudflare worker project.
 

--- a/templates/worker-websocket-durable-objects/README.md
+++ b/templates/worker-websocket-durable-objects/README.md
@@ -1,6 +1,6 @@
 # Template: worker-websocket-durable-objects
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-websocket-durable-objects)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-durable-objects)
 
 A template for working with Durable Objects as WebSocket backend in Cloudflare Workers. [Check out the announcement blog post to learn more.](https://blog.cloudflare.com/introducing-websockets-in-workers/)
 

--- a/templates/worker-websocket-durable-objects/README.md
+++ b/templates/worker-websocket-durable-objects/README.md
@@ -1,6 +1,6 @@
 # Template: worker-websocket-durable-objects
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-durable-objects)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-durable-objects)
 
 A template for working with Durable Objects as WebSocket backend in Cloudflare Workers. [Check out the announcement blog post to learn more.](https://blog.cloudflare.com/introducing-websockets-in-workers/)
 

--- a/templates/worker-websocket/README.md
+++ b/templates/worker-websocket/README.md
@@ -1,6 +1,6 @@
 # Template: worker-websocket
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-websocket)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-websocket)
 
 A simple template for working with WebSockets in Cloudflare Workers. [Check out the announcement blog post to learn more.](https://blog.cloudflare.com/introducing-websockets-in-workers/)
 

--- a/templates/worker-websocket/README.md
+++ b/templates/worker-websocket/README.md
@@ -1,6 +1,6 @@
 # Template: worker-websocket
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-websocket)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-websocket)
 
 A simple template for working with WebSockets in Cloudflare Workers. [Check out the announcement blog post to learn more.](https://blog.cloudflare.com/introducing-websockets-in-workers/)
 

--- a/templates/worker-worktop/README.md
+++ b/templates/worker-worktop/README.md
@@ -1,6 +1,6 @@
 ## Template: worker-worktop
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-worktop)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-worktop)
 
 This template utilizes the [`worktop`](https://github.com/lukeed/worktop) framework to construct an API endpoint to serve user-specific TODO lists. The endpoint includes:
 

--- a/templates/worker-worktop/README.md
+++ b/templates/worker-worktop/README.md
@@ -1,6 +1,6 @@
 ## Template: worker-worktop
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-worktop)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-worktop)
 
 This template utilizes the [`worktop`](https://github.com/lukeed/worktop) framework to construct an API endpoint to serve user-specific TODO lists. The endpoint includes:
 

--- a/templates/worker/README.md
+++ b/templates/worker/README.md
@@ -1,6 +1,6 @@
 # Template: worker
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker)
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker)
 
 A simple template for kick starting a Cloudflare worker project.
 

--- a/templates/worker/README.md
+++ b/templates/worker/README.md
@@ -1,6 +1,6 @@
 # Template: worker
 
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker)
+[![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker)
 
 A simple template for kick starting a Cloudflare worker project.
 


### PR DESCRIPTION
Fixes #2533.

I'm new to this project, so please advise if I've missed anything. Don't think it needs a changeset.

**What this PR solves / how to test:**

Find references to legacy https://github.com/cloudflare/templates and replace with appropriate link under https://github.com/cloudflare/workers-sdk.

Validated new links, including some templates that moved to experimental/ subdir.

Also found a fixed at least one tyop.

Fixed corresponding tests and tested.

Now the <picture><img alt="Deploy with Workers" src="https://deploy.workers.cloudflare.com/button"></picture> badge will load the newer/proper template!

**Author has included the following, where applicable:**

- [X] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
