### PR TITLE
GH workflow `matrix` replaced with `runner`

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -27,7 +27,7 @@ jobs:
           path: |
             .eslintcache
             tsconfig.tsbuildinfo
-          key: ${{ matrix.os }}-eslint-tsbuildinfo-${{ hashFiles('**/*.ts','**/*.js', 'package.json', 'tsconfig.json') }}
+          key: ${{ runner.os }}-eslint-tsbuildinfo-${{ hashFiles('**/*.ts','**/*.js', 'package.json', 'tsconfig.json') }}
 
       - name: Install workerd Dependencies
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
The `matrix.os` was being used to hash which only Linux is running in checks and there is no longer a matrix.

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
