### PR TITLE
Remove experimental status from `assets`

### DIFF
--- a/.changeset/many-pianos-unite.md
+++ b/.changeset/many-pianos-unite.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Remove experimental status from `assets`
+
+`assets` (imo/ime) work well as are, and any enhancements can be done on top of this. This patch removes the experimental warning when using it.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -499,13 +499,8 @@ describe("normalizeAndValidateConfig()", () => {
 			  "serve_single_page_app": false,
 			}
 		`);
-				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.hasErrors()).toBe(false);
-
-				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - \\"assets\\" fields are experimental and may change or break at any time."
-		`);
 			});
 
 			it("errors when input is not a string or object", () => {
@@ -518,13 +513,9 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 
 				expect(config.assets).toBeUndefined();
-				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.hasErrors()).toBe(true);
 
-				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - \\"assets\\" fields are experimental and may change or break at any time."
-		`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			"Processing wrangler configuration:
 			  - Expected the \`assets\` field to be a string or an object, but got number."
@@ -549,13 +540,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(config.assets).toEqual(
 					expect.objectContaining(expectedConfig.assets)
 				);
-				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.hasErrors()).toBe(true);
 
-				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - \\"assets\\" fields are experimental and may change or break at any time."
-		        `);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			          "Processing wrangler configuration:
 			            - \\"assets.bucket\\" is a required field."
@@ -580,11 +567,8 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 
 				expect(config).toEqual(expect.objectContaining(expectedConfig));
-				expect(diagnostics.hasWarnings()).toBe(true);
-				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - \\"assets\\" fields are experimental and may change or break at any time."
-		        `);
+				expect(diagnostics.hasWarnings()).toBe(false);
+
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			"Processing wrangler configuration:
 			  - Expected \\"assets.include.[0]\\" to be of type string but got 222.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1375,11 +1375,7 @@ describe("wrangler dev", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
-
-			    - \\"assets\\" fields are experimental and may change or break at any time.
-
-			",
+			  "warn": "",
 			}
 		`);
 		});

--- a/packages/wrangler/src/__tests__/publish.test.ts
+++ b/packages/wrangler/src/__tests__/publish.test.ts
@@ -1919,11 +1919,7 @@ addEventListener('fetch', event => {});`
 			  "info": "",
 			  "out": "
 			[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
-
-			    - \\"assets\\" fields are experimental and may change or break at any time.
-
-			",
+			  "warn": "",
 			}
 		`);
 		});
@@ -1953,11 +1949,7 @@ addEventListener('fetch', event => {});`
 			  "info": "",
 			  "out": "
 			[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
-
-			    - \\"assets\\" fields are experimental and may change or break at any time.
-
-			",
+			  "warn": "",
 			}
 		`);
 		});
@@ -2051,11 +2043,7 @@ addEventListener('fetch', event => {});`
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
 			Current Deployment ID: Galaxy-Class",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
-
-			    - \\"assets\\" fields are experimental and may change or break at any time.
-
-			",
+			  "warn": "",
 			}
 		`);
 		});

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -234,8 +234,6 @@ export function normalizeAndValidateConfig(
 		[...Object.keys(config), "env"]
 	);
 
-	experimental(diagnostics, rawConfig, "assets");
-
 	return { config, diagnostics };
 }
 


### PR DESCRIPTION
`assets` (imo/ime) work well as are, and any enhancements can be done on top of this. This patch removes the experimental warning when using it.

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

---

I can't install deps for this locally, so making a PR to see what CI says. 