### PR TITLE
use `shell-quote.quote(args)` instead of `args.join(" ")`

### DIFF
--- a/.changeset/cold-parrots-deliver.md
+++ b/.changeset/cold-parrots-deliver.md
@@ -1,0 +1,6 @@
+---
+"create-cloudflare": patch
+"wrangler": patch
+---
+
+fix various logging of shell commands to correctly quote args when needed

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -8,6 +8,7 @@ import { detectPackageManager } from "helpers/packages";
 import semver from "semver";
 import { version } from "../package.json";
 import { validateProjectDirectory } from "./common";
+import * as shellquote from "./helpers/shell-quote";
 import { templateMap } from "./templateMap";
 import type { C3Args } from "types";
 
@@ -55,7 +56,9 @@ export const runLatest = async () => {
 	// the parsing logic of `npm create` requires `--` to be supplied
 	// before any flags intended for the target command.
 	const argString =
-		npm === "npm" ? `-- ${args.join(" ")}` : `${args.join(" ")}`;
+		npm === "npm"
+			? `-- ${shellquote.quote(args)}`
+			: `${shellquote.quote(args)}`;
 
 	await runCommand(`${npm} create cloudflare@latest ${argString}`);
 };

--- a/packages/create-cloudflare/src/helpers/shell-quote.ts
+++ b/packages/create-cloudflare/src/helpers/shell-quote.ts
@@ -1,6 +1,10 @@
 import shellquote from "shell-quote";
 
