### PR TITLE
C3: Quarantine nuxt

### DIFF
--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -93,6 +93,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			quarantine: true,
 		},
 		nuxt: {
+			quarantine: true,
 			expectResponseToContain: "Welcome to Nuxt!",
 			overrides: {
 				packageScripts: {


### PR DESCRIPTION
**What this PR solves / how to test:**

Nuxt e2e runs started failing today and the same error is reproducible with the latest deployed version of c3. We need to look into what upstream change caused this, but in the mean time this PR quarantines nuxt.

![image](https://github.com/cloudflare/workers-sdk/assets/204386/1f113839-ab6d-4425-aa2a-1189f7122b0b)

**Associated docs issue(s)/PR(s):**

- [insert associated docs issue(s)/PR(s)]

**Author has included the following, where applicable:**

- [ ] Tests
- [ ] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
