### PR TITLE
[pages-shared] Remove extension name check when generating response

### DIFF
--- a/.changeset/cold-bugs-kick.md
+++ b/.changeset/cold-bugs-kick.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/pages-shared": minor
+---
+
+fix: remove extension name check when generating response
+
+Current regex logic to check whether a pathname is a file (has file extension) is causing trouble for some websites, and now \${pathname}/index.html is always checked before returning notFound().

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -293,8 +293,6 @@ export async function generateHandler<
 			);
 		} else if ((assetEntry = await findAssetEntryForPath(`${pathname}.html`))) {
 			return serveAsset(assetEntry);
-		} else if (hasFileExtension(pathname)) {
-			return notFound();
 		}
 
 		if ((assetEntry = await findAssetEntryForPath(`${pathname}/index.html`))) {
@@ -624,10 +622,6 @@ export function parseQualityWeightedList(list = "") {
 
 function isCacheable(request: Request) {
 	return !request.headers.has("authorization") && !request.headers.has("range");
-}
-
-function hasFileExtension(path: string) {
-	return /\/.+\.[a-z0-9]+$/i.test(path);
 }
 
 // Parses a request URL hostname to determine if the request


### PR DESCRIPTION
Fixes #2779.

**What this PR solves / how to test:**

Using regex for filename to check whether it is a directory or not is broken, and current regex logic `/\/.+\.[a-z0-9]+$/i.test(path)` causes troubles for dir filenames like:

- /0.0.1 (#2779)
- /binutils-gdb.git (https://github.com/vercel/next.js/issues/56090)

By removing the extension check, workers could always check whether `${pathname}/index.html` exists.

**Associated docs issue(s)/PR(s):**

- N/A

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
