### PR TITLE
pages: Add missing `isJwtExpired` check

### DIFF
--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -132,7 +132,10 @@ export const upload = async (
 					setTimeout(resolvePromise, Math.pow(2, attempts++) * 1000)
 				);
 
-				if ((e as { code: number }).code === ApiErrorCodes.UNAUTHORIZED) {
+				if (
+					(e as { code: number }).code === ApiErrorCodes.UNAUTHORIZED ||
+					isJwtExpired(jwt)
+				) {
 					// Looks like the JWT expired, fetch another one
 					jwt = await fetchJwt();
 				}


### PR DESCRIPTION
**What this PR solves / how to test:**
The `/pages/assets/check-missing` API request erorr handler, should check not only for the `ApiErrorCodes.UNAUTHORIZED` error code, but also for whether the JWT is expired, before fetching another JWT token.

This commit adds the missing `isJwtExpired(jwt)` check.

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
