### PR TITLE
[wrangler] teach d1 about location hints

### DIFF
--- a/.changeset/stale-onions-wait.md
+++ b/.changeset/stale-onions-wait.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: (alpha) - make it possible to give D1 a hint on where it should create the database

--- a/packages/wrangler/src/d1/constants.ts
+++ b/packages/wrangler/src/d1/constants.ts
@@ -1,2 +1,3 @@
 export const DEFAULT_MIGRATION_PATH = "./migrations";
 export const DEFAULT_MIGRATION_TABLE = "d1_migrations";
+export const LOCATION_CHOICES = ["weur", "eeur", "apac", "wnam", "enam"];

--- a/packages/wrangler/src/d1/types.ts
+++ b/packages/wrangler/src/d1/types.ts
@@ -23,3 +23,10 @@ export type Migration = {
 	name: string;
 	applied_at: string;
 };
+
+export type DatabaseCreationResult = {
+	uuid: string;
+	name: string;
+	primary_location_hint?: string;
+	created_in_region?: string;
+};


### PR DESCRIPTION
The changeset uses `fix` instead of `feat` as this is an experimental feature on top of an alpha product, and not recommended for production data and traffic.

Output:
```
npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/4923592092/npm-package-wrangler-3168 d1 create apac-db --location apac
✔ Select an account › xxxx@gmail.com's Account
--------------------
🚧 D1 is currently in open alpha and is not recommended for production data and traffic
🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
🚧 To request features, visit https://community.cloudflare.com/c/developers/d1
🚧 To give feedback, visit https://discord.gg/cloudflaredev
--------------------

✅ Successfully created DB 'apac-db' in region APAC

[[d1_databases]]
binding = "DB" # i.e. available in your Worker on env.DB
database_name = "apac-db"
database_id = "f3f8cb7c-xxxx-xxxx-xxxx-5727368f879f"
```