### PR TITLE
C3: Don't offer git if username and email unconfigured

### DIFF
--- a/.changeset/green-days-bow.md
+++ b/.changeset/green-days-bow.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Don't prompt the user to use git if `user.name` and `user.email` haven't been configured

--- a/packages/create-cloudflare/src/__tests__/common.test.ts
+++ b/packages/create-cloudflare/src/__tests__/common.test.ts
@@ -1,0 +1,41 @@
+import * as command from "helpers/command";
+import { describe, expect, test, vi } from "vitest";
+import { isGitConfigured } from "../common";
+
+function promisify<T>(value: T) {
+	return new Promise<T>((res) => res(value));
+}
+
+describe("isGitConfigured", () => {
+	test("fully configured", async () => {
+		const spy = vi.spyOn(command, "runCommand");
+		spy.mockImplementation((cmd) =>
+			promisify(cmd.includes("email") ? "test@user.com" : "test user")
+		);
+		expect(await isGitConfigured()).toBe(true);
+	});
+
+	test("no name", async () => {
+		const spy = vi.spyOn(command, "runCommand");
+		spy.mockImplementation((cmd) =>
+			promisify(cmd.includes("email") ? "test@user.com" : "")
+		);
+		expect(await isGitConfigured()).toBe(false);
+	});
+
+	test("no email", async () => {
+		const spy = vi.spyOn(command, "runCommand");
+		spy.mockImplementation((cmd) =>
+			promisify(cmd.includes("name") ? "test user" : "")
+		);
+		expect(await isGitConfigured()).toBe(false);
+	});
+
+	test("runCommand fails", async () => {
+		const spy = vi.spyOn(command, "runCommand");
+		spy.mockImplementation(() => {
+			throw new Error("git not found");
+		});
+		expect(await isGitConfigured()).toBe(false);
+	});
+});

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -371,11 +371,11 @@ async function getGitVersion() {
 /**
  * Check whether git is available on the user's machine.
  */
-async function isGitInstalled() {
+export async function isGitInstalled() {
 	return (await getGitVersion()) !== null;
 }
 
-async function isGitConfigured() {
+export async function isGitConfigured() {
 	try {
 		const userName = await runCommand("git config user.name", {
 			useSpinner: false,
@@ -383,7 +383,7 @@ async function isGitConfigured() {
 		});
 		if (!userName) return false;
 
-		const email = await runCommand("git config user.name", {
+		const email = await runCommand("git config user.email", {
 			useSpinner: false,
 			silent: true,
 		});

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -391,7 +391,7 @@ async function isGitConfigured() {
 
 		return true;
 	} catch {
-		return null;
+		return false;
 	}
 }
 


### PR DESCRIPTION
Fixes #3683.

**What this PR solves / how to test:**

Skips the prompt offering git to c3 users if they haven't yet configured `user.name` and `user.email`. 

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ x ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
