### PR TITLE
unquarantine nuxt

### DIFF
--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -93,7 +93,6 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			quarantine: true,
 		},
 		nuxt: {
-			quarantine: true,
 			expectResponseToContain: "Welcome to Nuxt!",
 			overrides: {
 				packageScripts: {


### PR DESCRIPTION
Removing nuxt from the C3 e2e quarantine since it seems like the nitro regression (that made nuxt not work) has been fixed: https://github.com/unjs/nitro/releases/tag/v2.7.2