### PR TITLE
chore: bump `miniflare` to `0.20230628.0`

### DIFF
--- a/fixtures/pages-ws-app/package.json
+++ b/fixtures/pages-ws-app/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",
-		"miniflare": "^3.0.2",
+		"miniflare": "0.20230628.0",
 		"wrangler": "*",
 		"ws": "^8.8.0"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,38 +260,12 @@
 			"version": "0.0.0",
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "^3.0.2",
+				"miniflare": "0.20230628.0",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"fixtures/pages-ws-app/node_modules/miniflare": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
-			"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230512.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
 			}
 		},
 		"fixtures/pages-ws-app/node_modules/ws": {
@@ -2684,81 +2658,6 @@
 			"dependencies": {
 				"fp-ts": "^2.1.1",
 				"io-ts": "^2.0.1"
-			}
-		},
-		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230512.0.tgz",
-			"integrity": "sha512-V80DswMTu0hiVue5BmjlC0cVufXLKk0KbkesbJ0IywHiuGk0f9uEOgwwL91ioOhPu+3Ss/ka5BNxwPXDxKkG3g==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230512.0.tgz",
-			"integrity": "sha512-HojEqgtCW8FCRQq/ENPsBVv1YoxJVp2kDrC27D7xfwOa2+LCmxh55c2cckxZuGTNAsBIqk6lczq4yQx9xcfSdg==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230512.0.tgz",
-			"integrity": "sha512-zhu61wFAyjbO+MtiQjcKDv+HUXYnW3GhGCKW8xKUsCktaXKr/l2Vp/t3VFzF+M8CuFMML5xmE/1gopHB9pIUcA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230512.0.tgz",
-			"integrity": "sha512-LvW/DFz35ISnkgagE6qra1CyFmak5sPJcOZ01fovtHIQdwtgUrU5Q+mTAoDZy+8yQnVIM8HCXJxe5gKxM9hnxQ==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230512.0.tgz",
-			"integrity": "sha512-OgRmn5FjroPSha/2JgcM8AQg5NpTig8TqDXgdM61Y/7DCCCEuOuMsZSqU1IrYkPU7gtOFvZSQZLgFA4XxbePbA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"node_modules/@cloudflare/workers-tsconfig": {
@@ -21139,6 +21038,146 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/miniflare": {
+			"version": "0.20230628.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-0.20230628.0.tgz",
+			"integrity": "sha512-XgnSDqrnxKYulDY8Qo31uo8fmFJH0i3675pcbnSV/wSTMtjOR2NxyTDK9rOnstZM86PWzk7kqF4X7ZSIzR4gwA==",
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"set-cookie-parser": "^2.6.0",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.13.0",
+				"workerd": "0.20230628.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"node_modules/miniflare/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "0.20230628.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-0.20230628.0.tgz",
+			"integrity": "sha512-sU09zB0qtxulvRfR9xP2j29PGS3xhv1IP6r3IetVI/OU1xNVVDc1u8P9E+YTewv35pIp5ji4i3RFRDHbXDk5/Q==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/miniflare/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "0.20230628.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-0.20230628.0.tgz",
+			"integrity": "sha512-eBOKZxQVDiemv13c3SOJU61hCveem2BGQ4m6Zgot2mHnBzn6DHAurEn1+J53bK4LIjPjokDGq9qH7/fA7nph9w==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/miniflare/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "0.20230628.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-0.20230628.0.tgz",
+			"integrity": "sha512-V+Xehom5mrSqXH9rETcwNjqS3n0P+NE+j+Wx5DbY+2oNWaAhqZ45TZCdB75BnFFemBdjHYGzw+bsMeum7uK/lQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/miniflare/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "0.20230628.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-0.20230628.0.tgz",
+			"integrity": "sha512-Gk3ovm+8dEMq+C/pyNaKdBJXFZn/836JRthPh4BgEoDv7pOhHklpDdpPj6YY2J6Ck6xFTf8xgNeJ6iUeKSOZCA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/miniflare/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "0.20230628.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-0.20230628.0.tgz",
+			"integrity": "sha512-E12UI3RYLc3+SEGNBXQYHS+520gYBcfnNV5j67S3de+W3GtLP4OLl71ZXRAKX158662H6Peh2iMGLRzyY/aF8A==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/miniflare/node_modules/workerd": {
+			"version": "0.20230628.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-0.20230628.0.tgz",
+			"integrity": "sha512-MNAxAhR6eJFWQ9yB3YpzU5E850rMclgSXLg4YcS3WiwkJDn3xhgW9W7/EwZVjn6+4ZTyUEcTDlgS4GIuQq32tg==",
+			"hasInstallScript": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "0.20230628.0",
+				"@cloudflare/workerd-darwin-arm64": "0.20230628.0",
+				"@cloudflare/workerd-linux-64": "0.20230628.0",
+				"@cloudflare/workerd-linux-arm64": "0.20230628.0",
+				"@cloudflare/workerd-windows-64": "0.20230628.0"
+			}
+		},
+		"node_modules/miniflare/node_modules/ws": {
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -25237,8 +25276,9 @@
 			"license": "ISC"
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "2.4.8",
-			"license": "MIT"
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
 		},
 		"node_modules/set-value": {
 			"version": "2.0.1",
@@ -29466,25 +29506,6 @@
 			"resolved": "fixtures/worker-ts",
 			"link": true
 		},
