### PR TITLE
Revert "C3: Temporarily disable astro npm e2e test (#4290)"

### DIFF
--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -36,7 +36,6 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 	// These are ordered based on speed and reliability for ease of debugging
 	const frameworkTests: Record<string, FrameworkTestConfig> = {
 		astro: {
-			unsupportedPms: ["npm"],
 			expectResponseToContain: "Hello, Astronaut!",
 			testCommitMessage: true,
 		},


### PR DESCRIPTION
This reverts commit 47b0b0ef24d128aaf3287298a5cd48fae43e3ce5.

Reverting the commit as the Astro Cloudflare adapter has been fixed