### PR TITLE
C3: Improve readability of framework e2e tests

### DIFF
--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -29,11 +29,13 @@ export type RunnerConfig = {
 	};
 	promptHandlers?: PromptHandler[];
 	argv?: string[];
+	outputPrefix?: string;
 };
 
 export const runC3 = async ({
 	argv = [],
 	promptHandlers = [],
+	outputPrefix = "",
 }: RunnerConfig) => {
 	const proc = spawn("node", ["./dist/cli.js", ...argv]);
 	const stdout: string[] = [];
@@ -47,7 +49,7 @@ export const runC3 = async ({
 			lines.forEach((line) => {
 				// Uncomment to debug test output
 				if (filterLine(line)) {
-					console.log(line);
+					console.log(`${outputPrefix} ${line}`);
 				}
 				stdout.push(line);
 

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -58,7 +58,11 @@ describe(`E2E: Web frameworks`, () => {
 
 		args.push(...argv);
 
-		const { output } = await runC3({ argv: args, promptHandlers });
+		const { output } = await runC3({
+			argv: args,
+			promptHandlers,
+			outputPrefix: `[${framework}]`,
+		});
 
 		// Relevant project files should have been created
 		expect(projectPath).toExist();


### PR DESCRIPTION
**What this PR solves / how to test:**

The e2e tests for the various framework all run in parallel today and vitest isn't doing the best job of labelling output from each respective suite. This change prepends the framework to the output lines so it's easier to decipher which output is coming from which test

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
