### PR TITLE
Support uploading batches of ndjson vectors from a source file

### DIFF
--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -21,6 +21,7 @@ describe("vectorize", () => {
 		  wrangler vectorize delete <name>  Delete a Vectorize index
 		  wrangler vectorize get <name>     Get a Vectorize index by name
 		  wrangler vectorize list           List your Vectorize indexes
+		  wrangler vectorize insert <name>  Insert vectors into a Vectorize index
 
 		Flags:
 		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
@@ -59,6 +60,7 @@ describe("vectorize", () => {
 		  wrangler vectorize delete <name>  Delete a Vectorize index
 		  wrangler vectorize get <name>     Get a Vectorize index by name
 		  wrangler vectorize list           List your Vectorize indexes
+		  wrangler vectorize insert <name>  Insert vectors into a Vectorize index
 
 		Flags:
 		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
@@ -1,0 +1,155 @@
+import { writeFileSync } from "node:fs";
+import { MockedRequest, rest, type RestRequest } from "msw";
+import { FormData } from "undici";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { msw } from "../helpers/msw";
+import { FileReaderSync } from "../helpers/msw/read-file-sync";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import type { VectorizeVector } from "@cloudflare/workers-types";
+
+describe("dataset upsert", () => {
+	const std = mockConsoleMethods();
+
+	runInTempDir();
+	mockAccountId();
+	mockApiToken();
+
+	const testVectors: VectorizeVector[] = [
+		{
+			id: "b0daca4a-ffd8-4865-926b-e24800af2a2d",
+			values: [0.2331, 1.0125, 0.6131, 0.9421, 0.9661, 0.8121],
+			metadata: { text: "She sells seashells by the seashore" },
+		},
+		{
+			id: "a44706aa-a366-48bc-8cc1-3feffd87d548",
+			values: [0.2321, 0.8121, 0.6315, 0.6151, 0.4121, 0.1512],
+			metadata: { text: "Peter Piper picked a peck of pickled peppers" },
+		},
+		{
+			id: "43cfcb31-07e2-411f-8bf9-f82a95ba8b96",
+			values: [0.0515, 0.7512, 0.8612, 0.2153, 0.1521, 0.6812],
+			metadata: {
+				text: "You know New York, you need New York, you know you need unique New York",
+			},
+		},
+		{
+			id: "15cc795d-93d3-416d-9a2a-36fa6fac73da",
+			values: [0.8525, 0.7751, 0.6326, 0.1512, 0.9655, 0.6626],
+			metadata: { text: "He threw three free throws" },
+		},
+		{
+			id: "15cc795d-93d3-416d-9a2a-36fa6fac73da",
+			values: [0.6323, 0.1111, 0.5136, 0.7512, 0.6632, 0.5254],
+			metadata: { text: "Which witch is which?" },
+		},
+	];
+
+	it("should batch uploads in ndjson format", async () => {
+		writeFileSync(
+			"vectors.ndjson",
+			testVectors.map((v) => JSON.stringify(v)).join(`\n`)
+		);
+
+		const batchSize = 3;
+		let insertRequestCount = 0;
+		msw.use(
+			rest.post(
+				"*/vectorize/indexes/:indexName/insert",
+				async (req, res, ctx) => {
+					expect(req.params.indexName).toEqual("my-index");
+					expect(req.headers.get("Content-Type")).toBe("multipart/form-data");
+					const formData = await (req as RestRequestWithFormData).formData();
+					const vectors = formData.get("vectors") as string;
+
+					if (insertRequestCount === 0) {
+						expect(formData).toMatchInlineSnapshot(`
+				FormData {
+				  Symbol(state): Array [
+				    Object {
+				      "name": "vectors",
+				      "value": "{\\"id\\":\\"b0daca4a-ffd8-4865-926b-e24800af2a2d\\",\\"values\\":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121],\\"metadata\\":{\\"text\\":\\"She sells seashells by the seashore\\"}}
+				{\\"id\\":\\"a44706aa-a366-48bc-8cc1-3feffd87d548\\",\\"values\\":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512],\\"metadata\\":{\\"text\\":\\"Peter Piper picked a peck of pickled peppers\\"}}
+				{\\"id\\":\\"43cfcb31-07e2-411f-8bf9-f82a95ba8b96\\",\\"values\\":[0.0515,0.7512,0.8612,0.2153,0.1521,0.6812],\\"metadata\\":{\\"text\\":\\"You know New York, you need New York, you know you need unique New York\\"}}",
+				    },
+				  ],
+				}
+			`);
+					} else {
+						expect(formData).toMatchInlineSnapshot(`
+				FormData {
+				  Symbol(state): Array [
+				    Object {
+				      "name": "vectors",
+				      "value": "{\\"id\\":\\"15cc795d-93d3-416d-9a2a-36fa6fac73da\\",\\"values\\":[0.8525,0.7751,0.6326,0.1512,0.9655,0.6626],\\"metadata\\":{\\"text\\":\\"He threw three free throws\\"}}
+				{\\"id\\":\\"15cc795d-93d3-416d-9a2a-36fa6fac73da\\",\\"values\\":[0.6323,0.1111,0.5136,0.7512,0.6632,0.5254],\\"metadata\\":{\\"text\\":\\"Which witch is which?\\"}}",
+				    },
+				  ],
+				}
+			`);
+					}
+					insertRequestCount++;
+
+					return res(
+						ctx.status(200),
+						ctx.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: { count: vectors.split(`\n`).length },
+						})
+					);
+				}
+			)
+		);
+
+		await runWrangler(
+			`vectorize insert my-index --file vectors.ndjson --batch-size ${batchSize}`
+		);
+
+		expect(insertRequestCount).toBe(2);
+		expect(std.out).toMatchInlineSnapshot(`
+		"✨ Uploading vector batch (3 vectors)
+		✨ Uploading vector batch (2 vectors)
+		{
+		  \\"count\\": 5
+		}"
+	`);
+	});
+});
+
+FormData.prototype.toString = mockFormDataToString;
+export interface RestRequestWithFormData extends MockedRequest, RestRequest {
+	formData(): Promise<FormData>;
+}
+(MockedRequest.prototype as RestRequestWithFormData).formData =
+	mockFormDataFromString;
+
+function mockFormDataToString(this: FormData) {
+	const entries = [];
+	for (const [key, value] of this.entries()) {
+		if (value instanceof Blob) {
+			const reader = new FileReaderSync();
+			reader.readAsText(value);
+			const result = reader.result;
+			entries.push([key, result]);
+		} else {
+			entries.push([key, value]);
+		}
+	}
+	return JSON.stringify({
+		__formdata: entries,
+	});
+}
+
+async function mockFormDataFromString(this: MockedRequest): Promise<FormData> {
+	const { __formdata } = await this.json();
+	expect(__formdata).toBeInstanceOf(Array);
+
+	const form = new FormData();
+	for (const [key, value] of __formdata) {
+		form.set(key, value);
+	}
+	return form;
+}

--- a/packages/wrangler/src/vectorize/client.ts
+++ b/packages/wrangler/src/vectorize/client.ts
@@ -9,6 +9,7 @@ import type {
 	VectorizeVector,
 	VectorizeVectorMutation,
 } from "@cloudflare/workers-types";
+import type { FormData } from "undici";
 
 const jsonContentType = "application/json; charset=utf-8;";
 
@@ -97,14 +98,18 @@ export async function updateIndex(
 export async function insertIntoIndex(
 	config: Config,
 	indexName: string,
-	vectors: Array<VectorizeVector>
+	body: FormData
 ): Promise<VectorizeVectorMutation> {
 	const accountId = await requireAuth(config);
+
 	return await fetchResult(
 		`/accounts/${accountId}/vectorize/indexes/${indexName}/insert`,
 		{
 			method: "POST",
-			body: JSON.stringify(vectors),
+			headers: {
+				"Content-Type": "multipart/form-data",
+			},
+			body: body,
 		}
 	);
 }
@@ -112,14 +117,18 @@ export async function insertIntoIndex(
 export async function upsertIntoIndex(
 	config: Config,
 	indexName: string,
-	vectors: VectorizeVector[]
+	body: FormData
 ): Promise<VectorizeVectorMutation> {
 	const accountId = await requireAuth(config);
+
 	return await fetchResult(
 		`/accounts/${accountId}/vectorize/indexes/${indexName}/upsert`,
 		{
 			method: "POST",
-			body: JSON.stringify(vectors),
+			headers: {
+				"Content-Type": "multipart/form-data",
+			},
+			body: body,
 		}
 	);
 }

--- a/packages/wrangler/src/vectorize/index.ts
+++ b/packages/wrangler/src/vectorize/index.ts
@@ -2,6 +2,7 @@ import { vectorizeBetaWarning } from "./common";
 import { options as createOptions, handler as createHandler } from "./create";
 import { options as deleteOptions, handler as deleteHandler } from "./delete";
 import { options as getOptions, handler as getHandler } from "./get";
+import { options as insertOptions, handler as insertHandler } from "./insert";
 import { options as listOptions, handler as listHandler } from "./list";
 import type { CommonYargsArgv } from "../yargs-types";
 
@@ -34,12 +35,12 @@ export function vectorize(yargs: CommonYargsArgv) {
 			// 	queryOptions,
 			// 	queryHandler
 			// )
-			// .command(
-			// 	"insert <name>",
-			// 	"Insert vectors into a Vectorize index",
-			// 	insertOptions,
-			// 	insertHandler
-			// )
+			.command(
+				"insert <name>",
+				"Insert vectors into a Vectorize index",
+				insertOptions,
+				insertHandler
+			)
 			.epilogue(vectorizeBetaWarning)
 	);
 }

--- a/packages/wrangler/src/vectorize/insert.ts
+++ b/packages/wrangler/src/vectorize/insert.ts
@@ -1,3 +1,5 @@
+import { type FileHandle, open } from "node:fs/promises";
+import { File, FormData } from "undici";
 import { readConfig } from "../config";
 import { logger } from "../logger";
 import { insertIntoIndex } from "./client";
@@ -6,7 +8,11 @@ import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
-import type { VectorizeVector } from "@cloudflare/workers-types";
+import type { VectorizeVectorMutation } from "@cloudflare/workers-types";
+
+type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+const VECTORIZE_UPSERT_BATCH_SIZE = 5_000;
+const VECTORIZE_MAX_UPSERT_VECTOR_RECORDS = 100_000;
 
 export function options(yargs: CommonYargsArgv) {
 	return yargs
@@ -16,11 +22,17 @@ export function options(yargs: CommonYargsArgv) {
 			description: "The name of the Vectorize index.",
 		})
 		.options({
-			vectors: {
-				type: "array",
-				demandOption: true,
+			file: {
 				describe:
-					"An array of one or more vectors in JSON format to insert into the index",
+					"A file containing line separated json (ndjson) vector objects.",
+				demandOption: true,
+				type: "string",
+			},
+			"batch-size": {
+				describe:
+					"Number of vector records to include when sending to the Cloudflare API.",
+				type: "number",
+				default: VECTORIZE_UPSERT_BATCH_SIZE,
 			},
 		})
 		.epilogue(vectorizeBetaWarning);
@@ -30,13 +42,42 @@ export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
 	const config = readConfig(args.config, args);
+	const file = await open(args.file);
 
-	const vectors: VectorizeVector[] = [];
-	if (args.vectors) {
-		// Parse each vector into a Vector type
-		// Think about potential limits on args.vectors.length?
+	let index: Optional<VectorizeVectorMutation, "ids"> | undefined;
+	for await (const batch of getBatchFromFile(file, args.batchSize)) {
+		const formData = new FormData();
+		formData.append("vectors", new File([batch.join(`\n`)], "vectors.ndjson"));
+		logger.log(`✨ Uploading vector batch (${batch.length} vectors)`);
+		const idxPart = await insertIntoIndex(config, args.name, formData);
+		if (!index) index = idxPart;
+		else index.count += idxPart.count;
+
+		if (index.count > VECTORIZE_MAX_UPSERT_VECTOR_RECORDS) {
+			logger.warn(
+				`🚧 While Vectorize is in beta, we've limited uploads to 100k vectors`
+			);
+			logger.warn(
+				`🚧 You may run this again with another batch to upload further`
+			);
+			break;
+		}
 	}
 
-	const index = await insertIntoIndex(config, args.name, vectors);
+	// remove the ids - skip tracking these for bulk uploads since this could be in the 100s of thousands.
+	if (index) delete index.ids;
 	logger.log(JSON.stringify(index, null, 2));
+}
+
+// helper method that reads an ndjson file line by line in batches. not this doesn't
+// actually do any parsing - that will be handled on the backend
+async function* getBatchFromFile(file: FileHandle, batchSize = 3) {
+	let batch: string[] = [];
+	for await (const line of file.readLines()) {
+		if (batch.push(line) >= batchSize) {
+			yield batch;
+			batch = [];
+		}
+	}
+	yield batch;
 }


### PR DESCRIPTION
Extends the Vectorize wrangler support work to allow uploading vectors from a file source.

**What this PR solves / how to test:**

We want to improve the Vector Store onboarding for our customers by allowing them an easy way to source vectors. This vector files may be quite big (100s of MB - GB). This supports a streaming approach to reading and loading these files in an efficient manner.

- [x] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
