### PR TITLE
fix: use correct header for disabling pretty-error page in tests

### DIFF
--- a/fixtures/additional-modules/test/index.test.ts
+++ b/fixtures/additional-modules/test/index.test.ts
@@ -19,10 +19,8 @@ async function getTmpDir() {
 type WranglerDev = Awaited<ReturnType<typeof runWranglerDev>>;
 function get(worker: WranglerDev, pathname: string) {
 	const url = `http://${worker.ip}:${worker.port}${pathname}`;
-	// Setting the `MF-Original-URL` header will make Miniflare think this is
-	// coming from a `dispatchFetch()` request, meaning it won't return the pretty
-	// error page, and we'll be able to parse errors as JSON.
-	return fetch(url, { headers: { "MF-Original-URL": url } });
+	// Disable Miniflare's pretty error page, so we can parse errors as JSON
+	return fetch(url, { headers: { "MF-Disable-Pretty-Error": "true" } });
 }
 
 async function retry<T>(closure: () => Promise<T>, max = 30): Promise<T> {


### PR DESCRIPTION
**What this PR solves / how to test:**

Use `MF-Disable-Pretty-Error` instead of `MF-Original-URL` for disabling the pretty-error page in the `additional-modules` fixture test. This was changed in cloudflare/miniflare#689.

**Associated docs issue(s)/PR(s):**

N/A

**Author has included the following, where applicable:**

- [ ] ~~Tests~~ (fixing existing)
- [ ] ~~Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))~~ (internal change)

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
