### PR TITLE
fix: update deployment E2E tests for v3

### DIFF
--- a/packages/wrangler/e2e/deploy.test.ts
+++ b/packages/wrangler/e2e/deploy.test.ts
@@ -22,25 +22,16 @@ describe("deploy", async () => {
 
 	it("init worker", async () => {
 		const { stdout } = await runIn(root, { [workerName]: "smoke-test-worker" })`
-    $ ${RUN} init ${workerName}
+    $ ${RUN} init --yes --no-delegate-c3 ${workerName}
     `;
 		expect(stdout).toMatchInlineSnapshot(`
 			"Using npm as package manager.
 			✨ Created smoke-test-worker/wrangler.toml
-			? Would you like to use git to manage this Worker?
-			🤖 Using default value in non-interactive context: yes
 			✨ Initialized git repository at smoke-test-worker
-			? No package.json found. Would you like to create one?
-			🤖 Using default value in non-interactive context: yes
 			✨ Created smoke-test-worker/package.json
-			? Would you like to use TypeScript?
-			🤖 Using default value in non-interactive context: yes
 			✨ Created smoke-test-worker/tsconfig.json
-			? Would you like to create a Worker at smoke-test-worker/src/index.ts?
-			🤖 Using default value in non-interactive context: Fetch handler
 			✨ Created smoke-test-worker/src/index.ts
-			? Would you like us to write your first test with Vitest?
-			🤖 Using default value in non-interactive context: yes
+			Your project will use Vitest to run your tests.
 			✨ Created smoke-test-worker/src/index.test.ts
 
 			added (N) packages, and audited (N) packages in (TIMINGS)
@@ -62,7 +53,7 @@ describe("deploy", async () => {
 			stderr,
 			raw: { stdout: rawStdout },
 		} = await runIn(workerPath, { [workerName]: "smoke-test-worker" })`
-	  $ ${RUN} publish
+	  $ ${RUN} deploy
 	`;
 		expect(stdout).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
@@ -93,7 +84,7 @@ describe("deploy", async () => {
 			stderr,
 			raw: { stdout: rawStdout },
 		} = await runIn(workerPath, { [workerName]: "smoke-test-worker" })`
-	  $ ${RUN} publish
+	  $ ${RUN} deploy
 	`;
 		expect(stdout).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -35,25 +35,16 @@ describe("deployments", async () => {
 
 	it("init worker", async () => {
 		const { stdout } = await runIn(root, { [workerName]: "smoke-test-worker" })`
-    $ ${RUN} init ${workerName}
+    $ ${RUN} init --yes --no-delegate-c3 ${workerName}
     `;
 		expect(stdout).toMatchInlineSnapshot(`
 			"Using npm as package manager.
 			✨ Created smoke-test-worker/wrangler.toml
-			? Would you like to use git to manage this Worker?
-			🤖 Using default value in non-interactive context: yes
 			✨ Initialized git repository at smoke-test-worker
-			? No package.json found. Would you like to create one?
-			🤖 Using default value in non-interactive context: yes
 			✨ Created smoke-test-worker/package.json
-			? Would you like to use TypeScript?
-			🤖 Using default value in non-interactive context: yes
 			✨ Created smoke-test-worker/tsconfig.json
-			? Would you like to create a Worker at smoke-test-worker/src/index.ts?
-			🤖 Using default value in non-interactive context: Fetch handler
 			✨ Created smoke-test-worker/src/index.ts
-			? Would you like us to write your first test with Vitest?
-			🤖 Using default value in non-interactive context: yes
+			Your project will use Vitest to run your tests.
 			✨ Created smoke-test-worker/src/index.test.ts
 
 			added (N) packages, and audited (N) packages in (TIMINGS)
@@ -75,7 +66,7 @@ describe("deployments", async () => {
 			stderr,
 			raw: { stdout: rawStdout },
 		} = await runIn(workerPath, { [workerName]: "smoke-test-worker" })`
-	  $ ${RUN} publish
+	  $ ${RUN} deploy
 	`;
 		expect(stdout).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
@@ -127,7 +118,7 @@ describe("deployments", async () => {
 			stderr,
 			raw: { stdout: rawStdout },
 		} = await runIn(workerPath, { [workerName]: "smoke-test-worker" })`
-	  $ ${RUN} publish
+	  $ ${RUN} deploy
 	`;
 		expect(stdout).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB

--- a/packages/wrangler/e2e/vite.config.ts
+++ b/packages/wrangler/e2e/vite.config.ts
@@ -5,5 +5,7 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	test: {},
+	test: {
+		testTimeout: 60_000,
+	},
 });

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -63,7 +63,7 @@
 		"test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch",
 		"test:ci": "npm run test -- --coverage",
 		"test:debug": "npm run test -- --silent=false --verbose=true",
-		"test:e2e": "vitest --no-threads ./e2e"
+		"test:e2e": "vitest --single-thread ./e2e"
 	},
 	"jest": {
 		"coverageReporters": [


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR updates our manual E2E tests for v3.

- Adds appropriate flags to `wrangler init`
- Replaces `wrangler publish` with `wrangler deploy`
- Increases the test timeout to 1 minute to allow time for `workerd` to install on `init` tests (was also seeing some tests taking about ~15s)
- Use `--single-thread` instead of `--no-threads` with `vitest` upgrade (see https://vitest.dev/config/#singlethread)

**Associated docs issue(s)/PR(s):**

- N/A

**Author has included the following, where applicable:**

- [ ] ~~Tests~~ (updating existing)
- [ ] ~~Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~~ (internal change)

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
