### PR TITLE
[c3] fix c3 js scheduled template to have correct main file reference.

### DIFF
--- a/.changeset/tiny-shrimps-train.md
+++ b/.changeset/tiny-shrimps-train.md
@@ -2,4 +2,4 @@
 "create-cloudflare": patch
 ---
 
-fix: update the main file to index.js in the c3 scheduled js template.
+fix: update the main file in the c3 scheduled js template to index.js.

--- a/.changeset/tiny-shrimps-train.md
+++ b/.changeset/tiny-shrimps-train.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: update the main file to index.js in the c3 scheduled js template.

--- a/packages/create-cloudflare/templates/scheduled/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/scheduled/js/wrangler.toml
@@ -1,5 +1,5 @@
 name = "<TBD>"
-main = "src/index.ts"
+main = "src/index.js"
 compatibility_date = "<TBD>"
 
 # Cron Triggers


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

#3913 

**What this PR solves / how to test:**

Create a Scheduled Worker via C3, selecting NO to TypeScript. The `main` entry in `wrangler.toml` should be `index.js`, and the project should be able to be deployed.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
