### PR TITLE
fix: keep configuration watcher alive

### DIFF
--- a/.changeset/nine-hounds-nail.md
+++ b/.changeset/nine-hounds-nail.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: keep configuration watcher alive
+
+Ensure `wrangler dev` watches the `wrangler.toml` file and reloads the server whenever configuration (e.g. KV namespaces, compatibility dates, etc) changes.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -513,8 +513,9 @@ To run an edge preview session for your Worker, use ${chalk.green(
 				await watcher?.close();
 			},
 		};
-	} finally {
+	} catch (e) {
 		await watcher?.close();
+		throw e;
 	}
 }
 


### PR DESCRIPTION
**What this PR solves / how to test:**

Previously, Wrangler would watch the `wrangler.toml` file then immediately clean-up the watcher. The prevented changes in the configuration (e.g. compatibility dates) reloading the server.

This change only cleans-up the watcher if `startDev()` throws, rather than if it returns normally.

To test, run `wrangler dev` on one of the fixtures, edit the `wrangler.toml` and check the dev server reloads with the new configuration.

**Associated docs issue(s)/PR(s):**

-  N/A

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
