### PR TITLE
[C3] better polling for Pages deployments

### DIFF
--- a/.changeset/early-rocks-crash.md
+++ b/.changeset/early-rocks-crash.md
@@ -1,0 +1,8 @@
+---
+"create-cloudflare": patch
+---
+
+fix: add polling for deployed Pages projects
+
+When create-cloudflare deploys to Pages, it can take a while before the website is ready to be viewed.
+This change adds back in polling of the site and then opening a browser when the URL is ready.

--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -3,10 +3,10 @@ name: C3 Tests
 on:
   pull_request:
     paths:
-      - packages/create-cloudflare
+      - packages/create-cloudflare/**
 
 env:
-  node-version: latest
+  node-version: 16.13
 
 jobs:
   check:
@@ -27,17 +27,38 @@ jobs:
           node-version: ${{ env.node-version }}
           cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
 
-      - name: Install NPM Dependencies
+      - name: ESlint and Typescript caching
+        uses: actions/cache@v3
+        id: eslint-cache
+        with:
+          path: |
+            .eslintcache
+            tsconfig.tsbuildinfo
+          key: ${{ matrix.os }}-eslint-tsbuildinfo-${{ hashFiles('**/*.ts','**/*.js', 'package.json', 'tsconfig.json') }}
+
+      # Attempt to cache all the node_modules directories based on the OS and package lock.
+      - name: Cache node_modules
+        id: npm-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          key: ${{ runner.os }}-${{ env.node-version }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: "**/node_modules"
+
+      # If the cache missed then install using `npm ci` to follow package lock exactly
+      - if: ${{ steps.npm-cache.outputs.cache-hit != 'true'}}
+        name: Install NPM Dependencies
         run: npm ci
 
       - name: Check Types
-        run: npm run check:types
+        run: npm run check:type -w create-cloudflare
 
       - name: Lint
-        run: npm run check:lint
+        run: npm run check:lint -w create-cloudflare
 
       - name: Unit Tests
-        run: npm run test:unit
+        run: npm run test:unit -w create-cloudflare
 
       - name: E2E Tests
-        run: npm run test:e2e
+        run: npm run test:e2e -w create-cloudflare

