### PR TITLE
[playground] Fix dark mode in Chrome

### DIFF
--- a/packages/workers-playground/src/QuickEditor/PreviewTab/useRefreshableIframe.tsx
+++ b/packages/workers-playground/src/QuickEditor/PreviewTab/useRefreshableIframe.tsx
@@ -84,7 +84,7 @@ export function useRefreshableIframe(
 				<Frame
 					innerRef={refs[0]}
 					style={{
-						background: "white",
+						opacity: index === 0 ? 1 : 0,
 						zIndex: index === 0 ? 10 : 5,
 						pointerEvents: isLoading || isPaneDragging ? "none" : "auto",
 					}}
@@ -93,7 +93,7 @@ export function useRefreshableIframe(
 				<Frame
 					innerRef={refs[1]}
 					style={{
-						background: "white",
+						opacity: index === 1 ? 1 : 0,
 						zIndex: index === 1 ? 10 : 5,
 						pointerEvents: isLoading || isPaneDragging ? "none" : "auto",
 					}}


### PR DESCRIPTION
**What this PR solves / how to test:**
- Chrome uses a dark-mode page for non-html content by default, which was showing as white-on-white

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
