### PR TITLE
[quick-edit] Fix CORS headers to allow arbitrary headers in raw HTTP preview requests

### DIFF
--- a/.changeset/breezy-coins-tan.md
+++ b/.changeset/breezy-coins-tan.md
@@ -1,0 +1,8 @@
+---
+"edge-preview-authenticated-proxy": patch
+---
+
+fix: Allowed arbitrary headers on cross-origin requests to Raw HTTP preview.
+
+Requests sent to the rawhttp preview endpoint with arbitrary headers were being blocked due to same-origin policy.
+We now include any request headers as part of `Access-Control-Allow-Headers` in the preflight response.

--- a/packages/edge-preview-authenticated-proxy/src/index.ts
+++ b/packages/edge-preview-authenticated-proxy/src/index.ts
@@ -145,7 +145,7 @@ async function handleRequest(
  * It must be called with a random subdomain (i.e. some-random-data.rawhttp.devprod.cloudflare.dev)
  * for consistency with the preview endpoint. This is not currently used, but may be in future
  *
- * It required two parameters, passed as headers:
+ * It requires two parameters, passed as headers:
  *  - `X-CF-Token`  A preview token, as in /.update-preview-token
  *  - `X-CF-Remote` Which endpoint to hit with preview requests, as in /.update-preview-token
  */
@@ -156,9 +156,11 @@ async function handleRawHttp(request: Request, url: URL) {
 				"Access-Control-Allow-Origin": request.headers.get("Origin") ?? "",
 				"Access-Control-Allow-Method": "*",
 				"Access-Control-Allow-Credentials": "true",
-				"Access-Control-Allow-Headers": "x-cf-token,x-cf-remote",
+				"Access-Control-Allow-Headers":
+					request.headers.get("Access-Control-Request-Headers") ??
+					"x-cf-token,x-cf-remote",
 				"Access-Control-Expose-Headers": "*",
-				Vary: "Origin",
+				Vary: "Origin, Access-Control-Request-Headers",
 			},
 		});
 	}
@@ -191,7 +193,6 @@ async function handleRawHttp(request: Request, url: URL) {
 			"Access-Control-Allow-Origin": request.headers.get("Origin") ?? "",
 			"Access-Control-Allow-Method": "*",
 			"Access-Control-Allow-Credentials": "true",
-			"Access-Control-Allow-Headers": "x-cf-token,x-cf-remote",
 			"cf-ew-status": workerResponse.status.toString(),
 			"Access-Control-Expose-Headers": "*",
 			Vary: "Origin",

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -255,3 +255,36 @@ describe("Preview Worker", () => {
 		expect(await resp.text()).toMatchInlineSnapshot('"407"');
 	});
 });
+
+describe("Raw HTTP preview", () => {
+	let worker: UnstableDevWorker;
+
+	beforeAll(async () => {
+		worker = await unstable_dev("src/index.ts", {
+			// @ts-expect-error TODO: figure out the right way to get the server to accept host from the request
+			host: "0000.rawhttp.devprod.cloudflare.dev",
+			experimental: {
+				disableExperimentalWarning: true,
+			},
+		});
+	});
+
+	afterAll(async () => {
+		await worker.stop();
+	});
+
+	it("should allow arbitrary headers in cross-origin requests", async () => {
+		const resp = await worker.fetch(
+			`https://0000.rawhttp.devprod.cloudflare.dev`,
+			{
+				method: "OPTIONS",
+				headers: {
+					"Access-Control-Request-Headers": "foo",
+					origin: "https://cloudflare.dev",
+				},
+			}
+		);
+
+		expect(resp.headers.get("Access-Control-Allow-Headers")).toBe("foo");
+	});
+});


### PR DESCRIPTION
**What this PR solves / how to test:**
This PR updates the `edge-preview-authenticated-proxy` Worker to properly handle cross-origin requests with arbitrary headers. The HTTP tab in the Quick Editor allows users to provide headers, but these requests were being blocked due to same-origin policy.

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
