### PR TITLE
[create_cloudflare/templates] Update instructions to use correct npm command to start dev server

### DIFF
--- a/packages/create-cloudflare/templates/common/js/src/index.js
+++ b/packages/create-cloudflare/templates/common/js/src/index.js
@@ -1,7 +1,7 @@
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
- * - Run `npm run dev` in your terminal to start a development server
+ * - Run `npm run start` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *

--- a/packages/create-cloudflare/templates/common/ts/src/index.ts
+++ b/packages/create-cloudflare/templates/common/ts/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
- * - Run `npm run dev` in your terminal to start a development server
+ * - Run `npm run start` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *

--- a/packages/create-cloudflare/templates/hello-world/js/src/index.js
+++ b/packages/create-cloudflare/templates/hello-world/js/src/index.js
@@ -1,7 +1,7 @@
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
- * - Run `npm run dev` in your terminal to start a development server
+ * - Run `npm run start` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *

--- a/packages/create-cloudflare/templates/hello-world/ts/src/index.ts
+++ b/packages/create-cloudflare/templates/hello-world/ts/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
- * - Run `npm run dev` in your terminal to start a development server
+ * - Run `npm run start` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *

--- a/packages/create-cloudflare/templates/queues/js/src/index.js
+++ b/packages/create-cloudflare/templates/queues/js/src/index.js
@@ -4,7 +4,7 @@
  * This is a template for a Queue consumer: a Worker that can consume from a
  * Queue: https://developers.cloudflare.com/queues/get-started/
  *
- * - Run `npm run dev` in your terminal to start a development server
+ * - Run `npm run start` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *

--- a/packages/create-cloudflare/templates/queues/ts/src/index.ts
+++ b/packages/create-cloudflare/templates/queues/ts/src/index.ts
@@ -4,7 +4,7 @@
  * This is a template for a Queue consumer: a Worker that can consume from a
  * Queue: https://developers.cloudflare.com/queues/get-started/
  *
- * - Run `npm run dev` in your terminal to start a development server
+ * - Run `npm run start` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *

--- a/packages/create-cloudflare/templates/scheduled/js/src/index.js
+++ b/packages/create-cloudflare/templates/scheduled/js/src/index.js
@@ -5,7 +5,7 @@
  * configurable interval:
  * https://developers.cloudflare.com/workers/platform/triggers/cron-triggers/
  *
- * - Run `npm run dev` in your terminal to start a development server
+ * - Run `npm run start` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *

--- a/packages/create-cloudflare/templates/scheduled/ts/src/index.ts
+++ b/packages/create-cloudflare/templates/scheduled/ts/src/index.ts
@@ -5,7 +5,7 @@
  * configurable interval:
  * https://developers.cloudflare.com/workers/platform/triggers/cron-triggers/
  *
- * - Run `npm run dev` in your terminal to start a development server
+ * - Run `npm run start` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**
The top-of-file comments in several templates instruct the user to run the command `npm run dev` to start a web server, whereas the actual command defined for each template in the relevant `package.json` to do that is `npm run start`.
This PR updates the comment section in each template to refer to the correct `npm run start` command.

Templates impacted:
- common/js/src/index.js
- common/ts/src/index.ts
- hello-world/js/src/index.js
- hello-world/ts/src/index.ts
- queues/js/src/index.js
- queues/ts/src/index.ts
- scheduled/js/src/index.js
- scheduled/ts/src/index.ts

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
