### PR TITLE
ci: fix prerelease comment job to also run when only pages-shared has changed

### DIFF
--- a/.github/extract-pr-and-workflow-id.js
+++ b/.github/extract-pr-and-workflow-id.js
@@ -17,6 +17,5 @@ for (const artifact of allArtifacts.data.artifacts) {
 			`\nWORKFLOW_RUN_PR_FOR_${packageName}=${match[2]}` +
 				`\nWORKFLOW_RUN_ID_FOR_${packageName}=${context.payload.workflow_run.id}`
 		);
-		break;
 	}
 }

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -38,9 +38,13 @@ jobs:
             }
 
       - name: "Comment on PR with Wrangler link"
+        env:
+          WORKFLOW_RUN_PR_FOR_WRANGLER: ${{env.WORKFLOW_RUN_PR_FOR_WRANGLER || env.WORKFLOW_RUN_PR_FOR_CLOUDFLARE-PAGES-SHARED}}
+          WORKFLOW_RUN_ID_FOR_WRANGLER: ${{env.WORKFLOW_RUN_ID_FOR_WRANGLER || env.WORKFLOW_RUN_ID_FOR_CLOUDFLARE-PAGES-SHARED}}
+
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
+          number: ${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER}}
           message: |
             A wrangler prerelease is available for testing. You can install this latest build in your project with:
 
@@ -51,7 +55,7 @@ jobs:
             You can reference the automatically updated head of this PR with:
 
             ```sh
-            npm install --save-dev https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/prs/${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
+            npm install --save-dev https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/prs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
             ```
 
             Or you can use `npx` with this latest build directly:


### PR DESCRIPTION
We were breaking out of the loop too early so only the first artifact was being added to the environment variables.