### PR TITLE
[Pages] feat: add `wrangler pages project delete` command

### DIFF
--- a/.changeset/lazy-boxes-deny.md
+++ b/.changeset/lazy-boxes-deny.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: add `wrangler pages project delete` command

--- a/packages/wrangler/src/__tests__/pages/project-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-delete.test.ts
@@ -1,0 +1,103 @@
+import { rest } from "msw";
+import { endEventLoop } from "../helpers/end-event-loop";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { mockConfirm, clearDialogs } from "../helpers/mock-dialogs";
+import { useMockIsTTY } from "../helpers/mock-istty";
+import { msw } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+
+describe("project delete", () => {
+	const std = mockConsoleMethods();
+
+	runInTempDir();
+	mockAccountId();
+	mockApiToken();
+	const { setIsTTY } = useMockIsTTY();
+
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	afterEach(async () => {
+		// Force a tick to ensure that all promises resolve
+		await endEventLoop();
+		// Reset MSW after tick to ensure that all requests have been handled
+		msw.resetHandlers();
+		msw.restoreHandlers();
+		clearDialogs();
+	});
+
+	it("should delete a project with the given name", async () => {
+		msw.use(
+			rest.delete(
+				"*/accounts/:accountId/pages/projects/:projectName",
+				async (req, res, ctx) => {
+					expect(req.params.accountId).toEqual("some-account-id");
+					expect(req.params.projectName).toEqual("some-project-name");
+					return res.once(
+						ctx.status(200),
+						ctx.json({
+							result: null,
+							success: true,
+							errors: [],
+							messages: [],
+						})
+					);
+				}
+			)
+		);
+
+		mockConfirm({
+			text: `Are you sure you want to delete "some-project-name"? This action cannot be undone.`,
+			result: true,
+		});
+
+		await runWrangler("pages project delete some-project-name");
+
+		expect(std.out).toMatchInlineSnapshot(`
+		"Deleting some-project-name
+		Successfully deleted some-project-name"
+	`);
+	});
+
+	it("should not delete a project if confirmation refused", async () => {
+		mockConfirm({
+			text: `Are you sure you want to delete "some-project-name-2"? This action cannot be undone.`,
+			result: false,
+		});
+
+		await runWrangler("pages project delete some-project-name-2");
+
+		expect(std.out).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should delete a project without asking if --yes provided", async () => {
+		msw.use(
+			rest.delete(
+				"*/accounts/:accountId/pages/projects/:projectName",
+				async (req, res, ctx) => {
+					expect(req.params.accountId).toEqual("some-account-id");
+					expect(req.params.projectName).toEqual("some-project-name");
+					return res.once(
+						ctx.status(200),
+						ctx.json({
+							result: null,
+							success: true,
+							errors: [],
+							messages: [],
+						})
+					);
+				}
+			)
+		);
+
+		await runWrangler("pages project delete some-project-name -y");
+
+		expect(std.out).toMatchInlineSnapshot(`
+		"Deleting some-project-name
+		Successfully deleted some-project-name"
+	`);
+	});
+});

--- a/packages/wrangler/src/pages/index.ts
+++ b/packages/wrangler/src/pages/index.ts
@@ -62,6 +62,12 @@ export function pages(yargs: CommonYargsArgv) {
 						Projects.CreateOptions,
 						Projects.CreateHandler
 					)
+					.command(
+						"delete [project-name]",
+						"Delete a Cloudflare Pages project",
+						Projects.DeleteOptions,
+						Projects.DeleteHandler
+					)
 					.command("upload [directory]", false, Upload.Options, Upload.Handler)
 					.epilogue(pagesBetaWarning)
 			)


### PR DESCRIPTION
**What this PR solves / how to test:**

Adds a command to delete Pages projects from the command line 

**Associated docs issue(s)/PR(s):**

- https://github.com/cloudflare/cloudflare-docs/pull/8996

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
