### PR TITLE
Clear worker logs on WebSocket connection

### DIFF
--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -386,7 +386,11 @@ export default function useInspector(props: InspectorProps) {
 		}
 
 		ws.addEventListener("open", () => {
-			send({ method: "Runtime.enable", id: messageCounterRef.current });
+			send({
+				method: "Runtime.discardConsoleEntries",
+				id: messageCounterRef.current++,
+			});
+			send({ method: "Runtime.enable", id: messageCounterRef.current++ });
 			// TODO: This doesn't actually work. Must fix.
 			send({ method: "Network.enable", id: messageCounterRef.current++ });
 


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/1811

**What this PR solves / how to test:**

Prevent log duplication when worker is reloaded in remote mode

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
