### PR TITLE
Quarantine flakey tests

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -78,13 +78,6 @@ jobs:
           echo TURBO_TOKEN=${{ secrets.TURBO_TOKEN }} >> .env
           echo TURBO_REMOTE_CACHE_SIGNATURE_KEY=${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }} >> .env
 
-      - name: Install workerd Dependencies
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install -y libc++1
-
       - name: Install NPM Dependencies
         run: pnpm install --frozen-lockfile
 
@@ -102,3 +95,46 @@ jobs:
 
       - name: Report Code Coverage
         uses: codecov/codecov-action@v3
+
+  quarantine:
+    name: "Quarantined Tests"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Use Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node-version }}
+          cache: "pnpm"
+
+      - name: "Create .env file"
+        run: |
+          touch .env
+          echo TURBO_API=${{ secrets.TURBO_API }} >> .env
+          echo TURBO_TEAM=${{ secrets.TURBO_TEAM }} >> .env
+          echo TURBO_TOKEN=${{ secrets.TURBO_TOKEN }} >> .env
+          echo TURBO_REMOTE_CACHE_SIGNATURE_KEY=${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }} >> .env
+
+      - name: Install NPM Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run builds
+        run: pnpm run build
+        env:
+          NODE_ENV: "production"
+
+      - name: Run tests
+        run: pnpm run test:ci:quarantine
+        env:
+          TMP_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TMP_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NODE_OPTIONS: "--max_old_space_size=8192"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"fix": "pnpm run prettify && dotenv -- turbo check:lint -- --fix",
 		"prettify": "prettier . --write --ignore-unknown",
 		"test": "dotenv -- turbo test --concurrency=1",
-		"test:ci": "dotenv -- turbo test:ci --filter=!local-mode-tests --filter=!playground-preview-worker --filter=!no-bundle-import --concurrency=1",
+		"test:ci": "dotenv -- turbo test:ci --filter=!local-mode-tests --filter=!playground-preview-worker --filter=!no-bundle-import --filter=!workers.new --concurrency=1",
+		"test:ci:quarantine": "dotenv -- turbo test:ci --filter=local-mode-tests --filter=playground-preview-worker --filter=no-bundle-import --filter=workers.new --concurrency=1",
 		"test:watch": "turbo test:watch",
 		"type:tests": "dotenv -- turbo type:tests",
 		"gen:package": "turbo gen package"


### PR DESCRIPTION
Some of our tests are disabled in CI for various reasons. This PR:
- Adds the `workers.new` package to the list of disabled tests
- Runs all disabled tests in a separate job