### PR TITLE
Pin chromium/tools/depot_tools to a specific commit

### DIFF
--- a/packages/wrangler-devtools/Makefile
+++ b/packages/wrangler-devtools/Makefile
@@ -1,16 +1,21 @@
 ROOT = $(realpath .)
 # The upstream devtools commit upon which our patches are based
-HEAD = f931aec3eca7c860dc4d657f328daca19d19221d
-PATCHES = $(shell ls ${PWD}/patches/*.patch)
+DEVTOOLS_HEAD = f931aec3eca7c860dc4d657f328daca19d19221d
+DEVTOOLS_PATCHES = $(shell ls ${PWD}/patches/*.patch)
+
+# The upstream depot_tools commit upon which our patches are based
+DEPOT_TOOLS_HEAD = 4786a41fb5aa74d356d2fc3e30545d59db5c0bf3
+
 depot:
 	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot
+	git -C depot checkout $(DEPOT_TOOLS_HEAD)
 
 devtools-frontend: depot
 	$(ROOT)/depot/fetch devtools-frontend
-	git -C devtools-frontend checkout $(HEAD)
+	git -C devtools-frontend checkout $(DEVTOOLS_HEAD)
 	git -C devtools-frontend config user.email "workers-devprod@cloudflare.com"
 	git -C devtools-frontend config user.name "Workers DevProd"
-	git -C devtools-frontend am $(PATCHES)
+	git -C devtools-frontend am $(DEVTOOLS_PATCHES)
 
 devtools-frontend/out/Default/gen/front_end: devtools-frontend
 	cd devtools-frontend && $(ROOT)/depot/gclient sync
@@ -27,4 +32,4 @@ cleanup:
 	rm -rf devtools-frontend .gclient* .cipd node_modules depot
 
 test:
-	git -C devtools-frontend am $(PATCHES)
+	git -C devtools-frontend am $(DEVTOOLS_PATCHES)


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

It looks like we currently fail on tests because a new set of commits in https://chromium.googlesource.com/chromium/tools/depot_tools.git has broken our workflow in the DevTools publish action. We don't need to be on the bleeding edge here so we are pinning it to a commit that works for now. 

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
