### PR TITLE
Fix Quick Edit and Devtools builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2571,7 +2571,7 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -35564,7 +35564,7 @@
 				"is-unicode-supported": {
 					"version": "1.3.0",
 					"bundled": true,
-					"dev": true
+					"extraneous": true
 				}
 			}
 		},

--- a/packages/quick-edit-extension/scripts/bundle.ts
+++ b/packages/quick-edit-extension/scripts/bundle.ts
@@ -7,7 +7,6 @@ type BuildFlags = {
 
 async function buildMain(flags: BuildFlags = {}) {
 	const options: esbuild.BuildOptions = {
-		watch: flags.watch,
 		entryPoints: ["./src/extension.ts"],
 		bundle: true,
 		outfile: "./dist/extension.js",
@@ -40,7 +39,12 @@ async function buildMain(flags: BuildFlags = {}) {
 			},
 		],
 	};
-	await esbuild.build(options);
+	if (flags.watch) {
+		const ctx = await esbuild.context(options);
+		await ctx.watch();
+	} else {
+		await esbuild.build(options);
+	}
 }
 
 async function run() {

--- a/packages/wrangler-devtools/Makefile
+++ b/packages/wrangler-devtools/Makefile
@@ -20,10 +20,7 @@ devtools-frontend/out/Default/gen/front_end: devtools-frontend
 	cd devtools-frontend && PATH=$(PATH_WITH_DEPOT) $(ROOT)/depot/gn gen out/Default
 	cd devtools-frontend && PATH=$(PATH_WITH_DEPOT) $(ROOT)/depot/autoninja -C out/Default
 
-node_modules:
-	npm ci
-
-publish: node_modules devtools-frontend/out/Default/gen/front_end
+publish: devtools-frontend/out/Default/gen/front_end
 	npx wrangler pages deploy --project-name cloudflare-devtools devtools-frontend/out/Default/gen/front_end
 
 cleanup:


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

Quick Edit: `esbuild` options were incorrectly changed to match a future version of `esbuild`
DevTools: Should no longer install dependencies in a specific package, rather than relying on the global monorepo install

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
