### PR TITLE
C3: Detect production branch when creating pages project

### DIFF
--- a/.changeset/nine-apes-fry.md
+++ b/.changeset/nine-apes-fry.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Detect production branch when creating pages project

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -315,3 +315,21 @@ export async function initializeGit(cwd: string) {
 		await runCommand(`git init`, { useSpinner: false, silent: true, cwd });
 	}
 }
+
+export async function getProductionBranch(cwd: string) {
+	try {
+		const producitonBranch = await runCommand(
+			"git rev-parse --abbrev-ref HEAD",
+			{
+				silent: true,
+				cwd,
+				useSpinner: false,
+				captureOutput: true,
+			}
+		);
+
+		return producitonBranch.trim();
+	} catch (err) {}
+
+	return "main";
+}

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -318,8 +318,9 @@ export async function initializeGit(cwd: string) {
 
 export async function getProductionBranch(cwd: string) {
 	try {
-		const producitonBranch = await runCommand(
-			"git rev-parse --abbrev-ref HEAD",
+		const productionBranch = await runCommand(
+			// "git branch --show-current", // git@^2.22
+			"git rev-parse --abbrev-ref HEAD", // git@^1.6.3
 			{
 				silent: true,
 				cwd,
@@ -328,7 +329,7 @@ export async function getProductionBranch(cwd: string) {
 			}
 		);
 
-		return producitonBranch.trim();
+		return productionBranch.trim();
 	} catch (err) {}
 
 	return "main";

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -52,7 +52,7 @@ export const runCommand = async (
 
 	return printAsyncStatus({
 		useSpinner: opts.useSpinner ?? opts.silent,
-		startText: opts.startText || command.join(" "),
+		startText: opts.startText || command.join(" ").trim(),
 		doneText: opts.doneText,
 		promise() {
 			const [executable, ...args] = command;

--- a/packages/create-cloudflare/src/pages.ts
+++ b/packages/create-cloudflare/src/pages.ts
@@ -12,7 +12,6 @@ import { C3_DEFAULTS } from "./cli";
 import {
 	getProductionBranch,
 	gitCommit,
-	isInsideGitRepo,
 	offerGit,
 	offerToDeploy,
 	printSummary,

--- a/packages/create-cloudflare/src/pages.ts
+++ b/packages/create-cloudflare/src/pages.ts
@@ -10,7 +10,9 @@ import { processArgument, spinner } from "helpers/interactive";
 import { detectPackageManager } from "helpers/packages";
 import { C3_DEFAULTS } from "./cli";
 import {
+	getProductionBranch,
 	gitCommit,
+	isInsideGitRepo,
 	offerGit,
 	offerToDeploy,
 	printSummary,
@@ -135,7 +137,8 @@ const createProject = async (ctx: PagesGeneratorContext) => {
 		? `--compatibility-flags ${compatFlags}`
 		: "";
 
-	const cmd = `${npx} wrangler pages project create ${ctx.project.name} --production-branch main ${compatFlagsArg}`;
+	const productionBranch = await getProductionBranch(ctx.project.path);
+	const cmd = `${npx} wrangler pages project create ${ctx.project.name} --production-branch ${productionBranch} ${compatFlagsArg}`;
 
 	try {
 		await retry(CREATE_PROJECT_RETRIES, async () =>
@@ -144,7 +147,7 @@ const createProject = async (ctx: PagesGeneratorContext) => {
 				cwd: ctx.project.path,
 				env: { CLOUDFLARE_ACCOUNT_ID },
 				startText: "Creating Pages project",
-				doneText: `${brandColor("created")} ${dim(`via \`${cmd}\``)}`,
+				doneText: `${brandColor("created")} ${dim(`via \`${cmd.trim()}\``)}`,
 			})
 		);
 	} catch (error) {


### PR DESCRIPTION
Fixes #3637.

**What this PR solves / how to test:**

This fixes an issue where pages project will fail to be created properly if the user has a different default branch name configured other than `main`. That's because the production branch is currently hardcoded. This fixes it by detecting the current branch and passing that along to `wrangler pages project create`.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ x ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
