### PR TITLE
chore: retry the e2e tests once if they fail

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,6 +79,17 @@ jobs:
           NODE_ENV: "production"
 
       - name: Run tests
+        id: e2e-1
+        continue-on-error: true
+        run: npm run -w wrangler test:e2e
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER: npm install ${{ steps.move-wrangler.outputs.dir}} && npx --prefer-offline wrangler
+          NODE_OPTIONS: "--max_old_space_size=8192"
+
+      - name: Retry tests
+        if: steps.e2e-1.outcome == 'failure'
         run: npm run -w wrangler test:e2e
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
A sneaky trick I saw at https://www.thisdot.co/blog/how-to-retry-failed-steps-in-github-action-workflows/#approach-2-duplicate-steps