### PR TITLE
fix Next.js bun pages:deploy script

### DIFF
--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -142,15 +142,16 @@ const config: FrameworkConfig = {
 	configure,
 	displayName: "Next",
 	getPackageScripts: async () => {
-		const isNpmOrBun = ["npm", "bun"].includes(npm);
+		const isNpm = npm === 'npm';
+		const isBun = npm === 'bun';
+		const isNpmOrBun = isNpm || isBun;
 		const nextOnPagesScope = isNpmOrBun ? "@cloudflare/" : "";
 		const nextOnPagesCommand = `${nextOnPagesScope}next-on-pages`;
 		const pmCommand = isNpmOrBun ? npx : npm;
+		const pagesDeployCommand = isNpm ? "npm run" : isBun ? 'bun' : pmCommand
 		return {
 			"pages:build": `${pmCommand} ${nextOnPagesCommand}`,
-			"pages:deploy": `${
-				npm === "npm" ? "npm run" : pmCommand
-			} pages:build && wrangler pages deploy .vercel/output/static`,
+			"pages:deploy": `${pagesDeployCommand} pages:build && wrangler pages deploy .vercel/output/static`,
 			"pages:watch": `${pmCommand} ${nextOnPagesCommand} --watch`,
 			"pages:dev": `${pmCommand} wrangler pages dev .vercel/output/static ${await compatDateFlag()} --compatibility-flag=nodejs_compat`,
 		};

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -142,13 +142,13 @@ const config: FrameworkConfig = {
 	configure,
 	displayName: "Next",
 	getPackageScripts: async () => {
-		const isNpm = npm === 'npm';
-		const isBun = npm === 'bun';
+		const isNpm = npm === "npm";
+		const isBun = npm === "bun";
 		const isNpmOrBun = isNpm || isBun;
 		const nextOnPagesScope = isNpmOrBun ? "@cloudflare/" : "";
 		const nextOnPagesCommand = `${nextOnPagesScope}next-on-pages`;
 		const pmCommand = isNpmOrBun ? npx : npm;
-		const pagesDeployCommand = isNpm ? "npm run" : isBun ? 'bun' : pmCommand
+		const pagesDeployCommand = isNpm ? "npm run" : isBun ? "bun" : pmCommand;
 		return {
 			"pages:build": `${pmCommand} ${nextOnPagesCommand}`,
 			"pages:deploy": `${pagesDeployCommand} pages:build && wrangler pages deploy .vercel/output/static`,


### PR DESCRIPTION
fixing the incorrect bun `pages:deploy` script that we generate for Next
(introduced in #4200)

How it is:
![Screenshot 2023-10-24 at 22 38 04](https://github.com/cloudflare/workers-sdk/assets/61631103/33752a64-1bdd-4b64-9a36-2fcdc79038b3)

How it should be:
![Screenshot 2023-10-24 at 22 38 57](https://github.com/cloudflare/workers-sdk/assets/61631103/d9fe530e-3c41-4d73-94d8-528f946eec27)

