### PR TITLE
Update wrangler dep in package.json for rust template

### DIFF
--- a/templates/experimental/worker-rust/Cargo.toml
+++ b/templates/experimental/worker-rust/Cargo.toml
@@ -11,7 +11,7 @@ wasm-opt = false
 crate-type = ["cdylib"]
 
 [dependencies]
-worker = "0.0.15"
+worker = "0.0.17"
 
 [profile.release]
 lto = true

--- a/templates/experimental/worker-rust/package.json
+++ b/templates/experimental/worker-rust/package.json
@@ -7,6 +7,6 @@
 		"dev": "wrangler dev --local"
 	},
 	"devDependencies": {
-		"wrangler": "^2.13.0"
+		"wrangler": "^3.1.2"
 	}
 }

--- a/templates/experimental/worker-rust/wrangler.toml
+++ b/templates/experimental/worker-rust/wrangler.toml
@@ -1,6 +1,6 @@
 name = "worker-rust"
 main = "build/worker/shim.mjs"
-compatibility_date = "2023-03-22"
+compatibility_date = "2023-06-28"
 
 [build]
 command = "cargo install -q worker-build && worker-build --release"


### PR DESCRIPTION
Fixes # [3566].

**What this PR solves / how to test:**
This PR fixes #3566 by updating the wrangler version for the rust worker template, as there was a package.json script in the template that calls `wrangler deploy` when the version in the package.json dependencies of wrangler doesn't support that command.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

(The change is too minor for a changes)

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
