### PR TITLE
[miniflare] fix: reject `Miniflare#ready` promise if `dispose()`ed while waiting

### DIFF
--- a/.changeset/forty-rice-smoke.md
+++ b/.changeset/forty-rice-smoke.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: reject `Miniflare#ready` promise if `Miniflare#dispose()` called while waiting

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1207,6 +1207,8 @@ export class Miniflare {
 		// `dispose()`d synchronously, immediately after constructing a `Miniflare`
 		// instance. In this case, return a discard URL which we'll ignore.
 		if (disposing) return new URL("http://[100::]/");
+		// Make sure `dispose()` wasn't called in the time we've been waiting
+		this.#checkDisposed();
 		// `#runtimeEntryURL` is assigned in `#assembleAndUpdateConfig()`, which is
 		// called by `#init()`, and `#initPromise` doesn't resolve until `#init()`
 		// returns.

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -728,8 +728,13 @@ test("Miniflare: listens on ipv6", async (t) => {
 
 test("Miniflare: dispose() immediately after construction", async (t) => {
 	const mf = new Miniflare({ script: "", modules: true });
+	const readyPromise = mf.ready;
 	await mf.dispose();
-	t.pass();
+	await t.throwsAsync(readyPromise, {
+		instanceOf: MiniflareCoreError,
+		code: "ERR_DISPOSED",
+		message: "Cannot use disposed instance",
+	});
 });
 
 test("Miniflare: getBindings() returns all bindings", async (t) => {


### PR DESCRIPTION
Fixes #4363.

**What this PR solves / how to test:**

This PR ensures `Miniflare#ready` is rejected if `Miniflare#dispose()` is called while waiting on the `ready` promise.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
