### PR TITLE
fix: remove unneeded polyfills from the Angular template

### DIFF
--- a/.changeset/shiny-worms-prove.md
+++ b/.changeset/shiny-worms-prove.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Remove redundant polyfills from the Angular template

--- a/packages/create-cloudflare/src/frameworks/angular/templates/tools/alter-polyfills.mjs
+++ b/packages/create-cloudflare/src/frameworks/angular/templates/tools/alter-polyfills.mjs
@@ -24,9 +24,6 @@ for (let index = 0; index < 2; index++) {
 // Add needed polyfills
 serverPolyfillsData.unshift(
 	`globalThis['process'] = {};`,
-	`globalThis['global'] = globalThis;`,
-	// Needed as performance.mark is not a function in worker.
-	`performance.mark = () => {};`
 );
 
 fs.writeFileSync(serverPolyfillsFile, serverPolyfillsData.join(EOL));

--- a/packages/create-cloudflare/src/frameworks/angular/templates/tools/alter-polyfills.mjs
+++ b/packages/create-cloudflare/src/frameworks/angular/templates/tools/alter-polyfills.mjs
@@ -22,8 +22,6 @@ for (let index = 0; index < 2; index++) {
 }
 
 // Add needed polyfills
-serverPolyfillsData.unshift(
-	`globalThis['process'] = {};`,
-);
+serverPolyfillsData.unshift(`globalThis['process'] = {};`);
 
 fs.writeFileSync(serverPolyfillsFile, serverPolyfillsData.join(EOL));

--- a/packages/create-cloudflare/src/frameworks/package.json
+++ b/packages/create-cloudflare/src/frameworks/package.json
@@ -7,7 +7,7 @@
 	],
 	"dependencies": {
 		"create-astro": "4.4.1",
-		"@angular/create": "17.0.0-rc.3",
+		"@angular/create": "17.0.0-rc.4",
 		"create-docusaurus": "3.0.0",
 		"create-hono": "0.3.2",
 		"create-next-app": "13.4.19",


### PR DESCRIPTION
`performance.mark` and `global` polyfills are no longer needed in a v17 application.

See: https://github.com/angular/angular/pull/52505