### PR TITLE
C3: Fix usage with yarn

### DIFF
--- a/.changeset/dirty-bobcats-eat.md
+++ b/.changeset/dirty-bobcats-eat.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Fixes c3 usage with yarn

--- a/.changeset/dirty-bobcats-eat.md
+++ b/.changeset/dirty-bobcats-eat.md
@@ -2,4 +2,5 @@
 "create-cloudflare": patch
 ---
 
-Fixes c3 usage with yarn
+Changes c3 to use `npx` for running framework creation tools when it is invoked with `yarn`. This is
+needed since yarn can't `yarn create some-package@some-particular-version`.

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        pm: [npm, pnpm, bun]
+        pm: [npm, pnpm, bun, yarn]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: E2E Tests
         uses: ./.github/actions/run-c3-e2e
+        env:
+          NPM_PUBLISH_TOKEN: NOT_USED
         with:
           package-manager: ${{ matrix.pm }}
           quarantine: false

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -52,7 +52,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 		},
 		gatsby: {
 			expectResponseToContain: "Gatsby!",
-			unsupportedPms: ["bun"],
+			unsupportedPms: ["bun", "pnpm"],
 			promptHandlers: [
 				{
 					matcher: /Would you like to use a template\?/,

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -32,9 +32,10 @@
 		"lint": "eslint",
 		"prepublishOnly": "pnpm run build",
 		"test:e2e:cleanup": "node -r esbuild-register scripts/e2eCleanup.ts",
-		"test:e2e:npm": "pnpm run build && TEST_PM=npm vitest run --config ./vitest-e2e.config.ts",
-		"test:e2e:pnpm": "pnpm run build && TEST_PM=pnpm vitest run --config ./vitest-e2e.config.ts",
-		"test:e2e:bun": "pnpm run build && TEST_PM=bun vitest run --config ./vitest-e2e.config.ts",
+		"test:e2e:npm": "pnpm run build && cross-env TEST_PM=npm vitest run --config ./vitest-e2e.config.ts",
+		"test:e2e:pnpm": "pnpm run build && cross-env TEST_PM=pnpm vitest run --config ./vitest-e2e.config.ts",
+		"test:e2e:bun": "pnpm run build && cross-env TEST_PM=bun vitest run --config ./vitest-e2e.config.ts",
+		"test:e2e:yarn": "pnpm run build && cross-env TEST_PM=yarn vitest run --config ./vitest-e2e.config.ts",
 		"test:unit": "vitest run --config ./vitest.config.ts",
 		"test:unit:watch": "vitest --config ./vitest.config.ts",
 		"watch": "node -r esbuild-register scripts/build.ts --watch"

--- a/packages/create-cloudflare/src/frameworks/angular/index.ts
+++ b/packages/create-cloudflare/src/frameworks/angular/index.ts
@@ -6,15 +6,12 @@ import { spinner } from "@cloudflare/cli/interactive";
 import { installPackages, runFrameworkGenerator } from "helpers/command";
 import { compatDateFlag, readFile, readJSON, writeFile } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { dlx, npm } = detectPackageManager();
+const { npm } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
-
-	await runFrameworkGenerator(ctx, `${dlx} ${cli} ${ctx.project.name} --ssr`);
+	await runFrameworkGenerator(ctx, `${ctx.project.name} --ssr`);
 
 	logRaw("");
 };

--- a/packages/create-cloudflare/src/frameworks/astro/index.ts
+++ b/packages/create-cloudflare/src/frameworks/astro/index.ts
@@ -3,18 +3,12 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { npmInstall, runCommand, runFrameworkGenerator } from "helpers/command";
 import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { npx, dlx } = detectPackageManager();
+const { npx } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
-
-	await runFrameworkGenerator(
-		ctx,
-		`${dlx} ${cli} ${ctx.project.name} --no-install`
-	);
+	await runFrameworkGenerator(ctx, `${ctx.project.name} --no-install`);
 
 	logRaw(""); // newline
 };

--- a/packages/create-cloudflare/src/frameworks/docusaurus/index.ts
+++ b/packages/create-cloudflare/src/frameworks/docusaurus/index.ts
@@ -1,15 +1,12 @@
 import { runFrameworkGenerator } from "helpers/command";
 import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { PagesGeneratorContext, FrameworkConfig } from "types";
 
-const { npm, dlx } = detectPackageManager();
+const { npm } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
-
-	await runFrameworkGenerator(ctx, `${dlx} ${cli} ${ctx.project.name} classic`);
+	await runFrameworkGenerator(ctx, `${ctx.project.name} classic`);
 };
 
 const config: FrameworkConfig = {

--- a/packages/create-cloudflare/src/frameworks/gatsby/index.ts
+++ b/packages/create-cloudflare/src/frameworks/gatsby/index.ts
@@ -2,10 +2,9 @@ import { inputPrompt } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "helpers/command";
 import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { npm, dlx } = detectPackageManager();
+const { npm } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
 	const defaultTemplate = "https://github.com/gatsbyjs/gatsby-starter-blog";
@@ -27,11 +26,7 @@ const generate = async (ctx: PagesGeneratorContext) => {
 		});
 	}
 
