### PR TITLE
Always use built C3 in e2e testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,20 @@ jobs:
         env:
           NODE_ENV: "production"
 
+      - name: Build C3 package for npm
+        run: cd packages/create-cloudflare && npm pack
+        env:
+          NODE_ENV: "production"
+
+      - name: Move C3 package to tmp directory
+        shell: bash
+        id: "move-c3"
+        run: |
+          cp packages/create-cloudflare/create-cloudflare-*.tgz $HOME
+          echo "dir=$(ls $HOME/create-cloudflare-*.tgz)" >> $GITHUB_OUTPUT;
+        env:
+          NODE_ENV: "production"
+
       - name: Run tests
         id: e2e-1
         continue-on-error: true
@@ -86,6 +100,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           WRANGLER: npm install ${{ steps.move-wrangler.outputs.dir}} && npx --prefer-offline wrangler
+          WRANGLER_C3_COMMAND: install ${{ steps.move-c3.outputs.dir}} && npm exec --prefer-offline create-cloudflare
           NODE_OPTIONS: "--max_old_space_size=8192"
 
       - name: Retry tests
@@ -95,4 +110,5 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           WRANGLER: npm install ${{ steps.move-wrangler.outputs.dir}} && npx --prefer-offline wrangler
+          WRANGLER_C3_COMMAND: install ${{ steps.move-c3.outputs.dir}} && npm exec --prefer-offline create-cloudflare
           NODE_OPTIONS: "--max_old_space_size=8192"

--- a/packages/wrangler/e2e/c3-integration.test.ts
+++ b/packages/wrangler/e2e/c3-integration.test.ts
@@ -35,16 +35,16 @@ describe("c3 integration", () => {
 
 	it("init project via c3", async () => {
 		const pathToC3 = path.resolve(__dirname, "../../create-cloudflare");
+		console.log(pathToC3);
 		const env = {
 			...process.env,
-			WRANGLER_C3_COMMAND: `exec ${pathToC3}`,
 			GIT_AUTHOR_NAME: "test-user",
 			GIT_AUTHOR_EMAIL: "test-user@cloudflare.com",
 			GIT_COMMITTER_NAME: "test-user",
 			GIT_COMMITTER_EMAIL: "test-user@cloudflare.com",
 		};
 
-		await runInRoot.env(env)`$ ${WRANGLER} init ${workerName} --yes`;
+		await runInRoot.env(env)`$$ ${WRANGLER} init ${workerName} --yes`;
 
 		expect(existsSync(workerPath)).toBe(true);
 	});


### PR DESCRIPTION
**What this PR solves / how to test:**

Previously, `npm exec` was used to run C3 in e2e tests. Unfortunately, it seems like `npm exec` maintains a cache of packages, and when passed a path to a package doesn't necessarily use the code from that filepath—instead fetching it from NPM or it's local cache. This led to issues in e2e tests where the `create-cloudflare` tests failed because of stale caches.
 
**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
