### PR TITLE
nodejs compat functions build

### DIFF
--- a/.changeset/metal-buckets-fly.md
+++ b/.changeset/metal-buckets-fly.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix pages building not taking into account the nodejs_compat flag (and improve the related error message)

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -448,6 +448,8 @@ export default {
 		"Build failed with 1 error:
 		hello.js:2:36: ERROR: Could not resolve \\"node:async_hooks\\""
 	`);
+	expect(std.err).toContain("The package \"node:async_hooks\" wasn't found on the file system but is built into node.");
+	expect(std.err).toContain("Add the \"nodejs_compat\" compatibility flag to your Pages project to enable Node.js compatibility.");
 	});
 
 	it("should compile a _worker.js/ directory", async () => {

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -448,8 +448,12 @@ export default {
 		"Build failed with 1 error:
 		hello.js:2:36: ERROR: Could not resolve \\"node:async_hooks\\""
 	`);
-	expect(std.err).toContain("The package \"node:async_hooks\" wasn't found on the file system but is built into node.");
-	expect(std.err).toContain("Add the \"nodejs_compat\" compatibility flag to your Pages project to enable Node.js compatibility.");
+		expect(std.err).toContain(
+			'The package "node:async_hooks" wasn\'t found on the file system but is built into node.'
+		);
+		expect(std.err).toContain(
+			'Add the "nodejs_compat" compatibility flag to your Pages project to enable Node.js compatibility.'
+		);
 	});
 
 	it("should compile a _worker.js/ directory", async () => {

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -7224,7 +7224,7 @@ export default{
 			expect(
 				esbuild.formatMessagesSync(err?.errors ?? [], { kind: "error" }).join()
 			).toMatch(
-				/The package "path" wasn't found on the file system but is built into node\.\s+Add "node_compat = true" to your wrangler\.toml file to enable Node compatibility\./
+				/The package "path" wasn't found on the file system but is built into node\.\s+Add "node_compat = true" to your wrangler\.toml file to enable Node.js compatibility\./
 			);
 		});
 

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -77,15 +77,25 @@ export function isBuildFailure(err: unknown): err is esbuild.BuildFailure {
  * Rewrites esbuild BuildFailures for failing to resolve Node built-in modules
  * to suggest enabling Node compat as opposed to `platform: "node"`.
  */
-export function rewriteNodeCompatBuildFailure(err: esbuild.BuildFailure) {
+export function rewriteNodeCompatBuildFailure(
+	err: esbuild.BuildFailure,
+	forPages = false
+) {
 	for (const error of err.errors) {
 		const match = nodeBuiltinResolveErrorText.exec(error.text);
 		if (match !== null) {
+			const issue = `The package "${match[1]}" wasn't found on the file system but is built into node.`;
+
+			const instructionForUser = `${
+				forPages
+					? 'Add the "nodejs_compat" compatibility flag to your Pages project'
+					: 'Add "node_compat = true" to your wrangler.toml file'
+			} to enable Node compatibility.`;
+
 			error.notes = [
 				{
 					location: null,
-					text: `The package "${match[1]}" wasn't found on the file system but is built into node.
-Add "node_compat = true" to your wrangler.toml file to enable Node compatibility.`,
+					text: `${issue}\n${instructionForUser}`,
 				},
 			];
 		}
@@ -148,6 +158,7 @@ export async function bundleWorker(
 		// TODO: Rip these out https://github.com/cloudflare/workers-sdk/issues/2153
 		disableModuleCollection?: boolean;
 		isOutfile?: boolean;
+		forPages?: boolean;
 	}
 ): Promise<BundleResult> {
 	const {
@@ -179,6 +190,7 @@ export async function bundleWorker(
 		plugins,
 		disableModuleCollection,
 		isOutfile,
+		forPages,
 	} = options;
 
 	// We create a temporary directory for any oneoff files we
@@ -412,7 +424,7 @@ export async function bundleWorker(
 		result = await esbuild.build(buildOptions);
 	} catch (e) {
 		if (!legacyNodeCompat && isBuildFailure(e))
-			rewriteNodeCompatBuildFailure(e);
+			rewriteNodeCompatBuildFailure(e, forPages);
 		throw e;
 	}
 

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -90,7 +90,7 @@ export function rewriteNodeCompatBuildFailure(
 				forPages
 					? 'Add the "nodejs_compat" compatibility flag to your Pages project'
 					: 'Add "node_compat = true" to your wrangler.toml file'
-			} to enable Node compatibility.`;
+			} to enable Node.js compatibility.`;
 
 			error.notes = [
 				{

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -233,6 +233,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 					sourcemap,
 					watch,
 					betaD1Shims: d1Databases,
+					nodejsCompat,
 				});
 			}
 		} else {

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -108,6 +108,7 @@ export function buildPlugin({
 			targetConsumer: local ? "dev" : "publish",
 			local,
 			experimentalLocal: false,
+			forPages: true
 		}
 	);
 }

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -108,7 +108,7 @@ export function buildPlugin({
 			targetConsumer: local ? "dev" : "publish",
 			local,
 			experimentalLocal: false,
-			forPages: true
+			forPages: true,
 		}
 	);
 }

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -153,7 +153,7 @@ export function buildWorker({
 			targetConsumer: local ? "dev" : "publish",
 			local,
 			experimentalLocal: false,
-			forPages: true
+			forPages: true,
 		}
 	);
 }

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -227,6 +227,7 @@ export function buildRawWorker({
 			targetConsumer: local ? "dev" : "publish",
 			local,
 			experimentalLocal: false,
+			forPages: true,
 		}
 	);
 }

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -153,6 +153,7 @@ export function buildWorker({
 			targetConsumer: local ? "dev" : "publish",
 			local,
 			experimentalLocal: false,
+			forPages: true
 		}
 	);
 }


### PR DESCRIPTION
> **Note** continuation of https://github.com/cloudflare/workers-sdk/pull/3100
___

Fixes [cloudflare/next-on-pages#199](https://github.com/cloudflare/next-on-pages/issues/199)

**What this PR solves / how to test:**

* Fixes passing the `nodejs_compat` flag through to `wrangler pages functions build`

* Also improve the error message so that for pages it doesn't ask to update wrangler.toml

**Reviewer has performed the following, where applicable:**

* [ ]  Checked for inclusion of relevant tests
* [ ]  Checked for inclusion of a relevant changeset
* [ ]  Checked for creation of associated docs updates
* [ ]  Manually pulled down the changes and spot-tested
