### PR TITLE
chore: update root /templates to use `wrangler generate` instead of `create-cloudflare@v1`

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -12,13 +12,13 @@ There are a few ways to quickly jumpstart your next project using one of the tem
 
 1. **Local development, via CLI quickstart utility**
 
-   We recommend using the `npm create cloudflare@1 [folder-name] [template-name]` command to create new projects with templates.
-
-   You may select the name of any subdirectory within this repository to create your project; for example, `worker-typescript` and `examples/fast-google-fonts` are both valid subdirectory names.
+   We recommend using the `npx wrangler generate [folder-name] [template-name]` command to create new projects with templates.
 
    To create a `my-project` directory using the [`worker-typescript`](/worker-typescript) template, you would run the following command:
 
-`npm create cloudflare@1 my-project worker-typescript`
+   `npx wrangler generate my-project worker-typescript`
+
+   Each template also comes with explicit installation and setup instructions in the README.
 
 1. **Local development, via full repository clone**
 

--- a/templates/experimental/worker-cobol/README.md
+++ b/templates/experimental/worker-cobol/README.md
@@ -11,11 +11,11 @@ A Cloudflare worker that runs COBOL.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-cobol
+$ npm init cloudflare my-project worker-cobol --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-cobol
+$ yarn create cloudflare my-project worker-cobol --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-cobol
+$ pnpm create cloudflare my-project worker-cobol --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-cobol/README.md
+++ b/templates/experimental/worker-cobol/README.md
@@ -17,5 +17,3 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 # or
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-cobol
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-cobol/README.md
+++ b/templates/experimental/worker-cobol/README.md
@@ -11,11 +11,11 @@ A Cloudflare worker that runs COBOL.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-cobol --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-cobol
 # or
-$ yarn create cloudflare my-project worker-cobol --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-cobol
 # or
