### PR TITLE
chore: upgrade `miniflare` to `3.0.1`

### DIFF
--- a/.changeset/stupid-birds-flash.md
+++ b/.changeset/stupid-birds-flash.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/pages-shared": patch
+"wrangler": patch
+---
+
+chore: upgrade `miniflare` to `3.0.1`
+
+This version ensures root CA certificates are trusted on Windows.
+It also loads extra certificates from the `NODE_EXTRA_CA_CERTS` environment variable,
+allowing `wrangler dev` to be used with Cloudflare WARP enabled.

--- a/fixtures/pages-ws-app/package.json
+++ b/fixtures/pages-ws-app/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",
-		"miniflare": "^3.0.0",
+		"miniflare": "^3.0.1",
 		"wrangler": "*",
 		"ws": "^8.8.0"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -298,58 +298,12 @@
 			"version": "0.0.0",
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "^3.0.0",
+				"miniflare": "^3.0.1",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"fixtures/pages-ws-app/node_modules/better-sqlite3": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.3.0.tgz",
-			"integrity": "sha512-JTmvBZL/JLTc+3Msbvq6gK6elbU9/wVMqiudplHrVJpr7sVMR9KJrNhZAbW+RhXKlpMcuEhYkdcHa3TXKNXQ1w==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"bindings": "^1.5.0",
-				"prebuild-install": "^7.1.0"
-			}
-		},
-		"fixtures/pages-ws-app/node_modules/cookie": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"fixtures/pages-ws-app/node_modules/miniflare": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.0.tgz",
-			"integrity": "sha512-CW8yS00pQCbq2o4K8drePzJBkE0heL9cCY/O8DcYJOHd4M0RVutjrp+LqUP4hfzweZ+LqrLo8+Rzy4cORisQoQ==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230512.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
 			}
 		},
 		"fixtures/pages-ws-app/node_modules/ws": {
@@ -371,17 +325,6 @@
 				"utf-8-validate": {
 					"optional": true
 				}
-			}
-		},
-		"fixtures/pages-ws-app/node_modules/youch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
-			"dev": true,
-			"dependencies": {
-				"cookie": "^0.5.0",
-				"mustache": "^4.2.0",
-				"stacktracey": "^2.1.8"
 			}
 		},
 		"fixtures/remix-pages-app": {
@@ -839,6 +782,32 @@
 			}
 		},
 		"node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.0.tgz",
+			"integrity": "sha512-RnanLx5ETe6aybRi1cO/edaRH+bNYWaryCEmjDDYyNr4wnSzyOp8T0dWipmqVHKEY3AbVKUom50AKSlj1zmKbg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-compilation-targets": "^7.17.7",
+				"@babel/helper-plugin-utils": "^7.16.7",
+				"debug": "^4.1.1",
+				"lodash.debounce": "^4.0.8",
+				"resolve": "^1.14.2",
+				"semver": "^6.1.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0-0"
+			}
+		},
+		"node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
@@ -2344,62 +2313,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/preset-env/node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.0.tgz",
-			"integrity": "sha512-RnanLx5ETe6aybRi1cO/edaRH+bNYWaryCEmjDDYyNr4wnSzyOp8T0dWipmqVHKEY3AbVKUom50AKSlj1zmKbg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.17.7",
-				"@babel/helper-plugin-utils": "^7.16.7",
-				"debug": "^4.1.1",
-				"lodash.debounce": "^4.0.8",
-				"resolve": "^1.14.2",
-				"semver": "^6.1.2"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.4.0-0"
-			}
-		},
-		"node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.3.tgz",
-			"integrity": "sha512-bM3gHc337Dta490gg+/AseNB9L4YLHxq1nGKZZSHbhXv4aTYU2MD2cjza1Ru4S6975YLTaL1K8uJf6ukJhhmtw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/compat-data": "^7.17.7",
-				"@babel/helper-define-polyfill-provider": "^0.4.0",
-				"semver": "^6.1.1"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.1.tgz",
-			"integrity": "sha512-ikFrZITKg1xH6pLND8zT14UPgjKHiGLqex7rGEZCH2EvhsneJaJPemmpQaIZV5AL03II+lXylw3UmddDK8RU5Q==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.0",
-				"core-js-compat": "^3.30.1"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.0.tgz",
-			"integrity": "sha512-hDJtKjMLVa7Z+LwnTCxoDLQj6wdc+B8dun7ayF2fYieI6OzfuvcLMB32ihJZ4UhCBwNYGl5bg/x/P9cMdnkc2g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"node_modules/@babel/preset-env/node_modules/semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -3005,9 +2918,9 @@
 			}
 		},
 		"node_modules/@emotion/hash": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-			"integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==",
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+			"integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==",
 			"dev": true
 		},
 		"node_modules/@esbuild-plugins/node-globals-polyfill": {
@@ -4800,9 +4713,9 @@
 			}
 		},
 		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+			"integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
 			"optional": true,
 			"peer": true,
 			"dependencies": {
@@ -6835,9 +6748,9 @@
 			"dev": true
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-			"integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+			"version": "8.5.5",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+			"integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
@@ -7959,6 +7872,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/array-buffer-byte-length": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+			"integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"is-array-buffer": "^3.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/array-flatten": {
 			"version": "1.1.1",
 			"dev": true,
@@ -8203,7 +8128,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
 			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -8331,6 +8255,54 @@
 				"node": ">= 10.14.2"
 			}
 		},
