### PR TITLE
shell-quote windows: unescape specific prefix char (@)

### DIFF
--- a/packages/create-cloudflare/src/helpers/shell-quote.ts
+++ b/packages/create-cloudflare/src/helpers/shell-quote.ts
@@ -18,6 +18,11 @@ export function parse(cmd: string, env?: Record<string, string>): string[] {
 	for (const entry of entries) {
 		// use string entries, as is
 		if (typeof entry === "string") {
+			if (entry.startsWith("\\@")) {
+				argv.push(entry.slice(1));
+				continue;
+			}
+
 			argv.push(entry);
 			continue;
 		}


### PR DESCRIPTION
**What this PR solves / how to test:**

Related to #4105

Some package installation that begin with @ (ex: `@sveltejs/adapter-cloudflare` package) will break because the output of [current](https://github.com/cloudflare/workers-sdk/blob/d74c35fc608f650fe82c12e62dfde47956a4db43/packages/create-cloudflare/src/helpers/shell-quote.ts#L5) shell-quote are `\@sveltejs/adapter-cloudflare` (instead of `@sveltejs/adapter-cloudflare`) which the beginning `\` will be read as `C:\` instead of escaping the `@` char

My PR here to bring temporary fixes for the case

Another thing I found is that `pnpm` will treat `\@sveltejs/adapter-cloudflare` as `@sveltejs/adapter-cloudflare` while `npm` read it as a local path

Log with 3.14.0

```
╰─ﬀ wrangler init sveltetest
 ⛅️ wrangler 3.14.0
-------------------
Using npm as package manager.
▲ [WARNING] The `init` command is no longer supported. Please use `npm create cloudflare@2 -- sveltetest` instead.

  The `init` command will be removed in a future version.


Running `npm create cloudflare@2 -- sveltetest`...

using create-cloudflare version 2.6.1

╭ Create an application with Cloudflare Step 1 of 3
│
├ In which directory do you want to create your application?
│ dir ./sveltetest
│
├ What type of application do you want to create?
│ type Website or web app
│
├ Which development framework do you want to use?
│ framework Svelte
│
╰ Continue with Svelte via `npx create-svelte@5.1.1 sveltetest`


create-svelte version 5.1.1

┌  Welcome to SvelteKit!
│
◇  Which Svelte app template?
│  SvelteKit demo app
│
◇  Add type checking with TypeScript?
│  Yes, using JavaScript with JSDoc comments
│
◇  Select additional options (use arrow keys/space bar)
│  none
│
└  Your project is ready!

✔ Type-checked JavaScript
  https://www.typescriptlang.org/tsconfig#checkJs

Install community-maintained integrations:
  https://github.com/svelte-add/svelte-add

Next steps:
  1: cd sveltetest
  2: npm install
  3: git init && git add -A && git commit -m "Initial commit" (optional)
  4: npm run dev -- --open

To close the dev server, hit Ctrl-C

Stuck? Visit us at https://svelte.dev/chat

╭ Configuring your application for Cloudflare Step 2 of 3
│
├ Installing dependencies
│ installed via `npm install`
│
├ Adding the Cloudflare Pages adapter
│ npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path C:\@sveltejs\adapter-cloudflare/package.json
npm ERR! errno -4058
npm ERR! enoent ENOENT: no such file or directory, open 'C:\@sveltejs\adapter-cloudflare\package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in: C:\Users\XXX\AppData\Local\npm-cache\_logs\2023-10-21T00_43_25_312
Z-debug-0.log

│
Error: npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path C:\@sveltejs\adapter-cloudflare/package.json
npm ERR! errno -4058
npm ERR! enoent ENOENT: no such file or directory, open 'C:\@sveltejs\adapter-cloudflare\package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in: C:\Users\Rubi\AppData\Local\npm-cache\_logs\2023-10-21T00_43_25_312Z-debug-0.log

npm ERR! code 1
npm ERR! path C:\Users\XXX\Documents\sat\undian-online\shellquotetest
npm ERR! command failed
npm ERR! command C:\WINDOWS\system32\cmd.exe /d /s /c create-cloudflare sveltetest

npm ERR! A complete log of this run can be found in: C:\Users\XXX\AppData\Local\npm-cache\_logs\2023-10-21T00_42_50_006Z-debug-0.log

✘ [ERROR] Command failed with exit code 1: npm create cloudflare@2 -- sveltetest
```

**Author has included the following, where applicable:**

- [x] Tests
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
