### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 /packages/wrangler/src/api/pages/ @cloudflare/pages
 /packages/wrangler/src/pages/ @cloudflare/pages
 
-/packages/wrangler/src/api/d1/ @cloudflare/d1
-/packages/wrangler/src/d1/ @cloudflare/d1
+/packages/wrangler/src/api/d1/ @cloudflare/d1 @cloudflare/wrangler
+/packages/wrangler/src/d1/ @cloudflare/d1 @cloudflare/wrangler
 
 /packages/create-cloudflare/ @jculvey @RamIdeas @petebacondarwin


### PR DESCRIPTION
I just noticed the prior PR means ONLY the codeowners can approve in particular folders - we just want to be notified when folks modify d1 files, not necessarily be a blocker.