### PR TITLE
[C3 + wrangler] `wrangler init … -y` delegates to C3 without prompts (respects the `-y` flag)

### DIFF
--- a/.changeset/seven-houses-end.md
+++ b/.changeset/seven-houses-end.md
@@ -1,0 +1,6 @@
+---
+"create-cloudflare": patch
+"wrangler": patch
+---
+
+`wrangler init ... -y` now delegates to C3 without prompts (respects the `-y` flag)

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -34,6 +34,8 @@ describe("E2E", () => {
 			"webFramework",
 			"--framework",
 			framework,
+			"--no-deploy",
+			"--no-git",
 			"--wrangler-defaults",
 		];
 

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -34,8 +34,7 @@ describe("E2E", () => {
 			"webFramework",
 			"--framework",
 			framework,
-			"--no-deploy",
-			"--no-git",
+			"--wrangler-defaults",
 		];
 
 		const result = await execa("node", ["./dist/cli.js", ...argv], {

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -19,8 +19,12 @@ export const main = async (argv: string[]) => {
 
 	const validatedArgs: PagesGeneratorArgs = {
 		...args,
-		projectName: await validateName(args.projectName),
-		type: await validateType(args.type),
+		projectName: await validateName(args.projectName, {
+			acceptDefault: args.wranglerDefaults,
+		}),
+		type: await validateType(args.type, {
+			acceptDefault: args.wranglerDefaults,
+		}),
 	};
 
 	const { handler } = templateMap[validatedArgs.type];

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import { existsSync } from "fs";
-import { resolve } from "path";
 import Haikunator from "haikunator";
 import { crash, logRaw, startSection } from "helpers/cli";
 import { dim, brandColor } from "helpers/colors";
@@ -8,6 +6,7 @@ import { selectInput, textInput } from "helpers/interactive";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { version } from "../package.json";
+import { validateProjectDirectory } from "./common";
 import { runPagesGenerator } from "./pages";
 import { runWorkersGenerator } from "./workers";
 import type { Option } from "helpers/interactive";
@@ -49,6 +48,11 @@ const parseArgs = async (argv: string[]) => {
 			description:
 				"opens your browser after your deployment, set --no-open to disable",
 		})
+		.option("existing-script", {
+			type: "string",
+			hidden: templateMap["pre-existing"].hidden,
+		})
+		.option("wrangler-defaults", { type: "boolean", hidden: true })
 		.help().argv;
 
 	return {
@@ -57,26 +61,26 @@ const parseArgs = async (argv: string[]) => {
 	};
 };
 
-const validateName = async (name: string | undefined): Promise<string> => {
-	const haikunator = new Haikunator();
-
-	return await textInput({
-		initialValue: name,
+const validateName = async (
+	name: string | undefined,
+	{ acceptDefault = false } = {}
+): Promise<string> => {
+	return textInput({
 		question: `Where do you want to create your application?`,
 		helpText: "also used as application name",
 		renderSubmitted: (value: string) => {
 			return `${brandColor("dir")} ${dim(value)}`;
 		},
-		defaultValue: haikunator.haikunate({ tokenHex: true }),
-		validate: (value: string) => {
-			if (value && existsSync(resolve(value))) {
-				return `\`${value}\` already exists. Please choose a new folder. `;
-			}
-		},
+		defaultValue: name ?? new Haikunator().haikunate({ tokenHex: true }),
+		acceptDefault,
+		validate: validateProjectDirectory,
 	});
 };
 
-const validateType = async (type: string | undefined) => {
+const validateType = async (
+	type: string | undefined,
+	{ acceptDefault = false } = {}
+) => {
 	const templateOptions = Object.entries(templateMap)
 		.filter(([_, { hidden }]) => !hidden)
 		.map(([value, { label }]) => ({ value, label }));
@@ -87,12 +91,14 @@ const validateType = async (type: string | undefined) => {
 		renderSubmitted: (option: Option) => {
 			return `${brandColor("type")} ${dim(option.label)}`;
 		},
-		initialValue: type,
+		defaultValue: type ?? "simple",
+		acceptDefault,
 	});
 
 	if (!type || !Object.keys(templateMap).includes(type)) {
 		crash("An application type must be specified to continue.");
 	}
+
 	return type;
 };
 

--- a/packages/create-cloudflare/src/frameworks/gatsby/index.ts
+++ b/packages/create-cloudflare/src/frameworks/gatsby/index.ts
@@ -16,6 +16,8 @@ const generate = async (ctx: PagesGeneratorContext) => {
 			const status = value ? "yes" : "no";
 			return `${brandColor(`template`)} ${status}`;
 		},
+		defaultValue: true,
+		acceptDefault: false,
 	});
 
 	let templateUrl = "";
@@ -27,6 +29,7 @@ const generate = async (ctx: PagesGeneratorContext) => {
 				return `${brandColor("template")} ${dim(result)}`;
 			},
 			defaultValue: defaultTemplate,
+			acceptDefault: false,
 		});
 	}
 

--- a/packages/create-cloudflare/src/helpers/interactive.ts
+++ b/packages/create-cloudflare/src/helpers/interactive.ts
@@ -12,13 +12,13 @@ export type TextOptions = {
 	renderSubmitted: (value: string) => string;
 	question: string;
 	defaultValue: string;
+	acceptDefault: boolean | undefined; // must be specified, but can be undefined (≈ false)
 	helpText?: string;
 	validate?: (value: string) => string | void;
-	initialValue?: string;
 };
 
 export const textInput = async (opts: TextOptions) => {
-	const { renderSubmitted, question, defaultValue, validate, initialValue } =
+	const { renderSubmitted, question, defaultValue, validate, acceptDefault } =
 		opts;
 	const helpText = opts.helpText || ``;
 
@@ -55,10 +55,11 @@ export const textInput = async (opts: TextOptions) => {
 	});
 
 	let value: string;
-	if (initialValue) {
+	if (acceptDefault) {
 		logRaw(`${leftT} ${question}`);
-		logRaw(`${grayBar} ${renderSubmitted(initialValue)}\n${grayBar}`);
-		value = initialValue;
+		logRaw(`${grayBar} ${renderSubmitted(defaultValue)}\n${grayBar}`);
+		value = defaultValue;
+		validate?.(value);
 	} else {
 		value = (await prompt.prompt()) as string;
 
@@ -81,16 +82,18 @@ type SelectOptions = {
 	renderSubmitted: (option: Option) => string;
 	options: Option[];
 	helpText?: string;
-	initialValue?: string;
+	defaultValue: string;
+	acceptDefault: boolean | undefined; // must be specified, but can be undefined (≈ false)
 };
 
 export const selectInput = async (opts: SelectOptions) => {
-	const { question, options, renderSubmitted, initialValue } = opts;
+	const { question, options, renderSubmitted, defaultValue, acceptDefault } =
+		opts;
 	const helpText = opts.helpText || ``;
 
 	const prompt = new SelectPrompt({
 		options,
-		initialValue: options[0].value,
+		initialValue: defaultValue ?? options[0].value,
 		render() {
 			const renderOption = (opt: Option, i: number) => {
 				const { label } = opt;
@@ -122,16 +125,16 @@ export const selectInput = async (opts: SelectOptions) => {
 	});
 
 	let value: string;
-	if (initialValue) {
+	if (acceptDefault) {
 		logRaw(`${leftT} ${question}`);
 		logRaw(
 			`${grayBar} ${renderSubmitted({
-				label: initialValue,
-				value: initialValue,
+				label: defaultValue,
+				value: defaultValue,
 			})}`
 		);
 		logRaw(`${grayBar}`);
-		value = initialValue;
+		value = defaultValue;
 	} else {
 		value = (await prompt.prompt()) as string;
 
@@ -148,10 +151,10 @@ type ConfirmOptions = {
 	question: string;
 	renderSubmitted: (value: boolean) => string;
 	defaultValue?: boolean;
+	acceptDefault: boolean | undefined; // must be specified, but can be undefined (≈ false)
 	activeText?: string;
 	inactiveText?: string;
 	helpText?: string;
-	initialValue?: boolean;
 };
 
 export const confirmInput = async (opts: ConfirmOptions) => {
@@ -160,18 +163,17 @@ export const confirmInput = async (opts: ConfirmOptions) => {
 		inactiveText,
 		question,
 		renderSubmitted,
-		defaultValue,
-		initialValue,
+		defaultValue = true,
+		acceptDefault,
 	} = opts;
 	const helpText = opts.helpText || `(y/n)`;
-
 	const active = activeText || "Yes";
 	const inactive = inactiveText || "No";
 
 	const prompt = new ConfirmPrompt({
 		active,
 		inactive,
-		initialValue: defaultValue || true,
+		initialValue: defaultValue,
 		render() {
 			const yesColor = this.value ? blue : dim;
 			const noColor = this.value ? dim : blue;
@@ -195,11 +197,11 @@ export const confirmInput = async (opts: ConfirmOptions) => {
 
 	let value: boolean;
 
-	if (initialValue !== undefined) {
+	if (acceptDefault) {
 		logRaw(`${leftT} ${question}`);
-		logRaw(`${grayBar} ${renderSubmitted(initialValue)}`);
+		logRaw(`${grayBar} ${renderSubmitted(defaultValue)}`);
 		logRaw(`${grayBar}`);
-		value = initialValue;
+		value = defaultValue;
 	} else {
 		value = Boolean(await prompt.prompt());
 

--- a/packages/create-cloudflare/src/pages.ts
+++ b/packages/create-cloudflare/src/pages.ts
@@ -34,14 +34,13 @@ const defaultFrameworkConfig = {
 };
 
 export const runPagesGenerator = async (args: PagesGeneratorArgs) => {
-	const { name, relativePath, path } = setupProjectDirectory(args);
+	const { name, path } = setupProjectDirectory(args);
 	const framework = await getFrameworkSelection(args);
 
 	const frameworkConfig = FrameworkMap[framework];
 	const ctx: PagesGeneratorContext = {
 		project: {
 			name,
-			relativePath,
 			path,
 		},
 		framework: {
@@ -91,7 +90,8 @@ const getFrameworkSelection = async (args: PagesGeneratorArgs) => {
 		renderSubmitted: (option: Option) => {
 			return `${brandColor("framework")} ${dim(option.label)}`;
 		},
-		initialValue: args.framework,
+		defaultValue: args.framework ?? "svelte",
+		acceptDefault: Boolean(args.framework),
 	});
 
 	// Validate answers

--- a/packages/create-cloudflare/src/types.ts
+++ b/packages/create-cloudflare/src/types.ts
@@ -11,6 +11,8 @@ export type PagesGeneratorArgs = {
 	ts?: boolean;
 	open: boolean;
 	git?: boolean;
+	existingScript?: string;
+	wranglerDefaults?: boolean;
 };
 
 export type PagesGeneratorContext = {
@@ -27,9 +29,7 @@ export type PagesGeneratorContext = {
 	project: {
 		name: string;
 		path: string;
-		relativePath: string;
 	};
-	existingScript?: string;
 };
 
 export type FrameworkConfig = {

--- a/packages/create-cloudflare/src/workers.ts
+++ b/packages/create-cloudflare/src/workers.ts
@@ -21,10 +21,10 @@ import type {
 } from "types";
 
 export const runWorkersGenerator = async (args: Args) => {
-	const { name, path, relativePath } = setupProjectDirectory(args);
+	const { name, path } = setupProjectDirectory(args);
 
 	const ctx: Context = {
-		project: { name, relativePath, path },
+		project: { name, path },
 		args,
 	};
 
@@ -53,6 +53,7 @@ async function getTemplate(ctx: Context) {
 			renderSubmitted: (value) =>
 				`${brandColor("typescript")} ${dim(`${value ? "yes" : "no"}`)}`,
 			defaultValue: true,
+			acceptDefault: ctx.args.wranglerDefaults,
 		});
 	}
 
@@ -85,13 +86,14 @@ async function copyExistingWorkerFiles(ctx: Context) {
 	if (preexisting) {
 		await chooseAccount(ctx);
 
-		if (ctx.existingScript === undefined) {
-			ctx.existingScript = await textInput({
+		if (ctx.args.existingScript === undefined) {
+			ctx.args.existingScript = await textInput({
 				question:
 					"Please specify the name of the existing worker in this account?",
 				renderSubmitted: (value) =>
 					`${brandColor("worker")} ${dim(`"${value}"`)}`,
 				defaultValue: ctx.project.name,
+				acceptDefault: ctx.args.wranglerDefaults,
 			});
 		}
 
@@ -101,14 +103,14 @@ async function copyExistingWorkerFiles(ctx: Context) {
 			join(tmpdir(), "c3-wrangler-init--from-dash-")
 		);
 		await runCommand(
-			`npx wrangler@3 init --from-dash ${ctx.existingScript} -y --no-delegate-c3`,
+			`npx wrangler@3 init --from-dash ${ctx.args.existingScript} -y --no-delegate-c3`,
 			{
 				silent: true,
 				cwd: tempdir, // use a tempdir because we don't want all the files
 				env: { CLOUDFLARE_ACCOUNT_ID: ctx.account?.id },
 				startText: "Downloading existing worker files",
 				doneText: `${brandColor("downloaded")} ${dim(
-					`existing "${ctx.existingScript}" worker files`
+					`existing "${ctx.args.existingScript}" worker files`
 				)}`,
 			}
 		);
@@ -120,14 +122,14 @@ async function copyExistingWorkerFiles(ctx: Context) {
 
 		// copy src/* files from the downloaded worker
 		await cp(
-			join(tempdir, ctx.existingScript, "src"),
+			join(tempdir, ctx.args.existingScript, "src"),
 			join(ctx.project.path, "src"),
 			{ recursive: true }
 		);
 
 		// copy wrangler.toml from the downloaded worker
 		await cp(
-			join(tempdir, ctx.existingScript, "wrangler.toml"),
+			join(tempdir, ctx.args.existingScript, "wrangler.toml"),
 			join(ctx.project.path, "wrangler.toml")
 		);
 	}

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -82,28 +82,48 @@ describe("init", () => {
 			});
 		});
 
-		test("with -y flag, delegates to c3 with --wrangler-defaults", async () => {
-			await runWrangler("init --yes");
-
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "Running \`mockpm create cloudflare@2 -- --wrangler-defaults\`...",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
-
-			  The \`init\` command will be removed in a future version.
-
-			",
-			}
-		`);
+		it("should initialize with no interactive prompts if `-y` is used", async () => {
+			await runWrangler("init -y");
 
 			expect(execa).toHaveBeenCalledWith(
 				"mockpm",
 				["create", "cloudflare@2", "--", "--wrangler-defaults"],
 				{ stdio: "inherit" }
 			);
+
+			checkFiles({
+				items: {
+					"./src/index.js": false,
+					"./src/index.ts": true,
+					"./tsconfig.json": true,
+					"./package.json": true,
+					"./wrangler.toml": true,
+				},
+			});
+
+			expect(std).toMatchInlineSnapshot(`
+        Object {
+          "debug": "",
+          "err": "",
+          "info": "Your project will use Vitest to run your tests.",
+          "out": "✨ Created wrangler.toml
+        ✨ Initialized git repository
+        ✨ Created package.json
+        ✨ Created tsconfig.json
+        ✨ Created src/index.ts
+        ✨ Created src/index.test.ts
+        ✨ Installed @cloudflare/workers-types, typescript, and vitest into devDependencies
+
+        To start developing your Worker, run \`npm start\`
+        To start testing your Worker, run \`npm test\`
+        To publish your Worker to the Internet, run \`npm run deploy\`",
+          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
+
+          The \`init\` command will be removed in a future version.
+
+        ",
+        }
+    `);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -81,6 +81,30 @@ describe("init", () => {
 				stdio: "inherit",
 			});
 		});
+
+		test("with -y flag, delegates to c3 with --wrangler-defaults", async () => {
+			await runWrangler("init --yes");
+
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "info": "",
+			  "out": "Running \`mockpm create cloudflare@2 -- --wrangler-defaults\`...",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
+
+			  The \`init\` command will be removed in a future version.
+
+			",
+			}
+		`);
+
+			expect(execa).toHaveBeenCalledWith(
+				"mockpm",
+				["create", "cloudflare@2", "--", "--wrangler-defaults"],
+				{ stdio: "inherit" }
+			);
+		});
 	});
 
 	describe("deprecated behaviour is retained with --no-delegate-c3", () => {
@@ -113,7 +137,7 @@ describe("init", () => {
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -152,7 +176,7 @@ describe("init", () => {
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -189,7 +213,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -658,7 +682,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -690,7 +714,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker/my-worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2232,7 +2256,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2268,7 +2292,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2306,7 +2330,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd WEIRD_w0rkr_N4m3.js.tsx.tar.gz && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2768,8 +2792,8 @@ describe("init", () => {
 			  "debug": "",
 			  "err": "",
 			  "info": "",
-			  "out": "Running \`mockpm create cloudflare@2 existing-memory-crystal -- --type pre-existing\`...",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init --from-dash\` command is no longer supported. Please use \`mockpm create cloudflare@2 existing-memory-crystal -- --type pre-existing\` instead.[0m
+			  "out": "Running \`mockpm create cloudflare@2 existing-memory-crystal -- --type pre-existing --existing-script existing-memory-crystal\`...",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init --from-dash\` command is no longer supported. Please use \`mockpm create cloudflare@2 existing-memory-crystal -- --type pre-existing --existing-script existing-memory-crystal\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -82,7 +82,7 @@ describe("init", () => {
 			});
 		});
 
-		it("should initialize with no interactive prompts if `-y` is used", async () => {
+		it("if `-y` is used, delegate to c3 with --wrangler-defaults", async () => {
 			await runWrangler("init -y");
 
 			expect(execa).toHaveBeenCalledWith(
@@ -90,40 +90,6 @@ describe("init", () => {
 				["create", "cloudflare@2", "--", "--wrangler-defaults"],
 				{ stdio: "inherit" }
 			);
-
-			checkFiles({
-				items: {
-					"./src/index.js": false,
-					"./src/index.ts": true,
-					"./tsconfig.json": true,
-					"./package.json": true,
-					"./wrangler.toml": true,
-				},
-			});
-
-			expect(std).toMatchInlineSnapshot(`
-        Object {
-          "debug": "",
-          "err": "",
-          "info": "Your project will use Vitest to run your tests.",
-          "out": "✨ Created wrangler.toml
-        ✨ Initialized git repository
-        ✨ Created package.json
-        ✨ Created tsconfig.json
-        ✨ Created src/index.ts
-        ✨ Created src/index.test.ts
-        ✨ Installed @cloudflare/workers-types, typescript, and vitest into devDependencies
-
-        To start developing your Worker, run \`npm start\`
-        To start testing your Worker, run \`npm test\`
-        To publish your Worker to the Internet, run \`npm run deploy\`",
-          "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 -- --wrangler-defaults\` instead.[0m
-
-          The \`init\` command will be removed in a future version.
-
-        ",
-        }
-    `);
 		});
 	});
 

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -132,6 +132,7 @@ export async function initHandler(args: InitArgs) {
 		throw new CommandLineArgsError(message);
 	}
 
+	const yesFlag = args.yes ?? false;
 	const devDepsToInstall: string[] = [];
 	const instructions: string[] = [];
 	let shouldRunPackageManagerInstall = false;
@@ -209,6 +210,10 @@ export async function initHandler(args: InitArgs) {
 			"pre-existing",
 		];
 
+		if (yesFlag) {
+			c3Arguments.push("--wrangler-defaults");
+		}
+
 		// Deprecate the `init --from-dash` command
 		const replacementC3Command = `\`${packageManager.type} ${c3Arguments.join(
 			" "
@@ -245,7 +250,16 @@ export async function initHandler(args: InitArgs) {
 		//    if a wrangler.toml file does not exist (C3 expects to scaffold *new* projects)
 		//    and if --from-dash is not set (C3 will run wrangler to communicate with the API)
 		if (!fromDashScriptName) {
-			const replacementC3Command = `\`${packageManager.type} create cloudflare@2\``;
+			const c3Arguments = ["create", "cloudflare@2"];
+
+			if (yesFlag) {
+				c3Arguments.push("--", "--wrangler-defaults");
+			}
+
+			// Deprecate the `init --from-dash` command
+			const replacementC3Command = `\`${packageManager.type} ${c3Arguments.join(
+				" "
+			)}\``;
 
 			logger.warn(
 				`The \`init\` command is no longer supported. Please use ${replacementC3Command} instead.\nThe \`init\` command will be removed in a future version.`
@@ -287,8 +301,6 @@ export async function initHandler(args: InitArgs) {
 			);
 		}
 	}
-
-	const yesFlag = args.yes ?? false;
 
 	if (!(await isInsideGitRepo(creationDirectory)) && (await getGitVersioon())) {
 		const shouldInitGit =

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -270,7 +270,7 @@ export async function initHandler(args: InitArgs) {
 			if (args.delegateC3) {
 				logger.log(`Running ${replacementC3Command}...`);
 
-				await execa(packageManager.type, ["create", "cloudflare@2"], {
+				await execa(packageManager.type, c3Arguments, {
 					stdio: "inherit",
 				});
 

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -208,6 +208,8 @@ export async function initHandler(args: InitArgs) {
 			"--",
 			"--type",
 			"pre-existing",
+			"--existing-script",
+			fromDashScriptName,
 		];
 
 		if (yesFlag) {


### PR DESCRIPTION
Fixes #3333 #3319 

**What this PR solves / how to test:**

When `wrangler init … -y` delegates to C3, it now sets a hidden flag `–wrangler-defaults` which will skip all prompts in C3. Fixes #3333

Test by running `wrangler init -y` or `wrangler init --from-dash test -y` and confirm the process exits without user input.

Also, C3 now allows to use an existing directory if it is empty. Fixes #3319

Test by setting the project directory to 1. an empty directory, and 2. a non-empty directory. The former succeeds while the latter will fail

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