+		"node_modules/babel-plugin-polyfill-corejs2": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.3.tgz",
+			"integrity": "sha512-bM3gHc337Dta490gg+/AseNB9L4YLHxq1nGKZZSHbhXv4aTYU2MD2cjza1Ru4S6975YLTaL1K8uJf6ukJhhmtw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/compat-data": "^7.17.7",
+				"@babel/helper-define-polyfill-provider": "^0.4.0",
+				"semver": "^6.1.1"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.1.tgz",
+			"integrity": "sha512-ikFrZITKg1xH6pLND8zT14UPgjKHiGLqex7rGEZCH2EvhsneJaJPemmpQaIZV5AL03II+lXylw3UmddDK8RU5Q==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.4.0",
+				"core-js-compat": "^3.30.1"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/babel-plugin-polyfill-regenerator": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.0.tgz",
+			"integrity": "sha512-hDJtKjMLVa7Z+LwnTCxoDLQj6wdc+B8dun7ayF2fYieI6OzfuvcLMB32ihJZ4UhCBwNYGl5bg/x/P9cMdnkc2g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.4.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
 		"node_modules/babel-preset-current-node-syntax": {
 			"version": "1.0.1",
 			"license": "MIT",
@@ -8438,6 +8410,16 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/better-sqlite3": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.4.0.tgz",
+			"integrity": "sha512-NmsNW1CQvqMszu/CFAJ3pLct6NEFlNfuGM6vw72KHkjOD1UDnL96XNN1BMQc1hiHo8vE2GbOWQYIpZ+YM5wrZw==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"prebuild-install": "^7.1.0"
 			}
 		},
 		"node_modules/big.js": {
@@ -10366,9 +10348,9 @@
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
 			"dependencies": {
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
@@ -10760,35 +10742,44 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.20.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-			"integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+			"version": "1.21.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+			"integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
 			"dependencies": {
+				"array-buffer-byte-length": "^1.0.0",
+				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",
+				"es-set-tostringtag": "^2.0.1",
 				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.3",
+				"get-intrinsic": "^1.2.0",
 				"get-symbol-description": "^1.0.0",
+				"globalthis": "^1.0.3",
 				"gopd": "^1.0.1",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
+				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3",
-				"internal-slot": "^1.0.3",
+				"internal-slot": "^1.0.5",
+				"is-array-buffer": "^3.0.2",
 				"is-callable": "^1.2.7",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.10",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.2",
+				"object-inspect": "^1.12.3",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
 				"safe-regex-test": "^1.0.0",
+				"string.prototype.trim": "^1.2.7",
 				"string.prototype.trimend": "^1.0.6",
 				"string.prototype.trimstart": "^1.0.6",
-				"unbox-primitive": "^1.0.2"
+				"typed-array-length": "^1.0.4",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.9"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -10821,6 +10812,19 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
 			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
 			"dev": true
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+			"integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+			"dependencies": {
+				"get-intrinsic": "^1.1.3",
+				"has": "^1.0.3",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/es-shim-unscopables": {
 			"version": "1.0.0",
@@ -13201,7 +13205,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
 			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dev": true,
 			"dependencies": {
 				"is-callable": "^1.1.3"
 			}
@@ -13445,12 +13448,13 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
+				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3"
 			},
 			"funding": {
@@ -13634,7 +13638,6 @@
 		},
 		"node_modules/globalthis": {
 			"version": "1.0.3",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-properties": "^1.1.3"
@@ -13807,6 +13810,17 @@
 			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
 			"dependencies": {
 				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -14698,10 +14712,11 @@
 			}
 		},
 		"node_modules/internal-slot": {
-			"version": "1.0.3",
-			"license": "MIT",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+			"integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
 			"dependencies": {
-				"get-intrinsic": "^1.1.0",
+				"get-intrinsic": "^1.2.0",
 				"has": "^1.0.3",
 				"side-channel": "^1.0.4"
 			},
@@ -14808,6 +14823,19 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-array-buffer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+			"integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.0",
+				"is-typed-array": "^1.1.10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -15244,7 +15272,6 @@
 			"version": "1.1.10",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
 			"integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-			"dev": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",
@@ -19445,9 +19472,9 @@
 			}
 		},
 		"node_modules/lilconfig": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-			"integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+			"integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -21073,6 +21100,51 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/miniflare": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.1.tgz",
+			"integrity": "sha512-aLOB8d26lOTn493GOv1LmpGHVLSxmeT4MixPG/k3Ze10j0wDKnMj8wsFgbZ6Q4cr1N4faf8O3IbNRJuQ+rLoJA==",
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.13.0",
+				"workerd": "^1.20230512.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/miniflare/node_modules/ws": {
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -21542,9 +21614,9 @@
 			"link": true
 		},
 		"node_modules/node-abi": {
-			"version": "3.28.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
-			"integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
+			"version": "3.45.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
+			"integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
 			"dependencies": {
 				"semver": "^7.3.5"
 			},
@@ -21553,9 +21625,9 @@
 			}
 		},
 		"node_modules/node-abi/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -21976,9 +22048,9 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -24283,11 +24355,11 @@
 			"devOptional": true
 		},
 		"node_modules/resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+			"version": "1.22.2",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+			"integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
 			"dependencies": {
-				"is-core-module": "^2.9.0",
+				"is-core-module": "^2.11.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -26011,6 +26083,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/string.prototype.trim": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+			"integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/string.prototype.trimend": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -27187,6 +27275,19 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/typed-array-length": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+			"integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"is-typed-array": "^1.1.9"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/typedarray": {
@@ -29123,7 +29224,6 @@
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
 			"integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-			"dev": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",
@@ -29567,6 +29667,24 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/youch": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
+			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
+			"dependencies": {
+				"cookie": "^0.5.0",
+				"mustache": "^4.2.0",
+				"stacktracey": "^2.1.8"
+			}
+		},
+		"node_modules/youch/node_modules/cookie": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/z-schema": {
@@ -30453,7 +30571,7 @@
 			"name": "@cloudflare/pages-shared",
 			"version": "0.5.1",
 			"dependencies": {
-				"miniflare": "^3.0.0"
+				"miniflare": "^3.0.1"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
@@ -30471,16 +30589,6 @@
 			"integrity": "sha512-Br4i/8+t60HDJIo8o7O9Rrmp03bhdejRW9klb0bK9EfG5Ii7qz5G3PJO12gUz+Vu9m1v9tZ9KOh3Gg8oshXtug==",
 			"dev": true
 		},