-		"node_modules/workerd": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230512.0.tgz",
-			"integrity": "sha512-rueIsVxLTVlqWyaSVHlDKFZRLkDAMmUhxiKXE+guMR3fauwPPsuzs/VKWUqX2sqR2UKF+1JxrUtH9OvaIqoHhA==",
-			"hasInstallScript": true,
-			"bin": {
-				"workerd": "bin/workerd"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20230512.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230512.0",
-				"@cloudflare/workerd-linux-64": "1.20230512.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230512.0",
-				"@cloudflare/workerd-windows-64": "1.20230512.0"
-			}
-		},
 		"node_modules/workers-chat-demo": {
 			"resolved": "fixtures/workers-chat-demo",
 			"link": true
@@ -30764,7 +30785,7 @@
 			"name": "@cloudflare/pages-shared",
 			"version": "0.5.2",
 			"dependencies": {
-				"miniflare": "^3.0.2"
+				"miniflare": "0.20230628.0"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
@@ -30810,31 +30831,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"packages/pages-shared/node_modules/miniflare": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
-			"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230512.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
-			}
-		},
 		"packages/pages-shared/node_modules/minimatch": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -30845,26 +30841,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"packages/pages-shared/node_modules/ws": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"packages/prerelease-registry": {
@@ -31798,7 +31774,7 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.16.3",
-				"miniflare": "^3.0.2",
+				"miniflare": "0.20230628.0",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
@@ -31971,31 +31947,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"packages/wrangler/node_modules/miniflare": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
-			"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230512.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
-			}
-		},
 		"packages/wrangler/node_modules/minimatch": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
@@ -32074,6 +32025,7 @@
 			"version": "8.13.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -35200,7 +35152,7 @@
 				"@types/service-worker-mock": "^2.0.1",
 				"concurrently": "^7.3.0",
 				"glob": "^8.0.3",
-				"miniflare": "^3.0.2",
+				"miniflare": "0.20230628.0",
 				"service-worker-mock": "^2.0.5",
 				"wrangler": "*"
 			},
@@ -35233,28 +35185,6 @@
 						"once": "^1.3.0"
 					}
 				},
-				"miniflare": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
-					"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
-					"requires": {
-						"acorn": "^8.8.0",
-						"acorn-walk": "^8.2.0",
-						"better-sqlite3": "^8.1.0",
-						"capnp-ts": "^0.7.0",
-						"exit-hook": "^2.2.1",
-						"glob-to-regexp": "^0.4.1",
-						"http-cache-semantics": "^4.1.0",
-						"kleur": "^4.1.5",
-						"source-map-support": "0.5.21",
-						"stoppable": "^1.1.0",
-						"undici": "^5.13.0",
-						"workerd": "^1.20230512.0",
-						"ws": "^8.11.0",
-						"youch": "^3.2.2",
-						"zod": "^3.20.6"
-					}
-				},
 				"minimatch": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -35263,12 +35193,6 @@
 					"requires": {
 						"brace-expansion": "^2.0.1"
 					}
-				},
-				"ws": {
-					"version": "8.13.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-					"requires": {}
 				}
 			}
 		},
@@ -35390,36 +35314,6 @@
 				"fp-ts": "^2.1.1",
 				"io-ts": "^2.0.1"
 			}
