### PR TITLE
c3: clearer language during init flow

### DIFF
--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -126,7 +126,7 @@ const templateMap: Record<string, TemplateConfig> = {
 		handler: runWorkersGenerator,
 	},
 	chatgptPlugin: {
-		label: `ChatGPT plugin (Typescript)`,
+		label: `ChatGPT plugin (TypeScript)`,
 		handler: (args) =>
 			runWorkersGenerator({
 				...args,

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -126,7 +126,7 @@ const templateMap: Record<string, TemplateConfig> = {
 		handler: runWorkersGenerator,
 	},
 	chatgptPlugin: {
-		label: `ChatGPT plugin (TypeScript)`,
+		label: `ChatGPT plugin`,
 		handler: (args) =>
 			runWorkersGenerator({
 				...args,

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -230,7 +230,7 @@ export const offerGit = async (ctx: PagesGeneratorContext) => {
 	if (insideGitRepo) return;
 
 	ctx.args.git ??= await confirmInput({
-		question: "Do you want to use git?",
+		question: "Do you want to use git for version control?",
 		renderSubmitted: (value: boolean) =>
 			`${brandColor("git")} ${dim(value ? `yes` : `no`)}`,
 		defaultValue: true,


### PR DESCRIPTION

* Fix a minor typo (`Typescript` -> `TypeScript`)
* Clarify what `git` is and why that choice is relevant.