### PR TITLE
Add e2e tests to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,3 +53,46 @@ jobs:
           TMP_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TMP_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           NODE_OPTIONS: "--max_old_space_size=8192"
+  e2e-test:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    name: "E2E Test"
+    strategy:
+      matrix:
+        os:
+          [
+            macos-11,
+            macos-12,
+            macos-13,
+            windows-2019,
+            windows-2022,
+            ubuntu-20.04,
+            ubuntu-22.04,
+          ]
+        node: ["16", "18"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: cd packages/wrangler && npm run test:e2e
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
+          NODE_OPTIONS: "--max_old_space_size=8192"

--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -113,3 +113,46 @@ jobs:
 
       - name: Report Code Coverage
         uses: codecov/codecov-action@v3
+  e2e-test:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    name: "E2E Test"
+    strategy:
+      matrix:
+        os:
+          [
+            macos-11,
+            macos-12,
+            macos-13,
+            windows-2019,
+            windows-2022,
+            ubuntu-20.04,
+            ubuntu-22.04,
+          ]
+        node: ["16", "18"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: cd packages/wrangler && npm run test:e2e
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
+          NODE_OPTIONS: "--max_old_space_size=8192"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38548,9 +38548,9 @@
 			}
 		},
 		"node_modules/shellac": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/shellac/-/shellac-0.7.3.tgz",
-			"integrity": "sha512-71lNUMVCEPde3oAZn9OxkgjHLPrgcH8Ma1vazut2nIbC9n7PYmQFoGyEZJapiOZ7wvjaJt2zCsuQzy25K0nVFA==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/shellac/-/shellac-0.8.0.tgz",
+			"integrity": "sha512-M3F2vzYIM7frKOs0+kgs/ITMlXhGpgtqs9HxDPciz3bckzAqqfd4LrBn+CCmSbICyJS+Jz5UDkmkR1jE+m+g+Q==",
 			"dev": true,
 			"dependencies": {
 				"reghex": "^1.0.2"
@@ -46531,7 +46531,7 @@
 				"remove-accents-esm": "^0.0.1",
 				"semiver": "^1.1.0",
 				"serve-static": "^1.15.0",
-				"shellac": "^0.7.3",
+				"shellac": "^0.8.0",
 				"signal-exit": "^3.0.7",
 				"strip-ansi": "^7.0.1",
 				"supports-color": "^9.2.2",
@@ -88284,9 +88284,9 @@
 			"integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ=="
 		},
 		"shellac": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/shellac/-/shellac-0.7.3.tgz",
