### PR TITLE
C3: offer eslint-plugin-next-on-pages

### DIFF
--- a/.changeset/honest-ghosts-switch.md
+++ b/.changeset/honest-ghosts-switch.md
@@ -1,0 +1,6 @@
+---
+"create-cloudflare": minor
+---
+
+Add the option to add the `eslint-plugin-next-on-pages` eslint plugin
+to developers creating a new Next.js app with eslint enabled

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -81,7 +81,7 @@ describe("E2E: Web frameworks", () => {
 		});
 	};
 
-	test.each(["astro", "hono", "next", "react", "remix", "vue"])(
+	test.each(["astro", "hono", "react", "remix", "vue"])(
 		"%s",
 		async (name) => {
 			await runCli(name, {});
@@ -95,6 +95,17 @@ describe("E2E: Web frameworks", () => {
 					build: "NITRO_PRESET=cloudflare-pages nuxt build",
 				},
 			},
+		});
+	});
+
+	test("next", async () => {
+		await runCli("next", {
+			promptHandlers: [
+				{
+					matcher: /Do you want to use the next-on-pages eslint-plugin\?/,
+					input: ["y"],
+				},
+			],
 		});
 	});
 

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -81,12 +81,9 @@ describe("E2E: Web frameworks", () => {
 		});
 	};
 
