### PR TITLE
run only a single framework on dependabot PRs

### DIFF
--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -122,7 +122,7 @@ jobs:
               )})\\]\\(.*?\\)\\s+from\\s+${semverRegexStr}\\s+to\\s+${semverRegexStr}`
             );
 
-            const bumpedFrameworkCli = body.match(frameworkCliRegex)?.[1];
+            const bumpedFrameworkCli = body.match(frameworkCliRegex)?.[1] ?? '';
             return bumpedFrameworkCli;
 
   # For dependabot versioning PRs we only want to run the e2es for the specifically bumped

--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -56,6 +56,8 @@ jobs:
   e2e:
     needs: cleanup
     name: "E2E"
+    if: |
+      github.event.pull_request.user.login != 'dependabot[bot]'
     strategy:
       matrix:
         # TODO: add back windows
@@ -76,5 +78,92 @@ jobs:
       - name: E2E Tests
         run: npm run test:e2e:${{matrix.pm}} -w create-cloudflare
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.C3_TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.C3_TEST_CLOUDFLARE_ACCOUNT_ID }}
+
+  get-dependabot-bumped-framework:
+    runs-on: ubuntu-latest
+    outputs:
+      bumped-framework-cli: ${{ steps.detect.outputs.result }}
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+          ref: ${{ github.head_ref }}
+      - name: Get PR description as string
+        id: get-pr-description
+        run: |
+          str=$(sed 's/`/\`/g' <<EOF
+            ${{ github.event.pull_request.body }}
+          EOF
+          )
+          echo 'result<<EOF' >> $GITHUB_OUTPUT
+          echo $str >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+      - name: detect-bumped-framework
+        id: detect
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const body = `${{ steps.get-pr-description.outputs.result }}`;
+
+            const frameworkCliPackages = [
+              '@angular/cli',
+              'create-astro',
+              'create-docusaurus',
+              'create-hono',
+              'create-next-app',
+              'create-qwik',
+              'create-react-app',
+              'create-remix',
+              'create-solid',
+              'create-svelte',
+              'create-vue',
+              'gatsby',
+              'nuxi',
+            ];
+
+            const semverRegexStr = '\\d+\\.\\d+\\.\\d+';
+
+            const frameworkCliRegex = new RegExp(
+              `(?:^|\\s+)Bumps\\s+\\[(${frameworkCliPackages.join(
+                '|'
+              )})\\]\\(.*?\\)\\s+from\\s+${semverRegexStr}\\s+to\\s+${semverRegexStr}`
+            );
+
+            const bumpedFrameworkCli = body.match(frameworkCliRegex)?.[1];
+            return bumpedFrameworkCli;
+
+  # For dependabot versioning PRs we only want to run the e2es for the specifically bumped
+  # framework (this is both for optimization and in order to reduce unnecessary flakyness)
+  e2e-only-dependabot-bumped-framework:
+    needs: cleanup
+      get-dependabot-bumped-framework
+    name: "Dependabot specific E2E"
+    strategy:
+      matrix:
+        # TODO: add back windows
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
+        # pm: [npm, yarn, pnpm]
+        pm: [npm, pnpm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: E2E Tests
+        run: npm run test:e2e:${{matrix.pm}} -w create-cloudflare
+        env:
+          FRAMEWORK_CLI_TO_TEST: ${{ needs.get-bumped-framework.outputs.bumped-framework-cli }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.C3_TEST_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.C3_TEST_CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -109,23 +109,10 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const body = `${{ steps.get-pr-description.outputs.result }}`;
+            const json = require('./packages/create-cloudflare/src/frameworks/package.json')
+            const frameworkCliPackages = Object.values(json.frameworkCliMap);
 
-            const frameworkCliPackages = [
-              '@angular/cli',
-              'create-astro',
-              'create-docusaurus',
-              'create-hono',
-              'create-next-app',
-              'create-qwik',
-              'create-react-app',
-              'create-remix',
-              'create-solid',
-              'create-svelte',
-              'create-vue',
-              'gatsby',
-              'nuxi',
-            ];
+            const body = `${{ steps.get-pr-description.outputs.result }}`;
 
             const semverRegexStr = '\\d+\\.\\d+\\.\\d+';
 

--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -128,8 +128,7 @@ jobs:
   # For dependabot versioning PRs we only want to run the e2es for the specifically bumped
   # framework (this is both for optimization and in order to reduce unnecessary flakiness)
   e2e-only-dependabot-bumped-framework:
-    needs: cleanup
-      get-dependabot-bumped-framework
+    needs: [cleanup, get-dependabot-bumped-framework]
     name: "Dependabot specific E2E"
     strategy:
       matrix:

--- a/.github/workflows/test-c3.yml
+++ b/.github/workflows/test-c3.yml
@@ -126,7 +126,7 @@ jobs:
             return bumpedFrameworkCli;
 
   # For dependabot versioning PRs we only want to run the e2es for the specifically bumped
-  # framework (this is both for optimization and in order to reduce unnecessary flakyness)
+  # framework (this is both for optimization and in order to reduce unnecessary flakiness)
   e2e-only-dependabot-bumped-framework:
     needs: cleanup
       get-dependabot-bumped-framework

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -3,9 +3,10 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { beforeEach, afterEach, describe, test, expect } from "vitest";
 import { version } from "../package.json";
+import { frameworkToTest } from "./frameworkToTest";
 import { keys, runC3 } from "./helpers";
 
-describe("E2E: Basic C3 functionality", () => {
+describe.skipIf(frameworkToTest)("E2E: Basic C3 functionality ", () => {
 	const tmpDirPath = realpathSync(mkdtempSync(join(tmpdir(), "c3-tests")));
 	const projectPath = join(tmpDirPath, "basic-tests");
 

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -6,6 +6,8 @@ import { version } from "../package.json";
 import { frameworkToTest } from "./frameworkToTest";
 import { keys, runC3 } from "./helpers";
 
+// Note: skipIf(frameworkToTest) makes it so that all the basic C3 functionality
+//       tests are skipped in case we are testing a specific framework
 describe.skipIf(frameworkToTest)("E2E: Basic C3 functionality ", () => {
 	const tmpDirPath = realpathSync(mkdtempSync(join(tmpdir(), "c3-tests")));
 	const projectPath = join(tmpDirPath, "basic-tests");

--- a/packages/create-cloudflare/e2e-tests/frameworkToTest.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworkToTest.ts
@@ -1,0 +1,20 @@
+import { frameworkCliMap } from "../src/frameworks/package.json";
+
+let targetFramework = undefined;
+
+const envCliToTest = process.env.FRAMEWORK_CLI_TO_TEST;
+
+if (envCliToTest) {
+	for (const [framework, cli] of Object.entries(frameworkCliMap)) {
+		if (cli === envCliToTest) {
+			targetFramework = framework;
+		}
+	}
+}
+
+/**
+ * In case the e2e run is supposed to only test a single framework
+ * the framework's name is set as the value of this variable, for standard
+ * runs this variable's value is `undefined`
+ */
+export const frameworkToTest = targetFramework;

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -5,6 +5,7 @@ import { fetch } from "undici";
 import { describe, expect, test, afterEach, beforeEach } from "vitest";
 import { version } from "../package.json";
 import { deleteProject } from "../scripts/e2eCleanup";
+import { frameworkToTest } from "./frameworkToTest";
 import { keys, runC3, testProjectDir } from "./helpers";
 import type { RunnerConfig } from "./helpers";
 
@@ -223,13 +224,19 @@ describe(`E2E: Web frameworks`, () => {
 		},
 	};
 
-	test.concurrent.each(Object.keys(frameworkTests))(
-		"%s",
-		async (name) => {
-			await runCliWithDeploy(name, frameworkTests[name].testCommitMessage);
-		},
-		{ retry: 3 }
-	);
+	Object.keys(frameworkTests).forEach((framework) => {
+		const skip = frameworkToTest && frameworkToTest !== framework;
+		test.skipIf(skip)(
+			framework,
+			async () => {
+				await runCliWithDeploy(
+					framework,
+					frameworkTests[framework].testCommitMessage
+				);
+			},
+			{ retry: 3 }
+		);
+	});
 
 	test.skip("Hono (wrangler defaults)", async () => {
 		await runCli("hono", { argv: ["--wrangler-defaults"] });

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -19,7 +19,7 @@ type FrameworkTestConfig = RunnerConfig & {
 	testCommitMessage: boolean;
 };
 
-describe(`E2E: Web frameworks`, () => {
+describe.concurrent(`E2E: Web frameworks`, () => {
 	const { getPath, getName, clean } = testProjectDir("pages");
 
 	beforeEach((ctx) => {

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -1,5 +1,6 @@
 import { join } from "path";
 import { describe, expect, test, afterEach, beforeEach } from "vitest";
+import { frameworkToTest } from "./frameworkToTest";
 import { runC3, testProjectDir } from "./helpers";
 
 /*
@@ -7,7 +8,7 @@ Areas for future improvement:
 - Make these actually e2e by verifying that deployment works
 */
 
-describe("E2E: Workers templates", () => {
+describe.skipIf(frameworkToTest)("E2E: Workers templates", () => {
 	const { getPath, clean } = testProjectDir("workers");
 
 	beforeEach((ctx) => {

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -8,6 +8,9 @@ Areas for future improvement:
 - Make these actually e2e by verifying that deployment works
 */
 
+// Note: skipIf(frameworkToTest) makes it so that all the worker tests are
+//       skipped in case we are testing a specific framework
+//       (since no worker template implements a framework application)
 describe.skipIf(frameworkToTest)("E2E: Workers templates", () => {
 	const { getPath, clean } = testProjectDir("workers");
 

--- a/packages/create-cloudflare/turbo.json
+++ b/packages/create-cloudflare/turbo.json
@@ -7,7 +7,11 @@
 			"env": ["VITEST", "TEST_PM", "CI"]
 		},
 		"test:e2e:*": {
-			"env": ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_TOKEN"]
+			"env": [
+				"CLOUDFLARE_ACCOUNT_ID",
+				"CLOUDFLARE_API_TOKEN",
+				"FRAMEWORK_CLI_TO_TEST"
+			]
 		}
 	}
 }


### PR DESCRIPTION
I did test the workflow logic to make sure it gets the correct bumped framework (see [this](https://github.com/dario-piotrowicz/dependabot-testing/actions/runs/5969953686/job/16196728060#step:2:5))

I also did test the e2es with the env variable set locally (`export FRAMEWORK_CLI_TO_TEST=nuxi`):
![Screenshot 2023-08-25 at 11 20 00](https://github.com/cloudflare/workers-sdk/assets/61631103/d6530867-b18f-42c7-8432-5e97e5269143)

But I couldn't test how the two work as expected together, hopefully this should all work fine, but I guess we can't be 100% sure until we merge and try it out 😬
