### PR TITLE
CLI: Change the status colors to their appropiate backgrounds

### DIFF
--- a/.changeset/three-doors-tickle.md
+++ b/.changeset/three-doors-tickle.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/cli": patch
+---
+
+change backgrounds of statuses from red to more appropriate ones

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,5 +1,16 @@
 import { exit } from "process";
-import { brandColor, dim, gray, white, red, hidden, bgRed } from "./colors";
+import {
+	brandColor,
+	dim,
+	gray,
+	white,
+	red,
+	hidden,
+	bgRed,
+	bgYellow,
+	bgBlue,
+	bgGreen,
+} from "./colors";
 
 export const shapes = {
 	diamond: "◇",
@@ -26,9 +37,9 @@ export const shapes = {
 
 export const status = {
 	error: bgRed(` ERROR `),
-	warning: bgRed(` WARNING `),
-	info: bgRed(` INFO `),
-	success: bgRed(` SUCCESS `),
+	warning: bgYellow(` WARNING `),
+	info: bgBlue(` INFO `),
+	success: bgGreen(` SUCCESS `),
 };
 
 // Returns a string containing n non-trimmable spaces


### PR DESCRIPTION
**What this PR solves / how to test:**
Warning, Info and Success statuses were printed with a red background.

- [x] Tests (not necessary? I added a unit test but seemed quite unnecessary)
- [x] Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))

**Reviewer is to perform the following, as applicable:**

- Checked for inclusion of relevant tests
- Checked for inclusion of a relevant changeset
- Checked for creation of associated docs updates
- Manually pulled down the changes and spot-tested

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
