### PR TITLE
refactor: remove unused firstPartyWorkerDevFacade property

### DIFF
--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -478,7 +478,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						// because we don't want to apply the dev-time
 						// facades on top of it
 						workerDefinitions: undefined,
-						firstPartyWorkerDevFacade: false,
 						// We want to know if the build is for development or publishing
 						// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
 						targetConsumer: "deploy",

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -135,7 +135,6 @@ export async function bundleWorker(
 		checkFetch: boolean;
 		services?: Config["services"];
 		workerDefinitions?: WorkerRegistry;
-		firstPartyWorkerDevFacade?: boolean;
 		targetConsumer: "dev" | "deploy";
 		testScheduled?: boolean;
 		inject?: string[];

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -247,7 +247,6 @@ function DevSession(props: DevSessionProps) {
 	useCustomBuild(props.entry, props.build);
 
 	const directory = useTmpDir();
-	const handleError = useErrorHandler();
 
 	const workerDefinitions = useDevRegistry(
 		props.name,
@@ -277,7 +276,6 @@ function DevSession(props: DevSessionProps) {
 		workerDefinitions,
 		services: props.bindings.services,
 		durableObjects: props.bindings.durable_objects || { bindings: [] },
-		firstPartyWorkerDevFacade: props.firstPartyWorker,
 		local: props.local,
 		// Enable the bundling to know whether we are using dev or deploy
 		targetConsumer: "dev",

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -93,7 +93,6 @@ export async function startDevServer(
 		assets: props.assetsConfig,
 		workerDefinitions,
 		services: props.bindings.services,
-		firstPartyWorkerDevFacade: props.firstPartyWorker,
 		testScheduled: props.testScheduled,
 		local: props.local,
 		doBindings: props.bindings.durable_objects?.bindings ?? [],
@@ -199,7 +198,6 @@ async function runEsbuild({
 	noBundle,
 	workerDefinitions,
 	services,
-	firstPartyWorkerDevFacade,
 	testScheduled,
 	doBindings,
 }: {
@@ -220,7 +218,6 @@ async function runEsbuild({
 	nodejsCompat: boolean | undefined;
 	noBundle: boolean;
 	workerDefinitions: WorkerRegistry;
-	firstPartyWorkerDevFacade: boolean | undefined;
 	testScheduled?: boolean;
 	local: boolean;
 	doBindings: DurableObjectBindings;
@@ -256,7 +253,6 @@ async function runEsbuild({
 			},
 			workerDefinitions,
 			services,
-			firstPartyWorkerDevFacade,
 			targetConsumer: "dev", // We are starting a dev server
 			testScheduled,
 			doBindings,

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -52,7 +52,6 @@ export function useEsbuild({
 	workerDefinitions,
 	services,
 	durableObjects,
-	firstPartyWorkerDevFacade,
 	local,
 	targetConsumer,
 	testScheduled,
@@ -76,7 +75,6 @@ export function useEsbuild({
 	noBundle: boolean;
 	workerDefinitions: WorkerRegistry;
 	durableObjects: Config["durable_objects"];
-	firstPartyWorkerDevFacade: boolean | undefined;
 	local: boolean;
 	targetConsumer: "dev" | "deploy";
 	testScheduled: boolean;
@@ -149,7 +147,6 @@ export function useEsbuild({
 					},
 					workerDefinitions,
 					services,
-					firstPartyWorkerDevFacade,
 					targetConsumer,
 					testScheduled,
 					additionalModules: dedupeModulesByName([
@@ -227,7 +224,6 @@ export function useEsbuild({
 		services,
 		durableObjects,
 		workerDefinitions,
-		firstPartyWorkerDevFacade,
 		local,
 		targetConsumer,
 		testScheduled,


### PR DESCRIPTION
This is a straightforward refactoring that removes unused code.