### PR TITLE
[workers-playground] TopBar fixes

### DIFF
--- a/packages/workers-playground/src/QuickEditor/TopBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/TopBar.tsx
@@ -43,6 +43,8 @@ export function TopBar() {
 		return searchParams.get("name") || "workers-playground";
 	});
 
+	const workerHash = location.hash.slice(1);
+
 	function setValue(v: string) {
 		const sanitised = v.replace(/[^a-z0-9-]+/g, "-");
 		_setValue(sanitised);
@@ -140,9 +142,12 @@ export function TopBar() {
 			</Button>
 			<A
 				target="_blank"
-				href={`https://dash.cloudflare.com/workers-and-pages/deploy/playground/${value}${location.hash}`}
+				href={`https://dash.cloudflare.com/workers-and-pages/deploy/playground/${value}#${workerHash}`}
+				style={workerHash ? undefined : { pointerEvents: "none" }}
 			>
-				<Button type="primary">Deploy</Button>
+				<Button type="primary" disabled={!Boolean(workerHash)} tabIndex={-1}>
+					Deploy
+				</Button>
 			</A>
 		</Wrapper>
 	);

--- a/packages/workers-playground/src/QuickEditor/TopBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/TopBar.tsx
@@ -79,68 +79,70 @@ export function TopBar() {
 
 			<Div ml="auto" mr="auto" display="flex" gap={1} alignItems="center">
 				{isEditing ? (
-			<Form
+					<Form
 						display="contents"
-				onSubmit={(e) => {
-					e.preventDefault();
-						persistValue();
+						onSubmit={(e) => {
+							e.preventDefault();
+							persistValue();
 							setIsEditing(false);
-				}}
-			>
-					<Input
-						name="path"
-						value={value}
-						autoComplete="off"
+						}}
+					>
+						<Input
+							name="path"
+							value={value}
+							autoComplete="off"
 							autoFocus={true}
-						spellCheck={false}
-						onChange={(e) => setValue(e.target.value)}
-						mb={0}
-					/>
+							spellCheck={false}
+							onChange={(e) => setValue(e.target.value)}
+							mb={0}
+						/>
 						<Button type="plain" submit={true} p={2} ml={1}>
 							<Icon type="ok" />
 						</Button>
 					</Form>
 				) : (
 					<>
-					<Strong>{value}</Strong>
-				<Button
-					type="plain"
+						<Strong>{value}</Strong>
+						<Button
+							type="plain"
 							onClick={() => setIsEditing(true)}
-					p={2}
-					ml={1}
-				>
+							p={2}
+							ml={1}
+						>
 							<Icon type="edit" />
-				</Button>
+						</Button>
 					</>
 				)}
 			</Div>
-			{hasCopied && (
-				<Div position="relative">
+
+			<Div position="relative">
+				{hasCopied && (
 					<Span
 						height="100%"
 						display="flex"
 						gap={1}
 						alignItems="center"
 						mr={2}
-						position={"absolute"}
-						right={0}
+						position="absolute"
+						right="100%"
 					>
-						<Icon type="ok" color={"green"} size={20}></Icon>
+						<Icon type="ok" color="green" size={20}></Icon>
 						Copied!
 					</Span>
-				</Div>
-			)}
-			<Button
-				type="primary"
-				inverted={true}
-				onClick={() => {
-					void navigator.clipboard.writeText(location.href);
-					setHasCopied(!hasCopied);
-				}}
-			>
-				<Icon label="Add" type="link" mr={1} />
-				Copy Link
-			</Button>
+				)}
+				<Button
+					type="primary"
+					inverted={true}
+					onClick={() => {
+						void navigator.clipboard.writeText(location.href);
+						setHasCopied(!hasCopied);
+					}}
+				>
+					<Icon label="Add" type="link" mr={1} />
+					Copy Link
+				</Button>
+			</Div>
+
 			<A
 				target="_blank"
 				href={`https://dash.cloudflare.com/workers-and-pages/deploy/playground/${value}#${workerHash}`}

--- a/packages/workers-playground/src/QuickEditor/TopBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/TopBar.tsx
@@ -76,43 +76,44 @@ export function TopBar() {
 					New
 				</Button>
 			</A>
+
+			<Div ml="auto" mr="auto" display="flex" gap={1} alignItems="center">
+				{isEditing ? (
 			<Form
-				ml="auto"
-				mr="auto"
-				display="flex"
-				gap={1}
-				alignItems="center"
+						display="contents"
 				onSubmit={(e) => {
 					e.preventDefault();
-					if (isEditing) {
 						persistValue();
-					}
+							setIsEditing(false);
 				}}
 			>
-				{isEditing ? (
 					<Input
 						name="path"
 						value={value}
 						autoComplete="off"
+							autoFocus={true}
 						spellCheck={false}
 						onChange={(e) => setValue(e.target.value)}
 						mb={0}
 					/>
+						<Button type="plain" submit={true} p={2} ml={1}>
+							<Icon type="ok" />
+						</Button>
+					</Form>
 				) : (
+					<>
 					<Strong>{value}</Strong>
-				)}
 				<Button
 					type="plain"
+							onClick={() => setIsEditing(true)}
 					p={2}
 					ml={1}
-					submit={isEditing}
-					onClick={() => {
-						setIsEditing(!isEditing);
-					}}
 				>
-					<Icon type={isEditing ? "ok" : "edit"} />
+							<Icon type="edit" />
 				</Button>
-			</Form>
+					</>
+				)}
+			</Div>
 			{hasCopied && (
 				<Div position="relative">
 					<Span

--- a/packages/workers-playground/src/QuickEditor/TopBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/TopBar.tsx
@@ -6,7 +6,6 @@ import { Icon } from "@cloudflare/component-icon";
 import { BAR_HEIGHT } from "./constants";
 import { WorkersLogo } from "./WorkersLogo";
 import { Input } from "@cloudflare/component-input";
-import { Toast } from "@cloudflare/component-toast";
 
 const Wrapper = createComponent(({ theme }) => ({
 	display: "flex",
@@ -18,19 +17,6 @@ const Wrapper = createComponent(({ theme }) => ({
 	paddingRight: theme.space[3],
 	backgroundColor: theme.colors.white,
 }));
-
-const AnimatedToast = createComponent(
-	({ theme }) => ({
-		position: "fixed",
-		right: theme.space[3],
-		top: `calc(${BAR_HEIGHT}px + ${theme.space[1] + theme.space[2]}px)`,
-		zIndex: 10,
-		display: "flex",
-		alignItems: "center",
-		gap: theme.space[2],
-	}),
-	Toast
-);
 
 export function TopBar() {
 	const [isEditing, setIsEditing] = useState(false);


### PR DESCRIPTION
This PR fixes a few things with the Workers Playground top-level toolbar:

- The Deploy button is now disabled when the hash fragment isn't present. (Fixes DEVX-968)
- Editing the worker name now properly updates the state stored in query params. Previously the query param value was lagging behind until another edit interaction was initiated.
- The Copy Link confirmation text no longer causes layout shift.
- Clean up of some unused code.