### PR TITLE
Report correct IP & port in local mode

### DIFF
--- a/.changeset/slow-beans-wink.md
+++ b/.changeset/slow-beans-wink.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Report correct IP & port in local mode
+
+In remote mode, the onReady callback was being incorrectly called with the remote host, rather than the local host of the proxy server. It was also only called with the pre port-assignment port, which is sometimes 0. This meant that the browser hotkey sometimes opened a remote route, rather the local proxy. Now, the borwser hotkey will always open the local proxy.

--- a/.changeset/slow-beans-wink.md
+++ b/.changeset/slow-beans-wink.md
@@ -4,4 +4,4 @@
 
 fix: Report correct IP & port in local mode
 
-In remote mode, the onReady callback was being incorrectly called with the remote host, rather than the local host of the proxy server. It was also only called with the pre port-assignment port, which is sometimes 0. This meant that the browser hotkey sometimes opened a remote route, rather the local proxy. Now, the borwser hotkey will always open the local proxy.
+In remote mode, the onReady callback was being incorrectly called with the remote host, rather than the local host of the proxy server. It was also only called with the pre port-assignment port, which is sometimes 0. This meant that the browser hotkey sometimes opened a remote route, rather the local proxy. Now, the browser hotkey will always open the local proxy.

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -83,7 +83,6 @@ export function Remote(props: RemoteProps) {
 		zone: props.zone,
 		host: props.host,
 		routes: props.routes,
-		onReady: props.onReady,
 		sendMetrics: props.sendMetrics,
 		port: props.port,
 	});
@@ -96,6 +95,7 @@ export function Remote(props: RemoteProps) {
 		localProtocol: props.localProtocol,
 		localPort: props.port,
 		ip: props.ip,
+		onReady: props.onReady,
 	});
 
 	useInspector({
@@ -172,7 +172,6 @@ interface RemoteWorkerProps {
 	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
-	onReady: ((ip: string, port: number) => void) | undefined;
 	sendMetrics: boolean | undefined;
 	port: number;
 }
@@ -187,8 +186,6 @@ export function useWorker(
 	// something's "happened" in our system; We make a ref and
 	// mark it once we log our initial message. Refs are vars!
 	const startedRef = useRef(false);
-	// functions must be destructured before use inside a useEffect, otherwise the entire props object has to be added to the dependency array
-	const { onReady } = props;
 	// This effect sets up the preview session
 	useEffect(() => {
 		const abortController = new AbortController();
@@ -323,7 +320,6 @@ export function useWorker(
 				});
 			}
 			*/
-			onReady?.(props.host || "localhost", props.port);
 		}
 		start().catch((err) => {
 			// we want to log the error, but not end the process
@@ -375,7 +371,6 @@ export function useWorker(
 		props.host,
 		props.routes,
 		session,
-		onReady,
 		props.sendMetrics,
 		props.port,
 	]);

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -194,12 +194,14 @@ export function usePreviewServer({
 	localProtocol,
 	localPort: port,
 	ip,
+	onReady,
 }: {
 	previewToken: CfPreviewToken | undefined;
 	assetDirectory: string | undefined;
 	localProtocol: "https" | "http";
 	localPort: number;
 	ip: string;
+	onReady: ((finalIp: string, finalPort: number) => void) | undefined;
 }) {
 	/** Creates an HTTP/1 proxy that sends requests over HTTP/2. */
 	const [proxy, setProxy] = useState<PreviewProxy>();
@@ -299,6 +301,7 @@ export function usePreviewServer({
 					const usedPort =
 						address && typeof address === "object" ? address.port : port;
 					logger.log(`⬣ Listening at ${localProtocol}://${ip}:${usedPort}`);
+					onReady?.(ip, usedPort);
 					const accessibleHosts =
 						ip !== "0.0.0.0" ? [ip] : getAccessibleHosts();
 					for (const accessibleHost of accessibleHosts) {
@@ -321,7 +324,7 @@ export function usePreviewServer({
 				.terminate()
 				.catch(() => logger.error("Failed to terminate the proxy server."));
 		};
-	}, [port, ip, proxy, localProtocol]);
+	}, [port, ip, proxy, localProtocol, onReady]);
 }
 
 function configureProxyServer({


### PR DESCRIPTION
Fixes #2610

**What this PR solves / how to test:**

In remote mode, the `onReady` callback was being incorrectly called with the remote host, rather than the local host of the proxy server. It was also only called with the pre port-assignment port, which is sometimes `0`.

**Author has included the following, where applicable:**

- ~[ ] Tests~
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
