### PR TITLE
Mark fixtures-shared and routing-app as private

### DIFF
--- a/fixtures/routing-app/package.json
+++ b/fixtures/routing-app/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "routing-app",
 	"version": "0.0.0",
+	"private": true,
 	"description": "routing-app for testing",
 	"scripts": {
 		"check:type": "tsc"

--- a/fixtures/shared/package.json
+++ b/fixtures/shared/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "fixtures-shared",
 	"version": "0.0.0",
+	"private": true,
 	"description": "Shared fixtures for testing"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2633,7 +2633,7 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -35135,7 +35135,7 @@
 				"is-unicode-supported": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true
+					"extraneous": true
 				}
 			}
 		},


### PR DESCRIPTION
We accidentally published these in the last release. This PR marks these packages as private to prevent that from happening in the future.