### PR TITLE
Add output for tail being in sampling mode

### DIFF
--- a/.changeset/witty-pumpkins-swim.md
+++ b/.changeset/witty-pumpkins-swim.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Added output for tail being in "sampling mode"

--- a/packages/wrangler/src/__tests__/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages-deployment-tail.test.ts
@@ -13,6 +13,7 @@ import type {
 	ScheduledEvent,
 	AlarmEvent,
 	EmailEvent,
+	TailInfo,
 } from "../tail/createTail";
 import type { RequestInit } from "undici";
 import type WebSocket from "ws";
@@ -655,6 +656,7 @@ function isRequest(
 		| RequestEvent
 		| AlarmEvent
 		| EmailEvent
+		| TailInfo
 		| undefined
 		| null
 ): event is RequestEvent {

--- a/packages/wrangler/src/tail/createTail.ts
+++ b/packages/wrangler/src/tail/createTail.ts
@@ -252,6 +252,7 @@ export type TailEventMessage = {
 		| ScheduledEvent
 		| AlarmEvent
 		| EmailEvent
+		| TailInfo
 		| undefined
 		| null;
 };
@@ -403,4 +404,12 @@ export type EmailEvent = {
 	 * Size of the email in bytes
 	 */
 	rawSize: number;
+};
+
+/**
+ * Message from tail with information about the tail itself
+ */
+export type TailInfo = {
+	message: string;
+	type: string;
 };

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -1,9 +1,11 @@
+import chalk from "chalk";
 import { logger } from "../logger";
 import type {
 	AlarmEvent,
 	EmailEvent,
 	RequestEvent,
 	ScheduledEvent,
+	TailInfo,
 	TailEventMessage,
 } from "./createTail";
 import type { Outcome } from "./filters";
@@ -48,6 +50,10 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 		).toLocaleString();
 
 		logger.log(`Alarm @ ${datetime} - ${outcome}`);
+	} else if (isTailInfo(eventMessage.event)) {
+		if (eventMessage.event.type === "overload") {
+			logger.log(`${chalk.red.bold(eventMessage.event.message)}`);
+		}
 	} else {
 		// Unknown event type
 		const outcome = prettifyOutcome(eventMessage.outcome);
@@ -101,6 +107,10 @@ function isEmailEvent(event: TailEventMessage["event"]): event is EmailEvent {
  */
 function isAlarmEvent(event: TailEventMessage["event"]): event is AlarmEvent {
 	return Boolean(event && "scheduledTime" in event && !("cron" in event));
+}
+
+function isTailInfo(event: TailEventMessage["event"]): event is TailInfo {
+	return Boolean(event && "message" in event && "type" in event);
 }
 
 function prettifyOutcome(outcome: Outcome): string {


### PR DESCRIPTION
If a tail enters sampling mode, it will forward a message saying that it's in sampling mode. The tail will send message every time the messages reaches over 100 requests per second. If we feel like that's not enough we could change this to happen periodically every 5 seconds.

One thing to keep in mind is that this will add messages to the tail stream that aren't actual trace events. Not sure if that is a concern, especially since the the non `--pretty` format is structured with event types which has different fields per message.

~~Also for the `--pretty` format we consider using something like ink to pin the sampling mode message? Not sure if that would be too much of a breaking change for users who might pipe the output of `--pretty` format to other tools~~

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer has performed the following, where applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