-		},
-		"@cloudflare/workerd-darwin-64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230512.0.tgz",
-			"integrity": "sha512-V80DswMTu0hiVue5BmjlC0cVufXLKk0KbkesbJ0IywHiuGk0f9uEOgwwL91ioOhPu+3Ss/ka5BNxwPXDxKkG3g==",
-			"optional": true
-		},
-		"@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230512.0.tgz",
-			"integrity": "sha512-HojEqgtCW8FCRQq/ENPsBVv1YoxJVp2kDrC27D7xfwOa2+LCmxh55c2cckxZuGTNAsBIqk6lczq4yQx9xcfSdg==",
-			"optional": true
-		},
-		"@cloudflare/workerd-linux-64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230512.0.tgz",
-			"integrity": "sha512-zhu61wFAyjbO+MtiQjcKDv+HUXYnW3GhGCKW8xKUsCktaXKr/l2Vp/t3VFzF+M8CuFMML5xmE/1gopHB9pIUcA==",
-			"optional": true
-		},
-		"@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230512.0.tgz",
-			"integrity": "sha512-LvW/DFz35ISnkgagE6qra1CyFmak5sPJcOZ01fovtHIQdwtgUrU5Q+mTAoDZy+8yQnVIM8HCXJxe5gKxM9hnxQ==",
-			"optional": true
-		},
-		"@cloudflare/workerd-windows-64": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230512.0.tgz",
-			"integrity": "sha512-OgRmn5FjroPSha/2JgcM8AQg5NpTig8TqDXgdM61Y/7DCCCEuOuMsZSqU1IrYkPU7gtOFvZSQZLgFA4XxbePbA==",
-			"optional": true
 		},
 		"@cloudflare/workers-tsconfig": {
 			"version": "file:packages/workers-tsconfig"
@@ -48590,6 +48484,79 @@
 		"min-indent": {
 			"version": "1.0.1"
 		},
+		"miniflare": {
+			"version": "0.20230628.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-0.20230628.0.tgz",
+			"integrity": "sha512-XgnSDqrnxKYulDY8Qo31uo8fmFJH0i3675pcbnSV/wSTMtjOR2NxyTDK9rOnstZM86PWzk7kqF4X7ZSIzR4gwA==",
+			"requires": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"set-cookie-parser": "^2.6.0",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.13.0",
+				"workerd": "0.20230628.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"dependencies": {
+				"@cloudflare/workerd-darwin-64": {
+					"version": "0.20230628.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-0.20230628.0.tgz",
+					"integrity": "sha512-sU09zB0qtxulvRfR9xP2j29PGS3xhv1IP6r3IetVI/OU1xNVVDc1u8P9E+YTewv35pIp5ji4i3RFRDHbXDk5/Q==",
+					"optional": true
+				},
+				"@cloudflare/workerd-darwin-arm64": {
+					"version": "0.20230628.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-0.20230628.0.tgz",
+					"integrity": "sha512-eBOKZxQVDiemv13c3SOJU61hCveem2BGQ4m6Zgot2mHnBzn6DHAurEn1+J53bK4LIjPjokDGq9qH7/fA7nph9w==",
+					"optional": true
+				},
+				"@cloudflare/workerd-linux-64": {
+					"version": "0.20230628.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-0.20230628.0.tgz",
+					"integrity": "sha512-V+Xehom5mrSqXH9rETcwNjqS3n0P+NE+j+Wx5DbY+2oNWaAhqZ45TZCdB75BnFFemBdjHYGzw+bsMeum7uK/lQ==",
+					"optional": true
+				},
+				"@cloudflare/workerd-linux-arm64": {
+					"version": "0.20230628.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-0.20230628.0.tgz",
+					"integrity": "sha512-Gk3ovm+8dEMq+C/pyNaKdBJXFZn/836JRthPh4BgEoDv7pOhHklpDdpPj6YY2J6Ck6xFTf8xgNeJ6iUeKSOZCA==",
+					"optional": true
+				},
+				"@cloudflare/workerd-windows-64": {
+					"version": "0.20230628.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-0.20230628.0.tgz",
+					"integrity": "sha512-E12UI3RYLc3+SEGNBXQYHS+520gYBcfnNV5j67S3de+W3GtLP4OLl71ZXRAKX158662H6Peh2iMGLRzyY/aF8A==",
+					"optional": true
+				},
+				"workerd": {
+					"version": "0.20230628.0",
+					"resolved": "https://registry.npmjs.org/workerd/-/workerd-0.20230628.0.tgz",
+					"integrity": "sha512-MNAxAhR6eJFWQ9yB3YpzU5E850rMclgSXLg4YcS3WiwkJDn3xhgW9W7/EwZVjn6+4ZTyUEcTDlgS4GIuQq32tg==",
+					"requires": {
+						"@cloudflare/workerd-darwin-64": "0.20230628.0",
+						"@cloudflare/workerd-darwin-arm64": "0.20230628.0",
+						"@cloudflare/workerd-linux-64": "0.20230628.0",
+						"@cloudflare/workerd-linux-arm64": "0.20230628.0",
+						"@cloudflare/workerd-windows-64": "0.20230628.0"
+					}
+				},
+				"ws": {
+					"version": "8.13.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+					"requires": {}
+				}
+			}
+		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -49666,34 +49633,11 @@
 			"version": "file:fixtures/pages-ws-app",
 			"requires": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "^3.0.2",
+				"miniflare": "0.20230628.0",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"dependencies": {
-				"miniflare": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
-					"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
-					"dev": true,
-					"requires": {
-						"acorn": "^8.8.0",
-						"acorn-walk": "^8.2.0",
-						"better-sqlite3": "^8.1.0",
-						"capnp-ts": "^0.7.0",
-						"exit-hook": "^2.2.1",
-						"glob-to-regexp": "^0.4.1",
-						"http-cache-semantics": "^4.1.0",
-						"kleur": "^4.1.5",
-						"source-map-support": "0.5.21",
-						"stoppable": "^1.1.0",
-						"undici": "^5.13.0",
-						"workerd": "^1.20230512.0",
-						"ws": "^8.11.0",
-						"youch": "^3.2.2",
-						"zod": "^3.20.6"
-					}
-				},
 				"ws": {
 					"version": "8.11.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
@@ -51851,7 +51795,9 @@
 			"version": "2.0.0"
 		},
 		"set-cookie-parser": {
-			"version": "2.4.8"
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -54810,18 +54756,6 @@
 				}
 			}
 		},
