### PR TITLE
Improve source map support

### DIFF
--- a/.changeset/short-eggs-destroy.md
+++ b/.changeset/short-eggs-destroy.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve source map support
+
+Extends stack trace translations to terminal logs and DevTools console. Error stack traces logged to the terminal will show relative paths and should now be CTRL-clickable in VSCode. Error stack traces shown in Dev console should now link to the mapped source file in the Sources panel for `console.log`ed errors in addition to thrown errors.

--- a/fixtures/worker-ts/src/index.ts
+++ b/fixtures/worker-ts/src/index.ts
@@ -28,7 +28,12 @@ export default {
 		ctx: ExecutionContext
 	): Promise<Response> {
 		const url = new URL(request.url);
-		if (url.pathname === "/error") throw new Error("Hello Error");
+		if (url.pathname === "/error") {
+			const err = new Error("Hello Error");
+			console.log(err);
+			console.log(err.stack);
+			throw err;
+		}
 		return new Response("Hello World!");
 	},
 };


### PR DESCRIPTION
**What this PR solves / how to test:**
This PR improves on #3140.

There are a few functional changes:
- Running sample scripts without `wrangler.toml` now properly translates traces
- Stack traces are translated before printed to cli output and dev tools console
- File references in cli output is relative to `process.cwd()`
- File references in stack traces in dev tools console is now clickable and reveals the relevant source code
- `Error.stack` strings are also parsed and translated
- `SourceMapConsumer` is managed in a `useEffect` and recreated whenever the script is reloaded
- `Network.loadNetworkResource` CDP commands can now load source files referenced in translated traces

Dev Tools Before:
![image](https://github.com/cloudflare/workers-sdk/assets/434125/5098e0d1-0b81-45dd-96d0-200e783e86cb)

Dev Tools After:
![image](https://github.com/cloudflare/workers-sdk/assets/434125/c3516b19-8146-4586-a807-7ba7bba9d6c8)

Terminal Before:
![image](https://github.com/cloudflare/workers-sdk/assets/434125/c2ca28e7-10ee-4a3a-9e5f-90d59e2cb272)

Terminal After:
![image](https://github.com/cloudflare/workers-sdk/assets/434125/aa56d6b2-ceaf-4f4f-9cd0-9d92aafeda81)


To test:
1. Run `npm start -w wrangler dev ../../fixtures/worker-ts/src/index.ts`
2. Press 'd' to open dev tools
3. Run `curl localhost:8787/error`
4. See translated stack traces

**Author has included the following, where applicable:**

- [x] Manual Test with the above steps
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
