### PR TITLE
[wrangler] Allows uploads with both cron triggers and smart placement enabled

### DIFF
--- a/.changeset/three-carpets-smile.md
+++ b/.changeset/three-carpets-smile.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Allows uploads with both cron triggers and smart placement enabled

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -963,7 +963,7 @@ describe("normalizeAndValidateConfig()", () => {
 				first_party_worker: true,
 				logpush: true,
 				placement: {
-					mode: "off",
+					mode: "smart",
 				},
 			};
 
@@ -4788,60 +4788,6 @@ describe("normalizeAndValidateConfig()", () => {
 			  - Expected \\"tail_consumers[3].service\\" to be of type string but got {}.
 			  - Expected \\"tail_consumers[4].service\\" to be of type string but got 123."
 		`);
-			});
-		});
-
-		describe("[placement]", () => {
-			it("should error if both placement and triggers are configured", () => {
-				const { diagnostics } = normalizeAndValidateConfig(
-					{
-						triggers: {
-							crons: [1111],
-						},
-						placement: { mode: "smart" },
-					} as unknown as RawConfig,
-					undefined,
-					{ env: undefined }
-				);
-
-				expect(diagnostics.hasWarnings()).toBe(false);
-				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - You cannot configure both [triggers] and [placement] in your wrangler.toml. Placement is not supported with cron triggers."
-		`);
-			});
-			it("should not error if triggers are configured and placement is set off", () => {
-				const { diagnostics } = normalizeAndValidateConfig(
-					{
-						triggers: {
-							crons: [1111],
-						},
-						placement: { mode: "off" },
-					} as unknown as RawConfig,
-					undefined,
-					{ env: undefined }
-				);
-
-				expect(diagnostics.hasWarnings()).toBe(false);
-				expect(diagnostics.hasErrors()).toBe(false);
-			});
-			it("should not error if placement is configured and triggers is empty array", () => {
-				const expectedConfig: RawEnvironment = {
-					triggers: { crons: [] },
-					placement: {
-						mode: "smart",
-					},
-				};
-				const { config, diagnostics } = normalizeAndValidateConfig(
-					expectedConfig,
-					undefined,
-					{ env: undefined }
-				);
-
-				expect(config).toEqual(expect.objectContaining({ ...expectedConfig }));
-
-				expect(diagnostics.hasWarnings()).toBe(false);
-				expect(diagnostics.hasErrors()).toBe(false);
 			});
 		});
 

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -534,27 +534,6 @@ export const validateAdditionalProperties = (
 };
 
 /**
- * Add a diagnostic error for any configurations that include both cron triggers and smart placement
- */
-export const validateSmartPlacementConfig = (
-	diagnostics: Diagnostics,
-	placement: { mode: "off" | "smart" } | undefined,
-	triggers:
-		| {
-				crons: string[];
-		  }
-		| undefined
-): boolean => {
-	if (placement?.mode === "smart" && !!triggers?.crons?.length) {
-		diagnostics.errors.push(
-			`You cannot configure both [triggers] and [placement] in your wrangler.toml. Placement is not supported with cron triggers.`
-		);
-		return false;
-	}
-	return true;
-};
-
-/**
  * Get the names of the bindings collection in `value`.
  *
  * Will return an empty array if it doesn't understand the value

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -26,7 +26,6 @@ import {
 	appendEnvName,
 	getBindingNames,
 	isValidName,
-	validateSmartPlacementConfig,
 } from "./validation-helpers";
 import type { Config, DevConfig, RawConfig, RawDevConfig } from "./config";
 import type {
@@ -237,8 +236,6 @@ export function normalizeAndValidateConfig(
 		Object.keys(rawConfig),
 		[...Object.keys(config), "env"]
 	);
-
-	validateSmartPlacementConfig(diagnostics, config.placement, config.triggers);
 
 	experimental(diagnostics, rawConfig, "assets");
 


### PR DESCRIPTION
Revert "Prevents uploads with both cron triggers and smart placement enabled (#3390)"

This reverts commit b5b46b4a52a309d0b15d1424e35eaae2877c5cb9.

Fixes [WP-591](https://jira.cfdata.org/browse/WP-591).

**What this PR solves / how to test:**

Lifts a temporary restriction that was put in place because of a bug with smart placement that made it incompatible with cron triggers. That bug has been fixed and users are now free to use smart placement and cron triggers together.

**Associated docs issue(s)/PR(s):**

- N/A

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
