### PR TITLE
Bumping version of create-cloudflare to 2.0.2

### DIFF
--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-cloudflare",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "A CLI for creating and deploying new applications to Cloudflare.",
 	"keywords": [
 		"cloudflare",


### PR DESCRIPTION
Just a version bump

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
