### PR TITLE
Allow setting d1 database id in pages dev

### DIFF
--- a/.changeset/weak-dolphins-carry.md
+++ b/.changeset/weak-dolphins-carry.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: Allow setting a D1 database ID when using `wrangler pages dev` by providing an optional `=<ID>` suffix to the argument like `--d1 BINDING_NAME=database-id`

--- a/fixtures/pages-workerjs-directory/package.json
+++ b/fixtures/pages-workerjs-directory/package.json
@@ -5,7 +5,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --d1=D1 --d1=PUT=elsewhere --port 8794",
+		"dev": "npx wrangler pages dev public --d1=D1 --d1=PUT=elsewhere --kv KV --kv KV_REF=other_kv --r2 R2 --r2=R2_REF=other_r2 --port 8794",
 		"test": "npx vitest run",
 		"test:ci": "npx vitest run",
 		"type:tests": "tsc -p ./tests/tsconfig.json"

--- a/fixtures/pages-workerjs-directory/package.json
+++ b/fixtures/pages-workerjs-directory/package.json
@@ -5,7 +5,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --port 8794",
+		"dev": "npx wrangler pages dev public --d1=D1 --d1=PUT=elsewhere --port 8794",
 		"test": "npx vitest run",
 		"test:ci": "npx vitest run",
 		"type:tests": "tsc -p ./tests/tsconfig.json"

--- a/fixtures/pages-workerjs-directory/public/_worker.js/index.js
+++ b/fixtures/pages-workerjs-directory/public/_worker.js/index.js
@@ -15,8 +15,12 @@ export default {
 		}
 
 		if (pathname === "/d1") {
-			const stmt = env.D1.prepare("SELECT 1");
+			const stmt1 = env.D1.prepare("SELECT 1");
+			const values1 = await stmt1.first();
+
+			const stmt = env.PUT.prepare("SELECT 1");
 			const values = await stmt.first();
+
 			return new Response(JSON.stringify(values));
 		}
 

