### PR TITLE
Refine typedef for `bindings.vars`

### DIFF
--- a/.changeset/twenty-snails-sip.md
+++ b/.changeset/twenty-snails-sip.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Refined the type of `CfVars` from `Record<string, unknown>` to `Record<string, string | Json>`

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -7,6 +7,7 @@ import type { Rule } from "../config/environment";
 import type { CfModule } from "../deployment-bundle/worker";
 import type { StartDevOptions } from "../dev";
 import type { EnablePagesAssetsServiceBindingOptions } from "../miniflare-cli/types";
+import type { Json } from "miniflare";
 import type { RequestInit, Response, RequestInfo } from "undici";
 
 export interface UnstableDevOptions {
@@ -26,9 +27,7 @@ export interface UnstableDevOptions {
 	compatibilityFlags?: string[]; // Flags to use for compatibility checks
 	persist?: boolean; // Enable persistence for local mode, using default path: .wrangler/state
 	persistTo?: string; // Specify directory to use for local persistence (implies --persist)
-	vars?: {
-		[key: string]: unknown;
-	};
+	vars?: Record<string, string | Json>;
 	kv?: {
 		binding: string;
 		id: string;

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -1,3 +1,5 @@
+import type { Json } from "miniflare";
+
 /**
  * The `Environment` interface declares all the configuration fields that
  * can be specified for an environment.
@@ -314,7 +316,7 @@ interface EnvironmentNonInheritable {
 	 * @default `{}`
 	 * @nonInheritable
 	 */
-	vars: { [key: string]: unknown };
+	vars: Record<string, string | Json>;
 
 	/**
 	 * A list of durable objects that your worker should be bound to.

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -7,6 +7,7 @@ import type {
 	CfPlacement,
 	CfTailConsumer,
 } from "./worker.js";
+import type { Json } from "miniflare";
 
 export function toMimeType(type: CfModuleType): string {
 	switch (type) {
@@ -29,7 +30,7 @@ export type WorkerMetadataBinding =
 	// If you add any new binding types here, also add it to safeBindings
 	// under validateUnsafeBinding in config/validation.ts
 	| { type: "plain_text"; name: string; text: string }
-	| { type: "json"; name: string; json: unknown }
+	| { type: "json"; name: string; json: Json }
 	| { type: "wasm_module"; name: string; part: string }
 	| { type: "text_blob"; name: string; part: string }
 	| { type: "browser"; name: string }

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -1,5 +1,6 @@
 import type { Environment } from "../config";
 import type { Route } from "../config/environment";
+import type { Json } from "miniflare";
 
 /**
  * The type of Worker
@@ -50,7 +51,7 @@ export interface CfModule {
  * A map of variable names to values.
  */
 export interface CfVars {
-	[key: string]: unknown;
+	[key: string]: string | Json;
 }
 
 /**

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -37,6 +37,7 @@ import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "./yargs-types";
+import type { Json } from "miniflare";
 
 export function devOptions(yargs: CommonYargsArgv) {
 	return (
@@ -303,9 +304,7 @@ This is currently not supported 😭, but we think that we'll get it to work soo
 }
 
 export type AdditionalDevProps = {
-	vars?: {
-		[key: string]: unknown;
-	};
+	vars?: Record<string, string | Json>;
 	kv?: {
 		binding: string;
 		id: string;


### PR DESCRIPTION
**What this PR solves / how to test:**
This PR fixes a TypeScript issue that cropped up while updating the miniflare dependency following https://github.com/cloudflare/miniflare/pull/635 fixing its exported types. This change refines the type from `unknown` to a more accurate `string | Json` type.

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
