### PR TITLE
bump miniflare version to v3.20230814.1

### DIFF
--- a/.changeset/spicy-cars-smell.md
+++ b/.changeset/spicy-cars-smell.md
@@ -1,0 +1,7 @@
+---
+"pages-ws-app": patch
+"@cloudflare/pages-shared": patch
+"wrangler": patch
+---
+
+bump miniflare version to 3.20230814.1

--- a/fixtures/pages-ws-app/package.json
+++ b/fixtures/pages-ws-app/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",
-		"miniflare": "3.20230801.0",
+		"miniflare": "3.20230814.1",
 		"wrangler": "*",
 		"ws": "^8.8.0"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,39 +260,12 @@
 			"version": "0.1.0",
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "3.20230801.0",
+				"miniflare": "3.20230814.1",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"fixtures/pages-ws-app/node_modules/miniflare": {
-			"version": "3.20230801.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230801.0.tgz",
-			"integrity": "sha512-jXl++AYc3PDMu9cxeMbFgzrnbgwU8VIkw49cdpOaIAz7jQgPcLuNLOyAw3G+uaLELnILHs81MM67fGR1hAc62A==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"set-cookie-parser": "^2.6.0",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230801.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
 			}
 		},
 		"fixtures/pages-ws-app/node_modules/ws": {
@@ -2670,9 +2643,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230807.0.tgz",
-			"integrity": "sha512-p1XgkX6OcomFSRSHiIo6XbWB40sMExnFUWtZFfSvB7oNmkrtEvUCI3iuh+ibFI5IDSZqsRKyIHx6Oe22Z0ei5A==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230814.1.tgz",
+			"integrity": "sha512-aQUO7q7qXl+SVtOiMMlVKLNOSeL6GX43RKeflwzsD74dGgyHPiSfw5KCvXhkVbyN7u+yYF6HyFdaIvHLfn5jyA==",
 			"cpu": [
 				"x64"
 			],
@@ -2685,9 +2658,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230807.0.tgz",
-			"integrity": "sha512-HjhjRFPvDg3Sh4TXyz38Z+AhaLA+0AiAmYKRadcnKhysjOaTew86POS3xdaKiZ3xG83J7rsLcqajW54znbmCkg==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230814.1.tgz",
+			"integrity": "sha512-U2mcgi+AiuI/4EY5Wk/GmygiNoCNw/V2mcHmxESqe4r6XbJYOzBdEsjnqJ05rqd0JlEM8m64jRtE6/qBnQHygg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2700,9 +2673,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230807.0.tgz",
-			"integrity": "sha512-PPuGKoRILFTlZDC7uGXgrYBucopqkvicaov/ypbPmUVb/DfrXGqftEkNbXlyiXY1g0t10wXRiSZWi7hOBOIH7w==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230814.1.tgz",
+			"integrity": "sha512-Q4kITXLTCuG2i2Z01fbb5AjVRRIf3+lS4ZVsFbTbIwtcOOG4Ozcw7ee7tKsFES7hFqR4Eg9gMG4/aS0mmi+L2g==",
 			"cpu": [
 				"x64"
 			],
@@ -2715,9 +2688,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230807.0.tgz",
-			"integrity": "sha512-ESAf2tXarK8dJl07voa/NI2BBpH1duldfgeQQQmor437A3+gSqQSBhAEmh05bjHy6dYHXgZtwLPky+LL6hmyBA==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230814.1.tgz",
+			"integrity": "sha512-BX5SaksXw+pkREVw3Rw2eSNXplqZw+14CcwW/5x/4oq/C6yn5qCvKxJfM7pukJGMI4wkJPOYops7B3g27FB/HA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2730,9 +2703,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230807.0.tgz",
-			"integrity": "sha512-DYKkLtT4lNRdVx+2fbYgPxdF7ypJn9bT2HYMZ93N7XPwaKFx2svBRMrZkwBcvwuNb+99Z0jnaQwdcFnHcFLzZA==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230814.1.tgz",
+			"integrity": "sha512-GWHqfyhsG/1wm2W8afkYX3q3fWXUWWD8NGtHfAs6ZVTHdW3mmYyMhKR0lc6ptBwz5i5aXRlP2S+CxxxwwDbKpw==",
 			"cpu": [
 				"x64"
 			],
@@ -8803,9 +8776,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.9",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-			"integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+			"version": "4.21.10",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+			"integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -8821,9 +8794,9 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001503",
-				"electron-to-chromium": "^1.4.431",
-				"node-releases": "^2.0.12",
+				"caniuse-lite": "^1.0.30001517",
+				"electron-to-chromium": "^1.4.477",
+				"node-releases": "^2.0.13",
 				"update-browserslist-db": "^1.0.11"
 			},
 			"bin": {
@@ -9089,9 +9062,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001515",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-			"integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+			"version": "1.0.30001520",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz",
+			"integrity": "sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -10817,9 +10790,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.455",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.455.tgz",
-			"integrity": "sha512-8tgdX0Odl24LtmLwxotpJCVjIndN559AvaOtd67u+2mo+IDsgsTF580NB+uuDCqsHw8yFg53l5+imFV9Fw3cbA=="
+			"version": "1.4.491",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.491.tgz",
+			"integrity": "sha512-ZzPqGKghdVzlQJ+qpfE+r6EB321zed7e5JsvHIlMM4zPFF8okXUkF5Of7h7F3l3cltPL0rG7YVmlp5Qro7RQLA=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -21344,9 +21317,9 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "3.20230807.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230807.0.tgz",
-			"integrity": "sha512-yq9Y9hzn9RIR2DDoohoGrWTRY7JgCAVmrtO3K3YqzUyjdycSLnUnyzRZmXnx8hep2xafNTbuig2ylKj2MPmGvg==",
+			"version": "3.20230814.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230814.1.tgz",
+			"integrity": "sha512-LMgqd1Ut0+fnlvQepVbbBYQczQnyuuap8bgUwOyPETka0S9NR9NxMQSNaBgVZ0uOaG7xMJ/OVTRlz+TGB86PWA==",
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
@@ -21360,7 +21333,7 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "1.20230807.0",
+				"workerd": "1.20230814.1",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
@@ -22033,9 +22006,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-			"integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
 		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
@@ -29845,9 +29818,9 @@
 			"link": true
 		},
 		"node_modules/workerd": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230807.0.tgz",
