### PR TITLE
fix usage of shell-quote.parse on windows

### DIFF
--- a/packages/create-cloudflare/src/helpers/shell-quote.ts
+++ b/packages/create-cloudflare/src/helpers/shell-quote.ts
@@ -9,7 +9,7 @@ export function parse(cmd: string, env?: Record<string, string>): string[] {
 	// We can remove this once we upgrade to a version that includes the fix
 	// tracked by https://github.com/ljharb/shell-quote/issues/10
 	if (process.platform === "win32") {
-		cmd = cmd.replaceAll(/\\\\/g, "\\");
+		cmd = cmd.replaceAll("\\", "\\\\");
 	}
 
 	const entries = shellquote.parse(cmd, env);

--- a/packages/create-cloudflare/src/helpers/shell-quote.ts
+++ b/packages/create-cloudflare/src/helpers/shell-quote.ts
@@ -3,6 +3,15 @@ import shellquote from "shell-quote";
 export const quote = shellquote.quote;
 
 export function parse(cmd: string, env?: Record<string, string>): string[] {
+	// This is a workaround for a bug in shell-quote on Windows
+	// It was fixed and then reverted in https://github.com/ljharb/shell-quote/commit/144e1c20cd57549a414c827fb3032e60b7b8721c#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L16
+	// because it was a breaking change
+	// We can remove this once we upgrade to a version that includes the fix
+	// tracked by https://github.com/ljharb/shell-quote/issues/10
+	if (process.platform === "win32") {
+		cmd = cmd.replace(/\\\\/g, "\\");
+	}
+
 	const entries = shellquote.parse(cmd, env);
 	const argv: string[] = [];
 

--- a/packages/create-cloudflare/src/helpers/shell-quote.ts
+++ b/packages/create-cloudflare/src/helpers/shell-quote.ts
@@ -9,7 +9,7 @@ export function parse(cmd: string, env?: Record<string, string>): string[] {
 	// We can remove this once we upgrade to a version that includes the fix
 	// tracked by https://github.com/ljharb/shell-quote/issues/10
 	if (process.platform === "win32") {
-		cmd = cmd.replace(/\\\\/g, "\\");
+		cmd = cmd.replaceAll(/\\\\/g, "\\");
 	}
 
 	const entries = shellquote.parse(cmd, env);

--- a/packages/create-cloudflare/src/helpers/shell-quote.ts
+++ b/packages/create-cloudflare/src/helpers/shell-quote.ts
@@ -4,8 +4,8 @@ export const quote = shellquote.quote;
 
 export function parse(cmd: string, env?: Record<string, string>): string[] {
 	// This is a workaround for a bug in shell-quote on Windows
-	// It was fixed and then reverted in https://github.com/ljharb/shell-quote/commit/144e1c20cd57549a414c827fb3032e60b7b8721c#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L16
-	// because it was a breaking change
+	// It was fixed and, because it was a breaking change, then reverted
+	// in https://github.com/ljharb/shell-quote/commit/144e1c2#diff-e727e4b
 	// We can remove this once we upgrade to a version that includes the fix
 	// tracked by https://github.com/ljharb/shell-quote/issues/10
 	if (process.platform === "win32") {

--- a/packages/wrangler/src/utils/shell-quote.ts
+++ b/packages/wrangler/src/utils/shell-quote.ts
@@ -9,7 +9,7 @@ export function parse(cmd: string, env?: Record<string, string>): string[] {
 	// We can remove this once we upgrade to a version that includes the fix
 	// tracked by https://github.com/ljharb/shell-quote/issues/10
 	if (process.platform === "win32") {
-		cmd = cmd.replaceAll(/\\\\/g, "\\");
+		cmd = cmd.replaceAll("\\", "\\\\");
 	}
 
 	const entries = shellquote.parse(cmd, env);

--- a/packages/wrangler/src/utils/shell-quote.ts
+++ b/packages/wrangler/src/utils/shell-quote.ts
@@ -3,6 +3,15 @@ import shellquote from "shell-quote";
 export const quote = shellquote.quote;
 
 export function parse(cmd: string, env?: Record<string, string>): string[] {
+	// This is a workaround for a bug in shell-quote on Windows
+	// It was fixed and then reverted in https://github.com/ljharb/shell-quote/commit/144e1c20cd57549a414c827fb3032e60b7b8721c#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L16
+	// because it was a breaking change
+	// We can remove this once we upgrade to a version that includes the fix
+	// tracked by https://github.com/ljharb/shell-quote/issues/10
+	if (process.platform === "win32") {
+		cmd = cmd.replace(/\\\\/g, "\\");
+	}
+
 	const entries = shellquote.parse(cmd, env);
 	const argv: string[] = [];
 

--- a/packages/wrangler/src/utils/shell-quote.ts
+++ b/packages/wrangler/src/utils/shell-quote.ts
@@ -9,7 +9,7 @@ export function parse(cmd: string, env?: Record<string, string>): string[] {
 	// We can remove this once we upgrade to a version that includes the fix
 	// tracked by https://github.com/ljharb/shell-quote/issues/10
 	if (process.platform === "win32") {
-		cmd = cmd.replace(/\\\\/g, "\\");
+		cmd = cmd.replaceAll(/\\\\/g, "\\");
 	}
 
 	const entries = shellquote.parse(cmd, env);

--- a/packages/wrangler/src/utils/shell-quote.ts
+++ b/packages/wrangler/src/utils/shell-quote.ts
@@ -4,8 +4,8 @@ export const quote = shellquote.quote;
 
 export function parse(cmd: string, env?: Record<string, string>): string[] {
 	// This is a workaround for a bug in shell-quote on Windows
-	// It was fixed and then reverted in https://github.com/ljharb/shell-quote/commit/144e1c20cd57549a414c827fb3032e60b7b8721c#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L16
-	// because it was a breaking change
+	// It was fixed and, because it was a breaking change, then reverted
+	// in https://github.com/ljharb/shell-quote/commit/144e1c2#diff-e727e4b
 	// We can remove this once we upgrade to a version that includes the fix
 	// tracked by https://github.com/ljharb/shell-quote/issues/10
 	if (process.platform === "win32") {


### PR DESCRIPTION
On Windows, paths contain `\` characters as delimiters. Our command parser was interpreting these as backslash escape characters. This is essentially a double encoding bug.

This fixes the issue on Windows by replacing the backslash characters with a double-backslash which will be interpreted as an escaped backslash (i.e. a single backslash).

The double and quadruple backslashes in the `cmd.replace(...)` call are a double-encoding of themselves but I'm sure everyone reviewing this is aware.

**Author has included the following, where applicable:**

- [x] Tests (adding the e2e label to this PR so the Windows e2e tests pass to prove this works)
- [x] Changeset (no need for a changeset as the bug this introduced has blocked the release)

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
