### PR TITLE
Ignore cached account id when `CLOUDFLARE_ACCOUNT_ID` is specified

### DIFF
--- a/.changeset/stupid-islands-relax.md
+++ b/.changeset/stupid-islands-relax.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Ignore cached account id when `CLOUDFLARE_ACCOUNT_ID` is specified

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -234,6 +234,7 @@ import {
 	getCloudflareAccessToken,
 	getCloudflareAPITokenFromEnv,
 	getCloudflareGlobalAuthEmailFromEnv,
+	getCloudflareAccountIdFromEnv,
 	getCloudflareGlobalAuthKeyFromEnv,
 	getRevokeUrlFromEnv,
 	getTokenUrlFromEnv,
@@ -1096,9 +1097,10 @@ export async function getAccountId(): Promise<string | undefined> {
 
 	// check if we have a cached value
 	const cachedAccount = getAccountFromCache();
-	if (cachedAccount) {
+	if (cachedAccount && !getCloudflareAccountIdFromEnv()) {
 		return cachedAccount.id;
 	}
+
 	const accounts = await getAccountChoices();
 	if (accounts.length === 1) {
 		saveAccountToCache({ id: accounts[0].id, name: accounts[0].name });


### PR DESCRIPTION
Fixes #1590 

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
