### PR TITLE
Add https support in dev local mode

### DIFF
--- a/.changeset/loud-pugs-end.md
+++ b/.changeset/loud-pugs-end.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Support https in wrangler dev local mode

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -10,6 +10,7 @@ import {
 	Mutex,
 	Miniflare,
 } from "miniflare";
+import { getHttpsOptions } from "../https-options";
 import { logger } from "../logger";
 import { ModuleTypeToRuleType } from "../module-collection";
 import type { Config } from "../config";
@@ -371,11 +372,6 @@ async function buildMiniflareOptions(
 	log: Log,
 	config: ConfigBundle
 ): Promise<{ options: MiniflareOptions; internalObjects: CfDurableObject[] }> {
-	if (config.localProtocol === "https") {
-		logger.warn(
-			"Miniflare 3 does not support HTTPS servers yet, starting an HTTP server instead..."
-		);
-	}
 	if (config.crons.length > 0) {
 		logger.warn("Miniflare 3 does not support CRON triggers yet, ignoring...");
 	}
@@ -391,6 +387,15 @@ async function buildMiniflareOptions(
 	const sitesOptions = buildSitesOptions(config);
 	const persistOptions = buildPersistOptions(config);
 
+	let httpsOptions: { httpsKey: string; httpsCert: string } | undefined;
+	if (config.localProtocol === "https") {
+		const cert = await getHttpsOptions();
+		httpsOptions = {
+			httpsKey: cert.key,
+			httpsCert: cert.cert,
+		};
+	}
+
 	const options: MiniflareOptions = {
 		host: config.initialIp,
 		port: config.initialPort,
@@ -400,6 +405,8 @@ async function buildMiniflareOptions(
 
 		log,
 		verbose: logger.loggerLevel === "debug",
+
+		...httpsOptions,
 
 		...persistOptions,
 		workers: [


### PR DESCRIPTION
Fixes #3353.

PR adds support for https in local mode for dev. Adds new options to provide custom key and cert for https server.

[Docs issue](https://github.com/cloudflare/cloudflare-docs/issues/9625)

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
