### PR TITLE
fix: add 24h read/write metrics to d1 info

### DIFF
--- a/.changeset/six-horses-punch.md
+++ b/.changeset/six-horses-punch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: add the number of read queries and write queries in the last 24 hours to the `d1 info` command

--- a/package-lock.json
+++ b/package-lock.json
@@ -2471,9 +2471,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.20.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
-			"integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+			"integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.11"
 			},
@@ -2802,7 +2802,7 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"extraneous": true,
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -10138,10 +10138,12 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/date-fns": {
-			"version": "2.29.3",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-			"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-			"dev": true,
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dependencies": {
+				"@babel/runtime": "^7.21.0"
+			},
 			"engines": {
 				"node": ">=0.11"
 			},
@@ -31511,6 +31513,7 @@
 				"@esbuild-plugins/node-modules-polyfill": "^0.1.4",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
+				"date-fns": "^2.30.0",
 				"esbuild": "0.16.3",
 				"miniflare": "^3.0.0",
 				"nanoid": "^3.3.3",
@@ -34655,9 +34658,9 @@
 			"dev": true
 		},
 		"@babel/runtime": {
-			"version": "7.20.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
-			"integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+			"integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.11"
 			}
@@ -34937,7 +34940,7 @@
 				"is-unicode-supported": {
 					"version": "1.3.0",
 					"bundled": true,
-					"extraneous": true
+					"dev": true
 				}
 			}
 		},
@@ -40810,10 +40813,12 @@
 			"version": "1.4.0"
 		},
 		"date-fns": {
-			"version": "2.29.3",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-			"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-			"dev": true
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"requires": {
+				"@babel/runtime": "^7.21.0"
+			}
 		},
 		"date-time": {
 			"version": "3.1.0",
@@ -54426,6 +54431,7 @@
 				"cmd-shim": "^4.1.0",
 				"command-exists": "^1.2.9",
 				"concurrently": "^7.2.2",
+				"date-fns": "*",
 				"devtools-protocol": "^0.0.955664",
 				"dotenv": "^16.0.0",
 				"esbuild": "0.16.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2802,7 +2802,7 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -10141,6 +10141,7 @@
 			"version": "2.30.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
 			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.21.0"
 			},
@@ -31513,7 +31514,6 @@
 				"@esbuild-plugins/node-modules-polyfill": "^0.1.4",
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
-				"date-fns": "^2.30.0",
 				"esbuild": "0.16.3",
 				"miniflare": "^3.0.0",
 				"nanoid": "^3.3.3",
@@ -34940,7 +34940,7 @@
 				"is-unicode-supported": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true
+					"extraneous": true
 				}
 			}
 		},
@@ -40816,6 +40816,7 @@
 			"version": "2.30.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
 			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.21.0"
 			}
@@ -54431,7 +54432,6 @@
 				"cmd-shim": "^4.1.0",
 				"command-exists": "^1.2.9",
 				"concurrently": "^7.2.2",
-				"date-fns": "*",
 				"devtools-protocol": "^0.0.955664",
 				"dotenv": "^16.0.0",
 				"esbuild": "0.16.3",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -102,7 +102,6 @@
 		"@esbuild-plugins/node-modules-polyfill": "^0.1.4",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
-		"date-fns": "^2.30.0",
 		"esbuild": "0.16.3",
 		"miniflare": "^3.0.0",
 		"nanoid": "^3.3.3",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -102,6 +102,7 @@
 		"@esbuild-plugins/node-modules-polyfill": "^0.1.4",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
+		"date-fns": "^2.30.0",
 		"esbuild": "0.16.3",
 		"miniflare": "^3.0.0",
 		"nanoid": "^3.3.3",

