### PR TITLE
chore: bump `miniflare` to `3.20230904.0`

### DIFF
--- a/.changeset/smooth-lemons-clean.md
+++ b/.changeset/smooth-lemons-clean.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/pages-shared": minor
+"wrangler": minor
+---
+
+chore: bump `miniflare` to [`3.20230904.0`](https://github.com/cloudflare/miniflare/releases/tag/v3.20230904.0)

--- a/.github/extract-runtime-versions.mjs
+++ b/.github/extract-runtime-versions.mjs
@@ -31,11 +31,11 @@ const wranglerVersion = wranglerPackage.version;
 const miniflareVersionConstraint = wranglerPackage.dependencies.miniflare;
 
 // 2. Load `miniflare` `package.json`, getting `miniflare` version and `workerd` version constraint
-const wranglerRequire = module.createRequire(wranglerPackagePath);
+// (`createRequire()` just needs to be passed a file in the `wrangler` directory)
+const wranglerRequire = module.createRequire(wranglerPackageJsonPath);
 const miniflareMainPath = wranglerRequire.resolve("miniflare");
 const miniflarePackageJsonPath = findClosestPackageJson(miniflareMainPath);
 assert(miniflarePackageJsonPath !== undefined);
-const miniflarePackagePath = path.dirname(miniflarePackageJsonPath);
 const miniflarePackageJson = await fs.readFile(
 	miniflarePackageJsonPath,
 	"utf8"
@@ -45,7 +45,7 @@ const miniflareVersion = miniflarePackage.version;
 const workerdVersionConstraint = miniflarePackage.dependencies.workerd;
 
 // 3. Load `workerd` `package.json`, getting `workerd` version
-const miniflareRequire = module.createRequire(miniflarePackagePath);
+const miniflareRequire = module.createRequire(miniflarePackageJsonPath);
 const workerdMainPath = miniflareRequire.resolve("workerd");
 const workerdPackageJsonPath = findClosestPackageJson(workerdMainPath);
 assert(workerdPackageJsonPath !== undefined);

--- a/fixtures/pages-ws-app/package.json
+++ b/fixtures/pages-ws-app/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",
-		"miniflare": "3.20230814.1",
+		"miniflare": "3.20230904.0",
 		"wrangler": "*",
 		"ws": "^8.8.0"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -261,12 +261,150 @@
 			"version": "0.1.1",
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "3.20230814.1",
+				"miniflare": "3.20230904.0",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"fixtures/pages-ws-app/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230904.0.tgz",
+			"integrity": "sha512-/GDlmxAFbDtrQwP4zOXFbqOfaPvkDxdsCoEa+KEBcAl5uR98+7WW5/b8naBHX+t26uS7p4bLlImM8J5F1ienRQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"fixtures/pages-ws-app/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230904.0.tgz",
+			"integrity": "sha512-x8WXNc2xnDqr5y1iirnNdyx8GZY3rL5xiF7ebK3mKQeB+jFjkhO71yuPTkDCzUWtOvw1Wfd4jbwy4wxacMX4mQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"fixtures/pages-ws-app/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230904.0.tgz",
+			"integrity": "sha512-V58xyMS3oDpKO8Dpdh0r0BXm99OzoGgvWe9ufttVraj/1NTMGELwb6i9ySb8k3F1J9m/sO26+TV7pQc/bGC1VQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"fixtures/pages-ws-app/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230904.0.tgz",
+			"integrity": "sha512-VrDaW+pjb5IAKEnNWtEaFiG377kXKmk5Fu0Era4W+jKzPON2BW/qRb/4LNHXQ4yxg/2HLm7RiUTn7JZtt1qO6A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"fixtures/pages-ws-app/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230904.0.tgz",
+			"integrity": "sha512-/R/dE8uy+8J2YeXfDhI8/Bg7YUirdbbjH5/l/Vv00ZRE0lC3nPLcYeyBXSwXIQ6/Xht3gN+lksLQgKd0ZWRd+Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"fixtures/pages-ws-app/node_modules/miniflare": {
+			"version": "3.20230904.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230904.0.tgz",
+			"integrity": "sha512-+OWQqEk8hV7vZaPCoj5dk1lZr4YUy56OiyNZ45/3ITYf+ZxgQOBPWhQhpw1jCahkRKGPa9Aykz01sc+GhPZYDA==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.22.1",
+				"workerd": "1.20230904.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"fixtures/pages-ws-app/node_modules/undici": {
+			"version": "5.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+			"integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+			"dev": true,
+			"dependencies": {
+				"busboy": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0"
+			}
+		},
+		"fixtures/pages-ws-app/node_modules/workerd": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230904.0.tgz",
+			"integrity": "sha512-t9znszH0rQGK4mJGvF9L3nN0qKEaObAGx0JkywFtAwH8OkSn+YfQbHNZE+YsJ4qa1hOz1DCNEk08UDFRBaYq4g==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20230904.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20230904.0",
+				"@cloudflare/workerd-linux-64": "1.20230904.0",
+				"@cloudflare/workerd-linux-arm64": "1.20230904.0",
+				"@cloudflare/workerd-windows-64": "1.20230904.0"
 			}
 		},
 		"fixtures/pages-ws-app/node_modules/ws": {
@@ -2635,81 +2773,6 @@
 			"dependencies": {
 				"fp-ts": "^2.1.1",
 				"io-ts": "^2.0.1"
-			}
-		},
-		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230814.1.tgz",
-			"integrity": "sha512-aQUO7q7qXl+SVtOiMMlVKLNOSeL6GX43RKeflwzsD74dGgyHPiSfw5KCvXhkVbyN7u+yYF6HyFdaIvHLfn5jyA==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230814.1.tgz",
-			"integrity": "sha512-U2mcgi+AiuI/4EY5Wk/GmygiNoCNw/V2mcHmxESqe4r6XbJYOzBdEsjnqJ05rqd0JlEM8m64jRtE6/qBnQHygg==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230814.1.tgz",
-			"integrity": "sha512-Q4kITXLTCuG2i2Z01fbb5AjVRRIf3+lS4ZVsFbTbIwtcOOG4Ozcw7ee7tKsFES7hFqR4Eg9gMG4/aS0mmi+L2g==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230814.1.tgz",
-			"integrity": "sha512-BX5SaksXw+pkREVw3Rw2eSNXplqZw+14CcwW/5x/4oq/C6yn5qCvKxJfM7pukJGMI4wkJPOYops7B3g27FB/HA==",
-			"cpu": [
-				"arm64"
-			],
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230814.1.tgz",
-			"integrity": "sha512-GWHqfyhsG/1wm2W8afkYX3q3fWXUWWD8NGtHfAs6ZVTHdW3mmYyMhKR0lc6ptBwz5i5aXRlP2S+CxxxwwDbKpw==",
-			"cpu": [
-				"x64"
-			],
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"node_modules/@cloudflare/workers-tsconfig": {
@@ -21407,52 +21470,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/miniflare": {
-			"version": "3.20230814.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230814.1.tgz",
-			"integrity": "sha512-LMgqd1Ut0+fnlvQepVbbBYQczQnyuuap8bgUwOyPETka0S9NR9NxMQSNaBgVZ0uOaG7xMJ/OVTRlz+TGB86PWA==",
-			"dependencies": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"set-cookie-parser": "^2.6.0",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "1.20230814.1",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"engines": {
-				"node": ">=16.13"
-			}
-		},
-		"node_modules/miniflare/node_modules/ws": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -28042,6 +28059,7 @@
 			"version": "5.20.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
 			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
