### PR TITLE
[devtools] Never cache script content

### DIFF
--- a/packages/wrangler-devtools/patches/0001-Support-viewing-files-over-the-network.patch
+++ b/packages/wrangler-devtools/patches/0001-Support-viewing-files-over-the-network.patch
@@ -1,7 +1,7 @@
-From 24644cc732ec4bf8589715e853067eadd1b52e29 Mon Sep 17 00:00:00 2001
+From c3099a96f68e24f68e4ae39baaeb5bbcdc5af8a0 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Mon, 2 Oct 2023 18:13:34 +0100
-Subject: [PATCH 01/15] Support viewing files over the network
+Subject: [PATCH 01/16] Support viewing files over the network
 
 ---
  front_end/core/sdk/Target.ts             |  4 ++++

--- a/packages/wrangler-devtools/patches/0002-Show-fallback-image-on-Safari.patch
+++ b/packages/wrangler-devtools/patches/0002-Show-fallback-image-on-Safari.patch
@@ -1,7 +1,7 @@
-From 0ccfb994361f1fa467f7ea441131f4a079cea607 Mon Sep 17 00:00:00 2001
+From 6e65cbf34e91aeba2979250d549cde384d662d3b Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Mon, 2 Oct 2023 18:18:45 +0100
-Subject: [PATCH 02/15] Show fallback image on Safari
+Subject: [PATCH 02/16] Show fallback image on Safari
 
 ---
  config/gni/devtools_grd_files.gni   |   1 +

--- a/packages/wrangler-devtools/patches/0003-Support-previewing-subrequest-responses.patch
+++ b/packages/wrangler-devtools/patches/0003-Support-previewing-subrequest-responses.patch
@@ -1,7 +1,7 @@
-From 95b2dc1f6cf0f02c3c52da17c0cec1f6fdbf6035 Mon Sep 17 00:00:00 2001
+From f278e7aaea75ce633098fabf9a37fd466807d116 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Mon, 2 Oct 2023 18:22:08 +0100
-Subject: [PATCH 03/15] Support previewing subrequest responses
+Subject: [PATCH 03/16] Support previewing subrequest responses
 
 ---
  front_end/core/sdk/NetworkManager.ts   | 7 ++++++-

--- a/packages/wrangler-devtools/patches/0004-Better-Firefox-support-for-network-tab.patch
+++ b/packages/wrangler-devtools/patches/0004-Better-Firefox-support-for-network-tab.patch
@@ -1,7 +1,7 @@
-From 83b63469d06e2318f880c417c168f5494edf89fa Mon Sep 17 00:00:00 2001
+From 3d75766397a7b9766d8608269630326eb7754ccc Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 19 Jan 2023 15:47:52 +0000
-Subject: [PATCH 04/15] Better Firefox support for network tab
+Subject: [PATCH 04/16] Better Firefox support for network tab
 
 ---
  front_end/entrypoints/js_app/js_app.ts               | 2 ++

--- a/packages/wrangler-devtools/patches/0005-Remove-unsupported-network-UI.patch
+++ b/packages/wrangler-devtools/patches/0005-Remove-unsupported-network-UI.patch
@@ -1,7 +1,7 @@
-From f2c4fc2bd919c743124df81d0b7ca9dc19cd2787 Mon Sep 17 00:00:00 2001
+From 548d614a5d677d4016701f133e2de620e3b451c4 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Mon, 2 Oct 2023 18:24:46 +0100
-Subject: [PATCH 05/15] Remove unsupported network UI
+Subject: [PATCH 05/16] Remove unsupported network UI
 
 ---
  front_end/panels/network/NetworkPanel.ts | 35 ------------------------

--- a/packages/wrangler-devtools/patches/0006-Remove-unsupported-profiler-UI.patch
+++ b/packages/wrangler-devtools/patches/0006-Remove-unsupported-profiler-UI.patch
@@ -1,7 +1,7 @@
-From a1602867b77541604c03f67da518044bb2209f8a Mon Sep 17 00:00:00 2001
+From aa5be8782d67d2ac671df347babaeafa7e9ed2d3 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Mon, 2 Oct 2023 18:26:03 +0100
-Subject: [PATCH 06/15] Remove unsupported profiler UI
+Subject: [PATCH 06/16] Remove unsupported profiler UI
 
 ---
  front_end/panels/profiler/HeapProfilerPanel.ts | 2 +-

