### PR TITLE
[wrangler] fix: allow `wrangler pages dev` sessions to be reloaded

### DIFF
--- a/.changeset/tricky-poems-type.md
+++ b/.changeset/tricky-poems-type.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: allow `wrangler pages dev` sessions to be reloaded
+
+Previously, `wrangler pages dev` attempted to send messages on a closed IPC
+channel when sources changed, resulting in an `ERR_IPC_CHANNEL_CLOSED` error.
+This change ensures the channel stays open until the user exits `wrangler pages dev`.

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -637,14 +637,13 @@ export const Handler = async ({
 
 	CLEANUP_CALLBACKS.push(stop);
 
-	void waitUntilExit().then(() => {
-		CLEANUP();
-		process.exit(0);
-	});
-
 	process.on("exit", CLEANUP);
 	process.on("SIGINT", CLEANUP);
 	process.on("SIGTERM", CLEANUP);
+
+	await waitUntilExit();
+	CLEANUP();
+	process.exit(0);
 };
 
 function isWindows() {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/4008, https://github.com/cloudflare/workers-sdk/issues/4017, https://github.com/remix-run/remix/issues/7510

**What this PR solves / how to test:**

#3951 introduced [a change](https://github.com/cloudflare/workers-sdk/pull/3951/files#diff-f64ec8fc0f101cfe619c859a32a565dbedacc3b95f1e3a1483cb832710dbbfb2R766-R772) that closed the bootstrapper's IPC channel when Wrangler exited. Whenever `wrangler (pages) dev` reloads, an event is sent on this channel to indicate the dev server is ready. Unfortunately, `wrangler pages dev`'s handler didn't wait for the dev session to exit before resolving its returned promise, meaning the channel was closed as soon as the dev server was ready, not when Wrangler exited. This meant that ready events sent from reloads resulted in an `ERR_IPC_CHANNEL_CLOSED` that crashed Wrangler. :(

This PR updates the code to only resolve the returned promise once the dev session exits, ensuring the channel stays open.

To test, run `npm run dev` in `fixtures/pages-functions-app`, wait for the dev server to start, then update a file. Before this change, this would crash. Afterwards, it should reload the dev server with the new script.

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
