### PR TITLE
Support outbounds for dispatch namespace bindings

### DIFF
--- a/.changeset/empty-kangaroos-sip.md
+++ b/.changeset/empty-kangaroos-sip.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Support outbounds for dispatch_namespace bindings

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -2401,6 +2401,113 @@ describe("normalizeAndValidateConfig()", () => {
 			  - \\"dispatch_namespaces[6]\\" should have a string \\"namespace\\" field but got {\\"binding\\":123,\\"service\\":456}."
 		`);
 			});
+
+			test("should error on invalid outbounds for a namespace", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						dispatch_namespaces: [
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_1",
+								namespace: "NAMESPACE",
+								outbound: "a string",
+							},
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_2",
+								namespace: "NAMESPACE",
+								outbound: [{ not: "valid" }],
+							},
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_3",
+								namespace: "NAMESPACE",
+								outbound: {
+									service: 123,
+								},
+							},
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_4",
+								namespace: "NAMESPACE",
+								outbound: {
+									service: "outbound",
+									environment: { bad: "env" },
+								},
+							},
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_5",
+								namespace: "NAMESPACE",
+								outbound: {
+									environment: "production",
+								},
+							},
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_6",
+								namespace: "NAMESPACE",
+								outbound: {
+									service: "outbound",
+									parameters: "bad",
+								},
+							},
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_7",
+								namespace: "NAMESPACE",
+								outbound: {
+									service: "outbound",
+									parameters: false,
+								},
+							},
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_8",
+								namespace: "NAMESPACE",
+								outbound: {
+									service: "outbound",
+									parameters: [true, { not: "good" }],
+								},
+							},
+							// these are correct
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_9",
+								namespace: "NAMESPACE",
+								outbound: {
+									service: "outbound",
+									parameters: ["finally", "real", "params"],
+								},
+							},
+							{
+								binding: "DISPATCH_NAMESPACE_BINDING_10",
+								namespace: "NAMESPACE",
+								outbound: {
+									service: "outbound",
+									environment: "production",
+									parameters: ["some", "more", "params"],
+								},
+							},
+						],
+					} as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(true);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+			"Processing wrangler configuration:
+			  - \\"dispatch_namespaces[0].outbound\\" should be an object, but got \\"a string\\"
+			  - \\"dispatch_namespaces[0]\\" has an invalid outbound definition.
+			  - \\"dispatch_namespaces[1].outbound.service\\" is a required field.
+			  - \\"dispatch_namespaces[1]\\" has an invalid outbound definition.
+			  - Expected \\"dispatch_namespaces[2].outbound.service\\" to be of type string but got 123.
+			  - \\"dispatch_namespaces[2]\\" has an invalid outbound definition.
+			  - Expected \\"dispatch_namespaces[3].outbound.environment\\" to be of type string but got {\\"bad\\":\\"env\\"}.
+			  - \\"dispatch_namespaces[3]\\" has an invalid outbound definition.
+			  - \\"dispatch_namespaces[4].outbound.service\\" is a required field.
+			  - \\"dispatch_namespaces[4]\\" has an invalid outbound definition.
+			  - Expected \\"dispatch_namespaces[5].outbound.parameters\\" to be an array of strings but got \\"bad\\"
+			  - \\"dispatch_namespaces[5]\\" has an invalid outbound definition.
+			  - Expected \\"dispatch_namespaces[6].outbound.parameters\\" to be an array of strings but got false
+			  - \\"dispatch_namespaces[6]\\" has an invalid outbound definition.
+			  - Expected \\"dispatch_namespaces[7].outbound.parameters.[0]\\" to be of type string but got true.
+			  - Expected \\"dispatch_namespaces[7].outbound.parameters.[1]\\" to be of type string but got {\\"not\\":\\"good\\"}.
+			  - \\"dispatch_namespaces[7]\\" has an invalid outbound definition."
+		`);
+			});
 		});
 
 		describe("[mtls_certificates]", () => {

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -221,6 +221,8 @@ interface EnvironmentInheritable {
 		binding: string;
 		/** The namespace to bind to. */
 		namespace: string;
+		/** Details about the outbound worker which will handle outbound requests from your namespace */
+		outbound?: DispatchNamespaceOutbound;
 	}[];
 
 	/**
@@ -657,3 +659,12 @@ export type TailConsumer = {
 	/** (Optional) The environt of the service. */
 	environment?: string;
 };
+
+export interface DispatchNamespaceOutbound {
+	/** Name of the service handling the outbound requests */
+	service: string;
+	/** (Optional) Name of the environment handling the outbound requests. */
+	environment?: string;
+	/** (Optional) List of parameter names, for sending context from your dispatch worker to the outbound handler */
+	parameters?: string[];
+}

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -337,10 +337,12 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 	if (dispatch_namespaces !== undefined && dispatch_namespaces.length > 0) {
 		output.push({
 			type: "dispatch namespaces",
-			entries: dispatch_namespaces.map(({ binding, namespace }) => {
+			entries: dispatch_namespaces.map(({ binding, namespace, outbound }) => {
 				return {
 					key: binding,
-					value: namespace,
+					value: outbound
+						? `${namespace} (outbound -> ${outbound.service})`
+						: namespace,
 				};
 			}),
 		});

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -34,6 +34,7 @@ import type {
 	Environment,
 	Rule,
 	TailConsumer,
+	DispatchNamespaceOutbound,
 } from "./environment";
 import type { ValidatorFn } from "./validation-helpers";
 
@@ -2368,8 +2369,65 @@ const validateWorkerNamespaceBinding: ValidatorFn = (
 		);
 		isValid = false;
 	}
+	if (hasProperty(value, "outbound")) {
+		if (
+			!validateWorkerNamespaceOutbound(
+				diagnostics,
+				`${field}.outbound`,
+				value.outbound ?? {}
+			)
+		) {
+			diagnostics.errors.push(`"${field}" has an invalid outbound definition.`);
+			isValid = false;
+		}
+	}
 	return isValid;
 };
+
+function validateWorkerNamespaceOutbound(
+	diagnostics: Diagnostics,
+	field: string,
+	value: DispatchNamespaceOutbound
+): boolean {
+	if (typeof value !== "object" || value === null) {
+		diagnostics.errors.push(
+			`"${field}" should be an object, but got ${JSON.stringify(value)}`
+		);
+		return false;
+	}
+
+	let isValid = true;
+
+	// Namespace outbounds need at least a service name
+	isValid =
+		isValid &&
+		validateRequiredProperty(
+			diagnostics,
+			field,
+			"service",
+			value.service,
+			"string"
+		);
+	isValid =
+		isValid &&
+		validateOptionalProperty(
+			diagnostics,
+			field,
+			"environment",
+			value.environment,
+			"string"
+		);
+	isValid =
+		isValid &&
+		validateOptionalTypedArray(
+			diagnostics,
+			`${field}.parameters`,
+			value.parameters,
+			"string"
+		);
+
+	return isValid;
+}
 
 const validateMTlsCertificateBinding: ValidatorFn = (
 	diagnostics,

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -54,7 +54,18 @@ export type WorkerMetadataBinding =
 	| { type: "constellation"; name: string; project: string }
 	| { type: "service"; name: string; service: string; environment?: string }
 	| { type: "analytics_engine"; name: string; dataset?: string }
-	| { type: "dispatch_namespace"; name: string; namespace: string }
+	| {
+			type: "dispatch_namespace";
+			name: string;
+			namespace: string;
+			outbound?: {
+				worker: {
+					service: string;
+					environment?: string;
+				};
+				params?: { name: string }[];
+			};
+	  }
 	| { type: "mtls_certificate"; name: string; certificate_id: string }
 	| {
 			type: "logfwdr";
@@ -194,11 +205,20 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		});
 	});
 
