### PR TITLE
simplify dependabot C3 single bump changesets

### DIFF
--- a/.github/generate-c3-dependabot-pr-changeset.mjs
+++ b/.github/generate-c3-dependabot-pr-changeset.mjs
@@ -42,7 +42,23 @@ if (!changes.length) {
 "dependabot-testing": patch
 ---
 
-Framework CLI versions updated in C3
+${generateChangesetBody(changes)}
+
+`
+	);
+
+	execSync("git add .changeset");
+	execSync("git commit --amend -m '[C3] Update frameworks cli dependencies'");
+	execSync("git push -f");
+}
+
+function generateChangesetBody(changes) {
+	if (changes.length === 1) {
+		const { package: pkg, from, to } = changes[0];
+		return `C3: Bumped \`${pkg}\` from \`${from}\` to \`${to}\``;
+	}
+
+	return `Framework CLI versions updated in C3
 
 The following framework CLI versions have been updated in C3:
 ${[
@@ -54,11 +70,6 @@ ${[
 ]
 	.map((str) => ` ${str}`)
 	.join("\n")}
-
-`
-	);
-
-	execSync("git add .changeset");
-	execSync("git commit --amend -m '[C3] Update frameworks cli dependencies'");
-	execSync("git push -f");
+	}
+`;
 }


### PR DESCRIPTION
Currently the C3 dependabot versioning is set to bump a single package per PR, the current implementation generates a changeset for this change containing a table, such would be nice if multiple packages were bumped but currently it is slightly too verbose

This PR updates the script generating the changeset so that to simplify it in case a single package is bumped, while still maintaining the table implementation in case more than one package is (which might useful in the future if/when we implement grouping)

[Result of the change](https://github.com/dario-piotrowicz/dependabot-testing/pull/25/files)