### PR TITLE
Bump miniflare@3.0.2

### DIFF
--- a/.changeset/nasty-foxes-sparkle.md
+++ b/.changeset/nasty-foxes-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/pages-shared": patch
+"wrangler": patch
+---
+
+chore: Bump miniflare@3.0.2

--- a/fixtures/pages-ws-app/package.json
+++ b/fixtures/pages-ws-app/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",
-		"miniflare": "^3.0.1",
+		"miniflare": "^3.0.2",
 		"wrangler": "*",
 		"ws": "^8.8.0"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,44 +43,6 @@
 				"node": ">=16.13.0"
 			}
 		},
-		"../miniflare3/packages/tre": {
-			"name": "@miniflare/tre",
-			"version": "3.0.0-next.12",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"get-port": "^5.1.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230221.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.18.0"
-			},
-			"devDependencies": {
-				"@cloudflare/workers-types": "^4.20221111.1",
-				"@types/better-sqlite3": "^7.6.2",
-				"@types/debug": "^4.1.7",
-				"@types/estree": "^1.0.0",
-				"@types/glob-to-regexp": "^0.4.1",
-				"@types/http-cache-semantics": "^4.0.1",
-				"@types/source-map-support": "^0.5.6",
-				"@types/stoppable": "^1.1.1",
-				"@types/ws": "^8.5.3"
-			},
-			"engines": {
-				"node": ">=16.13"
-			}
-		},
 		"fixtures/d1-worker-app": {
 			"version": "1.0.0",
 			"license": "ISC",
@@ -298,12 +260,38 @@
 			"version": "0.0.0",
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "^3.0.1",
+				"miniflare": "^3.0.2",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"fixtures/pages-ws-app/node_modules/miniflare": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
+			"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.13.0",
+				"workerd": "^1.20230512.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"engines": {
+				"node": ">=16.13"
 			}
 		},
 		"fixtures/pages-ws-app/node_modules/ws": {
@@ -21151,51 +21139,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/miniflare": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.1.tgz",
-			"integrity": "sha512-aLOB8d26lOTn493GOv1LmpGHVLSxmeT4MixPG/k3Ze10j0wDKnMj8wsFgbZ6Q4cr1N4faf8O3IbNRJuQ+rLoJA==",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230512.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
-			}
-		},
-		"node_modules/miniflare/node_modules/ws": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -30821,7 +30764,7 @@
 			"name": "@cloudflare/pages-shared",
 			"version": "0.5.2",
 			"dependencies": {
-				"miniflare": "^3.0.1"
+				"miniflare": "^3.0.2"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
@@ -30867,6 +30810,31 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"packages/pages-shared/node_modules/miniflare": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
+			"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.13.0",
+				"workerd": "^1.20230512.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
 		"packages/pages-shared/node_modules/minimatch": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -30877,6 +30845,26 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"packages/pages-shared/node_modules/ws": {
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"packages/prerelease-registry": {
@@ -31810,7 +31798,7 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.16.3",
-				"miniflare": "^3.0.1",
+				"miniflare": "^3.0.2",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
@@ -31983,6 +31971,31 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"packages/wrangler/node_modules/miniflare": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
+			"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.13.0",
+				"workerd": "^1.20230512.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
 		"packages/wrangler/node_modules/minimatch": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
@@ -32061,7 +32074,6 @@
 			"version": "8.13.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -35188,7 +35200,7 @@
 				"@types/service-worker-mock": "^2.0.1",
 				"concurrently": "^7.3.0",
 				"glob": "^8.0.3",
-				"miniflare": "^3.0.1",
+				"miniflare": "^3.0.2",
 				"service-worker-mock": "^2.0.5",
 				"wrangler": "*"
 			},
@@ -35221,6 +35233,28 @@
 						"once": "^1.3.0"
 					}
 				},
