### PR TITLE
C3 update name prompt

### DIFF
--- a/.changeset/lovely-trees-fail.md
+++ b/.changeset/lovely-trees-fail.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Improvements to the project name selection prompt.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29990,7 +29990,7 @@
 				"recast": "^0.22.0",
 				"semver": "^7.5.1",
 				"typescript": "^5.0.2",
-				"undici": "^5.22.0",
+				"undici": "5.20.0",
 				"vite-tsconfig-paths": "^4.0.8",
 				"vitest": "^0.30.0",
 				"which-pm-runs": "^1.1.0",
@@ -40484,7 +40484,7 @@
 				"recast": "^0.22.0",
 				"semver": "^7.5.1",
 				"typescript": "^5.0.2",
-				"undici": "^5.22.0",
+				"undici": "5.20.0",
 				"vite-tsconfig-paths": "^4.0.8",
 				"vitest": "^0.30.0",
 				"which-pm-runs": "^1.1.0",
@@ -40846,8 +40846,7 @@
 					"dev": true
 				},
 				"undici": {
-					"version": "5.22.1",
-					"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+					"version": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
 					"integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
 					"dev": true,
 					"requires": {

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -61,7 +61,7 @@
 		"recast": "^0.22.0",
 		"semver": "^7.5.1",
 		"typescript": "^5.0.2",
-		"undici": "^5.22.0",
+		"undici": "5.20.0",
 		"vite-tsconfig-paths": "^4.0.8",
 		"vitest": "^0.30.0",
 		"which-pm-runs": "^1.1.0",

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -79,6 +79,7 @@ const validateName = async (
 		defaultValue,
 		acceptDefault,
 		validate: (value = defaultValue) => validateProjectDirectory(value),
+		format: (val: string) => `./${val}`,
 	});
 };
 

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -78,7 +78,7 @@ const validateName = async (
 		},
 		defaultValue,
 		acceptDefault,
