### PR TITLE
C3: Prompt user to change directory in summary steps

### DIFF
--- a/.changeset/lucky-months-judge.md
+++ b/.changeset/lucky-months-judge.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+C3: Prompt user to change directory in summary steps

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -152,6 +152,7 @@ export const chooseAccount = async (ctx: PagesGeneratorContext) => {
 
 export const printSummary = async (ctx: PagesGeneratorContext) => {
 	const nextSteps = [
+		[`Navigate to the new directory:`, `cd ${ctx.project.name}`],
 		[
 			`Run the development server`,
 			`${npm} run ${ctx.framework?.config.devCommand ?? "start"}`,


### PR DESCRIPTION
Fixes #3476.

![image](https://github.com/cloudflare/workers-sdk/assets/204386/a4a75b69-cdef-4c7c-bb45-6ff70957247c)

**What this PR solves / how to test:**

Tells the user to `cd` into the application they just created before suggesting other commands

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