--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -6,14 +6,15 @@ on:
       - packages/create-cloudflare/**
 
 env:
-  node-version: 16.13
+  node-version: 16.14
 
 jobs:
   check:
     name: "Checks"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -13,7 +13,9 @@ jobs:
     name: "Checks"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # TODO: add back windows
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -13,8 +13,7 @@ jobs:
     name: "Checks"
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # TODO: add back windows
         # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"cSpell.words": [
 		"cfetch",
+		"chatgpt",
 		"clipboardy",
 		"cloudflareaccess",
 		"cloudflared",
@@ -9,6 +10,8 @@
 		"esbuild",
 		"eslintcache",
 		"execa",
+		"haikunate",
+		"haikunator",
 		"iarna",
 		"keyvalue",
 		"logfwdr",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4272,7 +4272,7 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -44607,6 +44607,7 @@
 				"execa": "^7.1.1",
 				"haikunator": "^2.1.2",
 				"log-update": "^5.0.1",
+				"open": "^8.4.0",
 				"recast": "^0.22.0",
 				"typescript": "^5.0.2",
 				"undici": "^5.22.0",
@@ -58537,7 +58538,7 @@
 				"is-unicode-supported": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true
+					"extraneous": true
 				}
 			}
 		},
@@ -65306,6 +65307,7 @@
 				"execa": "^7.1.1",
 				"haikunator": "^2.1.2",
 				"log-update": "^5.0.1",
+				"open": "^8.4.0",
 				"recast": "^0.22.0",
 				"typescript": "^5.0.2",
 				"undici": "^5.22.0",

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -74,21 +74,21 @@ describe("E2E", () => {
 		};
 	};
 
-	// test("Astro", async () => {
-	// 	await runCli("astro");
-	// });
+	test("Astro", async () => {
+		await runCli("astro");
+	});
 
 	test("Hono", async () => {
 		await runCli("hono");
 	});
 
-	// test("Next.js", async () => {
-	// 	await runCli("next");
-	// });
+	test("Next.js", async () => {
+		await runCli("next");
+	});
 
-	// test("Nuxt", async () => {
-	// 	await runCli("nuxt");
-	// });
+	test("Nuxt", async () => {
+		await runCli("nuxt");
+	});
 
 	// Not possible atm since `npx qwik add cloudflare-pages`
 	// requires interactive confirmation
@@ -96,13 +96,13 @@ describe("E2E", () => {
 	//   await runCli("next", flags);
 	// });
 
-	// test("React", async () => {
-	// 	await runCli("react");
-	// });
+	test("React", async () => {
+		await runCli("react");
+	});
 
-	// test("Remix", async () => {
-	// 	await runCli("remix");
-	// });
+	test("Remix", async () => {
+		await runCli("remix");
+	});
 
 	// Not possible atm since template selection is interactive only
 	// test("Solid", async () => {
@@ -116,7 +116,7 @@ describe("E2E", () => {
 	//   await runCli("svelte", flags);
 	// });
 
-	// test("Vue", async () => {
-	// 	await runCli("vue");
-	// });
+	test("Vue", async () => {
+		await runCli("vue");
+	});
 });

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -15,18 +15,18 @@ Areas for future improvement:
 describe("E2E", () => {
 	let dummyPath: string;
 
-	const removeDummyFolder = () => {
-		rmSync(dummyPath, { recursive: true, force: true });
+	const removeDummyFolder = (path: string) => {
+		rmSync(path, { recursive: true, force: true });
 	};
 
 	beforeEach(() => {
 		dummyPath = join(tmpdir(), "tmp");
-		removeDummyFolder();
+		removeDummyFolder(dummyPath);
 		mkdirSync(dummyPath);
 	});
 
 	afterEach(() => {
-		removeDummyFolder();
+		removeDummyFolder(dummyPath);
 	});
 
 	const runCli = async (framework: string) => {

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -43,6 +43,9 @@ describe("E2E", () => {
 		const result = await execa("node", ["./dist/cli.js", ...argv], {
 			stderr: process.stderr,
 		});
+		// For debugging purposes, uncomment the following to see the exact
+		// command the test uses. You can then run this via the command line.
+		// console.log("COMMAND: ", `node ${["./dist/cli.js", ...argv].join(" ")}`);
 
 		const { exitCode } = result;
 
@@ -71,21 +74,21 @@ describe("E2E", () => {
 		};
 	};
 
-	test("Astro", async () => {
-		await runCli("astro");
-	});
+	// test("Astro", async () => {
+	// 	await runCli("astro");
+	// });
 
 	test("Hono", async () => {
 		await runCli("hono");
 	});
 
-	test("Next.js", async () => {
-		await runCli("next");
-	});
+	// test("Next.js", async () => {
+	// 	await runCli("next");
+	// });
 
-	test("Nuxt", async () => {
-		await runCli("nuxt");
-	});
+	// test("Nuxt", async () => {
+	// 	await runCli("nuxt");
+	// });
 
 	// Not possible atm since `npx qwik add cloudflare-pages`
 	// requires interactive confirmation
@@ -93,13 +96,13 @@ describe("E2E", () => {
 	//   await runCli("next", flags);
 	// });
 
-	test("React", async () => {
-		await runCli("react");
-	});
+	// test("React", async () => {
+	// 	await runCli("react");
+	// });
 
-	test("Remix", async () => {
-		await runCli("remix");
-	});
+	// test("Remix", async () => {
+	// 	await runCli("remix");
+	// });
 
 	// Not possible atm since template selection is interactive only
 	// test("Solid", async () => {
@@ -113,7 +116,7 @@ describe("E2E", () => {
 	//   await runCli("svelte", flags);
 	// });
 
-	test("Vue", async () => {
-		await runCli("vue");
-	});
+	// test("Vue", async () => {
+	// 	await runCli("vue");
+	// });
 });

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync } from "fs";
+import { existsSync, rmSync, mkdtempSync, realpathSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { execa } from "execa";
@@ -15,18 +15,15 @@ Areas for future improvement:
 describe("E2E", () => {
 	let dummyPath: string;
 
-	const removeDummyFolder = (path: string) => {
-		rmSync(path, { recursive: true, force: true });
-	};
-
 	beforeEach(() => {
-		dummyPath = join(tmpdir(), "tmp");
-		removeDummyFolder(dummyPath);
-		mkdirSync(dummyPath);
+		// Use realpath because the temporary path can point to a symlink rather than the actual path.
+		dummyPath = realpathSync(mkdtempSync(join(tmpdir(), "c3-tests")));
 	});
 
 	afterEach(() => {
-		removeDummyFolder(dummyPath);
+		if (existsSync(dummyPath)) {
+			rmSync(dummyPath, { recursive: true });
+		}
 	});
 
 	const runCli = async (framework: string) => {
@@ -92,9 +89,9 @@ describe("E2E", () => {
 
 	// Not possible atm since `npx qwik add cloudflare-pages`
 	// requires interactive confirmation
-	// test("Qwik", async () => {
-	//   await runCli("next", flags);
-	// });
+	test.skip("Qwik", async () => {
+		await runCli("next");
+	});
 
 	test("React", async () => {
 		await runCli("react");
@@ -105,16 +102,14 @@ describe("E2E", () => {
 	});
 
 	// Not possible atm since template selection is interactive only
-	// test("Solid", async () => {
-	//   const flags = ["--no-deploy"];
-	//   await runCli("solid", flags);
-	// });
+	test.skip("Solid", async () => {
+		await runCli("solid");
+	});
 
 	// Not possible atm since everything is interactive only
-	// test("Svelte", async () => {
-	//   const flags = ["--no-deploy"];
-	//   await runCli("svelte", flags);
-	// });
+	test.skip("Svelte", async () => {
+		await runCli("svelte");
+	});
 
 	test("Vue", async () => {
 		await runCli("vue");

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -54,6 +54,7 @@
 		"execa": "^7.1.1",
 		"haikunator": "^2.1.2",
 		"log-update": "^5.0.1",
+		"open": "^8.4.0",
 		"recast": "^0.22.0",
 		"typescript": "^5.0.2",
 		"undici": "^5.22.0",

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -51,7 +51,7 @@ const parseArgs = async (argv: string[]) => {
 		.help().argv;
 
 	return {
-		projectName: String(args._[0]),
+		projectName: args._[0] as string | undefined,
 		...args,
 	};
 };

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -17,9 +17,10 @@ export const main = async (argv: string[]) => {
 	printBanner();
 
 	const args = await parseArgs(argv);
+
 	const validatedArgs: PagesGeneratorArgs = {
 		...args,
-		projectName: await validateName(args.name),
+		projectName: await validateName(args.projectName),
 		type: await validateType(args.type),
 	};
 
@@ -49,7 +50,10 @@ const parseArgs = async (argv: string[]) => {
 		})
 		.help().argv;
 
-	return args;
+	return {
+		projectName: String(args._[0]),
+		...args,
+	};
 };
 
 const validateName = async (name: string | undefined): Promise<string> => {

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -18,7 +18,7 @@ import {
 	runCommand,
 	wranglerLogin,
 } from "helpers/command";
-import { confirmInput, selectInput } from "helpers/interactive";
+import { confirmInput, selectInput, spinner } from "helpers/interactive";
 import { poll } from "helpers/poll";
 import type { Option } from "helpers/interactive";
 import type { PagesGeneratorArgs, PagesGeneratorContext } from "types";
@@ -108,13 +108,20 @@ export const runDeploy = async (ctx: PagesGeneratorContext) => {
 };
 
 export const chooseAccount = async (ctx: PagesGeneratorContext) => {
+	const s = spinner();
+	s.start(`Selecting Cloudflare account ${dim("retrieving accounts")}`);
 	const accounts = await listAccounts();
 
 	let accountId: string;
 
 	if (Object.keys(accounts).length == 1) {
-		accountId = Object.values(accounts)[0];
+		const accountName = Object.keys(accounts)[0];
+		accountId = accounts[accountName];
+		s.stop(`${brandColor("account")} ${dim(accountName)}`);
 	} else {
+		s.stop(
+			`${brandColor("account")} ${dim("more than one account available")}`
+		);
 		const accountOptions = Object.entries(accounts).map(([name, id]) => ({
 			label: name,
 			value: id,

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -7,6 +7,7 @@ import {
 	log,
 	logRaw,
 	newline,
+	openInBrowser,
 	shapes,
 	startSection,
 } from "helpers/cli";
@@ -18,6 +19,7 @@ import {
 	wranglerLogin,
 } from "helpers/command";
 import { confirmInput, selectInput } from "helpers/interactive";
+import { poll } from "helpers/poll";
 import type { Option } from "helpers/interactive";
 import type { PagesGeneratorArgs, PagesGeneratorContext } from "types";
 
@@ -158,7 +160,6 @@ export const printSummary = async (ctx: PagesGeneratorContext) => {
 			`${bgGreen(" SUCCESS ")}`,
 			`${dim(`View your deployed application at`)}`,
 			`${blue(ctx.deployedUrl)}`,
-			`${dim(`(this may take a few mins)`)}`,
 		].join(" ");
 		logRaw(msg);
 	} else {
@@ -179,5 +180,13 @@ export const printSummary = async (ctx: PagesGeneratorContext) => {
 	});
 	newline();
 
+	if (ctx.deployedUrl) {
+		const success = await poll(ctx.deployedUrl);
+		if (success) {
+			if (ctx.args.open) {
+				await openInBrowser(ctx.deployedUrl);
+			}
+		}
+	}
 	endSection("See you again soon!");
 };

--- a/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { spawn } from "cross-spawn";
 import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
 import whichPMRuns from "which-pm-runs";
 import {
@@ -16,7 +16,7 @@ describe("Command Helpers", () => {
 
 	beforeEach(() => {
 		// Mock out the child_process.spawn function
-		vi.mock("child_process", () => {
+		vi.mock("cross-spawn", () => {
 			const mockedSpawn = vi.fn().mockImplementation(() => ({
 				on: vi.fn().mockImplementation((event, cb) => {
 					if (event === "close") {

--- a/packages/create-cloudflare/src/helpers/cli.ts
+++ b/packages/create-cloudflare/src/helpers/cli.ts
@@ -1,4 +1,5 @@
 import { exit } from "process";
+import open from "open";
 import { brandColor, dim, gray, white, red, hidden, bgRed } from "./colors";
 
 export const shapes = {
@@ -111,3 +112,19 @@ export const crash = (msg?: string): never => {
 	}
 	exit(1);
 };
+
+/**
+ * An extremely simple wrapper around the open command.
+ * Specifically, it adds an 'error' event handler so that when this function
+ * is called in environments where we can't open the browser (e.g. GitHub Codespaces,
+ * StackBlitz, remote servers), it doesn't just crash the process.
+ *
+ * @param url the URL to point the browser at
+ */
+export async function openInBrowser(url: string): Promise<void> {
+	updateStatus("Opening browser");
+	const childProcess = await open(url);
+	childProcess.on("error", () => {
+		warn("Failed to open browser");
+	});
+}

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -172,10 +172,12 @@ export const isLoggedIn = async () => {
 export const wranglerLogin = async () => {
 	const { npx } = detectPackageManager();
 
+	const s = spinner();
+	s.start(`Logging into Cloudflare ${dim("checking authentication status")}`);
 	const alreadyLoggedIn = await isLoggedIn();
+	s.stop(brandColor(alreadyLoggedIn ? "logged in" : "not logged in"));
 	if (alreadyLoggedIn) return true;
 
-	const s = spinner();
 	s.start(`Logging into Cloudflare ${dim("This will open a browser window")}`);
 
 	// We're using a custom spinner since this is a little complicated.

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -67,6 +67,19 @@ export const runCommand = async (
 	});
 };
 
