### PR TITLE
[C3] fix: use a valid compatibility date for worker templates

### DIFF
--- a/.changeset/small-lies-thank.md
+++ b/.changeset/small-lies-thank.md
@@ -1,0 +1,14 @@
+---
+"create-cloudflare": patch
+---
+
+fix: use a valid compatibility date for worker templates
+
+Previously, we changed wrangler.toml to use the current date for the
+compatibility_date setting in wrangler.toml when generating workers.
+But this is almost always going to be too recent and results in a warning.
+
+Now we look up the most recent compatibility date via npm on the workerd
+package and use that instead.
+
+Fixes https://github.com/cloudflare/workers-sdk/issues/2385

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,6 +42,7 @@
 		"webassemblymemory",
 		"websockets",
 		"xxhash",
+		"workerd",
 		"zjcompt"
 	],
 	"cSpell.ignoreWords": [

--- a/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
@@ -178,6 +178,14 @@ describe("Command Helpers", () => {
 			expect(date).toBe("2023-05-18");
 		});
 
+		test("verbose output (e.g. yarn or debug mode)", async () => {
+			spawnStdout =
+				"Debugger attached.\nyarn info v1.22.19\n2.20250110.5\n✨  Done in 0.83s.";
+			const date = await getWorkerdCompatibilityDate();
+			expectSpawnWith("npm info workerd dist-tags.latest");
+			expect(date).toBe("2025-01-10");
+		});
+
 		test("command failed", async () => {
 			spawnResultCode = 1;
 			const date = await getWorkerdCompatibilityDate();

--- a/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
@@ -3,31 +3,51 @@ import { detectPackageManager } from "helpers/packages";
 import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
 import whichPMRuns from "which-pm-runs";
 import {
+	getWorkerdCompatibilityDate,
 	installPackages,
 	installWrangler,
 	npmInstall,
 	runCommand,
 } from "../command";
 
+// We can change how the mock spawn works by setting these variables
+let spawnResultCode = 0;
+let spawnStdout: string | undefined = undefined;
+let spawnStderr: string | undefined = undefined;
+
 describe("Command Helpers", () => {
 	afterEach(() => {
 		vi.clearAllMocks();
+		spawnResultCode = 0;
+		spawnStdout = undefined;
+		spawnStderr = undefined;
 	});
 
 	beforeEach(() => {
 		// Mock out the child_process.spawn function
 		vi.mock("cross-spawn", () => {
-			const mockedSpawn = vi.fn().mockImplementation(() => ({
-				on: vi.fn().mockImplementation((event, cb) => {
-					if (event === "close") {
-						cb(0);
-					}
-				}),
-			}));
+			const mockedSpawn = vi.fn().mockImplementation(() => {
+				return {
+					on: vi.fn().mockImplementation((event, cb) => {
+						if (event === "close") {
+							cb(spawnResultCode);
+						}
+					}),
+					stdout: {
+						on(event: "data", cb: (data: string) => void) {
+							spawnStdout !== undefined && cb(spawnStdout);
+						},
+					},
+					stderr: {
+						on(event: "data", cb: (data: string) => void) {
+							spawnStderr !== undefined && cb(spawnStderr);
+						},
+					},
+				};
+			});
 
 			return { spawn: mockedSpawn };
 		});
-
 		vi.mock("which-pm-runs");
 		vi.mocked(whichPMRuns).mockReturnValue({ name: "npm", version: "8.3.1" });
 
@@ -140,6 +160,29 @@ describe("Command Helpers", () => {
 			expect(pm.npm).toBe("yarn");
 			expect(pm.npx).toBe("yarn");
 			expect(pm.dlx).toBe("yarn");
+		});
+	});
+
+	describe("getWorkerdCompatibilityDate()", () => {
+		test("normal flow", async () => {
+			spawnStdout = "2.20250110.5";
+			const date = await getWorkerdCompatibilityDate();
+			expectSpawnWith("npm info workerd dist-tags.latest");
+			expect(date).toBe("2025-01-10");
+		});
+
+		test("empty result", async () => {
+			spawnStdout = "";
+			const date = await getWorkerdCompatibilityDate();
+			expectSpawnWith("npm info workerd dist-tags.latest");
+			expect(date).toBe("2023-05-18");
+		});
+
+		test("command failed", async () => {
+			spawnResultCode = 1;
+			const date = await getWorkerdCompatibilityDate();
+			expectSpawnWith("npm info workerd dist-tags.latest");
+			expect(date).toBe("2023-05-18");
 		});
 	});
 });

--- a/packages/create-cloudflare/src/workers.ts
+++ b/packages/create-cloudflare/src/workers.ts
@@ -4,7 +4,11 @@ import { resolve, join } from "path";
 import { chdir } from "process";
 import { endSection, updateStatus, startSection } from "helpers/cli";
 import { brandColor, dim } from "helpers/colors";
-import { npmInstall, runCommand } from "helpers/command";
+import {
+	getWorkerdCompatibilityDate,
+	npmInstall,
+	runCommand,
+} from "helpers/command";
 import { confirmInput, textInput } from "helpers/interactive";
 import {
 	chooseAccount,
@@ -149,12 +153,14 @@ async function updateFiles(ctx: Context) {
 	};
 
 	// update files
-	contents.packagejson.name = ctx.project.name;
+	if (contents.packagejson.name === "<TBD>") {
+		contents.packagejson.name = ctx.project.name;
+	}
 	contents.wranglertoml = contents.wranglertoml
-		.replace(/^name = .+$/m, `name = "${ctx.project.name}"`)
+		.replace(/^name\s*=\s*"<TBD>"/m, `name = "${ctx.project.name}"`)
 		.replace(
-			/^compatibility_date = .+$/m,
-			`compatibility_date = "${new Date().toISOString().substring(0, 10)}"`
+			/^compatibility_date\s*=\s*"<TBD>"/m,
+			`compatibility_date = "${await getWorkerdCompatibilityDate()}"`
 		);
 
 	// write files

--- a/packages/create-cloudflare/templates/chatgptPlugin/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/chatgptPlugin/ts/wrangler.toml
@@ -1,3 +1,3 @@
-name = "cloudflare-workers-chatgpt-plugin-example"
+name = "<TBD>"
 main = "src/index.ts"
-compatibility_date = "2023-04-07"
+compatibility_date = "<TBD>"

--- a/packages/create-cloudflare/templates/common/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/common/js/wrangler.toml
@@ -1,6 +1,6 @@
 name = "<TBD>"
 main = "src/worker.js"
-compatibility_date = "2023-04-21"
+compatibility_date = "<TBD>"
 
 # Variable bindings. These are arbitrary, plaintext strings (similar to environment variables)
 # Note: Use secrets to store sensitive data.

--- a/packages/create-cloudflare/templates/common/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/common/ts/wrangler.toml
@@ -1,6 +1,6 @@
 name = "<TBD>"
 main = "src/worker.ts"
-compatibility_date = "2023-04-21"
+compatibility_date = "<TBD>"
 
 # Variable bindings. These are arbitrary, plaintext strings (similar to environment variables)
 # Note: Use secrets to store sensitive data.

--- a/packages/create-cloudflare/templates/hello-world/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world/js/wrangler.toml
@@ -1,6 +1,6 @@
 name = "<TBD>"
 main = "src/worker.js"
-compatibility_date = "2023-04-21"
+compatibility_date = "<TBD>"
 
 # Variable bindings. These are arbitrary, plaintext strings (similar to environment variables)
 # Note: Use secrets to store sensitive data.

--- a/packages/create-cloudflare/templates/hello-world/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world/ts/wrangler.toml
@@ -1,6 +1,6 @@
 name = "<TBD>"
 main = "src/worker.ts"
-compatibility_date = "2023-04-21"
+compatibility_date = "<TBD>"
 
 # Variable bindings. These are arbitrary, plaintext strings (similar to environment variables)
 # Note: Use secrets to store sensitive data.

--- a/packages/create-cloudflare/templates/queues/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/queues/js/wrangler.toml
@@ -1,6 +1,6 @@
 name = "<TBD>"
 main = "src/worker.js"
-compatibility_date = "2023-05-15"
+compatibility_date = "<TBD>"
 
 # Bind a Queue producer. Use this binding to schedule an arbitrary task that may be processed later by a Queue consumer.
 # Docs: https://developers.cloudflare.com/queues/get-started

--- a/packages/create-cloudflare/templates/queues/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/queues/ts/wrangler.toml
@@ -1,6 +1,6 @@
 name = "<TBD>"
 main = "src/worker.ts"
-compatibility_date = "2023-05-15"
+compatibility_date = "<TBD>"
 
 # Bind a Queue producer. Use this binding to schedule an arbitrary task that may be processed later by a Queue consumer.
 # Docs: https://developers.cloudflare.com/queues/get-started

--- a/packages/create-cloudflare/templates/scheduled/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/scheduled/js/wrangler.toml
@@ -1,6 +1,6 @@
 name = "<TBD>"
 main = "src/worker.ts"
-compatibility_date = "2023-05-15"
+compatibility_date = "<TBD>"
 
 # Cron Triggers
 # Docs: https://developers.cloudflare.com/workers/platform/triggers/cron-triggers/


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/2385

**What this PR solves / how to test:**

Previously, we changed wrangler.toml to use the current date for the compatibility_date setting in wrangler.toml when generating workers. But this is almost always going to be new recent and results in a warning.

Now we look up the most recent compatibility date via npm on the workerd package and use that instead.

To test, build the create-cloudflare-package and then use it to build a workers project.
Check that the output displays:

```
├ Retrieving current workerd compatibility date 
│ compatibility date 2023-05-18
```

And that the generated wrangler.toml contains this date:

```toml
compatibility_date = "2023-05-18"
```

**Associated docs issue(s)/PR(s):**

- N/A

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
