### PR TITLE
Support user CPU time limit

### DIFF
--- a/.changeset/pink-jokes-double.md
+++ b/.changeset/pink-jokes-double.md
@@ -1,0 +1,14 @@
+---
+"wrangler": minor
+---
+
+Support user limits for CPU time
+
+User limits provided via script metadata on upload
+
+Example configuration:
+
+```
+[limits]
+cpu_ms = 20000
+```

--- a/packages/wrangler/src/__tests__/standard-pricing.test.ts
+++ b/packages/wrangler/src/__tests__/standard-pricing.test.ts
@@ -85,6 +85,34 @@ describe("standard-pricing", () => {
 		}
 	`);
 	});
+	it("should warn user about limits set if not enabled", async () => {
+		msw.use(...mswSuccessDeploymentScriptMetadata);
+		writeWranglerToml({ limits: { cpu_ms: 20_000 } });
+		writeWorkerSource();
+		mockSubDomainRequest();
+		mockUploadWorkerRequest();
+
+		mockStandardEnabled(false);
+
+		await runWrangler("deploy ./index");
+
+		expect(std).toMatchInlineSnapshot(`
+		Object {
+		  "debug": "",
+		  "err": "",
+		  "info": "",
+		  "out": "🚧 New Workers Standard pricing is now available. Please visit the dashboard to view details and opt-in to new pricing: https://dash.cloudflare.com/some-account-id/workers/standard/opt-in.
+		Total Upload: xx KiB / gzip: xx KiB
+		Uploaded test-name (TIMINGS)
+		Published test-name (TIMINGS)
+		  https://test-name.test-sub-domain.workers.dev
+		Current Deployment ID: Galaxy-Class",
+		  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`limits\` defined in wrangler.toml can only be applied to scripts opted into Workers Standard pricing. Agree to the new pricing details to set limits for your script.[0m
+
+		",
+		}
+	`);
+	});
 	it("should not notify user about new pricing if enterprise", async () => {
 		msw.use(...mswSuccessDeploymentScriptMetadata);
 		writeWranglerToml();

--- a/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
+++ b/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
@@ -78,6 +78,7 @@ function createWorkerBundleFormData(workerBundle: BundleResult): FormData {
 		logpush: undefined,
 		placement: undefined,
 		tail_consumers: undefined,
+		limits: undefined,
 	};
 
 	return createWorkerUploadForm(worker);

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -171,6 +171,14 @@ interface EnvironmentInheritable {
 	usage_model: "bundled" | "unbound" | undefined;
 
 	/**
+	 * Specify limits for runtime behavior.
+	 * Only supported for the "standard" Usage Model
+	 *
+	 * @inheritable
+	 */
+	limits: UserLimits | undefined;
+
+	/**
 	 * An ordered list of rules that define which modules to import,
 	 * and what type to import them as. You will need to specify rules
 	 * to use Text, Data, and CompiledWasm modules, or when you wish to
@@ -735,4 +743,9 @@ export interface DispatchNamespaceOutbound {
 	environment?: string;
 	/** (Optional) List of parameter names, for sending context from your dispatch worker to the outbound handler */
 	parameters?: string[];
+}
+
+export interface UserLimits {
+	/** Maximum allowed CPU time for a worker's invocation in milliseconds */
+	cpu_ms: number;
 }

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1155,6 +1155,7 @@ function normalizeAndValidateEnvironment(
 			isOneOf("bundled", "unbound"),
 			undefined
 		),
+		limits: normalizeAndValidateLimits(diagnostics, topLevelEnv, rawEnv),
 		placement: normalizeAndValidatePlacement(diagnostics, topLevelEnv, rawEnv),
 		build,
 		workers_dev,
@@ -2801,3 +2802,28 @@ const validateConsumer: ValidatorFn = (diagnostics, field, value, _config) => {
 
 	return isValid;
 };
+
+function normalizeAndValidateLimits(
+	diagnostics: Diagnostics,
+	topLevelEnv: Environment | undefined,
+	rawEnv: RawEnvironment
+): Config["limits"] {
+	if (rawEnv.limits) {
+		validateRequiredProperty(
+			diagnostics,
+			"limits",
+			"cpu_ms",
+			rawEnv.limits.cpu_ms,
+			"number"
+		);
+	}
+
+	return inheritable(
+		diagnostics,
+		topLevelEnv,
+		rawEnv,
+		"limits",
+		() => true,
+		undefined
+	);
+}

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -608,6 +608,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			logpush: props.logpush !== undefined ? props.logpush : config.logpush,
 			placement,
 			tail_consumers: config.tail_consumers,
+			limits: config.limits,
 		};
 
 		// As this is not deterministic for testing, we detect if in a jest environment and run asynchronously

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -37,6 +37,11 @@ async function standardPricingWarning(
 					`🚧 New Workers Standard pricing is now available. Please visit the dashboard to view details and opt-in to new pricing: https://dash.cloudflare.com/${accountId}/workers/standard/opt-in.`
 				)
 			);
+			if (config.limits?.cpu_ms !== undefined) {
+				logger.warn(
+					"The `limits` defined in wrangler.toml can only be applied to scripts opted into Workers Standard pricing. Agree to the new pricing details to set limits for your script."
+				);
+			}
 			return;
 		}
 		if (standard && config.usage_model !== undefined) {

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -9,6 +9,7 @@ import type {
 	CfDurableObjectMigrations,
 	CfPlacement,
 	CfTailConsumer,
+	CfUserLimits,
 } from "./worker.js";
 import type { Json } from "miniflare";
 
@@ -105,6 +106,7 @@ export interface WorkerMetadata {
 	logpush?: boolean;
 	placement?: CfPlacement;
 	tail_consumers?: CfTailConsumer[];
+	limits?: CfUserLimits;
 	// Allow unsafe.metadata to add arbitrary properties at runtime
 	[key: string]: unknown;
 }
@@ -125,6 +127,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		logpush,
 		placement,
 		tail_consumers,
+		limits,
 	} = worker;
 
 	let { modules } = worker;
@@ -462,6 +465,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		...(logpush !== undefined && { logpush }),
 		...(placement && { placement }),
 		...(tail_consumers && { tail_consumers }),
+		...(limits && { limits }),
 	};
 
 	if (bindings.unsafe?.metadata !== undefined) {

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -248,6 +248,10 @@ export interface CfTailConsumer {
 	environment?: string;
 }
 
+export interface CfUserLimits {
+	cpu_ms?: number;
+}
+
 /**
  * Options for creating a `CfWorker`.
  */
@@ -298,6 +302,7 @@ export interface CfWorkerInit {
 	logpush: boolean | undefined;
 	placement: CfPlacement | undefined;
 	tail_consumers: CfTailConsumer[] | undefined;
+	limits: CfUserLimits | undefined;
 }
 
 export interface CfWorkerContext {

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -585,6 +585,7 @@ async function createRemoteWorkerInit(props: {
 		logpush: false,
 		placement: undefined, // no placement in dev
 		tail_consumers: undefined, // no tail consumers in dev - TODO revisit?
+		limits: undefined, // no limits in preview - not supported yet but can be added
 	};
 
 	return init;

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -90,6 +90,7 @@ async function createDraftWorker({
 				logpush: false,
 				placement: undefined,
 				tail_consumers: undefined,
+				limits: undefined,
 			}),
 		}
 	);


### PR DESCRIPTION
User limits provided via script metadata on upload

Example configuration:
```
[limits]
cpu_ms = 20000
```

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
