### PR TITLE
[edge-preview] Support tokens > 4096 bytes by storing in a KV lookup table

### DIFF
--- a/packages/edge-preview-authenticated-proxy/worker-configuration.d.ts
+++ b/packages/edge-preview-authenticated-proxy/worker-configuration.d.ts
@@ -6,4 +6,5 @@ interface Env {
 	// Secrets
 	SENTRY_ACCESS_CLIENT_SECRET: string;
 	SENTRY_ACCESS_CLIENT_ID: string;
+	TOKEN_LOOKUP: KVNamespace;
 }

--- a/packages/edge-preview-authenticated-proxy/wrangler.toml
+++ b/packages/edge-preview-authenticated-proxy/wrangler.toml
@@ -17,3 +17,8 @@ RAW_HTTP = "rawhttp.devprod.cloudflare.dev"
 
 [dev]
 host = "preview.devprod.cloudflare.dev"
+
+[[kv_namespaces]]
+binding = "TOKEN_LOOKUP"
+id = "76afd4161617490b9d2addc59b1e22e4"
+preview_id = "76afd4161617490b9d2addc59b1e22e4"


### PR DESCRIPTION
**What this PR solves / how to test:**

Sometimes preview tokens can exceed the size limits for cookies. This store only an ID in a cookie, with the actual token stored in an attached KV namespace

**Author has included the following, where applicable:**

- [x] Tests
- ~[ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
