### PR TITLE
Allow tests to pass in western hemisphere

### DIFF
--- a/packages/wrangler/src/__tests__/d1/convert-timestamp-to-iso.test.ts
+++ b/packages/wrangler/src/__tests__/d1/convert-timestamp-to-iso.test.ts
@@ -18,7 +18,7 @@ describe("convertTimestampToISO", () => {
 			convertTimestampToISO(timestamp);
 		} catch (e) {
 			error = `${e}`.replace(
-				/\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d\+\d\d:\d\d/,
+				/\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d(\+|-)\d\d:\d\d/,
 				"(DATE)"
 			);
 		}


### PR DESCRIPTION
Currently tests assume the operating locale is east of the prime meridian. 