### PR TITLE
Ensure `pointer-events: none` is applied to iframes

### DIFF
--- a/packages/workers-playground/src/QuickEditor/DevtoolsIframe.tsx
+++ b/packages/workers-playground/src/QuickEditor/DevtoolsIframe.tsx
@@ -3,6 +3,7 @@ import React, { useContext } from "react";
 import { ServiceContext } from "./QuickEditor";
 import Frame from "./Frame";
 import FrameErrorBoundary from "./FrameErrorBoundary";
+import { DragContext } from "./SplitPane";
 
 function getDevtoolsIframeUrl(inspectorUrl: string) {
 	const url = new URL(`https://devtools.devprod.cloudflare.dev/js_app`);
@@ -15,9 +16,11 @@ function getDevtoolsIframeUrl(inspectorUrl: string) {
 
 export function DevtoolsIframe() {
 	const draftWorker = useContext(ServiceContext);
+	const isPaneDragging = useContext(DragContext);
 
 	return draftWorker?.devtoolsUrl ? (
 		<Frame
+			style={isPaneDragging ? { pointerEvents: "none" } : {}}
 			src={getDevtoolsIframeUrl(draftWorker.devtoolsUrl)}
 			sandbox="allow-scripts allow-same-origin"
 		/>

--- a/packages/workers-playground/src/QuickEditor/PreviewTab/useRefreshableIframe.tsx
+++ b/packages/workers-playground/src/QuickEditor/PreviewTab/useRefreshableIframe.tsx
@@ -1,5 +1,12 @@
 import Frame from "../Frame";
-import { useState, useRef, useLayoutEffect, useEffect } from "react";
+import {
+	useState,
+	useRef,
+	useLayoutEffect,
+	useEffect,
+	useContext,
+} from "react";
+import { DragContext } from "../SplitPane";
 
 /**
  * A wrapper around an iframe that loads any changes to the src in the background,
@@ -10,6 +17,7 @@ export function useRefreshableIframe(
 	src: string | undefined,
 	onLoad: (frame: HTMLIFrameElement) => void
 ) {
+	const isPaneDragging = useContext(DragContext);
 	const refs = [
 		useRef<HTMLIFrameElement>(null),
 		useRef<HTMLIFrameElement>(null),
@@ -74,7 +82,7 @@ export function useRefreshableIframe(
 					style={{
 						background: "white",
 						zIndex: index === 0 ? 10 : 5,
-						pointerEvents: isLoading ? "none" : "auto",
+						pointerEvents: isLoading || isPaneDragging ? "none" : "auto",
 					}}
 					sandbox="allow-forms allow-modals allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox"
 				/>
@@ -83,7 +91,7 @@ export function useRefreshableIframe(
 					style={{
 						background: "white",
 						zIndex: index === 1 ? 10 : 5,
-						pointerEvents: isLoading ? "none" : "auto",
+						pointerEvents: isLoading || isPaneDragging ? "none" : "auto",
 					}}
 					sandbox="allow-forms allow-modals allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox"
 				/>

--- a/packages/workers-playground/src/QuickEditor/VSCodeEditor.tsx
+++ b/packages/workers-playground/src/QuickEditor/VSCodeEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { Loading } from "@cloudflare/component-loading";
 
 import {
@@ -12,6 +12,7 @@ import Frame from "./Frame";
 import { Div } from "@cloudflare/elements";
 import { TypedModule } from "./useDraftWorker";
 import { isDarkMode } from "@cloudflare/style-const";
+import { DragContext } from "./SplitPane";
 
 function stripSlashPrefix(path: string) {
 	return path[0] === "/" ? path.slice(1) : path;
@@ -56,6 +57,8 @@ type Props = {
  */
 export function VSCodeEditor({ content, onChange }: Props) {
 	const editor = useRef<HTMLIFrameElement>(null);
+	const isPaneDragging = useContext(DragContext);
+
 	const [quickEdit, setQuickEdit] = useState<WrappedChannel<
 		ToQuickEditMessage,
 		FromQuickEditMessage
@@ -158,6 +161,7 @@ export function VSCodeEditor({ content, onChange }: Props) {
 		<Div position="relative">
 			<Frame
 				innerRef={editor}
+				style={isPaneDragging ? { pointerEvents: "none" } : {}}
 				src={constructVSCodeURL("workers-playground", quickEditHost)}
 				sandbox="allow-same-origin allow-scripts"
 			></Frame>
@@ -174,16 +178,6 @@ export function VSCodeEditor({ content, onChange }: Props) {
 					alignItems={"center"}
 				>
 					<Loading size="4x" />
-					{/* <SkeletonBlock width={48} height="100%"></SkeletonBlock>
-					<Div
-						width="calc(100% - 56px)"
-						display="flex"
-						flexDirection="column"
-						gap={2}
-					>
-						<SkeletonBlock height={32}></SkeletonBlock>
-						<CodeLoading></CodeLoading>
-					</Div> */}
 				</Div>
 			)}
 		</Div>


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

When dragging around the split pane view, we previously applied `pointer-events: none` to the _parents_ of rendered iframes (because iframes capture the pointer events and cause odd dragging behaviour). However, it turns out this doesn't capture all cases, and so this PR ensure that `pointer-events: none` is always applied to the actual iframes themselves.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
