### PR TITLE
Dependabot prittier fix

### DIFF
--- a/.github/generate-c3-dependabot-pr-changeset.mjs
+++ b/.github/generate-c3-dependabot-pr-changeset.mjs
@@ -66,9 +66,5 @@ ${[
 	...changes.map(
 		({ package: pkg, from, to }) => `| \`${pkg}\` | \`${from}\` | \`${to}\` |`
 	),
-]
-	.map((str) => ` ${str}`)
-	.join("\n")}
-	}
-`;
+].join("\n")}`;
 }

--- a/.github/generate-c3-dependabot-pr-changeset.mjs
+++ b/.github/generate-c3-dependabot-pr-changeset.mjs
@@ -43,7 +43,6 @@ if (!changes.length) {
 ---
 
 ${generateChangesetBody(changes)}
-
 `
 	);
 


### PR DESCRIPTION
The C3 changesets generated on dependabot PRs don't pass our prettier checks ([example](https://github.com/cloudflare/workers-sdk/actions/runs/6005067919/job/16287005472#step:9:388))

this PR is fixing that

(sorry my bad for not having checked this in the first place 🙇 )