### PR TITLE
Fix R2 bucket example in create-cloudflare wrangler.toml

### DIFF
--- a/packages/create-cloudflare/templates/common/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/common/ts/wrangler.toml
@@ -12,11 +12,10 @@ compatibility_date = "2023-04-21"
 # binding = "MY_DURABLE_OBJECT"
 # class_name = "MyDurableObject"
 
-# # Bucket binding - For more information: https://developers.cloudflare.com/workers/runtime-apis/kv#bucket
-# [[buckets]]
+# # R2 Bucket binding - For more information: https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#create-a-binding
+# [[r2_buckets]]
 # binding = "MY_BUCKET"
-# name = "my-bucket"
-# bucket_id = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+# bucket_name = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
 
 # # Service binding - For more information: https://developers.cloudflare.com/workers/platform/services
 # [[routes]]


### PR DESCRIPTION
I have to assume that this section was intended to be about R2? cc @jonesphillip 

**What this PR solves / how to test:**

- Previously, running create cloudflare gave you a `wrangler.toml` that included Queues, KV, etc., but didn't have R2. Looks like the intent was to include a section, but it didn't quite have the right format. This PR updates the `wrangler.toml` that is used when scaffolding out an example app.

**Author has included the following, where applicable:**

- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