-			"integrity": "sha512-yDdHld8wm5lQ6M/WYD68tIzbAmPjcgAoVAYhAHQFaXZSpryjIw9mT3O/NEloyZ8xiickpoPuNSQ4ffxPLao2+Q==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230814.1.tgz",
+			"integrity": "sha512-zJeSEteXuAD+bpYJT8WvzTAHvIAkKPVxOV+Jy6zCLKz5e08N3OUbAF+wrvGWc8b2aB1sj+IYsdXfkv4puH+qXQ==",
 			"hasInstallScript": true,
 			"bin": {
 				"workerd": "bin/workerd"
@@ -29856,11 +29829,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20230807.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230807.0",
-				"@cloudflare/workerd-linux-64": "1.20230807.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230807.0",
-				"@cloudflare/workerd-windows-64": "1.20230807.0"
+				"@cloudflare/workerd-darwin-64": "1.20230814.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20230814.1",
+				"@cloudflare/workerd-linux-64": "1.20230814.1",
+				"@cloudflare/workerd-linux-arm64": "1.20230814.1",
+				"@cloudflare/workerd-windows-64": "1.20230814.1"
 			}
 		},
 		"node_modules/workers-chat-demo": {
@@ -31191,7 +31164,7 @@
 			"name": "@cloudflare/pages-shared",
 			"version": "0.8.0",
 			"dependencies": {
-				"miniflare": "3.20230801.0"
+				"miniflare": "3.20230814.1"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
@@ -31237,32 +31210,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"packages/pages-shared/node_modules/miniflare": {
-			"version": "3.20230801.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230801.0.tgz",
-			"integrity": "sha512-jXl++AYc3PDMu9cxeMbFgzrnbgwU8VIkw49cdpOaIAz7jQgPcLuNLOyAw3G+uaLELnILHs81MM67fGR1hAc62A==",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"set-cookie-parser": "^2.6.0",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "^1.20230801.0",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
-			}
-		},
 		"packages/pages-shared/node_modules/minimatch": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -31273,26 +31220,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"packages/pages-shared/node_modules/ws": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"packages/prerelease-registry": {
@@ -32226,7 +32153,7 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.16.3",
-				"miniflare": "3.20230807.0",
+				"miniflare": "3.20230814.1",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
@@ -35602,7 +35529,7 @@
 				"@types/service-worker-mock": "^2.0.1",
 				"concurrently": "^7.3.0",
 				"glob": "^8.0.3",
-				"miniflare": "3.20230801.0",
+				"miniflare": "3.20230814.1",
 				"service-worker-mock": "^2.0.5",
 				"wrangler": "*"
 			},
@@ -35635,29 +35562,6 @@
 						"once": "^1.3.0"
 					}
 				},
