### PR TITLE
rename `NPM_TOKEN` to `NPM_PUBLISH_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           publish: pnpm exec changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
           NODE_ENV: "production"

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}
 git-checks=false


### PR DESCRIPTION
**What this PR solves / how to test:**
This PR follows https://github.com/cloudflare/workers-sdk/pull/3945. The change in that PR ended up breaking a bunch of our prerelease workflows that were expecting the `.npmrc` auth token to get populated by `$NPM_PUBLISH_TOKEN`.

We previously were using `NPM_TOKEN` in our `changeset publish` step because that's the name of the env var used in the `.npmrc` file that `changeset/action` [produced for us](https://github.com/changesets/action#with-publishing:~:text=By%20default%20the%20GitHub%20Action%20creates%20a%20.npmrc%20file%20with%20the%20following%20content%3A). Now that we're using our own `.npmrc` file instead of the one it generates for us, we're free to name it whatever. Our prerelease workflows already expect `NPM_PUBLISH_TOKEN`, as well as that being the name of the github secret, so it's easiest to just change the name in our release step and `.npmrc` file to match.

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