+				"miniflare": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
+					"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
+					"requires": {
+						"acorn": "^8.8.0",
+						"acorn-walk": "^8.2.0",
+						"better-sqlite3": "^8.1.0",
+						"capnp-ts": "^0.7.0",
+						"exit-hook": "^2.2.1",
+						"glob-to-regexp": "^0.4.1",
+						"http-cache-semantics": "^4.1.0",
+						"kleur": "^4.1.5",
+						"source-map-support": "0.5.21",
+						"stoppable": "^1.1.0",
+						"undici": "^5.13.0",
+						"workerd": "^1.20230512.0",
+						"ws": "^8.11.0",
+						"youch": "^3.2.2",
+						"zod": "^3.20.6"
+					}
+				},
 				"minimatch": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -35229,6 +35263,12 @@
 					"requires": {
 						"brace-expansion": "^2.0.1"
 					}
+				},
+				"ws": {
+					"version": "8.13.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+					"requires": {}
 				}
 			}
 		},
@@ -48550,36 +48590,6 @@
 		"min-indent": {
 			"version": "1.0.1"
 		},
-		"miniflare": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.1.tgz",
-			"integrity": "sha512-aLOB8d26lOTn493GOv1LmpGHVLSxmeT4MixPG/k3Ze10j0wDKnMj8wsFgbZ6Q4cr1N4faf8O3IbNRJuQ+rLoJA==",
-			"requires": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230512.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "8.13.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-					"requires": {}
-				}
-			}
-		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -49656,11 +49666,34 @@
 			"version": "file:fixtures/pages-ws-app",
 			"requires": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "^3.0.1",
+				"miniflare": "^3.0.2",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"dependencies": {
+				"miniflare": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
+					"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
+					"dev": true,
+					"requires": {
+						"acorn": "^8.8.0",
+						"acorn-walk": "^8.2.0",
+						"better-sqlite3": "^8.1.0",
+						"capnp-ts": "^0.7.0",
+						"exit-hook": "^2.2.1",
+						"glob-to-regexp": "^0.4.1",
+						"http-cache-semantics": "^4.1.0",
+						"kleur": "^4.1.5",
+						"source-map-support": "0.5.21",
+						"stoppable": "^1.1.0",
+						"undici": "^5.13.0",
+						"workerd": "^1.20230512.0",
+						"ws": "^8.11.0",
+						"youch": "^3.2.2",
+						"zod": "^3.20.6"
+					}
+				},
 				"ws": {
 					"version": "8.11.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
@@ -54868,7 +54901,7 @@
 				"jest-fetch-mock": "^3.0.3",
 				"jest-websocket-mock": "^2.3.0",
 				"mime": "^3.0.0",
-				"miniflare": "^3.0.1",
+				"miniflare": "^3.0.2",
 				"minimatch": "^5.1.0",
 				"msw": "^0.49.1",
 				"nanoid": "^3.3.3",
@@ -54946,6 +54979,28 @@
 						"p-locate": "^6.0.0"
 					}
 				},
+				"miniflare": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
+					"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
+					"requires": {
+						"acorn": "^8.8.0",
+						"acorn-walk": "^8.2.0",
+						"better-sqlite3": "^8.1.0",
+						"capnp-ts": "^0.7.0",
+						"exit-hook": "^2.2.1",
+						"glob-to-regexp": "^0.4.1",
+						"http-cache-semantics": "^4.1.0",
+						"kleur": "^4.1.5",
+						"source-map-support": "0.5.21",
+						"stoppable": "^1.1.0",
+						"undici": "^5.13.0",
+						"workerd": "^1.20230512.0",
+						"ws": "^8.11.0",
+						"youch": "^3.2.2",
+						"zod": "^3.20.6"
+					}
+				},
 				"minimatch": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
@@ -54990,7 +55045,6 @@
 					"version": "8.13.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-					"dev": true,
 					"requires": {}
 				},
 				"yocto-queue": {

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -43,7 +43,7 @@
 		]
 	},
 	"dependencies": {
-		"miniflare": "^3.0.1"
+		"miniflare": "^3.0.2"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -103,7 +103,7 @@
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.16.3",
-		"miniflare": "^3.0.1",
+		"miniflare": "^3.0.2",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",
 		"selfsigned": "^2.0.1",


### PR DESCRIPTION
**What this PR solves / how to test:**

Bumps miniflare@3.0.2:

- Fixes `--port=0` reloads, ensuring the randomly selected port is re-used, and we don't instead get a _second_ random (different) port.

**Associated docs issue(s)/PR(s):**

- https://github.com/cloudflare/miniflare/issues/608

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
