### PR TITLE
C3: Validate project name

### DIFF
--- a/.changeset/purple-eels-own.md
+++ b/.changeset/purple-eels-own.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Verify that project names are valid for pages projects

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -27,7 +27,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 		});
 
 		const runCli = async (template: string) => {
-			const projectPath = getPath(template);
+			const projectPath = getPath(template.toLowerCase());
 
 			const argv = [
 				projectPath,

--- a/packages/create-cloudflare/src/__tests__/common.test.ts
+++ b/packages/create-cloudflare/src/__tests__/common.test.ts
@@ -1,6 +1,7 @@
 import * as command from "helpers/command";
 import { describe, expect, test, vi } from "vitest";
 import { isGitConfigured } from "../common";
+import { validateProjectDirectory } from "../common";
 
 function promisify<T>(value: T) {
 	return new Promise<T>((res) => res(value));
@@ -37,5 +38,27 @@ describe("isGitConfigured", () => {
 			throw new Error("git not found");
 		});
 		expect(await isGitConfigured()).toBe(false);
+	});
+});
+
+describe("validateProjectDirectory", () => {
+	test("allow valid project names", async () => {
+		expect(validateProjectDirectory("foo")).toBeUndefined();
+		expect(validateProjectDirectory("foo/bar/baz")).toBeUndefined();
+		expect(validateProjectDirectory("./foobar")).toBeUndefined();
+		expect(validateProjectDirectory("f".repeat(58))).toBeUndefined();
+	});
+
+	test("disallow invalid project names", async () => {
+		// Invalid pages project names should return an error
+		expect(validateProjectDirectory("foobar-")).not.toBeUndefined();
+		expect(validateProjectDirectory("-foobar-")).not.toBeUndefined();
+		expect(validateProjectDirectory("fo*o{ba)r")).not.toBeUndefined();
+		expect(validateProjectDirectory("f".repeat(59))).not.toBeUndefined();
+	});
+
+	test("disallow existing, non-empty directories", async () => {
+		// Existing, non-empty directories should return an error
+		expect(validateProjectDirectory(".")).not.toBeUndefined();
 	});
 });

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -45,7 +45,7 @@ export const validateProjectDirectory = (relativePath: string) => {
 
 	// Ensure the name is valid per the pages schema
 	const projectName = basename(path);
-	const invalidChars = /^- | -$|[^a-z0-9-]/;
+	const invalidChars = /[^a-z0-9-]/;
 	const invalidStartEnd = /^-|-$/;
 
 	if (projectName.match(invalidStartEnd)) {

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -34,8 +34,17 @@ import type { C3Args, PagesGeneratorContext } from "types";
 const { name, npm } = detectPackageManager();
 
 export const validateProjectDirectory = (relativePath: string) => {
+	// Validate that the directory is non-existant or empty
+	const path = resolve(relativePath);
+	const existsAlready = existsSync(path);
+	const isEmpty = existsAlready && readdirSync(path).length === 0; // allow existing dirs _if empty_ to ensure c3 is non-destructive
+
+	if (existsAlready && !isEmpty) {
+		return `Directory \`${relativePath}\` already exists and is not empty. Please choose a new name.`;
+	}
+
 	// Ensure the name is valid per the pages schema
-	const projectName = basename(relativePath);
+	const projectName = basename(path);
 	const invalidChars = /^- | -$|[^a-z0-9-]/;
 	const invalidStartEnd = /^-|-$/;
 
@@ -49,15 +58,6 @@ export const validateProjectDirectory = (relativePath: string) => {
 
 	if (projectName.length > 58) {
 		return `Project names must be less than 58 characters.`;
-	}
-
-	// Validate that the directory is non-existant or empty
-	const path = resolve(relativePath);
-	const existsAlready = existsSync(path);
-	const isEmpty = existsAlready && readdirSync(path).length === 0; // allow existing dirs _if empty_ to ensure c3 is non-destructive
-
-	if (existsAlready && !isEmpty) {
-		return `Directory \`${relativePath}\` already exists and is not empty. Please choose a new name.`;
 	}
 };
 

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -34,6 +34,24 @@ import type { C3Args, PagesGeneratorContext } from "types";
 const { name, npm } = detectPackageManager();
 
 export const validateProjectDirectory = (relativePath: string) => {
+	// Ensure the name is valid per the pages schema
+	const projectName = basename(relativePath);
+	const invalidChars = /^- | -$|[^a-z0-9-]/;
+	const invalidStartEnd = /^-|-$/;
+
+	if (projectName.match(invalidStartEnd)) {
+		return `Project name cannot start or end with a dash.`;
+	}
+
+	if (projectName.match(invalidChars)) {
+		return `Project name must only contain lowercase characters, numbers, and dashes.`;
+	}
+
+	if (projectName.length > 58) {
+		return `Project names must be less than 58 characters.`;
+	}
+
+	// Validate that the directory is non-existant or empty
 	const path = resolve(relativePath);
 	const existsAlready = existsSync(path);
 	const isEmpty = existsAlready && readdirSync(path).length === 0; // allow existing dirs _if empty_ to ensure c3 is non-destructive


### PR DESCRIPTION
Fixes #3222

**What this PR solves / how to test:**

This change ensures that project names are also valid pages project names to prevent crashes during the deploy step. 

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ x ] Tests
- [ x ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