@@ -29635,25 +29653,6 @@
 			"resolved": "fixtures/worker-ts",
 			"link": true
 		},
-		"node_modules/workerd": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230814.1.tgz",
-			"integrity": "sha512-zJeSEteXuAD+bpYJT8WvzTAHvIAkKPVxOV+Jy6zCLKz5e08N3OUbAF+wrvGWc8b2aB1sj+IYsdXfkv4puH+qXQ==",
-			"hasInstallScript": true,
-			"bin": {
-				"workerd": "bin/workerd"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20230814.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20230814.1",
-				"@cloudflare/workerd-linux-64": "1.20230814.1",
-				"@cloudflare/workerd-linux-arm64": "1.20230814.1",
-				"@cloudflare/workerd-windows-64": "1.20230814.1"
-			}
-		},
 		"node_modules/workers-chat-demo": {
 			"resolved": "fixtures/workers-chat-demo",
 			"link": true
@@ -30577,7 +30576,7 @@
 			"name": "@cloudflare/pages-shared",
 			"version": "0.8.2",
 			"dependencies": {
-				"miniflare": "3.20230814.1"
+				"miniflare": "3.20230904.0"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-tsconfig": "*",
@@ -30587,6 +30586,81 @@
 				"glob": "^8.0.3",
 				"service-worker-mock": "^2.0.5",
 				"wrangler": "*"
+			}
+		},
+		"packages/pages-shared/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230904.0.tgz",
+			"integrity": "sha512-/GDlmxAFbDtrQwP4zOXFbqOfaPvkDxdsCoEa+KEBcAl5uR98+7WW5/b8naBHX+t26uS7p4bLlImM8J5F1ienRQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/pages-shared/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230904.0.tgz",
+			"integrity": "sha512-x8WXNc2xnDqr5y1iirnNdyx8GZY3rL5xiF7ebK3mKQeB+jFjkhO71yuPTkDCzUWtOvw1Wfd4jbwy4wxacMX4mQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/pages-shared/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230904.0.tgz",
+			"integrity": "sha512-V58xyMS3oDpKO8Dpdh0r0BXm99OzoGgvWe9ufttVraj/1NTMGELwb6i9ySb8k3F1J9m/sO26+TV7pQc/bGC1VQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/pages-shared/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230904.0.tgz",
+			"integrity": "sha512-VrDaW+pjb5IAKEnNWtEaFiG377kXKmk5Fu0Era4W+jKzPON2BW/qRb/4LNHXQ4yxg/2HLm7RiUTn7JZtt1qO6A==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/pages-shared/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230904.0.tgz",
+			"integrity": "sha512-/R/dE8uy+8J2YeXfDhI8/Bg7YUirdbbjH5/l/Vv00ZRE0lC3nPLcYeyBXSwXIQ6/Xht3gN+lksLQgKd0ZWRd+Q==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"packages/pages-shared/node_modules/brace-expansion": {
@@ -30617,6 +30691,31 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"packages/pages-shared/node_modules/miniflare": {
+			"version": "3.20230904.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230904.0.tgz",
+			"integrity": "sha512-+OWQqEk8hV7vZaPCoj5dk1lZr4YUy56OiyNZ45/3ITYf+ZxgQOBPWhQhpw1jCahkRKGPa9Aykz01sc+GhPZYDA==",
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.22.1",
+				"workerd": "1.20230904.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
 		"packages/pages-shared/node_modules/minimatch": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -30627,6 +30726,56 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"packages/pages-shared/node_modules/undici": {
+			"version": "5.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+			"integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+			"dependencies": {
+				"busboy": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0"
+			}
+		},
+		"packages/pages-shared/node_modules/workerd": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230904.0.tgz",
+			"integrity": "sha512-t9znszH0rQGK4mJGvF9L3nN0qKEaObAGx0JkywFtAwH8OkSn+YfQbHNZE+YsJ4qa1hOz1DCNEk08UDFRBaYq4g==",
+			"hasInstallScript": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20230904.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20230904.0",
+				"@cloudflare/workerd-linux-64": "1.20230904.0",
+				"@cloudflare/workerd-linux-arm64": "1.20230904.0",
+				"@cloudflare/workerd-windows-64": "1.20230904.0"
+			}
+		},
+		"packages/pages-shared/node_modules/ws": {
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"packages/playground-preview-worker": {
@@ -31577,7 +31726,8 @@
 				"zod": "^3.22.2"
 			},
 			"devDependencies": {
-				"@cloudflare/workers-tsconfig": "*"
+				"@cloudflare/workers-tsconfig": "*",
+				"wrangler": "*"
 			}
 		},
 		"packages/workers-tsconfig": {
@@ -31609,7 +31759,7 @@
 				"blake3-wasm": "^2.1.5",
 				"chokidar": "^3.5.3",
 				"esbuild": "0.17.19",
-				"miniflare": "3.20230814.1",
+				"miniflare": "3.20230904.0",
 				"nanoid": "^3.3.3",
 				"path-to-regexp": "^6.2.0",
 				"selfsigned": "^2.0.1",
@@ -31713,6 +31863,81 @@
 				"wrangler": "^3.0.0"
 			}
 		},
