### PR TITLE
C3: don't retry the project creation multiple times when it fails because the project's name is already used

### DIFF
--- a/.changeset/witty-trainers-battle.md
+++ b/.changeset/witty-trainers-battle.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+don't retry the project creation multiple times when it fails because the project's name is already used

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -176,10 +176,9 @@ export const retry = async <T>(
 			return await fn();
 		} catch (e) {
 			error = e;
+			times--;
 			if (exitCondition?.(e)) {
-				times = 0;
-			} else {
-				times--;
+				break;
 			}
 		}
 	}

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -178,8 +178,9 @@ export const retry = async <T>(
 			error = e;
 			if (exitCondition?.(e)) {
 				times = 0;
+			} else {
+				times--;
 			}
-			times--;
 		}
 	}
 	throw error;

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -163,13 +163,22 @@ export const printAsyncStatus = async <T>({
 	return promise;
 };
 
-export const retry = async <T>(times: number, fn: () => Promise<T>) => {
+export const retry = async <T>(
+	{
+		times,
+		exitCondition,
+	}: { times: number; exitCondition?: (e: unknown) => boolean },
+	fn: () => Promise<T>
+) => {
 	let error: unknown = null;
 	while (times > 0) {
 		try {
 			return await fn();
 		} catch (e) {
 			error = e;
+			if (exitCondition?.(e)) {
+				times = 0;
+			}
 			times--;
 		}
 	}

--- a/packages/create-cloudflare/src/pages.ts
+++ b/packages/create-cloudflare/src/pages.ts
@@ -168,16 +168,29 @@ const createProject = async (ctx: PagesGeneratorContext) => {
 		const productionBranch = await getProductionBranch(ctx.project.path);
 		const cmd = `${npx} wrangler pages project create ${ctx.project.name} --production-branch ${productionBranch} ${compatFlagsArg}`;
 
-		await retry(CREATE_PROJECT_RETRIES, async () =>
-			runCommand(cmd, {
-				// Make this command more verbose in test mode to aid
-				// troubleshooting API errors
-				silent: process.env.VITEST == undefined,
-				cwd: ctx.project.path,
-				env: { CLOUDFLARE_ACCOUNT_ID },
-				startText: "Creating Pages project",
-				doneText: `${brandColor("created")} ${dim(`via \`${cmd.trim()}\``)}`,
-			})
+		await retry(
+			{
+				times: CREATE_PROJECT_RETRIES,
+				exitCondition: (e) => {
+					return (
+						e instanceof Error &&
+						// if the error is regarding name duplication we can exist as retrying is not going to help
+						e.message.includes(
+							"A project with this name already exists. Choose a different project name."
+						)
+					);
+				},
+			},
+			async () =>
+				runCommand(cmd, {
+					// Make this command more verbose in test mode to aid
+					// troubleshooting API errors
+					silent: process.env.VITEST == undefined,
+					cwd: ctx.project.path,
+					env: { CLOUDFLARE_ACCOUNT_ID },
+					startText: "Creating Pages project",
+					doneText: `${brandColor("created")} ${dim(`via \`${cmd.trim()}\``)}`,
+				})
 		);
 	} catch (error) {
 		crash("Failed to create pages project. See output above.");
@@ -187,7 +200,7 @@ const createProject = async (ctx: PagesGeneratorContext) => {
 	try {
 		const verifyProject = `${npx} wrangler pages deployment list --project-name ${ctx.project.name}`;
 
-		await retry(VERIFY_PROJECT_RETRIES, async () =>
+		await retry({ times: VERIFY_PROJECT_RETRIES }, async () =>
 			runCommand(verifyProject, {
 				silent: process.env.VITEST == undefined,
 				cwd: ctx.project.path,


### PR DESCRIPTION
When trying to create a new pages project with C3 that is reusing the same name as an already existing project (for the same account) we retry the project creation multiple times, these add an exit condition to out retry logic so that we don't retry multiple times in such cases.

### Before
![Screenshot 2023-10-18 at 16 53 58](https://github.com/cloudflare/workers-sdk/assets/61631103/501e6551-8b73-4c2a-b9bf-c6fc47f4afe3)

### After
![Screenshot 2023-10-18 at 16 54 16](https://github.com/cloudflare/workers-sdk/assets/61631103/75a1312f-0fd2-4a52-92bf-1726c696be7f)
