### PR TITLE
Update versionMap.json to include angular @16.0.x rather than @next

### DIFF
--- a/.changeset/late-boats-tell.md
+++ b/.changeset/late-boats-tell.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Update versionMap.json to include angular @16.0.x rather than @next

--- a/packages/create-cloudflare/src/frameworks/versionMap.json
+++ b/packages/create-cloudflare/src/frameworks/versionMap.json
@@ -1,5 +1,5 @@
 {
-	"angular": "next",
+	"angular": "16.0.x",
 	"astro": "3.1.5",
 	"docusaurus": "2.4.1",
 	"gatsby": "5.10.0",


### PR DESCRIPTION
**What this PR solves / how to test:**
Installing version next of Angular fails during installation because of peer-deps error.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
