### PR TITLE
C3: E2E logging refactor

### DIFF
--- a/.github/actions/run-c3-e2e/action.yml
+++ b/.github/actions/run-c3-e2e/action.yml
@@ -50,5 +50,6 @@ runs:
         path: packages/create-cloudflare/.e2e-logs
 
     - name: Fail if errors detected
+      shell: bash
       if: ${{ steps.run-e2e.outcome == 'failure' }}
       run: exit 1

--- a/.github/actions/run-c3-e2e/action.yml
+++ b/.github/actions/run-c3-e2e/action.yml
@@ -40,3 +40,9 @@ runs:
         CLOUDFLARE_ACCOUNT_ID: ${{ inputs.accountId }}
         E2E_QUARANTINE: ${{ inputs.quarantine }}
         FRAMEWORK_CLI_TO_TEST: ${{ inputs.framework }}
+
+    - name: Upload Logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: e2e-logs
+        path: packages/create-cloudflare/.e2e-logs

--- a/.github/actions/run-c3-e2e/action.yml
+++ b/.github/actions/run-c3-e2e/action.yml
@@ -33,7 +33,9 @@ runs:
         git config --global user.name 'Wrangler automated PR updater'
 
     - name: E2E Tests
+      id: run-e2e
       shell: bash
+      continue-on-error: true
       run: pnpm run --filter create-cloudflare test:e2e:${{ inputs.package-manager }}
       env:
         CLOUDFLARE_API_TOKEN: ${{ inputs.apiToken }}
@@ -46,3 +48,7 @@ runs:
       with:
         name: e2e-logs
         path: packages/create-cloudflare/.e2e-logs
+
+    - name: Fail if errors detected
+      if: ${{ steps.run-e2e.outcome == 'failure' }}
+      run: exit 1

