### PR TITLE
C3: update templates to have `dev` command as index comments imply

### DIFF
--- a/.changeset/seven-zebras-cross.md
+++ b/.changeset/seven-zebras-cross.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Fixes Workers templates to have a `dev` command in package.json to match comments in `index` files.

--- a/packages/create-cloudflare/templates/chatgptPlugin/ts/package.json
+++ b/packages/create-cloudflare/templates/chatgptPlugin/ts/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"dependencies": {
 		"@cloudflare/itty-router-openapi": "^1.0.1"

--- a/packages/create-cloudflare/templates/chatgptPlugin/ts/package.json
+++ b/packages/create-cloudflare/templates/chatgptPlugin/ts/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"dependencies": {
 		"@cloudflare/itty-router-openapi": "^1.0.1"

--- a/packages/create-cloudflare/templates/common/js/package.json
+++ b/packages/create-cloudflare/templates/common/js/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"devDependencies": {
 		"itty-router": "^3.0.12",

--- a/packages/create-cloudflare/templates/common/js/package.json
+++ b/packages/create-cloudflare/templates/common/js/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"devDependencies": {
 		"itty-router": "^3.0.12",

--- a/packages/create-cloudflare/templates/common/ts/package.json
+++ b/packages/create-cloudflare/templates/common/ts/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230419.0",

--- a/packages/create-cloudflare/templates/common/ts/package.json
+++ b/packages/create-cloudflare/templates/common/ts/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230419.0",

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"devDependencies": {
 		"wrangler": "^3.0.0"

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"devDependencies": {
 		"wrangler": "^3.0.0"

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230419.0",

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230419.0",

--- a/packages/create-cloudflare/templates/openapi/ts/package.json
+++ b/packages/create-cloudflare/templates/openapi/ts/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"dependencies": {
 		"@cloudflare/itty-router-openapi": "^1.0.1"

--- a/packages/create-cloudflare/templates/openapi/ts/package.json
+++ b/packages/create-cloudflare/templates/openapi/ts/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"dependencies": {
 		"@cloudflare/itty-router-openapi": "^1.0.1"

--- a/packages/create-cloudflare/templates/queues/js/package.json
+++ b/packages/create-cloudflare/templates/queues/js/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"devDependencies": {
 		"wrangler": "^3.0.0"

--- a/packages/create-cloudflare/templates/queues/js/package.json
+++ b/packages/create-cloudflare/templates/queues/js/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"devDependencies": {
 		"wrangler": "^3.0.0"

--- a/packages/create-cloudflare/templates/queues/ts/package.json
+++ b/packages/create-cloudflare/templates/queues/ts/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230419.0",

--- a/packages/create-cloudflare/templates/queues/ts/package.json
+++ b/packages/create-cloudflare/templates/queues/ts/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230419.0",

--- a/packages/create-cloudflare/templates/scheduled/js/package.json
+++ b/packages/create-cloudflare/templates/scheduled/js/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"devDependencies": {
 		"wrangler": "^3.0.0"

--- a/packages/create-cloudflare/templates/scheduled/js/package.json
+++ b/packages/create-cloudflare/templates/scheduled/js/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"devDependencies": {
 		"wrangler": "^3.0.0"

--- a/packages/create-cloudflare/templates/scheduled/ts/package.json
+++ b/packages/create-cloudflare/templates/scheduled/ts/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"start": "wrangler dev"
+		"dev": "wrangler dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230419.0",

--- a/packages/create-cloudflare/templates/scheduled/ts/package.json
+++ b/packages/create-cloudflare/templates/scheduled/ts/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev",
+		"start": "wrangler dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230419.0",


### PR DESCRIPTION
Fixes #3669 .

**What this PR solves / how to test:**

All Workers templates created via C3 should support `npm run dev` as an alias for `wrangler dev` to match comments in `index` files.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
