### PR TITLE
ci: update eslint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,6 @@
 				"cross-env": "^7.0.3",
 				"esbuild-jest": "0.5.0",
 				"esbuild-register": "^3.3.2",
-				"eslint": "^8.13.0",
-				"eslint-plugin-import": "^2.26.0",
-				"eslint-plugin-react": "^7.29.4",
-				"eslint-plugin-react-hooks": "^4.4.0",
-				"eslint-plugin-unused-imports": "^2.0.0",
 				"ioredis": "^4.28.2",
 				"jest": "^28.1.3",
 				"jsonc-parser": "^3.2.0",
@@ -42,7 +37,12 @@
 			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20221111.1",
+				"eslint": "^8.40.0",
+				"eslint-plugin-import": "2.26.x",
 				"eslint-plugin-no-only-tests": "^3.1.0",
+				"eslint-plugin-react": "^7.32.2",
+				"eslint-plugin-react-hooks": "^4.6.0",
+				"eslint-plugin-unused-imports": "^2.0.0",
 				"patch-package": "^6.5.1"
 			},
 			"engines": {
@@ -5216,15 +5216,37 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"dependencies": {
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+			"integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+			"integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
-				"globals": "^13.15.0",
+				"espree": "^9.5.2",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -5244,9 +5266,9 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "13.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-			"integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+			"version": "13.20.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -5277,6 +5299,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.40.0.tgz",
+			"integrity": "sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@gar/promisify": {
@@ -5324,9 +5354,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.7",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
@@ -10843,12 +10873,14 @@
 			}
 		},
 		"node_modules/array.prototype.flat": {
-			"version": "1.2.5",
-			"license": "MIT",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.0"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"es-shim-unscopables": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -16160,12 +16192,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.29.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-			"integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.40.0.tgz",
+			"integrity": "sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==",
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@humanwhocodes/config-array": "^0.11.6",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@eslint/eslintrc": "^2.0.3",
+				"@eslint/js": "8.40.0",
+				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
@@ -16174,17 +16209,16 @@
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.1",
-				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"eslint-scope": "^7.2.0",
+				"eslint-visitor-keys": "^3.4.1",
+				"espree": "^9.5.2",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.15.0",
+				"globals": "^13.19.0",
 				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
@@ -16199,7 +16233,6 @@
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
-				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
@@ -16422,6 +16455,7 @@
 		},
 		"node_modules/eslint-import-resolver-node": {
 			"version": "0.3.6",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^3.2.7",
@@ -16430,6 +16464,7 @@
 		},
 		"node_modules/eslint-import-resolver-node/node_modules/debug": {
 			"version": "3.2.7",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.1"
@@ -16514,76 +16549,27 @@
 			}
 		},
 		"node_modules/eslint-module-utils": {
-			"version": "2.7.3",
-			"license": "MIT",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+			"integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
 			"dependencies": {
-				"debug": "^3.2.7",
-				"find-up": "^2.1.0"
+				"debug": "^3.2.7"
 			},
 			"engines": {
 				"node": ">=4"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/eslint-module-utils/node_modules/debug": {
 			"version": "3.2.7",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 			"dependencies": {
 				"ms": "^2.1.1"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/find-up": {
-			"version": "2.1.0",
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/locate-path": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/p-limit": {
-			"version": "1.3.0",
-			"license": "MIT",
-			"dependencies": {
-				"p-try": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/p-locate": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/p-try": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/path-exists": {
-			"version": "3.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/eslint-plugin-es": {
@@ -16648,7 +16634,8 @@
 		},
 		"node_modules/eslint-plugin-import": {
 			"version": "2.26.0",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+			"integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
 			"dependencies": {
 				"array-includes": "^3.1.4",
 				"array.prototype.flat": "^1.2.5",
@@ -16673,7 +16660,8 @@
 		},
 		"node_modules/eslint-plugin-import/node_modules/debug": {
 			"version": "2.6.9",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -16688,9 +16676,33 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node": {
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+			"integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+			"dependencies": {
+				"debug": "^3.2.7",
+				"is-core-module": "^2.11.0",
+				"resolve": "^1.22.1"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
 		"node_modules/eslint-plugin-import/node_modules/ms": {
 			"version": "2.0.0",
-			"license": "MIT"
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 		},
 		"node_modules/eslint-plugin-jest": {
 			"version": "26.9.0",
@@ -16849,9 +16861,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react": {
-			"version": "7.31.11",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
-			"integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
+			"version": "7.32.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
+			"integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
 			"dependencies": {
 				"array-includes": "^3.1.6",
 				"array.prototype.flatmap": "^1.3.1",
@@ -16865,7 +16877,7 @@
 				"object.hasown": "^1.1.2",
 				"object.values": "^1.1.6",
 				"prop-types": "^15.8.1",
-				"resolve": "^2.0.0-next.3",
+				"resolve": "^2.0.0-next.4",
 				"semver": "^6.3.0",
 				"string.prototype.matchall": "^4.0.8"
 			},
@@ -16898,11 +16910,16 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/resolve": {
-			"version": "2.0.0-next.3",
-			"license": "MIT",
+			"version": "2.0.0-next.4",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+			"integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
 			"dependencies": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -16932,7 +16949,9 @@
 		},
 		"node_modules/eslint-plugin-unused-imports": {
 			"version": "2.0.0",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+			"integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+			"dev": true,
 			"dependencies": {
 				"eslint-rule-composer": "^0.3.0"
 			},
@@ -16951,6 +16970,7 @@
 		},
 		"node_modules/eslint-rule-composer": {
 			"version": "0.3.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
@@ -17000,10 +17020,14 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"license": "Apache-2.0",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint-webpack-plugin": {
@@ -17146,14 +17170,18 @@
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.1.1",
-			"license": "BSD-2-Clause",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+			"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint/node_modules/find-up": {
@@ -17182,9 +17210,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/globals": {
-			"version": "13.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-			"integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+			"version": "13.20.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -17276,13 +17304,13 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"version": "9.5.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+			"integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -17303,8 +17331,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.4.0",
-			"license": "BSD-3-Clause",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -59608,15 +59637,28 @@
 			"integrity": "sha512-A+U4gM6OOkPS03UgVU08GTpAAAxPsP/8Z4FmneGo4TaVSD99bK9gVJXlqUEPMO/htFXEAht2O6pX4ErtLY5tVg==",
 			"optional": true
 		},
+		"@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"requires": {
+				"eslint-visitor-keys": "^3.3.0"
+			}
+		},
+		"@eslint-community/regexpp": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+			"integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ=="
+		},
 		"@eslint/eslintrc": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+			"integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
-				"globals": "^13.15.0",
+				"espree": "^9.5.2",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -59630,9 +59672,9 @@
 					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 				},
 				"globals": {
-					"version": "13.18.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-					"integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+					"version": "13.20.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+					"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 					"requires": {
 						"type-fest": "^0.20.2"
 					}
@@ -59651,6 +59693,11 @@
 					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
 				}
 			}
+		},
+		"@eslint/js": {
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.40.0.tgz",
+			"integrity": "sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA=="
 		},
 		"@gar/promisify": {
 			"version": "1.1.3",
@@ -59692,9 +59739,9 @@
 			}
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.11.7",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
 			"requires": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
@@ -63735,11 +63782,14 @@
 			"version": "0.3.2"
 		},
 		"array.prototype.flat": {
-			"version": "1.2.5",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.0"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"es-shim-unscopables": "^1.0.0"
 			}
 		},
 		"array.prototype.flatmap": {
@@ -67632,12 +67682,15 @@
 			}
 		},
 		"eslint": {
-			"version": "8.29.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-			"integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.40.0.tgz",
+			"integrity": "sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==",
 			"requires": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@humanwhocodes/config-array": "^0.11.6",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@eslint/eslintrc": "^2.0.3",
+				"@eslint/js": "8.40.0",
+				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
@@ -67646,17 +67699,16 @@
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.1",
-				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"eslint-scope": "^7.2.0",
+				"eslint-visitor-keys": "^3.4.1",
+				"espree": "^9.5.2",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.15.0",
+				"globals": "^13.19.0",
 				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
@@ -67671,7 +67723,6 @@
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
-				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
@@ -67706,7 +67757,9 @@
 					"version": "4.0.0"
 				},
 				"eslint-scope": {
-					"version": "7.1.1",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+					"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
 					"requires": {
 						"esrecurse": "^4.3.0",
 						"estraverse": "^5.2.0"
@@ -67728,9 +67781,9 @@
 					}
 				},
 				"globals": {
-					"version": "13.18.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
-					"integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
+					"version": "13.20.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+					"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 					"requires": {
 						"type-fest": "^0.20.2"
 					}
@@ -67901,6 +67954,7 @@
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
+			"dev": true,
 			"requires": {
 				"debug": "^3.2.7",
 				"resolve": "^1.20.0"
@@ -67908,6 +67962,7 @@
 			"dependencies": {
 				"debug": {
 					"version": "3.2.7",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -67967,48 +68022,20 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.7.3",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+			"integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
 			"requires": {
-				"debug": "^3.2.7",
-				"find-up": "^2.1.0"
+				"debug": "^3.2.7"
 			},
 			"dependencies": {
 				"debug": {
 					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 					"requires": {
 						"ms": "^2.1.1"
 					}
-				},
-				"find-up": {
-					"version": "2.1.0",
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0"
-				},
-				"path-exists": {
-					"version": "3.0.0"
 				}
 			}
 		},
@@ -68050,6 +68077,8 @@
 		},
 		"eslint-plugin-import": {
 			"version": "2.26.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+			"integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
 			"requires": {
 				"array-includes": "^3.1.4",
 				"array.prototype.flat": "^1.2.5",
@@ -68068,6 +68097,8 @@
 			"dependencies": {
 				"debug": {
 					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -68078,8 +68109,35 @@
 						"esutils": "^2.0.2"
 					}
 				},
+				"eslint-import-resolver-node": {
+					"version": "0.3.7",
+					"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+					"integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+					"requires": {
+						"debug": "^3.2.7",
+						"is-core-module": "^2.11.0",
+						"resolve": "^1.22.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.2.7",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+							"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"ms": {
+							"version": "2.1.3",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+							"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+						}
+					}
+				},
 				"ms": {
-					"version": "2.0.0"
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 				}
 			}
 		},
@@ -68188,9 +68246,9 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.31.11",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
-			"integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
+			"version": "7.32.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
+			"integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
 			"requires": {
 				"array-includes": "^3.1.6",
 				"array.prototype.flatmap": "^1.3.1",
@@ -68204,7 +68262,7 @@
 				"object.hasown": "^1.1.2",
 				"object.values": "^1.1.6",
 				"prop-types": "^15.8.1",
-				"resolve": "^2.0.0-next.3",
+				"resolve": "^2.0.0-next.4",
 				"semver": "^6.3.0",
 				"string.prototype.matchall": "^4.0.8"
 			},
@@ -68216,10 +68274,13 @@
 					}
 				},
 				"resolve": {
-					"version": "2.0.0-next.3",
+					"version": "2.0.0-next.4",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+					"integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
 					"requires": {
-						"is-core-module": "^2.2.0",
-						"path-parse": "^1.0.6"
+						"is-core-module": "^2.9.0",
+						"path-parse": "^1.0.7",
+						"supports-preserve-symlinks-flag": "^1.0.0"
 					}
 				},
 				"semver": {
@@ -68243,12 +68304,16 @@
 		},
 		"eslint-plugin-unused-imports": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+			"integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+			"dev": true,
 			"requires": {
 				"eslint-rule-composer": "^0.3.0"
 			}
 		},
 		"eslint-rule-composer": {
-			"version": "0.3.0"
+			"version": "0.3.0",
+			"dev": true
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -68278,7 +68343,9 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "3.3.0"
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA=="
 		},
 		"eslint-webpack-plugin": {
 			"version": "2.7.0",
@@ -68334,20 +68401,22 @@
 			}
 		},
 		"espree": {
-			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"version": "9.5.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+			"integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
 			"requires": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.1"
 			}
 		},
 		"esprima": {
 			"version": "4.0.1"
 		},
 		"esquery": {
-			"version": "1.4.0",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"requires": {
 				"estraverse": "^5.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -36,11 +36,6 @@
 		"cross-env": "^7.0.3",
 		"esbuild-jest": "0.5.0",
 		"esbuild-register": "^3.3.2",
-		"eslint": "^8.13.0",
-		"eslint-plugin-import": "^2.26.0",
-		"eslint-plugin-react": "^7.29.4",
-		"eslint-plugin-react-hooks": "^4.4.0",
-		"eslint-plugin-unused-imports": "^2.0.0",
 		"ioredis": "^4.28.2",
 		"jest": "^28.1.3",
 		"jsonc-parser": "^3.2.0",
@@ -54,7 +49,12 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20221111.1",
+		"eslint": "^8.40.0",
+		"eslint-plugin-import": "2.26.x",
 		"eslint-plugin-no-only-tests": "^3.1.0",
+		"eslint-plugin-react": "^7.32.2",
+		"eslint-plugin-react-hooks": "^4.6.0",
+		"eslint-plugin-unused-imports": "^2.0.0",
 		"patch-package": "^6.5.1"
 	},
 	"engines": {


### PR DESCRIPTION
Very small update to the eslint dependencies.
We have to pin the `eslint-plugin-import` package to 2.26.x because 2.27.0 introduces a nasty regression that re-orders all (but only) `type` imports incorrectly.