### PR TITLE
C3 - Re-enable pnpm test and cleanup pages projects between retries

### DIFF
--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -62,7 +62,7 @@ jobs:
         # os: [ubuntu-latest, windows-latest, macos-latest]
         os: [ubuntu-latest]
         # pm: [npm, yarn, pnpm]
-        pm: [npm]
+        pm: [npm, pnpm]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/package-lock.json
+++ b/package-lock.json
@@ -30354,7 +30354,7 @@
 				"vite-tsconfig-paths": "^4.0.8",
 				"vitest": "^0.30.0",
 				"which-pm-runs": "^1.1.0",
-				"wrangler": "^3.5.1",
+				"wrangler": "*",
 				"yargs": "^17.7.1",
 				"yarn": "^1.22.19"
 			},
@@ -40958,7 +40958,7 @@
 				"vite-tsconfig-paths": "^4.0.8",
 				"vitest": "^0.30.0",
 				"which-pm-runs": "^1.1.0",
-				"wrangler": "^3.5.1",
+				"wrangler": "*",
 				"yargs": "^17.7.1",
 				"yarn": "^1.22.19"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -30354,7 +30354,7 @@
 				"vite-tsconfig-paths": "^4.0.8",
 				"vitest": "^0.30.0",
 				"which-pm-runs": "^1.1.0",
-				"wrangler": "*",
+				"wrangler": "^3.5.1",
 				"yargs": "^17.7.1",
 				"yarn": "^1.22.19"
 			},
@@ -40958,7 +40958,7 @@
 				"vite-tsconfig-paths": "^4.0.8",
 				"vitest": "^0.30.0",
 				"which-pm-runs": "^1.1.0",
-				"wrangler": "*",
+				"wrangler": "^3.5.1",
 				"yargs": "^17.7.1",
 				"yarn": "^1.22.19"
 			},

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -1,9 +1,9 @@
 import { join } from "path";
-import spawn from "cross-spawn";
 import { FrameworkMap } from "frameworks/index";
 import { readJSON } from "helpers/files";
 import { fetch } from "undici";
 import { describe, expect, test, afterEach, beforeEach } from "vitest";
+import { deleteProject } from "../scripts/e2eCleanup";
 import { keys, runC3, testProjectDir } from "./helpers";
 import type { RunnerConfig } from "./helpers";
 
@@ -24,25 +24,14 @@ describe(`E2E: Web frameworks`, () => {
 		clean(framework);
 	});
 
-	afterEach((ctx) => {
+	afterEach(async (ctx) => {
 		const framework = ctx.meta.name;
 		clean(framework);
 
 		// Cleanup the pages project in case we need to retry it
 		const projectName = getName(framework);
 		try {
-			const { output } = spawn.sync("npx", [
-				"wrangler",
-				"pages",
-				"project",
-				"delete",
-				"-y",
-				projectName,
-			]);
-
-			if (!output.toString().includes(`Successfully deleted ${projectName}`)) {
-				console.error(output.toString());
-			}
+			await deleteProject(projectName);
 		} catch (error) {
 			console.error(`Failed to cleanup project: ${projectName}`);
 			console.error(error);

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -70,7 +70,7 @@
 		"vite-tsconfig-paths": "^4.0.8",
 		"vitest": "^0.30.0",
 		"which-pm-runs": "^1.1.0",
-		"wrangler": "*",
+		"wrangler": "^3.5.1",
 		"yargs": "^17.7.1",
 		"yarn": "^1.22.19"
 	},

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -26,16 +26,16 @@
 		"templates"
 	],
 	"scripts": {
-		"build": "node scripts/build.js",
+		"build": "node -r esbuild-register scripts/build.ts",
 		"check:lint": "eslint .",
 		"check:type": "tsc",
 		"lint": "eslint",
 		"prepublishOnly": "npm run build",
-		"test:e2e:cleanup": "node scripts/e2eCleanup.mjs",
+		"test:e2e:cleanup": "node -r esbuild-register scripts/e2eCleanup.ts",
 		"test:e2e:npm": "npm run build && TEST_PM=npm vitest run --config ./vitest-e2e.config.ts",
 		"test:e2e:pnpm": "npm run build && TEST_PM=pnpm vitest run --config ./vitest-e2e.config.ts",
 		"test:unit": "vitest run --config ./vitest.config.ts",
-		"watch": "node scripts/build.js --watch"
+		"watch": "node -r esbuild-register scripts/build.ts --watch"
 	},
 	"devDependencies": {
 		"@babel/parser": "^7.21.3",
@@ -70,7 +70,7 @@
 		"vite-tsconfig-paths": "^4.0.8",
 		"vitest": "^0.30.0",
 		"which-pm-runs": "^1.1.0",
-		"wrangler": "^3.5.1",
+		"wrangler": "*",
 		"yargs": "^17.7.1",
 		"yarn": "^1.22.19"
 	},

--- a/packages/create-cloudflare/scripts/build.ts
+++ b/packages/create-cloudflare/scripts/build.ts
@@ -1,11 +1,11 @@
-const { build, context } = require("esbuild");
-const { cp } = require("fs/promises");
+import { build, context, BuildOptions } from "esbuild";
+import { cp } from "fs/promises";
 
 const run = async () => {
 	const argv = process.argv.slice(2);
 	const watchMode = argv[0] === "--watch";
 
-	const config = {
+	const config: BuildOptions = {
 		entryPoints: ["./src/cli.ts"],
 		bundle: true,
 		outdir: "./dist",

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -251,6 +251,7 @@ export const resetPackageManager = async (ctx: PagesGeneratorContext) => {
 
 	await runCommand(`${npm} install`, {
 		silent: true,
+		cwd: ctx.project.path,
 		startText: "Installing dependencies",
 		doneText: `${brandColor("installed")} ${dim(`via \`${npm} install\``)}`,
 	});


### PR DESCRIPTION
Re-enables pnpm e2e tests for c3. Previous attempts were stalled by flakiness, and in an effort to expedite a release we deferred enabling pnpm coverage. This fixes an issue with `create-react-app` that was causing an issue pnpm and improves the reliability of cleanup in between test attempts.

**Author has included the following, where applicable:**

- [ x ] Tests

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