+		"packages/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230904.0.tgz",
+			"integrity": "sha512-/GDlmxAFbDtrQwP4zOXFbqOfaPvkDxdsCoEa+KEBcAl5uR98+7WW5/b8naBHX+t26uS7p4bLlImM8J5F1ienRQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230904.0.tgz",
+			"integrity": "sha512-x8WXNc2xnDqr5y1iirnNdyx8GZY3rL5xiF7ebK3mKQeB+jFjkhO71yuPTkDCzUWtOvw1Wfd4jbwy4wxacMX4mQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230904.0.tgz",
+			"integrity": "sha512-V58xyMS3oDpKO8Dpdh0r0BXm99OzoGgvWe9ufttVraj/1NTMGELwb6i9ySb8k3F1J9m/sO26+TV7pQc/bGC1VQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230904.0.tgz",
+			"integrity": "sha512-VrDaW+pjb5IAKEnNWtEaFiG377kXKmk5Fu0Era4W+jKzPON2BW/qRb/4LNHXQ4yxg/2HLm7RiUTn7JZtt1qO6A==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"packages/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230904.0.tgz",
+			"integrity": "sha512-/R/dE8uy+8J2YeXfDhI8/Bg7YUirdbbjH5/l/Vv00ZRE0lC3nPLcYeyBXSwXIQ6/Xht3gN+lksLQgKd0ZWRd+Q==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"packages/wrangler/node_modules/@esbuild-plugins/node-modules-polyfill": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
@@ -31799,6 +32024,42 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"packages/wrangler/node_modules/miniflare": {
+			"version": "3.20230904.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230904.0.tgz",
+			"integrity": "sha512-+OWQqEk8hV7vZaPCoj5dk1lZr4YUy56OiyNZ45/3ITYf+ZxgQOBPWhQhpw1jCahkRKGPa9Aykz01sc+GhPZYDA==",
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-walk": "^8.2.0",
+				"better-sqlite3": "^8.1.0",
+				"capnp-ts": "^0.7.0",
+				"exit-hook": "^2.2.1",
+				"glob-to-regexp": "^0.4.1",
+				"http-cache-semantics": "^4.1.0",
+				"kleur": "^4.1.5",
+				"source-map-support": "0.5.21",
+				"stoppable": "^1.1.0",
+				"undici": "^5.22.1",
+				"workerd": "1.20230904.0",
+				"ws": "^8.11.0",
+				"youch": "^3.2.2",
+				"zod": "^3.20.6"
+			},
+			"engines": {
+				"node": ">=16.13"
+			}
+		},
+		"packages/wrangler/node_modules/miniflare/node_modules/undici": {
+			"version": "5.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+			"integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+			"dependencies": {
+				"busboy": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0"
+			}
+		},
 		"packages/wrangler/node_modules/minimatch": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
