### PR TITLE
C3: Remove wrangler team from C3 CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,7 @@
 /packages/wrangler/src/api/d1/ @cloudflare/d1 @cloudflare/wrangler
 /packages/wrangler/src/d1/ @cloudflare/d1 @cloudflare/wrangler
 
-/packages/create-cloudflare/ @cloudflare/c3 @cloudflare/wrangler
+/packages/create-cloudflare/ @cloudflare/c3
 
 # Owners intentionally left blank on these shared directories
 # to avoid noisy review requests


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR removes the wrangler team as CODEOWNERS of c3. 

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
