### PR TITLE
C3: Fix the --version flag output

### DIFF
--- a/.changeset/olive-olives-compete.md
+++ b/.changeset/olive-olives-compete.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Fix the output of the --version flag

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -13,9 +13,9 @@ import type { Option } from "helpers/interactive";
 import type { PagesGeneratorArgs } from "types";
 
 export const main = async (argv: string[]) => {
-	printBanner();
-
 	const args = await parseArgs(argv);
+
+	printBanner();
 
 	const validatedArgs: PagesGeneratorArgs = {
 		...args,
@@ -57,6 +57,7 @@ const parseArgs = async (argv: string[]) => {
 			hidden: templateMap["pre-existing"].hidden,
 		})
 		.option("wrangler-defaults", { type: "boolean", hidden: true })
+		.version(version)
 		.help().argv;
 
 	return {


### PR DESCRIPTION
Fixes #3495.

**What this PR solves / how to test:**

Makes it so running c3 with only the `--version` flag produces the correct output (just the version number)

**Author has included the following, where applicable:**

- [ ] Tests
- [ x ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
