### PR TITLE
[wrangler] feature: warn when trying to use `wrangler dev` inside a WebContainer

### DIFF
--- a/.changeset/ninety-worms-beam.md
+++ b/.changeset/ninety-worms-beam.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feature: add warning when trying to use `wrangler dev` inside a WebContainer

--- a/package-lock.json
+++ b/package-lock.json
@@ -10347,9 +10347,10 @@
 			}
 		},
 		"node_modules/@webcontainer/env": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT"
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.0.tgz",
+			"integrity": "sha512-DreJFHUui8vq1N3nQGU3HwK5UI4hVNW7VQfhAOmeQbBVnpKtGhoNobjDNF8LzlN7ssmFI9Uhkc9Au4mtKvPK6Q==",
+			"dev": true
 		},
 		"node_modules/@xmldom/xmldom": {
 			"version": "0.8.6",
@@ -45523,7 +45524,7 @@
 				"@types/supports-color": "^8.1.1",
 				"@types/ws": "^8.5.3",
 				"@types/yargs": "^17.0.10",
-				"@webcontainer/env": "^1.0.1",
+				"@webcontainer/env": "^1.1.0",
 				"body-parser": "^1.20.0",
 				"chalk": "^2.4.2",
 				"cli-table3": "^0.6.3",
@@ -63774,7 +63775,9 @@
 			}
 		},
 		"@webcontainer/env": {
-			"version": "1.0.1",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.0.tgz",
+			"integrity": "sha512-DreJFHUui8vq1N3nQGU3HwK5UI4hVNW7VQfhAOmeQbBVnpKtGhoNobjDNF8LzlN7ssmFI9Uhkc9Au4mtKvPK6Q==",
 			"dev": true
 		},
 		"@xmldom/xmldom": {
@@ -94121,7 +94124,7 @@
 				"@types/supports-color": "^8.1.1",
 				"@types/ws": "^8.5.3",
 				"@types/yargs": "^17.0.10",
-				"@webcontainer/env": "^1.0.1",
+				"@webcontainer/env": "^1.1.0",
 				"blake3-wasm": "^2.1.5",
 				"body-parser": "^1.20.0",
 				"chalk": "^2.4.2",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -135,7 +135,7 @@
 		"@types/supports-color": "^8.1.1",
 		"@types/ws": "^8.5.3",
 		"@types/yargs": "^17.0.10",
-		"@webcontainer/env": "^1.0.1",
+		"@webcontainer/env": "^1.1.0",
 		"body-parser": "^1.20.0",
 		"chalk": "^2.4.2",
 		"cli-table3": "^0.6.3",

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { isWebContainer } from "@webcontainer/env";
 import chalk from "chalk";
 import { watch } from "chokidar";
 import getPort from "get-port";
@@ -293,6 +294,15 @@ export function devOptions(yargs: CommonYargsArgv) {
 type DevArguments = StrictYargsOptionsToInterface<typeof devOptions>;
 
 export async function devHandler(args: DevArguments) {
+	if (isWebContainer()) {
+		logger.error(
+			`Oh no! 😟You tried to run \`wrangler dev\` in a StackBlitz WebContainer. 🤯
+This is currently not supported 😭, but we think that we'll get it to work soon... hang in there! 🥺`
+		);
+		process.exitCode = 1;
+		return;
+	}
+
 	if (!(args.local || args.experimentalLocal)) {
 		const isLoggedIn = await loginOrRefreshIfRequired();
 		if (!isLoggedIn) {

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -213,7 +213,6 @@ import path from "node:path";
 import url from "node:url";
 import { TextEncoder } from "node:util";
 import TOML from "@iarna/toml";
-import { HostURL } from "@webcontainer/env";
 import { fetch } from "undici";
 import {
 	getConfigCache,
@@ -365,15 +364,7 @@ export function validateScopeKeys(
 	return scopes.every((scope) => scope in Scopes);
 }
 
-/**
- * To allow OAuth callbacks in environments such as WebContainer we need to
- * create a host URL which only resolves `localhost` to a WebContainer
- * hostname if the process is running in a WebContainer. On local this will
- * be a no-op and it leaves the URL unmodified.
- *
- * @see https://www.npmjs.com/package/@webcontainer/env
- */
-const CALLBACK_URL = HostURL.parse("http://localhost:8976/oauth/callback").href;
+const CALLBACK_URL = "http://localhost:8976/oauth/callback";
 
 let LocalState: State = {
 	...getAuthTokens(),


### PR DESCRIPTION
Fixes #3177

**What this PR solves / how to test:**

Wrangler v3 removes Miniflare 2 in favour of Miniflare 3 using `workerd`. Unfortunately, `workerd` doesn't run in the browser _(yet 😉)_, and WebContainers don't support remote mode yet. This change adds a warning when we detect `wrangler dev` running inside a WebContainer, so users know what's going on. Also removes some unused OAuth code.

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ] ~~Tests~~
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
