### PR TITLE
C3: Allow skipping specific pms in e2e on a per-framework basis

### DIFF
--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -17,9 +17,10 @@ import type { RunnerConfig } from "./helpers";
 const TEST_TIMEOUT = 1000 * 60 * 3;
 
 type FrameworkTestConfig = RunnerConfig & {
-	timeout?: number;
 	expectResponseToContain: string;
 	testCommitMessage: boolean;
+	timeout?: number;
+	unsupportedPms?: string[];
 };
 
 describe.concurrent(`E2E: Web frameworks`, () => {
@@ -36,6 +37,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 		gatsby: {
 			quarantine: true,
 			expectResponseToContain: "Gatsby!",
+			unsupportedPms: ["bun"],
 			promptHandlers: [
 				{
 					matcher: /Would you like to use a template\?/,
@@ -246,14 +248,22 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 	};
 
 	Object.keys(frameworkTests).forEach((framework) => {
-		const { quarantine, timeout, testCommitMessage } =
+		const { quarantine, timeout, testCommitMessage, unsupportedPms } =
 			frameworkTests[framework];
 
 		const quarantineModeMatch = isQuarantineMode() == (quarantine ?? false);
 
-		test.runIf(
-			frameworkToTest ? frameworkToTest === framework : quarantineModeMatch
-		)(
+		// If the framework in question is being run in isolation, always run it.
+		// Otherwise, only run the test if it's configured `quarantine` value matches
+		// what is set in E2E_QUARANTINE
+		let shouldRun = frameworkToTest
+			? frameworkToTest === framework
+			: quarantineModeMatch;
+
+		// Skip if the package manager is unsupported
+		shouldRun &&= !unsupportedPms?.includes(process.env.TEST_PM ?? "");
+
+		test.runIf(shouldRun)(
 			framework,
 			async () => {
 				await runCliWithDeploy(framework, testCommitMessage);

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -35,7 +35,6 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			testCommitMessage: true,
 		},
 		gatsby: {
-			quarantine: true,
 			expectResponseToContain: "Gatsby!",
 			unsupportedPms: ["bun"],
 			promptHandlers: [

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -32,6 +32,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 		},
 		docusaurus: {
 			expectResponseToContain: "Dinosaurs are cool",
+			unsupportedPms: ["bun"],
 			testCommitMessage: true,
 		},
 		gatsby: {

--- a/packages/create-cloudflare/src/frameworks/docusaurus/index.ts
+++ b/packages/create-cloudflare/src/frameworks/docusaurus/index.ts
@@ -19,5 +19,6 @@ const config: FrameworkConfig = {
 		"pages:dev": `wrangler pages dev ${compatDateFlag()} --proxy 3000 -- ${npm} run start`,
 		"pages:deploy": `NODE_VERSION=16 ${npm} run build && wrangler pages deploy ./build`,
 	},
+	testFlags: [`--package-manager`, npm],
 };
 export default config;

--- a/packages/create-cloudflare/src/helpers/packages.ts
+++ b/packages/create-cloudflare/src/helpers/packages.ts
@@ -29,6 +29,7 @@ export const detectPackageManager = () => {
 			case "bun":
 				name = "bun";
 				version = "1.0.0";
+				process.env.npm_config_user_agent = "bun";
 				break;
 			case "npm":
 				name = "npm";


### PR DESCRIPTION
Some frameworks are lacking support with current package managers (namely Gatsby with bun), so to avoid quarantining a framework this change allows us to skip certain package managers on a per-framework basis.

Branched off of https://github.com/cloudflare/workers-sdk/pull/4096 which contains a heavy refactor of c3 e2e tests.

**What this PR solves / how to test:**

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ x ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
