### PR TITLE
convert `\\n` into `\n` in wrangler pages deploy commit messages

### DIFF
--- a/.changeset/perfect-pears-hide.md
+++ b/.changeset/perfect-pears-hide.md
@@ -1,0 +1,22 @@
+---
+"wrangler": patch
+---
+
+convert `\\n` into `\n` in wrangler pages deploy commit messages
+
+If I currently run:
+```
+  $ npx wrangler pages deploy . --commit-message="this is a \ntest"
+```
+I will see the `\n` in the commit in the dashboard
+
+this is inconsistent with what happens if I have made a proper commit
+with the same newline:
+```
+this is a
+test
+```
+
+this inconsistency is generated because `\n`s in the `commit-massage` argument, get
+converted into `\\n`, so this change reverts that so that this type of commit can be
+more inline with the standard git ones

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -212,7 +212,7 @@ export async function deploy({
 	}
 
 	if (commitMessage) {
-		formData.append("commit_message", commitMessage);
+		formData.append("commit_message", commitMessage.replaceAll('\\n', '\n'));
 	}
 
 	if (commitHash) {


### PR DESCRIPTION
With the following command:
```sh
$ npx wrangler pages deploy . --commit-message="this is a \ntest"
```

Before:
![Screenshot 2023-08-17 at 16 15 25](https://github.com/cloudflare/workers-sdk/assets/61631103/23c8c043-9c29-4786-8047-f1563bba73d3)

After:
![Screenshot 2023-08-17 at 16 15 37](https://github.com/cloudflare/workers-sdk/assets/61631103/80612e88-0ebc-4b75-8b45-5663243a04e4)

(note: the newline in the dashboard is removed, that is ok as it is consistent with standard multiline git commits)
