### PR TITLE
[wrangler] Handle multi-module workers when downloading scripts

### DIFF
--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -4,6 +4,7 @@ import * as TOML from "@iarna/toml";
 import { execa, execaSync } from "execa";
 import { rest } from "msw";
 import { parseConfigFileTextToJson } from "typescript";
+import { FormData } from "undici";
 import { version as wranglerVersion } from "../../package.json";
 import { getPackageManager } from "../package-manager";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
@@ -2235,6 +2236,12 @@ describe("init", () => {
 			},
 		};
 		`;
+		afterEach(() => {
+			// some test has a side-effect which is overwriting the compatibility_date
+			mockServiceMetadata.default_environment.script.compatibility_date =
+				"1987-9-27";
+			mockConfigExpected.compatibility_date = "1987-9-27";
+		});
 		const mockServiceMetadata = {
 			id: "memory-crystal",
 			default_environment: {
@@ -3001,7 +3008,7 @@ describe("init", () => {
 								success: true,
 								errors: [],
 								messages: [],
-								result: mockServiceMetadata.default_environment,
+								result: mockData.default_environment,
 							})
 						);
 					}
@@ -3074,6 +3081,72 @@ describe("init", () => {
 				},
 			});
 		});
+
+		it("should download multi-module source scripts from dashboard", async () => {
+			mockSupportingDashRequests({
+				expectedAccountId: "LCARS",
+				expectedScriptName: "isolinear-optical-chip",
+				expectedEnvironment: "test",
+				expectedCompatDate: "1987-9-27",
+			});
+			const indexjs = `
+        import handleRequest from './handleRequest.js';
+
+        export default {
+          async fetch(request, env, ctx) {
+            return handleRequest(request, env, ctx);
+          },
+        };
+      `;
+			const otherjs = `
+        export default function (request, env, ctx) {
+          return new Response("Hello World!");
+        }
+      `;
+			setMockFetchDashScript([
+				{ name: "index.js", contents: indexjs },
+				{ name: "nested/other.js", contents: otherjs },
+			]);
+			mockConfirm(
+				{
+					text: "Would you like to use git to manage this Worker?",
+					result: false,
+				},
+				{
+					text: "No package.json found. Would you like to create one?",
+					result: true,
+				},
+				{
+					text: "Would you like to use TypeScript?",
+					result: false,
+				}
+			);
+
+			await runWrangler("init --from-dash isolinear-optical-chip");
+
+			checkFiles({
+				items: {
+					"isolinear-optical-chip/src/index.js": {
+						contents: indexjs,
+					},
+					"isolinear-optical-chip/src/nested/other.js": {
+						contents: otherjs,
+					},
+					"isolinear-optical-chip/src/index.ts": false,
+					"isolinear-optical-chip/package.json": {
+						contents: expect.objectContaining({
+							name: "isolinear-optical-chip",
+						}),
+					},
+					"isolinear-optical-chip/tsconfig.json": false,
+					"isolinear-optical-chip/wrangler.toml": wranglerToml({
+						...mockConfigExpected,
+						name: "isolinear-optical-chip",
+						main: "src/index.js",
+					}),
+				},
+			});
+		});
 	});
 });
 
@@ -3095,12 +3168,38 @@ function getDefaultBranchName() {
 /**
  * Mock setter for usage within test blocks for dashboard script
  */
-export function setMockFetchDashScript(mockResponse: string) {
+export function setMockFetchDashScript(
+	mockResponse: string | { name: string; contents: string }[]
+) {
 	msw.use(
 		rest.get(
 			`*/accounts/:accountId/workers/services/:fromDashScriptName/environments/:environment/content`,
 			(_, res, ctx) => {
-				return res(ctx.text(mockResponse));
+				if (typeof mockResponse === "string") {
+					return res(ctx.text(mockResponse));
+				}
+
+				const fd = new FormData();
+
+				for (const { name, contents } of mockResponse) {
+					fd.set(name, contents);
+				}
+
+				const boundary = "--------boundary-12761293712";
+				const responseText =
+					`--${boundary}\r\n` +
+					mockResponse
+						.map(
+							({ name, contents }) =>
+								`Content-Disposition: form-data; name="${name}"\r\n\r\n${contents}`
+						)
+						.join(`\r\n--${boundary}\r\n`) +
+					`\r\n--${boundary}--`;
+
+				return res(
+					ctx.set("Content-Type", `multipart/form-data; boundary=${boundary}`),
+					ctx.body(responseText)
+				);
 			}
 		)
 	);

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -8,6 +8,7 @@ import { ParseError, parseJSON } from "../parse";
 import { loginOrRefreshIfRequired, requireApiToken } from "../user";
 import type { ApiCredentials } from "../user";
 import type { URLSearchParams } from "node:url";
+import type { RequestInit, HeadersInit } from "undici";
 
 /*
  * performApiFetch does everything required to make a CF API request,

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import { writeFile, mkdir } from "node:fs/promises";
-import path, { dirname, resolve } from "node:path";
+import path, { dirname } from "node:path";
 import TOML from "@iarna/toml";
 import { findUp } from "find-up";
 import { version as wranglerVersion } from "../package.json";

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -29,6 +29,7 @@ import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "./yargs-types";
+import type { ReadableStream } from "stream/web";
 
 export function initOptions(yargs: CommonYargsArgv) {
 	return yargs
@@ -485,10 +486,12 @@ export async function initHandler(args: InitArgs) {
 					`/accounts/${accountId}/workers/services/${fromDashScriptName}/environments/${defaultEnvironment}/content`
 				);
 
-				await writeFile(
-					path.join(creationDirectory, "./src/index.ts"),
-					dashScript
-				);
+				for (const file of dashScript) {
+					await writeFile(
+						path.join(creationDirectory, `./src/${file.name}`),
+						file.stream() as ReadableStream
+					);
+				}
 
 				await writePackageJsonScriptsAndUpdateWranglerToml({
 					isWritingScripts: shouldWritePackageJsonScripts,
@@ -591,10 +594,12 @@ export async function initHandler(args: InitArgs) {
 					`/accounts/${accountId}/workers/services/${fromDashScriptName}/environments/${defaultEnvironment}/content`
 				);
 
-				await writeFile(
-					path.join(creationDirectory, "./src/index.js"),
-					dashScript
-				);
+				for (const file of dashScript) {
+					await writeFile(
+						path.join(creationDirectory, `./src/${file.name}`),
+						file.stream() as ReadableStream
+					);
+				}
 
 				await writePackageJsonScriptsAndUpdateWranglerToml({
 					isWritingScripts: shouldWritePackageJsonScripts,


### PR DESCRIPTION
Fixes #2886 

This PR adds support for downloading multi-module scripts from the API. The API endpoint already returns formdata, and the previous implementation in wrangler `throw`s when that formdata contains more than one entry. Therefore, this is not a breaking change requiring a major version bump (maybe a minor?).

Unfortunately, that block of code was not tested. The mocked API response was only ever a text response inferred to be one file with the filename hardcoded.

Regarding tests, since MSW does not support the `Response#formData` method and there's no (easy/understandable) way to hook into MSW's response (it's all functional objects, no class instances), **I've added an `if` statement to the runtime code** which turns the MSW MockedResponse into a undici Response. **This won't effect non-test execution** since the response will already be an undici Response returned from fetch.