--- a/packages/wrangler/src/__tests__/fetch-graphql-result.test.ts
+++ b/packages/wrangler/src/__tests__/fetch-graphql-result.test.ts
@@ -28,7 +28,6 @@ describe("fetchGraphqlResult", () => {
 		);
 		expect(
 			await fetchGraphqlResult({
-				method: "POST",
 				body: JSON.stringify({
 					query: `{
                     viewer {
@@ -38,5 +37,41 @@ describe("fetchGraphqlResult", () => {
 				}),
 			})
 		).toEqual({ data: { viewer: { __typename: "viewer" } }, errors: null });
+	});
+
+	it("should accept a request with no init, but return no data", async () => {
+		mockOAuthServerCallback();
+		const now = new Date().toISOString();
+		msw.use(
+			rest.post("*/graphql", async (req, res, ctx) => {
+				return res(
+					ctx.status(200),
+					ctx.json({
+						data: null,
+						errors: [
+							{
+								message: "failed to recognize JSON request: 'EOF'",
+								path: null,
+								extensions: {
+									timestamp: now,
+								},
+							},
+						],
+					})
+				);
+			})
+		);
+		expect(await fetchGraphqlResult()).toEqual({
+			data: null,
+			errors: [
+				{
+					message: "failed to recognize JSON request: 'EOF'",
+					path: null,
+					extensions: {
+						timestamp: now,
+					},
+				},
+			],
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/fetch-graphql-result.test.ts
+++ b/packages/wrangler/src/__tests__/fetch-graphql-result.test.ts
@@ -1,0 +1,42 @@
+import { rest } from "msw";
+import { fetchGraphqlResult } from "../cfetch";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockOAuthFlow } from "./helpers/mock-oauth-flow";
+import { msw } from "./helpers/msw";
+
+describe("fetchGraphqlResult", () => {
+	mockAccountId({ accountId: null });
+	mockApiToken();
+	const { mockOAuthServerCallback } = mockOAuthFlow();
+
+	it("should make a request against the graphql endpoint by default", async () => {
+		mockOAuthServerCallback();
+		msw.use(
+			rest.post("*/graphql", async (req, res, ctx) => {
+				return res(
+					ctx.status(200),
+					ctx.json({
+						data: {
+							viewer: {
+								__typename: "viewer",
+							},
+						},
+						errors: null,
+					})
+				);
+			})
+		);
+		expect(
+			await fetchGraphqlResult({
+				method: "POST",
+				body: JSON.stringify({
+					query: `{
+                    viewer {
+                      __typename
+                    }
+                  }`,
+				}),
+			})
+		).toEqual({ data: { viewer: { __typename: "viewer" } }, errors: null });
+	});
+});

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -44,6 +44,27 @@ export async function fetchResult<ResponseType>(
 }
 
 /**
+ * Make a fetch request to the GraphQL API, and return the JSON response.
+ */
+export async function fetchGraphqlResult<ResponseType>(
+	init: RequestInit = {},
+
+	abortSignal?: AbortSignal
+): Promise<ResponseType> {
+	const json = await fetchInternal<ResponseType>(
+		"/graphql",
+		init,
+		undefined,
+		abortSignal
+	);
+	if (json) {
+		return json;
+	} else {
+		throw new Error("A request to the Cloudflare API (/graphql) failed.");
+	}
+}
+
+/**
  * Make a fetch request for a list of values,
  * extracting the `result` from the JSON response,
  * and repeating the request if the results are paginated.

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -52,7 +52,7 @@ export async function fetchGraphqlResult<ResponseType>(
 ): Promise<ResponseType> {
 	const json = await fetchInternal<ResponseType>(
 		"/graphql",
-		{ ...init, method: "POST" }, //Cloudflare API v4 doesn't allow POSTs to /graphql
+		{ ...init, method: "POST" }, //Cloudflare API v4 doesn't allow GETs to /graphql
 		undefined,
 		abortSignal
 	);

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -52,7 +52,7 @@ export async function fetchGraphqlResult<ResponseType>(
 ): Promise<ResponseType> {
 	const json = await fetchInternal<ResponseType>(
 		"/graphql",
-		init, //you might be tempted to hardcode method = 'POST', but GET is allowed: https://graphql.org/learn/serving-over-http/#get-request
+		{ ...init, method: "POST" }, //Cloudflare API v4 doesn't allow POSTs to /graphql
 		undefined,
 		abortSignal
 	);

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -48,12 +48,11 @@ export async function fetchResult<ResponseType>(
  */
 export async function fetchGraphqlResult<ResponseType>(
 	init: RequestInit = {},
-
 	abortSignal?: AbortSignal
 ): Promise<ResponseType> {
 	const json = await fetchInternal<ResponseType>(
 		"/graphql",
-		init,
+		init, //you might be tempted to hardcode method = 'POST', but GET is allowed: https://graphql.org/learn/serving-over-http/#get-request
 		undefined,
 		abortSignal
 	);

--- a/packages/wrangler/src/d1/info.tsx
+++ b/packages/wrangler/src/d1/info.tsx
@@ -49,6 +49,10 @@ export const Handler = withConfig<HandlerOptions>(
 		);
 
 		let output: Record<string, string | number> = { ...result };
+		if (output["file_size"]) {
+			output["database_size"] = output["file_size"];
+			delete output["file_size"];
+		}
 		if (result.version === "beta") {
 			const today = new Date();
 			const yesterday = subDays(today, 1);
@@ -113,7 +117,7 @@ export const Handler = withConfig<HandlerOptions>(
 			const entries = Object.entries(output).filter(([k, _v]) => k !== "uuid");
 			const data = entries.map(([k, v]) => {
 				let value;
-				if (k === "file_size") {
+				if (k === "database_size") {
 					value = prettyBytes(Number(v));
 				} else if (k === "read_queries_24h" || k === "write_queries_24h") {
 					value = v.toLocaleString();

--- a/packages/wrangler/src/d1/info.tsx
+++ b/packages/wrangler/src/d1/info.tsx
@@ -99,8 +99,8 @@ export const Handler = withConfig<HandlerOptions>(
 			output = {
 				...output,
 				...(graphqlResult && {
-					read_queries_24h: metrics.readQueries,
-					write_queries_24h: metrics.writeQueries,
+					read_queries_24h: metrics.readQueries.toLocaleString(),
+					write_queries_24h: metrics.writeQueries.toLocaleString(),
 				}),
 			};
 		}

--- a/packages/wrangler/src/d1/info.tsx
+++ b/packages/wrangler/src/d1/info.tsx
@@ -75,6 +75,7 @@ export const Handler = withConfig<HandlerOptions>(
 							{
 								datetimeHour_geq: yesterday.toISOString(),
 								datetimeHour_leq: today.toISOString(),
+								databaseId: db.uuid,
 							},
 						],
 					},

--- a/packages/wrangler/src/d1/info.tsx
+++ b/packages/wrangler/src/d1/info.tsx
@@ -99,8 +99,8 @@ export const Handler = withConfig<HandlerOptions>(
 			output = {
 				...output,
 				...(graphqlResult && {
-					read_queries_24h: metrics.readQueries.toLocaleString(),
-					write_queries_24h: metrics.writeQueries.toLocaleString(),
+					read_queries_24h: metrics.readQueries,
+					write_queries_24h: metrics.writeQueries,
 				}),
 			};
 		}
@@ -111,10 +111,20 @@ export const Handler = withConfig<HandlerOptions>(
 			// Snip off the "uuid" property from the response and use those as the header
 
 			const entries = Object.entries(output).filter(([k, _v]) => k !== "uuid");
-			const data = entries.map(([k, v]) => ({
-				[db.binding || ""]: k,
-				[db.uuid]: k === "file_size" ? prettyBytes(Number(v)) : v,
-			}));
+			const data = entries.map(([k, v]) => {
+				let value;
+				if (k === "file_size") {
+					value = prettyBytes(Number(v));
+				} else if (k === "read_queries_24h" || k === "write_queries_24h") {
+					value = v.toLocaleString();
+				} else {
+					value = v;
+				}
+				return {
+					[db.binding || ""]: k,
+					[db.uuid]: value,
+				};
+			});
 
 			logger.log(renderToString(<Table data={data} />));
 		}

--- a/packages/wrangler/src/d1/types.ts
+++ b/packages/wrangler/src/d1/types.ts
@@ -30,3 +30,34 @@ export type Migration = {
 	name: string;
 	applied_at: string;
 };
+
+export interface D1Metrics {
+	sum?: {
+		readQueries?: number;
+		writeQueries?: number;
+		queryBatchResponseBytes?: number;
+	};
+	quantiles?: {
+		queryBatchTimeMsP90?: number;
+	};
+	avg?: {
+		queryBatchTimeMs?: number;
+	};
+	dimensions: {
+		databaseId?: string;
+		date?: string;
+		datetime?: string;
+		datetimeMinute?: string;
+		datetimeFiveMinutes?: string;
+		datetimeFifteenMinutes?: string;
+		datetimeHour?: string;
+	};
+}
+
+export interface D1MetricsGraphQLResponse {
+	data: {
+		viewer: {
+			accounts: { d1AnalyticsAdaptiveGroups?: D1Metrics[] }[];
+		};
+	};
+}


### PR DESCRIPTION
output for experimental dbs:
```
┌───────────────────┬──────────────────────────────────────┐
│                   │ xxxx-xxxx-xxxx-xxxx-xxxx             │
├───────────────────┼──────────────────────────────────────┤
│ name              │ northwind                            │
├───────────────────┼──────────────────────────────────────┤
│ version           │ beta                                 │
├───────────────────┼──────────────────────────────────────┤
│ num_tables        │ 13                                   │
├───────────────────┼──────────────────────────────────────┤
│ file_size         │ 33.1 MB                              │
├───────────────────┼──────────────────────────────────────┤
│ running_in_region │ WEUR                                 │
├───────────────────┼──────────────────────────────────────┤
│ read_queries_24h  │ 2219                                 │
├───────────────────┼──────────────────────────────────────┤
│ write_queries_24h │ 0                                    │
└───────────────────┴──────────────────────────────────────┘
```

```
{
  "uuid": "xxxx-xxxx-xxxx-xxxx-xxxx",
  "name": "northwind",
  "version": "beta",
  "num_tables": 13,
  "file_size": 33067008,
  "running_in_region": "WEUR",
  "read_queries_24h": 2219,
  "write_queries_24h": 0
}
```