@@ -31873,11 +32134,29 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"packages/wrangler/node_modules/workerd": {
+			"version": "1.20230904.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230904.0.tgz",
+			"integrity": "sha512-t9znszH0rQGK4mJGvF9L3nN0qKEaObAGx0JkywFtAwH8OkSn+YfQbHNZE+YsJ4qa1hOz1DCNEk08UDFRBaYq4g==",
+			"hasInstallScript": true,
+			"bin": {
+				"workerd": "bin/workerd"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"optionalDependencies": {
+				"@cloudflare/workerd-darwin-64": "1.20230904.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20230904.0",
+				"@cloudflare/workerd-linux-64": "1.20230904.0",
+				"@cloudflare/workerd-linux-arm64": "1.20230904.0",
+				"@cloudflare/workerd-windows-64": "1.20230904.0"
+			}
+		},
 		"packages/wrangler/node_modules/ws": {
 			"version": "8.13.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -35391,11 +35670,41 @@
 				"@types/service-worker-mock": "^2.0.1",
 				"concurrently": "^7.3.0",
 				"glob": "^8.0.3",
-				"miniflare": "3.20230814.1",
+				"miniflare": "3.20230904.0",
 				"service-worker-mock": "^2.0.5",
 				"wrangler": "*"
 			},
 			"dependencies": {
+				"@cloudflare/workerd-darwin-64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230904.0.tgz",
+					"integrity": "sha512-/GDlmxAFbDtrQwP4zOXFbqOfaPvkDxdsCoEa+KEBcAl5uR98+7WW5/b8naBHX+t26uS7p4bLlImM8J5F1ienRQ==",
+					"optional": true
+				},
+				"@cloudflare/workerd-darwin-arm64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230904.0.tgz",
+					"integrity": "sha512-x8WXNc2xnDqr5y1iirnNdyx8GZY3rL5xiF7ebK3mKQeB+jFjkhO71yuPTkDCzUWtOvw1Wfd4jbwy4wxacMX4mQ==",
+					"optional": true
+				},
+				"@cloudflare/workerd-linux-64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230904.0.tgz",
+					"integrity": "sha512-V58xyMS3oDpKO8Dpdh0r0BXm99OzoGgvWe9ufttVraj/1NTMGELwb6i9ySb8k3F1J9m/sO26+TV7pQc/bGC1VQ==",
+					"optional": true
+				},
+				"@cloudflare/workerd-linux-arm64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230904.0.tgz",
+					"integrity": "sha512-VrDaW+pjb5IAKEnNWtEaFiG377kXKmk5Fu0Era4W+jKzPON2BW/qRb/4LNHXQ4yxg/2HLm7RiUTn7JZtt1qO6A==",
+					"optional": true
+				},
+				"@cloudflare/workerd-windows-64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230904.0.tgz",
+					"integrity": "sha512-/R/dE8uy+8J2YeXfDhI8/Bg7YUirdbbjH5/l/Vv00ZRE0lC3nPLcYeyBXSwXIQ6/Xht3gN+lksLQgKd0ZWRd+Q==",
+					"optional": true
+				},
 				"brace-expansion": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -35418,6 +35727,28 @@
 						"once": "^1.3.0"
 					}
 				},
