### PR TITLE
Output .npmrc in CI release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
 
+      - name: Setup npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+
       - name: Create Version PR or Publish to NPM
         id: changesets
         uses: changesets/action@v1

--- a/packages/create-cloudflare/.npmrc
+++ b/packages/create-cloudflare/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}

--- a/packages/wrangler/.npmrc
+++ b/packages/wrangler/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}


### PR DESCRIPTION
**What this PR solves / how to test:**
We switched to pnpm but the CI publish job doesn't seem to pick up our auth token anymore. Currently our `.npmrc` files that configure the auth token are nested within the workspaces. This PR outputs the `.npmrc` at the root-level during the CI release job.

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested