### PR TITLE
[wrangler] R2 jurisdictions support

### DIFF
--- a/.changeset/lazy-beers-return.md
+++ b/.changeset/lazy-beers-return.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Jurisdictions support for R2

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -5058,6 +5058,16 @@ addEventListener('fetch', event => {});`
 				r2_buckets: [
 					{ binding: "R2_BUCKET_ONE", bucket_name: "r2-bucket-one-name" },
 					{ binding: "R2_BUCKET_TWO", bucket_name: "r2-bucket-two-name" },
+					{
+						binding: "R2_BUCKET_ONE_EU",
+						bucket_name: "r2-bucket-one-name",
+						jurisdiction: "eu",
+					},
+					{
+						binding: "R2_BUCKET_TWO_EU",
+						bucket_name: "r2-bucket-two-name",
+						jurisdiction: "eu",
+					},
 				],
 				analytics_engine_datasets: [
 					{ binding: "AE_DATASET_ONE", dataset: "ae-dataset-one-name" },
@@ -5170,6 +5180,18 @@ addEventListener('fetch', event => {});`
 						type: "r2_bucket",
 					},
 					{
+						bucket_name: "r2-bucket-one-name",
+						jurisdiction: "eu",
+						name: "R2_BUCKET_ONE_EU",
+						type: "r2_bucket",
+					},
+					{
+						bucket_name: "r2-bucket-two-name",
+						jurisdiction: "eu",
+						name: "R2_BUCKET_TWO_EU",
+						type: "r2_bucket",
+					},
+					{
 						dataset: "ae-dataset-one-name",
 						name: "AE_DATASET_ONE",
 						type: "analytics_engine",
@@ -5234,6 +5256,8 @@ addEventListener('fetch', event => {});`
 			- R2 Buckets:
 			  - R2_BUCKET_ONE: r2-bucket-one-name
 			  - R2_BUCKET_TWO: r2-bucket-two-name
+			  - R2_BUCKET_ONE_EU: r2-bucket-one-name (eu)
+			  - R2_BUCKET_TWO_EU: r2-bucket-two-name (eu)
 			- logfwdr:
 			  - httplogs: httplogs
 			  - trace: trace

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -108,7 +108,10 @@ describe("r2", () => {
 			  -c, --config                    Path to .toml configuration file  [string]
 			  -e, --env                       Environment to use for operations and .env files  [string]
 			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]"
+			  -v, --version                   Show version number  [boolean]
+
+			Options:
+			  -J, --jurisdiction  The jurisdiction where the new bucket will be created  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 				            "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
@@ -137,7 +140,10 @@ describe("r2", () => {
 			  -c, --config                    Path to .toml configuration file  [string]
 			  -e, --env                       Environment to use for operations and .env files  [string]
 			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]"
+			  -v, --version                   Show version number  [boolean]
+
+			Options:
+			  -J, --jurisdiction  The jurisdiction where the new bucket will be created  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 				            "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown arguments: def, ghi[0m
@@ -164,6 +170,26 @@ describe("r2", () => {
 				            Created bucket testBucket."
 			          `);
 			});
