### PR TITLE
WC-1559: Add alert when last deployed via API

### DIFF
--- a/.changeset/dirty-roses-appear.md
+++ b/.changeset/dirty-roses-appear.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Warn user when the last deployment was via the API

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -368,7 +368,7 @@ describe("deploy", () => {
 
 	describe("warnings", () => {
 		it("should warn user when worker was last deployed from api", async () => {
-			msw.use(...mswSuccessDeploymentScriptAPI)
+			msw.use(...mswSuccessDeploymentScriptAPI);
 			writeWranglerToml();
 			writeWorkerSource();
 			mockSubDomainRequest();
@@ -376,9 +376,11 @@ describe("deploy", () => {
 
 			await runWrangler("deploy ./index");
 
-			expect(std.warn).toMatch(/You are about to publish a Workers Service that was last updated via the script API/)
-		})
-	})
+			expect(std.warn).toMatch(
+				/You are about to publish a Workers Service that was last updated via the script API/
+			);
+		});
+	});
 
 	describe("environments", () => {
 		it("should use legacy environments by default", async () => {

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -36,6 +36,7 @@ import {
 	msw,
 	mswSuccessDeployments,
 	mswSuccessDeploymentScriptMetadata,
+	mswSuccessDeploymentScriptAPI,
 } from "./helpers/msw";
 import { FileReaderSync } from "./helpers/msw/read-file-sync";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -364,6 +365,20 @@ describe("deploy", () => {
 			});
 		});
 	});
+
+	describe("warnings", () => {
+		it("should warn user when worker was last deployed from api", async () => {
+			msw.use(...mswSuccessDeploymentScriptAPI)
+			writeWranglerToml();
+			writeWorkerSource();
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+
+			await runWrangler("deploy ./index");
+
+			expect(std.warn).toMatch(/You are about to publish a Workers Service that was last updated via the script API/)
+		})
+	})
 
 	describe("environments", () => {
 		it("should use legacy environments by default", async () => {

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
@@ -95,6 +95,23 @@ export const mswSuccessDeploymentScriptMetadata = [
 	),
 ];
 
+export const mswSuccessDeploymentScriptAPI = [
+	rest.get(
+		"*/accounts/:accountId/workers/services/:scriptName",
+		(_, res, ctx) => {
+			return res.once(
+				ctx.json(
+					createFetchResult({
+						default_environment: {
+							script: { last_deployed_from: "api", tag: "MOCK-TAG" },
+						},
+					})
+				)
+			);
+		}
+	),
+];
+
 export const mswSuccessDeploymentDetails = [
 	rest.get(
 		"*/accounts/:accountId/workers/deployments/by-script/:scriptTag/detail/:deploymentId",

--- a/packages/wrangler/src/__tests__/helpers/msw/index.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/index.ts
@@ -4,6 +4,7 @@ import {
 	mswSuccessDeployments,
 	mswSuccessDeploymentScriptMetadata,
 	mswSuccessDeploymentDetails,
+	mswSuccessDeploymentScriptAPI,
 } from "./handlers/deployments";
 import { mswSuccessNamespacesHandlers } from "./handlers/namespaces";
 import { mswSuccessOauthHandlers } from "./handlers/oauth";
@@ -49,4 +50,5 @@ export {
 	mswSuccessDeploymentDetails,
 	mswAccessHandlers,
 	mswSuccessDeploymentScriptMetadata,
+	mswSuccessDeploymentScriptAPI,
 };

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -283,6 +283,13 @@ export default async function deploy(props: Props): Promise<void> {
 				if (!(await confirm("Would you like to continue?"))) {
 					return;
 				}
+			} else if (default_environment.script.last_deployed_from === "api") {
+				logger.warn(
+					`You are about to publish a Workers Service that was last updated via the script API.\nEdits that have been made via the script API will be overridden by your local code and config.`
+				);
+				if (!(await confirm("Would you like to continue?"))) {
+					return;
+				}
 			}
 		} catch (e) {
 			// code: 10090, message: workers.api.error.service_not_found


### PR DESCRIPTION
Fixes WC-1559.

**What this PR solves / how to test:**
This PR simply adds a warning when the user tries to deploy and the last deployment was via the API. The warning is similar to the one that appears when the last warning was via the dashboard.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
