### PR TITLE
WC-1308 Reduce force-deletes unless explicitly confirmed

### DIFF
--- a/.changeset/twelve-pumpkins-crash.md
+++ b/.changeset/twelve-pumpkins-crash.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+Prefer non-force deletes unless a Worker is a dependency of another.
+
+If a Worker is used as a service binding, a durable object namespace, an outbounds for a dynamic dispatch namespace, or a tail consumer, then deleting that Worker will break those existing ones that depend upon it. Deleting with ?force=true allows you to delete anyway, which is currently the default in Wrangler.
+
+Force deletes are not often necessary, however, and using it as the default has unfortunate consequences in the API. To avoid them, we check if any of those conditions exist, and present the information to the user. If they explicitly acknowledge they're ok with breaking their other Workers, fine, we let them do it. Otherwise, we'll always use the much safer non-force deletes. We also add a "--force" flag to the delete command to skip the checks and confirmation and proceed with ?force=true

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -13,6 +13,53 @@ import type {
 	StrictYargsOptionsToInterface,
 } from "./yargs-types";
 
+// Types returned by the /script/{name}/references API
+type ServiceReference = {
+	name: string;
+	service: string;
+	environment: string;
+};
+
+type DurableObjectServiceReference = ServiceReference & {
+	durable_object_namespace_id: string;
+	durable_object_namespace_name: string;
+};
+
+type DispatchOutboundsServiceReference = ServiceReference & {
+	namespace: string;
+	params: { name: string }[];
+};
+
+export type ServiceReferenceResponse = {
+	services?: {
+		incoming: ServiceReference[];
+		outgoing: ServiceReference[];
+	};
+	durable_objects?: DurableObjectServiceReference[];
+	dispatch_outbounds?: DispatchOutboundsServiceReference[];
+};
+
+// Types returned by the /tails/by-consumer/{name} API
+export type Tail = {
+	tag: string;
+	producer:
+		| {
+				service: string;
+				environment?: string;
+		  }
+		| { script: string };
+	consumer:
+		| {
+				service: string;
+				environment?: string;
+		  }
+		| { script: string };
+	log_push?: boolean;
+	config?: unknown;
+	created_on: string;
+	modified_on: string;
+};
+
 export function deleteOptions(yargs: CommonYargsArgv) {
 	return yargs
 		.positional("script", {
@@ -27,6 +74,11 @@ export function deleteOptions(yargs: CommonYargsArgv) {
 		})
 		.option("dry-run", {
 			describe: "Don't actually delete",
+			type: "boolean",
+		})
+		.option("force", {
+			describe:
+				"Delete even if doing so will break other Workers that depend on this one",
 			type: "boolean",
 		})
 		.option("legacy-env", {
@@ -66,15 +118,25 @@ export async function deleteHandler(args: DeleteArgs) {
 
 	assert(accountId, "Missing accountId");
 
-	const confirmed = await confirm(
-		`Are you sure you want to delete ${scriptName}? This action cannot be undone.`
-	);
+	const confirmed =
+		args.force ||
+		(await confirm(
+			`Are you sure you want to delete ${scriptName}? This action cannot be undone.`
+		));
 
 	if (confirmed) {
+		const needsForceDelete =
+			args.force ||
+			(await checkAndConfirmForceDeleteIfNecessary(scriptName, accountId));
+		if (needsForceDelete === null) {
+			// null means the user rejected the extra confirmation - return early
+			return;
+		}
+
 		await fetchResult(
 			`/accounts/${accountId}/workers/services/${scriptName}`,
 			{ method: "DELETE" },
-			new URLSearchParams({ force: "true" })
+			new URLSearchParams({ force: needsForceDelete.toString() })
 		);
 
 		await deleteSiteNamespaceIfExisting(scriptName, accountId);
@@ -97,4 +159,105 @@ async function deleteSiteNamespaceIfExisting(
 		await deleteKVNamespace(accountId, ns.id);
 		logger.log(`🌀 Deleted asset namespace for Workers Site "${ns.title}"`);
 	}
+}
+
+type ScriptDetails =
+	| {
+			service: string;
+			environment?: string;
+	  }
+	| {
+			script: string;
+	  };
+
+function renderScriptName<T extends ScriptDetails = ScriptDetails>(details: T) {
+	let service: string;
+	let environment: string | undefined;
+	if ("script" in details) {
+		service = details.script;
+	} else {
+		service = details.service;
+		environment = details.environment;
+	}
+	return environment ? `${service} (${environment})` : service;
+}
+
+function isUsedAsServiceBinding(references: ServiceReferenceResponse) {
+	return (references.services?.incoming.length || 0) > 0;
+}
+
+function isUsedAsDurableObjectNamespace(
+	references: ServiceReferenceResponse,
+	scriptName: string
+) {
+	return (
+		(references.durable_objects?.filter((ref) => ref.service !== scriptName)
+			?.length || 0) > 0
+	);
+}
+
+function isUsedAsDispatchOutbound(references: ServiceReferenceResponse) {
+	return references.dispatch_outbounds?.length || 0;
+}
+
+function isUsedAsTailConsumer(tailProducers: Tail[]) {
+	return tailProducers.length > 0;
+}
+
+async function checkAndConfirmForceDeleteIfNecessary(
+	scriptName: string,
+	accountId: string
+): Promise<boolean | null> {
+	const references = await fetchResult<ServiceReferenceResponse>(
+		`/accounts/${accountId}/workers/scripts/${scriptName}/references`
+	);
+	const tailProducers = await fetchResult<Tail[]>(
+		`/accounts/${accountId}/workers/tails/by-consumer/${scriptName}`
+	);
+	const isDependentService =
+		isUsedAsServiceBinding(references) ||
+		isUsedAsDurableObjectNamespace(references, scriptName) ||
+		isUsedAsDispatchOutbound(references) ||
+		isUsedAsTailConsumer(tailProducers);
+	if (!isDependentService) return false;
+
+	const dependentMessages: string[] = [];
+	for (const serviceBindingReference of references.services?.incoming || []) {
+		const dependentScript = renderScriptName(serviceBindingReference);
+		dependentMessages.push(
+			`- Worker ${dependentScript} uses this Worker as a Service Binding`
+		);
+	}
+	for (const implementedDOBindingReference of references.durable_objects ||
+		[]) {
+		if (implementedDOBindingReference.service === scriptName) continue;
+		const dependentScript = renderScriptName(implementedDOBindingReference);
+		dependentMessages.push(
+			`- Worker ${dependentScript} has a binding to the Durable Object Namespace "${implementedDOBindingReference.durable_object_namespace_name}" implemented by this Worker`
+		);
+	}
+	for (const dispatchNamespaceOutboundReference of references.dispatch_outbounds ||
+		[]) {
+		const dependentScript = renderScriptName(
+			dispatchNamespaceOutboundReference
+		);
+		dependentMessages.push(
+			`- Worker ${dependentScript} uses this Worker as an Outbound Worker for the Dynamic Dispatch Namespace "${dispatchNamespaceOutboundReference.namespace}"`
+		);
+	}
+	for (const consumingTail of tailProducers) {
+		const dependentScript = renderScriptName(consumingTail.producer);
+		dependentMessages.push(
+			`- Worker ${dependentScript} uses this Worker as a Tail Worker`
+		);
+	}
+	const extraConfirmed =
+		await confirm(`${scriptName} is currently in use by other Workers:
+
+${dependentMessages.join("\n")}
+
+You can still delete this Worker, but doing so WILL BREAK the Workers that depend on it. This will cause unexpected failures, and cannot be undone.
+Are you sure you want to continue?`);
+
+	return extraConfirmed ? true : null;
 }


### PR DESCRIPTION
Changes the default ?force param to the delete API call to be false.

Also uses the /scripts/{scriptName}/references and /tails/by-consumer/{scriptName} endpoints to determine what resources depend on the current script. We check for other scripts that use this one as outbound worker (for dynamic dispatch), as a tail worker, as a service binding, or use a durable object implemented by this script. If any other resources rely on this worker, we require another step of confirmation, describing the dependencies, and only then do we allow doing a force delete.

for WC-1308

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
