### PR TITLE
Update prereleases comment (adding C3)

### DIFF
--- a/.github/extract-runtime-versions.mjs
+++ b/.github/extract-runtime-versions.mjs
@@ -59,7 +59,7 @@ const workerdBinary = path.resolve(workerdPackageJsonPath, "../bin/workerd");
 const workerdBinaryVersion = execSync(workerdBinary + " --version")
 	.toString()
 	.split(" ")[1]
-	.replace("\n", "");
+	.replaceAll("\n", "");
 
 // 4. Write basic markdown report
 const report = [

--- a/.github/extract-runtime-versions.mjs
+++ b/.github/extract-runtime-versions.mjs
@@ -59,7 +59,7 @@ const workerdBinary = path.resolve(workerdPackageJsonPath, "../bin/workerd");
 const workerdBinaryVersion = execSync(workerdBinary + " --version")
 	.toString()
 	.split(" ")[1]
-	.replace('\n', '');
+	.replace("\n", "");
 
 // 4. Write basic markdown report
 const report = [

--- a/.github/extract-runtime-versions.mjs
+++ b/.github/extract-runtime-versions.mjs
@@ -58,7 +58,8 @@ const workerdBinary = path.resolve(workerdPackageJsonPath, "../bin/workerd");
 
 const workerdBinaryVersion = execSync(workerdBinary + " --version")
 	.toString()
-	.split(" ")[1];
+	.split(" ")[1]
+	.replace('\n', '');
 
 // 4. Write basic markdown report
 const report = [

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -85,7 +85,7 @@ jobs:
 
             You can run this PR's `create-cloudflare` prerelease in your project with:
             ```sh
-            npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-create-cloudflare-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
+            npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-create-cloudflare-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
             ```
 
             ### `@cloudflare/pages-shared`

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -67,7 +67,7 @@ jobs:
 
             <details>
 
-            ### wrangler
+            ### `wrangler`
 
             You can install this PR's `wrangler` prerelease in your project with:
 
@@ -81,14 +81,14 @@ jobs:
             npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }} dev path/to/script.js
             ```
 
-            ### create-cloudflare (C3)
+            ### `create-cloudflare` (C3)
 
             You can run this PR's `create-cloudflare` prerelease in your project with:
             ```sh
             npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-create-cloudflare-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
             ```
 
-            ### cloudflare-pages-shared
+            ### `@cloudflare/pages-shared`
             You can install this PR's `@cloudflare/pages-shared` prerelease in your project with:
             ```sh
             npm install https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-cloudflare-pages-shared-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -95,7 +95,7 @@ jobs:
             ```
 
             > **Note**
-            > that these links will no longer work once [the GitHub Actions artifact expires](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
+            > These links will no longer work once [the GitHub Actions artifacts expire](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
 
             ---
 

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -103,7 +103,6 @@ jobs:
 
             </details>
 
-
       - name: "Comment on PR with C3 link"
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -65,34 +65,22 @@ jobs:
           message: |
             🧪 Prerelease packages have been built and are available for testing. 🧪
 
-            <details>
-
-            ### `wrangler`
-
-            You can install this PR's `wrangler` prerelease in your project with:
-
-            ```sh
-            npm install --save-dev https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
-            ```
-
-            Or you can use `npx` to run it directly:
-
+            #### `wrangler`
             ```sh
             npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }} dev path/to/script.js
             ```
 
-            ### `create-cloudflare` (C3)
-
-            You can run this PR's `create-cloudflare` prerelease in your project with:
+            #### `create-cloudflare` (C3)
             ```sh
-            npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-create-cloudflare-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
+            npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-create-cloudflare-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }} --no-auto-update
             ```
 
-            ### `@cloudflare/pages-shared`
-            You can install this PR's `@cloudflare/pages-shared` prerelease in your project with:
+            #### `@cloudflare/pages-shared`
             ```sh
             npm install https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-cloudflare-pages-shared-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
             ```
+
+            <details>
 
             > **Note**
             > These links will no longer work once [the GitHub Actions artifacts expire](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -63,37 +63,46 @@ jobs:
         with:
           number: ${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER}}
           message: |
-            A wrangler prerelease is available for testing. You can install this latest build in your project with:
+            🧪 Prerelease packages have been built and are available for testing. 🧪
+
+            <details>
+
+            ### wrangler
+
+            You can install this PR's `wrangler` prerelease in your project with:
 
             ```sh
             npm install --save-dev https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
             ```
 
-            You can reference the automatically updated head of this PR with:
-
-            ```sh
-            npm install --save-dev https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/prs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
-            ```
-
-            Or you can use `npx` with this latest build directly:
+            Or you can use `npx` to run it directly:
 
             ```sh
             npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-wrangler-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }} dev path/to/script.js
             ```
 
-            <details><summary>Additional artifacts:</summary>
+            ### create-cloudflare (C3)
 
+            You can run this PR's `create-cloudflare` prerelease in your project with:
+            ```sh
+            npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-create-cloudflare-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
+            ```
+
+            ### cloudflare-pages-shared
+            You can install this PR's `@cloudflare/pages-shared` prerelease in your project with:
             ```sh
             npm install https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-cloudflare-pages-shared-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
             ```
 
-            Note that these links will no longer work once [the GitHub Actions artifact expires](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
-
-            </details>
+            > **Note**
+            > that these links will no longer work once [the GitHub Actions artifact expires](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
 
             ---
 
             ${{ env.RUNTIME_VERSIONS }}
+
+            </details>
+
 
       - name: "Comment on PR with C3 link"
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
This PR updates the PR prereleases comment, I wanted to add the C3 prerelease there, but since I was at it I made other changes (hopefully improvements 😬)

This is what this PR changes:
 - removed the automatically updated head installation as it adds noise and it's likely rarely if at all used
 - put all the packages at the same level (wrangler being the first or course) (i.e. removed the `Additional artifacts` distinction)
 - added C3
 - moved all the packages instructions in a `details` section so that the comment doesn't add too much noise to PRs (I've been doing this for next-on-pages and it works quite well, see for example [this comment](https://github.com/cloudflare/next-on-pages/pull/478#issuecomment-1742122883) )
 - fixed a small formatting issue in the runtime dependencies message