### PR TITLE
[Editor] Hide type files

### DIFF
--- a/packages/quick-edit/functions/_middleware.ts
+++ b/packages/quick-edit/functions/_middleware.ts
@@ -15,40 +15,41 @@ export const onRequest = async ({
 				"workbench.startupEditor": "none",
 				"editor.minimap.autohide": true,
 				"files.exclude": {
-					"workers-types.d.ts": true,
+					"*.d.ts": true,
 					"jsconfig.json": true,
+				}
+			},
+			productConfiguration: {
+				nameShort: "Quick Edit",
+				nameLong: "Cloudflare Workers Quick Edit",
+				applicationName: "workers-quick-edit",
+				dataFolderName: ".quick-edit",
+				version: "1.76.0",
+				extensionsGallery: {
+					serviceUrl: "https://open-vsx.org/vscode/gallery",
+					itemUrl: "https://open-vsx.org/vscode/item",
+					resourceUrlTemplate:
+						"https://openvsxorg.blob.core.windows.net/resources/{publisher}/{name}/{version}/{path}",
 				},
-				productConfiguration: {
-					nameShort: "Quick Edit",
-					nameLong: "Cloudflare Workers Quick Edit",
-					applicationName: "workers-quick-edit",
-					dataFolderName: ".quick-edit",
-					version: "1.76.0",
-					extensionsGallery: {
-						serviceUrl: "https://open-vsx.org/vscode/gallery",
-						itemUrl: "https://open-vsx.org/vscode/item",
-						resourceUrlTemplate:
-							"https://openvsxorg.blob.core.windows.net/resources/{publisher}/{name}/{version}/{path}",
-					},
-					extensionEnabledApiProposals: {
-						"cloudflare.quick-edit-extension": [
-							"fileSearchProvider",
-							"textSearchProvider",
-							"ipc",
-						],
-					},
+				extensionEnabledApiProposals: {
+					"cloudflare.quick-edit-extension": [
+						"fileSearchProvider",
+						"textSearchProvider",
+						"ipc",
+					],
 				},
-				additionalBuiltinExtensions: [
-					{
-						scheme: url.protocol === "https:" ? "https" : "http",
-						path: "/quick-edit-extension",
-					},
-					{
-						scheme: url.protocol === "https:" ? "https" : "http",
-						path: "/solarflare-theme",
-					},
-				],
-			}).replace(/"/g, "&quot;"),
+			},
+			additionalBuiltinExtensions: [
+				{
+					scheme: url.protocol === "https:" ? "https" : "http",
+					path: "/quick-edit-extension",
+				},
+				{
+					scheme: url.protocol === "https:" ? "https" : "http",
+					path: "/solarflare-theme",
+				},
+			],
+		}).replace(/"/g, "&quot;"),
 		WORKBENCH_AUTH_SESSION: "",
 		WORKBENCH_WEB_BASE_URL: "/assets",
 	};

--- a/packages/quick-edit/functions/_middleware.ts
+++ b/packages/quick-edit/functions/_middleware.ts
@@ -14,38 +14,41 @@ export const onRequest = async ({
 						: "Solarflare Light",
 				"workbench.startupEditor": "none",
 				"editor.minimap.autohide": true,
-			},
-			productConfiguration: {
-				nameShort: "Quick Edit",
-				nameLong: "Cloudflare Workers Quick Edit",
-				applicationName: "workers-quick-edit",
-				dataFolderName: ".quick-edit",
-				version: "1.76.0",
-				extensionsGallery: {
-					serviceUrl: "https://open-vsx.org/vscode/gallery",
-					itemUrl: "https://open-vsx.org/vscode/item",
-					resourceUrlTemplate:
-						"https://openvsxorg.blob.core.windows.net/resources/{publisher}/{name}/{version}/{path}",
+				"files.exclude": {
+					"workers-types.d.ts": true,
+					"jsconfig.json": true,
 				},
-				extensionEnabledApiProposals: {
-					"cloudflare.quick-edit-extension": [
-						"fileSearchProvider",
-						"textSearchProvider",
-						"ipc",
-					],
+				productConfiguration: {
+					nameShort: "Quick Edit",
+					nameLong: "Cloudflare Workers Quick Edit",
+					applicationName: "workers-quick-edit",
+					dataFolderName: ".quick-edit",
+					version: "1.76.0",
+					extensionsGallery: {
+						serviceUrl: "https://open-vsx.org/vscode/gallery",
+						itemUrl: "https://open-vsx.org/vscode/item",
+						resourceUrlTemplate:
+							"https://openvsxorg.blob.core.windows.net/resources/{publisher}/{name}/{version}/{path}",
+					},
+					extensionEnabledApiProposals: {
+						"cloudflare.quick-edit-extension": [
+							"fileSearchProvider",
+							"textSearchProvider",
+							"ipc",
+						],
+					},
 				},
-			},
-			additionalBuiltinExtensions: [
-				{
-					scheme: url.protocol === "https:" ? "https" : "http",
-					path: "/quick-edit-extension",
-				},
-				{
-					scheme: url.protocol === "https:" ? "https" : "http",
-					path: "/solarflare-theme",
-				},
-			],
-		}).replace(/"/g, "&quot;"),
+				additionalBuiltinExtensions: [
+					{
+						scheme: url.protocol === "https:" ? "https" : "http",
+						path: "/quick-edit-extension",
+					},
+					{
+						scheme: url.protocol === "https:" ? "https" : "http",
+						path: "/solarflare-theme",
+					},
+				],
+			}).replace(/"/g, "&quot;"),
 		WORKBENCH_AUTH_SESSION: "",
 		WORKBENCH_WEB_BASE_URL: "/assets",
 	};

--- a/packages/quick-edit/functions/_middleware.ts
+++ b/packages/quick-edit/functions/_middleware.ts
@@ -17,7 +17,7 @@ export const onRequest = async ({
 				"files.exclude": {
 					"*.d.ts": true,
 					"jsconfig.json": true,
-				}
+				},
 			},
 			productConfiguration: {
 				nameShort: "Quick Edit",


### PR DESCRIPTION
Adding support for types in Quick Edit (not TS) resulted in some files showing up in everyone's file structure, this excludes them from the VSCode files shown.

Fixes # DEVX-650

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
