### PR TITLE
Fix off-white fallback color

### DIFF
--- a/packages/solarflare-theme/themes/cloudflare-light-color-theme.json
+++ b/packages/solarflare-theme/themes/cloudflare-light-color-theme.json
@@ -16,14 +16,16 @@
 		"statusBar.foreground": "#eeffff",
 		"tab.border": "#0051c30e",
 		"tab.activeBorder": "#0051c3",
-		"tab.inactiveBackground": "#f5f5f5"
+		"tab.inactiveBackground": "#f5f5f5",
+		"gitlens.gutterBackgroundColor": "#ff0000",
+		"gitlens.gutterForegroundColor": "#ff0000"
 	},
 	"tokenColors": [
 		{
 			"name": "Colors",
 			"scope": ["constant.other.color", "support.variable"],
 			"settings": {
-				"foreground": "#eeffff"
+				"foreground": "#FF8C00"
 			}
 		},
 		{
@@ -57,6 +59,19 @@
 			],
 			"settings": {
 				"foreground": "#00268f"
+			}
+		},
+		{
+			"name": "Support Tokens",
+			"scope": [
+				"support",
+				"support.variable",
+				"support.class",
+				"support.type",
+				"support.function"
+			],
+			"settings": {
+				"foreground": "#FF8C00"
 			}
 		},
 		{

--- a/packages/solarflare-theme/themes/cloudflare-light-color-theme.json
+++ b/packages/solarflare-theme/themes/cloudflare-light-color-theme.json
@@ -16,9 +16,7 @@
 		"statusBar.foreground": "#eeffff",
 		"tab.border": "#0051c30e",
 		"tab.activeBorder": "#0051c3",
-		"tab.inactiveBackground": "#f5f5f5",
-		"gitlens.gutterBackgroundColor": "#ff0000",
-		"gitlens.gutterForegroundColor": "#ff0000"
+		"tab.inactiveBackground": "#f5f5f5"
 	},
 	"tokenColors": [
 		{


### PR DESCRIPTION


Default color was an off-white which was basically invisible with the editors white background. The fallback color for the editor is now a contrasting orange.

Fixes # DEVX-700

**What this PR solves / how to test:**
In a JavaScript/TypeScript file in the new Quick Editor create a line of code like this 
```ts
RegEx(`\n data:${NAME.length}=(?<group>control|test);`).test(
  cookie
);
```
<img width="507" alt="Screenshot 2023-05-18 at 3 23 26 PM" src="https://github.com/cloudflare/workers-sdk/assets/27247160/4a3e4b87-57da-4c87-a083-a52f607d1e82">

The length is considered a "support variable" token which was not defined and therefore falling back to the "other" & "support" scope. 

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