-		"packages/pages-shared/node_modules/better-sqlite3": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.3.0.tgz",
-			"integrity": "sha512-JTmvBZL/JLTc+3Msbvq6gK6elbU9/wVMqiudplHrVJpr7sVMR9KJrNhZAbW+RhXKlpMcuEhYkdcHa3TXKNXQ1w==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"bindings": "^1.5.0",
-				"prebuild-install": "^7.1.0"
-			}
-		},
 		"packages/pages-shared/node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -30488,14 +30596,6 @@
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
-			}
-		},
-		"packages/pages-shared/node_modules/cookie": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"packages/pages-shared/node_modules/glob": {
@@ -30517,31 +30617,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"packages/pages-shared/node_modules/miniflare": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.0.tgz",
-			"integrity": "sha512-CW8yS00pQCbq2o4K8drePzJBkE0heL9cCY/O8DcYJOHd4M0RVutjrp+LqUP4hfzweZ+LqrLo8+Rzy4cORisQoQ==",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230512.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
-			}
-		},
 		"packages/pages-shared/node_modules/minimatch": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -30552,36 +30627,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"packages/pages-shared/node_modules/ws": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
-		"packages/pages-shared/node_modules/youch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
-			"dependencies": {
-				"cookie": "^0.5.0",
-				"mustache": "^4.2.0",
-				"stacktracey": "^2.1.8"
 			}
 		},
 		"packages/prerelease-registry": {
@@ -31515,7 +31560,7 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.16.3",
-				"miniflare": "^3.0.0",
+				"miniflare": "^3.0.1",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
@@ -31642,16 +31687,6 @@
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
-		"packages/wrangler/node_modules/better-sqlite3": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.3.0.tgz",
-			"integrity": "sha512-JTmvBZL/JLTc+3Msbvq6gK6elbU9/wVMqiudplHrVJpr7sVMR9KJrNhZAbW+RhXKlpMcuEhYkdcHa3TXKNXQ1w==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"bindings": "^1.5.0",
-				"prebuild-install": "^7.1.0"
-			}
-		},
 		"packages/wrangler/node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -31659,14 +31694,6 @@
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
-			}
-		},
-		"packages/wrangler/node_modules/cookie": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"packages/wrangler/node_modules/dotenv": {
@@ -31704,31 +31731,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"packages/wrangler/node_modules/miniflare": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.0.tgz",
-			"integrity": "sha512-CW8yS00pQCbq2o4K8drePzJBkE0heL9cCY/O8DcYJOHd4M0RVutjrp+LqUP4hfzweZ+LqrLo8+Rzy4cORisQoQ==",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230512.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
 			}
 		},
 		"packages/wrangler/node_modules/minimatch": {
@@ -31809,6 +31811,7 @@
 			"version": "8.13.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -31834,16 +31837,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"packages/wrangler/node_modules/youch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
-			"dependencies": {
-				"cookie": "^0.5.0",
-				"mustache": "^4.2.0",
-				"stacktracey": "^2.1.8"
 			}
 		},
 		"packages/wranglerjs-compat-webpack-plugin": {
@@ -33574,6 +33567,28 @@
 				}
 			}
 		},
