### PR TITLE
[C3] Uncomment Queues config lines in Queues C3 templates

### DIFF
--- a/packages/create-cloudflare/templates/queues/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/queues/js/wrangler.toml
@@ -4,13 +4,13 @@ compatibility_date = "<TBD>"
 
 # Bind a Queue producer. Use this binding to schedule an arbitrary task that may be processed later by a Queue consumer.
 # Docs: https://developers.cloudflare.com/queues/get-started
-# [[queues.producers]]
+[[queues.producers]]
 binding = "MY_QUEUE"
 queue = "my-queue"
 
 # Bind a Queue consumer. Queue Consumers can retrieve tasks scheduled by Producers to act on them.
 # Docs: https://developers.cloudflare.com/queues/get-started
-# [[queues.consumers]]
+[[queues.consumers]]
 queue = "my-queue"
 # Optional: Configure batching and retries: https://developers.cloudflare.com/queues/learning/batching-retries/
 # max_batch_size = 10

--- a/packages/create-cloudflare/templates/queues/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/queues/ts/wrangler.toml
@@ -4,13 +4,13 @@ compatibility_date = "<TBD>"
 
 # Bind a Queue producer. Use this binding to schedule an arbitrary task that may be processed later by a Queue consumer.
 # Docs: https://developers.cloudflare.com/queues/get-started
-# [[queues.producers]]
+[[queues.producers]]
 binding = "MY_QUEUE"
 queue = "my-queue"
 
 # Bind a Queue consumer. Queue Consumers can retrieve tasks scheduled by Producers to act on them.
 # Docs: https://developers.cloudflare.com/queues/get-started
-# [[queues.consumers]]
+[[queues.consumers]]
 queue = "my-queue"
 # Optional: Configure batching and retries: https://developers.cloudflare.com/queues/learning/batching-retries/
 # max_batch_size = 10


### PR DESCRIPTION
**What this PR solves / how to test:**

- Previously, running `npm create cloudflare` and choosing the `queues` option would copy a `wrangler.toml` file with the `[[queues.producers]]` and `[[queues.consumers]]` lines commented out.
- This resulted in an `Can't redefine existing key` error when running `wrangler dev`.
- This PR uncomments the `[[queues.producers]]` and `[[queues.consumers]]` lines in the template.

**Associated docs issue(s)/PR(s):**

- N/A

**Author has included the following, where applicable:**

- [X] Tests (N/A)
- [X] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets)) (change is very minor, N/A)

**Reviewer is to perform the following, as applicable:**

- ~~Checked for inclusion of relevant tests~~
- ~~Checked for inclusion of a relevant changeset~~
- ~~Checked for creation of associated docs updates~~
- ~~Manually pulled down the changes and spot-tested~~
