### PR TITLE
chore: include `workerd`/`miniflare` versions in pre-release comment

### DIFF
--- a/.github/extract-runtime-versions.mjs
+++ b/.github/extract-runtime-versions.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import module from "node:module";
+import path from "node:path";
+import url from "node:url";
+
+/**
+ * @param {string} from
+ * @returns {string | undefined}
+ */
+function findClosestPackageJson(from) {
+	while (true) {
+		const packageJsonPath = path.join(from, "package.json");
+		if (existsSync(packageJsonPath)) return packageJsonPath;
+		const parent = path.dirname(from);
+		if (parent === from) return;
+		from = parent;
+	}
+}
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// 1. Load `wrangler` `package.json`, getting `wrangler` version and `miniflare` version constraint
+const wranglerPackagePath = path.resolve(__dirname, "../packages/wrangler");
+const wranglerPackageJsonPath = path.join(wranglerPackagePath, "package.json");
+const wranglerPackageJson = await fs.readFile(wranglerPackageJsonPath, "utf8");
+const wranglerPackage = JSON.parse(wranglerPackageJson);
+const wranglerVersion = wranglerPackage.version;
+const miniflareVersionConstraint = wranglerPackage.dependencies.miniflare;
+
+// 2. Load `miniflare` `package.json`, getting `miniflare` version and `workerd` version constraint
+const wranglerRequire = module.createRequire(wranglerPackagePath);
+const miniflareMainPath = wranglerRequire.resolve("miniflare");
+const miniflarePackageJsonPath = findClosestPackageJson(miniflareMainPath);
+assert(miniflarePackageJsonPath !== undefined);
+const miniflarePackagePath = path.dirname(miniflarePackageJsonPath);
+const miniflarePackageJson = await fs.readFile(
+	miniflarePackageJsonPath,
+	"utf8"
+);
+const miniflarePackage = JSON.parse(miniflarePackageJson);
+const miniflareVersion = miniflarePackage.version;
+const workerdVersionConstraint = miniflarePackage.dependencies.workerd;
+
+// 3. Load `workerd` `package.json`, getting `workerd` version
+const miniflareRequire = module.createRequire(miniflarePackagePath);
+const workerdMainPath = miniflareRequire.resolve("workerd");
+const workerdPackageJsonPath = findClosestPackageJson(workerdMainPath);
+assert(workerdPackageJsonPath !== undefined);
+const workerdPackageJson = await fs.readFile(workerdPackageJsonPath, "utf8");
+const workerdPackage = JSON.parse(workerdPackageJson);
+const workerdVersion = workerdPackage.version;
+
+// 4. Write basic markdown report
+const report = [
+	`\`wrangler@${wranglerVersion}\` includes the following runtime dependencies:`,
+	"",
+	"|Package|Constraint|Resolved|",
+	"|-------|----------|--------|",
+	`|\`miniflare\`|${miniflareVersionConstraint}|${miniflareVersion}|`,
+	`|\`workerd\`|${workerdVersionConstraint}|${workerdVersion}|`,
+	"",
+	"Please ensure constraints are pinned, and `miniflare`/`workerd` minor versions match.",
+	"",
+].join("\n");
+await fs.writeFile("runtime-versions.md", report);

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Install NPM Dependencies
         run: npm ci
 
+      - name: Extract runtime versions
+        run: node .github/extract-runtime-versions.mjs # extract versions before modifying version to include commit hash
+
+      - name: Upload runtime versions
+        uses: actions/upload-artifact@v3
+        with:
+          name: runtime-versions.md
+          path: runtime-versions.md
+
       - name: Modify package.json version
         run: node .github/version-script.js
 

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -37,6 +37,23 @@ jobs:
               }
             }
 
+      - name: "Download runtime versions"
+        # Regular `actions/download-artifact` doesn't support downloading
+        # artifacts from another workflow
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: runtime-versions.md
+
+      - name: "Put runtime versions on the environment"
+        id: runtime_versions
+        run: |
+          {
+            echo 'RUNTIME_VERSIONS<<EOF'
+            cat runtime-versions.md
+            echo EOF
+          } >> "$GITHUB_ENV"
+
       - name: "Comment on PR with Wrangler link"
         env:
           WORKFLOW_RUN_PR_FOR_WRANGLER: ${{env.WORKFLOW_RUN_PR_FOR_WRANGLER || env.WORKFLOW_RUN_PR_FOR_CLOUDFLARE-PAGES-SHARED}}
@@ -71,6 +88,12 @@ jobs:
             ```
 
             Note that these links will no longer work once [the GitHub Actions artifact expires](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
+
+            </details>
+
+            ---
+
+            ${{ env.RUNTIME_VERSIONS }}
 
       - name: "Comment on PR with C3 link"
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ build/**
 dist/**
 .next/**
 .turbo
+
+# Runtime dependencies report
+runtime-versions.md


### PR DESCRIPTION
Closes DEVX-880

**What this PR solves / how to test:**

Hey! 👋 This PR adds some additional information on the resolved `workerd`/`miniflare` to the pre-release comment. This is a sanity check for releases to ensure constraints are pinned, and the minor versions match.

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ] ~~Tests~~
- [ ] ~~Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~~

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
