### PR TITLE
[wrangler] feature: remove delegation to locally installed versions

### DIFF
--- a/.changeset/spicy-peaches-worry.md
+++ b/.changeset/spicy-peaches-worry.md
@@ -1,0 +1,11 @@
+---
+"wrangler": major
+---
+
+feature: remove delegation to locally installed versions
+
+Previously, if Wrangler was installed globally _and_ locally within a project,
+running the global Wrangler would instead invoke the local version.
+This behaviour was contrary to most other JavaScript CLI tools and has now been
+removed. We recommend you use `npx wrangler` instead, which will invoke the
+local version if installed, or install globally if not.


### PR DESCRIPTION
Closes #2705
Closes DEVX-623

**What this PR solves / how to test:**

Previously, if Wrangler was installed globally _and_ locally within a project, running the global Wrangler would instead invoke the local version. This behaviour was contrary to most other JavaScript CLI tools and could be quite confusing.

**Associated docs issue(s)/PR(s):**

Not sure if we had docs for the delegation behaviour, so none.

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
