### PR TITLE
Revert revert of tail_consumers support

### DIFF
--- a/.changeset/strange-schools-dream.md
+++ b/.changeset/strange-schools-dream.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Support tail_consumers in script upload

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -2258,6 +2258,7 @@ describe("init", () => {
 					migration_tag: "some-migration-tag",
 					usage_model: "bundled",
 					compatibility_date: "1987-9-27",
+					tail_consumers: [{ service: "listener" }],
 				},
 			},
 			created_on: "1987-9-27",
@@ -2459,6 +2460,7 @@ describe("init", () => {
 					},
 				],
 			},
+			tail_consumers: [{ service: "listener" }],
 		};
 
 		function mockSupportingDashRequests({
@@ -2708,6 +2710,9 @@ describe("init", () => {
 			test = { }
 			staging = { }
 
+			[[tail_consumers]]
+			service = \\"listener\\"
+
 			[vars]
 			ANOTHER-NAME = \\"thing-TEXT\\"
 
@@ -2952,6 +2957,7 @@ describe("init", () => {
 						created_on: "1988-08-07",
 						usage_model: "bundled",
 						compatibility_date: "1988-08-07",
+						tail_consumers: [{ service: "listener" }],
 					},
 				},
 				environments: [],
@@ -3060,6 +3066,7 @@ describe("init", () => {
 						},
 						usage_model: "bundled",
 						name: "isolinear-optical-chip",
+						tail_consumers: [{ service: "listener" }],
 					}),
 				},
 			});

--- a/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
+++ b/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
@@ -73,6 +73,7 @@ function createWorkerBundleFormData(workerBundle: BundleResult): FormData {
 		keepVars: undefined,
 		logpush: undefined,
 		placement: undefined,
+		tail_consumers: undefined,
 	};
 
 	return createWorkerUploadForm(worker);

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -551,6 +551,8 @@ interface EnvironmentNonInheritable {
 		/** The uuid of the uploaded mTLS certificate */
 		certificate_id: string;
 	}[];
+
+	tail_consumers?: TailConsumer[];
 }
 
 /**
@@ -648,3 +650,10 @@ export type ConfigModuleRuleType =
 	| "CompiledWasm"
 	| "Text"
 	| "Data";
+
+export type TailConsumer = {
+	/** The name of the service tail events will be forwarded to. */
+	service: string;
+	/** (Optional) The environt of the service. */
+	environment?: string;
+};

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -33,6 +33,7 @@ import type {
 	DeprecatedUpload,
 	Environment,
 	Rule,
+	TailConsumer,
 } from "./environment";
 import type { ValidatorFn } from "./validation-helpers";
 
@@ -900,6 +901,62 @@ function normalizeAndValidatePlacement(
 	);
 }
 
+function validateTailConsumer(
+	diagnostics: Diagnostics,
+	field: string,
+	value: TailConsumer
+) {
+	if (typeof value !== "object" || value === null) {
+		diagnostics.errors.push(
+			`"${field}" should be an object but got ${JSON.stringify(value)}.`
+		);
+		return false;
+	}
+
+	let isValid = true;
+
+	isValid =
+		isValid &&
+		validateRequiredProperty(
+			diagnostics,
+			field,
+			"service",
+			value.service,
+			"string"
+		);
+	isValid =
+		isValid &&
+		validateOptionalProperty(
+			diagnostics,
+			field,
+			"environment",
+			value.environment,
+			"string"
+		);
+
+	return isValid;
+}
+
+const validateTailConsumers: ValidatorFn = (diagnostics, field, value) => {
+	if (!value) {
+		return true;
+	}
+	if (!Array.isArray(value)) {
+		diagnostics.errors.push(
+			`Expected "${field}" to be an array but got ${JSON.stringify(value)}.`
+		);
+		return false;
+	}
+
+	let isValid = true;
+	for (let i = 0; i < value.length; i++) {
+		isValid =
+			validateTailConsumer(diagnostics, `${field}[${i}]`, value[i]) && isValid;
+	}
+
+	return isValid;
+};
+
 /**
  * Validate top-level environment configuration and return the normalized values.
  */
