### PR TITLE
ci: publish beta releases of create-cloudflare to npm

### DIFF
--- a/.github/version-script.js
+++ b/.github/version-script.js
@@ -1,22 +1,35 @@
-const fs = require("fs");
-const { exec } = require("child_process");
+/**
+ * Update the package.json version property for the given package
+ *
+ * Usage:
+ *
+ * ```
+ * node ./.github/version-script.js <package-name>
+ * ```
+ *
+ * `<package-name>` defaults to `wrangler` if not provided.
+ */
+
+const { readFileSync, writeFileSync } = require("fs");
+const { execSync } = require("child_process");
 
 try {
-	const package = JSON.parse(
-		fs.readFileSync("./packages/wrangler/package.json")
-	);
-	exec("git rev-parse --short HEAD", (err, stdout) => {
-		if (err) {
-			console.log(err);
-			process.exit(1);
-		}
-		package.version = "0.0.0-" + stdout.trim();
-		fs.writeFileSync(
-			"./packages/wrangler/package.json",
-			JSON.stringify(package, null, "\t") + "\n"
-		);
-	});
+	const packageName = getArgs()[0] ?? "wrangler";
+	const packageJsonPath = `./packages/${packageName}/package.json`;
+	const package = JSON.parse(readFileSync(packageJsonPath));
+	const stdout = execSync("git rev-parse --short HEAD", { encoding: "utf8" });
+	package.version = "0.0.0-" + stdout.trim();
+	writeFileSync(packageJsonPath, JSON.stringify(package, null, "\t") + "\n");
 } catch (error) {
 	console.error(error);
 	process.exit(1);
+}
+
+/**
+ * Get the command line args, stripping `node` and script filename, etc.
+ */
+function getArgs() {
+	const args = Array.from(process.argv);
+	while (args.shift() !== module.filename) {}
+	return args;
 }

--- a/.github/workflows/prerelease-create-cloudflare.yml
+++ b/.github/workflows/prerelease-create-cloudflare.yml
@@ -1,9 +1,12 @@
-name: Prerelease
+name: Prerelease create-cloudflare
 
 on:
+  repository_dispatch:
+    types: [pre-release-create-cloudflare]
   push:
     branches:
       - main
+
 jobs:
   prerelease:
     if: ${{ github.repository_owner == 'cloudflare' }}

--- a/.github/workflows/prerelease-create-cloudflare.yml
+++ b/.github/workflows/prerelease-create-cloudflare.yml
@@ -1,0 +1,46 @@
+name: Prerelease
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  prerelease:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    name: Build & Publish a beta release of create-cloudflare to NPM
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 16.13
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.13
+          cache: "npm" # cache ~/.npm in case 'npm ci' needs to run
+
+      - name: Install workerd Dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y libc++1
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Modify package.json version
+        run: node .github/version-script.js create-cloudflare
+
+      - name: Build packages
+        run: npm run build
+        env:
+          NODE_ENV: "production"
+
+      - name: Publish Beta to NPM
+        run: npm publish -w create-cloudflare --tag beta
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR adds a new Github action that will publish the create-cloudflare package to npm using the `beta` dist-tag whenever a commit is merged to `main`.

It is only possible to test this PR by merging the PR 😱 

It is slightly annoying that a new beta release will be published on every merged PR rather than only ones that affect create-cloudflare, but this is also the case for the `wrangler` package right now.

**Associated docs issue(s)/PR(s):**

Not applicable

**Author has included the following, where applicable:**

- [N/A] Tests
- [N/A] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