-		validate: (value = defaultValue) => validateProjectDirectory(value),
+		validate: (value) => validateProjectDirectory(value || defaultValue),
 		format: (val: string) => `./${val}`,
 	});
 };

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -33,17 +33,20 @@ export const validateProjectDirectory = (relativePath: string) => {
 	const existsAlready = existsSync(path);
 	const isEmpty = existsAlready && readdirSync(path).length === 0; // allow existing dirs _if empty_ to ensure c3 is non-destructive
 
-	if (existsAlready && !isEmpty) {
-		crash(
-			`Directory \`${relativePath}\` already exists and is not empty. Please choose a new name.`
-		);
+	if (relativePath && existsAlready && !isEmpty) {
+		return `Directory \`${relativePath}\` already exists and is not empty. Please choose a new name.`;
 	}
 };
 
 export const setupProjectDirectory = (args: PagesGeneratorArgs) => {
 	// Crash if the directory already exists
 	const path = resolve(args.projectName);
-	validateProjectDirectory(path);
+	const err = validateProjectDirectory(path);
+	if (err) {
+		crash(
+			`Directory \`${path}\` already exists and is not empty. Please choose a new name.`
+		);
+	}
 
 	const directory = dirname(path);
 	const name = basename(path);

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -33,7 +33,7 @@ export const validateProjectDirectory = (relativePath: string) => {
 	const existsAlready = existsSync(path);
 	const isEmpty = existsAlready && readdirSync(path).length === 0; // allow existing dirs _if empty_ to ensure c3 is non-destructive
 
-	if (relativePath && existsAlready && !isEmpty) {
+	if (existsAlready && !isEmpty) {
 		return `Directory \`${relativePath}\` already exists and is not empty. Please choose a new name.`;
 	}
 };
@@ -43,9 +43,7 @@ export const setupProjectDirectory = (args: PagesGeneratorArgs) => {
 	const path = resolve(args.projectName);
 	const err = validateProjectDirectory(path);
 	if (err) {
-		crash(
-			`Directory \`${path}\` already exists and is not empty. Please choose a new name.`
-		);
+		crash(err);
 	}
 
 	const directory = dirname(path);

--- a/packages/create-cloudflare/src/helpers/cli.ts
+++ b/packages/create-cloudflare/src/helpers/cli.ts
@@ -36,7 +36,7 @@ export const status = {
 // This is useful for places where clack trims lines of output
 // but we need leading spaces
 export const space = (n = 1) => {
-	return [...Array(n)].map(() => hidden("-")).join("");
+	return [...Array(n)].map(() => hidden("\u200A")).join("");
 };
 
 // Primitive for printing to stdout. Use this instead of

--- a/packages/create-cloudflare/src/helpers/cli.ts
+++ b/packages/create-cloudflare/src/helpers/cli.ts
@@ -36,7 +36,7 @@ export const status = {
 // This is useful for places where clack trims lines of output
 // but we need leading spaces
 export const space = (n = 1) => {
-	return [...Array(n)].map(() => hidden("\u200A")).join("");
+	return hidden("\u200A".repeat(n));
 };
 
 // Primitive for printing to stdout. Use this instead of

--- a/packages/create-cloudflare/src/helpers/interactive.ts
+++ b/packages/create-cloudflare/src/helpers/interactive.ts
@@ -14,6 +14,7 @@ export type TextOptions = {
 	defaultValue: string;
 	acceptDefault: boolean | undefined; // must be specified, but can be undefined (≈ false)
 	helpText?: string;
+	format?: (value: string) => string;
 	validate?: (value: string) => string | void;
 };
 
@@ -21,6 +22,7 @@ export const textInput = async (opts: TextOptions) => {
 	const { renderSubmitted, question, defaultValue, validate, acceptDefault } =
 		opts;
 	const helpText = opts.helpText || ``;
+	const format = opts.format || ((val: string) => val);
 
 	const prompt = new TextPrompt({
 		defaultValue: defaultValue,
@@ -30,21 +32,23 @@ export const textInput = async (opts: TextOptions) => {
 			switch (this.state) {
 				case "initial":
 					body += `${blCorner} ${bold(question)} ${dim(helpText)}\n`;
-					body += `${space(2)}${gray(defaultValue)}\n`;
+					body += `${space(2)}${gray(format(defaultValue))}\n`;
 					break;
 				case "active":
 					body += `${blCorner} ${bold(question)} ${dim(helpText)}\n`;
-					body += `${space(2)}${this.value}\n`;
+					body += `${space(2)}${format(this.value)}\n`;
 					break;
 				case "submit":
 					body += `${leftT} ${question}\n`;
-					body += `${grayBar} ${renderSubmitted(this.value)}\n${grayBar}`;
+					body += `${grayBar} ${renderSubmitted(
+						format(this.value)
+					)}\n${grayBar}`;
 					break;
 				case "error":
 					body += `${leftT} ${status.error} ${dim(this.error)}\n`;
 					body += `${grayBar}\n`;
 					body += `${blCorner} ${question} ${dim(helpText)}\n`;
-					body += `${space(2)}${this.value}\n`;
+					body += `${space(2)}${format(this.value)}\n`;
 					break;
 				default:
 					break;

--- a/packages/create-cloudflare/src/helpers/interactive.ts
+++ b/packages/create-cloudflare/src/helpers/interactive.ts
@@ -36,7 +36,7 @@ export const textInput = async (opts: TextOptions) => {
 					break;
 				case "active":
 					body += `${blCorner} ${bold(question)} ${dim(helpText)}\n`;
-					body += `${space(2)}${format(this.value)}\n`;
+					body += `${space(2)}${format(this.value || dim(defaultValue))}\n`;
 					break;
 				case "submit":
 					body += `${leftT} ${question}\n`;


### PR DESCRIPTION
Fixes #3394.

**What this PR solves / how to test:**

This fixes a couple of things:
1. Formats the project name as a directory and fixes an issue where leading spaces were rendered as `-` in some terminals.
2. Fixes a bug where the default value of a project directory couldn't be selected in interactive mode
3. Displays the default value for text prompts if the user deletes all input


**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
