### PR TITLE
Support TailEvent messages in Tail sessions

### DIFF
--- a/.changeset/serious-beans-hug.md
+++ b/.changeset/serious-beans-hug.md
@@ -1,0 +1,18 @@
+---
+"wrangler": minor
+---
+
+Support TailEvent messages in Tail sessions
+
+When tailing a tail worker, messages previously had a null event
+property. Following https://github.com/cloudflare/workerd/pull/1248,
+these events have a valid event, specifying which scripts produced
+events that caused your tail worker to run.
+
+As part of rolling this out, we're filtering out tail events in the
+internal tail infrastructure, so we control when these new messages are
+forward to tail sessions, and can merge this freely.
+
+One idiosyncracy to note, however, is that tail workers always report an
+"OK" status, even if they run out of memory or throw. That is being
+tracked and worked on separately.

--- a/packages/wrangler/src/__tests__/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages-deployment-tail.test.ts
@@ -13,6 +13,7 @@ import type {
 	ScheduledEvent,
 	AlarmEvent,
 	EmailEvent,
+	TailEvent,
 	TailInfo,
 } from "../tail/createTail";
 import type { RequestInit } from "undici";
@@ -663,6 +664,7 @@ function isRequest(
 		| RequestEvent
 		| AlarmEvent
 		| EmailEvent
+		| TailEvent
 		| TailInfo
 		| undefined
 		| null

--- a/packages/wrangler/src/tail/createTail.ts
+++ b/packages/wrangler/src/tail/createTail.ts
@@ -252,6 +252,7 @@ export type TailEventMessage = {
 		| ScheduledEvent
 		| AlarmEvent
 		| EmailEvent
+		| TailEvent
 		| TailInfo
 		| undefined
 		| null;
@@ -404,6 +405,22 @@ export type EmailEvent = {
 	 * Size of the email in bytes
 	 */
 	rawSize: number;
+};
+
+/**
+ * An event that was triggered for a tail receiving TailEventMessages
+ * Only seen when tailing a tail worker
+ */
+export type TailEvent = {
+	/**
+	 * A minimal representation of the TailEventMessages that were delivered to the tail handler
+	 */
+	consumedEvents: {
+		/**
+		 * The name of script being tailed
+		 */
+		scriptName?: string;
+	}[];
 };
 
 /**


### PR DESCRIPTION
When tailing a tail worker, messages previously had a null event property. Following https://github.com/cloudflare/workerd/pull/1248, these events have a valid event, specifying which scripts produced events that caused your tail worker to run.

As part of rolling this out, we're filtering out tail events in the internal tail infrastructure, so we control when these new messages are forward to tail sessions, and can merge this freely.

One idiosyncracy to note, however, is that tail workers always report an "OK" status, even if they run out of memory or throw. That is being tracked and worked on separately.

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
