### PR TITLE
[wrangler] Add deploy --old-asset-ttl option

### DIFF
--- a/.changeset/tasty-beds-look.md
+++ b/.changeset/tasty-beds-look.md
@@ -2,4 +2,13 @@
 "wrangler": patch
 ---
 
-Add wrangler deploy option: --old-asset-ttl [seconds]
+feature: add wrangler deploy option: --old-asset-ttl [seconds]
+
+`wrangler deploy` immediately deletes assets that are no longer current, which has a side-effect for existing progressive web app users of seeing 404 errors as the app tries to access assets that no longer exist.
+
+This new feature:
+- does not change the default behavior of immediately deleting no-longer needed assets.
+- allows users to opt-in to expiring newly obsoleted assets after the provided number of seconds hence, so that current users will have a time buffer before seeing 404 errors.
+- is similar in concept to what was introduced in Wrangler 1.x with https://github.com/cloudflare/wrangler-legacy/pull/2221.
+- is careful to avoid extension of existing expiration targets on already expiring old assets, which may have contributed to unexpectedly large KV storage accumulations (perhaps why, in Wrangler 1.x, the reversion https://github.com/cloudflare/wrangler-legacy/pull/2228 happened).
+- no breaking changes for users relying on the default behavior, but some output changes exist when the new option is used, to indicate the change in behavior.

--- a/.changeset/tasty-beds-look.md
+++ b/.changeset/tasty-beds-look.md
@@ -7,6 +7,7 @@ feature: add wrangler deploy option: --old-asset-ttl [seconds]
 `wrangler deploy` immediately deletes assets that are no longer current, which has a side-effect for existing progressive web app users of seeing 404 errors as the app tries to access assets that no longer exist.
 
 This new feature:
+
 - does not change the default behavior of immediately deleting no-longer needed assets.
 - allows users to opt-in to expiring newly obsoleted assets after the provided number of seconds hence, so that current users will have a time buffer before seeing 404 errors.
 - is similar in concept to what was introduced in Wrangler 1.x with https://github.com/cloudflare/wrangler-legacy/pull/2221.

--- a/.changeset/tasty-beds-look.md
+++ b/.changeset/tasty-beds-look.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add wrangler deploy option: --old-asset-ttl [seconds]

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -63,6 +63,7 @@ type Props = {
 	noBundle: boolean | undefined;
 	keepVars: boolean | undefined;
 	logpush: boolean | undefined;
+	oldAssetTtl: number | undefined;
 };
 
 type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
@@ -525,7 +526,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			scriptName + (!props.legacyEnv && props.env ? `-${props.env}` : ""),
 			props.assetPaths,
 			false,
-			props.dryRun
+			props.dryRun,
+			props.oldAssetTtl
 		);
 
 		const bindings: CfWorkerInit["bindings"] = {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -181,6 +181,11 @@ export function deployOptions(yargs: CommonYargsArgv) {
 				describe:
 					"Send Trace Events from this worker to Workers Logpush.\nThis will not configure a corresponding Logpush job automatically.",
 			})
+			.option("old-asset-ttl", {
+				describe:
+					"Expire old assets in given seconds rather than immediate deletion.",
+				type: "number",
+			})
 	);
 }
 
