### PR TITLE
fix: Retry deployment errors in wrangler pages publish

### DIFF
--- a/.changeset/hip-rules-cross.md
+++ b/.changeset/hip-rules-cross.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Retry deployment errors in wrangler pages publish
+
+This will improve reliability when deploying to Cloudflare Pages

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -231,7 +231,7 @@ describe("deployment create", () => {
 							success: false,
 							errors: [
 								{
-									code: 800000,
+									code: 8000000,
 									message: "Something exploded, please retry",
 								},
 							],
@@ -297,6 +297,169 @@ describe("deployment create", () => {
 		);
 
 		await runWrangler("pages deploy . --project-name=foo");
+
+		// Should be 2 attempts to upload
+		expect(requests.length).toBe(2);
+
+		expect(normalizeProgressSteps(std.out)).toMatchInlineSnapshot(`
+		"✨ Success! Uploaded 1 files (TIMINGS)
+
+		✨ Deployment complete! Take a peek over at https://abcxyz.foo.pages.dev/"
+	`);
+	});
+
+	it("should retry POST /deployments", async () => {
+		writeFileSync("logo.txt", "foobar");
+
+		mockGetUploadTokenRequest(
+			"<<funfetti-auth-jwt>>",
+			"some-account-id",
+			"foo"
+		);
+
+		// Accumulate multiple requests then assert afterwards
+		const requests: RestRequest[] = [];
+		msw.use(
+			rest.post("*/pages/assets/check-missing", async (req, res, ctx) => {
+				const body = await req.json();
+
+				expect(req.headers.get("Authorization")).toBe(
+					"Bearer <<funfetti-auth-jwt>>"
+				);
+				expect(body).toMatchObject({
+					hashes: ["1a98fb08af91aca4a7df1764a2c4ddb0"],
+				});
+
+				return res.once(
+					ctx.status(200),
+					ctx.json({
+						success: true,
+						errors: [],
+						messages: [],
+						result: body.hashes,
+					})
+				);
+			}),
+			rest.post("*/pages/assets/upload", async (req, res, ctx) => {
+				expect(req.headers.get("Authorization")).toBe(
+					"Bearer <<funfetti-auth-jwt>>"
+				);
+				expect(await req.json()).toMatchObject([
+					{
+						key: "1a98fb08af91aca4a7df1764a2c4ddb0",
+						value: Buffer.from("foobar").toString("base64"),
+						metadata: {
+							contentType: "text/plain",
+						},
+						base64: true,
+					},
+				]);
+
+				return res(
+					ctx.status(200),
+					ctx.json({
+						success: true,
+						errors: [],
+						messages: [],
+						result: null,
+					})
+				);
+			}),
+			rest.post(
+				"*/accounts/:accountId/pages/projects/foo/deployments",
+				async (req, res, ctx) => {
+					requests.push(req);
+					expect(req.params.accountId).toEqual("some-account-id");
+					expect(await (req as RestRequestWithFormData).formData())
+						.toMatchInlineSnapshot(`
+				      FormData {
+				        Symbol(state): Array [
+				          Object {
+				            "name": "manifest",
+				            "value": "{\\"/logo.txt\\":\\"1a98fb08af91aca4a7df1764a2c4ddb0\\"}",
+				          },
+				        ],
+				      }
+			    `);
+
+					if (requests.length < 2) {
+						return res(
+							ctx.status(500),
+							ctx.json({
+								success: false,
+								errors: [
+									{
+										code: 8000000,
+										message: "Something exploded, please retry",
+									},
+								],
+								messages: [],
+								result: null,
+							})
+						);
+					} else {
+						return res.once(
+							ctx.status(200),
+							ctx.json({
+								success: true,
+								errors: [],
+								messages: [],
+								result: { url: "https://abcxyz.foo.pages.dev/" },
+							})
+						);
+					}
+				}
+			),
+			rest.post(
+				"*/accounts/:accountId/pages/projects/foo/deployments",
+				async (req, res, ctx) => {
+					requests.push(req);
+					expect(req.params.accountId).toEqual("some-account-id");
+					expect(await (req as RestRequestWithFormData).formData())
+						.toMatchInlineSnapshot(`
+				      FormData {
+				        Symbol(state): Array [
+				          Object {
+				            "name": "manifest",
+				            "value": "{\\"/logo.txt\\":\\"1a98fb08af91aca4a7df1764a2c4ddb0\\"}",
+				          },
+				        ],
+				      }
+			    `);
+
+					return res.once(
+						ctx.status(200),
+						ctx.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: { url: "https://abcxyz.foo.pages.dev/" },
+						})
+					);
+				}
+			),
+			rest.get(
+				"*/accounts/:accountId/pages/projects/foo",
+				async (req, res, ctx) => {
+					expect(req.params.accountId).toEqual("some-account-id");
+
+					return res.once(
+						ctx.status(200),
+						ctx.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: { deployment_configs: { production: {}, preview: {} } },
+						})
+					);
+				}
+			)
+		);
+
+		await runWrangler("pages deploy . --project-name=foo");
+
+		// Should be 2 attempts to POST /deployments
+		expect(requests.length).toBe(2);
 
 		expect(normalizeProgressSteps(std.out)).toMatchInlineSnapshot(`
 		"✨ Success! Uploaded 1 files (TIMINGS)

--- a/packages/wrangler/src/pages/constants.ts
+++ b/packages/wrangler/src/pages/constants.ts
@@ -7,6 +7,7 @@ export const MAX_BUCKET_SIZE = 50 * 1024 * 1024;
 export const MAX_BUCKET_FILE_COUNT = 5000;
 export const BULK_UPLOAD_CONCURRENCY = 3;
 export const MAX_UPLOAD_ATTEMPTS = 5;
+export const MAX_DEPLOYMENT_ATTEMPTS = 3;
 export const MAX_CHECK_MISSING_ATTEMPTS = 5;
 export const SECONDS_TO_WAIT_FOR_PROXY = 5;
 export const isInPagesCI = !!process.env.CF_PAGES;


### PR DESCRIPTION
Occasionally, creating a deployment can fail due to internal errors in the POST /deployments API call. Rather than failing the deployment, this will retry first.

Fixes PAGES-2935

**What this PR solves / how to test:**
The /deployments endpoint occasionally returns a 5XX error, causing a deployment to fail. This will improve reliability of the `wrangler pages publish` command.

**Author has included the following, where applicable:**

- [x ] Tests
- [ x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
