### PR TITLE
Turn back on fixture tests bar local-mode-tests and no-bundle-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"postinstall": "patch-package",
 		"prettify": "prettier . --write --ignore-unknown",
 		"test": "turbo test",
-		"test:ci": "turbo test:ci --filter=wrangler --filter=pages-shared",
+		"test:ci": "turbo test:ci --filter=!local-mode-tests --filter=!no-bundle-import",
 		"test:watch": "turbo test:watch",
 		"type:tests": "turbo type:tests"
 	},


### PR DESCRIPTION
**What this PR solves / how to test:**

Turns back on the fixture tests, except for `local-mode-tests` and `no-bundle-import`. These need a bit more of an investigation into how to make them pass reliably.

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