-			"integrity": "sha512-71lNUMVCEPde3oAZn9OxkgjHLPrgcH8Ma1vazut2nIbC9n7PYmQFoGyEZJapiOZ7wvjaJt2zCsuQzy25K0nVFA==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/shellac/-/shellac-0.8.0.tgz",
+			"integrity": "sha512-M3F2vzYIM7frKOs0+kgs/ITMlXhGpgtqs9HxDPciz3bckzAqqfd4LrBn+CCmSbICyJS+Jz5UDkmkR1jE+m+g+Q==",
 			"dev": true,
 			"requires": {
 				"reghex": "^1.0.2"
@@ -93227,7 +93227,7 @@
 				"selfsigned": "^2.0.1",
 				"semiver": "^1.1.0",
 				"serve-static": "^1.15.0",
-				"shellac": "^0.7.3",
+				"shellac": "^0.8.0",
 				"signal-exit": "^3.0.7",
 				"source-map": "^0.7.4",
 				"strip-ansi": "^7.0.1",

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
 import path from "node:path";
-import { setTimeout } from "node:timers/promises";
 import { fetch } from "undici";
 import { describe, expect, it } from "vitest";
+import { retry } from "./helpers/retry";
 import { RUN, runIn } from "./helpers/run";
 import { dedent, makeRoot, seed } from "./helpers/setup";
 
@@ -46,15 +46,11 @@ describe("deployments", async () => {
 			✨ Created smoke-test-worker/src/index.ts
 			Your project will use Vitest to run your tests.
 			✨ Created smoke-test-worker/src/index.test.ts
-
 			added (N) packages, and audited (N) packages in (TIMINGS)
-
 			(N) packages are looking for funding
 			  run \`npm fund\` for details
-
 			found 0 vulnerabilities
 			✨ Installed @cloudflare/workers-types, typescript, and vitest into devDependencies
-
 			To start developing your Worker, run \`cd smoke-test-worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`"
@@ -78,10 +74,11 @@ describe("deployments", async () => {
 		expect(stderr).toMatchInlineSnapshot('""');
 		workersDev = matchWorkersDev(rawStdout);
 
-		await setTimeout(2_000);
-		await expect(
-			fetch(`https://${workerName}.${workersDev}`).then((r) => r.text())
-		).resolves.toMatchInlineSnapshot('"Hello World!"');
+		await retry(() =>
+			expect(
+				fetch(`https://${workerName}.${workersDev}`).then((r) => r.text())
+			).resolves.toMatchInlineSnapshot('"Hello World!"')
+		);
 	});
 
 	it("list 1 deployment", async () => {
@@ -93,8 +90,6 @@ describe("deployments", async () => {
 	`;
 		expect(stdout).toMatchInlineSnapshot(`
 			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
-
-
 			Deployment ID: 00000000-0000-0000-0000-000000000000
 			Created on:    TIMESTAMP
 			Author:        person@example.com
@@ -130,10 +125,11 @@ describe("deployments", async () => {
 		expect(stderr).toMatchInlineSnapshot('""');
 		workersDev = matchWorkersDev(rawStdout);
 
-		await setTimeout(10_000);
-		await expect(
-			fetch(`https://${workerName}.${workersDev}`).then((r) => r.text())
-		).resolves.toMatchInlineSnapshot('"Updated Worker!"');
+		await retry(() =>
+			expect(
+				fetch(`https://${workerName}.${workersDev}`).then((r) => r.text())
+			).resolves.toMatchInlineSnapshot('"Updated Worker!"')
+		);
 	});
 
 	it("list 2 deployments", async () => {
@@ -145,13 +141,10 @@ describe("deployments", async () => {
 	`;
 		expect(stdout).toMatchInlineSnapshot(`
 			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
-
-
 			Deployment ID: 00000000-0000-0000-0000-000000000000
 			Created on:    TIMESTAMP
 			Author:        person@example.com
 			Source:        Upload from Wrangler 🤠
-
 			Deployment ID: 00000000-0000-0000-0000-000000000000
 			Created on:    TIMESTAMP
 			Author:        person@example.com
@@ -170,8 +163,6 @@ describe("deployments", async () => {
 	`;
 		expect(stdout).toMatchInlineSnapshot(`
 			"🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
-
-
 			Successfully rolled back to Deployment ID: 00000000-0000-0000-0000-000000000000
 			Current Deployment ID: 00000000-0000-0000-0000-000000000000"
 		`);
@@ -187,18 +178,14 @@ describe("deployments", async () => {
 	`;
 		expect(stdout).toMatchInlineSnapshot(`
 			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
-
-
 			Deployment ID: 00000000-0000-0000-0000-000000000000
 			Created on:    TIMESTAMP
 			Author:        person@example.com
 			Source:        Upload from Wrangler 🤠
-
 			Deployment ID: 00000000-0000-0000-0000-000000000000
 			Created on:    TIMESTAMP
 			Author:        person@example.com
 			Source:        Upload from Wrangler 🤠
-
 			Deployment ID: 00000000-0000-0000-0000-000000000000
 			Created on:    TIMESTAMP
 			Author:        person@example.com
@@ -222,9 +209,10 @@ describe("deployments", async () => {
 			Successfully deleted smoke-test-worker"
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
-		await setTimeout(10_000);
-		await expect(
-			fetch(`https://${workerName}.${workersDev}`).then((r) => r.status)
-		).resolves.toBe(404);
+		await retry(() =>
+			expect(
+				fetch(`https://${workerName}.${workersDev}`).then((r) => r.status)
+			).resolves.toBe(404)
+		);
 	});
 });

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -1,0 +1,135 @@
+import crypto from "node:crypto";
+import path from "node:path";
+import getPort from "get-port";
+import { fetch } from "undici";
+import { beforeEach, describe, expect, it } from "vitest";
+import { retry } from "./helpers/retry";
+import { RUN, runInBg } from "./helpers/run";
+import { dedent, makeRoot, seed } from "./helpers/setup";
+
+async function runDevSession(
+	workerName: string,
+	workerPath: string,
+	flags: string,
+	session: (port: number) => Promise<void>
+) {
+	const port = await getPort();
+	const { pid, promise } = await runInBg(workerPath, {
+		[workerName]: "smoke-test-worker",
+		[`http://127.0.0.1:${port}`]: "http://127.0.0.1:PORT",
+	})`
+	in ${workerPath} {
+		exits {
+			$$ ${RUN} dev ${flags} --port ${port}
+		}
+	}
+`;
+	await session(port);
+
+	process.kill(pid);
+
+	return await promise;
+}
+
+describe("basic dev tests", async () => {
+	const root = await makeRoot();
+	const workerName = `smoke-test-worker-${crypto
+		.randomBytes(4)
+		.toString("hex")}`;
+	const workerPath = path.join(root, workerName);
+
+	beforeEach(async () => {
+		await seed(workerPath, {
+			"wrangler.toml": dedent`
+					name = "${workerName}"
+					main = "src/index.ts"
+					compatibility_date = "2023-01-01"
+			`,
+			"src/index.ts": dedent`
+					export default {
+						fetch(request) {
+							return new Response("Hello World!")
+						}
+					}`,
+			"package.json": dedent`
+					{
+						"name": "${workerName}",
+						"version": "0.0.0",
+						"private": true
+					}
+					`,
+		});
+	}, 120_000);
+	it("can fetch worker after wrangler dev (local)", async () => {
+		await runDevSession(workerName, workerPath, "", async (port) => {
+			await retry(() =>
+				expect(
+					fetch(`http://127.0.0.1:${port}`).then((r) => r.text())
+				).resolves.toMatchInlineSnapshot('"Hello World!"')
+			);
+		});
+	}, 120_000);
+	it("can fetch worker after wrangler dev (remote)", async () => {
+		await runDevSession(
+			workerName,
+			workerPath,
+			"--remote --ip 127.0.0.1",
+			async (port) => {
+				await retry(() =>
+					expect(
+						fetch(`http://127.0.0.1:${port}`).then((r) => r.text())
+					).resolves.toMatchInlineSnapshot('"Hello World!"')
+				);
+			}
+		);
+	}, 120_000);
+	it("can modify worker during dev session (local)", async () => {
+		await runDevSession(workerName, workerPath, "", async (port) => {
+			await retry(() =>
+				expect(
+					fetch(`http://127.0.0.1:${port}`).then((r) => r.text())
+				).resolves.toMatchInlineSnapshot('"Hello World!"')
+			);
+			await seed(workerPath, {
+				"src/index.ts": dedent`
+						export default {
+							fetch(request) {
+								return new Response("Updated Worker!")
+							}
+						}`,
+			});
+			await retry(() =>
+				expect(
+					fetch(`http://127.0.0.1:${port}`).then((r) => r.text())
+				).resolves.toMatchInlineSnapshot('"Hello World!"')
+			);
+		});
+	});
+	it("can modify worker during dev session (remote)", async () => {
+		await runDevSession(
+			workerName,
+			workerPath,
+			"--remote --ip 127.0.0.1",
+			async (port) => {
+				await retry(() =>
+					expect(
+						fetch(`http://127.0.0.1:${port}`).then((r) => r.text())
+					).resolves.toMatchInlineSnapshot('"Hello World!"')
+				);
+				await seed(workerPath, {
+					"src/index.ts": dedent`
+						export default {
+							fetch(request) {
+								return new Response("Updated Worker!")
+							}
+						}`,
+				});
+				await retry(() =>
+					expect(
+						fetch(`http://127.0.0.1:${port}`).then((r) => r.text())
+					).resolves.toMatchInlineSnapshot('"Hello World!"')
+				);
+			}
+		);
+	});
+});

--- a/packages/wrangler/e2e/helpers/normalise.ts
+++ b/packages/wrangler/e2e/helpers/normalise.ts
@@ -16,6 +16,8 @@ export function normalizeOutput(
 		removeVersionHeader,
 		stripAnsi,
 		removeTimestamp,
+		stripDevTimings,
+		stripEmptyNewlines,
 	];
 	for (const f of functions) {
 		stdout = f(stdout);
@@ -27,6 +29,15 @@ export function normalizeOutput(
 	}
 	return stdout;
 }
+
+function stripEmptyNewlines(stdout: string): string {
+	return stdout.replace(/\n+/g, "\n");
+}
+
+function stripDevTimings(stdout: string): string {
+	return stdout.replace(/\(\dms\)/g, "(TIMINGS)");
+}
+
 function removeWorkersDev(str: string) {
 	return str.replace(
 		/https:\/\/(.+?)\..+?\.workers\.dev/g,
@@ -35,7 +46,9 @@ function removeWorkersDev(str: string) {
 }
 
 function removeTimestamp(str: string) {
-	return str.replace(/\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+?Z/g, "TIMESTAMP");
+	return str
+		.replace(/\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+?Z/g, "TIMESTAMP")
+		.replace(/\d\d:\d\d:\d\d/g, "TIMESTAMP");
 }
 function removeUUID(str: string) {
 	return str.replace(

--- a/packages/wrangler/e2e/helpers/retry.ts
+++ b/packages/wrangler/e2e/helpers/retry.ts
@@ -1,0 +1,17 @@
+import { setTimeout } from "node:timers/promises";
+
+export async function retry<Awaitable>(
+	promise: () => Promise<Awaitable>,
+	n = 20
+): Promise<void> {
+	if (n === 0) {
+		await promise();
+	} else {
+		try {
+			await promise();
+		} catch {
+			await setTimeout(2_000);
+			return retry(promise, n - 1);
+		}
+	}
+}

--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -76,12 +76,10 @@ describe("r2", async () => {
     `;
 		expect(stdout).toMatchInlineSnapshot(`
 			"Downloading \\"testr2\\" from \\"wrangler-smoke-test-bucket\\".
-
 			If you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose"
 		`);
 		expect(stderr).toMatchInlineSnapshot(`
 			"X [ERROR] Failed to fetch /accounts/CLOUDFLARE_ACCOUNT_ID/r2/buckets/wrangler-smoke-test-bucket/objects/testr2 - 404: Not Found);
-
 			"
 		`);
 	});
@@ -111,12 +109,10 @@ describe("r2", async () => {
 	`;
 		expect(stdout).toMatchInlineSnapshot(`
 			"Creating object \\"testr2\\" in bucket \\"wrangler-smoke-test-bucket\\".
-
 			If you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose"
 		`);
 		expect(stderr).toMatchInlineSnapshot(`
 			"X [ERROR] Failed to fetch /accounts/CLOUDFLARE_ACCOUNT_ID/r2/buckets/wrangler-smoke-test-bucket/objects/testr2 - 404: Not Found);
-
 			"
 		`);
 	});

--- a/packages/wrangler/e2e/vite.config.ts
+++ b/packages/wrangler/e2e/vite.config.ts
@@ -6,6 +6,6 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	test: {
-		testTimeout: 60_000,
+		testTimeout: 120_000,
 	},
 });

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -63,7 +63,7 @@
 		"test-watch": "npm run test -- --runInBand --testTimeout=50000 --watch",
 		"test:ci": "npm run test -- --coverage",
 		"test:debug": "npm run test -- --silent=false --verbose=true",
-		"test:e2e": "vitest --single-thread ./e2e"
+		"test:e2e": "vitest --single-thread --test-timeout 120000 --dir ./e2e"
 	},
 	"jest": {
 		"coverageReporters": [
@@ -168,7 +168,7 @@
 		"remove-accents-esm": "^0.0.1",
 		"semiver": "^1.1.0",
 		"serve-static": "^1.15.0",
-		"shellac": "^0.7.3",
+		"shellac": "^0.8.0",
 		"signal-exit": "^3.0.7",
 		"strip-ansi": "^7.0.1",
 		"supports-color": "^9.2.2",


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

e2e testing in CI! This adds a run of the e2e tests to the pull request and main branch workflows, as well as adding basic tests for `wrangler dev`. It will be removed from the pull request workflow before this PR gets merged, but it's there for now to demonstrate how the tests work. Currently, about half the tests fail because of OS limitations of `workerd`—I'm in two minds about whether we should keep those failing tests in to remind us, or skip them for now.

**Author has included the following, where applicable:**

- [x] Tests
- ~[ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
