### PR TITLE
Colorize Deployed Bundle Size

### DIFF
--- a/.changeset/gentle-chefs-smoke.md
+++ b/.changeset/gentle-chefs-smoke.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+Colorize Deployed Bundle Size
+Most bundlers, and other tooling that give you size outputs will colorize their the text to indicate if the value is within certain ranges.
+The current range values are:
+red 100% - 90%
+yellow 89% - 70%
+green <70%
+
+resolves #1312

--- a/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
@@ -1,5 +1,6 @@
 import { Blob } from "node:buffer";
 import { gzipSync } from "node:zlib";
+import chalk from "chalk";
 import { logger } from "../logger";
 import type { CfModule } from "./worker";
 import type { Metafile } from "esbuild";
@@ -29,7 +30,16 @@ export async function printBundleSize(
 		gzipSize / ONE_KIB_BYTES
 	).toFixed(2)} KiB`;
 
-	logger.log(`Total Upload: ${bundleReport}`);
+	const percentage = (gzipSize / ONE_MIB_BYTES) * 100;
+
+	const colorizedReport =
+		percentage > 90
+			? chalk.red(bundleReport)
+			: percentage > 70
+			? chalk.yellow(bundleReport)
+			: chalk.green(bundleReport);
+
+	logger.log(`Total Upload: ${colorizedReport}`);
 
 	if (gzipSize > ONE_MIB_BYTES && !process.env.NO_SCRIPT_SIZE_WARNING) {
 		logger.warn(

--- a/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
@@ -6,7 +6,7 @@ import type { CfModule } from "./worker";
 import type { Metafile } from "esbuild";
 
 const ONE_KIB_BYTES = 1024;
-const ALLOWED_MAX_SIZE = ONE_KIB_BYTES * ONE_KIB_BYTES * 10; // Current max is 10 MiB
+const ALLOWED_INITIAL_MAX = ONE_KIB_BYTES * 1024; // Current max is 1 MiB
 
 async function getSize(modules: CfModule[]) {
 	const gzipSize = gzipSync(
@@ -30,7 +30,7 @@ export async function printBundleSize(
 		gzipSize / ONE_KIB_BYTES
 	).toFixed(2)} KiB`;
 
-	const percentage = (gzipSize / ALLOWED_MAX_SIZE) * 100;
+	const percentage = (gzipSize / ALLOWED_INITIAL_MAX) * 100;
 
 	const colorizedReport =
 		percentage > 90
@@ -41,9 +41,9 @@ export async function printBundleSize(
 
 	logger.log(`Total Upload: ${colorizedReport}`);
 
-	if (gzipSize > ALLOWED_MAX_SIZE && !process.env.NO_SCRIPT_SIZE_WARNING) {
+	if (gzipSize > ALLOWED_INITIAL_MAX && !process.env.NO_SCRIPT_SIZE_WARNING) {
 		logger.warn(
-			"We recommend keeping your script less than 10MiB (10240 KiB) after gzip. Exceeding past this can affect cold start time"
+			"We recommend keeping your script less than 1MiB (1024 KiB) after gzip. Exceeding past this can affect cold start time"
 		);
 	}
 }

--- a/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
@@ -6,7 +6,7 @@ import type { CfModule } from "./worker";
 import type { Metafile } from "esbuild";
 
 const ONE_KIB_BYTES = 1024;
-const ONE_MIB_BYTES = ONE_KIB_BYTES * 1024;
+const ALLOWED_MAX_SIZE = ONE_KIB_BYTES * ONE_KIB_BYTES * 10; // Current max is 10 MiB
 
 async function getSize(modules: CfModule[]) {
 	const gzipSize = gzipSync(
@@ -30,7 +30,7 @@ export async function printBundleSize(
 		gzipSize / ONE_KIB_BYTES
 	).toFixed(2)} KiB`;
 
-	const percentage = (gzipSize / ONE_MIB_BYTES) * 100;
+	const percentage = (gzipSize / ALLOWED_MAX_SIZE) * 100;
 
 	const colorizedReport =
 		percentage > 90
@@ -41,9 +41,9 @@ export async function printBundleSize(
 
 	logger.log(`Total Upload: ${colorizedReport}`);
 
-	if (gzipSize > ONE_MIB_BYTES && !process.env.NO_SCRIPT_SIZE_WARNING) {
+	if (gzipSize > ALLOWED_MAX_SIZE && !process.env.NO_SCRIPT_SIZE_WARNING) {
 		logger.warn(
-			"We recommend keeping your script less than 1MiB (1024 KiB) after gzip. Exceeding past this can affect cold start time"
+			"We recommend keeping your script less than 10MiB (10240 KiB) after gzip. Exceeding past this can affect cold start time"
 		);
 	}
 }


### PR DESCRIPTION
Most bundlers, and other tooling that give you size outputs will colorize their the text to indicate if the value is within certain ranges.

<img width="401" alt="Screenshot 2023-09-12 at 10 03 17 AM" src="https://github.com/cloudflare/workers-sdk/assets/27247160/dbd070fe-5e7c-4218-ad7b-eaee38ef0bf8">


Fixes #1312
