### PR TITLE
[wrangler] Pass through `nodejs_compat` to pages functions build

### DIFF
--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -222,6 +222,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 				sourcemap,
 				watch,
 				betaD1Shims: d1Databases,
+				nodejsCompat,
 			});
 		} else {
 			try {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/next-on-pages/issues/199

**What this PR solves / how to test:**
- Fixes passing the `nodejs_compat` flag through to `wrangler pages functions build`

cc @dario-piotrowicz 

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