+		"@babel/helper-define-polyfill-provider": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.0.tgz",
+			"integrity": "sha512-RnanLx5ETe6aybRi1cO/edaRH+bNYWaryCEmjDDYyNr4wnSzyOp8T0dWipmqVHKEY3AbVKUom50AKSlj1zmKbg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-compilation-targets": "^7.17.7",
+				"@babel/helper-plugin-utils": "^7.16.7",
+				"debug": "^4.1.1",
+				"lodash.debounce": "^4.0.8",
+				"resolve": "^1.14.2",
+				"semver": "^6.1.2"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/helper-environment-visitor": {
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
@@ -34559,50 +34574,6 @@
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.0.tgz",
-					"integrity": "sha512-RnanLx5ETe6aybRi1cO/edaRH+bNYWaryCEmjDDYyNr4wnSzyOp8T0dWipmqVHKEY3AbVKUom50AKSlj1zmKbg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-compilation-targets": "^7.17.7",
-						"@babel/helper-plugin-utils": "^7.16.7",
-						"debug": "^4.1.1",
-						"lodash.debounce": "^4.0.8",
-						"resolve": "^1.14.2",
-						"semver": "^6.1.2"
-					}
-				},
-				"babel-plugin-polyfill-corejs2": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.3.tgz",
-					"integrity": "sha512-bM3gHc337Dta490gg+/AseNB9L4YLHxq1nGKZZSHbhXv4aTYU2MD2cjza1Ru4S6975YLTaL1K8uJf6ukJhhmtw==",
-					"dev": true,
-					"requires": {
-						"@babel/compat-data": "^7.17.7",
-						"@babel/helper-define-polyfill-provider": "^0.4.0",
-						"semver": "^6.1.1"
-					}
-				},
-				"babel-plugin-polyfill-corejs3": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.1.tgz",
-					"integrity": "sha512-ikFrZITKg1xH6pLND8zT14UPgjKHiGLqex7rGEZCH2EvhsneJaJPemmpQaIZV5AL03II+lXylw3UmddDK8RU5Q==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-define-polyfill-provider": "^0.4.0",
-						"core-js-compat": "^3.30.1"
-					}
-				},
-				"babel-plugin-polyfill-regenerator": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.0.tgz",
-					"integrity": "sha512-hDJtKjMLVa7Z+LwnTCxoDLQj6wdc+B8dun7ayF2fYieI6OzfuvcLMB32ihJZ4UhCBwNYGl5bg/x/P9cMdnkc2g==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-define-polyfill-provider": "^0.4.0"
-					}
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -34977,7 +34948,7 @@
 				"@types/service-worker-mock": "^2.0.1",
 				"concurrently": "^7.3.0",
 				"glob": "^8.0.3",
