### PR TITLE
Log size of additional modules

### DIFF
--- a/.changeset/tiny-icons-breathe.md
+++ b/.changeset/tiny-icons-breathe.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+When uploading additional modules with your worker, Wrangler will now report the (uncompressed) size of each individual module, as well as the aggregate size of your Worker

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -2276,10 +2276,6 @@ addEventListener('fetch', event => {});`
 
 			expect(std.info).toMatchInlineSnapshot(`
 			"Attaching additional modules:
-			- a/1.mjs (esm)
-			- a/b/2.mjs (esm)
-			- a/b/3.mjs (esm)
-			- a/b/c/4.mjs (esm)
 			Fetching list of already uploaded assets...
 			Building list of assets to upload...
 			 + file-1.2ca234f380.text (uploading new version of file-1.text)
@@ -2288,7 +2284,18 @@ addEventListener('fetch', event => {});`
 			Uploaded 100% [2 out of 2]"
 		`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"↗️  Done syncing assets
+			"┌─────────────┬──────┬──────────┐
+			│ Name        │ Type │ Size     │
+			├─────────────┼──────┼──────────┤
+			│ a/1.mjs     │ esm  │ xx KiB │
+			├─────────────┼──────┼──────────┤
+			│ a/b/2.mjs   │ esm  │ xx KiB │
+			├─────────────┼──────┼──────────┤
+			│ a/b/3.mjs   │ esm  │ xx KiB │
+			├─────────────┼──────┼──────────┤
+			│ a/b/c/4.mjs │ esm  │ xx KiB │
+			└─────────────┴──────┴──────────┘
+			↗️  Done syncing assets
 			Total Upload: xx KiB / gzip: xx KiB
 			Uploaded test-name (TIMINGS)
 			Published test-name (TIMINGS)

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -470,7 +470,16 @@ export const cat = "dog";`
 		await runWrangler(`pages functions build --outfile=public/_worker.bundle`);
 
 		expect(existsSync("public/_worker.bundle")).toBe(true);
-		expect(std.out).toMatchInlineSnapshot(`"✨ Compiled Worker successfully"`);
+		expect(std.out).toMatchInlineSnapshot(`
+		"┌─────────┬──────┬──────────┐
+		│ Name    │ Type │ Size     │
+		├─────────┼──────┼──────────┤
+		│ cat.js  │ esm  │ xx KiB │
+		├─────────┼──────┼──────────┤
+		│ dog.mjs │ esm  │ xx KiB │
+		└─────────┴──────┴──────────┘
+		✨ Compiled Worker successfully"
+	`);
 
 		const workerBundleContents = readFileSync("public/_worker.bundle", "utf-8");
 		const workerBundleWithConstantData = replaceRandomWithConstantData(

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -50,9 +50,15 @@ export async function findAdditionalModules(
 
 	if (modules.length > 0) {
 		logger.info(`Attaching additional modules:`);
-		modules.forEach(({ name, type }) => {
-			logger.info(`- ${chalk.blue(name)} (${chalk.green(type ?? "")})`);
-		});
+		logger.table(
+			modules.map(({ name, type, content }) => {
+				return {
+					Name: name,
+					Type: type ?? "",
+					Size: `${(content.length / 1024).toFixed(2)} KiB`,
+				};
+			})
+		);
 	}
 
 	return modules;


### PR DESCRIPTION
Fixes #1313

**What this PR solves / how to test:**

Log the size of additional modules uploaded as part of your worker

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
