### PR TITLE
Fix to AE line splitter for chunks with <1 message

### DIFF
--- a/templates/worker-analytics-engine-forwarder/src/index.js
+++ b/templates/worker-analytics-engine-forwarder/src/index.js
@@ -120,11 +120,8 @@ async function* readStream(body, compressed) {
 		}
 		const stringData = new TextDecoder().decode(value);
 		const chunks = stringData.split("\n");
-		if (chunks.length > 1) {
-			chunks[0] = remainder + chunks[0];
-			remainder = "";
-		}
 		if (chunks.length > 0) {
+			chunks[0] = remainder + chunks[0];
 			remainder = chunks.pop();
 		}
 		yield* chunks;


### PR DESCRIPTION
During testing, this splitter was failing occasionally.
This turned out to be in cases where the last chunk contained less than one whole message. In that case the "remainder" was not prepended. 