### PR TITLE
ci: move the Angular framework out of the C3 e2e test quarantine.

### DIFF
--- a/.changeset/afraid-lobsters-peel.md
+++ b/.changeset/afraid-lobsters-peel.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+ci: move the Angular framework out of the C3 e2e test quarantine.

--- a/packages/create-cloudflare/e2e-tests/pages.test.ts
+++ b/packages/create-cloudflare/e2e-tests/pages.test.ts
@@ -46,7 +46,6 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			timeout: 1000 * 60 * 5,
 		},
 		angular: {
-			quarantine: true,
 			expectResponseToContain: "Love Angular?",
 			testCommitMessage: true,
 		},


### PR DESCRIPTION
It does what it says on the tin!