### PR TITLE
C3: Fix bug with detecting wrangler login

### DIFF
--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -106,6 +106,10 @@ export const runCommand = async (
 						}
 					}
 				});
+
+				cmd.on("error", (code) => {
+					reject(code);
+				});
 			});
 		},
 	});
@@ -255,11 +259,14 @@ export const installWrangler = async () => {
 
 export const isLoggedIn = async () => {
 	const { npx } = detectPackageManager();
-	const output = await runCommand(`${npx} wrangler whoami`, {
-		silent: true,
-	});
-
-	return !/not authenticated/.test(output);
+	try {
+		const output = await runCommand(`${npx} wrangler whoami`, {
+			silent: true,
+		});
+		return /You are logged in/.test(output);
+	} catch (error) {
+		return false;
+	}
 };
 
 export const wranglerLogin = async () => {


### PR DESCRIPTION
Fixes #3219

**What this PR solves / how to test:**
Solves a bug where c3 sometimes incorrectly determines that a user is logged into wrangler when they aren't. Root cause is `wrangler whoami` opening a login url when the token is stale. This fixes the issue by only determining the user is logged in if the `wrangler whoami` output contains a positive confirmation.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
