### PR TITLE
C3: Relax validation for existing scripts

### DIFF
--- a/.changeset/plenty-colts-breathe.md
+++ b/.changeset/plenty-colts-breathe.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Relax name validation for projects created with `--existing-script` flag

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -36,6 +36,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			testCommitMessage: true,
 		},
 		angular: {
+			quarantine: true,
 			expectResponseToContain: "Love Angular?",
 			testCommitMessage: true,
 		},

--- a/packages/create-cloudflare/src/__tests__/common.test.ts
+++ b/packages/create-cloudflare/src/__tests__/common.test.ts
@@ -42,7 +42,7 @@ describe("isGitConfigured", () => {
 });
 
 describe("validateProjectDirectory", () => {
-	const args = {};
+	let args = {};
 
 	test("allow valid project names", async () => {
 		expect(validateProjectDirectory("foo", args)).toBeUndefined();
@@ -62,5 +62,12 @@ describe("validateProjectDirectory", () => {
 	test("disallow existing, non-empty directories", async () => {
 		// Existing, non-empty directories should return an error
 		expect(validateProjectDirectory(".", args)).not.toBeUndefined();
+	});
+
+	test("Relax validation when --existing-script is passed", async () => {
+		args = { existingScript: "FooBar" };
+		expect(validateProjectDirectory("foobar-", args)).toBeUndefined();
+		expect(validateProjectDirectory("FooBar", args)).toBeUndefined();
+		expect(validateProjectDirectory("f".repeat(59), args)).toBeUndefined();
 	});
 });

--- a/packages/create-cloudflare/src/__tests__/common.test.ts
+++ b/packages/create-cloudflare/src/__tests__/common.test.ts
@@ -42,23 +42,25 @@ describe("isGitConfigured", () => {
 });
 
 describe("validateProjectDirectory", () => {
+	const args = {};
+
 	test("allow valid project names", async () => {
-		expect(validateProjectDirectory("foo")).toBeUndefined();
-		expect(validateProjectDirectory("foo/bar/baz")).toBeUndefined();
-		expect(validateProjectDirectory("./foobar")).toBeUndefined();
-		expect(validateProjectDirectory("f".repeat(58))).toBeUndefined();
+		expect(validateProjectDirectory("foo", args)).toBeUndefined();
+		expect(validateProjectDirectory("foo/bar/baz", args)).toBeUndefined();
+		expect(validateProjectDirectory("./foobar", args)).toBeUndefined();
+		expect(validateProjectDirectory("f".repeat(58), args)).toBeUndefined();
 	});
 
 	test("disallow invalid project names", async () => {
 		// Invalid pages project names should return an error
-		expect(validateProjectDirectory("foobar-")).not.toBeUndefined();
-		expect(validateProjectDirectory("-foobar-")).not.toBeUndefined();
-		expect(validateProjectDirectory("fo*o{ba)r")).not.toBeUndefined();
-		expect(validateProjectDirectory("f".repeat(59))).not.toBeUndefined();
+		expect(validateProjectDirectory("foobar-", args)).not.toBeUndefined();
+		expect(validateProjectDirectory("-foobar-", args)).not.toBeUndefined();
+		expect(validateProjectDirectory("fo*o{ba)r", args)).not.toBeUndefined();
+		expect(validateProjectDirectory("f".repeat(59), args)).not.toBeUndefined();
 	});
 
 	test("disallow existing, non-empty directories", async () => {
 		// Existing, non-empty directories should return an error
-		expect(validateProjectDirectory(".")).not.toBeUndefined();
+		expect(validateProjectDirectory(".", args)).not.toBeUndefined();
 	});
 });

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -71,7 +71,7 @@ export const runCli = async (args: Partial<C3Args>) => {
 		defaultValue: C3_DEFAULTS.projectName,
 		label: "dir",
 		validate: (value) =>
-			validateProjectDirectory(String(value) || C3_DEFAULTS.projectName),
+			validateProjectDirectory(String(value) || C3_DEFAULTS.projectName, args),
 		format: (val) => `./${val}`,
 	});
 

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -55,11 +55,11 @@ export const validateProjectDirectory = (
 		const invalidStartEnd = /^-|-$/;
 
 		if (projectName.match(invalidStartEnd)) {
-			return `Project name cannot start or end with a dash.`;
+			return `Project names cannot start or end with a dash.`;
 		}
 
 		if (projectName.match(invalidChars)) {
-			return `Project name must only contain lowercase characters, numbers, and dashes.`;
+			return `Project names must only contain lowercase characters, numbers, and dashes.`;
 		}
 
 		if (projectName.length > 58) {

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -2,7 +2,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { version } from "../../package.json";
 import { templateMap } from "../templateMap";
-import { C3_DEFAULTS, WRANGLER_DEFAULTS, logRaw } from "./cli";
+import { C3_DEFAULTS, WRANGLER_DEFAULTS, crash, logRaw } from "./cli";
 import { getRenderers, inputPrompt } from "./interactive";
 import type { PromptConfig } from "./interactive";
 import type { C3Args } from "types";
@@ -82,8 +82,14 @@ export const processArgument = async <T>(
 
 	// If the value has already been set via args, use that
 	if (value !== undefined) {
-		promptConfig.validate?.(value);
+		// Crash if we can't validate the value
+		const error = promptConfig.validate?.(value);
+		if (error) {
+			crash(error);
+		}
 
+		// Show the user the submitted state as if they had
+		// supplied it interactively
 		const lines = renderSubmitted({ value });
 		logRaw(lines.join("\n"));
 


### PR DESCRIPTION
**What this PR solves / how to test:**

In a [previous PR ](https://github.com/cloudflare/workers-sdk/pull/4128) we made project validation a little more strict so that it conforms to the pages project API. However, this could mean that users with existing workers scripts won't be able to retain a name they used previously. This PR relaxes the validation for that one particular use case.

I also found an issue with `processArgument` where we weren't actually crashing on invalid arguments passed via the command line.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
