### PR TITLE
Revert "Report correct IP & port in local mode"

### DIFF
--- a/.changeset/slow-beans-wink.md
+++ b/.changeset/slow-beans-wink.md
@@ -1,7 +1,0 @@
----
-"wrangler": patch
----
-
-fix: Report correct IP & port in local mode
-
-In remote mode, the onReady callback was being incorrectly called with the remote host, rather than the local host of the proxy server. It was also only called with the pre port-assignment port, which is sometimes 0. This meant that the browser hotkey sometimes opened a remote route, rather the local proxy. Now, the browser hotkey will always open the local proxy.

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -83,6 +83,7 @@ export function Remote(props: RemoteProps) {
 		zone: props.zone,
 		host: props.host,
 		routes: props.routes,
+		onReady: props.onReady,
 		sendMetrics: props.sendMetrics,
 		port: props.port,
 	});
@@ -95,7 +96,6 @@ export function Remote(props: RemoteProps) {
 		localProtocol: props.localProtocol,
 		localPort: props.port,
 		ip: props.ip,
-		onReady: props.onReady,
 	});
 
 	useInspector({
@@ -172,6 +172,7 @@ interface RemoteWorkerProps {
 	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
+	onReady: ((ip: string, port: number) => void) | undefined;
 	sendMetrics: boolean | undefined;
 	port: number;
 }
@@ -186,6 +187,8 @@ export function useWorker(
 	// something's "happened" in our system; We make a ref and
 	// mark it once we log our initial message. Refs are vars!
 	const startedRef = useRef(false);
+	// functions must be destructured before use inside a useEffect, otherwise the entire props object has to be added to the dependency array
+	const { onReady } = props;
 	// This effect sets up the preview session
 	useEffect(() => {
 		const abortController = new AbortController();
@@ -320,6 +323,7 @@ export function useWorker(
 				});
 			}
 			*/
+			onReady?.(props.host || "localhost", props.port);
 		}
 		start().catch((err) => {
 			// we want to log the error, but not end the process
@@ -371,6 +375,7 @@ export function useWorker(
 		props.host,
 		props.routes,
 		session,
+		onReady,
 		props.sendMetrics,
 		props.port,
 	]);

--- a/packages/wrangler/src/proxy.ts
+++ b/packages/wrangler/src/proxy.ts
@@ -194,14 +194,12 @@ export function usePreviewServer({
 	localProtocol,
 	localPort: port,
 	ip,
-	onReady,
 }: {
 	previewToken: CfPreviewToken | undefined;
 	assetDirectory: string | undefined;
 	localProtocol: "https" | "http";
 	localPort: number;
 	ip: string;
-	onReady: ((finalIp: string, finalPort: number) => void) | undefined;
 }) {
 	/** Creates an HTTP/1 proxy that sends requests over HTTP/2. */
 	const [proxy, setProxy] = useState<PreviewProxy>();
@@ -301,7 +299,6 @@ export function usePreviewServer({
 					const usedPort =
 						address && typeof address === "object" ? address.port : port;
 					logger.log(`⬣ Listening at ${localProtocol}://${ip}:${usedPort}`);
-					onReady?.(ip, usedPort);
 					const accessibleHosts =
 						ip !== "0.0.0.0" ? [ip] : getAccessibleHosts();
 					for (const accessibleHost of accessibleHosts) {
@@ -324,7 +321,7 @@ export function usePreviewServer({
 				.terminate()
 				.catch(() => logger.error("Failed to terminate the proxy server."));
 		};
-	}, [port, ip, proxy, localProtocol, onReady]);
+	}, [port, ip, proxy, localProtocol]);
 }
 
 function configureProxyServer({


### PR DESCRIPTION
Reverts cloudflare/workers-sdk#3337, since it's breaking e2e tests