### PR TITLE
Prevent `wrangler pages dev` from serving asset files outside of the build output directory

### DIFF
--- a/.changeset/fuzzy-flowers-kneel.md
+++ b/.changeset/fuzzy-flowers-kneel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Prevent `wrangler pages dev` from serving asset files outside of the build output directory

--- a/fixtures/pages-simple-assets/tests/index.test.ts
+++ b/fixtures/pages-simple-assets/tests/index.test.ts
@@ -24,6 +24,18 @@ describe("Pages Functions", async () => {
 		expect(text).toContain("Hello, world!");
 	});
 
+	it("doesn't escape out of the build output directory", async ({ expect }) => {
+		let response = await fetch(`http://${ip}:${port}/..%2fpackage.json`);
+		let text = await response.text();
+		expect(text).toContain("Hello, world!");
+
+		response = await fetch(
+			`http://${ip}:${port}/other-path%2f..%2f..%2fpackage.json`
+		);
+		text = await response.text();
+		expect(text).toContain("Hello, world!");
+	});
+
 	it("doesn't redirect to protocol-less URLs", async ({ expect }) => {
 		{
 			const response = await fetch(

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -1,5 +1,5 @@
 import { existsSync, lstatSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { createMetadataObject } from "@cloudflare/pages-shared/metadata-generator/createMetadataObject";
 import { parseHeaders } from "@cloudflare/pages-shared/metadata-generator/parseHeaders";
 import { parseRedirects } from "@cloudflare/pages-shared/metadata-generator/parseRedirects";
@@ -72,6 +72,7 @@ async function generateAssetsFetch(
 	directory: string,
 	log: Logger
 ): Promise<typeof fetch> {
+	directory = resolve(directory);
 	// Defer importing miniflare until we really need it
 
 	// NOTE: These dynamic imports bring in `global` type augmentations from
@@ -146,7 +147,10 @@ async function generateAssetsFetch(
 			xServerEnvHeader: "dev",
 			logError: console.error,
 			findAssetEntryForPath: async (path) => {
-				const filepath = join(directory, path);
+				const filepath = resolve(join(directory, path));
+				if (!filepath.startsWith(directory)) {
+					return null;
+				}
 
 				if (
 					existsSync(filepath) &&


### PR DESCRIPTION
Fixes https://cflare.co/24935

**What this PR solves / how to test:**

Ensures only files from within the build output directory can be served in `wrangler pages dev`.

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
