### PR TITLE
C3: fix label name in the dependabot.yml config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,5 @@ updates:
     reviewers:
       - "@cloudflare/c3"
     labels:
-      - "C3"
+      - "c3"
       - "dependencies"


### PR DESCRIPTION
The label name is "c3" and not "C3".
