### PR TITLE
Use `zone_name` for deployment of custom hostnames

### DIFF
--- a/.changeset/rich-schools-fry.md
+++ b/.changeset/rich-schools-fry.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+fix: use `zone_name` to determine a zone when the pattern is a custom hostname
+
+In Cloudflare for SaaS, custom hostnames of third party domain owners can be used in Cloudflare.
+Workers are allowed to intercept these requests based on the routes configuration.
+Before this change, the same logic used by `wrangler dev` was used in `wrangler deploy`, which caused wrangler to fail with:
+
+✘ [ERROR] Could not find zone for [partner-saas-domain.com]

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -713,6 +713,84 @@ describe("deploy", () => {
 		`);
 		});
 
+		it("should deploy to a route with a SaaS domain", async () => {
+			writeWranglerToml({
+				workers_dev: false,
+				routes: [
+					{
+						pattern: "partner.com/*",
+						zone_name: "owned-zone.com",
+					},
+				],
+			});
+			writeWorkerSource();
+			mockUpdateWorkerRequest({ enabled: false });
+			mockUploadWorkerRequest({ available_on_subdomain: false });
+			mockGetZones("owned-zone.com", [{ id: "owned-zone-id-1" }]);
+			mockGetWorkerRoutes("owned-zone-id-1");
+			mockPublishRoutesRequest({
+				routes: [
+					{
+						pattern: "partner.com/*",
+						zone_name: "owned-zone.com",
+					},
+				],
+			});
+			await runWrangler("deploy ./index");
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "info": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  partner.com/* (zone name: owned-zone.com)
+			Current Deployment ID: Galaxy-Class",
+			  "warn": "",
+			}
+		`);
+		});
+
+		it("should deploy to a route with a SaaS subdomain", async () => {
+			writeWranglerToml({
+				workers_dev: false,
+				routes: [
+					{
+						pattern: "subdomain.partner.com/*",
+						zone_name: "owned-zone.com",
+					},
+				],
+			});
+			writeWorkerSource();
+			mockUpdateWorkerRequest({ enabled: false });
+			mockUploadWorkerRequest({ available_on_subdomain: false });
+			mockGetZones("owned-zone.com", [{ id: "owned-zone-id-1" }]);
+			mockGetWorkerRoutes("owned-zone-id-1");
+			mockPublishRoutesRequest({
+				routes: [
+					{
+						pattern: "subdomain.partner.com/*",
+						zone_name: "owned-zone.com",
+					},
+				],
+			});
+			await runWrangler("deploy ./index");
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "",
+			  "info": "",
+			  "out": "Total Upload: xx KiB / gzip: xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  subdomain.partner.com/* (zone name: owned-zone.com)
+			Current Deployment ID: Galaxy-Class",
+			  "warn": "",
+			}
+		`);
+		});
+
 		it("should deploy to a route with a pattern/{zone_id|zone_name} combo (service environments)", async () => {
 			writeWranglerToml({
 				env: {
@@ -8880,6 +8958,42 @@ function mockUnauthorizedPublishRoutesRequest({
 				);
 			}
 		)
+	);
+}
+
+function mockGetZones(domain: string, zones: { id: string }[] = []) {
+	msw.use(
+		rest.get("*/zones", (req, res, ctx) => {
+			expect([...req.url.searchParams.entries()]).toEqual([["name", domain]]);
+
+			return res(
+				ctx.status(200),
+				ctx.json({
+					success: true,
+					errors: [],
+					messages: [],
+					result: zones,
+				})
+			);
+		})
+	);
+}
+
+function mockGetWorkerRoutes(zoneId: string) {
+	msw.use(
+		rest.get("*/zones/:zoneId/workers/routes", (req, res, ctx) => {
+			expect(req.params.zoneId).toEqual(zoneId);
+
+			return res(
+				ctx.status(200),
+				ctx.json({
+					success: true,
+					errors: [],
+					messages: [],
+					result: [],
+				})
+			);
+		})
 	);
 }
 

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -369,22 +369,6 @@ describe("wrangler dev", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should fail for non-existing zones", async () => {
-			writeWranglerToml({
-				main: "index.js",
-				routes: [
-					{
-						pattern: "https://subdomain.does-not-exist.com/*",
-						zone_name: "exists.com",
-					},
-				],
-			});
-			await fs.promises.writeFile("index.js", `export default {};`);
-			await expect(runWrangler("dev --remote")).rejects.toEqual(
-				new Error("Could not find zone for subdomain.does-not-exist.com")
-			);
-		});
-
 		it("should fail for non-existing zones, when falling back from */*", async () => {
 			writeWranglerToml({
 				main: "index.js",

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -1,5 +1,6 @@
 import { rest } from "msw";
 import { getHostFromUrl, getZoneForRoute } from "../zones";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { msw } from "./helpers/msw";
 function mockGetZones(domain: string, zones: { id: string }[] = []) {
 	msw.use(
@@ -20,6 +21,8 @@ function mockGetZones(domain: string, zones: { id: string }[] = []) {
 }
 
 describe("Zones", () => {
+	mockAccountId();
+	mockApiToken();
 	describe("getHostFromUrl", () => {
 		test.each`
 			pattern                                             | host

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -1,4 +1,23 @@
-import { getHostFromUrl } from "../zones";
+import { rest } from "msw";
+import { getHostFromUrl, getZoneForRoute } from "../zones";
+import { msw } from "./helpers/msw";
+function mockGetZones(domain: string, zones: { id: string }[] = []) {
+	msw.use(
+		rest.get("*/zones", (req, res, ctx) => {
+			expect([...req.url.searchParams.entries()]).toEqual([["name", domain]]);
+
+			return res.once(
+				ctx.status(200),
+				ctx.json({
+					success: true,
+					errors: [],
+					messages: [],
+					result: zones,
+				})
+			);
+		})
+	);
+}
 
 describe("Zones", () => {
 	describe("getHostFromUrl", () => {
@@ -33,6 +52,86 @@ describe("Zones", () => {
 			${"https://invalid:host/path/name"}                 | ${undefined}
 		`("$pattern --> $host", ({ pattern, host }) => {
 			expect(getHostFromUrl(pattern)).toBe(host);
+		});
+	});
+	describe("getZoneForRoute", () => {
+		test("string route", async () => {
+			mockGetZones("example.com", [{ id: "example-id" }]);
+			expect(await getZoneForRoute("example.com/*")).toEqual({
+				host: "example.com",
+				id: "example-id",
+			});
+		});
+
+		test("string route (not a zone)", async () => {
+			mockGetZones("wrong.com", []);
+			await expect(
+				getZoneForRoute("wrong.com/*")
+			).rejects.toMatchInlineSnapshot(
+				`[Error: Could not find zone for wrong.com]`
+			);
+		});
+		test("zone_id route", async () => {
+			// example-id and other-id intentionally different to show that the API is not called
+			// when a zone_id is provided in the route
+			mockGetZones("example.com", [{ id: "example-id" }]);
+			expect(
+				await getZoneForRoute({ pattern: "example.com/*", zone_id: "other-id" })
+			).toEqual({
+				host: "example.com",
+				id: "other-id",
+			});
+		});
+		test("zone_id route (custom hostname)", async () => {
+			// example-id and other-id intentionally different to show that the API is not called
+			// when a zone_id is provided in the route
+			mockGetZones("example.com", [{ id: "example-id" }]);
+			expect(
+				await getZoneForRoute({
+					pattern: "some.third-party.com/*",
+					zone_id: "other-id",
+				})
+			).toEqual({
+				host: "some.third-party.com",
+				id: "other-id",
+			});
+		});
+
+		test("zone_name route (apex)", async () => {
+			mockGetZones("example.com", [{ id: "example-id" }]);
+			expect(
+				await getZoneForRoute({
+					pattern: "example.com/*",
+					zone_name: "example.com",
+				})
+			).toEqual({
+				host: "example.com",
+				id: "example-id",
+			});
+		});
+		test("zone_name route (subdomain)", async () => {
+			mockGetZones("example.com", [{ id: "example-id" }]);
+			expect(
+				await getZoneForRoute({
+					pattern: "subdomain.example.com/*",
+					zone_name: "example.com",
+				})
+			).toEqual({
+				host: "subdomain.example.com",
+				id: "example-id",
+			});
+		});
+		test("zone_name route (custom hostname)", async () => {
+			mockGetZones("example.com", [{ id: "example-id" }]);
+			expect(
+				await getZoneForRoute({
+					pattern: "some.third-party.com/*",
+					zone_name: "example.com",
+				})
+			).toEqual({
+				host: "some.third-party.com",
+				id: "example-id",
+			});
 		});
 	});
 });

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -16,11 +16,7 @@ import * as metrics from "./metrics";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";
 import { getAccountFromCache, loginOrRefreshIfRequired } from "./user";
 import { collectKeyValues } from "./utils/collectKeyValues";
-import {
-	getHostFromRoutePattern,
-	getZoneForRoute,
-	getZoneIdFromHost,
-} from "./zones";
+import { getHostFromRoute, getZoneForRoute, getZoneIdFromHost } from "./zones";
 import {
 	DEFAULT_INSPECTOR_PORT,
 	DEFAULT_LOCAL_PORT,
@@ -668,7 +664,7 @@ async function getZoneIdHostAndRoutes(args: StartDevOptions, config: Config) {
 		}
 		if (!zoneId && routes) {
 			const firstRoute = routes[0];
-			const zone = await getZoneForRoute(firstRoute, true);
+			const zone = await getZoneForRoute(firstRoute);
 			if (zone) {
 				zoneId = zone.id;
 				host = zone.host;
@@ -677,7 +673,7 @@ async function getZoneIdHostAndRoutes(args: StartDevOptions, config: Config) {
 	} else if (!host) {
 		if (routes) {
 			const firstRoute = routes[0];
-			host = getHostFromRoutePattern(firstRoute);
+			host = getHostFromRoute(firstRoute);
 
 			// TODO(consider): do we need really need to do this? I've added the condition to throw to match the previous implicit behaviour of `new URL()` throwing upon invalid URLs, but could we just continue here without an inferred host?
 			if (host === undefined) {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -16,7 +16,11 @@ import * as metrics from "./metrics";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";
 import { getAccountFromCache, loginOrRefreshIfRequired } from "./user";
 import { collectKeyValues } from "./utils/collectKeyValues";
-import { getHostFromRoute, getZoneForRoute, getZoneIdFromHost } from "./zones";
+import {
+	getHostFromRoutePattern,
+	getZoneForRoute,
+	getZoneIdFromHost,
+} from "./zones";
 import {
 	DEFAULT_INSPECTOR_PORT,
 	DEFAULT_LOCAL_PORT,
@@ -664,7 +668,7 @@ async function getZoneIdHostAndRoutes(args: StartDevOptions, config: Config) {
 		}
 		if (!zoneId && routes) {
 			const firstRoute = routes[0];
-			const zone = await getZoneForRoute(firstRoute);
+			const zone = await getZoneForRoute(firstRoute, true);
 			if (zone) {
 				zoneId = zone.id;
 				host = zone.host;
@@ -673,7 +677,7 @@ async function getZoneIdHostAndRoutes(args: StartDevOptions, config: Config) {
 	} else if (!host) {
 		if (routes) {
 			const firstRoute = routes[0];
-			host = getHostFromRoute(firstRoute);
+			host = getHostFromRoutePattern(firstRoute);
 
 			// TODO(consider): do we need really need to do this? I've added the condition to throw to match the previous implicit behaviour of `new URL()` throwing upon invalid URLs, but could we just continue here without an inferred host?
 			if (host === undefined) {


### PR DESCRIPTION
Fixes #3662

**What this PR solves / how to test:**
use `zone_name` to determine a zone when the pattern is a custom hostname

In Cloudflare for SaaS, custom hostnames of third party domain owners can be used in Cloudflare.
Workers are allowed to intercept these requests based on the routes configuration.
Before this change, the same logic used by `wrangler dev` was used in `wrangler deploy`, which caused wrangler to fail with:

✘ [ERROR] Could not find zone for [partner-saas-domain.com]

Example of routes definition that wouldn't work before this PR:
```toml
routes = [
    { pattern = "buy.partner-saas-domain.com/*", zone_name = "mydomain.com" }
]
```

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested
