### PR TITLE
Bump e2e timeout

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -64,7 +64,7 @@
 		"test": "npm run assert-git-version && jest",
 		"test:ci": "npm run test -- --coverage",
 		"test:debug": "npm run test -- --silent=false --verbose=true",
-		"test:e2e": "vitest --test-timeout 120000 --single-thread --dir ./e2e run",
+		"test:e2e": "vitest --test-timeout 240000 --single-thread --dir ./e2e run",
 		"test:watch": "npm run test -- --runInBand --testTimeout=50000 --watch",
 		"type:tests": "tsc -p ./src/__tests__/tsconfig.json && tsc -p ./e2e/tsconfig.json"
 	},


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**
Bump e2e tests to a 4 minute timeout to reduce flakiness

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
