### PR TITLE
fix: improve fixture test reliability/debugability

### DIFF
--- a/fixtures/node-app-pages/tests/index.test.ts
+++ b/fixtures/node-app-pages/tests/index.test.ts
@@ -12,12 +12,14 @@ describe("Pages Dev", () => {
 			"public",
 			["--node-compat", "--port=0"]
 		);
-		const response = await fetch(`http://${ip}:${port}/stripe`);
+		try {
+			const response = await fetch(`http://${ip}:${port}/stripe`);
 
-		await expect(response.text()).resolves.toContain(
-			`"PATH":"path/to/some-file","STRIPE_OBJECT"`
-		);
-
-		await stop();
+			await expect(response.text()).resolves.toContain(
+				`"PATH":"path/to/some-file","STRIPE_OBJECT"`
+			);
+		} finally {
+			await stop();
+		}
 	});
 });

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -4,7 +4,7 @@ import { describe, it, beforeAll, afterAll } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages Functions", () => {
-	let ip: string, port: number, stop: () => Promise<unknown>;
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
 	beforeAll(async () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
@@ -20,7 +20,7 @@ describe("Pages Functions", () => {
 	});
 
 	afterAll(async () => {
-		await stop();
+		await stop?.();
 	});
 
 	it("renders static pages", async ({ expect }) => {

--- a/fixtures/pages-functions-wasm-app/tests/index.test.ts
+++ b/fixtures/pages-functions-wasm-app/tests/index.test.ts
@@ -4,7 +4,7 @@ import { describe, it, beforeAll, afterAll } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages Functions with wasm module imports", () => {
-	let ip: string, port: number, stop: () => Promise<unknown>;
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
 	beforeAll(async () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
@@ -15,7 +15,7 @@ describe("Pages Functions with wasm module imports", () => {
 	});
 
 	afterAll(async () => {
-		await stop();
+		await stop?.();
 	});
 
 	it("should render static pages", async ({ expect }) => {

--- a/fixtures/pages-functions-with-routes-app/tests/index.test.ts
+++ b/fixtures/pages-functions-with-routes-app/tests/index.test.ts
@@ -4,7 +4,7 @@ import { describe, it, beforeAll, afterAll } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages Functions with custom _routes.json", () => {
-	let ip: string, port: number, stop: () => Promise<unknown>;
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
 	beforeAll(async () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
@@ -15,7 +15,7 @@ describe("Pages Functions with custom _routes.json", () => {
 	});
 
 	afterAll(async () => {
-		await stop();
+		await stop?.();
 	});
 
 	it("should render static pages", async ({ expect }) => {

--- a/fixtures/pages-simple-assets/tests/index.test.ts
+++ b/fixtures/pages-simple-assets/tests/index.test.ts
@@ -4,7 +4,7 @@ import { describe, it, afterAll, beforeAll } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages Functions", async () => {
-	let ip: string, port: number, stop: () => Promise<unknown>;
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
 	beforeAll(async () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
@@ -15,7 +15,7 @@ describe("Pages Functions", async () => {
 	});
 
 	afterAll(async () => {
-		await stop();
+		await stop?.();
 	});
 
 	it("renders static pages", async ({ expect }) => {

--- a/fixtures/pages-workerjs-and-functions-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-and-functions-app/tests/index.test.ts
@@ -4,7 +4,7 @@ import { describe, it, beforeAll, afterAll } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages project with `_worker.js` and `/functions` directory", () => {
-	let ip: string, port: number, stop: () => Promise<unknown>;
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
 	beforeAll(async () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
@@ -15,7 +15,7 @@ describe("Pages project with `_worker.js` and `/functions` directory", () => {
 	});
 
 	afterAll(async () => {
-		await stop();
+		await stop?.();
 	});
 
 	it("renders static pages", async ({ expect }) => {

--- a/fixtures/pages-workerjs-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-app/tests/index.test.ts
@@ -35,10 +35,13 @@ describe("Pages _worker.js", () => {
 			"./workerjs-test",
 			["--no-bundle=false", "--port=0"]
 		);
-		await expect(
-			fetch(`http://${ip}:${port}/`).then((resp) => resp.text())
-		).resolves.toContain("test");
-		await stop();
+		try {
+			await expect(
+				fetch(`http://${ip}:${port}/`).then((resp) => resp.text())
+			).resolves.toContain("test");
+		} finally {
+			await stop();
+		}
 	});
 
 	it("should not throw an error when the _worker.js file imports something if --bundle is true", async ({
@@ -49,9 +52,12 @@ describe("Pages _worker.js", () => {
 			"./workerjs-test",
 			["--bundle", "--port=0"]
 		);
-		await expect(
-			fetch(`http://${ip}:${port}/`).then((resp) => resp.text())
-		).resolves.toContain("test");
-		await stop();
+		try {
+			await expect(
+				fetch(`http://${ip}:${port}/`).then((resp) => resp.text())
+			).resolves.toContain("test");
+		} finally {
+			await stop();
+		}
 	});
 });

--- a/fixtures/pages-workerjs-directory/tests/index.test.ts
+++ b/fixtures/pages-workerjs-directory/tests/index.test.ts
@@ -24,36 +24,41 @@ describe("Pages _worker.js/ directory", () => {
 				"--r2=R2_REF=other_r2",
 			]
 		);
-		await expect(
-			fetch(`http://${ip}:${port}/`).then((resp) => resp.text())
-		).resolves.toContain("Hello, world!");
-		await expect(
-			fetch(`http://${ip}:${port}/wasm`).then((resp) => resp.text())
-		).resolves.toContain("3");
-		await expect(
-			fetch(`http://${ip}:${port}/static-js`).then((resp) => resp.text())
-		).resolves.toEqual("static import text (via js): 'js static'");
-		await expect(
-			fetch(`http://${ip}:${port}/static-mjs`).then((resp) => resp.text())
-		).resolves.toEqual("static import text (via mjs): 'mjs static'");
-		await expect(
-			fetch(`http://${ip}:${port}/other-script.js`).then((resp) => resp.text())
-		).resolves.toContain("other-script-test");
-		await expect(
-			fetch(`http://${ip}:${port}/other-other-script.mjs`).then((resp) =>
-				resp.text()
-			)
-		).resolves.toContain("other-other-script-test");
-		await expect(
-			fetch(`http://${ip}:${port}/d1`).then((resp) => resp.text())
-		).resolves.toContain('{"1":1}');
-		await expect(
-			fetch(`http://${ip}:${port}/kv`).then((resp) => resp.text())
-		).resolves.toContain("saved");
-		await expect(
-			fetch(`http://${ip}:${port}/r2`).then((resp) => resp.text())
-		).resolves.toContain("saved");
-		await stop();
+		try {
+			await expect(
+				fetch(`http://${ip}:${port}/`).then((resp) => resp.text())
+			).resolves.toContain("Hello, world!");
+			await expect(
+				fetch(`http://${ip}:${port}/wasm`).then((resp) => resp.text())
+			).resolves.toContain("3");
+			await expect(
+				fetch(`http://${ip}:${port}/static-js`).then((resp) => resp.text())
+			).resolves.toEqual("static import text (via js): 'js static'");
+			await expect(
+				fetch(`http://${ip}:${port}/static-mjs`).then((resp) => resp.text())
+			).resolves.toEqual("static import text (via mjs): 'mjs static'");
+			await expect(
+				fetch(`http://${ip}:${port}/other-script.js`).then((resp) =>
+					resp.text()
+				)
+			).resolves.toContain("other-script-test");
+			await expect(
+				fetch(`http://${ip}:${port}/other-other-script.mjs`).then((resp) =>
+					resp.text()
+				)
+			).resolves.toContain("other-other-script-test");
+			await expect(
+				fetch(`http://${ip}:${port}/d1`).then((resp) => resp.text())
+			).resolves.toContain('{"1":1}');
+			await expect(
+				fetch(`http://${ip}:${port}/kv`).then((resp) => resp.text())
+			).resolves.toContain("saved");
+			await expect(
+				fetch(`http://${ip}:${port}/r2`).then((resp) => resp.text())
+			).resolves.toContain("saved");
+		} finally {
+			await stop();
+		}
 
 		expect(existsSync(join(tmpDir, "./v3/d1/D1"))).toBeTruthy();
 		expect(existsSync(join(tmpDir, "./v3/d1/elsewhere"))).toBeTruthy();

--- a/fixtures/pages-workerjs-wasm-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-wasm-app/tests/index.test.ts
@@ -4,7 +4,7 @@ import { describe, it, beforeAll, afterAll } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages Advanced Mode with wasm module imports", () => {
-	let ip: string, port: number, stop: () => Promise<unknown>;
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
 	beforeAll(async () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
@@ -15,7 +15,7 @@ describe("Pages Advanced Mode with wasm module imports", () => {
 	});
 
 	afterAll(async () => {
-		await stop();
+		await stop?.();
 	});
 
 	it("should render static pages", async ({ expect }) => {

--- a/fixtures/pages-workerjs-with-routes-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-with-routes-app/tests/index.test.ts
@@ -4,7 +4,7 @@ import { describe, it, beforeAll, afterAll } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages Advanced Mode with custom _routes.json", () => {
-	let ip: string, port: number, stop: () => Promise<unknown>;
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
 	beforeAll(async () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
@@ -15,7 +15,7 @@ describe("Pages Advanced Mode with custom _routes.json", () => {
 	});
 
 	afterAll(async () => {
-		await stop();
+		await stop?.();
 	});
 
 	it("renders static pages", async ({ expect }) => {

--- a/fixtures/remix-pages-app/tests/index.test.ts
+++ b/fixtures/remix-pages-app/tests/index.test.ts
@@ -9,7 +9,7 @@ const isWindows = process.platform === "win32";
 describe("Remix", () => {
 	let ip: string;
 	let port: number;
-	let stop: () => void;
+	let stop: (() => Promise<unknown>) | undefined;
 
 	beforeAll(async () => {
 		spawnSync("npm", ["run", "build"], {
@@ -23,7 +23,9 @@ describe("Remix", () => {
 		));
 	});
 
-	afterAll(async () => await stop());
+	afterAll(async () => {
+		await stop?.();
+	});
 
 	it("renders", async ({ expect }) => {
 		const response = await fetch(`http://${ip}:${port}/`);

--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -29,24 +29,45 @@ export async function runWranglerDev(cwd: string, options: string[]) {
 }
 
 async function runLongLivedWrangler(command: string[], cwd: string) {
+	let settledReadyPromise = false;
 	let resolveReadyPromise: (value: { ip: string; port: number }) => void;
+	let rejectReadyPromise: (reason: unknown) => void;
 
-	const ready = new Promise<{ ip: string; port: number }>(
-		(resolve) => (resolveReadyPromise = resolve)
-	);
+	const ready = new Promise<{ ip: string; port: number }>((resolve, reject) => {
+		resolveReadyPromise = resolve;
+		rejectReadyPromise = reject;
+	});
 
 	const wranglerProcess = fork(
 		"../../packages/wrangler/bin/wrangler.js",
 		command,
 		{
-			stdio: ["ignore", "ignore", "ignore", "ipc"],
-			// If you have a test timing out unexpectedly, then try using this line to find out what is happening in Wrangler.
-			// stdio: ["inherit", "inherit", "inherit", "ipc"],
+			stdio: [/*stdin*/ "ignore", /*stdout*/ "pipe", /*stderr*/ "pipe", "ipc"],
 			cwd,
 		}
 	).on("message", (message) => {
+		if (settledReadyPromise) return;
+		settledReadyPromise = true;
+		clearTimeout(timeoutHandle);
 		resolveReadyPromise(JSON.parse(message.toString()));
 	});
+
+	const chunks: Buffer[] = [];
+	wranglerProcess.stdout?.on("data", (chunk) => chunks.push(chunk));
+	wranglerProcess.stderr?.on("data", (chunk) => chunks.push(chunk));
+
+	const timeoutHandle = setTimeout(() => {
+		if (settledReadyPromise) return;
+		settledReadyPromise = true;
+		const separator = "=".repeat(80);
+		const message = [
+			"Timed out starting long-lived Wrangler:",
+			separator,
+			Buffer.concat(chunks).toString(),
+			separator,
+		].join("\n");
+		rejectReadyPromise(new Error(message));
+	}, 10_000);
 
 	async function stop() {
 		return new Promise((resolve, reject) => {

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -4,7 +4,7 @@ import { describe, it, beforeAll, afterAll } from "vitest";
 import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("'wrangler dev' correctly renders pages", () => {
-	let ip: string, port: number, stop: () => Promise<unknown>;
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
 	beforeAll(async () => {
 		({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
@@ -14,7 +14,7 @@ describe("'wrangler dev' correctly renders pages", () => {
 	});
 
 	afterAll(async () => {
-		await stop();
+		await stop?.();
 	});
 
 	it("renders ", async ({ expect }) => {


### PR DESCRIPTION
**What this PR solves / how to test:**

Hey! 👋 This PR was part of debugging steps for #3799. We're not merging that PR, but these changes should still help to improve overall reliability and debugability of fixture tests. 🙂 

- Only call `stop()` when `beforeAll()` hooks succeed
- Call `stop()`s in `finally`-blocks to ensure cleanup
- Add timeout to `runLongLivedWrangler()` and log `stdout`/`stderr`

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ] ~~Tests~~ (passes existing)
- [ ] ~~Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~~

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
