### PR TITLE
[c3] fix: ensure the Angular fetch handler returns a "real" promise to Cloudflare

### DIFF
--- a/.changeset/stale-meals-yawn.md
+++ b/.changeset/stale-meals-yawn.md
@@ -1,0 +1,15 @@
+---
+"create-cloudflare": patch
+---
+
+fix: ensure the Angular fetch handler returns a "real" promise to Cloudflare
+
+Angular employs the Zone.js library to patch potentially async operations so that
+it can trigger change detection reliably. But in order to do this, it swaps out
+the native `Promise` with a `ZoneAwarePromise` class.
+
+The Cloudflare runtime (i.e. workerd) does runtime checks on the value returned
+from the `fetch()` handler, expecting it to be a native `Promise` and fails if not.
+
+This fix ensures that the actual object returned from the `fetch()` is actually a
+native `Promise`. We don't need to stop Angular using `ZoneAwarePromises` elsewhere.


### PR DESCRIPTION
Angular employs the Zone.js library to patch potentially async operations so that
it can trigger change detection reliably. But in order to do this, it swaps out
the native `Promise` with a `ZoneAwarePromise` class.

The Cloudflare runtime (i.e. workerd) does runtime checks on the value returned
from the `fetch()` handler, expecting it to be a native `Promise` and fails if not.

This fix ensures that the actual object returned from the `fetch()` is actually a
native `Promise`. We don't need to stop Angular using `ZoneAwarePromises` elsewhere.

Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
