### PR TITLE
[wrangler] feat: custom pages functions directory

### DIFF
--- a/.changeset/wrangler-custom-pages-functions-directory.md
+++ b/.changeset/wrangler-custom-pages-functions-directory.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: custom pages functions directory
+
+Supports `CF_PAGES_FUNCTIONS_DIR` to specify custom Pages functions directory

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -152,7 +152,9 @@ export async function deploy({
 	let workerBundle: BundleResult | undefined = undefined;
 
 	const functionsDirectory =
-		customFunctionsDirectory || join(cwd(), "functions");
+		customFunctionsDirectory ||
+		process.env.CF_PAGES_FUNCTIONS_DIR ||
+		join(cwd(), "functions");
 	const routesOutputPath = !existsSync(join(directory, "_routes.json"))
 		? join(tmpdir(), `_routes-${Math.random()}.json`)
 		: undefined;

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -286,7 +286,7 @@ export const Handler = async ({
 	// There is no sane way to get the true value out of yargs, so here we are.
 	const enableBundling = bundle ?? !noBundle;
 
-	const functionsDirectory = "./functions";
+	const functionsDirectory = process.env.CF_PAGES_FUNCTIONS_DIR || "./functions";
 	let usingFunctions = !usingWorkerScript && existsSync(functionsDirectory);
 
 	let scriptPath = "";


### PR DESCRIPTION
Fixes #2814 

**What this PR solves / how to test:**

`wrangler pages dev` & `wrangler pages deploy` will now check `CF_PAGES_FUNCTIONS_DIR` environment variable and use it instead of hardcoded `./functions` location.

```sh
CF_PAGES_FUNCTIONS_DIR=./src/functions wrangler pages dev
CF_PAGES_FUNCTIONS_DIR=./src/functions wrangler pages deploy
```

As the code change is a simple environment variable check, there is no worries about any breaking changes.
It's a nice opt-in feature without having to implement any CLI options for now, and CI friendly.

I'm open to any suggestion regarding better environment variable name.

**Author has included the following, where applicable:**

- [ ] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested