### PR TITLE
[wrangler] Deprecate the init command

### DIFF
--- a/.changeset/polite-beans-own.md
+++ b/.changeset/polite-beans-own.md
@@ -1,0 +1,5 @@
+---
+"wrangler": major
+---
+
+Deprecate the `init` command

--- a/.changeset/polite-beans-own.md
+++ b/.changeset/polite-beans-own.md
@@ -1,5 +1,0 @@
----
-"wrangler": major
----
-
-Deprecate the `init` command

--- a/packages/wrangler/src/__tests__/generate.test.ts
+++ b/packages/wrangler/src/__tests__/generate.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { getPackageManager } from "../package-manager";
+import { type PackageManager, getPackageManager } from "../package-manager";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
@@ -17,7 +17,7 @@ describe("generate", () => {
 
 		mockPackageManager = {
 			cwd: process.cwd(),
-			type: "mockpm",
+			type: "mockpm" as "npm",
 			addDevDeps: jest.fn(),
 			install: jest.fn(),
 		};

--- a/packages/wrangler/src/__tests__/generate.test.ts
+++ b/packages/wrangler/src/__tests__/generate.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { getPackageManager } from "../package-manager";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { mockConfirm } from "./helpers/mock-dialogs";
 import { useMockIsTTY } from "./helpers/mock-istty";
@@ -10,8 +11,17 @@ describe("generate", () => {
 	runInTempDir();
 	const { setIsTTY } = useMockIsTTY();
 	const std = mockConsoleMethods();
+	let mockPackageManager: PackageManager;
 	beforeEach(() => {
 		setIsTTY(true);
+
+		mockPackageManager = {
+			cwd: process.cwd(),
+			type: "mockpm",
+			addDevDeps: jest.fn(),
+			install: jest.fn(),
+		};
+		(getPackageManager as jest.Mock).mockResolvedValue(mockPackageManager);
 	});
 
 	describe("cli functionality", () => {
@@ -32,6 +42,13 @@ describe("generate", () => {
 			expect(std.out).toMatchInlineSnapshot(
 				`"✨ Created no-template/wrangler.toml"`
 			);
+			expect(std.warn).toMatchInlineSnapshot(`
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			"
+		`);
 		});
 
 		it("complains when given the --type argument", async () => {

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -76,7 +76,13 @@ describe("init", () => {
 			To publish your Worker to the Internet, run \`npm run deploy\`"
 		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			"
+		`);
 		});
 
 		it("should initialize with no interactive prompts if `--yes` is used (named worker)", async () => {
@@ -109,7 +115,13 @@ describe("init", () => {
 			To publish your Worker to the Internet, run \`npm run deploy\`"
 		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			"
+		`);
 		});
 
 		it("should initialize with no interactive prompts if `-y` is used", async () => {
@@ -141,7 +153,11 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -217,7 +233,11 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created wrangler.toml",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -252,7 +272,11 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created my-worker/wrangler.toml",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -553,7 +577,11 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Initialized git repository",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 			expect((await execa("git", ["branch", "--show-current"])).stdout).toEqual(
@@ -594,7 +622,11 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -622,7 +654,11 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker/my-worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -651,7 +687,11 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Initialized git repository",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 
@@ -709,7 +749,11 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Created package.json",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -761,7 +805,11 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created my-worker/wrangler.toml
 			✨ Created my-worker/package.json",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -807,7 +855,11 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created wrangler.toml",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -862,7 +914,11 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created path/to/worker/my-worker/wrangler.toml
 			✨ Created path/to/worker/my-worker/package.json",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -916,7 +972,11 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Installed wrangler into devDependencies",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -977,7 +1037,11 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Installed wrangler into devDependencies",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1033,7 +1097,11 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created wrangler.toml",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1096,7 +1164,11 @@ describe("init", () => {
 
 			To start developing your Worker, run \`npx wrangler dev\`
 			To publish your Worker to the Internet, run \`npx wrangler publish\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1156,7 +1228,11 @@ describe("init", () => {
 
 			To start developing your Worker, run \`npx wrangler dev\`
 			To publish your Worker to the Internet, run \`npx wrangler publish\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1331,7 +1407,11 @@ describe("init", () => {
 			  "out": "✨ Created wrangler.toml
 			✨ Created tsconfig.json
 			✨ Installed @cloudflare/workers-types and typescript into devDependencies",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1377,7 +1457,11 @@ describe("init", () => {
 			✨ Created my-worker/package.json
 			✨ Created my-worker/tsconfig.json
 			✨ Installed @cloudflare/workers-types and typescript into devDependencies",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1434,7 +1518,11 @@ describe("init", () => {
 			✨ Created package.json
 			✨ Created tsconfig.json
 			✨ Installed @cloudflare/workers-types and typescript into devDependencies",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1492,7 +1580,11 @@ describe("init", () => {
 
 			To start developing your Worker, run \`npx wrangler dev\`
 			To publish your Worker to the Internet, run \`npx wrangler publish\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1567,7 +1659,11 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker/my-worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1625,7 +1721,11 @@ describe("init", () => {
 			  "out": "✨ Created wrangler.toml
 			✨ Installed @cloudflare/workers-types into devDependencies
 			🚨 Please add \\"@cloudflare/workers-types\\" to compilerOptions.types in tsconfig.json",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1685,7 +1785,11 @@ describe("init", () => {
 
 			To start developing your Worker, run \`npx wrangler dev\`
 			To publish your Worker to the Internet, run \`npx wrangler publish\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -1973,7 +2077,11 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created wrangler.toml",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -2020,7 +2128,11 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created my-worker/wrangler.toml",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -2082,7 +2194,11 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -2114,7 +2230,11 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});
@@ -2146,7 +2266,11 @@ describe("init", () => {
 			To start developing your Worker, run \`cd WEIRD_w0rkr_N4m3.js.tsx.tar.gz && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
 			}
 		`);
 		});

--- a/packages/wrangler/src/generate/index.ts
+++ b/packages/wrangler/src/generate/index.ts
@@ -46,6 +46,7 @@ export async function generateHandler(args: GenerateArgs) {
 			site: undefined,
 			yes: undefined,
 			fromDash: undefined,
+			delegateC3: false,
 			v: undefined,
 			config: undefined,
 			env: undefined,

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -60,11 +60,11 @@ export function initOptions(yargs: CommonYargsArgv) {
 			type: "string",
 			requiresArg: true,
 		})
-		.option("do-not-delegate", {
-			describe: "Do not delegate to Create Cloudflare CLI (C3)",
+		.option("delegate-c3", {
+			describe: "Delegate to Create Cloudflare CLI (C3)",
 			type: "boolean",
 			hidden: true,
-			default: true, // will be false in v3
+			default: false, // will be true in v3
 		});
 }
 
@@ -204,7 +204,7 @@ export async function initHandler(args: InitArgs) {
 		);
 
 		// C3 will run wrangler with the --do-not-delegate flag to communicate with the API
-		if (!args.doNotDelegate) {
+		if (args.delegateC3) {
 			logger.log(`Running ${replacementC3Command}...`);
 
 			await execa(packageManager.type, [
@@ -244,7 +244,7 @@ export async function initHandler(args: InitArgs) {
 				`The \`init\` command is no longer supported. Please use ${replacementC3Command} instead.\nThe \`init\` command will be removed in a future version.`
 			);
 
-			if (!args.doNotDelegate) {
+			if (args.delegateC3) {
 				logger.log(`Running ${replacementC3Command}...`);
 
 				await execa(packageManager.type, ["create", "cloudflare"]);

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -210,10 +210,9 @@ export async function initHandler(args: InitArgs) {
 			await execa(packageManager.type, [
 				"create",
 				"cloudflare",
-				"--template",
-				"pre-existing",
-				"--name",
 				fromDashScriptName,
+				"--type",
+				"pre-existing",
 			]);
 
 			return;

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import { writeFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import TOML from "@iarna/toml";
+import { execa } from "execa";
 import { findUp } from "find-up";
 import { version as wranglerVersion } from "../package.json";
 
@@ -58,6 +59,11 @@ export function initOptions(yargs: CommonYargsArgv) {
 				"The name of the Worker you wish to download from the Cloudflare dashboard for local development.",
 			type: "string",
 			requiresArg: true,
+		})
+		.option("do-not-delegate", {
+			describe: "Do not delegate to Create Cloudflare CLI (C3)",
+			type: "boolean",
+			hidden: true,
 		});
 }
 
@@ -170,6 +176,10 @@ export async function initHandler(args: InitArgs) {
 	let serviceMetadata: undefined | ServiceMetadataRes;
 
 	// If --from-dash, check that script actually exists
+	/*
+    Even though the init command is now deprecated and replaced by Create Cloudflare CLI (C3),
+    run this first so, if the script doesn't exist, we can fail early
+  */
 	if (fromDashScriptName) {
 		const config = readConfig(args.config, args);
 		accountId = await requireAuth(config);
@@ -184,6 +194,28 @@ export async function initHandler(args: InitArgs) {
 				);
 			}
 			throw err;
+		}
+
+		// Deprecate the `init --from-dash` command
+		//    if --do-not-delegate is not set (C3 will run wrangler with this flag set to communicate with the API)
+		if (!args.doNotDelegate) {
+			const command = `\`${packageManager.type} create cloudflare --template pre-existing --name ${fromDashScriptName}\``;
+
+			logger.warn(
+				`The \`init --from-dash\` command is no longer supported. Please use ${command} instead.\nThe \`init\` command will be removed in a future version.`
+			);
+			logger.log(`Running ${command}...`);
+
+			await execa(packageManager.type, [
+				"create",
+				"cloudflare",
+				"--template",
+				"pre-existing",
+				"--name",
+				fromDashScriptName,
+			]);
+
+			return;
 		}
 	}
 
@@ -201,6 +233,22 @@ export async function initHandler(args: InitArgs) {
 			return;
 		}
 	} else {
+		// Deprecate the `init` command
+		//    if a wrangler.toml file does not exist (C3 expects to scaffold *new* projects)
+		//    and if --from-dash is not set (C3 will run wrangler to communicate with the API)
+		if (!fromDashScriptName) {
+			const command = `\`${packageManager.type} create cloudflare\``;
+
+			logger.warn(
+				`The \`init\` command is no longer supported. Please use ${command} instead.\nThe \`init\` command will be removed in a future version.`
+			);
+			logger.log(`Running ${command}...`);
+
+			await execa(packageManager.type, ["create", "cloudflare"]);
+
+			return;
+		}
+
 		await mkdir(creationDirectory, { recursive: true });
 		const compatibilityDate = new Date().toISOString().substring(0, 10);
 


### PR DESCRIPTION
Deprecate the init command and run C3 where we can reliably fallback

~~This should be merged in v3 only~~ No longer a breaking change with —delegate-c3 defaulting to false (thanks 
@penalosa and @petebacondarwin!)

The entire command will be deprecated.

Only part of it's functionality is being delegated to C3 — when the project doesn't exist on disk yet.

If the project does exist (a wrangler.toml is found in the creationDirectory), init's functionality is preserved. We will delegate this functionality to another command within wrangler in the future — before v4 when the init command is removed.

~~Tests still TODO~~