### PR TITLE
secret:bulk exit 1 on failure

### DIFF
--- a/.changeset/curly-wombats-suffer.md
+++ b/.changeset/curly-wombats-suffer.md
@@ -1,0 +1,8 @@
+---
+"wrangler": minor
+---
+
+secret:bulk exit 1 on failure
+Previously `secret"bulk` would only log an error on failure of any of the upload requests.
+Now when 'secret:bulk' has an upload request fail it throws an Error which sends an `process.exit(1)` at the root `.catch()` signal.
+This will enable error handling in programmatic uses of `secret:bulk`.

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -658,45 +658,53 @@ describe("wrangler secret", () => {
 				)
 			);
 
-			await runWrangler("secret:bulk ./secret.json --name script-name");
+			await expect(async () => {
+				await runWrangler("secret:bulk ./secret.json --name script-name");
+			}).rejects.toThrowErrorMatchingInlineSnapshot(
+				`"🚨 4 secrets failed to upload"`
+			);
 
 			expect(std.out).toMatchInlineSnapshot(`
-					"🌀 Creating the secrets for the Worker \\"script-name\\"
-					✨ Successfully created secret for key: secret-name-2
-					✨ Successfully created secret for key: secret-name-4
-					✨ Successfully created secret for key: secret-name-6
+			"🌀 Creating the secrets for the Worker \\"script-name\\"
+			✨ Successfully created secret for key: secret-name-2
+			✨ Successfully created secret for key: secret-name-4
+			✨ Successfully created secret for key: secret-name-6
 
-					Finished processing secrets JSON file:
-					✨ 3 secrets successfully uploaded
-					🚨 4 secrets failed to upload"
-			`);
+			Finished processing secrets JSON file:
+			✨ 3 secrets successfully uploaded
+
+			[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Error uploading secret for key: secret-name-1:[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1muploading secret for key: secret-name-1:[0m
 
 			                  request to
 			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/workers/scripts/script-name/secrets[0m
 			  failed, reason: Failed to create secret 1
 
 
-			[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Error uploading secret for key: secret-name-3:[0m
+			[31mX [41;31m[[41;97mERROR[41;31m][0m [1muploading secret for key: secret-name-3:[0m
 
 			                  request to
 			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/workers/scripts/script-name/secrets[0m
 			  failed, reason: Failed to create secret 3
 
 
-			[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Error uploading secret for key: secret-name-5:[0m
+			[31mX [41;31m[[41;97mERROR[41;31m][0m [1muploading secret for key: secret-name-5:[0m
 
 			                  request to
 			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/workers/scripts/script-name/secrets[0m
 			  failed, reason: Failed to create secret 5
 
 
-			[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Error uploading secret for key: secret-name-7:[0m
+			[31mX [41;31m[[41;97mERROR[41;31m][0m [1muploading secret for key: secret-name-7:[0m
 
 			                  request to
 			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/workers/scripts/script-name/secrets[0m
 			  failed, reason: Failed to create secret 7
+
+
+			[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 4 secrets failed to upload[0m
 
 			"
 		`);
@@ -725,28 +733,36 @@ describe("wrangler secret", () => {
 				)
 			);
 
-			await runWrangler("secret:bulk ./secret.json --name script-name");
+			await expect(async () => {
+				await runWrangler("secret:bulk ./secret.json --name script-name");
+			}).rejects.toThrowErrorMatchingInlineSnapshot(
+				`"🚨 2 secrets failed to upload"`
+			);
 
 			expect(std.out).toMatchInlineSnapshot(`
-					"🌀 Creating the secrets for the Worker \\"script-name\\"
+			"🌀 Creating the secrets for the Worker \\"script-name\\"
 
-					Finished processing secrets JSON file:
-					✨ 0 secrets successfully uploaded
-					🚨 2 secrets failed to upload"
-			`);
+			Finished processing secrets JSON file:
+			✨ 0 secrets successfully uploaded
+
+			[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
+		`);
 			expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Error uploading secret for key: secret-name-1:[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1muploading secret for key: secret-name-1:[0m
 
 			                  request to
 			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/workers/scripts/script-name/secrets[0m
 			  failed, reason: Failed to create secret 1
 
 
-			[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Error uploading secret for key: secret-name-2:[0m
+			[31mX [41;31m[[41;97mERROR[41;31m][0m [1muploading secret for key: secret-name-2:[0m
 
 			                  request to
 			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/workers/scripts/script-name/secrets[0m
 			  failed, reason: Failed to create secret 2
+
+
+			[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 2 secrets failed to upload[0m
 
 			"
 		`);

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -382,19 +382,20 @@ export const secretBulkHandler = async (secretBulkArgs: SecretBulkArgs) => {
 				})
 				.catch((e) => {
 					logger.error(
-						`🚨 Error uploading secret for key: ${key}:
+						`uploading secret for key: ${key}:
                 ${e.message}`
 					);
 					return false;
 				});
 		})
 	);
+
 	const successes = bulkOutcomes.filter((outcome) => outcome).length;
 	const failures = bulkOutcomes.length - successes;
 	logger.log("");
 	logger.log("Finished processing secrets JSON file:");
 	logger.log(`✨ ${successes} secrets successfully uploaded`);
 	if (failures > 0) {
-		logger.log(`🚨 ${failures} secrets failed to upload`);
+		throw new Error(`🚨 ${failures} secrets failed to upload`);
 	}
 };


### PR DESCRIPTION
**What this PR solves / how to test:**
When 'secret:bulk' has an upload request fail it now sends a exit 1 signal that will allow for error handling in other environments.

**What this PR solves / how to test:**
https://github.com/cloudflare/wrangler-action/pull/112

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested