### PR TITLE
Limit dev registry logs

### DIFF
--- a/.changeset/silver-dolphins-guess.md
+++ b/.changeset/silver-dolphins-guess.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Only log dev registry connection errors once

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -45,6 +45,8 @@ function useDevRegistry(
 ): WorkerRegistry {
 	const [workers, setWorkers] = useState<WorkerRegistry>({});
 
+	const hasFailedToFetch = useRef(false);
+
 	useEffect(() => {
 		// Let's try to start registry
 		// TODO: we should probably call this in a loop
@@ -73,7 +75,10 @@ function useDevRegistry(
 								});
 							},
 							(err) => {
-								logger.warn("Failed to get worker definitions", err);
+								if (!hasFailedToFetch.current) {
+									hasFailedToFetch.current = true;
+									logger.warn("Failed to get worker definitions", err);
+								}
 							}
 						);
 				  }, 300)


### PR DESCRIPTION
Fixes #3564

**What this PR solves / how to test:**

Sometimes the dev registry gets stuck, and Wrangler fails to connect. There may be underlying issues here we should investigate, but in the meantime this limits the error message generated to being logged once per Wrangler process rather than every 300 milliseconds.

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
