### PR TITLE
Add dummy NPM_PUBLISH_TOKEN to pacify yarn

### DIFF
--- a/.github/workflows/quick-edit.yml
+++ b/.github/workflows/quick-edit.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Build Quick Edit
         run: cd packages/quick-edit && yarn setup && yarn custom:build
+        env:
+          NPM_PUBLISH_TOKEN: NOT_USED # yarn will error if the env var from .npmrc can't be interpolated
 
       - name: Publish Quick Edit
         run: pnpm --filter quick-edit run publish


### PR DESCRIPTION
**What this PR solves / how to test:**

Yarn [throws errors](https://github.com/cloudflare/workers-sdk/actions/runs/6178131477/job/16770757056#step:8:8) if it finds an .npmrc file with a var substitution for an env var that doesn't exist. Now that we have a root-level .npmrc, we need to provide a dummy env var value to prevent this.

**Associated docs issue(s)/PR(s):**

Follows https://github.com/cloudflare/workers-sdk/pull/3945 and https://github.com/cloudflare/workers-sdk/pull/3946

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested