### PR TITLE
[wrangler] set additional c3 args to respect -y flag

### DIFF
--- a/.changeset/grumpy-rats-walk.md
+++ b/.changeset/grumpy-rats-walk.md
@@ -1,0 +1,6 @@
+---
+"create-cloudflare": patch
+"wrangler": patch
+---
+
+Allow wrangler to run C3 with additional flags to respect non-interactive flow when --yes/-y flag is set

--- a/.changeset/strange-buses-perform.md
+++ b/.changeset/strange-buses-perform.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Allow C3 to use the current working directory (cwd)

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -46,8 +46,11 @@ const parseArgs = async (argv: string[]) => {
 		.option("open", {
 			type: "boolean",
 			default: true,
-			description:
-				"opens your browser after your deployment, set --no-open to disable",
+			description: "Opens your browser after your deployment",
+		})
+		.option("existing-script", {
+			type: "string",
+			hidden: templateMap["pre-existing"].hidden,
 		})
 		.help().argv;
 

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -71,9 +71,15 @@ const validateName = async (name: string | undefined): Promise<string> => {
 			return `${brandColor("dir")} ${dim(value)}`;
 		},
 		defaultValue: haikunator.haikunate({ tokenHex: true }),
-		validate: (value: string) => {
-			if (value && existsSync(resolve(value))) {
-				return `\`${value}\` already exists. Please choose a new folder. `;
+		validate: (path: string) => {
+			if (!path) return; // will use default value
+
+			const absolutePath = resolve(path);
+			const isCWD = absolutePath === process.cwd();
+			const existsAlready = existsSync(absolutePath);
+
+			if (!isCWD && existsAlready) {
+				return `\`${path}\` already exists. Please choose a new folder. `;
 			}
 		},
 	});

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -31,8 +31,10 @@ const { npm } = detectPackageManager();
 export const setupProjectDirectory = (args: PagesGeneratorArgs) => {
 	// Crash if the directory already exists
 	const path = resolve(args.projectName);
+	const isCWD = path === process.cwd();
+	const existsAlready = existsSync(path);
 
-	if (existsSync(path)) {
+	if (!isCWD && existsAlready) {
 		crash(
 			`Directory \`${args.projectName}\` already exists. Please choose a new name.`
 		);
@@ -41,16 +43,13 @@ export const setupProjectDirectory = (args: PagesGeneratorArgs) => {
 	const directory = dirname(path);
 	const name = basename(path);
 
-	// resolve the relative path so we can give the user nice instructions
-	const relativePath = relative(process.cwd(), path);
-
 	// If the target is a nested directory, create the parent
 	mkdirSync(directory, { recursive: true });
 
 	// Change to the parent directory
 	chdir(directory);
 
-	return { name, relativePath, path };
+	return { name, path };
 };
 
 export const offerToDeploy = async (ctx: PagesGeneratorContext) => {

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync } from "fs";
-import { basename, dirname, relative, resolve } from "path";
+import { basename, dirname, resolve } from "path";
 import { chdir } from "process";
 import {
 	crash,

--- a/packages/create-cloudflare/src/pages.ts
+++ b/packages/create-cloudflare/src/pages.ts
@@ -34,14 +34,13 @@ const defaultFrameworkConfig = {
 };
 
 export const runPagesGenerator = async (args: PagesGeneratorArgs) => {
-	const { name, relativePath, path } = setupProjectDirectory(args);
+	const { name, path } = setupProjectDirectory(args);
 	const framework = await getFrameworkSelection(args);
 
 	const frameworkConfig = FrameworkMap[framework];
 	const ctx: PagesGeneratorContext = {
 		project: {
 			name,
-			relativePath,
 			path,
 		},
 		framework: {

--- a/packages/create-cloudflare/src/types.ts
+++ b/packages/create-cloudflare/src/types.ts
@@ -11,6 +11,7 @@ export type PagesGeneratorArgs = {
 	ts?: boolean;
 	open: boolean;
 	git?: boolean;
+	existingScript?: string;
 };
 
 export type PagesGeneratorContext = {
@@ -29,7 +30,6 @@ export type PagesGeneratorContext = {
 		path: string;
 		relativePath: string;
 	};
-	existingScript?: string;
 };
 
 export type FrameworkConfig = {

--- a/packages/create-cloudflare/src/types.ts
+++ b/packages/create-cloudflare/src/types.ts
@@ -28,7 +28,6 @@ export type PagesGeneratorContext = {
 	project: {
 		name: string;
 		path: string;
-		relativePath: string;
 	};
 };
 

--- a/packages/create-cloudflare/src/workers.ts
+++ b/packages/create-cloudflare/src/workers.ts
@@ -21,10 +21,10 @@ import type {
 } from "types";
 
 export const runWorkersGenerator = async (args: Args) => {
-	const { name, path, relativePath } = setupProjectDirectory(args);
+	const { name, path } = setupProjectDirectory(args);
 
 	const ctx: Context = {
-		project: { name, relativePath, path },
+		project: { name, path },
 		args,
 	};
 

--- a/packages/create-cloudflare/src/workers.ts
+++ b/packages/create-cloudflare/src/workers.ts
@@ -85,8 +85,8 @@ async function copyExistingWorkerFiles(ctx: Context) {
 	if (preexisting) {
 		await chooseAccount(ctx);
 
-		if (ctx.existingScript === undefined) {
-			ctx.existingScript = await textInput({
+		if (ctx.args.existingScript === undefined) {
+			ctx.args.existingScript = await textInput({
 				question:
 					"Please specify the name of the existing worker in this account?",
 				renderSubmitted: (value) =>
@@ -101,14 +101,14 @@ async function copyExistingWorkerFiles(ctx: Context) {
 			join(tmpdir(), "c3-wrangler-init--from-dash-")
 		);
 		await runCommand(
-			`npx wrangler@3 init --from-dash ${ctx.existingScript} -y --no-delegate-c3`,
+			`npx wrangler@3 init --from-dash ${ctx.args.existingScript} -y --no-delegate-c3`,
 			{
 				silent: true,
 				cwd: tempdir, // use a tempdir because we don't want all the files
 				env: { CLOUDFLARE_ACCOUNT_ID: ctx.account?.id },
 				startText: "Downloading existing worker files",
 				doneText: `${brandColor("downloaded")} ${dim(
-					`existing "${ctx.existingScript}" worker files`
+					`existing "${ctx.args.existingScript}" worker files`
 				)}`,
 			}
 		);
@@ -120,14 +120,14 @@ async function copyExistingWorkerFiles(ctx: Context) {
 
 		// copy src/* files from the downloaded worker
 		await cp(
-			join(tempdir, ctx.existingScript, "src"),
+			join(tempdir, ctx.args.existingScript, "src"),
 			join(ctx.project.path, "src"),
 			{ recursive: true }
 		);
 
 		// copy wrangler.toml from the downloaded worker
 		await cp(
-			join(tempdir, ctx.existingScript, "wrangler.toml"),
+			join(tempdir, ctx.args.existingScript, "wrangler.toml"),
 			join(ctx.project.path, "wrangler.toml")
 		);
 	}

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -113,7 +113,7 @@ describe("init", () => {
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 . -- --type simple --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -152,7 +152,7 @@ describe("init", () => {
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 . -- --type simple --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -189,7 +189,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 . -- --type simple --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -658,7 +658,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 . -- --type simple --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -690,7 +690,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker/my-worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 . -- --type simple --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2232,7 +2232,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 . -- --type simple --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2268,7 +2268,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 . -- --type simple --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2306,7 +2306,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd WEIRD_w0rkr_N4m3.js.tsx.tar.gz && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 . -- --type simple --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -113,7 +113,7 @@ describe("init", () => {
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -152,7 +152,7 @@ describe("init", () => {
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -189,7 +189,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -658,7 +658,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -690,7 +690,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker/my-worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2232,7 +2232,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2268,7 +2268,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2306,7 +2306,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd WEIRD_w0rkr_N4m3.js.tsx.tar.gz && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --ts --git --no-deploy\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2768,8 +2768,8 @@ describe("init", () => {
 			  "debug": "",
 			  "err": "",
 			  "info": "",
-			  "out": "Running \`mockpm create cloudflare@2 existing-memory-crystal -- --type pre-existing\`...",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init --from-dash\` command is no longer supported. Please use \`mockpm create cloudflare@2 existing-memory-crystal -- --type pre-existing\` instead.[0m
+			  "out": "Running \`mockpm create cloudflare@2 existing-memory-crystal -- --type pre-existing --existing-script existing-memory-crystal\`...",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init --from-dash\` command is no longer supported. Please use \`mockpm create cloudflare@2 existing-memory-crystal -- --type pre-existing --existing-script existing-memory-crystal\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -132,6 +132,7 @@ export async function initHandler(args: InitArgs) {
 		throw new CommandLineArgsError(message);
 	}
 
+	const yesFlag = args.yes ?? false;
 	const devDepsToInstall: string[] = [];
 	const instructions: string[] = [];
 	let shouldRunPackageManagerInstall = false;
@@ -207,7 +208,13 @@ export async function initHandler(args: InitArgs) {
 			"--",
 			"--type",
 			"pre-existing",
+			"--existing-script",
+			fromDashScriptName,
 		];
+
+		if (yesFlag) {
+			c3Arguments.push("--ts", "--git", "--no-deploy");
+		}
 
 		// Deprecate the `init --from-dash` command
 		const replacementC3Command = `\`${packageManager.type} ${c3Arguments.join(
@@ -243,9 +250,25 @@ export async function initHandler(args: InitArgs) {
 	} else {
 		// Deprecate the `init` command
 		//    if a wrangler.toml file does not exist (C3 expects to scaffold *new* projects)
-		//    and if --from-dash is not set (C3 will run wrangler to communicate with the API)
+		//    and if --from-dash is not set (C3 will run wrangler with --from-dash to communicate with the API)
 		if (!fromDashScriptName) {
-			const replacementC3Command = `\`${packageManager.type} create cloudflare@2\``;
+			const c3Arguments = ["create", "cloudflare@2"];
+
+			if (yesFlag) {
+				c3Arguments.push(
+					".",
+					"--",
+					"--type",
+					"simple",
+					"--ts",
+					"--git",
+					"--no-deploy"
+				);
+			}
+
+			const replacementC3Command = `\`${packageManager.type} ${c3Arguments.join(
+				" "
+			)}\``;
 
 			logger.warn(
 				`The \`init\` command is no longer supported. Please use ${replacementC3Command} instead.\nThe \`init\` command will be removed in a future version.`
@@ -254,7 +277,7 @@ export async function initHandler(args: InitArgs) {
 			if (args.delegateC3) {
 				logger.log(`Running ${replacementC3Command}...`);
 
-				await execa(packageManager.type, ["create", "cloudflare@2"], {
+				await execa(packageManager.type, c3Arguments, {
 					stdio: "inherit",
 				});
 
@@ -287,8 +310,6 @@ export async function initHandler(args: InitArgs) {
 			);
 		}
 	}
-
-	const yesFlag = args.yes ?? false;
 
 	if (!(await isInsideGitRepo(creationDirectory)) && (await getGitVersioon())) {
 		const shouldInitGit =


### PR DESCRIPTION
Fixes #3333 #3319 

**What this PR solves / how to test:**

When `wrangler init ... -y` delegates to C3, it now sets enough args to skip all prompts in C3.

Test by running `wrangler init -y` or `wrangler init --from-dash test -y` and confirm the process exits without user input.

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