+
+			it("should create a bucket with the expected jurisdiction", async () => {
+				msw.use(
+					rest.post(
+						"*/accounts/:accountId/r2/buckets",
+						async (request, response, context) => {
+							const { accountId } = request.params;
+							expect(accountId).toEqual("some-account-id");
+							expect(request.headers.get("cf-r2-jurisdiction")).toEqual("eu");
+							expect(await request.json()).toEqual({ name: "testBucket" });
+							return response.once(context.json(createFetchResult({})));
+						}
+					)
+				);
+				await runWrangler("r2 bucket create testBucket -J eu");
+				expect(std.out).toMatchInlineSnapshot(`
+				            "Creating bucket testBucket (eu).
+				            Created bucket testBucket (eu)."
+			          `);
+			});
 		});
 
 		describe("delete", () => {
@@ -187,7 +213,10 @@ describe("r2", () => {
 			  -c, --config                    Path to .toml configuration file  [string]
 			  -e, --env                       Environment to use for operations and .env files  [string]
 			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]"
+			  -v, --version                   Show version number  [boolean]
+
+			Options:
+			  -J, --jurisdiction  The jurisdiction where the bucket exists  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 				            "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
@@ -216,7 +245,10 @@ describe("r2", () => {
 			  -c, --config                    Path to .toml configuration file  [string]
 			  -e, --env                       Environment to use for operations and .env files  [string]
 			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]"
+			  -v, --version                   Show version number  [boolean]
+
+			Options:
+			  -J, --jurisdiction  The jurisdiction where the bucket exists  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 				            "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown arguments: def, ghi[0m

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -428,6 +428,8 @@ interface EnvironmentNonInheritable {
 		bucket_name: string;
 		/** The preview name of this R2 bucket at the edge. */
 		preview_bucket_name?: string;
+		/** The jurisdiction that the bucket exists in. Default if not present. */
+		jurisdiction?: string;
 	}[];
 
 	/**

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -223,7 +223,10 @@ export function printBindings(bindings: CfWorkerInit["bindings"]) {
 	if (r2_buckets !== undefined && r2_buckets.length > 0) {
 		output.push({
 			type: "R2 Buckets",
-			entries: r2_buckets.map(({ binding, bucket_name }) => {
+			entries: r2_buckets.map(({ binding, bucket_name, jurisdiction }) => {
+				if (jurisdiction !== undefined) {
+					bucket_name += ` (${jurisdiction})`;
+				}
 				return {
 					key: binding,
 					value: bucket_name,

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2164,6 +2164,14 @@ const validateR2Binding: ValidatorFn = (diagnostics, field, value) => {
 		);
 		isValid = false;
 	}
+	if (!isOptionalProperty(value, "jurisdiction", "string")) {
+		diagnostics.errors.push(
+			`"${field}" bindings should, optionally, have a string "jurisdiction" field but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		isValid = false;
+	}
 	return isValid;
 };
 

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -51,7 +51,12 @@ export type WorkerMetadataBinding =
 			environment?: string;
 	  }
 	| { type: "queue"; name: string; queue_name: string }
-	| { type: "r2_bucket"; name: string; bucket_name: string }
+	| {
+			type: "r2_bucket";
+			name: string;
+			bucket_name: string;
+			jurisdiction?: string;
+	  }
 	| { type: "d1"; name: string; id: string; internalEnv?: string }
 	| { type: "constellation"; name: string; project: string }
 	| { type: "service"; name: string; service: string; environment?: string }
@@ -163,11 +168,12 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		});
 	});
 
-	bindings.r2_buckets?.forEach(({ binding, bucket_name }) => {
+	bindings.r2_buckets?.forEach(({ binding, bucket_name, jurisdiction }) => {
 		metadataBindings.push({
 			name: binding,
 			type: "r2_bucket",
 			bucket_name,
+			jurisdiction,
 		});
 	});
 

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -120,6 +120,7 @@ export interface CfQueue {
 export interface CfR2Bucket {
 	binding: string;
 	bucket_name: string;
+	jurisdiction?: string;
 }
 
 // TODO: figure out if this is duplicated in packages/wrangler/src/config/environment.ts

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -319,6 +319,7 @@ export type AdditionalDevProps = {
 		binding: string;
 		bucket_name: string;
 		preview_bucket_name?: string;
+		jurisdiction?: string;
 	}[];
 	d1Databases?: Environment["d1_databases"];
 	processEntrypoint?: boolean;
@@ -889,7 +890,7 @@ function getBindings(
 		],
 		r2_buckets: [
 			...(configParam.r2_buckets?.map(
-				({ binding, preview_bucket_name, bucket_name }) => {
+				({ binding, preview_bucket_name, bucket_name, jurisdiction }) => {
 					// same idea as kv namespace preview id,
 					// same copy-on-write TODO
 					if (!preview_bucket_name && !local) {
@@ -900,6 +901,7 @@ function getBindings(
 					return {
 						binding,
 						bucket_name: preview_bucket_name ?? bucket_name,
+						jurisdiction,
 					};
 				}
 			) || []),

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -1050,7 +1050,11 @@ export function mapBindings(bindings: WorkerMetadataBinding[]): RawConfig {
 						{
 							configObj.r2_buckets = [
 								...(configObj.r2_buckets ?? []),
-								{ binding: binding.name, bucket_name: binding.bucket_name },
+								{
+									binding: binding.name,
+									bucket_name: binding.bucket_name,
+									jurisdiction: binding.jurisdiction,
+								},
 							];
 						}
 						break;

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -25,11 +25,16 @@ export interface R2BucketInfo {
  * Fetch a list of all the buckets under the given `accountId`.
  */
 export async function listR2Buckets(
-	accountId: string
+	accountId: string,
+	jurisdiction?: string
 ): Promise<R2BucketInfo[]> {
+	const headers: HeadersInit = {};
+	if (jurisdiction !== undefined) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
 	const results = await fetchResult<{
 		buckets: R2BucketInfo[];
-	}>(`/accounts/${accountId}/r2/buckets`);
+	}>(`/accounts/${accountId}/r2/buckets`, { headers });
 	return results.buckets;
 }
 
@@ -41,11 +46,17 @@ export async function listR2Buckets(
  */
 export async function createR2Bucket(
 	accountId: string,
-	bucketName: string
+	bucketName: string,
+	jurisdiction?: string
 ): Promise<void> {
+	const headers: HeadersInit = {};
+	if (jurisdiction !== undefined) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
 	return await fetchResult<void>(`/accounts/${accountId}/r2/buckets`, {
 		method: "POST",
 		body: JSON.stringify({ name: bucketName }),
+		headers,
 	});
 }
 
@@ -54,11 +65,16 @@ export async function createR2Bucket(
  */
 export async function deleteR2Bucket(
 	accountId: string,
-	bucketName: string
+	bucketName: string,
+	jurisdiction?: string
 ): Promise<void> {
+	const headers: HeadersInit = {};
+	if (jurisdiction !== undefined) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
 	return await fetchResult<void>(
 		`/accounts/${accountId}/r2/buckets/${bucketName}`,
-		{ method: "DELETE" }
+		{ method: "DELETE", headers }
 	);
 }
 
@@ -82,11 +98,19 @@ export function bucketAndKeyFromObjectPath(objectPath = ""): {
 export async function getR2Object(
 	accountId: string,
 	bucketName: string,
-	objectName: string
+	objectName: string,
+	jurisdiction?: string
 ): Promise<ReadableStream> {
+	const headers: HeadersInit = {};
+	if (jurisdiction !== undefined) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
 	const response = await fetchR2Objects(
 		`/accounts/${accountId}/r2/buckets/${bucketName}/objects/${objectName}`,
-		{ method: "GET" }
+		{
+			method: "GET",
+			headers,
+		}
 	);
 
 	return response.body;
@@ -100,7 +124,8 @@ export async function putR2Object(
 	bucketName: string,
 	objectName: string,
 	object: Readable | ReadableStream | Buffer,
-	options: Record<string, unknown>
+	options: Record<string, unknown>,
+	jurisdiction?: string
 ): Promise<void> {
 	const headerKeys = [
 		"content-length",
@@ -115,6 +140,9 @@ export async function putR2Object(
 	for (const key of headerKeys) {
 		const value = options[key] || "";
 		if (value && typeof value === "string") headers[key] = value;
+	}
+	if (jurisdiction !== undefined) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
 	}
 
 	await fetchR2Objects(
@@ -133,11 +161,16 @@ export async function putR2Object(
 export async function deleteR2Object(
 	accountId: string,
 	bucketName: string,
-	objectName: string
+	objectName: string,
+	jurisdiction?: string
 ): Promise<void> {
+	const headers: HeadersInit = {};
+	if (jurisdiction !== undefined) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
 	await fetchR2Objects(
 		`/accounts/${accountId}/r2/buckets/${bucketName}/objects/${objectName}`,
-		{ method: "DELETE" }
+		{ method: "DELETE", headers }
 	);
 }
 

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -63,13 +63,23 @@ export function r2(r2Yargs: CommonYargsArgv) {
 							.option("persist-to", {
 								type: "string",
 								describe: "Directory for local persistence",
+							})
+							.option("jurisdiction", {
+								describe: "The jurisdiction where the object exists",
+								alias: "J",
+								requiresArg: true,
+								type: "string",
 							});
 					},
 					async (objectGetYargs) => {
 						const config = readConfig(objectGetYargs.config, objectGetYargs);
 						const accountId = await requireAuth(config);
-						const { objectPath, pipe } = objectGetYargs;
+						const { objectPath, pipe, jurisdiction } = objectGetYargs;
 						const { bucket, key } = bucketAndKeyFromObjectPath(objectPath);
+						let fullBucketName = bucket;
+						if (jurisdiction !== undefined) {
+							fullBucketName += ` (${jurisdiction})`;
+						}
 
 						let file = objectGetYargs.file;
 						if (!file && !pipe) {
@@ -77,7 +87,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 						}
 						if (!pipe) {
 							await printWranglerBanner();
-							logger.log(`Downloading "${key}" from "${bucket}".`);
+							logger.log(`Downloading "${key}" from "${fullBucketName}".`);
 						}
 
 						let input: ReadableStream;
@@ -94,7 +104,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 								input = object.encode().value;
 							}
 						} else {
-							input = await getR2Object(accountId, bucket, key);
+							input = await getR2Object(accountId, bucket, key, jurisdiction);
 						}
 						const output = file ? fs.createWriteStream(file) : process.stdout;
 						await new Promise<void>((resolve, reject) => {
@@ -175,6 +185,12 @@ export function r2(r2Yargs: CommonYargsArgv) {
 							.option("persist-to", {
 								type: "string",
 								describe: "Directory for local persistence",
+							})
+							.option("jurisdiction", {
+								describe: "The jurisdiction where the object will be created",
+								alias: "J",
+								requiresArg: true,
+								type: "string",
 							});
 					},
 					async (objectPutYargs) => {
@@ -182,8 +198,15 @@ export function r2(r2Yargs: CommonYargsArgv) {
 
 						const config = readConfig(objectPutYargs.config, objectPutYargs);
 						const accountId = await requireAuth(config);
-						const { objectPath, file, pipe, local, persistTo, ...options } =
-							objectPutYargs;
+						const {
+							objectPath,
+							file,
+							pipe,
+							local,
+							persistTo,
+							jurisdiction,
+							...options
+						} = objectPutYargs;
 						const { bucket, key } = bucketAndKeyFromObjectPath(objectPath);
 						if (!file && !pipe) {
 							throw new CommandLineArgsError(
@@ -224,7 +247,14 @@ export function r2(r2Yargs: CommonYargsArgv) {
 							);
 						}
 
-						logger.log(`Creating object "${key}" in bucket "${bucket}".`);
+						let fullBucketName = bucket;
+						if (jurisdiction !== undefined) {
+							fullBucketName += ` (${jurisdiction})`;
+						}
+
+						logger.log(
+							`Creating object "${key}" in bucket "${fullBucketName}".`
+						);
 
 						if (local) {
 							const gateway = localGateway(
@@ -254,10 +284,17 @@ export function r2(r2Yargs: CommonYargsArgv) {
 								sha512: undefined,
 							});
 						} else {
-							await putR2Object(accountId, bucket, key, object, {
-								...options,
-								"content-length": `${objectSize}`,
-							});
+							await putR2Object(
+								accountId,
+								bucket,
+								key,
+								object,
+								{
+									...options,
+									"content-length": `${objectSize}`,
+								},
+								jurisdiction
+							);
 						}
 
 						logger.log("Upload complete.");
@@ -280,16 +317,29 @@ export function r2(r2Yargs: CommonYargsArgv) {
 							.option("persist-to", {
 								type: "string",
 								describe: "Directory for local persistence",
+							})
+							.option("jurisdiction", {
+								describe: "The jurisdiction where the object exists",
+								alias: "J",
+								requiresArg: true,
+								type: "string",
 							});
 					},
 					async (args) => {
-						const { objectPath } = args;
+						const { objectPath, jurisdiction } = args;
 						await printWranglerBanner();
 
 						const config = readConfig(args.config, args);
 						const accountId = await requireAuth(config);
 						const { bucket, key } = bucketAndKeyFromObjectPath(objectPath);
-						logger.log(`Deleting object "${key}" from bucket "${bucket}".`);
+						let fullBucketName = bucket;
+						if (jurisdiction !== undefined) {
+							fullBucketName += ` (${jurisdiction})`;
+						}
+
+						logger.log(
+							`Deleting object "${key}" from bucket "${fullBucketName}".`
+						);
 
 						if (args.local) {
 							const gateway = localGateway(
@@ -300,7 +350,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 
 							await gateway.delete(key);
 						} else {
-							await deleteR2Object(accountId, bucket, key);
+							await deleteR2Object(accountId, bucket, key, jurisdiction);
 						}
 
 						logger.log("Delete complete.");
@@ -313,11 +363,18 @@ export function r2(r2Yargs: CommonYargsArgv) {
 				"create <name>",
 				"Create a new R2 bucket",
 				(yargs) => {
-					return yargs.positional("name", {
-						describe: "The name of the new bucket",
-						type: "string",
-						demandOption: true,
-					});
+					return yargs
+						.positional("name", {
+							describe: "The name of the new bucket",
+							type: "string",
+							demandOption: true,
+						})
+						.option("jurisdiction", {
+							describe: "The jurisdiction where the new bucket will be created",
+							alias: "J",
+							requiresArg: true,
+							type: "string",
+						});
 				},
 				async (args) => {
 					await printWranglerBanner();
@@ -326,9 +383,13 @@ export function r2(r2Yargs: CommonYargsArgv) {
 
 					const accountId = await requireAuth(config);
 
-					logger.log(`Creating bucket ${args.name}.`);
-					await createR2Bucket(accountId, args.name);
-					logger.log(`Created bucket ${args.name}.`);
+					let fullBucketName = `${args.name}`;
+					if (args.jurisdiction !== undefined) {
+						fullBucketName += ` (${args.jurisdiction})`;
+					}
+					logger.log(`Creating bucket ${fullBucketName}.`);
+					await createR2Bucket(accountId, args.name, args.jurisdiction);
+					logger.log(`Created bucket ${fullBucketName}.`);
 					await metrics.sendMetricsEvent("create r2 bucket", {
 						sendMetrics: config.send_metrics,
 					});
@@ -338,13 +399,27 @@ export function r2(r2Yargs: CommonYargsArgv) {
 			r2BucketYargs.command(
 				"list",
 				"List R2 buckets",
-				(listArgs) => listArgs,
+				(listArgs) => {
+					return listArgs.option("jurisdiction", {
+						describe: "The jurisdiction to list",
+						alias: "J",
+						requiresArg: true,
+						type: "string",
+					});
+				},
 				async (args) => {
 					const config = readConfig(args.config, args);
+					const { jurisdiction } = args;
 
 					const accountId = await requireAuth(config);
 
-					logger.log(JSON.stringify(await listR2Buckets(accountId), null, 2));
+					logger.log(
+						JSON.stringify(
+							await listR2Buckets(accountId, jurisdiction),
+							null,
+							2
+						)
+					);
 					await metrics.sendMetricsEvent("list r2 buckets", {
 						sendMetrics: config.send_metrics,
 					});
@@ -355,11 +430,18 @@ export function r2(r2Yargs: CommonYargsArgv) {
 				"delete <name>",
 				"Delete an R2 bucket",
 				(yargs) => {
-					return yargs.positional("name", {
-						describe: "The name of the bucket to delete",
-						type: "string",
-						demandOption: true,
-					});
+					return yargs
+						.positional("name", {
+							describe: "The name of the bucket to delete",
+							type: "string",
+							demandOption: true,
+						})
+						.option("jurisdiction", {
+							describe: "The jurisdiction where the bucket exists",
+							alias: "J",
+							requiresArg: true,
+							type: "string",
+						});
 				},
 				async (args) => {
 					await printWranglerBanner();
@@ -368,9 +450,13 @@ export function r2(r2Yargs: CommonYargsArgv) {
 
 					const accountId = await requireAuth(config);
 
-					logger.log(`Deleting bucket ${args.name}.`);
-					await deleteR2Bucket(accountId, args.name);
-					logger.log(`Deleted bucket ${args.name}.`);
+					let fullBucketName = `${args.name}`;
+					if (args.jurisdiction !== undefined) {
+						fullBucketName += ` (${args.jurisdiction})`;
+					}
+					logger.log(`Deleting bucket ${fullBucketName}.`);
+					await deleteR2Bucket(accountId, args.name, args.jurisdiction);
+					logger.log(`Deleted bucket ${fullBucketName}.`);
 					await metrics.sendMetricsEvent("delete r2 bucket", {
 						sendMetrics: config.send_metrics,
 					});


### PR DESCRIPTION
Fixes # R2-1740

**What this PR solves / how to test:**
This PR adds two things:
1) Allow wrangler r2 commands to specify the jurisdiction where the bucket resides
2) Allow publishing a worker with a binding to an R2 bucket in a jurisdiction

**Associated docs issue(s)/PR(s):**
None

**Author has included the following, where applicable:**

- [y] Tests
- [y] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
