### PR TITLE
[miniflare] fix: ensure `Mutex` doesn't report itself as drained if locked

### DIFF
--- a/.changeset/rude-chicken-raise.md
+++ b/.changeset/rude-chicken-raise.md
@@ -1,0 +1,13 @@
+---
+"miniflare": patch
+---
+
+fix: ensure `Mutex` doesn't report itself as drained if locked
+
+Previously, Miniflare's `Mutex` implementation would report itself as drained
+if there were no waiters, regardless of the locked state. This bug meant that
+if you called but didn't `await` `Miniflare#setOptions()`, future calls to
+`Miniflare#dispatchFetch()` (or any other asynchronous `Miniflare` method)
+wouldn't wait for the options update to apply and the runtime to restart before
+sending requests. This change ensures we wait until the mutex is unlocked before
+reporting it as drained.

--- a/packages/miniflare/src/workers/shared/sync.ts
+++ b/packages/miniflare/src/workers/shared/sync.ts
@@ -71,7 +71,7 @@ export class Mutex {
 	}
 
 	async drained(): Promise<void> {
-		if (this.resolveQueue.length === 0) return;
+		if (this.resolveQueue.length === 0 && !this.locked) return;
 		return new Promise((resolve) => this.drainQueue.push(resolve));
 	}
 }

--- a/packages/miniflare/test/shared/sync.spec.ts
+++ b/packages/miniflare/test/shared/sync.spec.ts
@@ -46,6 +46,7 @@ test("Mutex: maintains separate drain queue", async (t) => {
 	void mutex.runWith(() => deferred1);
 	let drained = false;
 	mutex.drained().then(() => (drained = true));
+	await setTimeout();
 	t.false(drained);
 	deferred1.resolve();
 	await setTimeout();
@@ -64,6 +65,7 @@ test("Mutex: maintains separate drain queue", async (t) => {
 	});
 	drained = false;
 	mutex.drained().then(() => (drained = true));
+	await setTimeout();
 	t.false(drained);
 	deferred2.resolve();
 	await setTimeout();


### PR DESCRIPTION
**What this PR solves / how to test:**

Previously, Miniflare's `Mutex` implementation would report itself as drained if there were no waiters, regardless of the locked state. This bug meant that if you called but didn't `await` `Miniflare#setOptions()`, future calls to `Miniflare#dispatchFetch()` (or any other asynchronous `Miniflare` method) wouldn't wait for the options update to apply and the runtime to restart before sending requests. This change ensures we wait until the mutex is unlocked before reporting it as drained.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: this is a bug fix

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
