### PR TITLE
Warn that Hyperdrive bindings do not yet work in local dev

### DIFF
--- a/.changeset/tall-dodos-join.md
+++ b/.changeset/tall-dodos-join.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Log a warning when using a Hyperdrive binding in local wrangler dev

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -296,6 +296,12 @@ function DevSession(props: DevSessionProps) {
 		);
 	}
 
+	if (props.local && props.bindings.hyperdrive?.length) {
+		logger.warn(
+			"Hyperdrive does not currently support 'wrangler dev' in local mode at this stage of the beta. Use the '--remote' flag to test a Hyperdrive configuration before deploying."
+		);
+	}
+
 	const announceAndOnReady: typeof props.onReady = (finalIp, finalPort) => {
 		if (process.send) {
 			process.send(


### PR DESCRIPTION
Support is already in progress (see https://github.com/cloudflare/workerd/pull/1266) and should be coming in the next few weeks, but we've already had at least one user get very confused by this and cause us to spend time on debugging before realizing the problem was that they were talking about problems in wrangler dev rather than at the edge. This is an easy way to attempt to mitigate that for now.

Fixes #4133

**Author has included the following, where applicable:**

- [x] Tests (not applicable, it's just a warning log message)
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
