### PR TITLE
fix: remove unused env variable from sveltekit template

### DIFF
--- a/.changeset/modern-needles-develop.md
+++ b/.changeset/modern-needles-develop.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: remove unused env variable from sveltekit project template

--- a/packages/create-cloudflare/src/frameworks/svelte/index.ts
+++ b/packages/create-cloudflare/src/frameworks/svelte/index.ts
@@ -73,7 +73,7 @@ const config: FrameworkConfig = {
 	displayName: "Svelte",
 	packageScripts: {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --proxy 5173 -- ${npm} run dev`,
-		"pages:deploy": `NODE_VERSION=16 ${npm} run build && wrangler pages deploy .svelte-kit/cloudflare`,
+		"pages:deploy": `${npm} run build && wrangler pages deploy .svelte-kit/cloudflare`,
 	},
 };
 export default config;


### PR DESCRIPTION
remove NODE_VERSION env variable from sveltekit template - this variable is unused and only creates confusion.

Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
