### PR TITLE
refactor: enable `fetch` in Angular's HttpClient

### DIFF
--- a/packages/create-cloudflare/src/frameworks/angular/index.ts
+++ b/packages/create-cloudflare/src/frameworks/angular/index.ts
@@ -98,12 +98,18 @@ async function updateAppCode() {
 	const s = spinner();
 	s.start(`Updating application code`);
 
-	// Add the `provideClientHydration()` provider to the app config.
+	// Update an app config file to:
+	// - add the `provideClientHydration()` provider to enable hydration
+	// - add the `provideHttpClient(withFetch())` call to enable `fetch` usage in `HttpClient`
 	const appConfigPath = "src/app/app.config.ts";
 	const appConfig = readFile(resolve(appConfigPath));
 	const newAppConfig =
 		"import { provideClientHydration } from '@angular/platform-browser';\n" +
-		appConfig.replace("providers: [", "providers: [provideClientHydration(), ");
+		"import { provideHttpClient, withFetch } from '@angular/common/http';\n" +
+		appConfig.replace(
+			"providers: [",
+			"providers: [provideHttpClient(withFetch()), provideClientHydration(), "
+		);
 	writeFile(resolve(appConfigPath), newAppConfig);
 
 	// Remove the unwanted node.js server entry-point

--- a/packages/create-cloudflare/src/frameworks/versionMap.json
+++ b/packages/create-cloudflare/src/frameworks/versionMap.json
@@ -1,5 +1,5 @@
 {
-	"angular": "16.0.x",
+	"angular": "16.1.x",
 	"astro": "3.1.5",
 	"docusaurus": "2.4.1",
 	"gatsby": "5.10.0",


### PR DESCRIPTION
This commit updates the logic that modifies an app config file to add the `provideHttpClient(withFetch())` call, which enables the `fetch` in HttpClient. Since the `withFetch()` feature is available starting from Angular v16.1.0, the framework version was also updated.

// cc @petebacondarwin 