-		"workerd": {
-			"version": "1.20230512.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230512.0.tgz",
-			"integrity": "sha512-rueIsVxLTVlqWyaSVHlDKFZRLkDAMmUhxiKXE+guMR3fauwPPsuzs/VKWUqX2sqR2UKF+1JxrUtH9OvaIqoHhA==",
-			"requires": {
-				"@cloudflare/workerd-darwin-64": "1.20230512.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230512.0",
-				"@cloudflare/workerd-linux-64": "1.20230512.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230512.0",
-				"@cloudflare/workerd-windows-64": "1.20230512.0"
-			}
-		},
 		"workers-chat-demo": {
 			"version": "file:fixtures/workers-chat-demo"
 		},
@@ -54901,7 +54835,7 @@
 				"jest-fetch-mock": "^3.0.3",
 				"jest-websocket-mock": "^2.3.0",
 				"mime": "^3.0.0",
-				"miniflare": "^3.0.2",
+				"miniflare": "0.20230628.0",
 				"minimatch": "^5.1.0",
 				"msw": "^0.49.1",
 				"nanoid": "^3.3.3",
@@ -54979,28 +54913,6 @@
 						"p-locate": "^6.0.0"
 					}
 				},
-				"miniflare": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.0.2.tgz",
-					"integrity": "sha512-tSwmK+JPwHsV2KR7/dSZFGtTF/2M30OShjPDY7e5lAxyGE8SkHqXn/ckjg2TVltc9B8rXCSffMnCfYW1pH7R4A==",
-					"requires": {
-						"acorn": "^8.8.0",
-						"acorn-walk": "^8.2.0",
-						"better-sqlite3": "^8.1.0",
-						"capnp-ts": "^0.7.0",
-						"exit-hook": "^2.2.1",
-						"glob-to-regexp": "^0.4.1",
-						"http-cache-semantics": "^4.1.0",
-						"kleur": "^4.1.5",
-						"source-map-support": "0.5.21",
-						"stoppable": "^1.1.0",
-						"undici": "^5.13.0",
-						"workerd": "^1.20230512.0",
-						"ws": "^8.11.0",
-						"youch": "^3.2.2",
-						"zod": "^3.20.6"
-					}
-				},
 				"minimatch": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
@@ -55045,6 +54957,7 @@
 					"version": "8.13.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+					"dev": true,
 					"requires": {}
 				},
 				"yocto-queue": {

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -43,7 +43,7 @@
 		]
 	},
 	"dependencies": {
-		"miniflare": "^3.0.2"
+		"miniflare": "0.20230628.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -103,7 +103,7 @@
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.16.3",
-		"miniflare": "^3.0.2",
+		"miniflare": "0.20230628.0",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",
 		"selfsigned": "^2.0.1",


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR bumps and pins `miniflare` to the latest `beta` version. This allows us to get a `wrangler@beta` version with a bunch of `workerd` fixes, including support for older Linux and macOS versions (https://github.com/cloudflare/workers-sdk/issues/3457), and fixing some memory leaks (#2386).

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ] ~~Tests~~
- [ ] ~~Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~~ (we'll make another PR with a changeset once we have a full-release, otherwise we'd have to remove this beta bump changeset)

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
