### PR TITLE
respect options.local in unstable_dev

### DIFF
--- a/.changeset/curvy-onions-breathe.md
+++ b/.changeset/curvy-onions-breathe.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: respect the options.local value in unstable_dev (it was being ignored)

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -129,6 +129,7 @@ export async function unstable_dev(
 	});
 
 	const defaultLogLevel = testMode ? "none" : "log";
+	const local = options?.local ?? true;
 
 	const devOptions: StartDevOptions = {
 		script: script,
@@ -137,8 +138,8 @@ export async function unstable_dev(
 		_: [],
 		$0: "",
 		port: options?.port ?? 0,
-		remote: false,
-		local: undefined,
+		remote: !local,
+		local,
 		experimentalLocal: undefined,
 		d1Databases,
 		disableDevRegistry,


### PR DESCRIPTION
Fixes #3526

**What this PR solves / how to test:**

We now pass down `options.local` into the `StartDevOptions` whereas it was being ignored before

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
