### PR TITLE
fix: register middleware once for module workers

### DIFF
--- a/.changeset/empty-avocados-promise.md
+++ b/.changeset/empty-avocados-promise.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+fix: register middleware once for module workers
+
+Ensure middleware is only registered on the first request when using module workers.
+This should prevent stack overflows and slowdowns when making large number of requests to `wrangler dev` with infrequent reloads.

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -1084,6 +1084,7 @@ describe("middleware", () => {
 			  }
 			  return env;
 			}
+			var registeredMiddleware = false;
 			var facade2 = {
 			  ...middleware_insertion_facade_default.tail && {
 			    tail: maskHandlerEnv(middleware_insertion_facade_default.tail)
@@ -1103,8 +1104,11 @@ describe("middleware", () => {
 			  fetch(request, rawEnv, ctx) {
 			    const env = getMaskedEnv2(rawEnv);
 			    if (middleware_insertion_facade_default.middleware && middleware_insertion_facade_default.middleware.length > 0) {
-			      for (const middleware of middleware_insertion_facade_default.middleware) {
-			        __facade_register__(middleware);
+			      if (!registeredMiddleware) {
+			        registeredMiddleware = true;
+			        for (const middleware of middleware_insertion_facade_default.middleware) {
+			          __facade_register__(middleware);
+			        }
 			      }
 			      const __facade_modules_dispatch__ = function(type, init) {
 			        if (type === \\"scheduled\\" && middleware_insertion_facade_default.scheduled !== void 0) {


### PR DESCRIPTION
Fixes #2386

**What this PR solves / how to test:**

Previously, the middleware loader for module workers would register all middleware on each request. These registrations would be in addition to previous requests' registrations, meaning the middleware chain grew linearly with each request. This eventually lead to a stack overflow, as the middleware dispatcher is recursive. It also significantly slowed down requests over time. Editing code and reloading the dev server would reset the middleware chain.

This change ensures middleware is only registered on the first request.

To test this, follow the reproduction instructions here: https://github.com/BillBrower-Shopify/cf-workerd-crash-minimal
With this change stack overflows and slowdowns shouldn't be observed.

**Associated docs issue(s)/PR(s):**

- N/A

**Author has included the following, where applicable:**

- [ ] ~~Tests~~
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
