### PR TITLE
[wrangler] feature: enable persistent storage in local mode by default

### DIFF
--- a/.changeset/moody-ducks-pull.md
+++ b/.changeset/moody-ducks-pull.md
@@ -1,0 +1,10 @@
+---
+"wrangler": major
+---
+
+feature: enable persistent storage in local mode by default
+
+Wrangler will now persist local KV, R2, D1, Cache and Durable Object data
+in the `.wrangler` folder, by default, between reloads. This persistence
+directory can be customised with the `--persist-to` flag. The `--persist` flag
+has been removed, as this is now the default behaviour.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1257,8 +1257,7 @@ describe("wrangler dev", () => {
 			      --experimental-local-remote-kv               Read/write KV data from/to real namespaces on the Cloudflare network  [boolean] [default: false]
 			      --minify                                     Minify the script  [boolean]
 			      --node-compat                                Enable Node.js compatibility  [boolean]
-			      --persist                                    Enable persistence for local mode, using default path: .wrangler/state  [boolean]
-			      --persist-to                                 Specify directory to use for local persistence (implies --persist)  [string]
+			      --persist-to                                 Specify directory to use for local persistence (defaults to .wrangler/state)  [string]
 			      --live-reload                                Auto reload HTML pages when change is detected in local mode  [boolean]
 			      --test-scheduled                             Test scheduled events by visiting /__scheduled in browser  [boolean] [default: false]
 			      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]",

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -220,11 +220,7 @@ async function executeLocally({
 		);
 	}
 
-	const persistencePath = getLocalPersistencePath(
-		persistTo,
-		true,
-		config.configPath
-	);
+	const persistencePath = getLocalPersistencePath(persistTo, config.configPath);
 
 	const dbDir = path.join(persistencePath, "d1");
 	const dbPath = path.join(dbDir, `${localDB.binding}.sqlite3`);

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -239,14 +239,9 @@ export function devOptions(yargs: CommonYargsArgv) {
 				deprecated: true,
 				hidden: true,
 			})
-			.option("persist", {
-				describe:
-					"Enable persistence for local mode, using default path: .wrangler/state",
-				type: "boolean",
-			})
 			.option("persist-to", {
 				describe:
-					"Specify directory to use for local persistence (implies --persist)",
+					"Specify directory to use for local persistence (defaults to .wrangler/state)",
 				type: "string",
 				requiresArg: true,
 			})
@@ -774,7 +769,6 @@ async function validateDevServerSettings(
 
 	const localPersistencePath = getLocalPersistencePath(
 		args.persistTo,
-		Boolean(args.persist),
 		config.configPath
 	);
 

--- a/packages/wrangler/src/dev/get-local-persistence-path.ts
+++ b/packages/wrangler/src/dev/get-local-persistence-path.ts
@@ -2,30 +2,25 @@ import path from "node:path";
 
 export function getLocalPersistencePath(
 	persistTo: string | undefined,
-	doPersist: true,
 	configPath: string | undefined
 ): string;
 
 export function getLocalPersistencePath(
 	persistTo: string | undefined,
-	doPersist: boolean,
 	configPath: string | undefined
 ): string | null;
 
 export function getLocalPersistencePath(
 	persistTo: string | undefined,
-	doPersist: boolean,
 	configPath: string | undefined
 ) {
 	return persistTo
 		? // If path specified, always treat it as relative to cwd()
 		  path.resolve(process.cwd(), persistTo)
-		: doPersist
-		? // If just flagged on, treat it as relative to wrangler.toml,
+		: // Otherwise, treat it as relative to wrangler.toml,
 		  // if one can be found, otherwise cwd()
 		  path.resolve(
 				configPath ? path.dirname(configPath) : process.cwd(),
 				".wrangler/state"
-		  )
-		: null;
+		  );
 }

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -121,21 +121,9 @@ export function Options(yargs: CommonYargsArgv) {
 				describe: "Protocol to listen to requests on, defaults to http.",
 				choices: ["http", "https"] as const,
 			},
-			"experimental-enable-local-persistence": {
-				describe:
-					"Enable persistence for local mode (deprecated, use --persist)",
-				type: "boolean",
-				deprecated: true,
-				hidden: true,
-			},
-			persist: {
-				describe:
-					"Enable persistence for local mode, using default path: .wrangler/state",
-				type: "boolean",
-			},
 			"persist-to": {
 				describe:
-					"Specify directory to use for local persistence (implies --persist)",
+					"Specify directory to use for local persistence (defaults to .wrangler/state)",
 				type: "string",
 				requiresArg: true,
 			},
@@ -182,8 +170,6 @@ export const Handler = async ({
 	r2: r2s = [],
 	liveReload,
 	localProtocol,
-	experimentalEnableLocalPersistence,
-	persist,
 	persistTo,
 	nodeCompat: legacyNodeCompat,
 	experimentalLocal,
@@ -236,14 +222,6 @@ export const Handler = async ({
 				"See https://developers.cloudflare.com/workers/platform/compatibility-dates/ for more information."
 		);
 		compatibilityDate = currentDate;
-	}
-
-	if (experimentalEnableLocalPersistence) {
-		logger.warn(
-			`--experimental-enable-local-persistence is deprecated.\n` +
-				`Move any existing data to .wrangler/state and use --persist, or\n` +
-				`use --persist-to=./wrangler-local-state to keep using the old path.`
-		);
 	}
 
 	let scriptReadyResolve: () => void;
@@ -556,7 +534,6 @@ export const Handler = async ({
 			  ]
 			: undefined,
 		bundle: enableBundling,
-		persist,
 		persistTo,
 		inspect: undefined,
 		logLevel,


### PR DESCRIPTION
**What this PR solves / how to test:**

Wrangler will now persist local KV, R2, D1, Cache and Durable Object data in the `.wrangler` folder, by default, between reloads. This persistence directory can be customised with the `--persist-to` flag. The `--persist` flag has been removed, as this is now the default behaviour. To test, run `wrangler dev --(experimental-)local`, 

**Associated docs issue(s)/PR(s):**

None yet, but maybe we want one?

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
