### PR TITLE
fix(wrangler): allow direct mutation of context.data with Pages Functions

### DIFF
--- a/.changeset/hungry-pigs-refuse.md
+++ b/.changeset/hungry-pigs-refuse.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: allow context.data to be overriden in Pages Functions

--- a/fixtures/pages-functions-app/functions/middleware-data/additional-data.ts
+++ b/fixtures/pages-functions-app/functions/middleware-data/additional-data.ts
@@ -1,0 +1,9 @@
+export const onRequest = [
+	async (context) => {
+		context.data.foo = "bar";
+		return await context.next();
+	},
+	async (context) => {
+		return Response.json(context.data);
+	},
+];

--- a/fixtures/pages-functions-app/functions/middleware-data/bad-data.ts
+++ b/fixtures/pages-functions-app/functions/middleware-data/bad-data.ts
@@ -1,0 +1,4 @@
+export const onRequest = async (context) => {
+	context.data = "foo-bar";
+	return await context.next();
+};

--- a/fixtures/pages-functions-app/functions/middleware-data/merge-data.ts
+++ b/fixtures/pages-functions-app/functions/middleware-data/merge-data.ts
@@ -1,0 +1,13 @@
+export const onRequest = [
+	async (context) => {
+		context.data = { foo: "bar" };
+		return await context.next();
+	},
+	async (context) => {
+		context.data = { bar: "baz" };
+		return await context.next();
+	},
+	async (context) => {
+		return Response.json(context.data);
+	},
+];

--- a/fixtures/pages-functions-app/functions/middleware-data/mutate-data.ts
+++ b/fixtures/pages-functions-app/functions/middleware-data/mutate-data.ts
@@ -1,0 +1,13 @@
+export const onRequest = [
+	async (context) => {
+		context.data = { foo: "bar" };
+		return await context.next();
+	},
+	async (context) => {
+		context.data.bar = "baz";
+		return await context.next();
+	},
+	async (context) => {
+		return Response.json(context.data);
+	},
+];

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -318,5 +318,13 @@ describe.concurrent("Pages Functions", () => {
 				bar: "baz",
 			});
 		});
+
+		it("middleware throws when set to non-object", async ({ expect }) => {
+			const response = await fetch(
+				`http://${ip}:${port}/middleware-data/bad-data`
+			);
+
+			expect(response.status).toEqual(500);
+		});
 	});
 });

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -319,6 +319,18 @@ describe.concurrent("Pages Functions", () => {
 			});
 		});
 
+		it("allows middleware to be overriden and not merged", async ({
+			expect,
+		}) => {
+			const response = await fetch(
+				`http://${ip}:${port}/middleware-data/merge-data`
+			);
+			const data = await response.json();
+			expect(data).toEqual({
+				bar: "baz",
+			});
+		});
+
 		it("middleware throws when set to non-object", async ({ expect }) => {
 			const response = await fetch(
 				`http://${ip}:${port}/middleware-data/bad-data`

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -292,4 +292,31 @@ describe.concurrent("Pages Functions", () => {
 			);
 		});
 	});
+
+	describe.concurrent("middleware data", () => {
+		it("allows middleware to set data", async ({ expect }) => {
+			const response = await fetch(
+				`http://${ip}:${port}/middleware-data/additional-data`
+			);
+
+			expect(response.status).toEqual(200);
+			const data = await response.json();
+			expect(data).toEqual({
+				foo: "bar",
+			});
+		});
+
+		it("allows middleware to mutate data", async ({ expect }) => {
+			const response = await fetch(
+				`http://${ip}:${port}/middleware-data/mutate-data`
+			);
+
+			expect(response.status).toEqual(200);
+			const data = await response.json();
+			expect(data).toEqual({
+				foo: "bar",
+				bar: "baz",
+			});
+		});
+	});
 });