--- a/packages/wrangler-devtools/patches/0007-Support-theme-url-parameter-for-forcing-the-theme-fr.patch
+++ b/packages/wrangler-devtools/patches/0007-Support-theme-url-parameter-for-forcing-the-theme-fr.patch
@@ -1,7 +1,7 @@
-From 8b11e3150fbb5b70d328888664475ca9ebec39fa Mon Sep 17 00:00:00 2001
+From eab55678f5e9d86fccf02b844daf7d8485ffce05 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Fri, 20 Jan 2023 19:19:37 +0000
-Subject: [PATCH 07/15] Support theme= url parameter for forcing the theme from
+Subject: [PATCH 07/16] Support theme= url parameter for forcing the theme from
  outside
 
 ---

--- a/packages/wrangler-devtools/patches/0008-Basic-support-for-text-colour-in-dark-mode-in-browse.patch
+++ b/packages/wrangler-devtools/patches/0008-Basic-support-for-text-colour-in-dark-mode-in-browse.patch
@@ -1,7 +1,7 @@
-From 4f06ecdab94922e227b3f4d098d0875efbb724a1 Mon Sep 17 00:00:00 2001
+From 3ac3a6b4ed59c9f702cb200a06f0fd9737314f81 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Mon, 23 Jan 2023 15:12:38 +0000
-Subject: [PATCH 08/15] Basic support for text colour in dark mode in browsers
+Subject: [PATCH 08/16] Basic support for text colour in dark mode in browsers
  that don't implement :host-context
 
 ---

--- a/packages/wrangler-devtools/patches/0009-Fallback-to-location-for-domain.patch
+++ b/packages/wrangler-devtools/patches/0009-Fallback-to-location-for-domain.patch
@@ -1,7 +1,7 @@
-From 597f5cee506058efa09d952b94e7b9a2ad384e9d Mon Sep 17 00:00:00 2001
+From c03879e86e69bd0f00a337af9c0b1d9ce22a13ca Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 26 Jan 2023 15:27:04 +0000
-Subject: [PATCH 09/15] Fallback to location for domain
+Subject: [PATCH 09/16] Fallback to location for domain
 
 ---
  front_end/panels/sources/NavigatorView.ts | 3 ++-

--- a/packages/wrangler-devtools/patches/0010-Hide-unsupported-settings-UI.patch
+++ b/packages/wrangler-devtools/patches/0010-Hide-unsupported-settings-UI.patch
@@ -1,7 +1,7 @@
-From 3c9b2a24e6afefffe5485516fab7bfb38107c9d6 Mon Sep 17 00:00:00 2001
+From c136c7eed400674cc79f5d5547c33e3092dac275 Mon Sep 17 00:00:00 2001
 From: bcoll <bcoll@cloudflare.com>
 Date: Thu, 26 Jan 2023 15:30:34 +0000
-Subject: [PATCH 10/15] Hide unsupported settings UI
+Subject: [PATCH 10/16] Hide unsupported settings UI
 
 - Show CORS errors in console setting
 - Show XHR requests in console setting

--- a/packages/wrangler-devtools/patches/0011-Add-ping-to-improve-connection-stability.patch
+++ b/packages/wrangler-devtools/patches/0011-Add-ping-to-improve-connection-stability.patch
@@ -1,7 +1,7 @@
-From b2e4d126f70ba0a96163411c7bd60c2fe7af4872 Mon Sep 17 00:00:00 2001
+From 12ef2b62fcf75baca32cfa0252f2beaf2a6412d0 Mon Sep 17 00:00:00 2001
 From: Samuel Macleod <smacleod@cloudflare.com>
 Date: Thu, 4 May 2023 03:21:58 +0100
-Subject: [PATCH 11/15] Add ping to improve connection stability
+Subject: [PATCH 11/16] Add ping to improve connection stability
 
 ---
  front_end/core/protocol_client/InspectorBackend.ts | 9 +++++++++

--- a/packages/wrangler-devtools/patches/0012-Support-sourcemaps.patch
+++ b/packages/wrangler-devtools/patches/0012-Support-sourcemaps.patch
@@ -1,7 +1,7 @@
-From 85b0de956a4c57150c9b43fd1e6096074809df27 Mon Sep 17 00:00:00 2001
+From a33d77cb805d4393efdf26999e9ab701af913f40 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Mon, 2 Oct 2023 18:30:44 +0100
-Subject: [PATCH 12/15] Support sourcemaps:
+Subject: [PATCH 12/16] Support sourcemaps:
 
     * Recognise `wrangler://` URLs as "special", and always load them with Network.loadNetworkResource
 