-				"miniflare": "^3.0.0",
+				"miniflare": "^3.0.1",
 				"service-worker-mock": "^2.0.5",
 				"wrangler": "*"
 			},
@@ -34988,15 +34959,6 @@
 					"integrity": "sha512-Br4i/8+t60HDJIo8o7O9Rrmp03bhdejRW9klb0bK9EfG5Ii7qz5G3PJO12gUz+Vu9m1v9tZ9KOh3Gg8oshXtug==",
 					"dev": true
 				},
-				"better-sqlite3": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.3.0.tgz",
-					"integrity": "sha512-JTmvBZL/JLTc+3Msbvq6gK6elbU9/wVMqiudplHrVJpr7sVMR9KJrNhZAbW+RhXKlpMcuEhYkdcHa3TXKNXQ1w==",
-					"requires": {
-						"bindings": "^1.5.0",
-						"prebuild-install": "^7.1.0"
-					}
-				},
 				"brace-expansion": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -35005,11 +34967,6 @@
 					"requires": {
 						"balanced-match": "^1.0.0"
 					}
-				},
-				"cookie": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-					"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
 				},
 				"glob": {
 					"version": "8.0.3",
@@ -35024,28 +34981,6 @@
 						"once": "^1.3.0"
 					}
 				},
-				"miniflare": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.0.tgz",
-					"integrity": "sha512-CW8yS00pQCbq2o4K8drePzJBkE0heL9cCY/O8DcYJOHd4M0RVutjrp+LqUP4hfzweZ+LqrLo8+Rzy4cORisQoQ==",
-					"requires": {
-						"acorn": "^8.8.0",
-						"acorn-walk": "^8.2.0",
-						"better-sqlite3": "^8.1.0",
-						"capnp-ts": "^0.7.0",
-						"exit-hook": "^2.2.1",
-						"glob-to-regexp": "^0.4.1",
-						"http-cache-semantics": "^4.1.0",
-						"kleur": "^4.1.5",
-						"source-map-support": "0.5.21",
-						"stoppable": "^1.1.0",
-						"undici": "^5.13.0",
-						"workerd": "^1.20230512.0",
-						"ws": "^8.11.0",
-						"youch": "^3.2.2",
-						"zod": "^3.20.6"
-					}
-				},
 				"minimatch": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -35053,22 +34988,6 @@
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^2.0.1"
-					}
-				},
-				"ws": {
-					"version": "8.13.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-					"requires": {}
-				},
-				"youch": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-					"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
-					"requires": {
-						"cookie": "^0.5.0",
-						"mustache": "^4.2.0",
-						"stacktracey": "^2.1.8"
 					}
 				}
 			}
@@ -35276,9 +35195,9 @@
 			}
 		},
 		"@emotion/hash": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-			"integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==",
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+			"integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==",
 			"dev": true
 		},
 		"@esbuild-plugins/node-globals-polyfill": {
@@ -36364,9 +36283,9 @@
 			"version": "1.1.0"
 		},
 		"@jridgewell/source-map": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+			"integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
 			"optional": true,
 			"peer": true,
 			"requires": {
@@ -37998,9 +37917,9 @@
 			"dev": true
 		},
 		"@types/ws": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-			"integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+			"version": "8.5.5",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+			"integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -38829,6 +38748,15 @@
 		"arr-union": {
 			"version": "3.1.0"
 		},
+		"array-buffer-byte-length": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+			"integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"is-array-buffer": "^3.0.1"
+			}
+		},
 		"array-flatten": {
 			"version": "1.1.1",
 			"dev": true
@@ -39013,8 +38941,7 @@
 		"available-typed-arrays": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"dev": true
+			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
 		},
 		"axe-core": {
 			"version": "4.5.2",
@@ -39093,6 +39020,44 @@
 				"@types/babel__traverse": "^7.0.6"
 			}
 		},
