### PR TITLE
[quick-edit] Delete X-CF-Token and X-CF-Remote headers from proxied rawhttp requests

### DIFF
--- a/.changeset/warm-students-provide.md
+++ b/.changeset/warm-students-provide.md
@@ -1,0 +1,5 @@
+---
+"edge-preview-authenticated-proxy": patch
+---
+
+No longer included the preview token twice in rawhttp requests


### PR DESCRIPTION


Fixes CUSTESC-31513.

**What this PR solves / how to test:**

This PR removes the `X-CF-Token` and `X-CF-Remote` headers from the proxied request after they've been consumed. The token is included in the `cf-workers-preview-token` header.

We were previously including the token twice, which can be quite large in some cases. This was causing nginx to reject some requests due to `400 Request Header Or Cookie Too Large` errors.

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested