### PR TITLE
feat: support breakpoint debugging in local mode

### DIFF
--- a/.changeset/wild-rockets-bake.md
+++ b/.changeset/wild-rockets-bake.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: support breakpoint debugging in local mode
+
+`wrangler dev` now supports breakpoint debugging in local mode! Press `d` to open DevTools and set breakpoints.

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -546,7 +546,9 @@ function useHotkeys(props: {
 				// toggle inspector
 				case "d": {
 					if (inspect) {
-						await openInspector(inspectorPort, props.worker);
+						// For now, only enable breakpoint debugging in local mode
+						const enableDebugging = toggles.local;
+						await openInspector(inspectorPort, props.worker, enableDebugging);
 					}
 					break;
 				}

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -402,12 +402,18 @@ async function buildMiniflareOptions(
 		inspectorPort: config.inspect ? config.inspectorPort : undefined,
 		liveReload: config.liveReload,
 		upstream,
+		unsafeSourceMapIgnoreSourcePredicate(source) {
+			const tmpDir = config.bundle.sourceMapMetadata?.tmpDir;
+			return (
+				(tmpDir !== undefined && source.includes(tmpDir)) ||
+				source.includes("wrangler/templates")
+			);
+		},
 
 		log,
 		verbose: logger.loggerLevel === "debug",
 
 		...httpsOptions,
-
 		...persistOptions,
 		workers: [
 			{


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR adds support for breakpoint debugging to local mode. Breakpoints can be set using Wrangler's built-in DevTools, and WebStorm's `Attach to Node.js/Chrome` configurations. VSCode's `attach` configurations connect to `workerd`, but can't find source maps. From reading [VSCode docs](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-map-discovery),  it looks like VSCode ignores `//# sourceMappingURL` comments, and instead looks for source maps itself on disk? I may be misunderstanding this though.

**Associated docs issue(s)/PR(s):**

None yet, will definitely want some 👍 

**Author has included the following, where applicable:**

- [ ] ~~Tests~~
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
