### PR TITLE
[c3] handle trailing whitespace in runCommand helper

### DIFF
--- a/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
@@ -48,6 +48,15 @@ describe("Command Helpers", () => {
 	test("runCommand", async () => {
 		await runCommand("ls -l");
 		expectSpawnWith("ls -l");
+
+		await runCommand(" ls -l ");
+		expectSpawnWith("ls -l");
+
+		await runCommand(" ls  -l ");
+		expectSpawnWith("ls -l");
+
+		await runCommand(" ls \t -l ");
+		expectSpawnWith("ls -l");
 	});
 
 	test("installWrangler", async () => {

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -26,7 +26,7 @@ export const runCommand = async (
 		s.start(opts?.startText || command);
 	}
 
-	const [executable, ...args] = command.trim().split(" ");
+	const [executable, ...args] = command.trim().replace(/\s+/g, ` `).split(" ");
 
 	const squelch = opts?.silent || process.env.VITEST;
 

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -26,7 +26,7 @@ export const runCommand = async (
 		s.start(opts?.startText || command);
 	}
 
-	const [executable, ...args] = command.split(" ");
+	const [executable, ...args] = command.trim().split(" ");
 
 	const squelch = opts?.silent || process.env.VITEST;
 


### PR DESCRIPTION
**What this PR solves / how to test:**

Fixes a regression introduced by [4082cfcb](https://github.com/cloudflare/workers-sdk/commit/4082cfcbdf08740d4a608d3d87df22e51ad0ce4a) that breaks any framework not using compatibility flags. This introduces some code which invokes `runCommand` with trailing whitespace, which it incorrectly interprets as an extra command line argument. This in turn causes `wrangler pages project create` to fail unless compat flags are specified.

**Associated docs issue(s)/PR(s):**

- https://github.com/cloudflare/workers-sdk/pull/3245
- 
**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
