### PR TITLE
Add condition to add PR to GH project

### DIFF
--- a/.github/workflows/pullrequests.yml
+++ b/.github/workflows/pullrequests.yml
@@ -6,6 +6,7 @@ env:
   node-version: 16.14
 jobs:
   add-to-project:
+    if: ${{ github.repository_owner == 'cloudflare' }}
     name: Add PR to project
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes N/A/

**What this PR solves / how to test:** Currently the job to add PRs to the workers-sdk GH project runs on every PR. However, it fails for PRs not on the Cloudflare fork due to insufficient permissions. This updates the job to only run on PRs from the Cloudflare fork.

**Associated docs issue(s)/PR(s):** N/A


**Author has included the following, where applicable:**

- [ ] ~Tests~
- [ ] ~Changeset~ ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
