### PR TITLE
fix: wrangler rollback shouldn't print its warning in the global menu

### DIFF
--- a/.changeset/flat-singers-doubt.md
+++ b/.changeset/flat-singers-doubt.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: wrangler rollback shouldn't print its warning in the global menu

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -64,9 +64,7 @@ describe("wrangler", () => {
 			  -c, --config                    Path to .toml configuration file  [string]
 			  -e, --env                       Environment to use for operations and .env files  [string]
 			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]
-
-			🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
+			  -v, --version                   Show version number  [boolean]"
 		`);
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
@@ -118,9 +116,7 @@ describe("wrangler", () => {
 			  -c, --config                    Path to .toml configuration file  [string]
 			  -e, --env                       Environment to use for operations and .env files  [string]
 			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]
-
-			🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
+			  -v, --version                   Show version number  [boolean]"
 		`);
 			expect(std.err).toMatchInlineSnapshot(`
 			        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: invalid-command[0m

--- a/packages/wrangler/src/__tests__/mtls-certificates.test.ts
+++ b/packages/wrangler/src/__tests__/mtls-certificates.test.ts
@@ -394,9 +394,7 @@ describe("wrangler", () => {
 				  -c, --config                    Path to .toml configuration file  [string]
 				  -e, --env                       Environment to use for operations and .env files  [string]
 				  -h, --help                      Show help  [boolean]
-				  -v, --version                   Show version number  [boolean]
-
-				🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
+				  -v, --version                   Show version number  [boolean]"
 			`);
 				});
 			});

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -650,40 +650,42 @@ export function createCLIParser(argv: string[]) {
 				.command(subHelp)
 				.epilogue(deploymentsWarning)
 	);
+
 	const rollbackWarning =
 		"🚧`wrangler rollback` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose";
-	wrangler
-		.command(
-			"rollback [deployment-id]",
-			"🔙 Rollback a deployment",
-			(rollbackYargs) =>
-				rollbackYargs
-					.positional("deployment-id", {
-						describe: "The ID of the deployment to rollback to",
-						type: "string",
-						demandOption: false,
-					})
-					.option("message", {
-						alias: "m",
-						describe:
-							"Skip confirmation and message prompts, uses provided argument as message",
-						type: "string",
-						default: undefined,
-					}),
-			async (rollbackYargs) => {
-				const { accountId, scriptName, config } =
-					await commonDeploymentCMDSetup(rollbackYargs, rollbackWarning);
+	wrangler.command(
+		"rollback [deployment-id]",
+		"🔙 Rollback a deployment",
+		(rollbackYargs) =>
+			rollbackYargs
+				.positional("deployment-id", {
+					describe: "The ID of the deployment to rollback to",
+					type: "string",
+					demandOption: false,
+				})
+				.option("message", {
+					alias: "m",
+					describe:
+						"Skip confirmation and message prompts, uses provided argument as message",
+					type: "string",
+					default: undefined,
+				})
+				.epilogue(rollbackWarning),
+		async (rollbackYargs) => {
+			const { accountId, scriptName, config } = await commonDeploymentCMDSetup(
+				rollbackYargs,
+				rollbackWarning
+			);
 
-				await rollbackDeployment(
-					accountId,
-					scriptName,
-					config,
-					rollbackYargs.deploymentId,
-					rollbackYargs.message
-				);
-			}
-		)
-		.epilogue(rollbackWarning);
+			await rollbackDeployment(
+				accountId,
+				scriptName,
+				config,
+				rollbackYargs.deploymentId,
+				rollbackYargs.message
+			);
+		}
+	);
 
 	// This set to false to allow overwrite of default behaviour
 	wrangler.version(false);


### PR DESCRIPTION
Closes #3169

**What this PR solves / how to test:**

I didn't run wrangler rollback, so the message doesn't seem applicable to me:

```
🚧`wrangler rollback` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
```


**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