--- a/packages/wrangler/templates/pages-template-plugin.ts
+++ b/packages/wrangler/templates/pages-template-plugin.ts
@@ -144,38 +144,27 @@ export default function (pluginArgs: unknown) {
 			// Note we can't use `!result.done` because this doesn't narrow to the correct type
 			if (result.done === false) {
 				const { handler, params, path } = result.value;
-				const rawContext = {
+				const context = {
 					request: new Request(request.clone()),
 					functionPath: workerContext.functionPath + path,
 					next: pluginNext,
 					params,
-					data,
+					get data() {
+						return data;
+					},
+					set data(value) {
+						if (typeof value !== "object" || value === null) {
+							throw new Error("context.data must be an object");
+						}
+						// user has overriden context.data, so we need to merge it with the existing data
+						Object.assign(data, value);
+					},
 					pluginArgs,
 					env,
 					waitUntil: workerContext.waitUntil.bind(workerContext),
 					passThroughOnException:
 						workerContext.passThroughOnException.bind(workerContext),
 				};
-				const context = new Proxy(rawContext, {
-					set(obj, prop, value) {
-						if (prop === "data") {
-							if (typeof value !== "object" || value === null) {
-								throw new Error("context.data must be an object");
-							}
-							// user has overriden context.data, so we need to merge it with the existing data
-							Object.assign(data, value);
-							return true;
-						}
-						return Reflect.set(obj, prop, value);
-					},
-					get(target, prop, receiver) {
-						if (prop === "data") {
-							// if the user accesses context.data, return the merged data
-							return data;
-						}
-						return Reflect.get(target, prop, receiver);
-					},
-				});
 
 				const response = await handler(context);
 

--- a/packages/wrangler/templates/pages-template-plugin.ts
+++ b/packages/wrangler/templates/pages-template-plugin.ts
@@ -144,7 +144,7 @@ export default function (pluginArgs: unknown) {
 			// Note we can't use `!result.done` because this doesn't narrow to the correct type
 			if (result.done === false) {
 				const { handler, params, path } = result.value;
-				const context = {
+				const rawContext = {
 					request: new Request(request.clone()),
 					functionPath: workerContext.functionPath + path,
 					next: pluginNext,
@@ -156,6 +156,25 @@ export default function (pluginArgs: unknown) {
 					passThroughOnException:
 						workerContext.passThroughOnException.bind(workerContext),
 				};
+				const context = new Proxy(rawContext, {
+					set(obj, prop, value) {
+						if (prop === "data") {
+							if (typeof value !== "object" || value === null) {
+								throw new Error("context.data must be an object");
+							}
+							// user has overriden context.data, so we need to merge it with the existing data
+							Object.assign(data, value);
+						}
+						return Reflect.set(obj, prop, value);
+					},
+					get(target, prop, receiver) {
+						if (prop === "data") {
+							// if the user accesses context.data, return the merged data
+							return data;
+						}
+						return Reflect.get(target, prop, receiver);
+					},
+				});
 
 				const response = await handler(context);
 

--- a/packages/wrangler/templates/pages-template-plugin.ts
+++ b/packages/wrangler/templates/pages-template-plugin.ts
@@ -164,6 +164,7 @@ export default function (pluginArgs: unknown) {
 							}
 							// user has overriden context.data, so we need to merge it with the existing data
 							Object.assign(data, value);
+							return true;
 						}
 						return Reflect.set(obj, prop, value);
 					},

--- a/packages/wrangler/templates/pages-template-plugin.ts
+++ b/packages/wrangler/templates/pages-template-plugin.ts
@@ -122,7 +122,8 @@ function* executeRequest(request: Request, relativePathname: string) {
 export default function (pluginArgs: unknown) {
 	const onRequest: PagesPluginFunction = async (workerContext) => {
 		let { request } = workerContext;
-		const { env, next, data } = workerContext;
+		const { env, next } = workerContext;
+		let { data } = workerContext;
 
 		const url = new URL(request.url);
 		// TODO: Replace this with something actually legible.
@@ -157,7 +158,7 @@ export default function (pluginArgs: unknown) {
 							throw new Error("context.data must be an object");
 						}
 						// user has overriden context.data, so we need to merge it with the existing data
-						Object.assign(data, value);
+						data = value;
 					},
 					pluginArgs,
 					env,

--- a/packages/wrangler/templates/pages-template-worker.ts
+++ b/packages/wrangler/templates/pages-template-worker.ts
@@ -156,6 +156,7 @@ export default {
 							}
 							// user has overriden context.data, so we need to merge it with the existing data
 							Object.assign(data, value);
+							return true;
 						}
 						return Reflect.set(obj, prop, value);
 					},

--- a/packages/wrangler/templates/pages-template-worker.ts
+++ b/packages/wrangler/templates/pages-template-worker.ts
@@ -120,7 +120,7 @@ export default {
 	) {
 		let request = originalRequest;
 		const handlerIterator = executeRequest(request);
-		const data = {}; // arbitrary data the user can set between functions
+		let data = {}; // arbitrary data the user can set between functions
 		let isFailOpen = false;
 
 		const next = async (input?: RequestInfo, init?: RequestInit) => {
@@ -149,7 +149,7 @@ export default {
 							throw new Error("context.data must be an object");
 						}
 						// user has overriden context.data, so we need to merge it with the existing data
-						Object.assign(data, value);
+						data = value;
 					},
 					env,
 					waitUntil: workerContext.waitUntil.bind(workerContext),


### PR DESCRIPTION
Fixes #2797
**What this PR solves / how to test:**

Previously, Pages Functions exposed `context.data` like this:
```js
const data = {};

const context = {
	...,
	data
};
```
Which meant that users could set `context.data.foo = false` and it would work fine, since it's just a reference to the top-level `data` per request, but the second they tried to override `context.data` entirely, such as `context.data = {foo: false}`, the reference to the original `data` is lost, so this data wouldn't actually show up.

This PR fixes that by adding a getter/setter pair to `data`, so that folks can override this without any issues.

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
