### PR TITLE
Use manual redirects in the proxy worker

### DIFF
--- a/packages/edge-preview-authenticated-proxy/src/index.ts
+++ b/packages/edge-preview-authenticated-proxy/src/index.ts
@@ -125,6 +125,7 @@ async function handleRequest(
 			...request.headers,
 			"cf-workers-preview-token": token,
 		},
+		redirect: "manual",
 	});
 	const embeddable = new Response(original.body, original);
 	// This will be embedded in an iframe. In particular, the Cloudflare error page sets this header.
@@ -166,6 +167,7 @@ async function handleRawHttp(request: Request, url: URL) {
 			...request.headers,
 			"cf-workers-preview-token": token,
 		},
+		redirect: "manual",
 	});
 	// The client needs the raw headers from the worker
 	// Prefix them with `cf-ew-raw-`, so that response headers from _this_ worker don't interfere

--- a/packages/edge-preview-authenticated-proxy/src/index.ts
+++ b/packages/edge-preview-authenticated-proxy/src/index.ts
@@ -118,7 +118,8 @@ async function handleRequest(
 	if (!token || !remote) {
 		throw new PreviewRequestFailed();
 	}
-	const toForward = new Request(
+
+	const original = await fetch(
 		switchRemote(url, remote),
 		new Request(request, {
 			headers: {
@@ -128,8 +129,6 @@ async function handleRequest(
 			redirect: "manual",
 		})
 	);
-
-	const original = await fetch(toForward);
 	const embeddable = new Response(original.body, original);
 	// This will be embedded in an iframe. In particular, the Cloudflare error page sets this header.
 	embeddable.headers.delete("X-Frame-Options");
@@ -164,7 +163,7 @@ async function handleRawHttp(request: Request, url: URL) {
 		throw new RawHttpFailed();
 	}
 
-	const toForward = new Request(
+	const workerResponse = await fetch(
 		switchRemote(url, remote),
 		new Request(request, {
 			headers: {
@@ -174,8 +173,6 @@ async function handleRawHttp(request: Request, url: URL) {
 			redirect: "manual",
 		})
 	);
-
-	const workerResponse = await fetch(toForward);
 	// The client needs the raw headers from the worker
 	// Prefix them with `cf-ew-raw-`, so that response headers from _this_ worker don't interfere
 	const rawHeaders: Record<string, string> = {};


### PR DESCRIPTION
**What this PR solves / how to test:**
Previously the preview proxy worker would follow redirects rather than pass them onto the client. This adds `redirect: "manual"` to its fetches.

Note: the test only fails with `experimentalLocal`, but that can be added in v3

**Author has included the following, where applicable:**

- [x] Tests
- ~[ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