-				"miniflare": {
-					"version": "3.20230801.0",
-					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230801.0.tgz",
-					"integrity": "sha512-jXl++AYc3PDMu9cxeMbFgzrnbgwU8VIkw49cdpOaIAz7jQgPcLuNLOyAw3G+uaLELnILHs81MM67fGR1hAc62A==",
-					"requires": {
-						"acorn": "^8.8.0",
-						"acorn-walk": "^8.2.0",
-						"better-sqlite3": "^8.1.0",
-						"capnp-ts": "^0.7.0",
-						"exit-hook": "^2.2.1",
-						"glob-to-regexp": "^0.4.1",
-						"http-cache-semantics": "^4.1.0",
-						"kleur": "^4.1.5",
-						"set-cookie-parser": "^2.6.0",
-						"source-map-support": "0.5.21",
-						"stoppable": "^1.1.0",
-						"undici": "^5.13.0",
-						"workerd": "^1.20230801.0",
-						"ws": "^8.11.0",
-						"youch": "^3.2.2",
-						"zod": "^3.20.6"
-					}
-				},
 				"minimatch": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -35666,12 +35570,6 @@
 					"requires": {
 						"brace-expansion": "^2.0.1"
 					}
-				},
-				"ws": {
-					"version": "8.13.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-					"requires": {}
 				}
 			}
 		},
@@ -35795,33 +35693,33 @@
 			}
 		},
 		"@cloudflare/workerd-darwin-64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230807.0.tgz",
-			"integrity": "sha512-p1XgkX6OcomFSRSHiIo6XbWB40sMExnFUWtZFfSvB7oNmkrtEvUCI3iuh+ibFI5IDSZqsRKyIHx6Oe22Z0ei5A==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230814.1.tgz",
+			"integrity": "sha512-aQUO7q7qXl+SVtOiMMlVKLNOSeL6GX43RKeflwzsD74dGgyHPiSfw5KCvXhkVbyN7u+yYF6HyFdaIvHLfn5jyA==",
 			"optional": true
 		},
 		"@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230807.0.tgz",
