### PR TITLE
Make external-service-bindings-app work locally

### DIFF
--- a/fixtures/external-service-bindings-app/tests/index.test.ts
+++ b/fixtures/external-service-bindings-app/tests/index.test.ts
@@ -3,16 +3,17 @@ import * as path from "path";
 import type { ChildProcess } from "child_process";
 import { describe, expect, it, beforeAll, afterAll, beforeEach } from "vitest";
 import { fetch, type Response } from "undici";
+import { setTimeout } from "node:timers/promises";
 
 const waitUntilReady = async (url: string): Promise<Response> => {
 	let response: Response | undefined = undefined;
 
 	while (response === undefined) {
-		await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
+		await setTimeout(500);
 
 		try {
 			response = await fetch(url);
-		} catch {}
+		} catch (e) {}
 	}
 
 	return response as Response;
@@ -73,7 +74,7 @@ describe("Pages Functions", () => {
 
 	it("connects up Workers (both module and service ones) and fetches from them", async () => {
 		const combinedResponse = await waitUntilReady(
-			`http://localhost:${pagesAppPort}/`
+			`http://127.0.0.1:${pagesAppPort}/`
 		);
 		const json = await combinedResponse.json();
 		expect(json).toMatchInlineSnapshot(`
@@ -87,7 +88,7 @@ describe("Pages Functions", () => {
 
 	it("respects the environments specified for the service bindings (and doesn't connect if the env doesn't match)", async () => {
 		const combinedResponse = await waitUntilReady(
-			`http://localhost:${pagesAppPort}/env`
+			`http://127.0.0.1:${pagesAppPort}/env`
 		);
 		const json = await combinedResponse.json();
 		expect(json).toMatchInlineSnapshot(`


### PR DESCRIPTION
Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**
This makes the `external-service-bindings-app` fixture work locally. It wasn't working because the Pages dev server doesn't appear to listen on ipv6 by default.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: This fixes an existing test
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: Internal test change
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: Not user facing

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
