### PR TITLE
C3: Add angular e2e coverage

### DIFF
--- a/.changeset/purple-penguins-tie.md
+++ b/.changeset/purple-penguins-tie.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Replaces the "prestart" and "predeploy" scripts when using Angular to better support pnpm

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -35,6 +35,10 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			unsupportedPms: ["bun"],
 			testCommitMessage: true,
 		},
+		angular: {
+			expectResponseToContain: "Love Angular?",
+			testCommitMessage: true,
+		},
 		gatsby: {
 			expectResponseToContain: "Gatsby!",
 			unsupportedPms: ["bun"],

--- a/packages/create-cloudflare/src/frameworks/angular/index.ts
+++ b/packages/create-cloudflare/src/frameworks/angular/index.ts
@@ -53,6 +53,7 @@ const config: FrameworkConfig = {
 	},
 	deployCommand: "deploy",
 	devCommand: "start",
+	testFlags: ["--routing", "--style", "sass"],
 };
 export default config;
 

--- a/packages/create-cloudflare/src/frameworks/angular/index.ts
+++ b/packages/create-cloudflare/src/frameworks/angular/index.ts
@@ -27,9 +27,8 @@ const generate = async (ctx: PagesGeneratorContext) => {
 };
 
 const configure = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx, false);
 	process.chdir(ctx.project.path);
-	await runCommand(`${npx} ${cli}@next analytics disable`, {
+	await runCommand(`${npx} ng analytics disable`, {
 		silent: true,
 	});
 	await addSSRAdapter();
@@ -45,11 +44,9 @@ const config: FrameworkConfig = {
 	packageScripts: {
 		process:
 			"node ./tools/copy-worker-files.mjs && node ./tools/copy-client-files.mjs && node ./tools/bundle.mjs",
-		prestart: `${npm} run build:ssr && ${npm} run process`,
-		start:
-			"wrangler pages dev dist/cloudflare --compatibility-date=2021-09-20 --experimental-local",
-		predeploy: `${npm} run build:ssr && ${npm} run process`,
-		deploy: "wrangler pages deploy dist/cloudflare",
+		"pages:build": `${npm} run build:ssr && ${npm} run process`,
+		start: `${npm} run pages:build && wrangler pages dev dist/cloudflare --compatibility-date=2021-09-20 --experimental-local`,
+		deploy: `${npm} run pages:build && wrangler pages deploy dist/cloudflare`,
 	},
 	deployCommand: "deploy",
 	devCommand: "start",


### PR DESCRIPTION
Fixes #4023

**What this PR solves / how to test:**

This PR adds e2e coverage for angular. 

It also replaces the `predeploy` and `prestart` scripts in angular's package.json scripts as [pnpm doesn't support](https://pnpm.io/cli/run#differences-with-npm-run) `pre` and `post` scripts out of the box. 

This branch is based off of [this PR](https://github.com/cloudflare/workers-sdk/pull/4096) which refactors c3 e2e.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ x ] Tests
- [ x ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