-			"integrity": "sha512-HjhjRFPvDg3Sh4TXyz38Z+AhaLA+0AiAmYKRadcnKhysjOaTew86POS3xdaKiZ3xG83J7rsLcqajW54znbmCkg==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230814.1.tgz",
+			"integrity": "sha512-U2mcgi+AiuI/4EY5Wk/GmygiNoCNw/V2mcHmxESqe4r6XbJYOzBdEsjnqJ05rqd0JlEM8m64jRtE6/qBnQHygg==",
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230807.0.tgz",
-			"integrity": "sha512-PPuGKoRILFTlZDC7uGXgrYBucopqkvicaov/ypbPmUVb/DfrXGqftEkNbXlyiXY1g0t10wXRiSZWi7hOBOIH7w==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230814.1.tgz",
+			"integrity": "sha512-Q4kITXLTCuG2i2Z01fbb5AjVRRIf3+lS4ZVsFbTbIwtcOOG4Ozcw7ee7tKsFES7hFqR4Eg9gMG4/aS0mmi+L2g==",
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230807.0.tgz",
-			"integrity": "sha512-ESAf2tXarK8dJl07voa/NI2BBpH1duldfgeQQQmor437A3+gSqQSBhAEmh05bjHy6dYHXgZtwLPky+LL6hmyBA==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230814.1.tgz",
+			"integrity": "sha512-BX5SaksXw+pkREVw3Rw2eSNXplqZw+14CcwW/5x/4oq/C6yn5qCvKxJfM7pukJGMI4wkJPOYops7B3g27FB/HA==",
 			"optional": true
 		},
 		"@cloudflare/workerd-windows-64": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230807.0.tgz",
-			"integrity": "sha512-DYKkLtT4lNRdVx+2fbYgPxdF7ypJn9bT2HYMZ93N7XPwaKFx2svBRMrZkwBcvwuNb+99Z0jnaQwdcFnHcFLzZA==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230814.1.tgz",
+			"integrity": "sha512-GWHqfyhsG/1wm2W8afkYX3q3fWXUWWD8NGtHfAs6ZVTHdW3mmYyMhKR0lc6ptBwz5i5aXRlP2S+CxxxwwDbKpw==",
 			"optional": true
 		},
 		"@cloudflare/workers-tsconfig": {
@@ -40208,13 +40106,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.21.9",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-			"integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+			"version": "4.21.10",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+			"integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001503",
-				"electron-to-chromium": "^1.4.431",
-				"node-releases": "^2.0.12",
+				"caniuse-lite": "^1.0.30001517",
+				"electron-to-chromium": "^1.4.477",
+				"node-releases": "^2.0.13",
 				"update-browserslist-db": "^1.0.11"
 			}
 		},
