### PR TITLE
[C3] Build before publishing

### DIFF
--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-cloudflare",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"description": "A CLI for creating and deploying new applications to Cloudflare.",
 	"keywords": [
 		"cloudflare",
@@ -29,6 +29,7 @@
 		"build": "node scripts/build.js",
 		"check:lint": "eslint .",
 		"check:type": "tsc --noEmit",
+		"prepublishOnly": "npm run build",
 		"test:e2e": "npm run build && vitest run --config ./vitest-e2e.config.ts",
 		"test:unit": "vitest run --config ./vitest.config.ts",
 		"watch": "node scripts/build.js --watch"


### PR DESCRIPTION
**What this PR solves / how to test:**

Adds a `prepublishOnly` task that builds before publishing. Also includes the manual version bump to `2.0.4` that was required for a hotfix (due to publishing not working).

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
