### PR TITLE
Be more specific in create-cloudflare interactive prompt

### DIFF
--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -71,7 +71,7 @@ const validateName = async (
 ): Promise<string> => {
 	const defaultValue = name ?? new Haikunator().haikunate({ tokenHex: true });
 	return textInput({
-		question: `Where do you want to create your application?`,
+		question: `In which directory do you want to create your application?`,
 		helpText: "also used as application name",
 		renderSubmitted: (value: string) => {
 			return `${brandColor("dir")} ${dim(value)}`;


### PR DESCRIPTION
Currently the CLI asks, "Where do you want to create your application?"

This changes the language here to "In which directory do you want to create your application?" to reduce ambiguity with smart placement, region hints, and other potential meanings of "where".

Fixes DEVX-731