+		"babel-plugin-polyfill-corejs2": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.3.tgz",
+			"integrity": "sha512-bM3gHc337Dta490gg+/AseNB9L4YLHxq1nGKZZSHbhXv4aTYU2MD2cjza1Ru4S6975YLTaL1K8uJf6ukJhhmtw==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.17.7",
+				"@babel/helper-define-polyfill-provider": "^0.4.0",
+				"semver": "^6.1.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"babel-plugin-polyfill-corejs3": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.1.tgz",
+			"integrity": "sha512-ikFrZITKg1xH6pLND8zT14UPgjKHiGLqex7rGEZCH2EvhsneJaJPemmpQaIZV5AL03II+lXylw3UmddDK8RU5Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-define-polyfill-provider": "^0.4.0",
+				"core-js-compat": "^3.30.1"
+			}
+		},
+		"babel-plugin-polyfill-regenerator": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.0.tgz",
+			"integrity": "sha512-hDJtKjMLVa7Z+LwnTCxoDLQj6wdc+B8dun7ayF2fYieI6OzfuvcLMB32ihJZ4UhCBwNYGl5bg/x/P9cMdnkc2g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-define-polyfill-provider": "^0.4.0"
+			}
+		},
 		"babel-preset-current-node-syntax": {
 			"version": "1.0.1",
 			"requires": {
@@ -39159,6 +39124,15 @@
 			"version": "1.0.0",
 			"requires": {
 				"is-windows": "^1.0.0"
+			}
+		},
+		"better-sqlite3": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.4.0.tgz",
+			"integrity": "sha512-NmsNW1CQvqMszu/CFAJ3pLct6NEFlNfuGM6vw72KHkjOD1UDnL96XNN1BMQc1hiHo8vE2GbOWQYIpZ+YM5wrZw==",
+			"requires": {
+				"bindings": "^1.5.0",
+				"prebuild-install": "^7.1.0"
 			}
 		},
 		"big.js": {
@@ -40968,9 +40942,9 @@
 			"dev": true
 		},
 		"define-properties": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
 			"requires": {
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
@@ -41277,35 +41251,44 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.20.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-			"integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+			"version": "1.21.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+			"integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
 			"requires": {
+				"array-buffer-byte-length": "^1.0.0",
+				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",
+				"es-set-tostringtag": "^2.0.1",
 				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.3",
+				"get-intrinsic": "^1.2.0",
 				"get-symbol-description": "^1.0.0",
+				"globalthis": "^1.0.3",
 				"gopd": "^1.0.1",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
+				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3",
-				"internal-slot": "^1.0.3",
+				"internal-slot": "^1.0.5",
+				"is-array-buffer": "^3.0.2",
 				"is-callable": "^1.2.7",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.10",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.2",
+				"object-inspect": "^1.12.3",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
 				"safe-regex-test": "^1.0.0",
+				"string.prototype.trim": "^1.2.7",
 				"string.prototype.trimend": "^1.0.6",
 				"string.prototype.trimstart": "^1.0.6",
-				"unbox-primitive": "^1.0.2"
+				"typed-array-length": "^1.0.4",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.9"
 			}
 		},
 		"es-get-iterator": {
@@ -41330,6 +41313,16 @@
 					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
 					"dev": true
 				}
+			}
+		},
+		"es-set-tostringtag": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+			"integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+			"requires": {
+				"get-intrinsic": "^1.1.3",
+				"has": "^1.0.3",
+				"has-tostringtag": "^1.0.0"
 			}
 		},
 		"es-shim-unscopables": {
@@ -42895,7 +42888,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
 			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.3"
 			}
@@ -43101,12 +43093,13 @@
 			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig=="
 		},
 		"get-intrinsic": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+			"integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
+				"has-proto": "^1.0.1",
 				"has-symbols": "^1.0.3"
 			}
 		},
@@ -43224,7 +43217,6 @@
 		},
 		"globalthis": {
 			"version": "1.0.3",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3"
 			}
@@ -43352,6 +43344,11 @@
 			"requires": {
 				"get-intrinsic": "^1.1.1"
 			}
