### PR TITLE
C3: Disable astro e2e for npm

### DIFF
--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -36,7 +36,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 	// These are ordered based on speed and reliability for ease of debugging
 	const frameworkTests: Record<string, FrameworkTestConfig> = {
 		astro: {
-			quarantine: true,
+			unsupportedPms: ["npm"],
 			expectResponseToContain: "Hello, Astronaut!",
 			testCommitMessage: true,
 		},

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -36,6 +36,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 	// These are ordered based on speed and reliability for ease of debugging
 	const frameworkTests: Record<string, FrameworkTestConfig> = {
 		astro: {
+			quarantine: true,
 			expectResponseToContain: "Hello, Astronaut!",
 			testCommitMessage: true,
 		},


### PR DESCRIPTION
Not ideal but the Cloudflare Astro adapter is currently broken when used with npm.

We're looking into fixing this upstream, in the meantime I am disabling the astro npm e2e test so that we can at least keep using the e2e CI checks in the meantime.