@@ -277,5 +282,6 @@ export async function deployHandler(
 		noBundle: !(args.bundle ?? !config.no_bundle),
 		keepVars: args.keepVars,
 		logpush: args.logpush,
+		oldAssetTtl: args.oldAssetTtl,
 	});
 }

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -536,7 +536,8 @@ async function createRemoteWorkerInit(props: {
 		props.name + (!props.legacyEnv && props.env ? `-${props.env}` : ""),
 		props.isWorkersSite ? props.assetPaths : undefined,
 		true,
-		false
+		false,
+		undefined
 	); // TODO: cancellable?
 
 	const init: CfWorkerInit = {

--- a/packages/wrangler/src/sites.ts
+++ b/packages/wrangler/src/sites.ts
@@ -12,6 +12,8 @@ import {
 	deleteKVBulkKeyValue,
 	BATCH_KEY_MAX,
 	formatNumber,
+	getKVKeyValue,
+	putKVKeyValue,
 } from "./kv/helpers";
 import { logger, LOGGER_LEVELS } from "./logger";
 import type { Config } from "./config";
@@ -120,7 +122,8 @@ export async function syncAssets(
 	scriptName: string,
 	siteAssets: AssetPaths | undefined,
 	preview: boolean,
-	dryRun: boolean | undefined
+	dryRun: boolean | undefined,
+	oldAssetTTL: number | undefined
 ): Promise<{
 	manifest: { [filePath: string]: string } | undefined;
 	namespace: string | undefined;
@@ -146,6 +149,9 @@ export async function syncAssets(
 	// Get all existing keys in asset namespace
 	logger.info("Fetching list of already uploaded assets...");
 	const namespaceKeysResponse = await listKVNamespaceKeys(accountId, namespace);
+	const namespaceKeyInfoMap = new Map<string, typeof namespaceKeysResponse[0]>(
+		namespaceKeysResponse.map((x) => [x.name, x])
+	);
 	const namespaceKeys = new Set(namespaceKeysResponse.map((x) => x.name));
 
 	const assetDirectory = path.join(
@@ -243,7 +249,9 @@ export async function syncAssets(
 	if (uploadBucket.length > 0) uploadBuckets.push(uploadBucket);
 
 	for (const key of namespaceKeys) {
-		logDiff(chalk.red(` - ${key} (removing as stale)`));
+		logDiff(
+			chalk.red(` - ${key} (${oldAssetTTL ? "expiring" : "removing"} as stale)`)
+		);
 	}
 
 	// Upload new assets, with 5 concurrent uploaders
@@ -328,12 +336,48 @@ export async function syncAssets(
 
 	// Delete stale assets
 	const deleteCount = namespaceKeys.size;
+
 	if (deleteCount > 0) {
 		const s = pluralise(deleteCount);
-		logger.info(`Removing ${formatNumber(deleteCount)} stale asset${s}...`);
-	}
-	await deleteKVBulkKeyValue(accountId, namespace, Array.from(namespaceKeys));
+		logger.info(
+			`${oldAssetTTL ? "Expiring" : "Removing"} ${formatNumber(
+				deleteCount
+			)} stale asset${s}...`
+		);
 
+		if (!oldAssetTTL) {
+			await deleteKVBulkKeyValue(
+				accountId,
+				namespace,
+				Array.from(namespaceKeys)
+			);
+		} else {
+			for (const namespaceKey of namespaceKeys) {
+				const expiration = namespaceKeyInfoMap.get(namespaceKey)?.expiration;
+
+				logger.info(
+					` - ${namespaceKey} ${
+						expiration ? `(already expiring at ${expiration})` : ""
+					}`
+				);
+
+				if (expiration) {
+					continue;
+				}
+
+				const currentValue = await getKVKeyValue(
+					accountId,
+					namespace,
+					namespaceKey
+				);
+				await putKVKeyValue(accountId, namespace, {
+					key: namespaceKey,
+					value: Buffer.from(currentValue),
+					expiration_ttl: oldAssetTTL,
+				});
+			}
+		}
+	}
 	logger.log("↗️  Done syncing assets");
 
 	return { manifest, namespace };


### PR DESCRIPTION
Fixes #3385

**What this PR solves / how to test:**

When a `wrangler deploy` happens, the old assets are immediately deleted, causing users of previously obtained web applications that expect to find specific resources to no longer have access to them, resulting in users seeing 404 errors rather quickly.

Wrangler 1.x attempted to address this by way of https://github.com/cloudflare/wrangler-legacy/pull/2221, which caused the default behavior to be a delaying of the old asset removal, but, the cache could become large with repeated deploys causing expirations being extended repeatedly (well, that was one issue...), so it was reverted.

Even though this delayed expiration of old assets was removed in subsequent Wrangler 1.x builds, we see this as a needed behavior, and stuck with the version of Wrangler 1.x that had this delayed removal of old content.

Now, migrating to Wrangler 3.x, and finding that having delayed expiration of old assets is not available, we want to add this as a non-default optional behavior, so that those that want it can have it, while not affecting others.

This implementation also avoids the extending of existing expiration target times, which helps limit cache growth.

Test by running `wrangler deploy` and see that old assets are immediately removed.

Test by running `wrangler deploy --old-asset-ttl 300`.

The console output will show some slight differences in the `Building list of assets to upload...` section, in the case where assets are to be expired rather than removed.

Later, after the upload of new assets is done, the heading of `Expiring [x] stale assets...` (default behavior shows `Removing [x] stale assets`), and the new listing of each of the individual assets as they are processed.  Each asset listed will either have no suffix (meaning they are *newly* being set an expiration), or, a suffix of `(already expiring at [x])` which indicates we are *not modifying their expiration* and informs what the expiration target is.

Here is an example:

```
Fetching list of already uploaded assets...
Building list of assets to upload...
 + asset-manifest.bb06bb849a.json (uploading new version of asset-manifest.json)
 = favicon.0d8f16a2e5.ico (already uploaded favicon.ico)
 + index.a03bf1cef7.html (uploading new version of index.html)
 = logo192.354824eae7.png (already uploaded logo192.png)
 = logo512.06ae39e3db.png (already uploaded logo512.png)
 = manifest.a8a29b1c26.json (already uploaded manifest.json)
 = robots.3dc2c2b649.txt (already uploaded robots.txt)
 = static/css/main.073c9b0a.3ef794adc1.css (already uploaded static/css/main.073c9b0a.css)
 = static/css/main.073c9b0a.css.853edb5083.map (already uploaded static/css/main.073c9b0a.css.map)
 = static/js/787.28cb0dcd.chunk.e0a3d4baf0.js (already uploaded static/js/787.28cb0dcd.chunk.js)
 = static/js/787.28cb0dcd.chunk.js.7768df2e2b.map (already uploaded static/js/787.28cb0dcd.chunk.js.map)
 + static/js/main.abc72fab.19dedd345b.js (uploading new version of static/js/main.abc72fab.js)
 + static/js/main.abc72fab.js.LICENSE.755a56ab2d.txt (uploading new version of static/js/main.abc72fab.js.LICENSE.txt)
 + static/js/main.abc72fab.js.823c394a10.map (uploading new version of static/js/main.abc72fab.js.map)
 = static/media/logo.6ce24c58023cc2f8fd88fe9d219db6c6.aa1ff94b2b.svg (already uploaded static/media/logo.6ce24c58023cc2f8fd88fe9d219db6c6.svg)
 - asset-manifest.2d6fcfc986.json (expiring as stale)
 - asset-manifest.83a7455e64.json (expiring as stale)
 - asset-manifest.f282d05f73.json (expiring as stale)
 - index.39d4ff0064.html (expiring as stale)
 - index.8c7a61abd5.html (expiring as stale)
 - index.f45e002b58.html (expiring as stale)
 - static/js/main.24df5ff3.5102bcbe6b.js (expiring as stale)
 - static/js/main.24df5ff3.js.9e4aa97270.map (expiring as stale)
 - static/js/main.24df5ff3.js.LICENSE.755a56ab2d.txt (expiring as stale)
 - static/js/main.2e94c4c7.b9d33f0ca9.js (expiring as stale)
 - static/js/main.2e94c4c7.js.5f68c68cfd.map (expiring as stale)
 - static/js/main.2e94c4c7.js.LICENSE.755a56ab2d.txt (expiring as stale)
 - static/js/main.eeb9fd6c.1d6ce605a9.js (expiring as stale)
 - static/js/main.eeb9fd6c.js.8091f2a262.map (expiring as stale)
 - static/js/main.eeb9fd6c.js.LICENSE.755a56ab2d.txt (expiring as stale)
Uploading 5 new assets...
Skipped uploading 10 existing assets.
Uploaded 100% [5 out of 5]
Expiring 15 stale assets...
 - asset-manifest.2d6fcfc986.json (already expiring at 1685554399)
 - asset-manifest.83a7455e64.json (already expiring at 1685554375)
 - asset-manifest.f282d05f73.json 
 - index.39d4ff0064.html (already expiring at 1685554400)
 - index.8c7a61abd5.html (already expiring at 1685554376)
 - index.f45e002b58.html 
 - static/js/main.24df5ff3.5102bcbe6b.js (already expiring at 1685554377)
 - static/js/main.24df5ff3.js.9e4aa97270.map (already expiring at 1685554378)
 - static/js/main.24df5ff3.js.LICENSE.755a56ab2d.txt (already expiring at 1685554379)
 - static/js/main.2e94c4c7.b9d33f0ca9.js 
 - static/js/main.2e94c4c7.js.5f68c68cfd.map 
 - static/js/main.2e94c4c7.js.LICENSE.755a56ab2d.txt 
 - static/js/main.eeb9fd6c.1d6ce605a9.js (already expiring at 1685554401)
 - static/js/main.eeb9fd6c.js.8091f2a262.map (already expiring at 1685554402)
 - static/js/main.eeb9fd6c.js.LICENSE.755a56ab2d.txt (already expiring at 1685554403)
↗️  Done syncing assets
```

Note: previous immediate removals did not show a list of the assets being deleted.  However, when updating the expiration target, it is considered helpful to see the list, as, each asset having its expiration changed must be pulled and then pushed again with the expiration target set, and for sites having many resources, seeing this list grow over time will be helpful to be assured progress is being made.

**Associated docs issue(s)/PR(s):**

https://github.com/cloudflare/wrangler-legacy/pull/2221 where similar was added to Wrangler 1.x

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
[tasty-beds-look.md](https://github.com/cloudflare/workers-sdk/blob/3eefbfddd7028a197d1459810d27c3eceef0040b/.changeset/tasty-beds-look.md)

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
