### PR TITLE
tail: add a --yes flag to bypass the DO prompt

### DIFF
--- a/.changeset/rotten-keys-occur.md
+++ b/.changeset/rotten-keys-occur.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Adds a --yes flag to wrangler tail to implicitly accept any confirmation prompts. This includes the prompt when using tail on a Worker with a Durable Object, as tail will reset any active connections.

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -142,7 +142,6 @@ export async function tailHandler(args: TailArgs) {
 	if (
 		scriptContent.toLowerCase().includes("websocket") &&
 		bindings.find((b) => b.type === "durable_object_namespace")
-
 	) {
 		logger.warn(
 			`Beginning log collection requires restarting the Durable Objects associated with ${scriptName}. Any WebSocket connections or other non-persisted state will be lost as part of this restart.`

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -81,6 +81,11 @@ export function tailOptions(yargs: CommonYargsArgv) {
 			type: "boolean",
 			describe: "Use legacy environments",
 			hidden: true,
+		})
+		.option("yes", {
+			type: "boolean",
+			describe: "Answer yes to any prompts",
+			alias: "y",
 		});
 }
 
@@ -137,12 +142,13 @@ export async function tailHandler(args: TailArgs) {
 	if (
 		scriptContent.toLowerCase().includes("websocket") &&
 		bindings.find((b) => b.type === "durable_object_namespace")
+
 	) {
 		logger.warn(
 			`Beginning log collection requires restarting the Durable Objects associated with ${scriptName}. Any WebSocket connections or other non-persisted state will be lost as part of this restart.`
 		);
 
-		if (!(await confirm("Would you like to continue?"))) {
+		if (!args.yes && !(await confirm("Would you like to continue?"))) {
 			return;
 		}
 	}


### PR DESCRIPTION
This PR adds a `--yes` flag to `wrangler tail` to bypass the confirmation prompt for WebSocket/DO.

* It will still print the warning text
* Includes an alias for `-y`
* Adds a changeset