--- a/packages/create-cloudflare/.gitignore
+++ b/packages/create-cloudflare/.gitignore
@@ -2,7 +2,6 @@ node_modules
 /dist
 create-cloudflare-*.tgz
 /.e2e-logs/*
-!/.e2e-logs/.gitkeep
 
 .DS_Store
 

--- a/packages/create-cloudflare/.gitignore
+++ b/packages/create-cloudflare/.gitignore
@@ -2,6 +2,7 @@ node_modules
 /dist
 create-cloudflare-*.tgz
 /.e2e-logs/*
+!/.e2e-logs/.gitkeep
 
 .DS_Store
 

--- a/packages/create-cloudflare/.gitignore
+++ b/packages/create-cloudflare/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 /dist
 create-cloudflare-*.tgz
+/.e2e-logs/*
 
 .DS_Store
 

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -145,7 +145,7 @@ export const recreateLogFolder = (suite: Suite) => {
 		force: true,
 	});
 
-	mkdirSync(getLogPath(suite));
+	mkdirSync(getLogPath(suite), { recursive: true });
 };
 
 const getLogPath = (suite: Suite) => {
@@ -155,7 +155,7 @@ const getLogPath = (suite: Suite) => {
 		? basename(file.name).replace(".test.ts", "")
 		: "unknown";
 
-	return join("./.e2e-logs/", suiteFilename);
+	return join("./.e2e-logs/", process.env.TEST_PM as string, suiteFilename);
 };
 
 const normalizeTestName = (ctx: TestContext) => {

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -118,7 +118,6 @@ export const runC3 = async ({
 			if (code === 0) {
 				resolve(null);
 			} else {
-				console.log(stderr.join("\n").trim());
 				rejects(code);
 			}
 		});

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -43,6 +43,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			expectResponseToContain: "Dinosaurs are cool",
 			unsupportedPms: ["bun"],
 			testCommitMessage: true,
+			timeout: 1000 * 60 * 5,
 		},
 		angular: {
 			quarantine: true,

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -10,7 +10,7 @@ import {
 	beforeEach,
 	beforeAll,
 } from "vitest";
-import { deleteProject } from "../scripts/e2eCleanup";
+import { deleteProject } from "../scripts/common";
 import { frameworkToTest } from "./frameworkToTest";
 import {
 	isQuarantineMode,

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -1,7 +1,20 @@
 import { join } from "path";
-import { describe, expect, test, afterEach, beforeEach } from "vitest";
+import {
+	describe,
+	expect,
+	test,
+	afterEach,
+	beforeEach,
+	beforeAll,
+} from "vitest";
 import { frameworkToTest } from "./frameworkToTest";
-import { isQuarantineMode, runC3, testProjectDir } from "./helpers";
+import {
+	isQuarantineMode,
+	recreateLogFolder,
+	runC3,
+	testProjectDir,
+} from "./helpers";
+import type { Suite, TestContext } from "vitest";
 
 /*
 Areas for future improvement:
@@ -16,6 +29,10 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 	() => {
 		const { getPath, clean } = testProjectDir("workers");
 
+		beforeAll((ctx) => {
+			recreateLogFolder(ctx as Suite);
+		});
+
 		beforeEach((ctx) => {
 			const template = ctx.meta.name;
 			clean(template);
@@ -26,7 +43,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 			clean(template);
 		});
 
-		const runCli = async (template: string) => {
+		const runCli = async (template: string, ctx: TestContext) => {
 			const projectPath = getPath(template.toLowerCase());
 
 			const argv = [
@@ -39,7 +56,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 				"--wrangler-defaults",
 			];
 
-			await runC3({ argv });
+			await runC3({ ctx, argv });
 
 			// Relevant project files should have been created
 			expect(projectPath).toExist();
@@ -54,7 +71,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 			expect(wranglerPath).toExist();
 		};
 
-		test.each([
+		describe.each([
 			"hello-world",
 			"common",
 			"chatgptPlugin",
@@ -62,7 +79,9 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 			"scheduled",
 			"openapi",
 		])("%s", async (name) => {
-			await runCli(name);
+			test(name, async (ctx) => {
+				await runCli(name, ctx);
+			});
 		});
 	}
 );

--- a/packages/create-cloudflare/scripts/common.ts
+++ b/packages/create-cloudflare/scripts/common.ts
@@ -1,0 +1,85 @@
+import { fetch } from "undici";
+
+type ApiErrorBody = {
+	errors: string[];
+};
+
+type ApiSuccessBody = {
+	result: any[];
+};
+
+export type Project = {
+	name: string;
+};
+
+const apiFetch = async (
+	path: string,
+	init = { method: "GET" },
+	queryParams = {}
+) => {
+	const baseUrl = `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}`;
+	const queryString = queryParams
+		? `?${new URLSearchParams(queryParams).toString()}`
+		: "";
+	const url = `${baseUrl}${path}${queryString}`;
+
+	const response = await fetch(url, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
+		},
+	});
+
+	if (response.status >= 400) {
+		console.error(`REQUEST ERROR: ${url}`);
+		console.error(`(${response.status}) ${response.statusText}`);
+		const body = (await response.json()) as ApiErrorBody;
+		console.error(body.errors);
+
+		// Returning null instead of throwing an error here allows the caller to decide whether
+		// to continue on fail or not. A failure to list projects should end the script, whereas
+		// a failure to delete a project may happen due to concurrent runs of this script, and should
+		// be tolerated.
+		return null;
+	}
+
+	const json = (await response.json()) as ApiSuccessBody;
+
+	return json.result;
+};
+
+export const listC3Projects = async () => {
+	const pageSize = 10;
+	let page = 1;
+
+	const projects = [];
+	while (projects.length % pageSize === 0) {
+		const res = await apiFetch(
+			`/pages/projects`,
+			{ method: "GET" },
+			{
+				per_page: pageSize,
+				page,
+			}
+		);
+
+		if (res === null) {
+			console.error("Failed to fetch project list");
+			process.exit(1);
+		}
+
+		projects.push(...res);
+		page++;
+		if (res.length < pageSize) {
+			break;
+		}
+	}
+
+	return projects.filter((p) => p.name.startsWith("c3-e2e-"));
+};
+
+export const deleteProject = async (project: string) => {
+	await apiFetch(`/pages/projects/${project}`, {
+		method: "DELETE",
+	});
+};

--- a/packages/create-cloudflare/scripts/e2eCleanup.ts
+++ b/packages/create-cloudflare/scripts/e2eCleanup.ts
@@ -1,4 +1,4 @@
-import { fetch } from "undici";
+import { Project, deleteProject, listC3Projects } from "./common";
 
 if (!process.env.CLOUDFLARE_API_TOKEN) {
 	console.error("CLOUDFLARE_API_TOKEN must be set");
@@ -9,91 +9,6 @@ if (!process.env.CLOUDFLARE_ACCOUNT_ID) {
 	console.error("CLOUDFLARE_ACCOUNT_ID must be set");
 	process.exit(1);
 }
-
-type ApiErrorBody = {
-	errors: string[];
-};
-
-type ApiSuccessBody = {
-	result: any[];
-};
-
-type Project = {
-	name: string;
-};
-
-const apiFetch = async (
-	path: string,
-	init = { method: "GET" },
-	queryParams = {}
-) => {
-	const baseUrl = `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}`;
-	const queryString = queryParams
-		? `?${new URLSearchParams(queryParams).toString()}`
-		: "";
-	const url = `${baseUrl}${path}${queryString}`;
-
-	const response = await fetch(url, {
-		...init,
-		headers: {
-			Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
-		},
-	});
-
-	if (response.status >= 400) {
-		console.error(`REQUEST ERROR: ${url}`);
-		console.error(`(${response.status}) ${response.statusText}`);
-		const body = (await response.json()) as ApiErrorBody;
-		console.error(body.errors);
-
-		// Returning null instead of throwing an error here allows the caller to decide whether
-		// to continue on fail or not. A failure to list projects should end the script, whereas
-		// a failure to delete a project may happen due to concurrent runs of this script, and should
-		// be tolerated.
-		return null;
-	}
-
-	const json = (await response.json()) as ApiSuccessBody;
-
-	return json.result;
-};
-
-const listC3Projects = async () => {
-	const pageSize = 10;
-	let page = 1;
-
-	const projects = [];
-	while (projects.length % pageSize === 0) {
-		const res = await apiFetch(
-			`/pages/projects`,
-			{ method: "GET" },
-			{
-				per_page: pageSize,
-				page,
-			}
-		);
-
-		if (res === null) {
-			console.error("Failed to fetch project list");
-			process.exit(1);
-		}
-
-		projects.push(...res);
-		page++;
-		if (res.length < pageSize) {
-			break;
-		}
-	}
-
-	return projects.filter((p) => p.name.startsWith("c3-e2e-"));
-};
-
-export const deleteProject = async (project: string) => {
-	console.log(`Deleting project: ${project}`);
-	await apiFetch(`/pages/projects/${project}`, {
-		method: "DELETE",
-	});
-};
 
 const run = async () => {
 	const projectsToDelete = (await listC3Projects()) as Project[];

--- a/packages/create-cloudflare/src/frameworks/angular/index.ts
+++ b/packages/create-cloudflare/src/frameworks/angular/index.ts
@@ -23,6 +23,9 @@ const generate = async (ctx: PagesGeneratorContext) => {
 		`${dlx} ${cli} new ${ctx.project.name} --standalone`
 	);
 
+	// TODO: Hack for testing only
+	process.exit(1);
+
 	logRaw("");
 };
 

--- a/packages/create-cloudflare/src/frameworks/angular/index.ts
+++ b/packages/create-cloudflare/src/frameworks/angular/index.ts
@@ -23,9 +23,6 @@ const generate = async (ctx: PagesGeneratorContext) => {
 		`${dlx} ${cli} new ${ctx.project.name} --standalone`
 	);
 
-	// TODO: Hack for testing only
-	process.exit(1);
-
 	logRaw("");
 };
 

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { spawn } from "cross-spawn";
 import { endSection, stripAnsi } from "./cli";
 import { brandColor, dim } from "./colors";
-import { spinner } from "./interactive";
+import { isInteractive, spinner } from "./interactive";
 import { detectPackageManager } from "./packages";
 import * as shellquote from "./shell-quote";
 import type { PagesGeneratorContext } from "types";
@@ -136,7 +136,7 @@ export const printAsyncStatus = async <T>({
 }: PrintOptions<T>): Promise<T> => {
 	let s: ReturnType<typeof spinner> | undefined;
 
-	if (opts.useSpinner) {
+	if (opts.useSpinner && isInteractive()) {
 		s = spinner();
 	}
 

--- a/packages/create-cloudflare/src/helpers/interactive.ts
+++ b/packages/create-cloudflare/src/helpers/interactive.ts
@@ -274,31 +274,40 @@ export const spinner = (
 			currentMsg = msg;
 			startMsg = `${currentMsg} ${dim(helpText)}`;
 
-			let index = 0;
+			if (isInteractive()) {
+				let index = 0;
 
-			clearLoop();
-			loop = setInterval(() => {
-				index++;
-				const spinnerFrame = frames[index % frames.length];
-				const ellipsisFrame = ellipsisFrames[index % ellipsisFrames.length];
+				clearLoop();
+				loop = setInterval(() => {
+					index++;
+					const spinnerFrame = frames[index % frames.length];
+					const ellipsisFrame = ellipsisFrames[index % ellipsisFrames.length];
 
-				if (msg) {
-					logUpdate(`${color(spinnerFrame)} ${currentMsg} ${ellipsisFrame}`);
-				}
-			}, frameRate);
+					if (msg) {
+						logUpdate(`${color(spinnerFrame)} ${currentMsg} ${ellipsisFrame}`);
+					}
+				}, frameRate);
+			} else {
+				logUpdate(`${leftT} ${startMsg}`);
+			}
 		},
 		update(msg: string) {
 			currentMsg = msg;
 		},
 		stop(msg?: string) {
-			// Write the final message and clear the loop
-			logUpdate.clear();
-			if (msg) {
-				logUpdate(`${leftT} ${startMsg}\n${grayBar} ${msg}`);
-				logUpdate.done();
+			if (isInteractive()) {
+				// Write the final message and clear the loop
+				logUpdate.clear();
+				if (msg) {
+					logUpdate(`${leftT} ${startMsg}\n${grayBar} ${msg}`);
+					logUpdate.done();
+					newline();
+				}
+				clearLoop();
+			} else {
+				logUpdate(`\n${grayBar} ${msg}`);
 				newline();
 			}
-			clearLoop();
 		},
 	};
 };


### PR DESCRIPTION
**What this PR solves / how to test:**

This is a long overdue rework of how we handle logging in c3 e2e tests.

The current e2e logging situation is extremely annoying. The test runner pipes output directly to stdout with minimal filtering, and since the output contains interactive cli commands it's usually cluttered with various animations and terminal escape codes. To make matters worse, tests are run in parallel and output to the same stdout, which means that the output of multiple frameworks are interleaved with one another, making almost impossible to discern where the output of the problematic test begins and ends.

This PR changes things by:
- Formatting the output in a simpler way for non-interactive terminals (which happens to be useful outside of testing as well)
- Giving each test its own dedicated output log. Each file gets it's own folder, and each test attempt gets its own file. If a test is retried, each attempt gets its own file
- Fixes an issue where the cleanup script was being run as a side effect of import, often running the cleanup script more often than was required

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ x ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
