### PR TITLE
Refactor checkFetch from a separate method to a proxy around fetch

### DIFF
--- a/.changeset/selfish-files-flow.md
+++ b/.changeset/selfish-files-flow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Refactor dev-only checkedFetch check from a method substitution to a JavaScript Proxy to be able to support Proxied global fetch function.

--- a/packages/wrangler/src/bundle.ts
+++ b/packages/wrangler/src/bundle.ts
@@ -395,7 +395,6 @@ export async function bundleWorker(
 				// when we do a build of wrangler. (re: https://github.com/cloudflare/workers-sdk/issues/1477)
 				"process.env.NODE_ENV": `"${process.env["NODE_ENV" + ""]}"`,
 				...(legacyNodeCompat ? { global: "globalThis" } : {}),
-				...(checkFetch ? { fetch: "checkedFetch" } : {}),
 				...options.define,
 			},
 		}),

--- a/packages/wrangler/templates/checked-fetch.js
+++ b/packages/wrangler/templates/checked-fetch.js
@@ -23,8 +23,8 @@ function checkURL(request, init) {
 
 globalThis.fetch = new Proxy(globalThis.fetch, {
 	apply(target, thisArg, argArray) {
-		const [request, init] = argArray
-		checkURL(request, init)
-		return Reflect.apply(target, thisArg, argArray)
-	}
-})
+		const [request, init] = argArray;
+		checkURL(request, init);
+		return Reflect.apply(target, thisArg, argArray);
+	},
+});

--- a/packages/wrangler/templates/checked-fetch.js
+++ b/packages/wrangler/templates/checked-fetch.js
@@ -1,6 +1,6 @@
 const urls = new Set();
 
-export function checkedFetch(request, init) {
+function checkURL(request, init) {
 	const url =
 		request instanceof URL
 			? request
@@ -19,5 +19,12 @@ export function checkedFetch(request, init) {
 			);
 		}
 	}
-	return globalThis.fetch(request, init);
 }
+
+globalThis.fetch = new Proxy(globalThis.fetch, {
+	apply(target, thisArg, argArray) {
+		const [request, init] = argArray
+		checkURL(request, init)
+		return Reflect.apply(target, thisArg, argArray)
+	}
+})


### PR DESCRIPTION
Fixes #3478

**What this PR solves / how to test:**

This PR makes it possible to locally test Workers where the global `fetch` object is proxied with a Javascript Proxy.
While this won't happen often in regular Workers, things like the [Open Telemetry SDK](https://github.com/evanderkoogh/otel-cf-workers) do need that to intercept and instrument outgoing `fetch` calls.

**Associated docs issue(s)/PR(s):**

This does not change any externally observable behaviour, so no tests are needed.

**Author has included the following, where applicable:**

- [ ] Tests (NA, no outside observable behaviour change)
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