-	const cli = getFrameworkCli(ctx);
-	await runFrameworkGenerator(
-		ctx,
-		`${dlx} ${cli} new ${ctx.project.name} ${templateUrl}`
-	);
+	await runFrameworkGenerator(ctx, `new ${ctx.project.name} ${templateUrl}`);
 };
 
 const config: FrameworkConfig = {

--- a/packages/create-cloudflare/src/frameworks/hono/index.ts
+++ b/packages/create-cloudflare/src/frameworks/hono/index.ts
@@ -1,17 +1,11 @@
 import { logRaw } from "@cloudflare/cli";
 import { runFrameworkGenerator } from "helpers/command";
-import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { dlx } = detectPackageManager();
-
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
-
 	await runFrameworkGenerator(
 		ctx,
-		`${dlx} ${cli} ${ctx.project.name} --template cloudflare-workers`
+		`${ctx.project.name} --template cloudflare-workers`
 	);
 
 	logRaw(""); // newline

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -13,7 +13,6 @@ import {
 	writeJSON,
 } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import {
 	apiAppDirHelloJs,
 	apiAppDirHelloTs,
@@ -22,13 +21,12 @@ import {
 } from "./templates";
 import type { C3Args, FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { npm, npx, dlx } = detectPackageManager();
+const { npm, npx } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
 	const projectName = ctx.project.name;
-	const cli = getFrameworkCli(ctx);
 
-	await runFrameworkGenerator(ctx, `${dlx} ${cli} ${projectName}`);
+	await runFrameworkGenerator(ctx, `${projectName}`);
 };
 
 const getApiTemplate = (

--- a/packages/create-cloudflare/src/frameworks/nuxt/index.ts
+++ b/packages/create-cloudflare/src/frameworks/nuxt/index.ts
@@ -2,18 +2,16 @@ import { logRaw } from "@cloudflare/cli";
 import { npmInstall, runFrameworkGenerator } from "helpers/command";
 import { compatDateFlag, writeFile } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { npm, dlx } = detectPackageManager();
+const { npm } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
 	const gitFlag = ctx.args.git ? `--gitInit` : `--no-gitInit`;
 
 	await runFrameworkGenerator(
 		ctx,
-		`${dlx} ${cli} init ${ctx.project.name} --packageManager ${npm} ${gitFlag}`
+		`init ${ctx.project.name} --packageManager ${npm} ${gitFlag}`
 	);
 
 	logRaw(""); // newline

--- a/packages/create-cloudflare/src/frameworks/qwik/index.ts
+++ b/packages/create-cloudflare/src/frameworks/qwik/index.ts
@@ -2,17 +2,12 @@ import { endSection } from "@cloudflare/cli";
 import { npmInstall, runCommand, runFrameworkGenerator } from "helpers/command";
 import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { npm, npx, dlx } = detectPackageManager();
+const { npm, npx } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
-
-	// TODO: make this interactive when its possible to specify the project name
-	// to create-qwik in interactive mode
-	await runFrameworkGenerator(ctx, `${dlx} ${cli} basic ${ctx.project.name}`);
+	await runFrameworkGenerator(ctx, `basic ${ctx.project.name}`);
 };
 
 const configure = async (ctx: PagesGeneratorContext) => {

--- a/packages/create-cloudflare/src/frameworks/react/index.ts
+++ b/packages/create-cloudflare/src/frameworks/react/index.ts
@@ -1,27 +1,19 @@
 import { logRaw } from "@cloudflare/cli";
-import { resetPackageManager, runFrameworkGenerator } from "helpers/command";
+import { runFrameworkGenerator } from "helpers/command";
 import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { npm, dlx } = detectPackageManager();
+const { npm } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
-
-	await runFrameworkGenerator(ctx, `${dlx} ${cli} ${ctx.project.name}`);
+	await runFrameworkGenerator(ctx, `${ctx.project.name}`);
 
 	logRaw("");
 };
 
-const configure = async (ctx: PagesGeneratorContext) => {
-	await resetPackageManager(ctx);
-};
-
 const config: FrameworkConfig = {
 	generate,
-	configure,
 	displayName: "React",
 	getPackageScripts: async () => ({
 		"pages:dev": `wrangler pages dev ${await compatDateFlag()} --port 3000 -- ${npm} start`,

--- a/packages/create-cloudflare/src/frameworks/remix/index.ts
+++ b/packages/create-cloudflare/src/frameworks/remix/index.ts
@@ -1,17 +1,14 @@
 import { logRaw } from "@cloudflare/cli";
 import { runFrameworkGenerator } from "helpers/command.js";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { npm, dlx } = detectPackageManager();
+const { npm } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
-
 	await runFrameworkGenerator(
 		ctx,
-		`${dlx} ${cli} ${ctx.project.name} --template https://github.com/remix-run/remix/tree/main/templates/cloudflare-pages`
+		`${ctx.project.name} --template https://github.com/remix-run/remix/tree/main/templates/cloudflare-pages`
 	);
 
 	logRaw(""); // newline

--- a/packages/create-cloudflare/src/frameworks/solid/index.ts
+++ b/packages/create-cloudflare/src/frameworks/solid/index.ts
@@ -3,16 +3,14 @@ import { brandColor, dim, blue } from "@cloudflare/cli/colors";
 import { installPackages, runFrameworkGenerator } from "helpers/command";
 import { compatDateFlag, usesTypescript, writeFile } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import { viteConfig } from "./templates";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { npm, dlx } = detectPackageManager();
+const { npm } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
 	// Run the create-solid command
-	const cli = getFrameworkCli(ctx);
-	await runFrameworkGenerator(ctx, `${dlx} ${cli} ${ctx.project.name}`);
+	await runFrameworkGenerator(ctx, `${ctx.project.name}`);
 
 	logRaw("");
 };

--- a/packages/create-cloudflare/src/frameworks/svelte/index.ts
+++ b/packages/create-cloudflare/src/frameworks/svelte/index.ts
@@ -8,16 +8,14 @@ import {
 } from "helpers/command";
 import { compatDateFlag, usesTypescript } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import { platformInterface } from "./templates";
 import type * as recast from "recast";
 import type { FrameworkConfig, PagesGeneratorContext } from "types";
 
-const { npm, dlx } = detectPackageManager();
+const { npm } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
-	await runFrameworkGenerator(ctx, `${dlx} ${cli} ${ctx.project.name}`);
+	await runFrameworkGenerator(ctx, `${ctx.project.name}`);
 
 	logRaw("");
 };

--- a/packages/create-cloudflare/src/frameworks/vue/index.ts
+++ b/packages/create-cloudflare/src/frameworks/vue/index.ts
@@ -1,14 +1,12 @@
 import { runFrameworkGenerator } from "helpers/command";
 import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
-import { getFrameworkCli } from "../index";
 import type { PagesGeneratorContext, FrameworkConfig } from "types";
 
-const { npm, dlx } = detectPackageManager();
+const { npm } = detectPackageManager();
 
 const generate = async (ctx: PagesGeneratorContext) => {
-	const cli = getFrameworkCli(ctx);
-	await runFrameworkGenerator(ctx, `${dlx} ${cli} ${ctx.project.name}`);
+	await runFrameworkGenerator(ctx, `${ctx.project.name}`);
 };
 
 const config: FrameworkConfig = {

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -194,7 +194,7 @@ export const runFrameworkGenerator = async (
 	const { npm, dlx } = detectPackageManager();
 
 	// yarn cannot `yarn create@some-version` and doesn't have an npx equivalent
-	// So to retain the ability to lock verisons we run it with `npx` and spoof
+	// So to retain the ability to lock versions we run it with `npx` and spoof
 	// the user agent so scaffolding tools treat the invocation like yarn
 	let cmd = `${npm === "yarn" ? "npx" : dlx} ${cli} ${argString}`;
 	const env = npm === "yarn" ? { npm_config_user_agent: "yarn" } : {};

--- a/packages/create-cloudflare/src/pages.ts
+++ b/packages/create-cloudflare/src/pages.ts
@@ -7,7 +7,12 @@ import { spinner } from "@cloudflare/cli/interactive";
 import { FrameworkMap, supportedFramework } from "frameworks/index";
 import { processArgument } from "helpers/args";
 import { C3_DEFAULTS } from "helpers/cli";
-import { installWrangler, retry, runCommand } from "helpers/command";
+import {
+	installWrangler,
+	resetPackageManager,
+	retry,
+	runCommand,
+} from "helpers/command";
 import { readJSON, writeFile } from "helpers/files";
 import { debug } from "helpers/logging";
 import { detectPackageManager } from "helpers/packages";
@@ -66,6 +71,11 @@ export const runPagesGenerator = async (args: C3Args) => {
 
 	// Configure
 	startSection("Configuring your application for Cloudflare", "Step 2 of 3");
+
+	// Rectify discrepancies between installed node_modules and package specific
+	// lockfile before potentially adding new packages in `configure`
+	await resetPackageManager(ctx);
+
 	if (configure) {
 		await configure({ ...ctx });
 	}


### PR DESCRIPTION
Fixes #4230

**What this PR solves / how to test:**

This fixes a regression that was causing c3 to fail with web frameworks when using yarn. 

Being able to version the framework creators we use is important for c3, but unfortunately `yarn` can't `yarn create some-framework@some-particular-version`. This change modifies the `runFrameworkGenerator` helper to use `npx` and spoof the npm user agent so framework creators treat it like a `yarn create` invocation. 

It also patches the package manager reset logic to make it only run when truly needed (i.e. when there's a mismatch between installed node modules and the type of lockfile used by the desired package manager).

This also adds e2e coverage for yarn to hopefully prevent future regressions.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
