### PR TITLE
[C3] fix: use full Remix template URL

### DIFF
--- a/.changeset/mighty-goats-fry.md
+++ b/.changeset/mighty-goats-fry.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Use full Remix template URL rather than the `cloudflare-pages` shorthand since it will be removed in a future version of `create-remix`

--- a/packages/create-cloudflare/src/frameworks/remix/index.ts
+++ b/packages/create-cloudflare/src/frameworks/remix/index.ts
@@ -13,7 +13,7 @@ const generate = async (ctx: PagesGeneratorContext) => {
 
 	await runFrameworkGenerator(
 		ctx,
-		`${npx} create-remix@${version} ${ctx.project.name} --template cloudflare-pages`
+		`${npx} create-remix@${version} ${ctx.project.name} --template https://github.com/remix-run/remix/tree/main/templates/cloudflare-pages`
 	);
 
 	logRaw(""); // newline


### PR DESCRIPTION
**What this PR solves:**

With `create-remix` we're wanting to move away from having built-in templates, so your current usage of the CLI will break in the future.

In the next major version (which I'm currently working on) we're removing the template prompt entirely, and we're removing shorthands like `create-remix --template cloudflare-pages`. Instead, we're wanting to surface more of the community ecosystem, and allow third parties to take more ownership of their templates.

This PR is intended to future-proof the `--template` option so you don't need to worry about updating this when you upgrade in the future. This also helps to further normalise full URLs for Remix templates in the meantime until our next major release goes out.

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))