-	test.each(["astro", "hono", "react", "remix", "vue"])(
-		"%s",
-		async (name) => {
-			await runCli(name, {});
-		}
-	);
+	test.each(["astro", "hono", "react", "remix", "vue"])("%s", async (name) => {
+		await runCli(name, {});
+	});
 
 	test("Nuxt", async () => {
 		await runCli("nuxt", {

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "fs";
+import { mkdirSync } from "fs";
 import { updateStatus, warn } from "helpers/cli";
 import { brandColor, dim } from "helpers/colors";
 import { installPackages, runFrameworkGenerator } from "helpers/command";

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -1,8 +1,9 @@
-import { mkdirSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { updateStatus } from "helpers/cli";
 import { brandColor, dim } from "helpers/colors";
 import { installPackages, runFrameworkGenerator } from "helpers/command";
 import { probePaths, usesTypescript, writeFile } from "helpers/files";
+import { processArgument } from "helpers/interactive";
 import { detectPackageManager } from "helpers/packages";
 import { getFrameworkVersion } from "../index";
 import {
@@ -11,7 +12,7 @@ import {
 	apiPagesDirHelloJs,
 	apiPagesDirHelloTs,
 } from "./templates";
-import type { PagesGeneratorContext, FrameworkConfig } from "types";
+import type { PagesGeneratorContext, FrameworkConfig, C3Args } from "types";
 
 const { npm, npx, dlx } = detectPackageManager();
 
@@ -72,14 +73,63 @@ const configure = async (ctx: PagesGeneratorContext) => {
 	writeFile(handlerPath, handlerFile);
 	updateStatus("Created an example API route handler");
 
+	const installEslintPlugin = await shouldInstallNextOnPagesEslintPlugin(ctx);
+
+	if (installEslintPlugin) {
+		await writeEslintrc(ctx);
+		updateStatus("eslint-plugin-next-on-pages added to eslintrc");
+	}
+
 	// Add some dev dependencies
 	process.chdir(projectName);
-	const packages = ["@cloudflare/next-on-pages@1", "vercel"];
+	const packages = [
+		"@cloudflare/next-on-pages@1",
+		"vercel",
+		...(installEslintPlugin ? ["eslint-plugin-next-on-pages"] : []),
+	];
 	await installPackages(packages, {
 		dev: true,
 		startText: "Adding the Cloudflare Pages adapter",
 		doneText: `${brandColor(`installed`)} ${dim(packages.join(", "))}`,
 	});
+};
+
+// Note: this isn't a generic helper since it's Next specific, this can be
+//       made into a generic helper by checking all possible types of configs
+//       (including a field in the package.json)
+//       (and potentially returning what type of config is used)
+export const usesEslint = (projectRoot = ".") => {
+	return existsSync(`${projectRoot}/.eslintrc.json`);
+};
+
+export const shouldInstallNextOnPagesEslintPlugin = async (
+	ctx: PagesGeneratorContext
+): Promise<boolean> => {
+	if (!usesEslint(ctx.project.name)) return false;
+
+	return await processArgument(ctx.args, "eslint-plugin" as keyof C3Args, {
+		type: "confirm",
+		question: "Do you want to use the next-on-pages eslint-plugin?",
+		label: "",
+		defaultValue: true,
+	});
+};
+
+export const writeEslintrc = async (
+	ctx: PagesGeneratorContext
+): Promise<void> => {
+	const eslintConfig = {
+		plugins: ["eslint-plugin-next-on-pages"],
+		extends: [
+			"next/core-web-vitals",
+			"plugin:eslint-plugin-next-on-pages/recommended",
+		],
+	};
+
+	writeFileSync(
+		`${ctx.project.name}/.eslintrc.json`,
+		JSON.stringify(eslintConfig, null, "  ") + "\n"
+	);
 };
 
 const config: FrameworkConfig = {

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -4,9 +4,11 @@ import { brandColor, dim } from "helpers/colors";
 import { installPackages, runFrameworkGenerator } from "helpers/command";
 import {
 	probePaths,
+	readJSON,
 	usesEslint,
 	usesTypescript,
 	writeFile,
+	writeJSON,
 } from "helpers/files";
 import { processArgument } from "helpers/interactive";
 import { detectPackageManager } from "helpers/packages";
@@ -123,18 +125,18 @@ export const shouldInstallNextOnPagesEslintPlugin = async (
 export const writeEslintrc = async (
 	ctx: PagesGeneratorContext
 ): Promise<void> => {
-	const eslintConfig = {
-		plugins: ["eslint-plugin-next-on-pages"],
-		extends: [
-			"next/core-web-vitals",
-			"plugin:eslint-plugin-next-on-pages/recommended",
-		],
-	};
+	const eslintConfig = readJSON(`${ctx.project.name}/.eslintrc.json`);
 
-	writeFileSync(
-		`${ctx.project.name}/.eslintrc.json`,
-		JSON.stringify(eslintConfig, null, "  ") + "\n"
-	);
+	eslintConfig.plugins ??= [];
+	eslintConfig.plugins.push("eslint-plugin-next-on-pages");
+
+	if(typeof eslintConfig.extends === 'string') {
+		eslintConfig.extends = [eslintConfig.extends];
+	}
+	eslintConfig.extends ??= [];
+	eslintConfig.extends.push("plugin:eslint-plugin-next-on-pages/recommended");
+
+	writeJSON(`${ctx.project.name}/.eslintrc.json`, eslintConfig, 2);
 };
 
 const config: FrameworkConfig = {

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -77,7 +77,6 @@ const configure = async (ctx: PagesGeneratorContext) => {
 
 	if (installEslintPlugin) {
 		await writeEslintrc(ctx);
-		updateStatus("eslint-plugin-next-on-pages added to eslintrc");
 	}
 
 	// Add some dev dependencies

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -130,7 +130,7 @@ export const writeEslintrc = async (
 	eslintConfig.plugins ??= [];
 	eslintConfig.plugins.push("eslint-plugin-next-on-pages");
 
-	if(typeof eslintConfig.extends === 'string') {
+	if (typeof eslintConfig.extends === "string") {
 		eslintConfig.extends = [eslintConfig.extends];
 	}
 	eslintConfig.extends ??= [];

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -109,7 +109,7 @@ export const shouldInstallNextOnPagesEslintPlugin = async (
 	return await processArgument(ctx.args, "eslint-plugin" as keyof C3Args, {
 		type: "confirm",
 		question: "Do you want to use the next-on-pages eslint-plugin?",
-		label: "",
+		label: "eslint-plugin",
 		defaultValue: true,
 	});
 };

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -103,7 +103,7 @@ const configure = async (ctx: PagesGeneratorContext) => {
 export const shouldInstallNextOnPagesEslintPlugin = async (
 	ctx: PagesGeneratorContext
 ): Promise<boolean> => {
-	const eslintUsage = usesEslint(ctx.project.name);
+	const eslintUsage = usesEslint(ctx);
 
 	if (!eslintUsage.used) return false;
 

--- a/packages/create-cloudflare/src/helpers/files.ts
+++ b/packages/create-cloudflare/src/helpers/files.ts
@@ -1,5 +1,6 @@
 import fs, { existsSync } from "fs";
 import { crash } from "./cli";
+import type { PagesGeneratorContext } from "types";
 
 export const writeFile = (path: string, content: string) => {
 	try {
@@ -69,10 +70,10 @@ type EslintUsageInfo =
 		- https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-formats
 		- https://eslint.org/docs/latest/use/configure/configuration-files-new )
 */
-export const usesEslint = (projectRoot = "."): EslintUsageInfo => {
+export const usesEslint = (ctx: PagesGeneratorContext): EslintUsageInfo => {
 	for (const ext of eslintRcExts) {
 		const eslintRcFilename = `.eslintrc.${ext}` as EslintRcFileName;
-		if (existsSync(`${projectRoot}/${eslintRcFilename}`)) {
+		if (existsSync(`${ctx.project.path}/${eslintRcFilename}`)) {
 			return {
 				used: true,
 				configType: eslintRcFilename,
@@ -80,7 +81,7 @@ export const usesEslint = (projectRoot = "."): EslintUsageInfo => {
 		}
 	}
 
-	if (existsSync(`${projectRoot}/eslint.config.js`)) {
+	if (existsSync(`${ctx.project.path}/eslint.config.js`)) {
 		return {
 			used: true,
 			configType: "eslint.config.js",
@@ -88,7 +89,7 @@ export const usesEslint = (projectRoot = "."): EslintUsageInfo => {
 	}
 
 	try {
-		const pkgJson = readJSON(`${projectRoot}/package.json`);
+		const pkgJson = readJSON(`${ctx.project.path}/package.json`);
 		if (pkgJson.eslintConfig) {
 			return {
 				used: true,

--- a/packages/create-cloudflare/src/helpers/files.ts
+++ b/packages/create-cloudflare/src/helpers/files.ts
@@ -22,7 +22,11 @@ export const readJSON = (path: string) => {
 	return contents ? JSON.parse(contents) : contents;
 };
 
-export const writeJSON = (path: string, object: object, stringifySpace?: number|string) => {
+export const writeJSON = (
+	path: string,
+	object: object,
+	stringifySpace?: number | string
+) => {
 	writeFile(path, JSON.stringify(object, null, stringifySpace));
 };
 

--- a/packages/create-cloudflare/src/helpers/files.ts
+++ b/packages/create-cloudflare/src/helpers/files.ts
@@ -22,8 +22,8 @@ export const readJSON = (path: string) => {
 	return contents ? JSON.parse(contents) : contents;
 };
 
-export const writeJSON = (path: string, object: object) => {
-	writeFile(path, JSON.stringify(object));
+export const writeJSON = (path: string, object: object, stringifySpace?: number|string) => {
+	writeFile(path, JSON.stringify(object, null, stringifySpace));
 };
 
 // Probes a list of paths and returns the first one that exists


### PR DESCRIPTION
Add the option to add the eslint-plugin-next-on-pages eslint plugin to developers creating a new Next.js app with eslint enabled

Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
