### PR TITLE
pages: Add mechanism to handle API error codes

### DIFF
--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -18,6 +18,7 @@ import { runWrangler } from "../helpers/run-wrangler";
 import { normalizeProgressSteps } from "./project-upload.test";
 import type { Project, UploadPayloadFile } from "../../pages/types";
 import type { RestRequest } from "msw";
+import { ApiErrorCodes } from "../../pages/errors";
 
 describe("deployment create", () => {
 	const std = mockConsoleMethods();
@@ -231,7 +232,7 @@ describe("deployment create", () => {
 							success: false,
 							errors: [
 								{
-									code: 8000000,
+									code: ApiErrorCodes.UNKNOWN_ERROR,
 									message: "Something exploded, please retry",
 								},
 							],
@@ -389,7 +390,7 @@ describe("deployment create", () => {
 								success: false,
 								errors: [
 									{
-										code: 8000000,
+										code: ApiErrorCodes.UNKNOWN_ERROR,
 										message: "Something exploded, please retry",
 									},
 								],
@@ -523,7 +524,7 @@ describe("deployment create", () => {
 							success: false,
 							errors: [
 								{
-									code: 8000013,
+									code: ApiErrorCodes.UNAUTHORIZED,
 									message: "Authorization failed",
 								},
 							],

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -8,6 +8,7 @@ import { FatalError } from "../../errors";
 import { logger } from "../../logger";
 import { buildFunctions } from "../../pages/buildFunctions";
 import {
+	ApiErrorCodes,
 	FunctionsNoRoutesError,
 	getFunctionsNoRoutesWarning,
 } from "../../pages/errors";
@@ -379,7 +380,7 @@ export async function deploy({
 		} catch (e) {
 			lastErr = e;
 			if (
-				(e as { code: number }).code === 8000000 &&
+				(e as { code: number }).code === ApiErrorCodes.UNKNOWN_ERROR &&
 				attempts < MAX_DEPLOYMENT_ATTEMPTS
 			) {
 				logger.debug("failed:", e, "retrying...");

--- a/packages/wrangler/src/pages/errors.ts
+++ b/packages/wrangler/src/pages/errors.ts
@@ -6,6 +6,15 @@ import {
 import { RoutesValidationError } from "./functions/routes-validation";
 
 /**
+ * Error codes returned by requests to Pages APIs
+ */
+/* eslint-disable-next-line no-shadow */
+export enum ApiErrorCodes {
+	UNKNOWN_ERROR = 8000000,
+	UNAUTHORIZED = 8000013,
+}
+
+/**
  * Exit code for `pages functions build` when no routes are found.
  */
 export const EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR = 156;

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -23,6 +23,7 @@ import type {
 } from "../yargs-types";
 import type { UploadPayloadFile } from "./types";
 import type { FileContainer } from "./validate";
+import { ApiErrorCodes } from "./errors";
 
 type UploadArgs = StrictYargsOptionsToInterface<typeof Options>;
 
@@ -131,7 +132,7 @@ export const upload = async (
 					setTimeout(resolvePromise, Math.pow(2, attempts++) * 1000)
 				);
 
-				if ((e as { code: number }).code === 8000013) {
+				if ((e as { code: number }).code === ApiErrorCodes.UNAUTHORIZED) {
 					// Looks like the JWT expired, fetch another one
 					jwt = await fetchJwt();
 				}
@@ -227,7 +228,10 @@ export const upload = async (
 						setTimeout(resolvePromise, Math.pow(2, attempts++) * 1000)
 					);
 
-					if ((e as { code: number }).code === 8000013 || isJwtExpired(jwt)) {
+					if (
+						(e as { code: number }).code === ApiErrorCodes.UNAUTHORIZED ||
+						isJwtExpired(jwt)
+					) {
 						// Looks like the JWT expired, fetch another one
 						jwt = await fetchJwt();
 					}
@@ -289,7 +293,10 @@ export const upload = async (
 		} catch (e) {
 			await new Promise((resolvePromise) => setTimeout(resolvePromise, 1000));
 
-			if ((e as { code: number }).code === 8000013 || isJwtExpired(jwt)) {
+			if (
+				(e as { code: number }).code === ApiErrorCodes.UNAUTHORIZED ||
+				isJwtExpired(jwt)
+			) {
 				// Looks like the JWT expired, fetch another one
 				jwt = await fetchJwt();
 			}


### PR DESCRIPTION
**What this PR solves / how to test:**
Currently, Pages specific API request error codes are spread all over the codebase, without any uniform mechanism to handle them. This leads to error codes that are unreadable and difficult to keep track of.

This commit introduces a very simple and straightforward mechanism (by means of a top level `enum`) that handles and makes such API error codes easier to reason about.

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
