### PR TITLE
vectorize: fix preset/model property

### DIFF
--- a/.changeset/fresh-poems-pump.md
+++ b/.changeset/fresh-poems-pump.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fixed a bug in Vectorize that send preset configurations with the wrong key. This was patched on the server-side to work around this for users in the meantime.

--- a/packages/wrangler/src/vectorize/create.tsx
+++ b/packages/wrangler/src/vectorize/create.tsx
@@ -69,7 +69,7 @@ export async function handler(
 
 	let indexConfig;
 	if (args.preset) {
-		indexConfig = { model: args.preset as VectorizePreset };
+		indexConfig = { preset: args.preset as VectorizePreset };
 		logger.log(
 			`Configuring index based for the embedding model ${args.preset}.`
 		);


### PR DESCRIPTION
This PR fixes drift between the server and wrangler on the `preset` field. In the meantime, we will accept both `preset` and `model`.

- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