@@ -1222,6 +1279,16 @@ function normalizeAndValidateEnvironment(
 			"mtls_certificates",
 			validateBindingArray(envName, validateMTlsCertificateBinding),
 			[]
+		),
+		tail_consumers: notInheritable(
+			diagnostics,
+			topLevelEnv,
+			rawConfig,
+			rawEnv,
+			envName,
+			"tail_consumers",
+			validateTailConsumers,
+			undefined
 		),
 		logfwdr: inheritable(
 			diagnostics,

--- a/packages/wrangler/src/create-worker-upload-form.ts
+++ b/packages/wrangler/src/create-worker-upload-form.ts
@@ -5,6 +5,7 @@ import type {
 	CfModuleType,
 	CfDurableObjectMigrations,
 	CfPlacement,
+	CfTailConsumer,
 } from "./worker.js";
 
 export function toMimeType(type: CfModuleType): string {
@@ -75,6 +76,7 @@ export interface WorkerMetadata {
 	keep_bindings?: WorkerMetadataBinding["type"][];
 	logpush?: boolean;
 	placement?: CfPlacement;
+	tail_consumers?: CfTailConsumer[];
 	// Allow unsafe.metadata to add arbitary properties at runtime
 	[key: string]: unknown;
 }
@@ -94,6 +96,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		keepVars,
 		logpush,
 		placement,
+		tail_consumers,
 	} = worker;
 
 	let { modules } = worker;
@@ -341,6 +344,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		...(keepVars && { keep_bindings: ["plain_text", "json"] }),
 		...(logpush !== undefined && { logpush }),
 		...(placement && { placement }),
+		...(tail_consumers && { tail_consumers }),
 	};
 
 	if (bindings.unsafe?.metadata !== undefined) {

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -577,6 +577,7 @@ async function createRemoteWorkerInit(props: {
 		keepVars: true,
 		logpush: false,
 		placement: undefined, // no placement in dev
+		tail_consumers: undefined, // no tail consumers in dev - TODO revist?
 	};
 
 	return init;

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -18,7 +18,7 @@ import { requireAuth } from "./user";
 import { CommandLineArgsError, printWranglerBanner } from "./index";
 
 import type { RawConfig } from "./config";
-import type { Route, SimpleRoute } from "./config/environment";
+import type { Route, SimpleRoute, TailConsumer } from "./config/environment";
 import type {
 	WorkerMetadata,
 	WorkerMetadataBinding,
@@ -82,6 +82,7 @@ export type ServiceMetadataRes = {
 			compatibility_date: string;
 			last_deployed_from?: "wrangler" | "dash" | "api";
 			placement_mode?: "smart";
+			tail_consumers?: TailConsumer[];
 		};
 	};
 	created_on: string;
@@ -915,6 +916,7 @@ async function getWorkerConfig(
 				return { ...envObj, [environment]: {} };
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			}, {} as RawConfig["env"]),
+		tail_consumers: serviceEnvMetadata.script.tail_consumers,
 		...mappedBindings,
 	};
 }

--- a/packages/wrangler/src/publish/publish.ts
+++ b/packages/wrangler/src/publish/publish.ts
@@ -593,6 +593,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			keepVars,
 			logpush: props.logpush !== undefined ? props.logpush : config.logpush,
 			placement,
+			tail_consumers: config.tail_consumers,
 		};
 
 		// As this is not deterministic for testing, we detect if in a jest environment and run asynchronously

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -126,6 +126,7 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 								keepVars: false, // this doesn't matter since it's a new script anyway
 								logpush: false,
 								placement: undefined,
+								tail_consumers: undefined,
 							}),
 						}
 					);

--- a/packages/wrangler/src/worker.ts
+++ b/packages/wrangler/src/worker.ts
@@ -220,6 +220,11 @@ export interface CfPlacement {
 	mode: "smart";
 }
 
+export interface CfTailConsumer {
+	service: string;
+	environment?: string;
+}
+
 /**
  * Options for creating a `CfWorker`.
  */
@@ -266,6 +271,7 @@ export interface CfWorkerInit {
 	keepVars: boolean | undefined;
 	logpush: boolean | undefined;
 	placement: CfPlacement | undefined;
+	tail_consumers: CfTailConsumer[] | undefined;
 }
 
 export interface CfWorkerContext {


### PR DESCRIPTION
This reverts commit 521fc8d572819fadddb18d59a26e26067004819c
which reverted commit 0589b48f378d28c06940c09719ee110a07db51e3

Effectively re-enabling the support for tail_consumers, described here https://github.com/cloudflare/workers-sdk/pull/3199

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
