### PR TITLE
add quotes to wrangler init names containing whitespaces before delegating to C3

### DIFF
--- a/.changeset/lazy-chicken-lay.md
+++ b/.changeset/lazy-chicken-lay.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+add quotes to wrangler init names containing whitespaces before delegating to C3

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -238,7 +238,8 @@ export async function initHandler(args: InitArgs) {
 			const c3Arguments: string[] = [];
 
 			if (args.name) {
-				c3Arguments.push(args.name);
+				const name = /\s/.test(args.name) ? `"${args.name}"` : args.name;
+				c3Arguments.push(name);
 			}
 
 			if (yesFlag) {


### PR DESCRIPTION
fixes #3647