### PR TITLE
[C3] Use workers template for `create-hono`

### DIFF
--- a/.changeset/lazy-brooms-live.md
+++ b/.changeset/lazy-brooms-live.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+fix: use workers template for Hono
+
+Use a workers template instead of a pages template for `create-hono`.

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -166,7 +166,11 @@ export const printSummary = async (ctx: PagesGeneratorContext) => {
 		[
 			`Read the documentation`,
 			`https://developers.cloudflare.com/${
-				ctx.framework ? "pages" : "workers"
+				ctx.framework
+					? ctx.framework.config.type === "workers"
+						? "workers"
+						: "pages"
+					: "workers"
 			}`,
 		],
 		[`Stuck? Join us at`, `https://discord.gg/cloudflaredev`],

--- a/packages/create-cloudflare/src/frameworks/hono/index.ts
+++ b/packages/create-cloudflare/src/frameworks/hono/index.ts
@@ -11,7 +11,7 @@ const generate = async (ctx: PagesGeneratorContext) => {
 
 	await runFrameworkGenerator(
 		ctx,
-		`${dlx} create-hono@${version} ${ctx.project.name} --template cloudflare-pages`
+		`${dlx} create-hono@${version} ${ctx.project.name} --template cloudflare-workers`
 	);
 
 	logRaw(""); // newline
@@ -23,5 +23,6 @@ const config: FrameworkConfig = {
 	packageScripts: {},
 	deployCommand: "deploy",
 	devCommand: "dev",
+	type: "workers",
 };
 export default config;

--- a/packages/create-cloudflare/src/pages.ts
+++ b/packages/create-cloudflare/src/pages.ts
@@ -126,6 +126,7 @@ const updatePackageScripts = async (ctx: PagesGeneratorContext) => {
 
 const createProject = async (ctx: PagesGeneratorContext) => {
 	if (ctx.args.deploy === false) return;
+	if (ctx.framework?.config.type === "workers") return;
 	if (!ctx.account?.id) {
 		crash("Failed to read Cloudflare account.");
 		return;

--- a/packages/create-cloudflare/src/types.ts
+++ b/packages/create-cloudflare/src/types.ts
@@ -41,4 +41,5 @@ export type FrameworkConfig = {
 	devCommand?: string;
 	testFlags?: string[];
 	compatibilityFlags?: string[];
+	type?: "pages" | "workers";
 };


### PR DESCRIPTION
Fixes #3477

**What this PR solves / how to test:**

Currently, in C3, when you choose "Hono" from "Website or web app", it creates the project using the `create-hono` command with the `--template cloudflare-pages` option:

```
npx create-hono@latest my-app --template cloudflare-pages
```

But as I mentioned in #3477, using the template for *Workers* is more appropriate for Hono. In this PR, I've switched to using the `--template cloudflare-workers` option for the `create-hono` command and implemented the following related changes:

* Added an optional `type?` property to `FrameworkConfig`, which can be either `"pages"` or `"workers"`.
* Set the `type` as "`workers`" for Hono.
* If the `type` is set to `workers`, the project isn't created, and a link to `https://developers.cloudflare.com/workers` is displayed instead.

I initially considered whether we should create a separate category for "Web APIs / Backend", but I believe the solution proposed in this PR is better.

**Need to consider**

That the "workers framework" is under "pages" is causing some confusion. It might be worth to refactor by such renaming of some elements. But, I don't have any good ideas at the moment. I'd like to know your opinions.

**What is my motivation?**

I'm planning to write a tutorial for the official Cloudflare documentation. I want to use C3 in this tutorial, but there's currently no suitable way to create a Workers skeleton using Hono. The current Hono template is designed for Pages, which isn't appropriate for this use case.

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
