### PR TITLE
fix(create-cloudflare): use correct start command

### DIFF
--- a/.changeset/real-rockets-argue.md
+++ b/.changeset/real-rockets-argue.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: specify correct startup command in logs for newly created c3 projects

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -137,7 +137,7 @@ export const printSummary = async (ctx: PagesGeneratorContext) => {
 	const nextSteps = [
 		[
 			`Run the development server`,
-			`${npm} run ${ctx.framework?.config.devCommand ?? "dev"}`,
+			`${npm} run ${ctx.framework?.config.devCommand ?? "start"}`,
 		],
 		[
 			`Deploy your application`,


### PR DESCRIPTION
**What this PR solves / how to test:**

C3 would recommend to use `npm run dev` previously instead of `npm run start`, which is what all the templates use. Happy to invert this if preferred.

**Author has included the following, where applicable:**

- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
