### PR TITLE
C3: fail e2e dependabot PRs if no framework Cli is detected

### DIFF
--- a/.github/workflows/c3-e2e-dependabot.yml
+++ b/.github/workflows/c3-e2e-dependabot.yml
@@ -54,7 +54,12 @@ jobs:
               )})\\]\\(.*?\\)\\s+from\\s+${semverRegexStr}\\s+to\\s+${semverRegexStr}`
             );
 
-            const bumpedFrameworkCli = body.match(frameworkCliRegex)?.[1] ?? '';
+            const bumpedFrameworkCli = body.match(frameworkCliRegex)?.[1];
+
+            if(!bumpedFrameworkCli) {
+              throw new Error('Error: Failed to determine framework cli to test');
+            }
+
             return bumpedFrameworkCli;
 
   # For dependabot versioning PRs we only want to run the e2es for the specifically bumped


### PR DESCRIPTION
throwing inside the `actions/github-script@v6` script causes the workflow to fail, I've tested it [here](https://github.com/dario-piotrowicz/dependabot-testing/commit/5f8aeaa4afd1c484b73ceb83639e166d67f13878) with this [result](https://github.com/dario-piotrowicz/dependabot-testing/actions/runs/6481838120/job/17600146758?pr=75#step:4:17)

if preferred instead of throwing in the script I can leave the script as is and add a new steps that does the check and fails the workflow more explicitly, something like:
```yml
- name: Check FrameworkCli
   if: ${{ steps.detect.outputs.result == '' }}
   run: |
     echo "Error: Framework Cli not detected"
     exit 1
```

I don't have a strong preference so please let me know if you have and I can just quickly update this PR 🙂 