+				"miniflare": {
+					"version": "3.20230904.0",
+					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230904.0.tgz",
+					"integrity": "sha512-+OWQqEk8hV7vZaPCoj5dk1lZr4YUy56OiyNZ45/3ITYf+ZxgQOBPWhQhpw1jCahkRKGPa9Aykz01sc+GhPZYDA==",
+					"requires": {
+						"acorn": "^8.8.0",
+						"acorn-walk": "^8.2.0",
+						"better-sqlite3": "^8.1.0",
+						"capnp-ts": "^0.7.0",
+						"exit-hook": "^2.2.1",
+						"glob-to-regexp": "^0.4.1",
+						"http-cache-semantics": "^4.1.0",
+						"kleur": "^4.1.5",
+						"source-map-support": "0.5.21",
+						"stoppable": "^1.1.0",
+						"undici": "^5.22.1",
+						"workerd": "1.20230904.0",
+						"ws": "^8.11.0",
+						"youch": "^3.2.2",
+						"zod": "^3.20.6"
+					}
+				},
 				"minimatch": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
@@ -35426,6 +35757,32 @@
 					"requires": {
 						"brace-expansion": "^2.0.1"
 					}
+				},
+				"undici": {
+					"version": "5.23.0",
+					"resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+					"integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+					"requires": {
+						"busboy": "^1.6.0"
+					}
+				},
+				"workerd": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230904.0.tgz",
+					"integrity": "sha512-t9znszH0rQGK4mJGvF9L3nN0qKEaObAGx0JkywFtAwH8OkSn+YfQbHNZE+YsJ4qa1hOz1DCNEk08UDFRBaYq4g==",
+					"requires": {
+						"@cloudflare/workerd-darwin-64": "1.20230904.0",
+						"@cloudflare/workerd-darwin-arm64": "1.20230904.0",
+						"@cloudflare/workerd-linux-64": "1.20230904.0",
+						"@cloudflare/workerd-linux-arm64": "1.20230904.0",
+						"@cloudflare/workerd-windows-64": "1.20230904.0"
+					}
+				},
+				"ws": {
+					"version": "8.13.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+					"requires": {}
 				}
 			}
 		},
@@ -35547,36 +35904,6 @@
 				"fp-ts": "^2.1.1",
 				"io-ts": "^2.0.1"
 			}
