### PR TITLE
fix: c3 runs wrangler init --from-dash with --no-delegate-c3

### DIFF
--- a/packages/create-cloudflare/src/workers.ts
+++ b/packages/create-cloudflare/src/workers.ts
@@ -97,7 +97,7 @@ async function copyExistingWorkerFiles(ctx: Context) {
 			join(tmpdir(), "c3-wrangler-init--from-dash-")
 		);
 		await runCommand(
-			`npx wrangler@3 init --from-dash ${ctx.existingScript} -y`,
+			`npx wrangler@3 init --from-dash ${ctx.existingScript} -y --no-delegate-c3`,
 			{
 				silent: true,
 				cwd: tempdir, // use a tempdir because we don't want all the files


### PR DESCRIPTION
from wrangler@3 onwards, `--delegate-c3` defaults to true

however, when run from C3 we should set `--no-delegate-c3` to avoid an infinite loop