### PR TITLE
C3: Fixing double prompt for ts during hello world worker creation

### DIFF
--- a/.changeset/eighty-plums-ring.md
+++ b/.changeset/eighty-plums-ring.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Fixes an issue where users were prompted for TypeScript twice during worker creation

--- a/packages/create-cloudflare/src/workers.ts
+++ b/packages/create-cloudflare/src/workers.ts
@@ -34,6 +34,13 @@ export const runWorkersGenerator = async (args: C3Args) => {
 		args,
 	};
 
+	ctx.args.ts = await processArgument<boolean>(ctx.args, "ts", {
+		type: "confirm",
+		question: "Do you want to use TypeScript?",
+		label: "typescript",
+		defaultValue: C3_DEFAULTS.ts,
+	});
+
 	await copyFiles(ctx);
 	await copyExistingWorkerFiles(ctx);
 	await updateFiles(ctx);
@@ -53,13 +60,6 @@ export const runWorkersGenerator = async (args: C3Args) => {
 };
 
 async function getTemplate(ctx: Context) {
-	ctx.args.ts = await processArgument<boolean>(ctx.args, "ts", {
-		type: "confirm",
-		question: "Do you want to use TypeScript?",
-		label: "typescript",
-		defaultValue: C3_DEFAULTS.ts,
-	});
-
 	const preexisting = ctx.args.type === "pre-existing";
 	const template = preexisting ? "hello-world" : ctx.args.type;
 	const path = resolve(


### PR DESCRIPTION
Fixes #3979.

**What this PR solves / how to test:**

Fixes an issue in the "Hello World" worker creation workflow where the user is prompted for typescript twice:

![268923065-fa36007c-7bc9-4e95-ba7b-330b40387a79](https://github.com/cloudflare/workers-sdk/assets/204386/3eae70f7-8425-4cf7-99d1-d9d80cb085b7)

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ x ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
