### PR TITLE
C3: Remove remix from quarantine

### DIFF
--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -68,7 +68,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 		remix: {
 			expectResponseToContain: "Welcome to Remix",
 			testCommitMessage: true,
-			quarantine: true,
+			timeout: 1000 * 60 * 5,
 		},
 		next: {
 			expectResponseToContain: "Create Next App",


### PR DESCRIPTION
**What this PR solves / how to test:**
Attempts to remove remix from the e2e quarantine by increasing the timeout. Remix seems to eventually succeed but takes a little longer than the other frameworks.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ x ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