+export const retry = async <T>(times: number, fn: () => Promise<T>) => {
+	let error: unknown = null;
+	while (times > 0) {
+		try {
+			return await fn();
+		} catch (e) {
+			error = e;
+			times--;
+		}
+	}
+	throw error;
+};
+
 // Prints the section header & footer while running the `cmd`
 export const runFrameworkGenerator = async (
 	ctx: PagesGeneratorContext,

--- a/packages/create-cloudflare/src/helpers/interactive.ts
+++ b/packages/create-cloudflare/src/helpers/interactive.ts
@@ -227,9 +227,16 @@ export const spinner = () => {
 	const color = brandColor;
 	const frameRate = 120;
 	const maxDots = 4;
-	let loop: NodeJS.Timer;
+	let loop: NodeJS.Timer | null = null;
 	let startMsg: string;
 	let currentMsg: string;
+
+	function clearLoop() {
+		if (loop) {
+			clearTimeout(loop);
+		}
+		loop = null;
+	}
 
 	return {
 		start: (msg: string, helpText?: string) => {
@@ -240,6 +247,7 @@ export const spinner = () => {
 			let index = 0;
 			let dots = 1;
 
+			clearLoop();
 			loop = setInterval(() => {
 				const frame = frames[(index = ++index % frames.length)];
 				dots = ++dots % maxDots;
@@ -255,8 +263,7 @@ export const spinner = () => {
 			logUpdate(`${leftT} ${startMsg}\n${grayBar} ${msg}`);
 			logUpdate.done();
 			newline();
-
-			clearTimeout(loop);
+			clearLoop();
 		},
 	};
 };

--- a/packages/create-cloudflare/src/helpers/interactive.ts
+++ b/packages/create-cloudflare/src/helpers/interactive.ts
@@ -229,11 +229,13 @@ export const spinner = () => {
 	const maxDots = 4;
 	let loop: NodeJS.Timer;
 	let startMsg: string;
+	let currentMsg: string;
 
 	return {
 		start: (msg: string, helpText?: string) => {
 			helpText ||= ``;
-			startMsg = `${msg} ${dim(helpText)}`;
+			currentMsg = msg;
+			startMsg = `${currentMsg} ${dim(helpText)}`;
 
 			let index = 0;
 			let dots = 1;
@@ -241,8 +243,11 @@ export const spinner = () => {
 			loop = setInterval(() => {
 				const frame = frames[(index = ++index % frames.length)];
 				dots = ++dots % maxDots;
-				logUpdate(`${color(frame)} ${msg} ${".".repeat(dots)}`);
+				logUpdate(`${color(frame)} ${currentMsg} ${".".repeat(dots)}`);
 			}, frameRate);
+		},
+		update(msg: string) {
+			currentMsg = msg;
 		},
 		stop: (msg: string) => {
 			// Write the final message and clear the loop

--- a/packages/create-cloudflare/src/helpers/poll.ts
+++ b/packages/create-cloudflare/src/helpers/poll.ts
@@ -1,0 +1,78 @@
+import { Resolver } from "node:dns/promises";
+import { request } from "undici";
+import { blue, brandColor, dim } from "./colors";
+import { spinner } from "./interactive";
+
+const TIMEOUT = 1000 * 60 * 5;
+const POLL_INTERVAL = 1000;
+
+export const poll = async (url: string): Promise<boolean> => {
+	const start = Date.now();
+	const domain = new URL(url).host;
+	const s = spinner();
+
+	s.start("Waiting for DNS to propagate");
+	while (Date.now() - start < TIMEOUT) {
+		s.update(`Waiting for DNS to propagate (${secondsSince(start)}s)`);
+		if (await dnsLookup(domain)) {
+			s.stop(`${brandColor("DNS propagation")} ${dim("complete")}.`);
+			break;
+		}
+		await sleep(POLL_INTERVAL);
+	}
+
+	s.start("Waiting for deployment to become available");
+	while (Date.now() - start < TIMEOUT) {
+		s.update(
+			`Waiting for deployment to become available (${secondsSince(start)}s)`
+		);
+		try {
+			const { statusCode } = await request(url, {
+				reset: true,
+				headers: { "Cache-Control": "no-cache" },
+			});
+			if (statusCode === 200) {
+				s.stop(
+					`${brandColor("deployment")} ${dim("is ready at:")} ${blue(url)}`
+				);
+				return true;
+			}
+		} catch (e) {
+			// Re-throw if the error is not ENOTFOUND
+			if ((e as { code: string }).code !== "ENOTFOUND") {
+				throw e;
+			}
+		}
+		await sleep(POLL_INTERVAL);
+	}
+
+	s.stop(
+		`${brandColor(
+			"timed out"
+		)} while waiting for ${url} - try accessing it in a few minutes.`
+	);
+	return false;
+};
+
+async function dnsLookup(domain: string): Promise<boolean> {
+	try {
+		const resolver = new Resolver({ timeout: TIMEOUT, tries: 1 });
+		resolver.setServers([
+			"1.1.1.1",
+			"1.0.0.1",
+			"2606:4700:4700::1111",
+			"2606:4700:4700::1001",
+		]);
+		return (await resolver.resolve4(domain)).length > 0;
+	} catch (e) {
+		return false;
+	}
+}
+
+async function sleep(ms: number) {
+	return new Promise((res) => setTimeout(res, ms));
+}
+
+function secondsSince(start: number): number {
+	return Math.round((Date.now() - start) / 1000);
+}

--- a/packages/create-cloudflare/src/types.ts
+++ b/packages/create-cloudflare/src/types.ts
@@ -9,6 +9,7 @@ export type PagesGeneratorArgs = {
 	frameworkChoices?: FrameworkName[];
 	deploy?: boolean;
 	ts?: boolean;
+	open: boolean;
 };
 
 export type PagesGeneratorContext = {


### PR DESCRIPTION
**What this PR solves / how to test:**

When create-cloudflare deploys to Pages, it can take a while before the website is ready to be viewed.
This change adds back in polling of the site and then opening a browser when the URL is ready.

Test by building create-cloudflare and then generating and deploying a web framework project that will deploy to Pages.

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