-		},
-		"@cloudflare/workerd-darwin-64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230814.1.tgz",
-			"integrity": "sha512-aQUO7q7qXl+SVtOiMMlVKLNOSeL6GX43RKeflwzsD74dGgyHPiSfw5KCvXhkVbyN7u+yYF6HyFdaIvHLfn5jyA==",
-			"optional": true
-		},
-		"@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230814.1.tgz",
-			"integrity": "sha512-U2mcgi+AiuI/4EY5Wk/GmygiNoCNw/V2mcHmxESqe4r6XbJYOzBdEsjnqJ05rqd0JlEM8m64jRtE6/qBnQHygg==",
-			"optional": true
-		},
-		"@cloudflare/workerd-linux-64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230814.1.tgz",
-			"integrity": "sha512-Q4kITXLTCuG2i2Z01fbb5AjVRRIf3+lS4ZVsFbTbIwtcOOG4Ozcw7ee7tKsFES7hFqR4Eg9gMG4/aS0mmi+L2g==",
-			"optional": true
-		},
-		"@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230814.1.tgz",
-			"integrity": "sha512-BX5SaksXw+pkREVw3Rw2eSNXplqZw+14CcwW/5x/4oq/C6yn5qCvKxJfM7pukJGMI4wkJPOYops7B3g27FB/HA==",
-			"optional": true
-		},
-		"@cloudflare/workerd-windows-64": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230814.1.tgz",
-			"integrity": "sha512-GWHqfyhsG/1wm2W8afkYX3q3fWXUWWD8NGtHfAs6ZVTHdW3mmYyMhKR0lc6ptBwz5i5aXRlP2S+CxxxwwDbKpw==",
-			"optional": true
 		},
 		"@cloudflare/workers-tsconfig": {
 			"version": "file:packages/workers-tsconfig"
@@ -48780,37 +49107,6 @@
 		"min-indent": {
 			"version": "1.0.1"
 		},
-		"miniflare": {
-			"version": "3.20230814.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230814.1.tgz",
-			"integrity": "sha512-LMgqd1Ut0+fnlvQepVbbBYQczQnyuuap8bgUwOyPETka0S9NR9NxMQSNaBgVZ0uOaG7xMJ/OVTRlz+TGB86PWA==",
-			"requires": {
-				"acorn": "^8.8.0",
-				"acorn-walk": "^8.2.0",
-				"better-sqlite3": "^8.1.0",
-				"capnp-ts": "^0.7.0",
-				"exit-hook": "^2.2.1",
-				"glob-to-regexp": "^0.4.1",
-				"http-cache-semantics": "^4.1.0",
-				"kleur": "^4.1.5",
-				"set-cookie-parser": "^2.6.0",
-				"source-map-support": "0.5.21",
-				"stoppable": "^1.1.0",
-				"undici": "^5.13.0",
-				"workerd": "1.20230814.1",
-				"ws": "^8.11.0",
-				"youch": "^3.2.2",
-				"zod": "^3.20.6"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "8.13.0",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-					"requires": {}
-				}
-			}
-		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -49887,11 +50183,91 @@
 			"version": "file:fixtures/pages-ws-app",
 			"requires": {
 				"@cloudflare/workers-tsconfig": "*",
-				"miniflare": "3.20230814.1",
+				"miniflare": "3.20230904.0",
 				"wrangler": "*",
 				"ws": "^8.8.0"
 			},
 			"dependencies": {
+				"@cloudflare/workerd-darwin-64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230904.0.tgz",
+					"integrity": "sha512-/GDlmxAFbDtrQwP4zOXFbqOfaPvkDxdsCoEa+KEBcAl5uR98+7WW5/b8naBHX+t26uS7p4bLlImM8J5F1ienRQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@cloudflare/workerd-darwin-arm64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230904.0.tgz",
+					"integrity": "sha512-x8WXNc2xnDqr5y1iirnNdyx8GZY3rL5xiF7ebK3mKQeB+jFjkhO71yuPTkDCzUWtOvw1Wfd4jbwy4wxacMX4mQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@cloudflare/workerd-linux-64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230904.0.tgz",
+					"integrity": "sha512-V58xyMS3oDpKO8Dpdh0r0BXm99OzoGgvWe9ufttVraj/1NTMGELwb6i9ySb8k3F1J9m/sO26+TV7pQc/bGC1VQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@cloudflare/workerd-linux-arm64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230904.0.tgz",
+					"integrity": "sha512-VrDaW+pjb5IAKEnNWtEaFiG377kXKmk5Fu0Era4W+jKzPON2BW/qRb/4LNHXQ4yxg/2HLm7RiUTn7JZtt1qO6A==",
+					"dev": true,
+					"optional": true
+				},
+				"@cloudflare/workerd-windows-64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230904.0.tgz",
+					"integrity": "sha512-/R/dE8uy+8J2YeXfDhI8/Bg7YUirdbbjH5/l/Vv00ZRE0lC3nPLcYeyBXSwXIQ6/Xht3gN+lksLQgKd0ZWRd+Q==",
+					"dev": true,
+					"optional": true
+				},
+				"miniflare": {
+					"version": "3.20230904.0",
+					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230904.0.tgz",
+					"integrity": "sha512-+OWQqEk8hV7vZaPCoj5dk1lZr4YUy56OiyNZ45/3ITYf+ZxgQOBPWhQhpw1jCahkRKGPa9Aykz01sc+GhPZYDA==",
+					"dev": true,
+					"requires": {
+						"acorn": "^8.8.0",
+						"acorn-walk": "^8.2.0",
+						"better-sqlite3": "^8.1.0",
+						"capnp-ts": "^0.7.0",
+						"exit-hook": "^2.2.1",
+						"glob-to-regexp": "^0.4.1",
+						"http-cache-semantics": "^4.1.0",
+						"kleur": "^4.1.5",
+						"source-map-support": "0.5.21",
+						"stoppable": "^1.1.0",
+						"undici": "^5.22.1",
+						"workerd": "1.20230904.0",
+						"ws": "^8.11.0",
+						"youch": "^3.2.2",
+						"zod": "^3.20.6"
+					}
+				},
+				"undici": {
+					"version": "5.23.0",
+					"resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+					"integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+					"dev": true,
+					"requires": {
+						"busboy": "^1.6.0"
+					}
+				},
+				"workerd": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230904.0.tgz",
+					"integrity": "sha512-t9znszH0rQGK4mJGvF9L3nN0qKEaObAGx0JkywFtAwH8OkSn+YfQbHNZE+YsJ4qa1hOz1DCNEk08UDFRBaYq4g==",
+					"dev": true,
+					"requires": {
+						"@cloudflare/workerd-darwin-64": "1.20230904.0",
+						"@cloudflare/workerd-darwin-arm64": "1.20230904.0",
+						"@cloudflare/workerd-linux-64": "1.20230904.0",
+						"@cloudflare/workerd-linux-arm64": "1.20230904.0",
+						"@cloudflare/workerd-windows-64": "1.20230904.0"
+					}
+				},
 				"ws": {
 					"version": "8.11.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
@@ -53732,6 +54108,7 @@
 				"@cloudflare/workers-tsconfig": "*",
 				"@hono/zod-validator": "^0.1.8",
 				"hono": "^3.5.6",
+				"wrangler": "*",
 				"zod": "^3.22.2"
 			}
 		},
