### PR TITLE
d1: make experimental-backend flag consistent

### DIFF
--- a/.changeset/dull-carrots-shout.md
+++ b/.changeset/dull-carrots-shout.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fixed `wrangler d1 migrations` to use `--experimental-backend` and not `--experimentalBackend` so that it is consistent with `wrangler d1 create`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -457,7 +457,7 @@
 			"version": "0.0.0",
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20230419.0",
-				"wrangler": "3.0.0"
+				"wrangler": "3.0.1"
 			}
 		},
 		"fixtures/worker-ts/node_modules/@cloudflare/workers-types": {
@@ -4272,7 +4272,7 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -44582,7 +44582,7 @@
 			}
 		},
 		"packages/create-cloudflare": {
-			"version": "2.0.7",
+			"version": "2.0.8",
 			"license": "MIT OR Apache-2.0",
 			"bin": {
 				"create-cloudflare": "dist/cli.js"
@@ -44614,7 +44614,7 @@
 				"vite-tsconfig-paths": "^4.0.8",
 				"vitest": "^0.30.0",
 				"which-pm-runs": "^1.1.0",
-				"wrangler": "^3.0.0",
+				"wrangler": "^3.0.1",
 				"yargs": "^17.7.1"
 			},
 			"engines": {
@@ -46451,7 +46451,7 @@
 			"dev": true
 		},
 		"packages/wrangler": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "^0.2.0",
@@ -58538,7 +58538,7 @@
 				"is-unicode-supported": {
 					"version": "1.3.0",
 					"bundled": true,
-					"extraneous": true
+					"dev": true
 				}
 			}
 		},
@@ -65314,7 +65314,7 @@
 				"vite-tsconfig-paths": "^4.0.8",
 				"vitest": "^0.30.0",
 				"which-pm-runs": "^1.1.0",
-				"wrangler": "^3.0.0",
+				"wrangler": "^3.0.1",
 				"yargs": "^17.7.1"
 			},
 			"dependencies": {
@@ -92897,7 +92897,7 @@
 			"version": "file:fixtures/worker-ts",
 			"requires": {
 				"@cloudflare/workers-types": "^4.20230419.0",
-				"wrangler": "3.0.0"
+				"wrangler": "3.0.1"
 			},
 			"dependencies": {
 				"@cloudflare/workers-types": {

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -33,7 +33,7 @@ import type {
 
 export function ApplyOptions(yargs: CommonYargsArgv) {
 	return MigrationOptions(yargs)
-		.option("experimentalBackend", {
+		.option("experimental-backend", {
 			default: false,
 			describe: "Use new experimental DB backend",
 			type: "boolean",


### PR DESCRIPTION
* `create` uses `experimental-backend`
* Blog uses it
* Release notes use it: https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%403.0.0

Fixing to be consistent.
