### PR TITLE
Improve loading in Playground

### DIFF
--- a/packages/workers-playground/src/QuickEditor/PreviewTab/PreviewTab.tsx
+++ b/packages/workers-playground/src/QuickEditor/PreviewTab/PreviewTab.tsx
@@ -6,6 +6,7 @@ import { ServiceContext } from "../QuickEditor";
 import FrameErrorBoundary, { FrameError } from "../FrameErrorBoundary";
 import { useRefreshableIframe } from "./useRefreshableIframe";
 import { theme } from "@cloudflare/style-const";
+import { Loading } from "@cloudflare/component-loading";
 
 export function getPreviewIframeUrl(edgePreview: string, previewUrl: string) {
 	const url = new URL(edgePreview);
@@ -30,7 +31,7 @@ function PreviewTab() {
 		draftWorker.service?.modules
 	);
 
-	const { isLoading, frame, refresh } = useRefreshableIframe(
+	const { isLoading, frame, refresh, firstLoad } = useRefreshableIframe(
 		previewSrc,
 		onLoad
 	);
@@ -47,6 +48,21 @@ function PreviewTab() {
 				}}
 				loading={isLoading}
 			/>
+			{!firstLoad && (
+				<Div
+					zIndex={1000}
+					p={2}
+					position="relative"
+					height="100%"
+					display="flex"
+					gap={2}
+					backgroundColor="white"
+					justifyContent={"center"}
+					alignItems={"center"}
+				>
+					<Loading size="4x" />
+				</Div>
+			)}
 			<Div
 				flex="1"
 				position="relative"

--- a/packages/workers-playground/src/QuickEditor/PreviewTab/useRefreshableIframe.tsx
+++ b/packages/workers-playground/src/QuickEditor/PreviewTab/useRefreshableIframe.tsx
@@ -18,6 +18,8 @@ export function useRefreshableIframe(
 
 	const [isLoadingContent, setIsLoadingContent] = useState(false);
 
+	const [firstLoad, setFirstLoad] = useState(false);
+
 	useEffect(() => {
 		function onLoadEvent(this: HTMLIFrameElement) {
 			onLoad(this);
@@ -35,6 +37,7 @@ export function useRefreshableIframe(
 	}, [onLoad]);
 
 	function listen() {
+		!firstLoad && setFirstLoad(true);
 		requestAnimationFrame(() => {
 			setIndex(index === 0 ? 1 : 0);
 			setIsLoadingContent(false);
@@ -61,6 +64,7 @@ export function useRefreshableIframe(
 	}, [src]);
 	const isLoading = isLoadingContent;
 	return {
+		firstLoad,
 		isLoading,
 		refresh() {
 			if (src) {

--- a/packages/workers-playground/src/QuickEditor/VSCodeEditor.tsx
+++ b/packages/workers-playground/src/QuickEditor/VSCodeEditor.tsx
@@ -169,21 +169,11 @@ export function VSCodeEditor({ content, onChange }: Props) {
 					height="100%"
 					display="flex"
 					gap={2}
-					backgroundColor="white"
+					backgroundColor={isDarkMode() ? "#313131" : "white"}
 					justifyContent={"center"}
 					alignItems={"center"}
 				>
 					<Loading size="4x" />
-					{/* <SkeletonBlock width={48} height="100%"></SkeletonBlock>
-					<Div
-						width="calc(100% - 56px)"
-						display="flex"
-						flexDirection="column"
-						gap={2}
-					>
-						<SkeletonBlock height={32}></SkeletonBlock>
-						<CodeLoading></CodeLoading>
-					</Div> */}
 				</Div>
 			)}
 		</Div>


### PR DESCRIPTION
Fixes DEVX-911

**What this PR solves / how to test:**

* Use a softer grey as the VSCode loading background
* Show a loading spinner until the preview pane has loaded once

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