@@ -53850,6 +54227,7 @@
 			"version": "5.20.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
 			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"
 			}
@@ -55023,18 +55401,6 @@
 				"wrangler": "*"
 			}
 		},
-		"workerd": {
-			"version": "1.20230814.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230814.1.tgz",
-			"integrity": "sha512-zJeSEteXuAD+bpYJT8WvzTAHvIAkKPVxOV+Jy6zCLKz5e08N3OUbAF+wrvGWc8b2aB1sj+IYsdXfkv4puH+qXQ==",
-			"requires": {
-				"@cloudflare/workerd-darwin-64": "1.20230814.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20230814.1",
-				"@cloudflare/workerd-linux-64": "1.20230814.1",
-				"@cloudflare/workerd-linux-arm64": "1.20230814.1",
-				"@cloudflare/workerd-windows-64": "1.20230814.1"
-			}
-		},
 		"workers-chat-demo": {
 			"version": "file:fixtures/workers-chat-demo"
 		},
@@ -55114,7 +55480,7 @@
 				"jest-fetch-mock": "^3.0.3",
 				"jest-websocket-mock": "^2.3.0",
 				"mime": "^3.0.0",
-				"miniflare": "3.20230814.1",
+				"miniflare": "3.20230904.0",
 				"minimatch": "^5.1.0",
 				"msw": "^0.49.1",
 				"nanoid": "^3.3.3",
@@ -55148,6 +55514,36 @@
 				"yoga-layout": "file:../../vendor/yoga-layout-2.0.0-beta.1.tgz"
 			},
 			"dependencies": {
+				"@cloudflare/workerd-darwin-64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230904.0.tgz",
+					"integrity": "sha512-/GDlmxAFbDtrQwP4zOXFbqOfaPvkDxdsCoEa+KEBcAl5uR98+7WW5/b8naBHX+t26uS7p4bLlImM8J5F1ienRQ==",
+					"optional": true
+				},
+				"@cloudflare/workerd-darwin-arm64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230904.0.tgz",
+					"integrity": "sha512-x8WXNc2xnDqr5y1iirnNdyx8GZY3rL5xiF7ebK3mKQeB+jFjkhO71yuPTkDCzUWtOvw1Wfd4jbwy4wxacMX4mQ==",
+					"optional": true
+				},
+				"@cloudflare/workerd-linux-64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230904.0.tgz",
+					"integrity": "sha512-V58xyMS3oDpKO8Dpdh0r0BXm99OzoGgvWe9ufttVraj/1NTMGELwb6i9ySb8k3F1J9m/sO26+TV7pQc/bGC1VQ==",
+					"optional": true
+				},
+				"@cloudflare/workerd-linux-arm64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230904.0.tgz",
+					"integrity": "sha512-VrDaW+pjb5IAKEnNWtEaFiG377kXKmk5Fu0Era4W+jKzPON2BW/qRb/4LNHXQ4yxg/2HLm7RiUTn7JZtt1qO6A==",
+					"optional": true
+				},
+				"@cloudflare/workerd-windows-64": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230904.0.tgz",
+					"integrity": "sha512-/R/dE8uy+8J2YeXfDhI8/Bg7YUirdbbjH5/l/Vv00ZRE0lC3nPLcYeyBXSwXIQ6/Xht3gN+lksLQgKd0ZWRd+Q==",
+					"optional": true
+				},
 				"@esbuild-plugins/node-modules-polyfill": {
 					"version": "0.2.2",
 					"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
@@ -55200,6 +55596,38 @@
 						"p-locate": "^6.0.0"
 					}
 				},
