### PR TITLE
ci: implement PR previews for C3

### DIFF
--- a/.github/extract-pr-and-workflow-id.js
+++ b/.github/extract-pr-and-workflow-id.js
@@ -1,3 +1,6 @@
+// This file is not used directly.
+// Instead its contents are used in of `.github/workflows/write-prerelease-comment.yml`
+// Any changes here should be copied into the CI step there.
 const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
 	owner: context.repo.owner,
 	repo: context.repo.repo,
@@ -6,12 +9,13 @@ const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
 
 for (const artifact of allArtifacts.data.artifacts) {
 	// Extract the PR number from the artifact name
-	const match = /^npm-package-wrangler-(\d+)$/.exec(artifact.name);
+	const match = /^npm-package-(.+)-(\d+)$/.exec(artifact.name);
 	if (match) {
+		const packageName = match[1].toUpperCase();
 		fs.appendFileSync(
 			process.env.GITHUB_ENV,
-			`\nWORKFLOW_RUN_PR=${match[1]}` +
-				`\nWORKFLOW_RUN_ID=${context.payload.workflow_run.id}`
+			`\nWORKFLOW_RUN_PR_FOR_${packageName}=${match[2]}` +
+				`\nWORKFLOW_RUN_ID_FOR_${packageName}=${context.payload.workflow_run.id}`
 		);
 		break;
 	}

--- a/.github/extract-pr-and-workflow-id.js
+++ b/.github/extract-pr-and-workflow-id.js
@@ -1,5 +1,5 @@
 // This file is not used directly.
-// Instead its contents are used in of `.github/workflows/write-prerelease-comment.yml`
+// Instead its contents are used in `.github/workflows/write-prerelease-comment.yml`
 // Any changes here should be copied into the CI step there.
 const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
 	owner: context.repo.owner,

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: packages/wrangler
 
       - name: Upload packaged wrangler artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: npm-package-wrangler-${{ github.event.number }} # encode the PR number into the artifact name
           path: packages/wrangler/wrangler-*.tgz
@@ -55,7 +55,7 @@ jobs:
         working-directory: packages/pages-shared
 
       - name: Upload packaged @cloudflare/pages-shared artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: npm-package-cloudflare-pages-shared-${{ github.event.number }} # encode the PR number into the artifact name
           path: packages/pages-shared/cloudflare-pages-shared-*.tgz
@@ -65,7 +65,7 @@ jobs:
         working-directory: packages/create-cloudflare
 
       - name: Upload packaged @cloudflare/create-cloudflare artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: npm-package-create-cloudflare-${{ github.event.number }} # encode the PR number into the artifact name
           path: packages/create-cloudflare/create-cloudflare-*.tgz

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -44,18 +44,28 @@ jobs:
         run: npm pack
         working-directory: packages/wrangler
 
-      - name: Pack @cloudflare/pages-shared
-        run: npm pack
-        working-directory: packages/pages-shared
-
       - name: Upload packaged wrangler artifact
         uses: actions/upload-artifact@v2
         with:
           name: npm-package-wrangler-${{ github.event.number }} # encode the PR number into the artifact name
           path: packages/wrangler/wrangler-*.tgz
 
+      - name: Pack @cloudflare/pages-shared
+        run: npm pack
+        working-directory: packages/pages-shared
+
       - name: Upload packaged @cloudflare/pages-shared artifact
         uses: actions/upload-artifact@v2
         with:
           name: npm-package-cloudflare-pages-shared-${{ github.event.number }} # encode the PR number into the artifact name
           path: packages/pages-shared/cloudflare-pages-shared-*.tgz
+
+      - name: Pack @cloudflare/create-cloudflare
+        run: npm pack
+        working-directory: packages/create-cloudflare
+
+      - name: Upload packaged @cloudflare/create-cloudflare artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: npm-package-cloudflare-create-cloudflare-${{ github.event.number }} # encode the PR number into the artifact name
+          path: packages/create-cloudflare/cloudflare-create-cloudflare-*.tgz

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -67,5 +67,5 @@ jobs:
       - name: Upload packaged @cloudflare/create-cloudflare artifact
         uses: actions/upload-artifact@v2
         with:
-          name: npm-package-cloudflare-create-cloudflare-${{ github.event.number }} # encode the PR number into the artifact name
-          path: packages/create-cloudflare/cloudflare-create-cloudflare-*.tgz
+          name: npm-package-create-cloudflare-${{ github.event.number }} # encode the PR number into the artifact name
+          path: packages/create-cloudflare/create-cloudflare-*.tgz

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -13,7 +13,7 @@ jobs:
     name: Write comment to the PR
     steps:
       - name: "Put PR and workflow ID on the environment"
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             // Copied from .github/extract-pr-and-workflow-id.js
@@ -68,7 +68,7 @@ jobs:
 
             Note that these links will no longer work once [the GitHub Actions artifact expires](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
 
-      - name: "Comment on PR with Wrangler link"
+      - name: "Comment on PR with C3 link"
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ env.WORKFLOW_RUN_PR_FOR_CREATE_CLOUDFLARE }}

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
+            // Copied from .github/extract-pr-and-workflow-id.js
             const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -24,44 +25,59 @@ jobs:
 
             for (const artifact of allArtifacts.data.artifacts) {
               // Extract the PR number from the artifact name
-              const match = /^npm-package-wrangler-(\d+)$/.exec(artifact.name);
+              const match = /^npm-package-(.+)-(\d+)$/.exec(artifact.name);
               if (match) {
-                require("fs").appendFileSync(
+                const packageName = match[1].toUpperCase();
+                fs.appendFileSync(
                   process.env.GITHUB_ENV,
-                  `\nWORKFLOW_RUN_PR=${match[1]}` +
-                    `\nWORKFLOW_RUN_ID=${context.payload.workflow_run.id}`
+                  `\nWORKFLOW_RUN_PR_FOR_${packageName}=${match[2]}` +
+                    `\nWORKFLOW_RUN_ID_FOR_${packageName}=${context.payload.workflow_run.id}`
                 );
                 break;
               }
             }
 
-      - name: "Comment on PR with Link"
+      - name: "Comment on PR with Wrangler link"
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ env.WORKFLOW_RUN_PR }}
+          number: ${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
           message: |
             A wrangler prerelease is available for testing. You can install this latest build in your project with:
 
             ```sh
-            npm install --save-dev https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR }}
+            npm install --save-dev https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
             ```
 
             You can reference the automatically updated head of this PR with:
 
             ```sh
-            npm install --save-dev https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/prs/${{ env.WORKFLOW_RUN_PR }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR }}
+            npm install --save-dev https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/prs/${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
             ```
 
             Or you can use `npx` with this latest build directly:
 
             ```sh
-            npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR }} dev path/to/script.js
+            npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }} dev path/to/script.js
             ```
 
             <details><summary>Additional artifacts:</summary>
 
             ```sh
-            npm install https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID }}/npm-package-cloudflare-pages-shared-${{ env.WORKFLOW_RUN_PR }}
+            npm install https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-cloudflare-pages-shared-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
+            ```
+
+            Note that these links will no longer work once [the GitHub Actions artifact expires](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
+
+      - name: "Comment on PR with Wrangler link"
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ env.WORKFLOW_RUN_PR_FOR_CREATE_CLOUDFLARE }}
+          message: |
+            A create-cloudflare (C3) prerelease is available for testing.
+            You can use `npx` with this latest build directly:
+
+            ```sh
+            npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_CREATE_CLOUDFLARE }}/npm-package-create-cloudflare-${{ env.WORKFLOW_RUN_PR_FOR_CREATE_CLOUDFLARE }}
             ```
 
             Note that these links will no longer work once [the GitHub Actions artifact expires](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).


### PR DESCRIPTION
The changes to [.github/workflows/write-prerelease-comment.yml](https://github.com/cloudflare/workers-sdk/pull/3603/files#diff-14f1093401a0e312fb8ada4cb51580148fbed83e0c479a9ec2fffc81e052643f) will only be testable when this PR lands, as those jobs only run on `main`.