### PR TITLE
Add auth token to root .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 git-checks=false

--- a/packages/create-cloudflare/.npmrc
+++ b/packages/create-cloudflare/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}

--- a/packages/wrangler/.npmrc
+++ b/packages/wrangler/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}


### PR DESCRIPTION
**What this PR solves / how to test:**
This PR attempts to fix pnpm publishing, following up from the first attempt in https://github.com/cloudflare/workers-sdk/pull/3943.

`changesets/action` creates a `.npmrc` file at the root with the auth token pulled from an `$NPM_TOKEN` environment variable. However, if there's already a `.npmrc` at the root it skips this step. We introduced a new `.npmrc` file at the root in https://github.com/cloudflare/workers-sdk/pull/3899/files#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35de so our publish job no longer had the proper auth token.

I also suspect the `.npmrc` files within the `wrangler` and `create-cloudflare` workspaces weren't actually being used during publish. Note that the workflow runner environment doesn't have an environment variable called `$NPM_PUBLISH_TOKEN`.

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