+		},
+		"has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
 		},
 		"has-symbols": {
 			"version": "1.0.3",
@@ -43941,9 +43938,11 @@
 			}
 		},
 		"internal-slot": {
-			"version": "1.0.3",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+			"integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
 			"requires": {
-				"get-intrinsic": "^1.1.0",
+				"get-intrinsic": "^1.2.0",
 				"has": "^1.0.3",
 				"side-channel": "^1.0.4"
 			}
@@ -44016,6 +44015,16 @@
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-array-buffer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+			"integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.0",
+				"is-typed-array": "^1.1.10"
 			}
 		},
 		"is-arrayish": {
@@ -44265,7 +44274,6 @@
 			"version": "1.1.10",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
 			"integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-			"dev": true,
 			"requires": {
 				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",
@@ -47113,9 +47121,9 @@
 			}
 		},
 		"lilconfig": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-			"integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+			"integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
 			"dev": true
 		},
 		"lines-and-columns": {
@@ -48197,6 +48205,36 @@
 		"min-indent": {
 			"version": "1.0.1"
 		},
+		"miniflare": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.1.tgz",
+			"integrity": "sha512-aLOB8d26lOTn493GOv1LmpGHVLSxmeT4MixPG/k3Ze10j0wDKnMj8wsFgbZ6Q4cr1N4faf8O3IbNRJuQ+rLoJA==",
+			"requires": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.13.0",
+				"workerd": "^1.20230512.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "8.13.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+					"requires": {}
+				}
+			}
+		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -48539,17 +48577,17 @@
 			}
 		},
 		"node-abi": {
-			"version": "3.28.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
-			"integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
+			"version": "3.45.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
+			"integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
 			"requires": {
 				"semver": "^7.3.5"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"version": "7.5.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+					"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -48865,9 +48903,9 @@
 			"dev": true
 		},
 		"object-inspect": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
 		},
 		"object-is": {
 			"version": "1.1.5",
@@ -49273,67 +49311,17 @@
 			"version": "file:fixtures/pages-ws-app",
 			"requires": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "^3.0.0",
+				"miniflare": "^3.0.1",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"dependencies": {
-				"better-sqlite3": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.3.0.tgz",
-					"integrity": "sha512-JTmvBZL/JLTc+3Msbvq6gK6elbU9/wVMqiudplHrVJpr7sVMR9KJrNhZAbW+RhXKlpMcuEhYkdcHa3TXKNXQ1w==",
-					"dev": true,
-					"requires": {
-						"bindings": "^1.5.0",
-						"prebuild-install": "^7.1.0"
-					}
-				},
-				"cookie": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-					"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-					"dev": true
-				},
-				"miniflare": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.0.tgz",
-					"integrity": "sha512-CW8yS00pQCbq2o4K8drePzJBkE0heL9cCY/O8DcYJOHd4M0RVutjrp+LqUP4hfzweZ+LqrLo8+Rzy4cORisQoQ==",
-					"dev": true,
-					"requires": {
-						"acorn": "^8.8.0",
-						"acorn-walk": "^8.2.0",
-						"better-sqlite3": "^8.1.0",
-						"capnp-ts": "^0.7.0",
-						"exit-hook": "^2.2.1",
-						"glob-to-regexp": "^0.4.1",
-						"http-cache-semantics": "^4.1.0",
-						"kleur": "^4.1.5",
-						"source-map-support": "0.5.21",
-						"stoppable": "^1.1.0",
-						"undici": "^5.13.0",
-						"workerd": "^1.20230512.0",
-						"ws": "^8.11.0",
-						"youch": "^3.2.2",
-						"zod": "^3.20.6"
-					}
-				},
 				"ws": {
 					"version": "8.11.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
 					"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
 					"dev": true,
 					"requires": {}
-				},
-				"youch": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-					"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
-					"dev": true,
-					"requires": {
-						"cookie": "^0.5.0",
-						"mustache": "^4.2.0",
-						"stacktracey": "^2.1.8"
-					}
 				}
 			}
 		},
@@ -50913,11 +50901,11 @@
 			"devOptional": true
 		},
 		"resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+			"version": "1.22.2",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+			"integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
 			"requires": {
-				"is-core-module": "^2.9.0",
+				"is-core-module": "^2.11.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
@@ -52159,6 +52147,16 @@
 				"es-abstract": "^1.19.1"
 			}
 		},
+		"string.prototype.trim": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+			"integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
+			}
+		},
 		"string.prototype.trimend": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
