### PR TITLE
Pin chromium/tools/depot_tools to a specific commit

### DIFF
--- a/packages/wrangler-devtools/Makefile
+++ b/packages/wrangler-devtools/Makefile
@@ -1,4 +1,5 @@
 ROOT = $(realpath .)
+PATH_WITH_DEPOT = $(PATH):"$(ROOT)/depot/"
 # The upstream devtools commit upon which our patches are based
 HEAD = f931aec3eca7c860dc4d657f328daca19d19221d
 PATCHES = $(shell ls ${PWD}/patches/*.patch)
@@ -6,16 +7,18 @@ depot:
 	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot
 
 devtools-frontend: depot
-	$(ROOT)/depot/fetch devtools-frontend
+	git clone https://chromium.googlesource.com/devtools/devtools-frontend
+  # Ensure other depot_tools can be called from gclient config
+	PATH=$(PATH_WITH_DEPOT) $(ROOT)/depot/gclient config https://chromium.googlesource.com/devtools/devtools-frontend --unmanaged
 	git -C devtools-frontend checkout $(HEAD)
 	git -C devtools-frontend config user.email "workers-devprod@cloudflare.com"
 	git -C devtools-frontend config user.name "Workers DevProd"
 	git -C devtools-frontend am $(PATCHES)
 
 devtools-frontend/out/Default/gen/front_end: devtools-frontend
-	cd devtools-frontend && $(ROOT)/depot/gclient sync
-	cd devtools-frontend && $(ROOT)/depot/gn gen out/Default
-	cd devtools-frontend && $(ROOT)/depot/autoninja -C out/Default
+	cd devtools-frontend && PATH=$(PATH_WITH_DEPOT) $(ROOT)/depot/gclient sync
+	cd devtools-frontend && PATH=$(PATH_WITH_DEPOT) $(ROOT)/depot/gn gen out/Default
+	cd devtools-frontend && PATH=$(PATH_WITH_DEPOT) $(ROOT)/depot/autoninja -C out/Default
 
 node_modules:
 	npm ci


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

It looks like we currently fail on tests because a new set of commits in https://chromium.googlesource.com/chromium/tools/depot_tools.git has broken our workflow in the DevTools publish action. We don't need to be on the bleeding edge here so we are pinning it to a commit that works for now.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
