### PR TITLE
c3: remove ts dependencies from js templates

### DIFF
--- a/.changeset/sour-numbers-sing.md
+++ b/.changeset/sour-numbers-sing.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Removes all typescript dependencies from javascript templates.

--- a/packages/create-cloudflare/templates/common/js/package.json
+++ b/packages/create-cloudflare/templates/common/js/package.json
@@ -7,7 +7,6 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20230419.0",
 		"itty-router": "^3.0.12",
 		"wrangler": "^3.0.0"
 	}

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -7,8 +7,6 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20230419.0",
-		"typescript": "^5.0.4",
 		"wrangler": "^3.0.0"
 	}
 }

--- a/packages/create-cloudflare/templates/queues/js/package.json
+++ b/packages/create-cloudflare/templates/queues/js/package.json
@@ -7,8 +7,6 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20230419.0",
-		"typescript": "^5.0.4",
 		"wrangler": "^3.0.0"
 	}
 }

--- a/packages/create-cloudflare/templates/scheduled/js/package.json
+++ b/packages/create-cloudflare/templates/scheduled/js/package.json
@@ -7,8 +7,6 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20230419.0",
-		"typescript": "^5.0.4",
 		"wrangler": "^3.0.0"
 	}
 }


### PR DESCRIPTION
Fixes #3548 

**What this PR solves / how to test:**

Typescript and workers/types were included in the package.json of js-only template folders. 

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
