### PR TITLE
[playground] Use in-memory state

### DIFF
--- a/packages/workers-playground/src/QuickEditor/QuickEditor.tsx
+++ b/packages/workers-playground/src/QuickEditor/QuickEditor.tsx
@@ -48,11 +48,12 @@ export default function QuickEditor() {
 	useEffect(() => {
 		observeDarkMode(() => setDarkMode(isDarkMode()));
 	}, []);
-	const workerHash = window.location.hash.slice(1);
 
 	const [previewUrl, setPreviewUrl] = React.useState(`/`);
 
-	const [initialWorkerContentHash, setInitialHash] = React.useState(workerHash);
+	const [initialWorkerContentHash, setInitialHash] = React.useState(
+		window.location.hash.slice(1)
+	);
 
 	function updateWorkerHash(hash: string) {
 		history.replaceState(null, "", hash);

--- a/packages/workers-playground/src/QuickEditor/TopBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/TopBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { A, Div, Form, Span, Strong } from "@cloudflare/elements";
 import { createComponent } from "@cloudflare/style-container";
 import { Button } from "@cloudflare/component-button";
@@ -6,6 +6,7 @@ import { Icon } from "@cloudflare/component-icon";
 import { BAR_HEIGHT } from "./constants";
 import { WorkersLogo } from "./WorkersLogo";
 import { Input } from "@cloudflare/component-input";
+import { ServiceContext } from "./QuickEditor";
 
 const Wrapper = createComponent(({ theme }) => ({
 	display: "flex",
@@ -19,6 +20,7 @@ const Wrapper = createComponent(({ theme }) => ({
 }));
 
 export function TopBar() {
+	const { previewHash } = useContext(ServiceContext);
 	const [isEditing, setIsEditing] = useState(false);
 
 	const [hasCopied, setHasCopied] = useState(false);
@@ -28,8 +30,6 @@ export function TopBar() {
 
 		return searchParams.get("name") || "workers-playground";
 	});
-
-	const workerHash = location.hash.slice(1);
 
 	function setValue(v: string) {
 		const sanitised = v.replace(/[^a-z0-9-]+/g, "-");
@@ -119,6 +119,7 @@ export function TopBar() {
 				<Button
 					type="primary"
 					inverted={true}
+					disabled={!Boolean(previewHash?.serialised)}
 					onClick={() => {
 						void navigator.clipboard.writeText(location.href);
 						setHasCopied(!hasCopied);
@@ -131,10 +132,14 @@ export function TopBar() {
 
 			<A
 				target="_blank"
-				href={`https://dash.cloudflare.com/workers-and-pages/deploy/playground/${value}#${workerHash}`}
-				style={workerHash ? undefined : { pointerEvents: "none" }}
+				href={`https://dash.cloudflare.com/workers-and-pages/deploy/playground/${value}#${previewHash?.serialised}`}
+				style={previewHash?.serialised ? undefined : { pointerEvents: "none" }}
 			>
-				<Button type="primary" disabled={!Boolean(workerHash)} tabIndex={-1}>
+				<Button
+					type="primary"
+					disabled={!Boolean(previewHash?.serialised)}
+					tabIndex={-1}
+				>
 					Deploy
 				</Button>
 			</A>

--- a/packages/workers-playground/src/QuickEditor/useDraftWorker.ts
+++ b/packages/workers-playground/src/QuickEditor/useDraftWorker.ts
@@ -91,6 +91,7 @@ export type PreviewHash = {
 	previewUrl: string;
 	devtoolsUrl: string;
 	playgroundUrl: string;
+	serialised: string;
 };
 
 async function compressWorker(worker: FormData) {
@@ -116,14 +117,17 @@ async function updatePreviewHash(content: Worker): Promise<PreviewHash> {
 		throw new Error(deploy.message);
 	}
 
+	const serialised = await compressWorker(worker);
+
 	return {
-		playgroundUrl: `/playground#${await compressWorker(worker)}`,
+		playgroundUrl: `/playground#${serialised}`,
 		previewUrl: `https://${v4()}.${
 			import.meta.env.VITE_PLAYGROUND_PREVIEW
 		}/.update-preview-token?token=${encodeURIComponent(deploy.preview)}`,
 		devtoolsUrl: `wss://${import.meta.env.VITE_PLAYGROUND_ROOT}${
 			deploy.inspector
 		}`,
+		serialised: serialised,
 	};
 }
 


### PR DESCRIPTION
Fixes DEVX-969

**What this PR solves / how to test:**

Uses in-memory state for the deploy button hash

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