@@ -40398,9 +40296,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001515",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-			"integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA=="
+			"version": "1.0.30001520",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz",
+			"integrity": "sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA=="
 		},
 		"capnp-ts": {
 			"version": "0.7.0",
@@ -42082,9 +41980,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.455",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.455.tgz",
-			"integrity": "sha512-8tgdX0Odl24LtmLwxotpJCVjIndN559AvaOtd67u+2mo+IDsgsTF580NB+uuDCqsHw8yFg53l5+imFV9Fw3cbA=="
+			"version": "1.4.491",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.491.tgz",
+			"integrity": "sha512-ZzPqGKghdVzlQJ+qpfE+r6EB321zed7e5JsvHIlMM4zPFF8okXUkF5Of7h7F3l3cltPL0rG7YVmlp5Qro7RQLA=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -49144,9 +49042,9 @@
 			"version": "1.0.1"
 		},
 		"miniflare": {
-			"version": "3.20230807.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230807.0.tgz",
-			"integrity": "sha512-yq9Y9hzn9RIR2DDoohoGrWTRY7JgCAVmrtO3K3YqzUyjdycSLnUnyzRZmXnx8hep2xafNTbuig2ylKj2MPmGvg==",
+			"version": "3.20230814.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230814.1.tgz",
+			"integrity": "sha512-LMgqd1Ut0+fnlvQepVbbBYQczQnyuuap8bgUwOyPETka0S9NR9NxMQSNaBgVZ0uOaG7xMJ/OVTRlz+TGB86PWA==",
 			"requires": {
 				"acorn": "^8.8.0",
 				"acorn-walk": "^8.2.0",
@@ -49160,7 +49058,7 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "1.20230807.0",
+				"workerd": "1.20230814.1",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
@@ -49670,9 +49568,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-			"integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -50250,35 +50148,11 @@
 			"version": "file:fixtures/pages-ws-app",
 			"requires": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "3.20230801.0",
+				"miniflare": "3.20230814.1",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"dependencies": {
-				"miniflare": {
-					"version": "3.20230801.0",
-					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230801.0.tgz",
-					"integrity": "sha512-jXl++AYc3PDMu9cxeMbFgzrnbgwU8VIkw49cdpOaIAz7jQgPcLuNLOyAw3G+uaLELnILHs81MM67fGR1hAc62A==",
-					"dev": true,
-					"requires": {
-						"acorn": "^8.8.0",
-						"acorn-walk": "^8.2.0",
-						"better-sqlite3": "^8.1.0",
-						"capnp-ts": "^0.7.0",
-						"exit-hook": "^2.2.1",
-						"glob-to-regexp": "^0.4.1",
-						"http-cache-semantics": "^4.1.0",
-						"kleur": "^4.1.5",
-						"set-cookie-parser": "^2.6.0",
-						"source-map-support": "0.5.21",
-						"stoppable": "^1.1.0",
-						"undici": "^5.13.0",
-						"workerd": "^1.20230801.0",
-						"ws": "^8.11.0",
-						"youch": "^3.2.2",
-						"zod": "^3.20.6"
-					}
-				},
 				"ws": {
 					"version": "8.11.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
@@ -55483,15 +55357,15 @@
 			}
 		},
 		"workerd": {
-			"version": "1.20230807.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230807.0.tgz",
-			"integrity": "sha512-yDdHld8wm5lQ6M/WYD68tIzbAmPjcgAoVAYhAHQFaXZSpryjIw9mT3O/NEloyZ8xiickpoPuNSQ4ffxPLao2+Q==",
+			"version": "1.20230814.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230814.1.tgz",
+			"integrity": "sha512-zJeSEteXuAD+bpYJT8WvzTAHvIAkKPVxOV+Jy6zCLKz5e08N3OUbAF+wrvGWc8b2aB1sj+IYsdXfkv4puH+qXQ==",
 			"requires": {
-				"@cloudflare/workerd-darwin-64": "1.20230807.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230807.0",
-				"@cloudflare/workerd-linux-64": "1.20230807.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230807.0",
-				"@cloudflare/workerd-windows-64": "1.20230807.0"
+				"@cloudflare/workerd-darwin-64": "1.20230814.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20230814.1",
+				"@cloudflare/workerd-linux-64": "1.20230814.1",
+				"@cloudflare/workerd-linux-arm64": "1.20230814.1",
+				"@cloudflare/workerd-windows-64": "1.20230814.1"
 			}
 		},
 		"workers-chat-demo": {
@@ -55573,7 +55447,7 @@
 				"jest-fetch-mock": "^3.0.3",
 				"jest-websocket-mock": "^2.3.0",
 				"mime": "^3.0.0",
-				"miniflare": "3.20230807.0",
+				"miniflare": "3.20230814.1",
 				"minimatch": "^5.1.0",
 				"msw": "^0.49.1",
 				"nanoid": "^3.3.3",

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -18,7 +18,7 @@
 		"test:ci": "vitest run"
 	},
 	"dependencies": {
-		"miniflare": "3.20230801.0"
+		"miniflare": "3.20230814.1"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -103,7 +103,7 @@
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.16.3",
-		"miniflare": "3.20230807.0",
+		"miniflare": "3.20230814.1",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",
 		"selfsigned": "^2.0.1",


### PR DESCRIPTION
bumping the miniflare version to 3.20230814.1

Note: the miniflare version for pages-shared and pages-ws-app wasn't updated last week