### PR TITLE
C3: Relax empty directory check

### DIFF
--- a/.changeset/gentle-news-laugh.md
+++ b/.changeset/gentle-news-laugh.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Relax empty directory check. Directories containing certain common config files and/or files created by an ide will be exempt from the pre-flight check

--- a/packages/create-cloudflare/src/__tests__/common.test.ts
+++ b/packages/create-cloudflare/src/__tests__/common.test.ts
@@ -1,6 +1,6 @@
 import * as command from "helpers/command";
 import { describe, expect, test, vi } from "vitest";
-import { isGitConfigured } from "../common";
+import { isAllowedExistingFile, isGitConfigured } from "../common";
 import { validateProjectDirectory } from "../common";
 
 function promisify<T>(value: T) {
@@ -69,5 +69,17 @@ describe("validateProjectDirectory", () => {
 		expect(validateProjectDirectory("foobar-", args)).toBeUndefined();
 		expect(validateProjectDirectory("FooBar", args)).toBeUndefined();
 		expect(validateProjectDirectory("f".repeat(59), args)).toBeUndefined();
+	});
+});
+
+describe("isAllowedExistingFile", () => {
+	const allowed = ["LICENSE"];
+	test.each(allowed)("%s", (val) => {
+		expect(isAllowedExistingFile(val)).toBe(true);
+	});
+
+	const disallowed = ["foobar", "potato"];
+	test.each(disallowed)("%s", (val) => {
+		expect(isAllowedExistingFile(val)).toBe(false);
 	});
 });

--- a/packages/create-cloudflare/src/__tests__/common.test.ts
+++ b/packages/create-cloudflare/src/__tests__/common.test.ts
@@ -73,7 +73,14 @@ describe("validateProjectDirectory", () => {
 });
 
 describe("isAllowedExistingFile", () => {
-	const allowed = ["LICENSE"];
+	const allowed = [
+		"LICENSE",
+		"LICENSE.md",
+		"license",
+		".npmignore",
+		".git",
+		".DS_Store",
+	];
 	test.each(allowed)("%s", (val) => {
 		expect(isAllowedExistingFile(val)).toBe(true);
 	});

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -32,6 +32,32 @@ import type { C3Args, PagesGeneratorContext } from "types";
 
 const { name, npm } = detectPackageManager();
 
+// C3 shouldn't prevent a user from using an existing directory if it
+// only contains benign config and/or other files from the following set
+const allowedExistingFiles = new Set([
+	".DS_Store",
+	".git",
+	".gitattributes",
+	".gitignore",
+	".gitlab-ci.yml",
+	".hg",
+	".hgcheck",
+	".hgignore",
+	".idea",
+	".npmignore",
+	".travis.yml",
+	"LICENSE",
+	"Thumbs.db",
+	"docs",
+	"mkdocs.yml",
+	"npm-debug.log",
+	"yarn-debug.log",
+	"yarn-error.log",
+	"yarnrc.yml",
+	".yarn",
+	".gitkeep",
+]);
+
 export const validateProjectDirectory = (
 	relativePath: string,
 	args: Partial<C3Args>
@@ -39,10 +65,13 @@ export const validateProjectDirectory = (
 	// Validate that the directory is non-existent or empty
 	const path = resolve(relativePath);
 	const existsAlready = existsSync(path);
-	const isEmpty = existsAlready && readdirSync(path).length === 0; // allow existing dirs _if empty_ to ensure c3 is non-destructive
 
-	if (existsAlready && !isEmpty) {
-		return `Directory \`${relativePath}\` already exists and is not empty. Please choose a new name.`;
+	if (existsAlready) {
+		for (const file of readdirSync(path)) {
+			if (!allowedExistingFiles.has(file)) {
+				return `Directory \`${relativePath}\` already exists and contains files that might conflict. Please choose a new name.`;
+			}
+		}
 	}
 
 	// Ensure the name is valid per the pages schema

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -32,32 +32,6 @@ import type { C3Args, PagesGeneratorContext } from "types";
 
 const { name, npm } = detectPackageManager();
 
-// C3 shouldn't prevent a user from using an existing directory if it
-// only contains benign config and/or other files from the following set
-const allowedExistingFiles = new Set([
-	".DS_Store",
-	".git",
-	".gitattributes",
-	".gitignore",
-	".gitlab-ci.yml",
-	".hg",
-	".hgcheck",
-	".hgignore",
-	".idea",
-	".npmignore",
-	".travis.yml",
-	"LICENSE",
-	"Thumbs.db",
-	"docs",
-	"mkdocs.yml",
-	"npm-debug.log",
-	"yarn-debug.log",
-	"yarn-error.log",
-	"yarnrc.yml",
-	".yarn",
-	".gitkeep",
-]);
-
 export const validateProjectDirectory = (
 	relativePath: string,
 	args: Partial<C3Args>
@@ -68,7 +42,7 @@ export const validateProjectDirectory = (
 
 	if (existsAlready) {
 		for (const file of readdirSync(path)) {
-			if (!allowedExistingFiles.has(file)) {
+			if (!isAllowedExistingFile(file)) {
 				return `Directory \`${relativePath}\` already exists and contains files that might conflict. Please choose a new name.`;
 			}
 		}
@@ -94,6 +68,36 @@ export const validateProjectDirectory = (
 			return `Project names must be less than 58 characters.`;
 		}
 	}
+};
+
+export const isAllowedExistingFile = (file: string) => {
+	// C3 shouldn't prevent a user from using an existing directory if it
+	// only contains benign config and/or other files from the following set
+	const allowedExistingFiles = new Set([
+		".DS_Store",
+		".git",
+		".gitattributes",
+		".gitignore",
+		".gitlab-ci.yml",
+		".hg",
+		".hgcheck",
+		".hgignore",
+		".idea",
+		".npmignore",
+		".travis.yml",
+		"LICENSE",
+		"Thumbs.db",
+		"docs",
+		"mkdocs.yml",
+		"npm-debug.log",
+		"yarn-debug.log",
+		"yarn-error.log",
+		"yarnrc.yml",
+		".yarn",
+		".gitkeep",
+	]);
+
+	return allowedExistingFiles.has(file);
 };
 
 export const setupProjectDirectory = (args: C3Args) => {

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -85,7 +85,7 @@ export const isAllowedExistingFile = (file: string) => {
 		".idea",
 		".npmignore",
 		".travis.yml",
-		"LICENSE",
+		".vscode",
 		"Thumbs.db",
 		"docs",
 		"mkdocs.yml",
@@ -97,7 +97,22 @@ export const isAllowedExistingFile = (file: string) => {
 		".gitkeep",
 	]);
 
-	return allowedExistingFiles.has(file);
+	if (allowedExistingFiles.has(file)) return true;
+
+	const allowedExistingPatters = [
+		/readme(\.md)?$/i,
+		/license(\.md)?$/i,
+		/\.iml$/,
+		/^npm-debug\.log/,
+		/^yarn-debug\.log/,
+		/^yarn-error\.log/,
+	];
+
+	for (const regex of allowedExistingPatters) {
+		if (regex.test(file)) return true;
+	}
+
+	return false;
 };
 
 export const setupProjectDirectory = (args: C3Args) => {


### PR DESCRIPTION
Fixes #4212.

**What this PR solves / how to test:**

This relaxes the existing directory check to allow files such as `.git`, `.hg`, and `.DS_Store` that are created by IDEs, the OS, or are benign config files. These don't conflict with c3 and the existing check impedes the workflow of users who create folders via their IDE.

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ x ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
