### PR TITLE
Disconnect parent process IPC channel when child process disconnects

### DIFF
--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -76,6 +76,11 @@ Consider using a Node.js version manager such as https://volta.sh/ or https://gi
 			if (process.send) {
 				process.send(message);
 			}
+		})
+		.on("disconnect", () => {
+			if (process.disconnect) {
+				process.disconnect();
+			}
 		});
 }
 


### PR DESCRIPTION
**What this PR solves / how to test:**

In #3951, we added a [`finally` block](https://github.com/cloudflare/workers-sdk/blob/b5e62b931ad6671e4dce9444a279bb3ec8f63991/packages/wrangler/src/index.ts#L796-L802) to ensure that the wrangler CLI child process disconnects from the IPC channel connecting it to the parent process. Since the parent process forwards any messages it receives on the child IPC channel up to any higher-level IPC channel, we should follow suit and also disconnect any higher-level IPC channel as well.

Refs CUSTESC-34125