### PR TITLE
Mark shared directories as unowned in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,9 +2,6 @@
 
 /packages/wrangler/CHANGELOG.md @cloudflare/wrangler-admins
 
-/.changeset/ @cloudflare/wrangler @cloudflare/pages @cloudflare/d1 @cloudflare/c3
-/fixtures/ @cloudflare/wrangler @cloudflare/pages @cloudflare/d1
-
 /packages/pages-shared/ @cloudflare/pages
 /packages/wrangler/pages/ @cloudflare/pages @cloudflare/wrangler
 /packages/wrangler/src/api/pages/ @cloudflare/pages @cloudflare/wrangler
@@ -15,3 +12,8 @@
 /packages/wrangler/src/d1/ @cloudflare/d1 @cloudflare/wrangler
 
 /packages/create-cloudflare/ @cloudflare/c3 @cloudflare/wrangler
+
+# Owners intentionally left blank on these shared directories
+# to avoid noisy review requests
+/.changeset/
+/fixtures/


### PR DESCRIPTION
This PR adjusts this repo's CODEOWNERS to mark some shared directories as explicitly unowned.

The @cloudflare/wrangler team is the default owner of every file and currently the repo settings require a codeowner approval on any changes to owned files. Other teams are listed as code owners of their respective parts of the codebase. These other teams working in this repo would often get blocked waiting for @cloudflare/wrangler approval when they would make changes to shared top-level directories (e.g. adding a changeset file) as part of their feature work.

To work around that, we added these other teams as owners to these shared directories. While this allowed these teams to move quickly without waiting for outside approval, this caused another problem. Now all teams were being tagged as reviewers on pretty much every PR in the repo, causing a lot of distracting noise.

It turns out `CODEOWNERS` allows leaving the owners for a given path pattern empty, which leaves it unowned. This is exactly  what we need in this scenario. This change will avoid the noise of requesting reviews from all teams due to trivial parts of PR while still allowing teams to move quickly.