### PR TITLE
Use PAT for changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
+          # See https://github.com/changesets/action/issues/187
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: 0
       - uses: pnpm/action-setup@v2
         with:
@@ -49,7 +51,7 @@ jobs:
           version: node .github/changeset-version.js
           publish: pnpm exec changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}


### PR DESCRIPTION
See https://github.com/changesets/action/issues/187

**What this PR solves / how to test:**

We use Changesets to manage releases in this repo. It creates a PR, which when merged will kick off an NPM release. Unfortunately, when changesets pushed to that PR, checks weren't triggered (since changesets is a bot user). This change makes changesets use a PAT for the repo.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
