### PR TITLE
[WIP] Support CryptoKey Secret Type

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -124,6 +124,7 @@
 		"@types/glob-to-regexp": "0.4.1",
 		"@types/javascript-time-ago": "^2.0.3",
 		"@types/mime": "^2.0.3",
+		"@types/node": "^20.3.1",
 		"@types/prompts": "^2.0.14",
 		"@types/react": "^17.0.37",
 		"@types/serve-static": "^1.13.10",

--- a/packages/wrangler/src/secret/secretKey.ts
+++ b/packages/wrangler/src/secret/secretKey.ts
@@ -1,0 +1,60 @@
+import { confirm, prompt, select } from "../dialogs";
+import { readFromStdin, trimTrailingWhitespace } from "./util";
+import type { SecretKeyBody } from "./types";
+
+/**
+ * Walks the user through a wizard, configuring the secret key and building a payload
+ * from among the many permutations of types, algorithms, usages, and formats.
+ *
+ * @param name
+ * @param isInteractive
+ * @returns
+ */
+export const secretKeyWizard = async (
+	name: string,
+	isInteractive: boolean
+): Promise<SecretKeyBody> => {
+	// TODO: Take in the type of secret, 'raw', 'pkcs8', 'spki', 'jwk' and walk through different wizard
+	const algorithmName = await select<string>("Select an algorithm:", {
+		choices: [
+			{ title: "AES-CBC", value: "AES-CBC" },
+			{ title: "AES-CTR", value: "AES-CTR" },
+			{ title: "AES-GCM (default)", value: "AES-GCM" },
+			{ title: "AES-KW", value: "AES-KW" },
+		],
+		defaultOption: 2,
+	});
+	const keyLength = await select<string>("Select the key length:", {
+		choices: [
+			{ title: "128", value: "128" },
+			{ title: "192", value: "192" },
+			{ title: "256 (default)", value: "256" },
+		],
+		defaultOption: 2,
+	});
+	const usages: string[] = [];
+	const encrypt = await confirm("Can the key be used for encryption?");
+	if (encrypt) {
+		usages.push("encrypt");
+	}
+	const decrypt = await confirm("Can the key be used to decryption?");
+	if (decrypt) {
+		usages.push("decrypt");
+	}
+	const secretKey = trimTrailingWhitespace(
+		isInteractive
+			? await prompt("Enter a secret key:", { isSecret: true })
+			: await readFromStdin()
+	);
+	return {
+		name: name,
+		type: "secret_key",
+		format: "raw",
+		usages: usages,
+		algorithm: {
+			name: algorithmName,
+			length: parseInt(keyLength),
+		},
+		key_base64: secretKey,
+	};
+};

--- a/packages/wrangler/src/secret/types.ts
+++ b/packages/wrangler/src/secret/types.ts
@@ -1,0 +1,48 @@
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+// eslint-disable-next-line no-shadow
+export enum SecretBindingType {
+	text = "text", // traditional wrangler secret, can be any text
+	key = "key", // CryptoKey object bound to environment
+}
+
+export type SecretTextBody = {
+	name?: string;
+	type: "secret_text";
+	text: string;
+};
+
+export type SecretKeyBody = {
+	name?: string;
+	type: "secret_key";
+	format: "raw"; // TODO support more formats
+	usages: string[];
+	algorithm: {
+		name: string;
+		length: number;
+	};
+	key_base64?: string;
+};
+
+export type CreateSecretBody = SecretTextBody | SecretKeyBody;
+
+export const secretBulkOptions = (yargs: CommonYargsArgv) => {
+	return yargs
+		.positional("json", {
+			describe: `The JSON file of key-value pairs to upload, in form {"key": value, ...}`,
+			type: "string",
+			demandOption: "true",
+		})
+		.option("name", {
+			describe: "Name of the Worker",
+			type: "string",
+			requiresArg: true,
+		});
+};
+
+export type SecretBulkArgs = StrictYargsOptionsToInterface<
+	typeof secretBulkOptions
+>;

--- a/packages/wrangler/src/secret/util.ts
+++ b/packages/wrangler/src/secret/util.ts
@@ -1,0 +1,40 @@
+/**
+ * Remove trailing white space from inputs.
+ * Matching Wrangler legacy behavior with handling inputs
+ */
+export function trimTrailingWhitespace(str: string) {
+	return str.trimEnd();
+}
+
+/**
+ * Get a promise to the streamed input from stdin.
+ *
+ * This function can be used to grab the incoming stream of data from, say,
+ * piping the output of another process into the wrangler process.
+ */
+export function readFromStdin(): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const stdin = process.stdin;
+		const chunks: string[] = [];
+
+		// When there is data ready to be read, the `readable` event will be triggered.
+		// In the handler for `readable` we call `read()` over and over until all the available data has been read.
+		stdin.on("readable", () => {
+			let chunk;
+			while (null !== (chunk = stdin.read())) {
+				chunks.push(chunk);
+			}
+		});
+
+		// When the streamed data is complete the `end` event will be triggered.
+		// In the handler for `end` we join the chunks together and resolve the promise.
+		stdin.on("end", () => {
+			resolve(chunks.join(""));
+		});
+
+		// If there is an `error` event then the handler will reject the promise.
+		stdin.on("error", (err) => {
+			reject(err);
+		});
+	});
+}


### PR DESCRIPTION
Fixes # WC-1322.

**What this PR solves / how to test:**

Opening this PR to solicit input from the DevProd team.

This PR is a first stab at supporting a new secret type: secret key. This secret type allows Workers users to attach a [CryptoKey](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey) to their Worker script in the environment. This crypto key can be used for a large variety of cryptographic usecases, and has the advantage of obfuscating the underlying cryptographic secret, preventing it from leaking unintentionally, like via a `console.log(env)` call.

**Associated docs issue(s)/PR(s):**

- WC-1322 internally.

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
