### PR TITLE
C3: Turn auto-update back on

### DIFF
--- a/.changeset/yellow-cycles-fix.md
+++ b/.changeset/yellow-cycles-fix.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Fixes an issue that was causing the auto-update check not to run

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -51,7 +51,13 @@ const isUpdateAvailable = async () => {
 // Spawn a separate process running the most recent version of c3
 export const runLatest = async () => {
 	const args = process.argv.slice(2);
-	await runCommand(`${npm} create cloudflare@latest -- ${args.join(" ")}`);
+
+	// the parsing logic of `npm create` requires `--` to be supplied
+	// before any flags intended for the target command.
+	const argString =
+		npm === "npm" ? `-- ${args.join(" ")}` : `${args.join(" ")}`;
+
+	await runCommand(`${npm} create cloudflare@latest ${argString}`);
 };
 
 // Entrypoint to c3

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -51,7 +51,7 @@ const isUpdateAvailable = async () => {
 // Spawn a separate process running the most recent version of c3
 export const runLatest = async () => {
 	const args = process.argv.slice(2);
-	await runCommand(`${npm} create cloudflare@latest ${args.join(" ")}`);
+	await runCommand(`${npm} create cloudflare@latest -- ${args.join(" ")}`);
 };
 
 // Entrypoint to c3

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -39,6 +39,12 @@ export const parseArgs = async (argv: string[]): Promise<Partial<C3Args>> => {
 			alias: "y",
 			type: "boolean",
 		})
+		.option("auto-update", {
+			type: "boolean",
+			default: C3_DEFAULTS.autoUpdate,
+			description:
+				"Automatically uses the latest version of `create-cloudflare`. Set --no-auto-update to disable",
+		})
 		.option("wrangler-defaults", { type: "boolean", hidden: true })
 		.version(version)
 		// note: we use strictOptions since `strict()` seems not to handle `positional`s correctly

--- a/packages/create-cloudflare/src/workers.ts
+++ b/packages/create-cloudflare/src/workers.ts
@@ -23,6 +23,7 @@ import {
 	npmInstall,
 	runCommand,
 } from "helpers/command";
+import { detectPackageManager } from "helpers/packages";
 import {
 	chooseAccount,
 	gitCommit,
@@ -33,6 +34,8 @@ import {
 	setupProjectDirectory,
 } from "./common";
 import type { C3Args, PagesGeneratorContext as Context } from "types";
+
+const { dlx } = detectPackageManager();
 
 export const runWorkersGenerator = async (args: C3Args) => {
 	const { name, path } = setupProjectDirectory(args);
@@ -120,7 +123,7 @@ async function copyExistingWorkerFiles(ctx: Context) {
 			join(tmpdir(), "c3-wrangler-init--from-dash-")
 		);
 		await runCommand(
-			`npx wrangler@3 init --from-dash ${ctx.args.existingScript} -y --no-delegate-c3`,
+			`${dlx} wrangler@3 init --from-dash ${ctx.args.existingScript} -y --no-delegate-c3`,
 			{
 				silent: true,
 				cwd: tempdir, // use a tempdir because we don't want all the files


### PR DESCRIPTION
Fixes #3865.

**What this PR solves / how to test:**

In an [earlier PR](https://github.com/cloudflare/workers-sdk/pull/3803), we changes c3 so that it would automatically update to the latest minor version of the package when available. Unfortunately, this behavior was accidentally reverted shortly afterwards due to a merge conflict.

This PR turns auto-updates back on and fixes an issue with this functionality when used in conjunction with `wrangler init`. 

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ x ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
