### PR TITLE
Bail early on middleware format mismatch

### DIFF
--- a/.changeset/itchy-experts-sniff.md
+++ b/.changeset/itchy-experts-sniff.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: When a middleware is configured which doesn't support your Worker's script format, fail early with a helpful error message

--- a/packages/wrangler/src/deployment-bundle/apply-middleware.ts
+++ b/packages/wrangler/src/deployment-bundle/apply-middleware.ts
@@ -4,6 +4,7 @@ import { getBasePath } from "../paths";
 import { dedent } from "../utils/dedent";
 import type { DurableObjectBindings } from "../config/environment";
 import type { Entry } from "./entry";
+import type { CfScriptFormat } from "./worker";
 
 /**
  * A facade that acts as a "middleware loader".
@@ -18,6 +19,7 @@ export interface MiddlewareLoader {
 	// where `name` is the name of this middleware, and the module contains
 	// named exports for each property on the `config` record.
 	config?: Record<string, unknown>;
+	supports: CfScriptFormat[];
 }
 
 export async function applyMiddlewareLoaderFacade(

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -138,6 +138,7 @@ export async function bundleWorker(
 		middlewareToLoad.push({
 			name: "scheduled",
 			path: "templates/middleware/middleware-scheduled.ts",
+			supports: ["modules", "service-worker"],
 		});
 	}
 
@@ -160,6 +161,7 @@ export async function bundleWorker(
 		middlewareToLoad.push({
 			name: "miniflare3-json-error",
 			path: "templates/middleware/middleware-miniflare3-json-error.ts",
+			supports: ["modules", "service-worker"],
 		});
 	}
 
@@ -179,6 +181,7 @@ export async function bundleWorker(
 						  }
 						: {},
 			},
+			supports: ["modules", "service-worker"],
 		});
 	}
 
@@ -202,6 +205,7 @@ export async function bundleWorker(
 					])
 				),
 			},
+			supports: ["modules"],
 		});
 	}
 
@@ -243,7 +247,14 @@ export async function bundleWorker(
 
 		inject.push(checkedFetchFileToInject);
 	}
-
+	// Check that the current worker format is supported by all the active middleware
+	for (const middleware of middlewareToLoad) {
+		if (!middleware.supports.includes(entry.format)) {
+			throw new Error(
+				`Your Worker is written using the "${entry.format}" format, which isn't supported by the "${middleware.name}" middleware. To use "${middleware.name}" middleware, convert your Worker to the "${middleware.supports[0]}" format`
+			);
+		}
+	}
 	if (
 		middlewareToLoad.length > 0 ||
 		process.env.EXPERIMENTAL_MIDDLEWARE === "true"


### PR DESCRIPTION
Fixes #3575

**What this PR solves / how to test:**

Fail early with a helpful error message when a configured middleware doesn't support your Worker's script format (i.e. D1 and multiworker only support the modules format).

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
