### PR TITLE
[wrangler] Fix typo (persistance -> persistence)

### DIFF
--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -570,7 +570,7 @@ describe("wrangler", () => {
 			      --metadata      Arbitrary JSON that is associated with a key  [string]
 			      --path          Read value from the file at a given path  [string]
 			      --local         Interact with local storage  [boolean]
-			      --persist-to    Directory for local persistance  [string]"
+			      --persist-to    Directory for local persistence  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
@@ -612,7 +612,7 @@ describe("wrangler", () => {
 			      --metadata      Arbitrary JSON that is associated with a key  [string]
 			      --path          Read value from the file at a given path  [string]
 			      --local         Interact with local storage  [boolean]
-			      --persist-to    Directory for local persistance  [string]"
+			      --persist-to    Directory for local persistence  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments binding and namespace-id is required[0m
@@ -654,7 +654,7 @@ describe("wrangler", () => {
 			      --metadata      Arbitrary JSON that is associated with a key  [string]
 			      --path          Read value from the file at a given path  [string]
 			      --local         Interact with local storage  [boolean]
-			      --persist-to    Directory for local persistance  [string]"
+			      --persist-to    Directory for local persistence  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments binding and namespace-id are mutually exclusive[0m
@@ -696,7 +696,7 @@ describe("wrangler", () => {
 			      --metadata      Arbitrary JSON that is associated with a key  [string]
 			      --path          Read value from the file at a given path  [string]
 			      --local         Interact with local storage  [boolean]
-			      --persist-to    Directory for local persistance  [string]"
+			      --persist-to    Directory for local persistence  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments value and path is required[0m
@@ -738,7 +738,7 @@ describe("wrangler", () => {
 			      --metadata      Arbitrary JSON that is associated with a key  [string]
 			      --path          Read value from the file at a given path  [string]
 			      --local         Interact with local storage  [boolean]
-			      --persist-to    Directory for local persistance  [string]"
+			      --persist-to    Directory for local persistence  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments value and path are mutually exclusive[0m
@@ -1114,7 +1114,7 @@ describe("wrangler", () => {
 			      --preview       Interact with a preview namespace  [boolean] [default: false]
 			      --text          Decode the returned value as a utf8 string  [boolean] [default: false]
 			      --local         Interact with local storage  [boolean]
-			      --persist-to    Directory for local persistance  [string]"
+			      --persist-to    Directory for local persistence  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
@@ -1151,7 +1151,7 @@ describe("wrangler", () => {
 			      --preview       Interact with a preview namespace  [boolean] [default: false]
 			      --text          Decode the returned value as a utf8 string  [boolean] [default: false]
 			      --local         Interact with local storage  [boolean]
-			      --persist-to    Directory for local persistance  [string]"
+			      --persist-to    Directory for local persistence  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mExactly one of the arguments binding and namespace-id is required[0m
@@ -1189,7 +1189,7 @@ describe("wrangler", () => {
 			      --preview       Interact with a preview namespace  [boolean] [default: false]
 			      --text          Decode the returned value as a utf8 string  [boolean] [default: false]
 			      --local         Interact with local storage  [boolean]
-			      --persist-to    Directory for local persistance  [string]"
+			      --persist-to    Directory for local persistence  [string]"
 		`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments binding and namespace-id are mutually exclusive[0m

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -235,7 +235,7 @@ export const kvKey = (kvYargs: CommonYargsArgv) => {
 					})
 					.option("persist-to", {
 						type: "string",
-						describe: "Directory for local persistance",
+						describe: "Directory for local persistence",
 					})
 					.check(demandOneOfOption("value", "path"));
 			},
@@ -332,7 +332,7 @@ export const kvKey = (kvYargs: CommonYargsArgv) => {
 					})
 					.option("persist-to", {
 						type: "string",
-						describe: "Directory for local persistance",
+						describe: "Directory for local persistence",
 					});
 			},
 			async ({ prefix, ...args }) => {
@@ -410,7 +410,7 @@ export const kvKey = (kvYargs: CommonYargsArgv) => {
 					})
 					.option("persist-to", {
 						type: "string",
-						describe: "Directory for local persistance",
+						describe: "Directory for local persistence",
 					});
 			},
 			async ({ key, ...args }) => {
@@ -486,7 +486,7 @@ export const kvKey = (kvYargs: CommonYargsArgv) => {
 					})
 					.option("persist-to", {
 						type: "string",
-						describe: "Directory for local persistance",
+						describe: "Directory for local persistence",
 					});
 			},
 			async ({ key, ...args }) => {
@@ -552,7 +552,7 @@ export const kvBulk = (kvYargs: CommonYargsArgv) => {
 					})
 					.option("persist-to", {
 						type: "string",
-						describe: "Directory for local persistance",
+						describe: "Directory for local persistence",
 					});
 			},
 			async ({ filename, ...args }) => {
@@ -681,7 +681,7 @@ export const kvBulk = (kvYargs: CommonYargsArgv) => {
 					})
 					.option("persist-to", {
 						type: "string",
-						describe: "Directory for local persistance",
+						describe: "Directory for local persistence",
 					});
 			},
 			async ({ filename, ...args }) => {

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -59,7 +59,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 							})
 							.option("persist-to", {
 								type: "string",
-								describe: "Directory for local persistance",
+								describe: "Directory for local persistence",
 							});
 					},
 					async (objectGetYargs) => {
@@ -171,7 +171,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 							})
 							.option("persist-to", {
 								type: "string",
-								describe: "Directory for local persistance",
+								describe: "Directory for local persistence",
 							});
 					},
 					async (objectPutYargs) => {
@@ -276,7 +276,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 							})
 							.option("persist-to", {
 								type: "string",
-								describe: "Directory for local persistance",
+								describe: "Directory for local persistence",
 							});
 					},
 					async (args) => {


### PR DESCRIPTION
**What this PR solves / how to test:**

Fixes a typo in the following commands:

* `wrangler r2 object {put,get,delete} --help`
* `wrangler kv:key {put,list,get,delete} --help`
* `wrangler kv:bulk {put,delete} --help`

**Associated docs issue(s)/PR(s):**

None

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
