### PR TITLE
Fix: Avoid unnecessary rebuilding pages functions in wrangler pages dev

### DIFF
--- a/.changeset/cuddly-weeks-behave.md
+++ b/.changeset/cuddly-weeks-behave.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix: Avoid unnecessary rebuilding pages functions in wrangler pages dev

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -150,6 +150,8 @@ export const Handler = async (args: PagesBuildArgs) => {
 				minify,
 				sourcemap,
 				fallbackService,
+				// This only watches already existing files using the esbuild watching mechanism
+				// it will not watch new files that are added to the functions directory!
 				watch,
 				plugin,
 				legacyNodeCompat,

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -298,7 +298,7 @@ export const Handler = async ({
 						nodejsCompat,
 						local: true,
 						sourcemap: true,
-						watch: true,
+						watch: false,
 						onEnd: () => scriptReadyResolve(),
 					});
 				} catch (e: unknown) {
@@ -339,7 +339,7 @@ export const Handler = async ({
 					outfile: scriptPath,
 					functionsDirectory,
 					sourcemap: true,
-					watch: true,
+					watch: false,
 					onEnd,
 					buildOutputDirectory: directory,
 					legacyNodeCompat,


### PR DESCRIPTION
Fixes #3258.

Avoid unnecessary rebuilding pages functions in wrangler pages dev

This was happening as we were using esbuild's watching mechanism + our own custom watcher which was causing high cpu usage and duplicate rebuilds on any file changes.

We have our own custom watcher setup in dev mode so that we can watch for new files that are added, as esbuild's watcher doesn't catch this

**Author has included the following, where applicable:**

- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
