### PR TITLE
Update eslint-config to raise errors instead of warnings

### DIFF
--- a/.changeset/unlucky-apes-film.md
+++ b/.changeset/unlucky-apes-film.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/eslint-config-worker": major
+---
+
+Updated `import/order` and `unused-imports/no-unused-vars` to raise errors.
+
+This change updates all rules currently raising warnings to instead raise errors. Our lint philosophy should not allow problems to be merged without being explicitly ignored.

--- a/packages/eslint-config-worker/index.js
+++ b/packages/eslint-config-worker/index.js
@@ -57,7 +57,7 @@ module.exports = {
 				"@typescript-eslint/no-floating-promises": "error",
 				"@typescript-eslint/no-unused-vars": "off",
 				"import/order": [
-					"warn",
+					"error",
 					{
 						groups: [
 							"builtin",
@@ -76,7 +76,7 @@ module.exports = {
 				],
 				"unused-imports/no-unused-imports": "error",
 				"unused-imports/no-unused-vars": [
-					"warn",
+					"error",
 					{
 						vars: "all",
 						varsIgnorePattern: "^_",


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR changes the `import/order` and `unused-imports/no-unused-vars` eslint rules to raise errors. Currently these rules only raise warnings, which has led to noisy output in PRs since it allows problems to be merged in without being dealt with, potentially confusing future developers as to whether they caused these issues with their own changes. Given we feel these things are important enough to warn about, it's probably worth making the developer address the issue or explicitly ignore it in cases where it's appropriate.

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
