### PR TITLE
feat(workers): allow namespaced scripts to be used as Worker tail consumers

### DIFF
--- a/.changeset/thin-pears-repeat.md
+++ b/.changeset/thin-pears-repeat.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+[Workers] Allow namespace to be specified for a tail script

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -4772,6 +4772,7 @@ describe("normalizeAndValidateConfig()", () => {
 							// these are valid
 							{ service: "tail_listener" },
 							{ service: "listener_two", environment: "production" },
+							{ service: "listener_three", namespace: "a-dispatch-namespace" },
 						],
 					} as unknown as RawConfig,
 					undefined,

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -5135,6 +5135,7 @@ addEventListener('fetch', event => {});`
 				tail_consumers: [
 					{ service: "listener " },
 					{ service: "test-listener", environment: "production" },
+					{ service: "namespaced-listener", namespace: "a-dispatch-namespace" },
 				],
 			});
 			await fs.promises.writeFile("index.js", `export default {};`);
@@ -5143,6 +5144,7 @@ addEventListener('fetch', event => {});`
 				expectedTailConsumers: [
 					{ service: "listener " },
 					{ service: "test-listener", environment: "production" },
+					{ service: "namespaced-listener", namespace: "a-dispatch-namespace" },
 				],
 			});
 

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -732,8 +732,10 @@ export type ConfigModuleRuleType =
 export type TailConsumer = {
 	/** The name of the service tail events will be forwarded to. */
 	service: string;
-	/** (Optional) The environt of the service. */
+	/** (Optional) The environment of the service. */
 	environment?: string;
+	/** (Optional) The dispatch namespace the Tail Worker script belongs to (if any). */
+	namespace?: string;
 };
 
 export interface DispatchNamespaceOutbound {

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -246,6 +246,7 @@ export interface CfPlacement {
 export interface CfTailConsumer {
 	service: string;
 	environment?: string;
+	namespace?: string;
 }
 
 export interface CfUserLimits {


### PR DESCRIPTION
Fixes CUSTESC-32212.

**What this PR solves / how to test:**

We have recently added additional functionality to Tail Workers to allow scripts within a dispatch namespace to be used. This adds support for that optional field to wrangler configuration. 

**Associated docs issue(s)/PR(s):**

See the [tail consumers section of the Workers script upload docs](
https://developers.cloudflare.com/api/operations/worker-script-upload-worker-module?schema_url=https%3A%2F%2Fraw.githubusercontent.com%2Fcloudflare%2Fapi-schemas%2Fmain%2Fopenapi.yaml#Responses)

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested