### PR TITLE
C3: Defaulting project type to webFramework

### DIFF
--- a/.changeset/khaki-experts-reflect.md
+++ b/.changeset/khaki-experts-reflect.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Defaults the project type to `Web Framework`. The previous default was `"Hello World" worker`

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -47,7 +47,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 				promptHandlers: [
 					{
 						matcher: /What type of application do you want to create/,
-						input: [keys.enter],
+						input: [keys.down, keys.enter],
 					},
 					{
 						matcher: /Do you want to use TypeScript/,
@@ -82,7 +82,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 					},
 					{
 						matcher: /What type of application do you want to create/,
-						input: [keys.down, keys.enter],
+						input: [keys.down, keys.down, keys.enter],
 					},
 					{
 						matcher: /Do you want to use TypeScript/,
@@ -112,7 +112,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 				promptHandlers: [
 					{
 						matcher: /What type of application do you want to create/,
-						input: [keys.enter],
+						input: [keys.down, keys.enter],
 					},
 					{
 						matcher: /Do you want to use git for version control/,

--- a/packages/create-cloudflare/src/helpers/cli.ts
+++ b/packages/create-cloudflare/src/helpers/cli.ts
@@ -129,7 +129,7 @@ export async function openInBrowser(url: string): Promise<void> {
 
 export const C3_DEFAULTS = {
 	projectName: new Haikunator().haikunate({ tokenHex: true }),
-	type: "hello-world",
+	type: "webFramework",
 	framework: "angular",
 	autoUpdate: true,
 	deploy: true,


### PR DESCRIPTION
Fixes #3931.

**What this PR solves / how to test:**

Defaults the C3 project type to `webFramework`. The previous default was the hello-world worker that appeared second in the list, leading to a somewhat awkward user interaction.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
