### PR TITLE
fix getHostFromUrl to not infer pathnames from the pattern as the host

### DIFF
--- a/.changeset/twenty-deers-crash.md
+++ b/.changeset/twenty-deers-crash.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: we no longer infer pathnames from route patterns as the host
+
+During local development, inside your worker, the host of `request.url` is inferred from the `routes` in your config.
+
+Previously, route patterns like "\*/some/path/name" would infer the host as "some". We now handle this case and determine we cannot infer a host from such patterns.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -428,9 +428,16 @@ describe("wrangler dev", () => {
 			});
 			await fs.promises.writeFile("index.js", `export default {};`);
 
-			await expect(runWrangler("dev")).rejects.toMatchInlineSnapshot(
-				`[Error: Cannot infer host from first route: {"pattern":"*/*","zone_id":"exists-com"}]`
-			);
+			await expect(runWrangler("dev")).rejects.toMatchInlineSnapshot(`
+			[Error: Cannot infer host from first route: {"pattern":"*/*","zone_id":"exists-com"}.
+			You can explicitly set the \`dev.host\` configuration in your wrangler.toml file, for example:
+
+				\`\`\`
+				[dev]
+				host = "example.com"
+				\`\`\`
+			]
+		`);
 		});
 
 		it("given a long host, it should use the longest subdomain that resolves to a zone", async () => {

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -428,10 +428,9 @@ describe("wrangler dev", () => {
 			});
 			await fs.promises.writeFile("index.js", `export default {};`);
 
-			await expect(runWrangler("dev")).rejects.toMatchInlineSnapshot(`
-			[Error: Cannot infer host from first route: {"pattern":"*/*","zone_id":"exists-com"}
-			Try making sure your route pattern contains a host like {"pattern":"*.example.com","zone_id":"exists-com"}]
-		`);
+			await expect(runWrangler("dev")).rejects.toMatchInlineSnapshot(
+				`[Error: Cannot infer host from first route: {"pattern":"*/*","zone_id":"exists-com"}]`
+			);
 		});
 
 		it("given a long host, it should use the longest subdomain that resolves to a zone", async () => {

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -427,11 +427,10 @@ describe("wrangler dev", () => {
 				],
 			});
 			await fs.promises.writeFile("index.js", `export default {};`);
-			const err = new TypeError() as unknown as { code: string; input: string };
-			err.code = "ERR_INVALID_URL";
-			err.input = "http:///";
 
-			await expect(runWrangler("dev")).rejects.toEqual(err);
+			await expect(runWrangler("dev")).rejects.toMatchInlineSnapshot(
+				`[Error: Cannot infer host from first route: {"pattern":"*/*","zone_id":"exists-com"}]`
+			);
 		});
 
 		it("given a long host, it should use the longest subdomain that resolves to a zone", async () => {

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -428,9 +428,10 @@ describe("wrangler dev", () => {
 			});
 			await fs.promises.writeFile("index.js", `export default {};`);
 
-			await expect(runWrangler("dev")).rejects.toMatchInlineSnapshot(
-				`[Error: Cannot infer host from first route: {"pattern":"*/*","zone_id":"exists-com"}]`
-			);
+			await expect(runWrangler("dev")).rejects.toMatchInlineSnapshot(`
+			[Error: Cannot infer host from first route: {"pattern":"*/*","zone_id":"exists-com"}
+			Try making sure your route pattern contains a host like {"pattern":"*.example.com","zone_id":"exists-com"}]
+		`);
 		});
 
 		it("given a long host, it should use the longest subdomain that resolves to a zone", async () => {

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -1,33 +1,35 @@
 import { getHostFromUrl } from "../zones";
 
 describe("Zones", () => {
-	test.each`
-		pattern                              | host
-		${"example.com"}                     | ${"example.com"}
-		${"*.example.com"}                   | ${"example.com"}
-		${"*example.com"}                    | ${"example.com"}
-		${"example.com/path/name"}           | ${"example.com"}
-		${"*.example.com/path/name"}         | ${"example.com"}
-		${"*example.com/path/name"}          | ${"example.com"}
-		${"*example.com"}                    | ${"example.com"}
-		${"*/path/name"}                     | ${undefined}
-		${"http://example.com"}              | ${"example.com"}
-		${"http://*.example.com"}            | ${"example.com"}
-		${"http://*example.com"}             | ${"example.com"}
-		${"http://example.com/path/name"}    | ${"example.com"}
-		${"http://*.example.com/path/name"}  | ${"example.com"}
-		${"http://*example.com/path/name"}   | ${"example.com"}
-		${"http://*example.com"}             | ${"example.com"}
-		${"http://*/path/name"}              | ${undefined}
-		${"https://example.com"}             | ${"example.com"}
-		${"https://*.example.com"}           | ${"example.com"}
-		${"https://*example.com"}            | ${"example.com"}
-		${"https://example.com/path/name"}   | ${"example.com"}
-		${"https://*.example.com/path/name"} | ${"example.com"}
-		${"https://*example.com/path/name"}  | ${"example.com"}
-		${"https://*example.com"}            | ${"example.com"}
-		${"https://*/path/name"}             | ${undefined}
-	`('getHostFromUrl("$pattern") === "$host"', ({ pattern, host }) => {
-		expect(getHostFromUrl(pattern)).toBe(host);
+	describe("getHostFromUrl", () => {
+		test.each`
+			pattern                                             | host
+			${"rootdomain.com"}                                 | ${"rootdomain.com"}
+			${"*.subdomain.com"}                                | ${"subdomain.com"}
+			${"*rootdomain-or-subdomain.com"}                   | ${"rootdomain-or-subdomain.com"}
+			${"rootdomain.com/path/name"}                       | ${"rootdomain.com"}
+			${"*.subdomain.com/path/name"}                      | ${"subdomain.com"}
+			${"*rootdomain-or-subdomain.com/path/name"}         | ${"rootdomain-or-subdomain.com"}
+			${"*rootdomain-or-subdomain.com"}                   | ${"rootdomain-or-subdomain.com"}
+			${"*/path/name"}                                    | ${undefined}
+			${"http://rootdomain.com"}                          | ${"rootdomain.com"}
+			${"http://*.subdomain.com"}                         | ${"subdomain.com"}
+			${"http://*rootdomain-or-subdomain.com"}            | ${"rootdomain-or-subdomain.com"}
+			${"http://rootdomain.com/path/name"}                | ${"rootdomain.com"}
+			${"http://*.subdomain.com/path/name"}               | ${"subdomain.com"}
+			${"http://*rootdomain-or-subdomain.com/path/name"}  | ${"rootdomain-or-subdomain.com"}
+			${"http://*rootdomain-or-subdomain.com"}            | ${"rootdomain-or-subdomain.com"}
+			${"http://*/path/name"}                             | ${undefined}
+			${"https://rootdomain.com"}                         | ${"rootdomain.com"}
+			${"https://*.subdomain.com"}                        | ${"subdomain.com"}
+			${"https://*rootdomain-or-subdomain.com"}           | ${"rootdomain-or-subdomain.com"}
+			${"https://rootdomain.com/path/name"}               | ${"rootdomain.com"}
+			${"https://*.subdomain.com/path/name"}              | ${"subdomain.com"}
+			${"https://*rootdomain-or-subdomain.com/path/name"} | ${"rootdomain-or-subdomain.com"}
+			${"https://*rootdomain-or-subdomain.com"}           | ${"rootdomain-or-subdomain.com"}
+			${"https://*/path/name"}                            | ${undefined}
+		`("$pattern --> $host", ({ pattern, host }) => {
+			expect(getHostFromUrl(pattern)).toBe(host);
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -2,15 +2,31 @@ import { getHostFromUrl } from "../zones";
 
 describe("Zones", () => {
 	test.each`
-		pattern                      | host
-		${"example.com"}             | ${"example.com"}
-		${"*.example.com"}           | ${"example.com"}
-		${"*example.com"}            | ${"example.com"}
-		${"example.com/path/name"}   | ${"example.com"}
-		${"*.example.com/path/name"} | ${"example.com"}
-		${"*example.com/path/name"}  | ${"example.com"}
-		${"*example.com"}            | ${"example.com"}
-		${"*/path/name"}             | ${undefined}
+		pattern                              | host
+		${"example.com"}                     | ${"example.com"}
+		${"*.example.com"}                   | ${"example.com"}
+		${"*example.com"}                    | ${"example.com"}
+		${"example.com/path/name"}           | ${"example.com"}
+		${"*.example.com/path/name"}         | ${"example.com"}
+		${"*example.com/path/name"}          | ${"example.com"}
+		${"*example.com"}                    | ${"example.com"}
+		${"*/path/name"}                     | ${undefined}
+		${"http://example.com"}              | ${"example.com"}
+		${"http://*.example.com"}            | ${"example.com"}
+		${"http://*example.com"}             | ${"example.com"}
+		${"http://example.com/path/name"}    | ${"example.com"}
+		${"http://*.example.com/path/name"}  | ${"example.com"}
+		${"http://*example.com/path/name"}   | ${"example.com"}
+		${"http://*example.com"}             | ${"example.com"}
+		${"http://*/path/name"}              | ${undefined}
+		${"https://example.com"}             | ${"example.com"}
+		${"https://*.example.com"}           | ${"example.com"}
+		${"https://*example.com"}            | ${"example.com"}
+		${"https://example.com/path/name"}   | ${"example.com"}
+		${"https://*.example.com/path/name"} | ${"example.com"}
+		${"https://*example.com/path/name"}  | ${"example.com"}
+		${"https://*example.com"}            | ${"example.com"}
+		${"https://*/path/name"}             | ${undefined}
 	`('getHostFromUrl("$pattern") === "$host"', ({ pattern, host }) => {
 		expect(getHostFromUrl(pattern)).toBe(host);
 	});

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -1,0 +1,17 @@
+import { getHostFromUrl } from "../zones";
+
+describe("Zones", () => {
+	test.each`
+		pattern                      | host
+		${"example.com"}             | ${"example.com"}
+		${"*.example.com"}           | ${"example.com"}
+		${"*example.com"}            | ${"example.com"}
+		${"example.com/path/name"}   | ${"example.com"}
+		${"*.example.com/path/name"} | ${"example.com"}
+		${"*example.com/path/name"}  | ${"example.com"}
+		${"*example.com"}            | ${"example.com"}
+		${"*/path/name"}             | ${undefined}
+	`('getHostFromUrl("$pattern") === "$host"', ({ pattern, host }) => {
+		expect(getHostFromUrl(pattern)).toBe(host);
+	});
+});

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -10,24 +10,27 @@ describe("Zones", () => {
 			${"rootdomain.com/path/name"}                       | ${"rootdomain.com"}
 			${"*.subdomain.com/path/name"}                      | ${"subdomain.com"}
 			${"*rootdomain-or-subdomain.com/path/name"}         | ${"rootdomain-or-subdomain.com"}
-			${"*rootdomain-or-subdomain.com"}                   | ${"rootdomain-or-subdomain.com"}
 			${"*/path/name"}                                    | ${undefined}
+			${"invalid:host"}                                   | ${undefined}
+			${"invalid:host/path/name"}                         | ${undefined}
 			${"http://rootdomain.com"}                          | ${"rootdomain.com"}
 			${"http://*.subdomain.com"}                         | ${"subdomain.com"}
 			${"http://*rootdomain-or-subdomain.com"}            | ${"rootdomain-or-subdomain.com"}
 			${"http://rootdomain.com/path/name"}                | ${"rootdomain.com"}
 			${"http://*.subdomain.com/path/name"}               | ${"subdomain.com"}
 			${"http://*rootdomain-or-subdomain.com/path/name"}  | ${"rootdomain-or-subdomain.com"}
-			${"http://*rootdomain-or-subdomain.com"}            | ${"rootdomain-or-subdomain.com"}
 			${"http://*/path/name"}                             | ${undefined}
+			${"http://invalid:host"}                            | ${undefined}
+			${"http://invalid:host/path/name"}                  | ${undefined}
 			${"https://rootdomain.com"}                         | ${"rootdomain.com"}
 			${"https://*.subdomain.com"}                        | ${"subdomain.com"}
 			${"https://*rootdomain-or-subdomain.com"}           | ${"rootdomain-or-subdomain.com"}
 			${"https://rootdomain.com/path/name"}               | ${"rootdomain.com"}
 			${"https://*.subdomain.com/path/name"}              | ${"subdomain.com"}
 			${"https://*rootdomain-or-subdomain.com/path/name"} | ${"rootdomain-or-subdomain.com"}
-			${"https://*rootdomain-or-subdomain.com"}           | ${"rootdomain-or-subdomain.com"}
 			${"https://*/path/name"}                            | ${undefined}
+			${"https://invalid:host"}                           | ${undefined}
+			${"https://invalid:host/path/name"}                 | ${undefined}
 		`("$pattern --> $host", ({ pattern, host }) => {
 			expect(getHostFromUrl(pattern)).toBe(host);
 		});

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -684,6 +684,13 @@ async function getZoneIdHostAndRoutes(args: StartDevOptions, config: Config) {
 		if (routes) {
 			const firstRoute = routes[0];
 			host = getHostFromRoute(firstRoute);
+
+			// TODO(consider): do we need really need to do this? I've added the condition to throw to match the previous implicit behaviour of `new URL()` throwing upon invalid URLs, but could we just continue here without an inferred host?
+			if (host === undefined) {
+				throw new Error(
+					`Cannot infer host from first route: ${JSON.stringify(firstRoute)}`
+				);
+			}
 		}
 	}
 	return { host, routes, zoneId };

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -688,7 +688,15 @@ async function getZoneIdHostAndRoutes(args: StartDevOptions, config: Config) {
 			// TODO(consider): do we need really need to do this? I've added the condition to throw to match the previous implicit behaviour of `new URL()` throwing upon invalid URLs, but could we just continue here without an inferred host?
 			if (host === undefined) {
 				throw new Error(
-					`Cannot infer host from first route: ${JSON.stringify(firstRoute)}`
+					`Cannot infer host from first route: ${JSON.stringify(
+						firstRoute
+					)}.\nYou can explicitly set the \`dev.host\` configuration in your wrangler.toml file, for example:
+
+	\`\`\`
+	[dev]
+	host = "example.com"
+	\`\`\`
+`
 				);
 			}
 		}

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -688,13 +688,7 @@ async function getZoneIdHostAndRoutes(args: StartDevOptions, config: Config) {
 			// TODO(consider): do we need really need to do this? I've added the condition to throw to match the previous implicit behaviour of `new URL()` throwing upon invalid URLs, but could we just continue here without an inferred host?
 			if (host === undefined) {
 				throw new Error(
-					`Cannot infer host from first route: ${JSON.stringify(
-						firstRoute
-					)}\nTry making sure your route pattern contains a host like ${JSON.stringify(
-						typeof firstRoute === "string"
-							? "*.example.com"
-							: { ...firstRoute, pattern: "*.example.com" }
-					)}`
+					`Cannot infer host from first route: ${JSON.stringify(firstRoute)}`
 				);
 			}
 		}

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -688,7 +688,13 @@ async function getZoneIdHostAndRoutes(args: StartDevOptions, config: Config) {
 			// TODO(consider): do we need really need to do this? I've added the condition to throw to match the previous implicit behaviour of `new URL()` throwing upon invalid URLs, but could we just continue here without an inferred host?
 			if (host === undefined) {
 				throw new Error(
-					`Cannot infer host from first route: ${JSON.stringify(firstRoute)}`
+					`Cannot infer host from first route: ${JSON.stringify(
+						firstRoute
+					)}\nTry making sure your route pattern contains a host like ${JSON.stringify(
+						typeof firstRoute === "string"
+							? "*.example.com"
+							: { ...firstRoute, pattern: "*.example.com" }
+					)}`
 				);
 			}
 		}

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -26,21 +26,19 @@ export interface Zone {
  * @param route
  */
 export function getHostFromRoute(route: Route): string | undefined {
+	let host: string | undefined;
+
 	if (typeof route === "string") {
-		return getHostFromUrl(route);
+		host = getHostFromUrl(route);
 	} else if (typeof route === "object") {
-		try {
-			return getHostFromUrl(route.pattern);
-		} catch (e) {
-			if (
-				(e as { code: string }).code === "ERR_INVALID_URL" &&
-				"zone_name" in route
-			) {
-				return getHostFromUrl(route.zone_name);
-			}
-			throw e;
+		host = getHostFromUrl(route.pattern);
+
+		if (host === undefined && "zone_name" in route) {
+			host = getHostFromUrl(route.zone_name);
 		}
 	}
+
+	return host;
 }
 
 /**
@@ -82,8 +80,8 @@ export function getHostFromUrl(urlLike: string): string | undefined {
 		urlLike = "http://" + urlLike;
 	}
 
-	// now urlLike is a valid url string which we can pass to `new URL()` to get the host
-
+	// now we've done our best to make urlLike a valid url string which we can pass to `new URL()` to get the host
+	// if it still isn't, this will throw
 	return new URL(urlLike).host;
 }
 

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -66,11 +66,15 @@ export async function getZoneForRoute(route: Route): Promise<Zone | undefined> {
  */
 export function getHostFromUrl(urlLike: string): string | undefined {
 	// if the urlLike-pattern uses a splat for the entire host and is only concerned with the pathname, we cannot infer a host
-	if (urlLike.startsWith("*/")) {
+	if (
+		urlLike.startsWith("*/") ||
+		urlLike.startsWith("http://*/") ||
+		urlLike.startsWith("https://*/")
+	) {
 		return undefined;
 	}
 
-	// if the urlLike-pattern uses a split for the sub-domain (*.example.com) or for the root-domain (*example.com), remove the wildcard parts
+	// if the urlLike-pattern uses a splat for the sub-domain (*.example.com) or for the root-domain (*example.com), remove the wildcard parts
 	urlLike = urlLike.replace(/\*(\.)?/g, "");
 
 	// prepend a protocol if the pattern did not specify one

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -65,12 +65,21 @@ export async function getZoneForRoute(route: Route): Promise<Zone | undefined> {
  * Given something that resembles a URL, try to extract a host from it.
  */
 export function getHostFromUrl(urlLike: string): string | undefined {
-	// strip leading * / *.
+	// if the urlLike-pattern uses a splat for the entire host and is only concerned with the pathname, we cannot infer a host
+	if (urlLike.startsWith("*/")) {
+		return undefined;
+	}
+
+	// if the urlLike-pattern uses a split for the sub-domain (*.example.com) or for the root-domain (*example.com), remove the wildcard parts
 	urlLike = urlLike.replace(/\*(\.)?/g, "");
 
+	// prepend a protocol if the pattern did not specify one
 	if (!(urlLike.startsWith("http://") || urlLike.startsWith("https://"))) {
 		urlLike = "http://" + urlLike;
 	}
+
+	// now urlLike is a valid url string which we can pass to `new URL()` to get the host
+
 	return new URL(urlLike).host;
 }
 

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -22,7 +22,7 @@ export interface Zone {
  * ```
  * However, in the case of patterns that _can't_ be parsed as a hostname
  * (primarily the pattern `*/ /*`), we fall back to the `zone_name`
- * (and in the absence of that throw an error).
+ * (and in the absence of that return undefined).
  * @param route
  */
 export function getHostFromRoute(route: Route): string | undefined {
@@ -81,8 +81,12 @@ export function getHostFromUrl(urlLike: string): string | undefined {
 	}
 
 	// now we've done our best to make urlLike a valid url string which we can pass to `new URL()` to get the host
-	// if it still isn't, this will throw
-	return new URL(urlLike).host;
+	// if it still isn't, return undefined to indicate we couldn't infer a host
+	try {
+		return new URL(urlLike).host;
+	} catch {
+		return undefined;
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes #3635

**What this PR solves / how to test:**

During local development, the host of `request.url` is inferred from the `routes` in the config.

Previously, route patterns like "*/some/path/name" would infer the host as "some". We now handle this case and determine we cannot infer a host from such patterns.

I have also added tests which enumerate examples of url patterns and the expected host to be inferred.

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
