### PR TITLE
fix(create-cloudflare): use wrangler deploy instead of wrangler publish

### DIFF
--- a/.changeset/three-news-sip.md
+++ b/.changeset/three-news-sip.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: use wrangler deploy command for deploying applications instead of the deprecated wrangler publish

--- a/packages/create-cloudflare/src/frameworks/angular/index.ts
+++ b/packages/create-cloudflare/src/frameworks/angular/index.ts
@@ -44,11 +44,11 @@ const config: FrameworkConfig = {
 	packageScripts: {
 		process:
 			"node ./tools/copy-worker-files.mjs && node ./tools/copy-client-files.mjs && node ./tools/bundle.mjs",
-		prestart: `${npm} run build:ssr && npm run process`,
+		prestart: `${npm} run build:ssr && ${npm} run process`,
 		start:
 			"wrangler pages dev dist/cloudflare --compatibility-date=2021-09-20 --experimental-local",
-		predeploy: `${npm} run build:ssr && npm run process`,
-		deploy: "wrangler pages publish dist/cloudflare",
+		predeploy: `${npm} run build:ssr && ${npm} run process`,
+		deploy: "wrangler pages deploy dist/cloudflare",
 	},
 	deployCommand: "deploy",
 	devCommand: "start",

--- a/packages/create-cloudflare/src/frameworks/astro/index.ts
+++ b/packages/create-cloudflare/src/frameworks/astro/index.ts
@@ -41,7 +41,7 @@ const config: FrameworkConfig = {
 	displayName: "Astro",
 	packageScripts: {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --proxy 3000 -- astro dev`,
-		"pages:deploy": `astro build && wrangler pages publish ./dist`,
+		"pages:deploy": `astro build && wrangler pages deploy ./dist`,
 	},
 	testFlags: [
 		"--skip-houston",

--- a/packages/create-cloudflare/src/frameworks/docusaurus/index.ts
+++ b/packages/create-cloudflare/src/frameworks/docusaurus/index.ts
@@ -20,7 +20,7 @@ const config: FrameworkConfig = {
 	displayName: "Docusaurus",
 	packageScripts: {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --proxy 3000 -- ${npm} run start`,
-		"pages:deploy": `NODE_VERSION=16 ${npm} run build && wrangler pages publish ./build`,
+		"pages:deploy": `NODE_VERSION=16 ${npm} run build && wrangler pages deploy ./build`,
 	},
 };
 export default config;

--- a/packages/create-cloudflare/src/frameworks/gatsby/index.ts
+++ b/packages/create-cloudflare/src/frameworks/gatsby/index.ts
@@ -46,7 +46,7 @@ const config: FrameworkConfig = {
 	displayName: "Gatsby",
 	packageScripts: {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --proxy 8000 -- ${npm} run develop`,
-		"pages:deploy": `${npm} run build && wrangler pages publish ./public`,
+		"pages:deploy": `${npm} run build && wrangler pages deploy ./public`,
 	},
 };
 export default config;

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -88,7 +88,7 @@ const config: FrameworkConfig = {
 	displayName: "Next",
 	packageScripts: {
 		"pages:build": `${npx} @cloudflare/next-on-pages@1`,
-		"pages:deploy": `${npm} run pages:build && wrangler pages publish .vercel/output/static`,
+		"pages:deploy": `${npm} run pages:build && wrangler pages deploy .vercel/output/static`,
 		"pages:watch": `${npx} @cloudflare/next-on-pages@1 --watch`,
 		"pages:dev": `${npx} wrangler pages dev .vercel/output/static --compatibility-flag=nodejs_compat`,
 	},

--- a/packages/create-cloudflare/src/frameworks/nuxt/index.ts
+++ b/packages/create-cloudflare/src/frameworks/nuxt/index.ts
@@ -29,7 +29,7 @@ const config: FrameworkConfig = {
 	displayName: "Nuxt",
 	packageScripts: {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --proxy 3000 -- npm run dev`,
-		"pages:deploy": `NODE_VERSION=17 npm run generate && wrangler pages publish ./dist`,
+		"pages:deploy": `NODE_VERSION=17 npm run generate && wrangler pages deploy ./dist`,
 	},
 };
 export default config;

--- a/packages/create-cloudflare/src/frameworks/react/index.ts
+++ b/packages/create-cloudflare/src/frameworks/react/index.ts
@@ -23,7 +23,7 @@ const config: FrameworkConfig = {
 	displayName: "React",
 	packageScripts: {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --port 3000 -- ${npm} start`,
-		"pages:deploy": `${npm} run build && wrangler pages publish ./build`,
+		"pages:deploy": `${npm} run build && wrangler pages deploy ./build`,
 	},
 };
 export default config;

--- a/packages/create-cloudflare/src/frameworks/remix/index.ts
+++ b/packages/create-cloudflare/src/frameworks/remix/index.ts
@@ -21,7 +21,7 @@ const config: FrameworkConfig = {
 	generate,
 	displayName: "Remix",
 	packageScripts: {
-		"pages:deploy": `${npm} run build && wrangler pages publish ./public`,
+		"pages:deploy": `${npm} run build && wrangler pages deploy ./public`,
 	},
 	devCommand: "dev",
 	testFlags: ["--typescript", "--no-install"],

--- a/packages/create-cloudflare/src/frameworks/solid/index.ts
+++ b/packages/create-cloudflare/src/frameworks/solid/index.ts
@@ -47,7 +47,7 @@ const config: FrameworkConfig = {
 	displayName: "Solid",
 	packageScripts: {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --proxy 3000 -- ${npm} run dev`,
-		"pages:deploy": `${npm} run build build && wrangler pages publish ./dist/public`,
+		"pages:deploy": `${npm} run build build && wrangler pages deploy ./dist/public`,
 	},
 };
 export default config;

--- a/packages/create-cloudflare/src/frameworks/svelte/index.ts
+++ b/packages/create-cloudflare/src/frameworks/svelte/index.ts
@@ -76,7 +76,7 @@ const config: FrameworkConfig = {
 	displayName: "Svelte",
 	packageScripts: {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --proxy 5173 -- ${npm} run dev`,
-		"pages:deploy": `NODE_VERSION=16 ${npm} run build && wrangler pages publish .svelte-kit/cloudflare`,
+		"pages:deploy": `NODE_VERSION=16 ${npm} run build && wrangler pages deploy .svelte-kit/cloudflare`,
 	},
 };
 export default config;

--- a/packages/create-cloudflare/src/frameworks/vue/index.ts
+++ b/packages/create-cloudflare/src/frameworks/vue/index.ts
@@ -19,7 +19,7 @@ const config: FrameworkConfig = {
 	displayName: "Vue",
 	packageScripts: {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --proxy 5173 -- ${npm} run dev`,
-		"pages:deploy": `${npm} run build && wrangler pages publish ./dist`,
+		"pages:deploy": `${npm} run build && wrangler pages deploy ./dist`,
 	},
 	testFlags: ["--ts"],
 };

--- a/packages/create-cloudflare/templates/chatgptPlugin/ts/README.md
+++ b/packages/create-cloudflare/templates/chatgptPlugin/ts/README.md
@@ -12,7 +12,7 @@ The sample plugin allows ChatGPT users to search for repositories using GitHub's
 1. Install [wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update), the Cloudflare Workers CLI
 2. Clone this project and install dependencies with `npm install`
 3. Run `wrangler login` to login to your Cloudflare account in wrangler
-4. Run `wrangler publish` to publish the plugin to Cloudflare Workers
+4. Run `wrangler deploy` to publish the plugin to Cloudflare Workers
 
 ## Usage
 

--- a/packages/create-cloudflare/templates/chatgptPlugin/ts/package.json
+++ b/packages/create-cloudflare/templates/chatgptPlugin/ts/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler publish",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev"
 	},
 	"dependencies": {

--- a/packages/create-cloudflare/templates/common/js/package.json
+++ b/packages/create-cloudflare/templates/common/js/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler publish",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev"
 	},
 	"devDependencies": {

--- a/packages/create-cloudflare/templates/common/ts/package.json
+++ b/packages/create-cloudflare/templates/common/ts/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler publish",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev"
 	},
 	"devDependencies": {

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler publish",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev"
 	},
 	"devDependencies": {

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler publish",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev"
 	},
 	"devDependencies": {

--- a/packages/create-cloudflare/templates/queues/js/package.json
+++ b/packages/create-cloudflare/templates/queues/js/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler publish",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev"
 	},
 	"devDependencies": {

--- a/packages/create-cloudflare/templates/queues/ts/package.json
+++ b/packages/create-cloudflare/templates/queues/ts/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler publish",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev"
 	},
 	"devDependencies": {

--- a/packages/create-cloudflare/templates/scheduled/js/package.json
+++ b/packages/create-cloudflare/templates/scheduled/js/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler publish",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev"
 	},
 	"devDependencies": {

--- a/packages/create-cloudflare/templates/scheduled/ts/package.json
+++ b/packages/create-cloudflare/templates/scheduled/ts/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler publish",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

This fixes C3 scripts and READMEs to use the wrangler 3 `deploy` command instead of `publish`.

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
