### PR TITLE
[miniflare] Bump Miniflare Durable Object eviction test timeout

### DIFF
--- a/packages/miniflare/test/plugins/do/index.spec.ts
+++ b/packages/miniflare/test/plugins/do/index.spec.ts
@@ -331,7 +331,7 @@ test("proxies Durable Object methods", async (t) => {
 
 test("Durable Object eviction", async (t) => {
 	// this test requires testing over a 10 second timeout
-	t.timeout(12_000);
+	t.timeout(20_000);
 
 	// first set unsafePreventEviction to undefined
 	const mf = new Miniflare({
@@ -356,7 +356,7 @@ test("Durable Object eviction", async (t) => {
 
 test("prevent Durable Object eviction", async (t) => {
 	// this test requires testing over a 10 second timeout
-	t.timeout(12_000);
+	t.timeout(20_000);
 
 	// first set unsafePreventEviction to undefined
 	const mf = new Miniflare({


### PR DESCRIPTION
**What this PR solves / how to test:**

I've seen this test time out a couple of times in CI. Increasing the timeout to hopefully prevent this happening again. Note, this shouldn't make the tests run any slower, it just means if they do, they won't fail. 👍 

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: bumping timeout in existing test
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: not a user facing change
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: not a user facing change

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
