### PR TITLE
fix: ensure that the default project path is used if the user does not choose one

### DIFF
--- a/.changeset/lucky-trainers-punch.md
+++ b/.changeset/lucky-trainers-punch.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: ensure that the default project path is used if the user does not choose one.

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -78,7 +78,8 @@ const validateName = async (
 		},
 		defaultValue,
 		acceptDefault,
-		validate: (value = defaultValue) => validateProjectDirectory(value),
+		// if the user deletes all the text then it should revert to the default
+		validate: (value) => validateProjectDirectory(value || defaultValue),
 	});
 };
 


### PR DESCRIPTION
Resolves bad fix in #3496.

**What this PR solves / how to test:**

To test manually:

Run npm run build in the root to ensure the binaries are up to date.
Then run node ./packages/create-cloudflare/dist/cli.js
And hit enter.

**Author has included the following, where applicable:**

- [x] Manual test plan - see above
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- [ ] Checked for inclusion of relevant tests
- [ ] Checked for inclusion of a relevant changeset
- [ ] Checked for creation of associated docs updates
- [ ] Manually pulled down the changes and spot-tested