+				"miniflare": {
+					"version": "3.20230904.0",
+					"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20230904.0.tgz",
+					"integrity": "sha512-+OWQqEk8hV7vZaPCoj5dk1lZr4YUy56OiyNZ45/3ITYf+ZxgQOBPWhQhpw1jCahkRKGPa9Aykz01sc+GhPZYDA==",
+					"requires": {
+						"acorn": "^8.8.0",
+						"acorn-walk": "^8.2.0",
+						"better-sqlite3": "^8.1.0",
+						"capnp-ts": "^0.7.0",
+						"exit-hook": "^2.2.1",
+						"glob-to-regexp": "^0.4.1",
+						"http-cache-semantics": "^4.1.0",
+						"kleur": "^4.1.5",
+						"source-map-support": "0.5.21",
+						"stoppable": "^1.1.0",
+						"undici": "^5.22.1",
+						"workerd": "1.20230904.0",
+						"ws": "^8.11.0",
+						"youch": "^3.2.2",
+						"zod": "^3.20.6"
+					},
+					"dependencies": {
+						"undici": {
+							"version": "5.23.0",
+							"resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+							"integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+							"requires": {
+								"busboy": "^1.6.0"
+							}
+						}
+					}
+				},
 				"minimatch": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
@@ -55240,11 +55668,22 @@
 					"version": "9.2.2",
 					"dev": true
 				},
+				"workerd": {
+					"version": "1.20230904.0",
+					"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230904.0.tgz",
+					"integrity": "sha512-t9znszH0rQGK4mJGvF9L3nN0qKEaObAGx0JkywFtAwH8OkSn+YfQbHNZE+YsJ4qa1hOz1DCNEk08UDFRBaYq4g==",
+					"requires": {
+						"@cloudflare/workerd-darwin-64": "1.20230904.0",
+						"@cloudflare/workerd-darwin-arm64": "1.20230904.0",
+						"@cloudflare/workerd-linux-64": "1.20230904.0",
+						"@cloudflare/workerd-linux-arm64": "1.20230904.0",
+						"@cloudflare/workerd-windows-64": "1.20230904.0"
+					}
+				},
 				"ws": {
 					"version": "8.13.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
 					"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-					"dev": true,
 					"requires": {}
 				},
 				"yocto-queue": {

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -18,7 +18,7 @@
 		"test:ci": "vitest run"
 	},
 	"dependencies": {
-		"miniflare": "3.20230814.1"
+		"miniflare": "3.20230904.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "*",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -103,7 +103,7 @@
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
 		"esbuild": "0.17.19",
-		"miniflare": "3.20230814.1",
+		"miniflare": "3.20230904.0",
 		"nanoid": "^3.3.3",
 		"path-to-regexp": "^6.2.0",
 		"selfsigned": "^2.0.1",

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -1,8 +1,11 @@
 import { Blob } from "node:buffer";
 import * as fs from "node:fs";
 import * as stream from "node:stream";
-import { createFileReadableStream, R2ObjectBody, R2Object } from "miniflare";
-
+import {
+	createFileReadableStream,
+	InternalR2ObjectBody as MiniflareR2ObjectBody,
+	InternalR2Object as MiniflareR2Object,
+} from "miniflare";
 import prettyBytes from "pretty-bytes";
 import { readConfig } from "../config";
 import { FatalError } from "../errors";
@@ -85,9 +88,9 @@ export function r2(r2Yargs: CommonYargsArgv) {
 								bucket
 							);
 							const object = await gateway.get(key);
-							if (object instanceof R2ObjectBody) {
+							if (object instanceof MiniflareR2ObjectBody) {
 								input = object.body;
-							} else if (object instanceof R2Object) {
+							} else if (object instanceof MiniflareR2Object) {
 								input = object.encode().value;
 							}
 						} else {


### PR DESCRIPTION
**What this PR solves / how to test:**

Hey! 👋 This PR bumps `miniflare` to [`3.20230904.0`](https://github.com/cloudflare/miniflare/releases/tag/v3.20230904.0). Whilst this won't cause major user facing changes on its own, it's a pre-requisite for #3726 and #3774.

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ] ~~Tests~~ (passes existing)
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
