### PR TITLE
Use wrangler publish to prevent deprecation warning

### DIFF
--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler deploy",
+		"deploy": "wrangler publish",
 		"dev": "wrangler dev",
 		"start": "wrangler dev"
 	},


### PR DESCRIPTION
When I create a new project via C3, I see the following warning any time I run `npm run deploy` within the project:

```
 ⛅️ wrangler 3.10.1
-------------------
▲ [WARNING] `wrangler publish` is deprecated and will be removed in the next major version.

  Please use `wrangler deploy` instead, which accepts exactly the same arguments.
```

Changing the project template to use the current wrangler commands, and suppress this warning.

We should update everywhere. Will follow up with that