@@ -52985,6 +52983,16 @@
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
+			}
+		},
+		"typed-array-length": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+			"integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"is-typed-array": "^1.1.9"
 			}
 		},
 		"typedarray": {
@@ -54305,7 +54313,6 @@
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
 			"integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
-			"dev": true,
 			"requires": {
 				"available-typed-arrays": "^1.0.5",
 				"call-bind": "^1.0.2",
@@ -54455,7 +54462,7 @@
 				"jest-fetch-mock": "^3.0.3",
 				"jest-websocket-mock": "^2.3.0",
 				"mime": "^3.0.0",
-				"miniflare": "^3.0.0",
+				"miniflare": "^3.0.1",
 				"minimatch": "^5.1.0",
 				"msw": "^0.49.1",
 				"nanoid": "^3.3.3",
@@ -54505,15 +54512,6 @@
 					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
 					"dev": true
 				},
-				"better-sqlite3": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.3.0.tgz",
-					"integrity": "sha512-JTmvBZL/JLTc+3Msbvq6gK6elbU9/wVMqiudplHrVJpr7sVMR9KJrNhZAbW+RhXKlpMcuEhYkdcHa3TXKNXQ1w==",
-					"requires": {
-						"bindings": "^1.5.0",
-						"prebuild-install": "^7.1.0"
-					}
-				},
 				"brace-expansion": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -54522,11 +54520,6 @@
 					"requires": {
 						"balanced-match": "^1.0.0"
 					}
-				},
-				"cookie": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-					"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
 				},
 				"dotenv": {
 					"version": "16.0.0",
@@ -54545,28 +54538,6 @@
 					"dev": true,
 					"requires": {
 						"p-locate": "^6.0.0"
-					}
-				},
-				"miniflare": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.0.tgz",
-					"integrity": "sha512-CW8yS00pQCbq2o4K8drePzJBkE0heL9cCY/O8DcYJOHd4M0RVutjrp+LqUP4hfzweZ+LqrLo8+Rzy4cORisQoQ==",
-					"requires": {
-						"acorn": "^8.8.0",
-						"acorn-walk": "^8.2.0",
-						"better-sqlite3": "^8.1.0",
-						"capnp-ts": "^0.7.0",
-						"exit-hook": "^2.2.1",
-						"glob-to-regexp": "^0.4.1",
-						"http-cache-semantics": "^4.1.0",
-						"kleur": "^4.1.5",
-						"source-map-support": "0.5.21",
-						"stoppable": "^1.1.0",
-						"undici": "^5.13.0",
-						"workerd": "^1.20230512.0",
-						"ws": "^8.11.0",
-						"youch": "^3.2.2",
-						"zod": "^3.20.6"
 					}
 				},
 				"minimatch": {
@@ -54613,21 +54584,12 @@
 					"version": "8.13.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+					"dev": true,
 					"requires": {}
 				},
 				"yocto-queue": {
 					"version": "1.0.0",
 					"dev": true
-				},
-				"youch": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
-					"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
-					"requires": {
-						"cookie": "^0.5.0",
-						"mustache": "^4.2.0",
-						"stacktracey": "^2.1.8"
-					}
 				}
 			}
 		},
@@ -55758,6 +55720,23 @@
 			"dev": true,
 			"requires": {
 				"@types/yoga-layout": "1.9.2"
+			}
+		},
+		"youch": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/youch/-/youch-3.2.3.tgz",
+			"integrity": "sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==",
+			"requires": {
+				"cookie": "^0.5.0",
+				"mustache": "^4.2.0",
+				"stacktracey": "^2.1.8"
+			},
+			"dependencies": {
+				"cookie": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+					"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+				}
 			}
 		},
 		"z-schema": {

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -43,7 +43,7 @@
 		]
 	},
 	"dependencies": {
-		"miniflare": "^3.0.0"
+		"miniflare": "^3.0.1"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -103,7 +103,7 @@
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.16.3",
-		"miniflare": "^3.0.0",
+		"miniflare": "^3.0.1",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",
 		"selfsigned": "^2.0.1",


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/3264
Fixes https://github.com/cloudflare/workers-sdk/issues/3218

Supersedes https://github.com/cloudflare/workers-sdk/pull/3352

**What this PR solves / how to test:**

This PR bumps the minimum `miniflare` version to `3.0.1`, fixing some HTTPS `fetch()` issues.

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