-export const quote = shellquote.quote;
+export const quote = function (args: (string | number | boolean)[]) {
+	const stringArgs = args.map((arg) => String(arg));
+
+	return shellquote.quote(stringArgs);
+};
 
 export function parse(cmd: string, env?: Record<string, string>): string[] {
 	// This is a workaround for a bug in shell-quote on Windows

--- a/packages/create-cloudflare/src/pages.ts
+++ b/packages/create-cloudflare/src/pages.ts
@@ -19,6 +19,7 @@ import {
 	runDeploy,
 	setupProjectDirectory,
 } from "./common";
+import * as shellquote from "./helpers/shell-quote";
 import type { C3Args, PagesGeneratorContext } from "types";
 
 /** How many times to retry the create project command before failing. */
@@ -162,7 +163,9 @@ const createProject = async (ctx: PagesGeneratorContext) => {
 	const CLOUDFLARE_ACCOUNT_ID = ctx.account.id;
 
 	try {
-		const compatFlags = ctx.framework?.config.compatibilityFlags?.join(" ");
+		const compatFlags = shellquote.quote(
+			ctx.framework?.config.compatibilityFlags ?? []
+		);
 		const compatFlagsArg = compatFlags
 			? `--compatibility-flags ${compatFlags}`
 			: "";

--- a/packages/wrangler/src/__tests__/generate.test.ts
+++ b/packages/wrangler/src/__tests__/generate.test.ts
@@ -43,7 +43,7 @@ describe("generate", () => {
 				`"✨ Created no-template/wrangler.toml"`
 			);
 			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 no-template\` instead.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 no-template\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -68,8 +68,8 @@ describe("init", () => {
 			  "debug": "",
 			  "err": "",
 			  "info": "",
-			  "out": "Running \`mockpm create cloudflare@2\`...",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "out": "Running \`mockpm create cloudflare/@2\`...",
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -184,7 +184,7 @@ describe("init", () => {
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 --wrangler-defaults\` instead.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -223,7 +223,7 @@ describe("init", () => {
 		`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 my-worker --wrangler-defaults\` instead.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 my-worker --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -260,7 +260,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 --wrangler-defaults\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -340,7 +340,7 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created wrangler.toml",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -379,7 +379,7 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created my-worker/wrangler.toml",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 my-worker\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 my-worker\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -684,7 +684,7 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Initialized git repository",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -729,7 +729,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 --wrangler-defaults\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -761,7 +761,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker/my-worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 path/to/worker/my-worker --wrangler-defaults\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 path/to/worker/my-worker --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -794,7 +794,7 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Initialized git repository",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -856,7 +856,7 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Created package.json",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -912,7 +912,7 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created my-worker/wrangler.toml
 			✨ Created my-worker/package.json",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 my-worker\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 my-worker\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -962,7 +962,7 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created wrangler.toml",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1021,7 +1021,7 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created path/to/worker/my-worker/wrangler.toml
 			✨ Created path/to/worker/my-worker/package.json",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 path/to/worker/my-worker\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 path/to/worker/my-worker\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1079,7 +1079,7 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Installed wrangler into devDependencies",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1144,7 +1144,7 @@ describe("init", () => {
 			  "info": "",
 			  "out": "✨ Created wrangler.toml
 			✨ Installed wrangler into devDependencies",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1204,7 +1204,7 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created wrangler.toml",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1271,7 +1271,7 @@ describe("init", () => {
 
 			To start developing your Worker, run \`npx wrangler dev\`
 			To publish your Worker to the Internet, run \`npx wrangler deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1335,7 +1335,7 @@ describe("init", () => {
 
 			To start developing your Worker, run \`npx wrangler dev\`
 			To publish your Worker to the Internet, run \`npx wrangler deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1514,7 +1514,7 @@ describe("init", () => {
 			  "out": "✨ Created wrangler.toml
 			✨ Created tsconfig.json
 			✨ Installed @cloudflare/workers-types and typescript into devDependencies",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1564,7 +1564,7 @@ describe("init", () => {
 			✨ Created my-worker/package.json
 			✨ Created my-worker/tsconfig.json
 			✨ Installed @cloudflare/workers-types and typescript into devDependencies",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 my-worker\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 my-worker\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1625,7 +1625,7 @@ describe("init", () => {
 			✨ Created package.json
 			✨ Created tsconfig.json
 			✨ Installed @cloudflare/workers-types and typescript into devDependencies",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1687,7 +1687,7 @@ describe("init", () => {
 
 			To start developing your Worker, run \`npx wrangler dev\`
 			To publish your Worker to the Internet, run \`npx wrangler deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1768,7 +1768,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker/my-worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 path/to/worker/my-worker\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 path/to/worker/my-worker\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1830,7 +1830,7 @@ describe("init", () => {
 			  "out": "✨ Created wrangler.toml
 			✨ Installed @cloudflare/workers-types into devDependencies
 			🚨 Please add \\"@cloudflare/workers-types\\" to compilerOptions.types in tsconfig.json",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1894,7 +1894,7 @@ describe("init", () => {
 
 			To start developing your Worker, run \`npx wrangler dev\`
 			To publish your Worker to the Internet, run \`npx wrangler deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -1951,13 +1951,13 @@ describe("init", () => {
 					},
 				});
 				expect(std.out).toMatchInlineSnapshot(`
-			        "✨ Created wrangler.toml
-			        ✨ Created package.json
-			        ✨ Created src/index.js
+			"✨ Created wrangler.toml
+			✨ Created package.json
+			✨ Created src/index.js
 
-			        To start developing your Worker, run \`npm start\`
-			        To publish your Worker to the Internet, run \`npm run deploy\`"
-		      `);
+			To start developing your Worker, run \`npm start\`
+			To publish your Worker to the Internet, run \`npm run deploy\`"
+		`);
 			});
 			it("should add a jest test for a non-ts project with .js extension", async () => {
 				mockConfirm(
@@ -2141,12 +2141,12 @@ describe("init", () => {
 					},
 				});
 				expect(std.out).toMatchInlineSnapshot(`
-			        "✨ Created wrangler.toml
-			        ✨ Created src/index.js
+			"✨ Created wrangler.toml
+			✨ Created src/index.js
 
-			        To start developing your Worker, run \`npx wrangler dev\`
-			        To publish your Worker to the Internet, run \`npx wrangler deploy\`"
-		      `);
+			To start developing your Worker, run \`npx wrangler dev\`
+			To publish your Worker to the Internet, run \`npx wrangler deploy\`"
+		`);
 			});
 
 			it("should not offer to create a worker in a non-ts project if a file already exists at the location", async () => {
@@ -2186,7 +2186,7 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created wrangler.toml",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2237,7 +2237,7 @@ describe("init", () => {
 			  "err": "",
 			  "info": "",
 			  "out": "✨ Created my-worker/wrangler.toml",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 my-worker\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 my-worker\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2303,7 +2303,7 @@ describe("init", () => {
 			To start developing your Worker, run \`npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 . --wrangler-defaults\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 . --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2339,7 +2339,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd path/to/worker && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 path/to/worker --wrangler-defaults\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 path/to/worker --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 
@@ -2377,7 +2377,7 @@ describe("init", () => {
 			To start developing your Worker, run \`cd WEIRD_w0rkr_N4m3.js.tsx.tar.gz && npm start\`
 			To start testing your Worker, run \`npm test\`
 			To publish your Worker to the Internet, run \`npm run deploy\`",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare@2 WEIRD_w0rkr_N4m3.js.tsx.tar.gz --wrangler-defaults\` instead.[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe \`init\` command is no longer supported. Please use \`mockpm create cloudflare/@2 WEIRD_w0rkr_N4m3.js.tsx.tar.gz --wrangler-defaults\` instead.[0m
 
 			  The \`init\` command will be removed in a future version.
 

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -256,8 +256,8 @@ export async function initHandler(args: InitArgs) {
 			c3Arguments.unshift(...shellquote.parse(getC3CommandFromEnv()));
 
 			// Deprecate the `init --from-dash` command
-			const replacementC3Command = `\`${packageManager.type} ${c3Arguments.join(
-				" "
+			const replacementC3Command = `\`${packageManager.type} ${shellquote.quote(
+				c3Arguments
 			)}\``;
 
 			logger.warn(

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -11,6 +11,7 @@ import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { getBasePath } from "../paths";
+import * as shellquote from "../utils/shell-quote";
 import { buildFunctions } from "./buildFunctions";
 import { ROUTES_SPEC_VERSION, SECONDS_TO_WAIT_FOR_PROXY } from "./constants";
 import {
@@ -797,7 +798,7 @@ async function spawnProxyProcess({
 		);
 	}
 
-	logger.log(`Running ${command.join(" ")}...`);
+	logger.log(`Running ${shellquote.quote(command)}...`);
 	const proxy = spawn(
 		command[0].toString(),
 		command.slice(1).map((value) => value.toString()),

--- a/packages/wrangler/src/utils/shell-quote.ts
+++ b/packages/wrangler/src/utils/shell-quote.ts
@@ -1,6 +1,10 @@
 import shellquote from "shell-quote";
 
-export const quote = shellquote.quote;
+export const quote = function (args: (string | number | boolean)[]) {
+	const stringArgs = args.map((arg) => String(arg));
+
+	return shellquote.quote(stringArgs);
+};
 
 export function parse(cmd: string, env?: Record<string, string>): string[] {
 	// This is a workaround for a bug in shell-quote on Windows


### PR DESCRIPTION
**What this PR solves / how to test:**

Follow-up to #4080, prompted by https://github.com/cloudflare/workers-sdk/pull/4211#issuecomment-1768101260

In my previous PR introducing `shell-quote`, I searched for instances of `split(" ")` and changed them to `shellquote.parse(cmd)`

In this PR, I searched for instances of `join(" ")` and changed them to `shellquote.quote(args) `

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