--- a/packages/wrangler-devtools/patches/0013-Enable-debugger-when-query-parameter-debugger-is-tru.patch
+++ b/packages/wrangler-devtools/patches/0013-Enable-debugger-when-query-parameter-debugger-is-tru.patch
@@ -1,7 +1,7 @@
-From d3add591e59cefa45458a29341185824df9334b2 Mon Sep 17 00:00:00 2001
+From ea4ba0a5a5589fa8e2ad30054072f3ad0a9585a8 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Wed, 4 Oct 2023 00:57:43 +0100
-Subject: [PATCH 13/15] Enable debugger when query parameter `debugger` is true
+Subject: [PATCH 13/16] Enable debugger when query parameter `debugger` is true
 
 ---
  front_end/panels/sources/DebuggerPlugin.ts |  7 +++-

--- a/packages/wrangler-devtools/patches/0014-Show-Profiling-panel.patch
+++ b/packages/wrangler-devtools/patches/0014-Show-Profiling-panel.patch
@@ -1,7 +1,7 @@
-From 0488c38300b4125cd9c8d1956894baac47d03d9a Mon Sep 17 00:00:00 2001
+From e3ca5d3d9c1ae08d9403cdf7cf25d472b0ccab64 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Wed, 4 Oct 2023 01:11:14 +0100
-Subject: [PATCH 14/15] Show Profiling panel
+Subject: [PATCH 14/16] Show Profiling panel
 
 ---
  front_end/entrypoints/main/MainImpl.ts        |  1 +

--- a/packages/wrangler-devtools/patches/0015-Basic-support-for-Safari.patch
+++ b/packages/wrangler-devtools/patches/0015-Basic-support-for-Safari.patch
@@ -1,7 +1,7 @@
-From 8b0cffa7ec0679ca5aff6eb86654b08956fa33f9 Mon Sep 17 00:00:00 2001
+From 4dc21116b4c3719c9fd97e255a76b3a46481cfb2 Mon Sep 17 00:00:00 2001
 From: Workers DevProd <workers-devprod@cloudflare.com>
 Date: Thu, 5 Oct 2023 16:37:38 +0100
-Subject: [PATCH 15/15] Basic support for Safari
+Subject: [PATCH 15/16] Basic support for Safari
 
 ---
  front_end/core/dom_extension/DOMExtension.ts | 2 +-

--- a/packages/wrangler-devtools/patches/0016-Never-cache-script-content.patch
+++ b/packages/wrangler-devtools/patches/0016-Never-cache-script-content.patch
@@ -1,0 +1,27 @@
+From d29e6630ed7bea0542b4518b25a5f938c454d73c Mon Sep 17 00:00:00 2001
+From: Workers DevProd <workers-devprod@cloudflare.com>
+Date: Fri, 3 Nov 2023 00:59:32 +0000
+Subject: [PATCH 16/16] Never cache script content
+
+---
+ front_end/core/sdk/DebuggerModel.ts | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/front_end/core/sdk/DebuggerModel.ts b/front_end/core/sdk/DebuggerModel.ts
+index ebed9cacdd..f4dc64f914 100644
+--- a/front_end/core/sdk/DebuggerModel.ts
++++ b/front_end/core/sdk/DebuggerModel.ts
+@@ -681,10 +681,6 @@ export class DebuggerModel extends SDKModel<EventTypes> {
+       isModule: boolean|null, originStackTrace: Protocol.Runtime.StackTrace|null, codeOffset: number|null,
+       scriptLanguage: string|null, debugSymbols: Protocol.Debugger.DebugSymbols|null,
+       embedderName: Platform.DevToolsPath.UrlString|null): Script {
+-    const knownScript = this.#scriptsInternal.get(scriptId);
+-    if (knownScript) {
+-      return knownScript;
+-    }
+     let isContentScript = false;
+     if (executionContextAuxData && ('isDefault' in executionContextAuxData)) {
+       isContentScript = !executionContextAuxData['isDefault'];
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
**What this PR solves / how to test:**

When viewing a Worker's source in DevTools, a user expects the source to update if the underlying code on disk changes. Unfortunately, Chrome DevTools caches script content by script ID, and although script content changes on Worker reloads, the script ID doesn't.

This default makes sense for the web environment that Chrome DevTools usually runs in, but for us it makes more sense to always construct a new script when the runtime sends a `Debugger.scriptParsed` event, since those only happen when the script has actually changed.

When testing this (using the preview build of DevTools that this PR will generate in CI), please pay special attention to the DX of breakpoint debugging, since this could change the experience here (I've tested it myself, but I don't often use breakpoint debugging, so may have missed some corner cases).

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: this can't really be tested in an automated fashion. Reviewers should test this manually.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: Not a user facing package
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: bugfix in a non user facing package

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
