### PR TITLE
Hide File Explorer by default

### DIFF
--- a/packages/quick-edit-extension/scripts/bundle.ts
+++ b/packages/quick-edit-extension/scripts/bundle.ts
@@ -7,6 +7,7 @@ type BuildFlags = {
 
 async function buildMain(flags: BuildFlags = {}) {
 	const options: esbuild.BuildOptions = {
+		watch: flags.watch,
 		entryPoints: ["./src/extension.ts"],
 		bundle: true,
 		outfile: "./dist/extension.js",
@@ -39,12 +40,7 @@ async function buildMain(flags: BuildFlags = {}) {
 			},
 		],
 	};
-	if (flags.watch) {
-		const ctx = await esbuild.context(options);
-		await ctx.watch();
-	} else {
-		await esbuild.build(options);
-	}
+	await esbuild.build(options);
 }
 
 async function run() {

--- a/packages/quick-edit-extension/src/cfs.ts
+++ b/packages/quick-edit-extension/src/cfs.ts
@@ -4,7 +4,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import workersTypes from "raw:@cloudflare/workers-types/index.d.ts";
+import workersTypes from "raw:@cloudflare/workers-types/experimental/index.d.ts";
 import {
 	Disposable,
 	EventEmitter,

--- a/packages/quick-edit/patches/0001-Add-Custom-workbench-for-Cloudflare.patch
+++ b/packages/quick-edit/patches/0001-Add-Custom-workbench-for-Cloudflare.patch
@@ -1,7 +1,7 @@
-From 803d9586d79c67538780343038952019a1566d03 Mon Sep 17 00:00:00 2001
+From 16ded598b00356eaa00940713a25502cf32c2206 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Mon, 3 Apr 2023 11:18:10 +0100
-Subject: [PATCH 01/12] Add Custom workbench for Cloudflare
+Subject: [PATCH 01/13] Add Custom workbench for Cloudflare
 
 ---
  src/vs/code/browser/workbench/workbench.ts | 522 +++------------------

--- a/packages/quick-edit/patches/0002-Remove-Themes-from-Setting-SubMenu.patch
+++ b/packages/quick-edit/patches/0002-Remove-Themes-from-Setting-SubMenu.patch
@@ -1,7 +1,7 @@
-From 2d7e7aa6b1274e430ca8fff107afb1c67212bbf5 Mon Sep 17 00:00:00 2001
+From 2890ec43e2c34f8cf530eed8b1a5a7d887c8da66 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:11:08 -0500
-Subject: [PATCH 02/12] Remove Themes from Setting SubMenu
+Subject: [PATCH 02/13] Remove Themes from Setting SubMenu
 
 ---
  .../themes/browser/themes.contribution.ts     | 76 +++++++++----------

--- a/packages/quick-edit/patches/0003-Removed-Menu.patch
+++ b/packages/quick-edit/patches/0003-Removed-Menu.patch
@@ -1,7 +1,7 @@
-From ee5aade609cba730afa828dc8ed8083295967981 Mon Sep 17 00:00:00 2001
+From 63b3a3fe21e1838b8c0088b4b147c49e94f4b511 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Tue, 28 Mar 2023 14:41:00 -0500
-Subject: [PATCH 03/12] Removed Menu
+Subject: [PATCH 03/13] Removed Menu
 
 ---
  .../browser/parts/titlebar/menubarControl.ts  | 94 +++++++++----------

--- a/packages/quick-edit/patches/0004-Remove-Profile-from-Setting-SubMenu.patch
+++ b/packages/quick-edit/patches/0004-Remove-Profile-from-Setting-SubMenu.patch
@@ -1,7 +1,7 @@
-From 77cc99bffd428f001d5e7b47a87db4489704c952 Mon Sep 17 00:00:00 2001
+From 35e7910db93886b1414918d5de46037564915058 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:11:28 -0500
-Subject: [PATCH 04/12] Remove Profile from Setting SubMenu
+Subject: [PATCH 04/13] Remove Profile from Setting SubMenu
 
 ---
  .../browser/userDataProfile.ts                | 46 +++++++++----------

--- a/packages/quick-edit/patches/0005-Remove-Account-Extension.patch
+++ b/packages/quick-edit/patches/0005-Remove-Account-Extension.patch
@@ -1,7 +1,7 @@
-From dbcdf643a9672eaed6e308a4c9037e4b72e7d391 Mon Sep 17 00:00:00 2001
+From 0525ed3c91d18e948e45df6f4331c58d5af9718b Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Tue, 28 Mar 2023 14:53:02 -0500
-Subject: [PATCH 05/12] Remove Account & Extension
+Subject: [PATCH 05/13] Remove Account & Extension
 
 ---
  .../parts/activitybar/activitybarPart.ts      | 26 +++++++++----------

--- a/packages/quick-edit/patches/0006-Remove-Debug-Icon-other-default-views.patch
+++ b/packages/quick-edit/patches/0006-Remove-Debug-Icon-other-default-views.patch
@@ -1,7 +1,7 @@
-From 57de9b8a7cc8709329a055dcd84242d3757521e2 Mon Sep 17 00:00:00 2001
+From 8346d89989d4c1698eeb5dd4e06c094a0fe6b2d7 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:08:40 -0500
-Subject: [PATCH 06/12] Remove Debug Icon & other default views
+Subject: [PATCH 06/13] Remove Debug Icon & other default views
 
 ---
  .../debug/browser/debug.contribution.ts       | 46 +++++++++----------

--- a/packages/quick-edit/patches/0007-Remove-Source-Control.patch
+++ b/packages/quick-edit/patches/0007-Remove-Source-Control.patch
@@ -1,7 +1,7 @@
-From d6910aabcbc5119d20381bec1991ad4f87bc9d79 Mon Sep 17 00:00:00 2001
+From 96714e7b0ca2dcc3d15d1d6dd63bba95247cea81 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Tue, 28 Mar 2023 14:42:09 -0500
-Subject: [PATCH 07/12] Remove Source Control
+Subject: [PATCH 07/13] Remove Source Control
 
 ---
  .../contrib/scm/browser/scm.contribution.ts   | 100 +++++++++---------

--- a/packages/quick-edit/patches/0008-Remove-Custom-Menu-hamburger.patch
+++ b/packages/quick-edit/patches/0008-Remove-Custom-Menu-hamburger.patch
@@ -1,7 +1,7 @@
-From b6ee4f8e0f50ac823e5c60993eba979e649b039e Mon Sep 17 00:00:00 2001
+From 5696bfbc875536f679c172a957ce076c226ff241 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:07:44 -0500
-Subject: [PATCH 08/12] Remove 'Custom' Menu (hamburger)
+Subject: [PATCH 08/13] Remove 'Custom' Menu (hamburger)
 
 ---
  .../parts/activitybar/activitybarPart.ts      |   6 +-

--- a/packages/quick-edit/patches/0009-Remove-Extensions-Icon-Quick-Access.patch
+++ b/packages/quick-edit/patches/0009-Remove-Extensions-Icon-Quick-Access.patch
@@ -1,7 +1,7 @@
-From 84003f197d80a9a68158b2512ae820168150660d Mon Sep 17 00:00:00 2001
+From 49ec89ece73e541d28e0e4ef304858f02a2aa713 Mon Sep 17 00:00:00 2001
 From: Jacob M-G Evans <jacobmgevans@gmail.com>
 Date: Fri, 31 Mar 2023 17:10:30 -0500
-Subject: [PATCH 09/12] Remove Extensions Icon & Quick Access
+Subject: [PATCH 09/13] Remove Extensions Icon & Quick Access
 
 ---
  .../browser/extensions.contribution.ts        | 98 +++++++++----------

--- a/packages/quick-edit/patches/0010-Remove-dead-code.patch
+++ b/packages/quick-edit/patches/0010-Remove-dead-code.patch
@@ -1,7 +1,7 @@
-From 1d05f8f1f80de3a2a506c7ccb8e88ece927fd69f Mon Sep 17 00:00:00 2001
+From 8f04eea76ae9da150dc69b3c100e80812fafa3ce Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Wed, 12 Apr 2023 18:46:53 +0100
-Subject: [PATCH 10/12] Remove dead code
+Subject: [PATCH 10/13] Remove dead code
 
 ---
  .../parts/activitybar/activitybarPart.ts      |  16 +-

--- a/packages/quick-edit/patches/0011-Support-project-wide-typescript-on-web.patch
+++ b/packages/quick-edit/patches/0011-Support-project-wide-typescript-on-web.patch
@@ -1,7 +1,7 @@
-From 65d5eb29077b8a5158799c0af0f559af667956ad Mon Sep 17 00:00:00 2001
+From 2307f6d059a3e555ba1e0d3e1ec4482b2617cbb6 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Fri, 14 Apr 2023 01:54:40 +0100
-Subject: [PATCH 11/12] Support project-wide typescript on web
+Subject: [PATCH 11/13] Support project-wide typescript on web
 
 ---
  .../typescript-language-features/package.json |   2 +-

--- a/packages/quick-edit/patches/0012-Remove-nls.patch
+++ b/packages/quick-edit/patches/0012-Remove-nls.patch
@@ -1,7 +1,7 @@
-From 67cdfbf7791adf0e0a0467856e75389d4505ec4d Mon Sep 17 00:00:00 2001
+From 6ef1528fb4a6de178b545a91f1f5ea1c5e333c95 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Tue, 23 May 2023 12:09:58 +0100
-Subject: [PATCH 12/12] Remove nls
+Subject: [PATCH 12/13] Remove nls
 
 ---
  src/vs/code/browser/workbench/workbench.html | 15 +--------------

--- a/packages/quick-edit/patches/0013-Hide-File-Explorer-by-default.patch
+++ b/packages/quick-edit/patches/0013-Hide-File-Explorer-by-default.patch
@@ -1,0 +1,24 @@
+From dca4f37b1b0c5b6488896e58b1fb649502b4b2dd Mon Sep 17 00:00:00 2001
+From: Workers DevProd <workers-devprod@cloudflare.com>
+Date: Fri, 25 Aug 2023 16:48:29 -0400
+Subject: [PATCH 13/13] Hide File Explorer by default
+
+---
+ src/vs/workbench/browser/layout.ts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/vs/workbench/browser/layout.ts b/src/vs/workbench/browser/layout.ts
+index b522eaa..64933ff 100644
+--- a/src/vs/workbench/browser/layout.ts
++++ b/src/vs/workbench/browser/layout.ts
+@@ -534,6 +534,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
+ 			initialization: initialLayoutState,
+ 			runtime: layoutRuntimeState,
+ 		};
++	  this.stateModel.setRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN, true);
+ 
+ 		// Sidebar View Container To Restore
+ 		if (this.isVisible(Parts.SIDEBAR_PART)) {
+-- 
+2.39.2 (Apple Git-143)
+


### PR DESCRIPTION
**What this PR solves / how to test:**
Hides File Explorer in VSCode by default. Additionally, workers are now typed relative to the `experimental` types entrypoint (rather than an older one)

**Author has included the following, where applicable:**

- ~[ ] Tests~
- ~[ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