-$ pnpm create cloudflare my-project worker-cobol --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-cobol
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-dart/README.md
+++ b/templates/experimental/worker-dart/README.md
@@ -4,24 +4,33 @@ Your [Dart](https://dart.dev/) code in [index.dart](https://github.com/cloudflar
 
 In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need to [install Dart](https://dart.dev/get-dart).
 
-#### Wrangler
+## Setup
 
-To generate using [wrangler](https://github.com/cloudflare/wrangler)
+To create a `my-project` directory using this template, run:
 
+```sh
+$ npm init cloudflare my-project worker-dart --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-dart --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-dart --no-delegate-c3
 ```
-wrangler generate projectname https://github.com/cloudflare/dart-worker-hello-world
-```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
-#### Dart
+## Dart
 
 After installing Dart per the linked instructions above,
 
-```
+```sh
 cd projectname
+```
 
-# run once to get dependencies
+Then run the following to get dependencies:
+
+```sh
 pub get
 
 dart2js -O2 --server-mode -o index.js index.dart
@@ -31,11 +40,11 @@ That will compile your code into index.js, after which you can run `wrangler dep
 
 For more information on how Dart translates to JavaScript, see the [docs for dart2js](https://dart.dev/tools/dart2js) and the [interop guide](https://dart.dev/web/js-interop).
 
-#### Errors
+## Errors
 
 Dart `2.13.0` and above require the `dart2js --server-mode` flag when using native JavaScript classes. Server mode is used to compile JS to run on server side VMs such as nodejs. If this flag is not used, the following errors are displayed:
 
-```
+```sh
 index.dart:4:7:
 Error: JS interop class 'Request' conflicts with natively supported class '_Request' in 'dart:html'.
 class Request {

--- a/templates/experimental/worker-dart/README.md
+++ b/templates/experimental/worker-dart/README.md
@@ -16,7 +16,7 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-dart
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 

--- a/templates/experimental/worker-dart/README.md
+++ b/templates/experimental/worker-dart/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-dart
 ```
 
-
-
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
 ## Dart

--- a/templates/experimental/worker-dart/README.md
+++ b/templates/experimental/worker-dart/README.md
@@ -9,11 +9,11 @@ In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-dart --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-dart
 # or
-$ yarn create cloudflare my-project worker-dart --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-dart
 # or
-$ pnpm create cloudflare my-project worker-dart --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-dart
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-emscripten/README.md
+++ b/templates/experimental/worker-emscripten/README.md
@@ -16,11 +16,11 @@ This template requires [Docker](https://docs.docker.com/install/) for providing 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-emscripten
+$ npm init cloudflare my-project worker-emscripten --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-emscripten
+$ yarn create cloudflare my-project worker-emscripten --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-emscripten
+$ pnpm create cloudflare my-project worker-emscripten --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-emscripten/README.md
+++ b/templates/experimental/worker-emscripten/README.md
@@ -23,8 +23,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-emscripten
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Credits
 
 Shoutout to [Surma](https://twitter.com/dassurma) for his [webpack-emscripten-wasm](https://gist.github.com/surma/b2705b6cca29357ebea1c9e6e15684cc) gist that was instrumental in getting this working!

--- a/templates/experimental/worker-emscripten/README.md
+++ b/templates/experimental/worker-emscripten/README.md
@@ -16,11 +16,11 @@ This template requires [Docker](https://docs.docker.com/install/) for providing 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-emscripten --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-emscripten
 # or
-$ yarn create cloudflare my-project worker-emscripten --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-emscripten
 # or
-$ pnpm create cloudflare my-project worker-emscripten --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-emscripten
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-fsharp/README.md
+++ b/templates/experimental/worker-fsharp/README.md
@@ -33,11 +33,17 @@ To authenticate wrangler commands it is recomended you [configure wrangler](http
 
 ### Generate a New Project
 
-To create a new project based on this template execute:
+To create a `my-project` directory using this template, run:
 
+```sh
+$ npm init cloudflare my-project worker-fsharp --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-fsharp --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-fsharp --no-delegate-c3
 ```
-wrangler generate projectname https://github.com/fable-compiler/cfworker-hello-world
-```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
 
 ### Build and Deploy to Dev
 

--- a/templates/experimental/worker-fsharp/README.md
+++ b/templates/experimental/worker-fsharp/README.md
@@ -43,8 +43,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-fsharp
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ### Build and Deploy to Dev
 
 1. Run `dotnet tool restore`

--- a/templates/experimental/worker-fsharp/README.md
+++ b/templates/experimental/worker-fsharp/README.md
@@ -36,11 +36,11 @@ To authenticate wrangler commands it is recomended you [configure wrangler](http
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-fsharp --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-fsharp
 # or
-$ yarn create cloudflare my-project worker-fsharp --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-fsharp
 # or
-$ pnpm create cloudflare my-project worker-fsharp --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-fsharp
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-kotlin/README.md
+++ b/templates/experimental/worker-kotlin/README.md
@@ -4,6 +4,20 @@ Your Kotlin code in [main.kt](https://github.com/cloudflare/kotlin-worker-hello-
 
 In addition to [Wrangler v2.x](https://github.com/cloudflare/wrangler2) you will need to install Kotlin, including a JDK and support for Gradle projects. The easiest way to do this is using the free Community Edition of [IntelliJ IDEA](https://kotlinlang.org/docs/tutorials/jvm-get-started.html).
 
+## Setup
+
+To create a `my-project` directory using this template, run:
+
+```sh
+$ npm init cloudflare my-project worker-kotlin --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-kotlin --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-kotlin --no-delegate-c3
+```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
 ## Wrangler
 
 Configure the [wrangler.toml](wrangler.toml) by filling in the `account_id` from the Workers pages of your Cloudflare Dashboard.

--- a/templates/experimental/worker-kotlin/README.md
+++ b/templates/experimental/worker-kotlin/README.md
@@ -9,11 +9,11 @@ In addition to [Wrangler v2.x](https://github.com/cloudflare/wrangler2) you will
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-kotlin --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-kotlin
 # or
-$ yarn create cloudflare my-project worker-kotlin --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-kotlin
 # or
-$ pnpm create cloudflare my-project worker-kotlin --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-kotlin
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-kotlin/README.md
+++ b/templates/experimental/worker-kotlin/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-kotlin
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Wrangler
 
 Configure the [wrangler.toml](wrangler.toml) by filling in the `account_id` from the Workers pages of your Cloudflare Dashboard.

--- a/templates/experimental/worker-perl/README.md
+++ b/templates/experimental/worker-perl/README.md
@@ -4,21 +4,32 @@ Your Perl code in [index.pl](https://github.com/cloudflare/perl-worker-hello-wor
 
 In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need to install Perl 5 and [Perlito](https://github.com/fglock/Perlito), a compiler from Perl to Java and JavaScript. Clone Perlito from GitHub (last tested on commit 97c296f), don't install the older version available on CPAN.
 
-#### Wrangler
+## Setup
 
-To generate using [wrangler](https://github.com/cloudflare/wrangler)
+To create a `my-project` directory using this template, run:
 
+```sh
+$ npm init cloudflare my-project worker-perl --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-perl --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-perl --no-delegate-c3
 ```
-wrangler generate projectname https://github.com/cloudflare/perl-worker-hello-world
-```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
+
+## Wrangler
+
+Wrangler is used to develop, deploy, and configure your Worker via CLI.
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
-#### Perlito
+## Perlito
 
 Assuming you've cloned the Perlito repo to `~/Perlito` and `perl` on your path is Perl 5, run
 
-```
+```sh
 cd projectname
 echo -e "const window = this;\n" > index.js && \
 perl ~/Perlito/perlito5.pl -Cjs index.pl >> index.js

--- a/templates/experimental/worker-perl/README.md
+++ b/templates/experimental/worker-perl/README.md
@@ -18,7 +18,6 @@ $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
 
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-perl/README.md
+++ b/templates/experimental/worker-perl/README.md
@@ -9,11 +9,11 @@ In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-perl --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-perl
 # or
-$ yarn create cloudflare my-project worker-perl --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-perl
 # or
-$ pnpm create cloudflare my-project worker-perl --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-perl
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-perl/README.md
+++ b/templates/experimental/worker-perl/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-perl
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-php/README.md
+++ b/templates/experimental/worker-php/README.md
@@ -4,19 +4,30 @@ Your PHP code in [index.php](https://github.com/cloudflare/php-worker-hello-worl
 
 This project uses [babel-preset-php](https://gitlab.com/kornelski/babel-preset-php) to convert PHP to JavaScript.
 
-#### Wrangler
+## Setup
 
-To generate using [wrangler](https://github.com/cloudflare/wrangler)
+To create a `my-project` directory using this template, run:
 
+```sh
+$ npm init cloudflare my-project worker-php --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-php --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-php --no-delegate-c3
 ```
-wrangler generate projectname https://github.com/cloudflare/php-worker-hello-world
-```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
+
+## Wrangler
+
+Wrangler is used to develop, deploy, and configure your Worker via CLI.
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
-#### babel-preset-php
+## babel-preset-php
 
-```
+```sh
 cd projectname
 
 # run once to install babel-preset-php and dependencies

--- a/templates/experimental/worker-php/README.md
+++ b/templates/experimental/worker-php/README.md
@@ -18,7 +18,6 @@ $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
 
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-php/README.md
+++ b/templates/experimental/worker-php/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-php
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-php/README.md
+++ b/templates/experimental/worker-php/README.md
@@ -9,11 +9,11 @@ This project uses [babel-preset-php](https://gitlab.com/kornelski/babel-preset-p
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-php --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-php
 # or
-$ yarn create cloudflare my-project worker-php --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-php
 # or
-$ pnpm create cloudflare my-project worker-php --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-php
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-python/README.md
+++ b/templates/experimental/worker-python/README.md
@@ -4,19 +4,32 @@ Your Python code in [index.py](https://github.com/cloudflare/python-worker-hello
 
 In addition to [Wrangler](https://github.com/cloudflare/wrangler2) and [npm](https://www.npmjs.com/get-npm), you will need to install [Transcrypt](https://www.transcrypt.org/docs/html/installation_use.html), including Python 3.7 and virtualenv.
 
-#### Wrangler
+## Setup
 
-- Clone repository (`git clone https://github.com/cloudflare/python-worker-hello-world`)
-- Run `npm install`
-- Update `wrangler.toml` with your project `name`, `account_id`, and `route` as required
+To create a `my-project` directory using this template, run:
 
-Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/wrangler/).
+```sh
+$ npm init cloudflare my-project worker-python --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-python --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-python --no-delegate-c3
+```
 
-#### Transcrypt
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
+
+## Wrangler
+
+Wrangler is used to develop, deploy, and configure your Worker via CLI.
+
+Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
+
+## Transcrypt
 
 Before building your project, you'll need to do one-time setup of Transcrypt. Assuming you have Python 3.7 and virtualenv installed per the linked instructions above, that setup on unix systems looks like the following (for windows see [virtualenv docs](https://virtualenv.pypa.io/en/latest/user_guide.html#activators)):
 
-```
+```sh
 cd projectname
 
 virtualenv env
@@ -34,7 +47,7 @@ For more information on how Python translates to Javascript, see the [Transcrypt
 
 Because of aliases, for a KV namespace binding named `KV` you can use `KV.put` normally, but need to use `KV.js_get` instead of `KV.get`. For example, a handler using KV might look like:
 
-```
+```sh
 def handleRequest(request):
     return KV.js_get('foo').then(
         lambda v: __new__(Response('Python Worker hello world! ' + v, {

--- a/templates/experimental/worker-python/README.md
+++ b/templates/experimental/worker-python/README.md
@@ -18,7 +18,6 @@ $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
 
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-python/README.md
+++ b/templates/experimental/worker-python/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-python
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-python/README.md
+++ b/templates/experimental/worker-python/README.md
@@ -9,11 +9,11 @@ In addition to [Wrangler](https://github.com/cloudflare/wrangler2) and [npm](htt
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-python --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-python
 # or
-$ yarn create cloudflare my-project worker-python --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-python
 # or
-$ pnpm create cloudflare my-project worker-python --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-python
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-reason/README.md
+++ b/templates/experimental/worker-reason/README.md
@@ -4,21 +4,32 @@ Your [Reason](https://reasonml.github.io/) code in [Demo.re](https://github.com/
 
 In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need to [install BuckleScript](https://reasonml.github.io/docs/en/installation) using npm or Yarn.
 
-#### Wrangler
+## Setup
 
-To generate using [wrangler](https://github.com/cloudflare/wrangler)
+To create a `my-project` directory using this template, run:
 
+```sh
+$ npm init cloudflare my-project worker-reason --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-reason --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-reason --no-delegate-c3
 ```
-wrangler generate projectname https://github.com/cloudflare/reason-worker-hello-world
-```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
+
+## Wrangler
+
+Wrangler is used to develop, deploy, and configure your Worker via CLI.
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
-#### BuckleScript
+## BuckleScript
 
 After installing BuckleScript per the linked instructions above,
 
-```
+```sh
 cd projectname
 
 # assuming you installed BuckleScript globally, need to run this once

--- a/templates/experimental/worker-reason/README.md
+++ b/templates/experimental/worker-reason/README.md
@@ -18,7 +18,6 @@ $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
 
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-reason/README.md
+++ b/templates/experimental/worker-reason/README.md
@@ -9,11 +9,11 @@ In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-reason --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-reason
 # or
-$ yarn create cloudflare my-project worker-reason --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-reason
 # or
-$ pnpm create cloudflare my-project worker-reason --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-reason
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-reason/README.md
+++ b/templates/experimental/worker-reason/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-reason
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-rust/README.md
+++ b/templates/experimental/worker-rust/README.md
@@ -11,14 +11,21 @@ This template is designed for compiling Rust to WebAssembly and publishing the r
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-rust
+$ npm init cloudflare my-project worker-rust --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-rust
+$ yarn create cloudflare my-project worker-rust --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-rust
+$ pnpm create cloudflare my-project worker-rust --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
+## Wrangler
+
+Wrangler is used to develop, deploy, and configure your Worker via CLI.
+
+Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
+
 
 ## Usage
 

--- a/templates/experimental/worker-rust/README.md
+++ b/templates/experimental/worker-rust/README.md
@@ -11,11 +11,11 @@ This template is designed for compiling Rust to WebAssembly and publishing the r
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-rust --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-rust
 # or
-$ yarn create cloudflare my-project worker-rust --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-rust
 # or
-$ pnpm create cloudflare my-project worker-rust --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-rust
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-rust/README.md
+++ b/templates/experimental/worker-rust/README.md
@@ -18,8 +18,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-rust
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-rust/README.md
+++ b/templates/experimental/worker-rust/README.md
@@ -26,7 +26,6 @@ Wrangler is used to develop, deploy, and configure your Worker via CLI.
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
-
 ## Usage
 
 This template starts you off with a `src/lib.rs` file, acting as an entrypoint for requests hitting your Worker. Feel free to add more code in this file, or create Rust modules anywhere else for this project to use.

--- a/templates/experimental/worker-scala-kv/README.md
+++ b/templates/experimental/worker-scala-kv/README.md
@@ -4,23 +4,32 @@
 
 In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need to install the Scala build tool [sbt](https://www.scala-sbt.org/1.x/docs/Setup.html), including a JDK.
 
-#### Wrangler
+## Setup
 
-To generate using [wrangler](https://github.com/cloudflare/wrangler)
+To create a `my-project` directory using this template, run:
 
+```sh
+$ npm init cloudflare my-project worker-scala-kv --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-scala-kv --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-scala-kv --no-delegate-c3
 ```
-wrangler generate projectname https://github.com/cloudflare/scala-worker-kv
-```
 
-When editing wrangler.toml to include your account_id, you will also need to add your kv namespace id to the binding under kv-namespaces.
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
+## Wrangler
+
+Wrangler is used to develop, deploy, and configure your Worker via CLI.
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
-#### sbt
+
+## sbt
 
 After installing sbt per the linked instructions above,
 
-```
+```sh
 cd projectname
 sbt fullOptJS
 ```

--- a/templates/experimental/worker-scala-kv/README.md
+++ b/templates/experimental/worker-scala-kv/README.md
@@ -9,11 +9,11 @@ In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-scala-kv --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-scala-kv
 # or
-$ yarn create cloudflare my-project worker-scala-kv --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-scala-kv
 # or
-$ pnpm create cloudflare my-project worker-scala-kv --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-scala-kv
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-scala-kv/README.md
+++ b/templates/experimental/worker-scala-kv/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-scala-kv
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-scala-kv/README.md
+++ b/templates/experimental/worker-scala-kv/README.md
@@ -24,7 +24,6 @@ Wrangler is used to develop, deploy, and configure your Worker via CLI.
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
-
 ## sbt
 
 After installing sbt per the linked instructions above,

--- a/templates/experimental/worker-scala/README.md
+++ b/templates/experimental/worker-scala/README.md
@@ -4,21 +4,32 @@ Your Scala code in [Main.scala](https://github.com/cloudflare/scala-worker-hello
 
 In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need to install the Scala build tool [sbt](https://www.scala-sbt.org/1.x/docs/Setup.html), including a JDK.
 
-#### Wrangler
+## Setup
 
-To generate using [wrangler](https://github.com/cloudflare/wrangler)
+To create a `my-project` directory using this template, run:
 
+```sh
+$ npm init cloudflare my-project worker-scala --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-scala --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-scala --no-delegate-c3
 ```
-wrangler generate projectname https://github.com/cloudflare/scala-worker-hello-world
-```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
+## Wrangler
+
+Wrangler is used to develop, deploy, and configure your Worker via CLI.
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
-#### sbt
+
+## sbt
 
 After installing sbt per the linked instructions above,
 
-```
+```sh
 cd projectname
 sbt fullOptJS
 ```

--- a/templates/experimental/worker-scala/README.md
+++ b/templates/experimental/worker-scala/README.md
@@ -9,11 +9,11 @@ In addition to [Wrangler](https://github.com/cloudflare/wrangler) you will need 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-scala --no-delegate-c3
+$ npx wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-scala
 # or
-$ yarn create cloudflare my-project worker-scala --no-delegate-c3
+$ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-scala
 # or
-$ pnpm create cloudflare my-project worker-scala --no-delegate-c3
+$ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-scala
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/experimental/worker-scala/README.md
+++ b/templates/experimental/worker-scala/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project https://github.com/cloudflare/workers-sdk/te
 $ pnpm wrangler generate my-project https://github.com/cloudflare/workers-sdk/templates/experimental/worker-scala
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Wrangler
 
 Wrangler is used to develop, deploy, and configure your Worker via CLI.

--- a/templates/experimental/worker-scala/README.md
+++ b/templates/experimental/worker-scala/README.md
@@ -24,7 +24,6 @@ Wrangler is used to develop, deploy, and configure your Worker via CLI.
 
 Further documentation for Wrangler can be found [here](https://developers.cloudflare.com/workers/tooling/wrangler).
 
-
 ## sbt
 
 After installing sbt per the linked instructions above,

--- a/templates/pages-example-forum-app/README.md
+++ b/templates/pages-example-forum-app/README.md
@@ -23,11 +23,11 @@ This repo contains example code for a forum applications that uses the following
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project pages-example-forum-app
+$ npm init cloudflare my-project pages-example-forum-app --no-delegate-c3
 # or
-$ yarn create cloudflare my-project pages-example-forum-app
+$ yarn create cloudflare my-project pages-example-forum-app --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project pages-example-forum-app
+$ pnpm create cloudflare my-project pages-example-forum-app --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/pages-example-forum-app/README.md
+++ b/templates/pages-example-forum-app/README.md
@@ -23,11 +23,11 @@ This repo contains example code for a forum applications that uses the following
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project pages-example-forum-app --no-delegate-c3
+$ npx wrangler generate my-project pages-example-forum-app
 # or
-$ yarn create cloudflare my-project pages-example-forum-app --no-delegate-c3
+$ yarn wrangler generate my-project pages-example-forum-app
 # or
-$ pnpm create cloudflare my-project pages-example-forum-app --no-delegate-c3
+$ pnpm wrangler generate my-project pages-example-forum-app
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/pages-example-forum-app/README.md
+++ b/templates/pages-example-forum-app/README.md
@@ -30,8 +30,6 @@ $ yarn wrangler generate my-project pages-example-forum-app
 $ pnpm wrangler generate my-project pages-example-forum-app
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 To run this locally, ensure you have `Wrangler` version `>=16.7.0` then run
 
 ```sh

--- a/templates/pages-functions-cors/README.md
+++ b/templates/pages-functions-cors/README.md
@@ -9,11 +9,11 @@ A template for Pages Functions appending CORS headers.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project pages-functions-cors
+$ npm init cloudflare my-project pages-functions-cors --no-delegate-c3
 # or
-$ yarn create cloudflare my-project pages-functions-cors
+$ yarn create cloudflare my-project pages-functions-cors --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project pages-functions-cors
+$ pnpm create cloudflare my-project pages-functions-cors --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/pages-functions-cors/README.md
+++ b/templates/pages-functions-cors/README.md
@@ -15,5 +15,3 @@ $ yarn wrangler generate my-project pages-functions-cors
 # or
 $ pnpm wrangler generate my-project pages-functions-cors
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/pages-functions-cors/README.md
+++ b/templates/pages-functions-cors/README.md
@@ -9,11 +9,11 @@ A template for Pages Functions appending CORS headers.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project pages-functions-cors --no-delegate-c3
+$ npx wrangler generate my-project pages-functions-cors
 # or
-$ yarn create cloudflare my-project pages-functions-cors --no-delegate-c3
+$ yarn wrangler generate my-project pages-functions-cors
 # or
-$ pnpm create cloudflare my-project pages-functions-cors --no-delegate-c3
+$ pnpm wrangler generate my-project pages-functions-cors
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/pages-plugin-static-forms/README.md
+++ b/templates/pages-plugin-static-forms/README.md
@@ -9,11 +9,11 @@ A template for Pages using static-forms plugin.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project pages-plugin-static-forms
+$ npm init cloudflare my-project pages-plugin-static-forms --no-delegate-c3
 # or
-$ yarn create cloudflare my-project pages-plugin-static-forms
+$ yarn create cloudflare my-project pages-plugin-static-forms --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project pages-plugin-static-forms
+$ pnpm create cloudflare my-project pages-plugin-static-forms --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/pages-plugin-static-forms/README.md
+++ b/templates/pages-plugin-static-forms/README.md
@@ -15,5 +15,3 @@ $ yarn wrangler generate my-project pages-plugin-static-forms
 # or
 $ pnpm wrangler generate my-project pages-plugin-static-forms
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/pages-plugin-static-forms/README.md
+++ b/templates/pages-plugin-static-forms/README.md
@@ -9,11 +9,11 @@ A template for Pages using static-forms plugin.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project pages-plugin-static-forms --no-delegate-c3
+$ npx wrangler generate my-project pages-plugin-static-forms
 # or
-$ yarn create cloudflare my-project pages-plugin-static-forms --no-delegate-c3
+$ yarn wrangler generate my-project pages-plugin-static-forms
 # or
-$ pnpm create cloudflare my-project pages-plugin-static-forms --no-delegate-c3
+$ pnpm wrangler generate my-project pages-plugin-static-forms
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-analytics-engine-forwarder/README.md
+++ b/templates/worker-analytics-engine-forwarder/README.md
@@ -6,6 +6,20 @@ Messages should be POSTed to the worker as JSON objects. One JSON object per lin
 Optionally, the payload can be gzipped and a `Content-Encoding: gzip` header set, otherwise it will assume the data is uncompressed.
 Up to 25 events can be received at one time.
 
+## Setup
+
+To create a `my-project` directory using this template, run:
+
+```sh
+$ npm init cloudflare my-project worker-analytics-engine-forwarder --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-analytics-engine-forwarder --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-analytics-engine-forwarder --no-delegate-c3
+```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
 ## Authentication
 
 Authentication is via bearer token. You can use any token or password string as long as you supply the same string to both the worker and the caller. To configure the token on the worker side you must set the `BEARER_TOKEN` secret to the token value by running (in a terminal, from within this project directory):

--- a/templates/worker-analytics-engine-forwarder/README.md
+++ b/templates/worker-analytics-engine-forwarder/README.md
@@ -18,8 +18,6 @@ $ yarn wrangler generate my-project worker-analytics-engine-forwarder
 $ pnpm wrangler generate my-project worker-analytics-engine-forwarder
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Authentication
 
 Authentication is via bearer token. You can use any token or password string as long as you supply the same string to both the worker and the caller. To configure the token on the worker side you must set the `BEARER_TOKEN` secret to the token value by running (in a terminal, from within this project directory):

--- a/templates/worker-analytics-engine-forwarder/README.md
+++ b/templates/worker-analytics-engine-forwarder/README.md
@@ -11,11 +11,11 @@ Up to 25 events can be received at one time.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-analytics-engine-forwarder --no-delegate-c3
+$ npx wrangler generate my-project worker-analytics-engine-forwarder
 # or
-$ yarn create cloudflare my-project worker-analytics-engine-forwarder --no-delegate-c3
+$ yarn wrangler generate my-project worker-analytics-engine-forwarder
 # or
-$ pnpm create cloudflare my-project worker-analytics-engine-forwarder --no-delegate-c3
+$ pnpm wrangler generate my-project worker-analytics-engine-forwarder
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-aws/README.md
+++ b/templates/worker-aws/README.md
@@ -11,11 +11,11 @@ This project is not related to, affiliated with, sponsored or endorsed by Amazon
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-aws
+$ npm init cloudflare my-project worker-aws --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-aws
+$ yarn create cloudflare my-project worker-aws --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-aws
+$ pnpm create cloudflare my-project worker-aws --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-aws/README.md
+++ b/templates/worker-aws/README.md
@@ -11,11 +11,11 @@ This project is not related to, affiliated with, sponsored or endorsed by Amazon
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-aws --no-delegate-c3
+$ npx wrangler generate my-project worker-aws
 # or
-$ yarn create cloudflare my-project worker-aws --no-delegate-c3
+$ yarn wrangler generate my-project worker-aws
 # or
-$ pnpm create cloudflare my-project worker-aws --no-delegate-c3
+$ pnpm wrangler generate my-project worker-aws
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-aws/README.md
+++ b/templates/worker-aws/README.md
@@ -18,8 +18,6 @@ $ yarn wrangler generate my-project worker-aws
 $ pnpm wrangler generate my-project worker-aws
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 [`index.js`](https://github.com/cloudflare/workers-aws-template/blob/master/index.js) is the content of the Workers script. In `handleRequest`, uncomment the example for the service you want to try out.
 
 You'll need to use wrangler secrets to add appropriate values for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, plus any of the service specific secrets, e.g.

--- a/templates/worker-d1-api/README.md
+++ b/templates/worker-d1-api/README.md
@@ -7,7 +7,7 @@
 This project is based off the Default Typescript Worker starter. To create a new project like this, run the following:
 
 ```sh
-npx wrangler@d1 init -y
+npx wrangler@d1 init -y --no-delegate-c3
 ```
 
 > **Note the "@d1"**—we're using a prerelease version of Wrangler under the `d1` tag. You can install this into an existing Wrangler project using `npm install wrangler@d1`

--- a/templates/worker-d1-api/README.md
+++ b/templates/worker-d1-api/README.md
@@ -7,7 +7,7 @@
 This project is based off the Default Typescript Worker starter. To create a new project like this, run the following:
 
 ```sh
-npx wrangler@d1 init -y --no-delegate-c3
+npx wrangler@d1 init -y
 ```
 
 > **Note the "@d1"**—we're using a prerelease version of Wrangler under the `d1` tag. You can install this into an existing Wrangler project using `npm install wrangler@d1`
@@ -19,7 +19,7 @@ Alternatively:
 ```sh
 git clone https://github.com/cloudflare/templates.git
 cd templates
-npm init cloudflare northwind-demo worker-d1-api
+npx wrangler generate northwind-demo worker-d1-api
 ```
 
 ### Getting started

--- a/templates/worker-d1/README.md
+++ b/templates/worker-d1/README.md
@@ -5,7 +5,7 @@
 This project is based off the Default Typescript Worker starter. To create a new project like this, run the following:
 
 ```sh
-npx wrangler@d1 init -y
+npx wrangler@d1 init -y --no-delegate-c3
 ```
 
 > **Note the "@d1"**—we're using a prerelease version of Wrangler under the `d1` tag. You can install this into an existing Wrangler project using `npm install wrangler@d1`

--- a/templates/worker-d1/README.md
+++ b/templates/worker-d1/README.md
@@ -5,7 +5,7 @@
 This project is based off the Default Typescript Worker starter. To create a new project like this, run the following:
 
 ```sh
-npx wrangler@d1 init -y --no-delegate-c3
+npx wrangler@d1 init -y
 ```
 
 > **Note the "@d1"**—we're using a prerelease version of Wrangler under the `d1` tag. You can install this into an existing Wrangler project using `npm install wrangler@d1`
@@ -17,7 +17,7 @@ Alternatively:
 ```sh
 git clone https://github.com/cloudflare/templates.git
 cd templates
-npm init cloudflare northwind-demo worker-d1
+npx wrangler generate northwind-demo worker-d1
 ```
 
 ### Getting started

--- a/templates/worker-durable-objects/README.md
+++ b/templates/worker-durable-objects/README.md
@@ -13,11 +13,11 @@ A template for kick-starting a Cloudflare Workers project that uses Durable Obje
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-durable-objects
+$ npm init cloudflare my-project worker-durable-objects --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-durable-objects
+$ yarn create cloudflare my-project worker-durable-objects --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-durable-objects
+$ pnpm create cloudflare my-project worker-durable-objects --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-durable-objects/README.md
+++ b/templates/worker-durable-objects/README.md
@@ -13,11 +13,11 @@ A template for kick-starting a Cloudflare Workers project that uses Durable Obje
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-durable-objects --no-delegate-c3
+$ npx wrangler generate my-project worker-durable-objects
 # or
-$ yarn create cloudflare my-project worker-durable-objects --no-delegate-c3
+$ yarn wrangler generate my-project worker-durable-objects
 # or
-$ pnpm create cloudflare my-project worker-durable-objects --no-delegate-c3
+$ pnpm wrangler generate my-project worker-durable-objects
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-durable-objects/README.md
+++ b/templates/worker-durable-objects/README.md
@@ -19,5 +19,3 @@ $ yarn wrangler generate my-project worker-durable-objects
 # or
 $ pnpm wrangler generate my-project worker-durable-objects
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-example-request-scheduler/README.md
+++ b/templates/worker-example-request-scheduler/README.md
@@ -9,11 +9,11 @@ A example for building a scalable request scheduler.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-example-request-scheduler
+$ npm init cloudflare my-project worker-example-request-scheduler --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-example-request-scheduler
+$ yarn create cloudflare my-project worker-example-request-scheduler --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-example-request-scheduler
+$ pnpm create cloudflare my-project worker-example-request-scheduler --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-example-request-scheduler/README.md
+++ b/templates/worker-example-request-scheduler/README.md
@@ -9,11 +9,11 @@ A example for building a scalable request scheduler.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-example-request-scheduler --no-delegate-c3
+$ npx wrangler generate my-project worker-example-request-scheduler
 # or
-$ yarn create cloudflare my-project worker-example-request-scheduler --no-delegate-c3
+$ yarn wrangler generate my-project worker-example-request-scheduler
 # or
-$ pnpm create cloudflare my-project worker-example-request-scheduler --no-delegate-c3
+$ pnpm wrangler generate my-project worker-example-request-scheduler
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-example-request-scheduler/README.md
+++ b/templates/worker-example-request-scheduler/README.md
@@ -15,5 +15,3 @@ $ yarn wrangler generate my-project worker-example-request-scheduler
 # or
 $ pnpm wrangler generate my-project worker-example-request-scheduler
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-example-wordle/README.md
+++ b/templates/worker-example-wordle/README.md
@@ -9,11 +9,11 @@ A template for kickstarting a multiplayer clone of the [Wordle](https://www.nyti
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-example-wordle
+$ npm init cloudflare my-project worker-example-wordle --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-example-wordle
+$ yarn create cloudflare my-project worker-example-wordle --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-example-wordle
+$ pnpm create cloudflare my-project worker-example-wordle --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-example-wordle/README.md
+++ b/templates/worker-example-wordle/README.md
@@ -9,11 +9,11 @@ A template for kickstarting a multiplayer clone of the [Wordle](https://www.nyti
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-example-wordle --no-delegate-c3
+$ npx wrangler generate my-project worker-example-wordle
 # or
-$ yarn create cloudflare my-project worker-example-wordle --no-delegate-c3
+$ yarn wrangler generate my-project worker-example-wordle
 # or
-$ pnpm create cloudflare my-project worker-example-wordle --no-delegate-c3
+$ pnpm wrangler generate my-project worker-example-wordle
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-example-wordle/README.md
+++ b/templates/worker-example-wordle/README.md
@@ -15,5 +15,3 @@ $ yarn wrangler generate my-project worker-example-wordle
 # or
 $ pnpm wrangler generate my-project worker-example-wordle
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-mysql/README.md
+++ b/templates/worker-mysql/README.md
@@ -9,11 +9,11 @@ This repo contains example code and a MySQL driver that can be used in any Worke
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-mysql
+$ npm init cloudflare my-project worker-mysql --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-mysql
+$ yarn create cloudflare my-project worker-mysql --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-mysql
+$ pnpm create cloudflare my-project worker-mysql --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-mysql/README.md
+++ b/templates/worker-mysql/README.md
@@ -9,11 +9,11 @@ This repo contains example code and a MySQL driver that can be used in any Worke
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-mysql --no-delegate-c3
+$ npx wrangler generate my-project worker-mysql
 # or
-$ yarn create cloudflare my-project worker-mysql --no-delegate-c3
+$ yarn wrangler generate my-project worker-mysql
 # or
-$ pnpm create cloudflare my-project worker-mysql --no-delegate-c3
+$ pnpm wrangler generate my-project worker-mysql
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-mysql/README.md
+++ b/templates/worker-mysql/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project worker-mysql
 $ pnpm wrangler generate my-project worker-mysql
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Usage
 
 Before you start, please refer to the **[official tutorial](https://developers.cloudflare.com/workers/tutorials/query-postgres-from-workers-using-database-connectors)**.

--- a/templates/worker-openapi/README.md
+++ b/templates/worker-openapi/README.md
@@ -11,11 +11,11 @@ You can try this template in your browser [here](https://worker-openapi-example.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-openapi
+$ npm init cloudflare my-project worker-openapi --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-openapi
+$ yarn create cloudflare my-project worker-openapi --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-openapi
+$ pnpm create cloudflare my-project worker-openapi --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-openapi/README.md
+++ b/templates/worker-openapi/README.md
@@ -18,8 +18,6 @@ $ yarn wrangler generate my-project worker-openapi
 $ pnpm wrangler generate my-project worker-openapi
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Local development
 
 Run `wrangler dev` and head to `/docs` our `/redocs` with your browser.

--- a/templates/worker-openapi/README.md
+++ b/templates/worker-openapi/README.md
@@ -11,11 +11,11 @@ You can try this template in your browser [here](https://worker-openapi-example.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-openapi --no-delegate-c3
+$ npx wrangler generate my-project worker-openapi
 # or
-$ yarn create cloudflare my-project worker-openapi --no-delegate-c3
+$ yarn wrangler generate my-project worker-openapi
 # or
-$ pnpm create cloudflare my-project worker-openapi --no-delegate-c3
+$ pnpm wrangler generate my-project worker-openapi
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-postgres/README.md
+++ b/templates/worker-postgres/README.md
@@ -9,11 +9,11 @@ This repo contains example code and a PostgreSQL driver that can be used in any 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-postgres
+$ npm init cloudflare my-project worker-postgres --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-postgres
+$ yarn create cloudflare my-project worker-postgres --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-postgres
+$ pnpm create cloudflare my-project worker-postgres --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-postgres/README.md
+++ b/templates/worker-postgres/README.md
@@ -16,8 +16,6 @@ $ yarn wrangler generate my-project worker-postgres
 $ pnpm wrangler generate my-project worker-postgres
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Usage
 
 Before you start, please refer to the **[official tutorial](https://developers.cloudflare.com/workers/tutorials/query-postgres-from-workers-using-database-connectors)**.

--- a/templates/worker-postgres/README.md
+++ b/templates/worker-postgres/README.md
@@ -9,11 +9,11 @@ This repo contains example code and a PostgreSQL driver that can be used in any 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-postgres --no-delegate-c3
+$ npx wrangler generate my-project worker-postgres
 # or
-$ yarn create cloudflare my-project worker-postgres --no-delegate-c3
+$ yarn wrangler generate my-project worker-postgres
 # or
-$ pnpm create cloudflare my-project worker-postgres --no-delegate-c3
+$ pnpm wrangler generate my-project worker-postgres
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-prospector/readme.md
+++ b/templates/worker-prospector/readme.md
@@ -9,11 +9,11 @@ An open-source template built for internal use by Cloudflare's SEO experts to pa
 Clone the repository from the `cloudflare/tmemplates` repository:
 
 ```bash
-$ npm init cloudflare my-project prospector
+$ npm init cloudflare my-project prospector --no-delegate-c3
 # or
-$ yarn create cloudflare my-project prospector
+$ yarn create cloudflare my-project prospector --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project prospector
+$ pnpm create cloudflare my-project prospector --no-delegate-c3
 ```
 
 Install Wrangler if not already installed.

--- a/templates/worker-prospector/readme.md
+++ b/templates/worker-prospector/readme.md
@@ -9,11 +9,11 @@ An open-source template built for internal use by Cloudflare's SEO experts to pa
 Clone the repository from the `cloudflare/tmemplates` repository:
 
 ```bash
-$ npm init cloudflare my-project prospector --no-delegate-c3
+$ npx wrangler generate my-project prospector
 # or
-$ yarn create cloudflare my-project prospector --no-delegate-c3
+$ yarn wrangler generate my-project prospector
 # or
-$ pnpm create cloudflare my-project prospector --no-delegate-c3
+$ pnpm wrangler generate my-project prospector
 ```
 
 Install Wrangler if not already installed.

--- a/templates/worker-r2/README.md
+++ b/templates/worker-r2/README.md
@@ -11,11 +11,11 @@ Please refer to the [Use R2 from Workers](https://developers.cloudflare.com/r2/d
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-r2
+$ npm init cloudflare my-project worker-r2 --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-r2
+$ yarn create cloudflare my-project worker-r2 --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-r2
+$ pnpm create cloudflare my-project worker-r2 --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-r2/README.md
+++ b/templates/worker-r2/README.md
@@ -18,8 +18,6 @@ $ yarn wrangler generate my-project worker-r2
 $ pnpm wrangler generate my-project worker-r2
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 ## Getting started
 
 Run the following commands in the console:

--- a/templates/worker-r2/README.md
+++ b/templates/worker-r2/README.md
@@ -11,11 +11,11 @@ Please refer to the [Use R2 from Workers](https://developers.cloudflare.com/r2/d
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-r2 --no-delegate-c3
+$ npx wrangler generate my-project worker-r2
 # or
-$ yarn create cloudflare my-project worker-r2 --no-delegate-c3
+$ yarn wrangler generate my-project worker-r2
 # or
-$ pnpm create cloudflare my-project worker-r2 --no-delegate-c3
+$ pnpm wrangler generate my-project worker-r2
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-router/README.md
+++ b/templates/worker-router/README.md
@@ -11,11 +11,11 @@ This template demonstrates using the [`itty-router`](https://github.com/kwhitley
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker
+$ npm init cloudflare my-project worker --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker
+$ yarn create cloudflare my-project worker --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker
+$ pnpm create cloudflare my-project worker --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-router/README.md
+++ b/templates/worker-router/README.md
@@ -11,11 +11,11 @@ This template demonstrates using the [`itty-router`](https://github.com/kwhitley
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker --no-delegate-c3
+$ npx wrangler generate my-project worker
 # or
-$ yarn create cloudflare my-project worker --no-delegate-c3
+$ yarn wrangler generate my-project worker
 # or
-$ pnpm create cloudflare my-project worker --no-delegate-c3
+$ pnpm wrangler generate my-project worker
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-router/README.md
+++ b/templates/worker-router/README.md
@@ -18,8 +18,6 @@ $ yarn wrangler generate my-project worker
 $ pnpm wrangler generate my-project worker
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 Before publishing your code you need to edit `wrangler.toml` file and add your Cloudflare `account_id` - more information about configuring and publishing your code can be found [in the documentation](https://developers.cloudflare.com/workers/learning/getting-started).
 
 Once you are ready, you can publish your code by running the following command:

--- a/templates/worker-sites-react/README.md
+++ b/templates/worker-sites-react/README.md
@@ -11,11 +11,11 @@ To learn how to deploy your own sites to Workers, check out the [video tutorial]
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-sites-react
+$ npm init cloudflare my-project worker-sites-react --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-sites-react
+$ yarn create cloudflare my-project worker-sites-react --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-sites-react
+$ pnpm create cloudflare my-project worker-sites-react --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-sites-react/README.md
+++ b/templates/worker-sites-react/README.md
@@ -11,11 +11,11 @@ To learn how to deploy your own sites to Workers, check out the [video tutorial]
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-sites-react --no-delegate-c3
+$ npx wrangler generate my-project worker-sites-react
 # or
-$ yarn create cloudflare my-project worker-sites-react --no-delegate-c3
+$ yarn wrangler generate my-project worker-sites-react
 # or
-$ pnpm create cloudflare my-project worker-sites-react --no-delegate-c3
+$ pnpm wrangler generate my-project worker-sites-react
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-sites-react/README.md
+++ b/templates/worker-sites-react/README.md
@@ -17,5 +17,3 @@ $ yarn wrangler generate my-project worker-sites-react
 # or
 $ pnpm wrangler generate my-project worker-sites-react
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-sites/README.md
+++ b/templates/worker-sites/README.md
@@ -9,11 +9,11 @@ A bare minimum template of deploying a [Workers Site](https://developers.cloudfl
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-sites
+$ npm init cloudflare my-project worker-sites --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-sites
+$ yarn create cloudflare my-project worker-sites --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-sites
+$ pnpm create cloudflare my-project worker-sites --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-sites/README.md
+++ b/templates/worker-sites/README.md
@@ -9,11 +9,11 @@ A bare minimum template of deploying a [Workers Site](https://developers.cloudfl
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-sites --no-delegate-c3
+$ npx wrangler generate my-project worker-sites
 # or
-$ yarn create cloudflare my-project worker-sites --no-delegate-c3
+$ yarn wrangler generate my-project worker-sites
 # or
-$ pnpm create cloudflare my-project worker-sites --no-delegate-c3
+$ pnpm wrangler generate my-project worker-sites
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-sites/README.md
+++ b/templates/worker-sites/README.md
@@ -15,5 +15,3 @@ $ yarn wrangler generate my-project worker-sites
 # or
 $ pnpm wrangler generate my-project worker-sites
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-speedtest/README.md
+++ b/templates/worker-speedtest/README.md
@@ -13,11 +13,11 @@ _Note:_ when running this as your own worker, your latency measurements may diff
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-speedtest
+$ npm init cloudflare my-project worker-speedtest --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-speedtest
+$ yarn create cloudflare my-project worker-speedtest --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-speedtest
+$ pnpm create cloudflare my-project worker-speedtest --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-speedtest/README.md
+++ b/templates/worker-speedtest/README.md
@@ -13,11 +13,11 @@ _Note:_ when running this as your own worker, your latency measurements may diff
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-speedtest --no-delegate-c3
+$ npx wrangler generate my-project worker-speedtest
 # or
-$ yarn create cloudflare my-project worker-speedtest --no-delegate-c3
+$ yarn wrangler generate my-project worker-speedtest
 # or
-$ pnpm create cloudflare my-project worker-speedtest --no-delegate-c3
+$ pnpm wrangler generate my-project worker-speedtest
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-speedtest/README.md
+++ b/templates/worker-speedtest/README.md
@@ -20,8 +20,6 @@ $ yarn wrangler generate my-project worker-speedtest
 $ pnpm wrangler generate my-project worker-speedtest
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 Before publishing your code you need to edit `wrangler.toml` file and add your Cloudflare `account_id` - more information about publishing your code can be found [in the documentation](https://developers.cloudflare.com/workers/learning/getting-started).
 
 Once you are ready, you can publish your code by running the following command:

--- a/templates/worker-turso-rs/README.md
+++ b/templates/worker-turso-rs/README.md
@@ -1,1 +1,15 @@
 # CloudFlare workers with Turso and Rust
+
+## Setup
+
+To create a `my-project` directory using this template, run:
+
+```sh
+$ npm init cloudflare my-project worker-turso-rs --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-turso-rs --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-turso-rs --no-delegate-c3
+```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-turso-rs/README.md
+++ b/templates/worker-turso-rs/README.md
@@ -5,11 +5,11 @@
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-turso-rs --no-delegate-c3
+$ npx wrangler generate my-project worker-turso-rs
 # or
-$ yarn create cloudflare my-project worker-turso-rs --no-delegate-c3
+$ yarn wrangler generate my-project worker-turso-rs
 # or
-$ pnpm create cloudflare my-project worker-turso-rs --no-delegate-c3
+$ pnpm wrangler generate my-project worker-turso-rs
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-turso-rs/README.md
+++ b/templates/worker-turso-rs/README.md
@@ -11,5 +11,3 @@ $ yarn wrangler generate my-project worker-turso-rs
 # or
 $ pnpm wrangler generate my-project worker-turso-rs
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-turso-ts/README.md
+++ b/templates/worker-turso-ts/README.md
@@ -5,6 +5,20 @@ database, and TypeScript to implement routes that read and write the database.
 It is provided as part of a [tutorial], which walks you through the process of
 setting up Turso and creating a database.
 
+## Setup
+
+To create a `my-project` directory using this template, run:
+
+```sh
+$ npm init cloudflare my-project worker-turso-ts --no-delegate-c3
+# or
+$ yarn create cloudflare my-project worker-turso-ts --no-delegate-c3
+# or
+$ pnpm create cloudflare my-project worker-turso-ts --no-delegate-c3
+```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
 In order to get this code to run, you will need to:
 
 - Edit `wrangler.toml` and set the `LIBSQL_DB_URL` [environment variable]

--- a/templates/worker-turso-ts/README.md
+++ b/templates/worker-turso-ts/README.md
@@ -17,8 +17,6 @@ $ yarn wrangler generate my-project worker-turso-ts
 $ pnpm wrangler generate my-project worker-turso-ts
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 In order to get this code to run, you will need to:
 
 - Edit `wrangler.toml` and set the `LIBSQL_DB_URL` [environment variable]

--- a/templates/worker-turso-ts/README.md
+++ b/templates/worker-turso-ts/README.md
@@ -10,11 +10,11 @@ setting up Turso and creating a database.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-turso-ts --no-delegate-c3
+$ npx wrangler generate my-project worker-turso-ts
 # or
-$ yarn create cloudflare my-project worker-turso-ts --no-delegate-c3
+$ yarn wrangler generate my-project worker-turso-ts
 # or
-$ pnpm create cloudflare my-project worker-turso-ts --no-delegate-c3
+$ pnpm wrangler generate my-project worker-turso-ts
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-typescript/README.md
+++ b/templates/worker-typescript/README.md
@@ -9,11 +9,11 @@ A batteries included template for kick starting a TypeScript Cloudflare worker p
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-typescript
+$ npm init cloudflare my-project worker-typescript --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-typescript
+$ yarn create cloudflare my-project worker-typescript --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-typescript
+$ pnpm create cloudflare my-project worker-typescript --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-typescript/README.md
+++ b/templates/worker-typescript/README.md
@@ -15,5 +15,3 @@ $ yarn wrangler generate my-project worker-typescript
 # or
 $ pnpm wrangler generate my-project worker-typescript
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-typescript/README.md
+++ b/templates/worker-typescript/README.md
@@ -9,11 +9,11 @@ A batteries included template for kick starting a TypeScript Cloudflare worker p
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-typescript --no-delegate-c3
+$ npx wrangler generate my-project worker-typescript
 # or
-$ yarn create cloudflare my-project worker-typescript --no-delegate-c3
+$ yarn wrangler generate my-project worker-typescript
 # or
-$ pnpm create cloudflare my-project worker-typescript --no-delegate-c3
+$ pnpm wrangler generate my-project worker-typescript
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-websocket-durable-objects/README.md
+++ b/templates/worker-websocket-durable-objects/README.md
@@ -9,11 +9,11 @@ A template for working with Durable Objects as WebSocket backend in Cloudflare W
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-websocket-durable-objects
+$ npm init cloudflare my-project worker-websocket-durable-objects --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-websocket-durable-objects
+$ yarn create cloudflare my-project worker-websocket-durable-objects --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-websocket-durable-objects
+$ pnpm create cloudflare my-project worker-websocket-durable-objects --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-websocket-durable-objects/README.md
+++ b/templates/worker-websocket-durable-objects/README.md
@@ -9,11 +9,11 @@ A template for working with Durable Objects as WebSocket backend in Cloudflare W
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-websocket-durable-objects --no-delegate-c3
+$ npx wrangler generate my-project worker-websocket-durable-objects
 # or
-$ yarn create cloudflare my-project worker-websocket-durable-objects --no-delegate-c3
+$ yarn wrangler generate my-project worker-websocket-durable-objects
 # or
-$ pnpm create cloudflare my-project worker-websocket-durable-objects --no-delegate-c3
+$ pnpm wrangler generate my-project worker-websocket-durable-objects
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-websocket-durable-objects/README.md
+++ b/templates/worker-websocket-durable-objects/README.md
@@ -15,5 +15,3 @@ $ yarn wrangler generate my-project worker-websocket-durable-objects
 # or
 $ pnpm wrangler generate my-project worker-websocket-durable-objects
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-websocket/README.md
+++ b/templates/worker-websocket/README.md
@@ -9,11 +9,11 @@ A simple template for working with WebSockets in Cloudflare Workers. [Check out 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-websocket
+$ npm init cloudflare my-project worker-websocket --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker-websocket
+$ yarn create cloudflare my-project worker-websocket --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker-websocket
+$ pnpm create cloudflare my-project worker-websocket --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-websocket/README.md
+++ b/templates/worker-websocket/README.md
@@ -15,5 +15,3 @@ $ yarn wrangler generate my-project worker-websocket
 # or
 $ pnpm wrangler generate my-project worker-websocket
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-websocket/README.md
+++ b/templates/worker-websocket/README.md
@@ -9,11 +9,11 @@ A simple template for working with WebSockets in Cloudflare Workers. [Check out 
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker-websocket --no-delegate-c3
+$ npx wrangler generate my-project worker-websocket
 # or
-$ yarn create cloudflare my-project worker-websocket --no-delegate-c3
+$ yarn wrangler generate my-project worker-websocket
 # or
-$ pnpm create cloudflare my-project worker-websocket --no-delegate-c3
+$ pnpm wrangler generate my-project worker-websocket
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-worktop/README.md
+++ b/templates/worker-worktop/README.md
@@ -15,11 +15,11 @@ This template utilizes the [`worktop`](https://github.com/lukeed/worktop) framew
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worktop
+$ npm init cloudflare my-project worktop --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worktop
+$ yarn create cloudflare my-project worktop --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worktop
+$ pnpm create cloudflare my-project worktop --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker-worktop/README.md
+++ b/templates/worker-worktop/README.md
@@ -22,8 +22,6 @@ $ yarn wrangler generate my-project worktop
 $ pnpm wrangler generate my-project worktop
 ```
 
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
-
 You will need to add a `JWT_SECRET` for your project for JWT token signing and verification.
 
 ```sh

--- a/templates/worker-worktop/README.md
+++ b/templates/worker-worktop/README.md
@@ -15,11 +15,11 @@ This template utilizes the [`worktop`](https://github.com/lukeed/worktop) framew
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worktop --no-delegate-c3
+$ npx wrangler generate my-project worktop
 # or
-$ yarn create cloudflare my-project worktop --no-delegate-c3
+$ yarn wrangler generate my-project worktop
 # or
-$ pnpm create cloudflare my-project worktop --no-delegate-c3
+$ pnpm wrangler generate my-project worktop
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker/README.md
+++ b/templates/worker/README.md
@@ -9,11 +9,11 @@ A simple template for kick starting a Cloudflare worker project.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker
+$ npm init cloudflare my-project worker --no-delegate-c3
 # or
-$ yarn create cloudflare my-project worker
+$ yarn create cloudflare my-project worker --no-delegate-c3
 # or
-$ pnpm create cloudflare my-project worker
+$ pnpm create cloudflare my-project worker --no-delegate-c3
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker/README.md
+++ b/templates/worker/README.md
@@ -15,5 +15,3 @@ $ yarn wrangler generate my-project worker
 # or
 $ pnpm wrangler generate my-project worker
 ```
-
-> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.

--- a/templates/worker/README.md
+++ b/templates/worker/README.md
@@ -9,11 +9,11 @@ A simple template for kick starting a Cloudflare worker project.
 To create a `my-project` directory using this template, run:
 
 ```sh
-$ npm init cloudflare my-project worker --no-delegate-c3
+$ npx wrangler generate my-project worker
 # or
-$ yarn create cloudflare my-project worker --no-delegate-c3
+$ yarn wrangler generate my-project worker
 # or
-$ pnpm create cloudflare my-project worker --no-delegate-c3
+$ pnpm wrangler generate my-project worker
 ```
 
 > **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

This updates all template READMEs to include `--no-delegate-c3` any time that the `init` command is used. This allows for each template to be initialized as expected in a project folder. 

There are also a number of docs fixes in certain templates like: proper heading structure, adding Wrangler sections, and fixing other lint-type errors.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
