### PR TITLE
wrangler: add mutable id to first_party_worker logs

### DIFF
--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -110,6 +110,7 @@ describe("deploy", () => {
 			Worker ID:  abc12345
 			Worker ETag:  etag98765
 			Worker PipelineHash:  hash9999
+			Worker Mutable PipelineID (Development ONLY!): mutableId
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -8749,6 +8750,7 @@ function mockUploadWorkerRequest(
 					id: "abc12345",
 					etag: "etag98765",
 					pipeline_hash: "hash9999",
+					mutable_pipeline_id: "mutableId",
 					tag: "sample-tag",
 					deployment_id: "Galaxy-Class",
 				})

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -649,6 +649,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					id: string | null;
 					etag: string | null;
 					pipeline_hash: string | null;
+					mutable_pipeline_id: string | null;
 					deployment_id: string | null;
 				}>(
 					workerUrl,
@@ -676,6 +677,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					if (result.etag) logger.log("Worker ETag: ", result.etag);
 					if (result.pipeline_hash)
 						logger.log("Worker PipelineHash: ", result.pipeline_hash);
+					if (result.mutable_pipeline_id)
+						logger.log(
+							"Worker Mutable PipelineID (Development ONLY!):",
+							result.mutable_pipeline_id
+						);
 				}
 			} catch (err) {
 				helpIfErrorIsSizeOrScriptStartup(err, dependencies);


### PR DESCRIPTION
**What this PR solves / how to test:**
Adds another field to printed output for internal first-party workers.

**Author has included the following, where applicable:**

- [x] Tests

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
