### PR TITLE
[wrangler] Add compatibility flags option to pages create command

### DIFF
--- a/.changeset/tasty-pandas-cough.md
+++ b/.changeset/tasty-pandas-cough.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add a `--compatability-flags` option to the `pages project create` command

--- a/.changeset/tasty-pandas-cough.md
+++ b/.changeset/tasty-pandas-cough.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Add a `--compatibility-flags` option to the `pages project create` command
+Add the `--compatibility-flags` and `--compatibility-date` options to the `pages project create` command

--- a/.changeset/tasty-pandas-cough.md
+++ b/.changeset/tasty-pandas-cough.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Add a `--compatability-flags` option to the `pages project create` command
+Add a `--compatibility-flags` option to the `pages project create` command

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -32,6 +32,10 @@ describe("project create", () => {
 					expect(body).toEqual({
 						name: "a-new-project",
 						production_branch: "main",
+						deployment_configs: {
+							preview: {},
+							production: {},
+						},
 					});
 
 					return res.once(
@@ -41,9 +45,8 @@ describe("project create", () => {
 							errors: [],
 							messages: [],
 							result: {
-								name: "a-new-project",
+								...body,
 								subdomain: "a-new-project.pages.dev",
-								production_branch: "main",
 							},
 						})
 					);
@@ -66,6 +69,16 @@ describe("project create", () => {
 			rest.post(
 				"*/accounts/:accountId/pages/projects",
 				async (req, res, ctx) => {
+					const body = await req.json();
+					expect(body).toEqual({
+						name: "a-new-project",
+						production_branch: "main",
+						deployment_configs: {
+							production: { compatibility_flags: ["foo", "bar"] },
+							preview: { compatibility_flags: ["foo", "bar"] },
+						},
+					});
+
 					return res.once(
 						ctx.status(200),
 						ctx.json({
@@ -73,13 +86,8 @@ describe("project create", () => {
 							errors: [],
 							messages: [],
 							result: {
-								name: "a-new-project",
+								...body,
 								subdomain: "a-new-project.pages.dev",
-								production_branch: "main",
-								deployment_configs: {
-									production: { compatibility_flags: ["foo", "baz"] },
-									preview: { compatibility_flags: ["foo", "baz"] },
-								},
 							},
 						})
 					);
@@ -89,6 +97,47 @@ describe("project create", () => {
 
 		await runWrangler(
 			"pages project create a-new-project --production-branch=main --compatibility-flags foo bar"
+		);
+
+		expect(std.out).toMatchInlineSnapshot(`
+            "✨ Successfully created the 'a-new-project' project. It will be available at https://a-new-project.pages.dev/ once you create your first deployment.
+            To deploy a folder of assets, run 'wrangler pages deploy [directory]'."
+        `);
+	});
+
+	it("should create a project with a compatibility date", async () => {
+		msw.use(
+			rest.post(
+				"*/accounts/:accountId/pages/projects",
+				async (req, res, ctx) => {
+					const body = await req.json();
+					expect(body).toEqual({
+						name: "a-new-project",
+						production_branch: "main",
+						deployment_configs: {
+							production: { compatibility_date: "2022-03-08" },
+							preview: { compatibility_date: "2022-03-08" },
+						},
+					});
+
+					return res.once(
+						ctx.status(200),
+						ctx.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								...body,
+								subdomain: "a-new-project.pages.dev",
+							},
+						})
+					);
+				}
+			)
+		);
+
+		await runWrangler(
+			"pages project create a-new-project --production-branch=main --compatibility-date 2022-03-08"
 		);
 
 		expect(std.out).toMatchInlineSnapshot(`

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -60,4 +60,67 @@ describe("project create", () => {
             To deploy a folder of assets, run 'wrangler pages deploy [directory]'."
         `);
 	});
+
+	it("should create a project with compatibility flags", async () => {
+		msw.use(
+			rest.post(
+				"*/accounts/:accountId/pages/projects",
+				async (req, res, ctx) => {
+					return res.once(
+						ctx.status(200),
+						ctx.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								name: "a-new-project",
+								subdomain: "a-new-project.pages.dev",
+								production_branch: "main",
+							},
+						})
+					);
+				}
+			),
+			rest.patch(
+				"*/accounts/:accountId/pages/projects/a-new-project",
+				async (req, res, ctx) => {
+					const body = await req.json();
+
+					expect(body).toEqual({
+						deployment_configs: {
+							production: { compatibility_flags: ["foo", "bar"] },
+							preview: { compatibility_flags: ["foo", "bar"] },
+						},
+					});
+
+					return res.once(
+						ctx.status(200),
+						ctx.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								name: "a-new-project",
+								subdomain: "a-new-project.pages.dev",
+								production_branch: "main",
+								deployment_configs: {
+									production: { compatibility_flags: ["foo", "baz"] },
+									preview: { compatibility_flags: ["foo", "baz"] },
+								},
+							},
+						})
+					);
+				}
+			)
+		);
+
+		await runWrangler(
+			"pages project create a-new-project --production-branch=main --compatibility-flags foo bar"
+		);
+
+		expect(std.out).toMatchInlineSnapshot(`
+            "✨ Successfully created the 'a-new-project' project. It will be available at https://a-new-project.pages.dev/ once you create your first deployment.
+            To deploy a folder of assets, run 'wrangler pages deploy [directory]'."
+        `);
+	});
 });

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -76,33 +76,6 @@ describe("project create", () => {
 								name: "a-new-project",
 								subdomain: "a-new-project.pages.dev",
 								production_branch: "main",
-							},
-						})
-					);
-				}
-			),
-			rest.patch(
-				"*/accounts/:accountId/pages/projects/a-new-project",
-				async (req, res, ctx) => {
-					const body = await req.json();
-
-					expect(body).toEqual({
-						deployment_configs: {
-							production: { compatibility_flags: ["foo", "bar"] },
-							preview: { compatibility_flags: ["foo", "bar"] },
-						},
-					});
-
-					return res.once(
-						ctx.status(200),
-						ctx.json({
-							success: true,
-							errors: [],
-							messages: [],
-							result: {
-								name: "a-new-project",
-								subdomain: "a-new-project.pages.dev",
-								production_branch: "main",
 								deployment_configs: {
 									production: { compatibility_flags: ["foo", "baz"] },
 									preview: { compatibility_flags: ["foo", "baz"] },

--- a/packages/wrangler/src/pages/projects.tsx
+++ b/packages/wrangler/src/pages/projects.tsx
@@ -86,12 +86,20 @@ export function CreateOptions(yargs: CommonYargsArgv) {
 				type: "string",
 				description: "The name of the production branch of your project",
 			},
+			"compatibility-flags": {
+				describe: "Flags to use for compatibility checks",
+				alias: "compatibility-flag",
+				type: "string",
+				requiresArg: true,
+				array: true,
+			},
 		})
 		.epilogue(pagesBetaWarning);
 }
 
 export async function CreateHandler({
 	productionBranch,
+	compatibilityFlags,
 	projectName,
 }: StrictYargsOptionsToInterface<typeof CreateOptions>) {
 	const config = getConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME);
@@ -143,6 +151,21 @@ export async function CreateHandler({
 			}),
 		}
 	);
+
+	if (compatibilityFlags) {
+		await fetchResult<Project>(
+			`/accounts/${accountId}/pages/projects/${projectName}`,
+			{
+				method: "PATCH",
+				body: JSON.stringify({
+					deployment_configs: {
+						production: { compatibility_flags: [...compatibilityFlags] },
+						preview: { compatibility_flags: [...compatibilityFlags] },
+					},
+				}),
+			}
+		);
+	}
 
 	saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
 		account_id: accountId,

--- a/packages/wrangler/src/pages/projects.tsx
+++ b/packages/wrangler/src/pages/projects.tsx
@@ -141,31 +141,25 @@ export async function CreateHandler({
 		throw new FatalError("Must specify a production branch.", 1);
 	}
 
+	const body: Partial<Project> = {
+		name: projectName,
+		production_branch: productionBranch,
+	};
+
+	if (compatibilityFlags) {
+		body.deployment_configs = {
+			production: { compatibility_flags: [...compatibilityFlags] },
+			preview: { compatibility_flags: [...compatibilityFlags] },
+		};
+	}
+
 	const { subdomain } = await fetchResult<Project>(
 		`/accounts/${accountId}/pages/projects`,
 		{
 			method: "POST",
-			body: JSON.stringify({
-				name: projectName,
-				production_branch: productionBranch,
-			}),
+			body: JSON.stringify(body),
 		}
 	);
-
-	if (compatibilityFlags) {
-		await fetchResult<Project>(
-			`/accounts/${accountId}/pages/projects/${projectName}`,
-			{
-				method: "PATCH",
-				body: JSON.stringify({
-					deployment_configs: {
-						production: { compatibility_flags: [...compatibilityFlags] },
-						preview: { compatibility_flags: [...compatibilityFlags] },
-					},
-				}),
-			}
-		);
-	}
 
 	saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
 		account_id: accountId,

--- a/packages/wrangler/src/pages/types.ts
+++ b/packages/wrangler/src/pages/types.ts
@@ -2,6 +2,7 @@ type DeploymentConfig = {
 	d1_databases?: Record<string, { id: string }>;
 	compatibility_flags?: string[];
 	compatibility_flag?: string;
+	compatibility_date?: string;
 };
 
 export type Project = {

--- a/packages/wrangler/src/pages/types.ts
+++ b/packages/wrangler/src/pages/types.ts
@@ -1,3 +1,9 @@
+type DeploymentConfig = {
+	d1_databases?: Record<string, { id: string }>;
+	compatibility_flags?: string[];
+	compatibility_flag?: string;
+};
+
 export type Project = {
 	name: string;
 	subdomain: string;
@@ -11,9 +17,8 @@ export type Project = {
 	created_on: string;
 	production_branch: string;
 	deployment_configs?: {
-		production?: {
-			d1_databases?: Record<string, { id: string }>;
-		};
+		production?: DeploymentConfig;
+		preview?: DeploymentConfig;
 	};
 };
 export type Deployment = {


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR adds the ability to specify a `--compatability-flags` option to `wrangler pages project create` so that we can support project creation workflows that don't involve visiting the dashboard. In particular we need this for c3 where some of the frameworks we support require the `nodejs_compat` flag. 

This work would [unblock this PR](https://github.com/cloudflare/workers-sdk/pull/3245) which bumps c3 support to the latest version of `nextjs`.

**Associated docs issue(s)/PR(s):**

- https://github.com/cloudflare/workers-sdk/pull/3245

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
