### PR TITLE
Add DispatchNamespace as binding type

### DIFF
--- a/.changeset/chilly-files-think.md
+++ b/.changeset/chilly-files-think.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Changed the binding type of WfP Dispatch Namespaces to `DispatchNamespace`

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -123,7 +123,7 @@ describe("generateTypes()", () => {
 			D1_TESTING_SOMETHING: D1Database;
 			SERVICE_BINDING: Fetcher;
 			AE_DATASET_BINDING: AnalyticsEngineDataset;
-			NAMESPACE_BINDING: any;
+			NAMESPACE_BINDING: DispatchNamespace;
 			LOGFWDR_SCHEMA: any;
 			SOME_DATA_BLOB1: ArrayBuffer;
 			SOME_DATA_BLOB2: ArrayBuffer;

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -75,7 +75,7 @@ export async function generateTypes(
 
 	if (configToDTS.dispatch_namespaces) {
 		for (const namespace of configToDTS.dispatch_namespaces) {
-			envTypeStructure.push(`${namespace.binding}: any;`);
+			envTypeStructure.push(`${namespace.binding}: DispatchNamespace;`);
 		}
 	}
 


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

The `DispatchNamespace` was recently added to `workers-types`, but `wrangler types` command would generate `any`.

**Associated docs issue(s)/PR(s):**


**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
