### PR TITLE
Feat(unstable_dev): Don't fetch from npm on boot

### DIFF
--- a/.changeset/cyan-books-act.md
+++ b/.changeset/cyan-books-act.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Feat(unstable_dev): Provide an option for unstable_dev to perform the check that prompts users to update wrangler, defaulting to false. This will prevent unstable_dev from sending a request to NPM on startup to determine whether it needs to be updated.

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -93,6 +93,8 @@ fetchMock.doMock(() => {
 
 jest.mock("../package-manager");
 
+jest.mock("../update-check");
+
 // requests not mocked with `jest-fetch-mock` fall through
 // to `mock-service-worker`
 fetchMock.dontMock();

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -55,6 +55,7 @@ export interface UnstableDevOptions {
 	inspect?: boolean;
 	local?: boolean;
 	accountId?: string;
+	updateCheck?: boolean;
 	experimental?: {
 		processEntrypoint?: boolean;
 		additionalModules?: CfModule[];
@@ -139,10 +140,8 @@ export async function unstable_dev(
 	const devOptions: StartDevOptions = {
 		script: script,
 		inspect: false,
-		logLevel: options?.logLevel ?? defaultLogLevel,
 		_: [],
 		$0: "",
-		port: options?.port ?? 0,
 		remote: !local,
 		local,
 		experimentalLocal: undefined,
@@ -194,6 +193,9 @@ export async function unstable_dev(
 		legacyEnv: undefined,
 		public: undefined,
 		...options,
+		logLevel: options?.logLevel ?? defaultLogLevel,
+		port: options?.port ?? 0,
+		updateCheck: options?.updateCheck ?? false,
 	};
 
 	//due to Pages adoption of unstable_dev, we can't *just* disable rebuilds and watching. instead, we'll have two versions of startDev, which will converge.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -342,6 +342,7 @@ export type StartDevOptions = DevArguments &
 		enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
 		onReady?: (ip: string, port: number) => void;
 		showInteractiveDevSession?: boolean;
+		updateCheck?: boolean;
 	};
 
 export async function startDev(args: StartDevOptions) {
@@ -351,7 +352,7 @@ export async function startDev(args: StartDevOptions) {
 		if (args.logLevel) {
 			logger.loggerLevel = args.logLevel;
 		}
-		await printWranglerBanner();
+		await printWranglerBanner(args.updateCheck);
 		if (args.local) {
 			logger.warn(
 				"--local is no longer required and will be removed in a future version.\n`wrangler dev` now uses the local Cloudflare Workers runtime by default. 🎉"
@@ -518,7 +519,7 @@ export async function startApiDev(args: StartDevOptions) {
 	if (args.logLevel) {
 		logger.loggerLevel = args.logLevel;
 	}
-	await printWranglerBanner();
+	await printWranglerBanner(args.updateCheck);
 
 	const configPath =
 		args.config || (args.script && findWranglerToml(path.dirname(args.script)));

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -1,8 +1,6 @@
 import module from "node:module";
 import os from "node:os";
 import TOML from "@iarna/toml";
-import chalk from "chalk";
-import supportsColor from "supports-color";
 import { ProxyAgent, setGlobalDispatcher } from "undici";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
@@ -50,7 +48,7 @@ import { r2 } from "./r2";
 import { secret, secretBulkHandler, secretBulkOptions } from "./secret";
 import { tailOptions, tailHandler } from "./tail";
 import { generateTypes } from "./type-generation";
-import { updateCheck } from "./update-check";
+import { printWranglerBanner } from "./update-check";
 import { listScopes, login, logout, validateScopeKeys } from "./user";
 import { vectorize } from "./vectorize/index";
 import { whoami } from "./whoami";
@@ -95,41 +93,6 @@ ${TOML.stringify({ rules: config.build.upload.rules })}`
 		);
 	}
 	return rules;
-}
-
-export async function printWranglerBanner() {
-	// Let's not print this in tests
-	if (typeof jest !== "undefined") {
-		return;
-	}
-
-	let text = ` ⛅️ wrangler ${wranglerVersion}`;
-	const maybeNewVersion = await updateCheck();
-	if (maybeNewVersion !== undefined) {
-		text += ` (update available ${chalk.green(maybeNewVersion)})`;
-	}
-
-	logger.log(
-		text +
-			"\n" +
-			(supportsColor.stdout
-				? chalk.hex("#FF8800")("-".repeat(text.length))
-				: "-".repeat(text.length))
-	);
-
-	// Log a slightly more noticeable message if this is a major bump
-	if (maybeNewVersion !== undefined) {
-		const currentMajor = parseInt(wranglerVersion.split(".")[0]);
-		const newMajor = parseInt(maybeNewVersion.split(".")[0]);
-		if (newMajor > currentMajor) {
-			logger.warn(
-				`The version of Wrangler you are using is now out-of-date.
-Please update to the latest version to prevent critical errors.
-Run \`npm install --save-dev wrangler@${newMajor}\` to update to the latest version.
-After installation, run Wrangler with \`npx wrangler\`.`
-			);
-		}
-	}
 }
 
 export function isLegacyEnv(config: Config): boolean {
@@ -832,3 +795,5 @@ export function getDevCompatibilityDate(
 	}
 	return compatibilityDate ?? currentDate;
 }
+
+export { printWranglerBanner };

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -682,6 +682,7 @@ export const Handler = async ({
 		persistTo,
 		inspect: undefined,
 		logLevel,
+		updateCheck: true,
 		experimental: {
 			processEntrypoint: true,
 			additionalModules: modules,

--- a/packages/wrangler/src/update-check.ts
+++ b/packages/wrangler/src/update-check.ts
@@ -1,6 +1,43 @@
+import chalk from "chalk";
+import supportsColor from "supports-color";
 import checkForUpdate from "update-check";
 import pkg from "../package.json";
+import { version as wranglerVersion } from "../package.json";
+import { logger } from "./logger";
 import type { Result } from "update-check";
+
+export async function printWranglerBanner(performUpdateCheck = true) {
+	let text = ` ⛅️ wrangler ${wranglerVersion}`;
+	let maybeNewVersion: string | undefined;
+	if (performUpdateCheck) {
+		maybeNewVersion = await updateCheck();
+		if (maybeNewVersion !== undefined) {
+			text += ` (update available ${chalk.green(maybeNewVersion)})`;
+		}
+	}
+
+	logger.log(
+		text +
+			"\n" +
+			(supportsColor.stdout
+				? chalk.hex("#FF8800")("-".repeat(text.length))
+				: "-".repeat(text.length))
+	);
+
+	// Log a slightly more noticeable message if this is a major bump
+	if (maybeNewVersion !== undefined) {
+		const currentMajor = parseInt(wranglerVersion.split(".")[0]);
+		const newMajor = parseInt(maybeNewVersion.split(".")[0]);
+		if (newMajor > currentMajor) {
+			logger.warn(
+				`The version of Wrangler you are using is now out-of-date.
+Please update to the latest version to prevent critical errors.
+Run \`npm install --save-dev wrangler@${newMajor}\` to update to the latest version.
+After installation, run Wrangler with \`npx wrangler\`.`
+			);
+		}
+	}
+}
 
 async function doUpdateCheck(): Promise<string | undefined> {
 	let update: Result | null = null;


### PR DESCRIPTION
Remake of #2982 
Fixes #2956.

**What this PR solves / how to test:**

Wrangler makes a HTTP request to the NPM registry, checking for updates to inform end users. While this makes sense in regular commands, it (generally) has little place in it's API, particularly when this is primarily used for tests. 

This pull request adds an experimental option which **disables** the update check, and optionally allows users to enable it. (There are cases for this, such as `pages dev`)

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: Bugfix

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