-	bindings.dispatch_namespaces?.forEach(({ binding, namespace }) => {
+	bindings.dispatch_namespaces?.forEach(({ binding, namespace, outbound }) => {
 		metadataBindings.push({
 			name: binding,
 			type: "dispatch_namespace",
 			namespace,
+			...(outbound && {
+				outbound: {
+					worker: {
+						service: outbound.service,
+						environment: outbound.environment,
+					},
+					params: outbound.parameters?.map((p) => ({ name: p })),
+				},
+			}),
 		});
 	});
 

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -1010,7 +1010,18 @@ export function mapBindings(bindings: WorkerMetadataBinding[]): RawConfig {
 						{
 							configObj.dispatch_namespaces = [
 								...(configObj.dispatch_namespaces ?? []),
-								{ binding: binding.name, namespace: binding.namespace },
+								{
+									binding: binding.name,
+									namespace: binding.namespace,
+									...(binding.outbound && {
+										outbound: {
+											service: binding.outbound.worker.service,
+											environment: binding.outbound.worker.environment,
+											parameters:
+												binding.outbound.params?.map((p) => p.name) ?? [],
+										},
+									}),
+								},
 							];
 						}
 						break;

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -174,6 +174,11 @@ interface CfAnalyticsEngineDataset {
 interface CfDispatchNamespace {
 	binding: string;
 	namespace: string;
+	outbound?: {
+		service: string;
+		environment?: string;
+		parameters?: string[];
+	};
 }
 
 interface CfMTlsCertificate {


### PR DESCRIPTION
Adds key "outbound" to the dispatch_namespaces binding section

Additionally, outbounds can declare params (string[]) that will be forwarded from the dispatcher to the outbound worker

Fixes WC-1262

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
