### PR TITLE
Log token info after authentication errors

### DIFF
--- a/.changeset/orange-berries-relax.md
+++ b/.changeset/orange-berries-relax.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Log more detail about tokens after authentication errors

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -37,6 +37,8 @@ import {
 	mswSuccessDeployments,
 	mswSuccessDeploymentScriptMetadata,
 	mswSuccessDeploymentScriptAPI,
+	mswSuccessOauthHandlers,
+	mswSuccessUserHandlers,
 } from "./helpers/msw";
 import { FileReaderSync } from "./helpers/msw/read-file-sync";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -373,12 +375,20 @@ describe("deploy", () => {
 			writeWorkerSource();
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();
+			mockConfirm({
+				text: "Would you like to continue?",
+				result: false,
+			});
 
 			await runWrangler("deploy ./index");
 
-			expect(std.warn).toMatch(
-				/You are about to publish a Workers Service that was last updated via the script API/
-			);
+			expect(std.warn).toMatchInlineSnapshot(`
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are about to publish a Workers Service that was last updated via the script API.[0m
+
+			  Edits that have been made via the script API will be overridden by your local code and config.
+
+			"
+		`);
 		});
 	});
 
@@ -1079,6 +1089,8 @@ Update them to point to this script instead?`,
 					],
 				});
 				writeWorkerSource();
+				mockServiceScriptData({});
+
 				await expect(
 					runWrangler("deploy ./index")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -8105,7 +8117,7 @@ export default{
 		writeWranglerToml();
 		mockSubDomainRequest();
 		mockUploadWorkerRequest();
-
+		msw.use(...mswSuccessOauthHandlers, ...mswSuccessUserHandlers);
 		msw.use(
 			rest.get(
 				"*/accounts/:accountId/workers/services/:scriptName",
@@ -8133,10 +8145,31 @@ export default{
 			)
 		);
 
-		await runWrangler("deploy index.js");
-		expect(std.err).toContain(
-			`A request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed`
+		await expect(
+			runWrangler("deploy index.js")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"A request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed."`
 		);
+		expect(std.out).toMatchInlineSnapshot(`
+		"
+		[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed.[0m
+
+		  Authentication error [code: 10000]
+
+
+		Getting User settings...
+		👋 You are logged in with an API Token, associated with the email user@example.com!
+		┌───────────────┬────────────┐
+		│ Account Name  │ Account ID │
+		├───────────────┼────────────┤
+		│ Account One   │ account-1  │
+		├───────────────┼────────────┤
+		│ Account Two   │ account-2  │
+		├───────────────┼────────────┤
+		│ Account Three │ account-3  │
+		└───────────────┴────────────┘
+		🔓 To see token permissions visit https://dash.cloudflare.com/profile/api-tokens"
+	`);
 	});
 
 	describe("queues", () => {

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -294,11 +294,8 @@ export default async function deploy(props: Props): Promise<void> {
 		} catch (e) {
 			// code: 10090, message: workers.api.error.service_not_found
 			// is thrown from the above fetchResult on the first deploy of a Worker
-			if (
-				(e as { code?: number }).code !== 10090 &&
-				(e as { code?: number }).code !== 10000
-			) {
-				logger.error(e);
+			if ((e as { code?: number }).code !== 10090) {
+				throw e;
 			}
 		}
 	}

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -294,7 +294,10 @@ export default async function deploy(props: Props): Promise<void> {
 		} catch (e) {
 			// code: 10090, message: workers.api.error.service_not_found
 			// is thrown from the above fetchResult on the first deploy of a Worker
-			if ((e as { code?: number }).code !== 10090) {
+			if (
+				(e as { code?: number }).code !== 10090 &&
+				(e as { code?: number }).code !== 10000
+			) {
 				logger.error(e);
 			}
 		}
@@ -1001,7 +1004,7 @@ async function publishRoutesFallback(
 	return deployedRoutes;
 }
 
-function isAuthenticationError(e: unknown): e is ParseError {
+export function isAuthenticationError(e: unknown): e is ParseError {
 	return e instanceof ParseError && (e as { code?: number }).code === 10000;
 }
 

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -10,6 +10,7 @@ import { constellation } from "./constellation";
 import { d1 } from "./d1";
 import { deleteHandler, deleteOptions } from "./delete";
 import { deployOptions, deployHandler } from "./deploy";
+import { isAuthenticationError } from "./deploy/deploy";
 import { isBuildFailure } from "./deployment-bundle/bundle";
 import {
 	deployments,
@@ -721,6 +722,9 @@ export async function main(argv: string[]): Promise<void> {
 			// The workaround is to re-run the parsing with an additional `--help` flag, which will result in the correct help message being displayed.
 			// The `wrangler` object is "frozen"; we cannot reuse that with different args, so we must create a new CLI parser to generate the help message.
 			await createCLIParser([...argv, "--help"]).parse();
+		} else if (isAuthenticationError(e)) {
+			logger.log(formatMessage(e));
+			await whoami();
 		} else if (e instanceof ParseError) {
 			e.notes.push({
 				text: "\nIf you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose",


### PR DESCRIPTION
Fixes #1197.

**What this PR solves / how to test:**

After the API returns an authentication error, log the token info returned by `whoami()`, to help the user diagnose the issue.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- ~[ ] Tests~
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