--- a/fixtures/pages-workerjs-directory/public/_worker.js/index.js
+++ b/fixtures/pages-workerjs-directory/public/_worker.js/index.js
@@ -21,7 +21,11 @@ export default {
 			const stmt = env.PUT.prepare("SELECT 1");
 			const values = await stmt.first();
 
-			return new Response(JSON.stringify(values));
+			if (JSON.stringify(values1) === JSON.stringify(values)) {
+				return new Response(JSON.stringify(values));
+			}
+
+			return new Response("couldn't select 1");
 		}
 
 		if (pathname === "/kv") {

--- a/fixtures/pages-workerjs-directory/public/_worker.js/index.js
+++ b/fixtures/pages-workerjs-directory/public/_worker.js/index.js
@@ -24,6 +24,22 @@ export default {
 			return new Response(JSON.stringify(values));
 		}
 
+		if (pathname === "/kv") {
+			await env.KV.put("key", "value");
+
+			await env.KV_REF.put("key", "value");
+
+			return new Response("saved");
+		}
+
+		if (pathname === "/r2") {
+			await env.R2.put("key", "value");
+
+			await env.R2_REF.put("key", "value");
+
+			return new Response("saved");
+		}
+
 		if (pathname !== "/") {
 			return new Response((await import(`./${pathname.slice(1)}`)).default);
 		}

--- a/fixtures/pages-workerjs-directory/tests/index.test.ts
+++ b/fixtures/pages-workerjs-directory/tests/index.test.ts
@@ -1,4 +1,3 @@
-import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";

--- a/fixtures/pages-workerjs-directory/tests/index.test.ts
+++ b/fixtures/pages-workerjs-directory/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path, { join, resolve } from "node:path";
 import { fetch } from "undici";
@@ -11,7 +11,7 @@ describe("Pages _worker.js/ directory", () => {
 		const { ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0", "--d1=D1"]
+			["--port=0", "--d1=D1", "--d1=PUT=elsewhere"]
 		);
 		await expect(
 			fetch(`http://${ip}:${port}/`).then((resp) => resp.text())
@@ -29,6 +29,15 @@ describe("Pages _worker.js/ directory", () => {
 			fetch(`http://${ip}:${port}/d1`).then((resp) => resp.text())
 		).resolves.toContain('{"1":1}');
 		await stop();
+
+		console.log(__dirname);
+
+		expect(
+			existsSync(join(__dirname, "../.wrangler/state/v3/d1/D1"))
+		).toBeTruthy();
+		expect(
+			existsSync(join(__dirname, "../.wrangler/state/v3/d1/elsewhere"))
+		).toBeTruthy();
 	});
 
 	it("should bundle", async ({ expect }) => {

--- a/fixtures/pages-workerjs-directory/tests/index.test.ts
+++ b/fixtures/pages-workerjs-directory/tests/index.test.ts
@@ -11,7 +11,15 @@ describe("Pages _worker.js/ directory", () => {
 		const { ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0", "--d1=D1", "--d1=PUT=elsewhere"]
+			[
+				"--port=0",
+				"--d1=D1",
+				"--d1=PUT=elsewhere",
+				"--kv=KV",
+				"--kv=KV_REF=other_kv",
+				"--r2=R2",
+				"--r2=R2_REF=other_r2",
+			]
 		);
 		await expect(
 			fetch(`http://${ip}:${port}/`).then((resp) => resp.text())
@@ -37,6 +45,18 @@ describe("Pages _worker.js/ directory", () => {
 		).toBeTruthy();
 		expect(
 			existsSync(join(__dirname, "../.wrangler/state/v3/d1/elsewhere"))
+		).toBeTruthy();
+		expect(
+			existsSync(join(__dirname, "../.wrangler/state/v3/kv/KV"))
+		).toBeTruthy();
+		expect(
+			existsSync(join(__dirname, "../.wrangler/state/v3/kv/other_kv"))
+		).toBeTruthy();
+		expect(
+			existsSync(join(__dirname, "../.wrangler/state/v3/r2/R2"))
+		).toBeTruthy();
+		expect(
+			existsSync(join(__dirname, "../.wrangler/state/v3/r2/other_r2"))
 		).toBeTruthy();
 	});
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -28,10 +28,26 @@ import type {
 } from "../yargs-types";
 import type { RoutesJSONSpec } from "./functions/routes-transformation";
 
+/*
+ * DURABLE_OBJECTS_BINDING_REGEXP matches strings like:
+ * - "binding=className"
+ * - "BINDING=MyClass"
+ * - "BINDING=MyClass@service-name"
+ * Every DO needs a binding (the JS reference) and the exported class name it refers to.
+ * Optionally, users can also provide a service name if they want to reference a DO from another dev session over the dev registry.
+ */
 const DURABLE_OBJECTS_BINDING_REGEXP = new RegExp(
 	/^(?<binding>[^=]+)=(?<className>[^@\s]+)(@(?<scriptName>.*)$)?$/
 );
 
+/* BINDING_REGEXP matches strings like:
+ * - "binding"
+ * - "BINDING"
+ * - "BINDING=ref"
+ * This is used to capture both the binding name (how the binding is used in JS) as well as the reference if provided.
+ * In the case of a D1 database, that's the database ID.
+ * This is useful to people who want to reference the same database in multiple bindings, or a Worker and Pages project dev session want to reference the same database.
+ */
 const BINDING_REGEXP = new RegExp(/^(?<binding>[^=]+)(?:=(?<ref>[^\s]+))?$/);
 
 export function Options(yargs: CommonYargsArgv) {

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -538,14 +538,22 @@ export const Handler = async ({
 				.map((binding) => binding.toString().split("="))
 				.map(([key, ...values]) => [key, values.join("=")])
 		),
-		kv: kvs.map((kv) => {
-			const { binding, ref } = BINDING_REGEXP.exec(kv.toString())?.groups || {};
+		kv: kvs
+			.map((kv) => {
+				const { binding, ref } =
+					BINDING_REGEXP.exec(kv.toString())?.groups || {};
 
-			return {
-				binding,
-				id: ref || kv.toString(),
-			};
-		}),
+				if (!binding) {
+					logger.warn("Could not parse KV binding:", kv.toString());
+					return;
+				}
+
+				return {
+					binding,
+					id: ref || kv.toString(),
+				};
+			})
+			.filter(Boolean) as AdditionalDevProps["kv"],
 		durableObjects: durableObjects
 			.map((durableObject) => {
 				const { binding, className, scriptName } =
@@ -567,11 +575,19 @@ export const Handler = async ({
 				};
 			})
 			.filter(Boolean) as AdditionalDevProps["durableObjects"],
-		r2: r2s.map((r2) => {
-			const { binding, ref } = BINDING_REGEXP.exec(r2.toString())?.groups || {};
+		r2: r2s
+			.map((r2) => {
+				const { binding, ref } =
+					BINDING_REGEXP.exec(r2.toString())?.groups || {};
 
-			return { binding, bucket_name: ref || binding.toString() };
-		}),
+				if (!binding) {
+					logger.warn("Could not parse R2 binding:", r2.toString());
+					return;
+				}
+
+				return { binding, bucket_name: ref || binding.toString() };
+			})
+			.filter(Boolean) as AdditionalDevProps["r2"],
 		rules: usingWorkerDirectory
 			? [
 					{
@@ -587,16 +603,23 @@ export const Handler = async ({
 		experimental: {
 			processEntrypoint: true,
 			additionalModules: modules,
-			d1Databases: d1s.map((d1) => {
-				const { binding, ref } =
-					BINDING_REGEXP.exec(d1.toString())?.groups || {};
+			d1Databases: d1s
+				.map((d1) => {
+					const { binding, ref } =
+						BINDING_REGEXP.exec(d1.toString())?.groups || {};
 
-				return {
-					binding,
-					database_id: ref || d1.toString(),
-					database_name: `local-${d1}`,
-				};
-			}),
+					if (!binding) {
+						logger.warn("Could not parse D1 binding:", d1.toString());
+						return;
+					}
+
+					return {
+						binding,
+						database_id: ref || d1.toString(),
+						database_name: `local-${d1}`,
+					};
+				})
+				.filter(Boolean) as AdditionalDevProps["d1Databases"],
 			disableExperimentalWarning: true,
 			enablePagesAssetsServiceBinding: {
 				proxyPort,

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -32,6 +32,10 @@ const DURABLE_OBJECTS_BINDING_REGEXP = new RegExp(
 	/^(?<binding>[^=]+)=(?<className>[^@\s]+)(@(?<scriptName>.*)$)?$/
 );
 
+const D1_BINDING_REGEXP = new RegExp(
+	/^(?<binding>[^=]+)(?:=(?<databaseId>[^\s]+))?$/
+);
+
 export function Options(yargs: CommonYargsArgv) {
 	return yargs
 		.positional("directory", {
@@ -563,11 +567,16 @@ export const Handler = async ({
 		experimental: {
 			processEntrypoint: true,
 			additionalModules: modules,
-			d1Databases: d1s.map((binding) => ({
-				binding: binding.toString(),
-				database_id: binding.toString(),
-				database_name: `local-${binding}`,
-			})),
+			d1Databases: d1s.map((d1) => {
+				const { binding, databaseId } =
+					D1_BINDING_REGEXP.exec(d1.toString())?.groups || {};
+
+				return {
+					binding,
+					database_id: databaseId || d1.toString(),
+					database_name: `local-${d1}`,
+				};
+			}),
 			disableExperimentalWarning: true,
 			enablePagesAssetsServiceBinding: {
 				proxyPort,


### PR DESCRIPTION
**What this PR solves / how to test:**

Allows setting a D1 database ID when using `wrangler pages dev` by providing an optional `=<ID>` suffix to the argument like `--d1 BINDING_NAME=database-id`.

This is useful when a Worker and a Pages project are sharing local dev state (`--persist-to`) location.

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
