### PR TITLE
startDevWorker Milestone 1 - Reboot

### DIFF
--- a/.changeset/serious-toys-repeat.md
+++ b/.changeset/serious-toys-repeat.md
@@ -1,0 +1,12 @@
+---
+"wrangler": minor
+---
+
+Reintroduces some internal refactorings of wrangler dev servers (including `wrangler dev`, `wrangler dev --remote`, and `unstable_dev()`).
+
+These changes were released in 3.13.0 and reverted in 3.13.1 -- we believe the changes are now more stable and ready for release again.
+
+There are no changes required for developers to opt-in. Improvements include:
+
+- fewer 'address in use' errors upon reloads
+- upon config/source file changes, requests are buffered to guarantee the response is from the new version of the Worker

--- a/fixtures/dev-env/package.json
+++ b/fixtures/dev-env/package.json
@@ -16,7 +16,7 @@
 		"@types/ws": "^8.5.7",
 		"@cloudflare/workers-tsconfig": "workspace:^",
 		"get-port": "^7.0.0",
-		"miniflare": "3.20231002.1",
+		"miniflare": "3.20231025.1",
 		"undici": "^5.23.0",
 		"wrangler": "workspace:*",
 		"ws": "^8.14.2"

--- a/fixtures/dev-env/tests/index.test.ts
+++ b/fixtures/dev-env/tests/index.test.ts
@@ -18,7 +18,7 @@ const fakeBundle = {} as EsbuildBundle;
 
 let devEnv: DevEnv;
 let mf: Miniflare | undefined;
-let res: MiniflareResponse | undici.Response | undefined;
+let res: MiniflareResponse | undici.Response;
 let ws: WebSocket | undefined;
 
 type OptionalKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
@@ -26,7 +26,7 @@ type OptionalKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 beforeEach(() => {
 	devEnv = new DevEnv();
 	mf = undefined;
-	res = undefined;
+	res = undefined as any;
 	ws = undefined;
 });
 afterEach(async () => {
@@ -67,10 +67,11 @@ async function fakeStartUserWorker(options: {
 	fakeReloadStart(config);
 
 	const worker = devEnv.startWorker(config);
-	const { proxyWorker, inspectorProxyWorker } = await devEnv.proxy.ready
-		.promise;
+	const { proxyWorker } = await devEnv.proxy.ready.promise;
 	const proxyWorkerUrl = await proxyWorker.ready;
-	const inspectorProxyWorkerUrl = await inspectorProxyWorker.ready;
+	const inspectorProxyWorkerUrl = await proxyWorker.unsafeGetDirectURL(
+		"InspectorProxyWorker"
+	);
 
 	mf = new Miniflare(mfOpts);
 

--- a/fixtures/dev-env/tests/index.test.ts
+++ b/fixtures/dev-env/tests/index.test.ts
@@ -52,7 +52,7 @@ async function fakeStartUserWorker(options: {
 	};
 	const mfOpts: MiniflareOptions = Object.assign(
 		{
-			port: 0,
+			port: undefined,
 			inspectorPort: 0,
 			modules: true,
 			compatibilityDate: "2023-08-01",

--- a/fixtures/worker-ts/src/index.ts
+++ b/fixtures/worker-ts/src/index.ts
@@ -29,6 +29,6 @@ export default {
 	): Promise<Response> {
 		const url = new URL(request.url);
 		if (url.pathname === "/error") throw new Error("Hello Error");
-		return new Response("Hello World!");
+		return new Response("Hi9 World!");
 	},
 };

--- a/fixtures/worker-ts/src/index.ts
+++ b/fixtures/worker-ts/src/index.ts
@@ -29,6 +29,6 @@ export default {
 	): Promise<Response> {
 		const url = new URL(request.url);
 		if (url.pathname === "/error") throw new Error("Hello Error");
-		return new Response("Hi9 World!");
+		return new Response("Hello World 3!");
 	},
 };

--- a/fixtures/worker-ts/src/index.ts
+++ b/fixtures/worker-ts/src/index.ts
@@ -29,6 +29,6 @@ export default {
 	): Promise<Response> {
 		const url = new URL(request.url);
 		if (url.pathname === "/error") throw new Error("Hello Error");
-		return new Response("Hello World 3!");
+		return new Response("Hello World!");
 	},
 };

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -150,10 +150,10 @@ compatibility_date = "2023-01-01"
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ignoring this test type error for sake of turborepo PR
 		const json = (await resp.json()) as any;
 
-		expect(
-			json.headers.find(([h]: [string]) => h === "cf-workers-preview-token")[1]
-		).toBe(token);
-		expect(json.url).toMatchInlineSnapshot('"http://127.0.0.1:6756/"');
+		expect(json).toMatchObject({
+			url: `http://127.0.0.1:${remote.port}/`,
+			headers: expect.arrayContaining([["cf-workers-preview-token", token]]),
+		});
 	});
 	it("should be redirected with cookie", async () => {
 		const resp = await worker.fetch(
@@ -192,10 +192,12 @@ compatibility_date = "2023-01-01"
 		);
 
 		const json = (await resp.json()) as { headers: string[][]; url: string };
-		expect(Object.fromEntries([...json.headers])).toMatchObject({
-			"cf-workers-preview-token": "TEST_TOKEN",
+		expect(json).toMatchObject({
+			url: `http://127.0.0.1:${remote.port}/`,
+			headers: expect.arrayContaining([
+				["cf-workers-preview-token", "TEST_TOKEN"],
+			]),
 		});
-		expect(json.url).toMatchInlineSnapshot('"http://127.0.0.1:6756/"');
 	});
 	it("should not follow redirects", async () => {
 		const resp = await worker.fetch(

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -60,11 +60,11 @@
 		"emit-types": "tsc -p tsconfig.emit.json && node -r esbuild-register scripts/emit-types.ts",
 		"prepublishOnly": "SOURCEMAPS=false npm run build",
 		"start": "pnpm run bundle && cross-env NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
-		"test": "pnpm run assert-git-version && jest --runInBand",
+		"test": "pnpm run assert-git-version && jest",
 		"test:ci": "pnpm run test --coverage",
 		"test:debug": "pnpm run test --silent=false --verbose=true",
 		"test:e2e": "vitest --test-timeout 240000 --single-thread --dir ./e2e --retry 2 run",
-		"test:watch": "pnpm run test --runInBand --testTimeout=50000 --watch",
+		"test:watch": "pnpm run test --testTimeout=50000 --watch",
 		"type:tests": "tsc -p ./src/__tests__/tsconfig.json && tsc -p ./e2e/tsconfig.json"
 	},
 	"jest": {

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -169,7 +169,7 @@ export async function unstable_dev(
 		compatibilityDate: options?.compatibilityDate,
 		compatibilityFlags: options?.compatibilityFlags,
 		ip: options?.ip,
-		inspectorPort: options?.inspectorPort,
+		inspectorPort: options?.inspectorPort ?? 0,
 		v: undefined,
 		localProtocol: options?.localProtocol,
 		assets: options?.assets,

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "node:events";
-import { fetch, Request, type RequestInit } from "miniflare";
 import { logger } from "../../logger";
 import { BundlerController } from "./BundlerController";
 import { ConfigController } from "./ConfigController";

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -120,18 +120,7 @@ export function createWorkerObject(devEnv: DevEnv): DevWorker {
 		},
 		async fetch(...args) {
 			const { proxyWorker } = await devEnv.proxy.ready.promise;
-			// return proxyWorker.dispatchFetch(...args);
-			// ^ bug: Miniflare#dispatchFetch uses one HTTP/1.1 connection, preventing parallel requests (pause/play requests + buffered eyeball requests)
-			// workaround: use undici.fetch
-			const proxyWorkerUrl = await proxyWorker.ready;
-			const req = new Request(...args);
-			const url = new URL(req.url);
-			url.protocol = proxyWorkerUrl.protocol;
-			url.hostname = proxyWorkerUrl.hostname;
-			url.port = proxyWorkerUrl.port;
-			// /workaround
-
-			return fetch(url, req as RequestInit);
+			return proxyWorker.dispatchFetch(...args);
 		},
 		async queue(..._args) {
 			// const { worker } = await devEnv.proxy.ready;

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -120,6 +120,8 @@ export function createWorkerObject(devEnv: DevEnv): DevWorker {
 		},
 		async fetch(...args) {
 			const { proxyWorker } = await devEnv.proxy.ready.promise;
+			await devEnv.proxy.runtimeMessageMutex.drained();
+
 			return proxyWorker.dispatchFetch(...args);
 		},
 		async queue(..._args) {

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -108,7 +108,7 @@ export class ProxyController extends EventEmitter {
 					},
 
 					unsafeDirectHost: this.latestConfig.dev?.inspector?.hostname,
-					unsafeDirectPort: this.latestConfig.dev?.inspector?.port,
+					unsafeDirectPort: this.latestConfig.dev?.inspector?.port ?? 0,
 				},
 			],
 

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -328,14 +328,19 @@ export class ProxyController extends EventEmitter {
 		this.latestConfig = data.config;
 		this.latestBundle = data.bundle;
 
+		const proxyData = {
+			proxyLogsToController: data.config.dev?.remote, // in local mode, workerd logs to terminal directly
+			...data.proxyData,
+		};
+
 		void this.sendMessageToProxyWorker({
 			type: "play",
-			proxyData: data.proxyData,
+			proxyData,
 		});
 
 		void this.sendMessageToInspectorProxyWorker({
 			type: "reloadComplete",
-			proxyData: data.proxyData,
+			proxyData,
 		});
 	}
 	onProxyWorkerMessage(message: ProxyWorkerOutgoingRequestBody) {

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -204,11 +204,7 @@ export class ProxyController extends EventEmitter {
 			const error = castErrorCause(cause);
 
 			this.inspectorProxyWorkerWebSocket?.reject(error);
-			this.emitErrorEvent(
-				"Could not connect to InspectorProxyWorker " +
-					JSON.stringify({ webSocket, readyState: webSocket?.readyState }),
-				error
-			);
+			this.emitErrorEvent("Could not connect to InspectorProxyWorker", error);
 			return;
 		}
 
@@ -283,14 +279,11 @@ export class ProxyController extends EventEmitter {
 		if (this._torndown) return;
 
 		try {
-			let websocket = await this.inspectorProxyWorkerWebSocket?.promise;
+			// returns the existing websocket, if already connected
+			const websocket = await this.reconnectInspectorProxyWorker();
 			assert(websocket);
 
-			if (websocket.readyState >= WebSocket.READY_STATE_CLOSING) {
-				websocket = await this.reconnectInspectorProxyWorker();
-			}
-
-			websocket?.send(JSON.stringify(message));
+			websocket.send(JSON.stringify(message));
 		} catch (cause) {
 			if (this._torndown) return;
 

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -328,19 +328,14 @@ export class ProxyController extends EventEmitter {
 		this.latestConfig = data.config;
 		this.latestBundle = data.bundle;
 
-		const proxyData = {
-			proxyLogsToController: data.config.dev?.remote, // in local mode, workerd logs to terminal directly
-			...data.proxyData,
-		};
-
 		void this.sendMessageToProxyWorker({
 			type: "play",
-			proxyData,
+			proxyData: data.proxyData,
 		});
 
 		void this.sendMessageToInspectorProxyWorker({
 			type: "reloadComplete",
-			proxyData,
+			proxyData: data.proxyData,
 		});
 	}
 	onProxyWorkerMessage(message: ProxyWorkerOutgoingRequestBody) {

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -10,6 +10,7 @@ import {
 	maybeHandleNetworkLoadResource,
 } from "../../dev/inspect";
 import { WranglerLog, castLogLevel } from "../../dev/miniflare";
+import { handleRuntimeStdio } from "../../dev/miniflare";
 import { getHttpsOptions } from "../../https-options";
 import { logger } from "../../logger";
 import { getSourceMappedStack } from "../../sourcemap";
@@ -133,6 +134,7 @@ export class ProxyController extends EventEmitter {
 					// if debugging, log requests with specic ProxyWorker prefix
 					logger.loggerLevel === "debug" ? "wrangler-ProxyWorker" : "wrangler",
 			}),
+			handleRuntimeStdio,
 		};
 
 		const proxyWorkerOptionsChanged = didMiniflareOptionsChange(

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -10,8 +10,7 @@ import {
 	logConsoleMessage,
 	maybeHandleNetworkLoadResource,
 } from "../../dev/inspect";
-import { maybeRegisterLocalWorker } from "../../dev/local";
-import { ReloadedEvent, WranglerLog, castLogLevel } from "../../dev/miniflare";
+import { WranglerLog, castLogLevel } from "../../dev/miniflare";
 import { getHttpsOptions } from "../../https-options";
 import { logger } from "../../logger";
 import { getSourceMappedStack } from "../../sourcemap";
@@ -178,13 +177,10 @@ export class ProxyController extends EventEmitter {
 		}
 
 		// store the non-null versions for callbacks
-		const { proxyWorker, inspectorProxyWorker, latestConfig: config } = this;
+		const { proxyWorker, inspectorProxyWorker } = this;
 
 		void Promise.all([proxyWorker.ready, this.reconnectInspectorProxyWorker()])
-			.then(async ([proxyWorkerUrl]) => {
-				// wait for registration to complete before emitting ready event
-				await maybeRegisterProxyWorkerWithDevRegistry(proxyWorkerUrl, config);
-
+			.then(() => {
 				this.emitReadyEvent(proxyWorker, inspectorProxyWorker);
 			})
 			.catch((error) => {
@@ -528,27 +524,4 @@ function didMiniflareOptionsChange(
 
 	// otherwise, if they're not deeply equal, they've changed
 	return !deepEquality(prev, next);
-}
-
-async function maybeRegisterProxyWorkerWithDevRegistry(
-	proxyWorkerUrl: URL,
-	config: StartDevWorkerOptions
-) {
-	const reloadedEvent = new ReloadedEvent("reloaded", {
-		url: proxyWorkerUrl,
-		internalDurableObjects: Object.entries(config.bindings ?? {}).flatMap(
-			([bindingName, binding]) => {
-				const isInternalDurableObject =
-					binding.type === "durable-object" &&
-					(binding.service?.name === undefined ||
-						binding.service?.name === config.name);
-
-				if (!isInternalDurableObject) return [];
-
-				return [{ name: bindingName, class_name: binding.className }];
-			}
-		),
-	});
-
-	await maybeRegisterLocalWorker(reloadedEvent, config.name);
 }

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -60,7 +60,7 @@ export class ProxyController extends EventEmitter {
 				: undefined;
 
 		const proxyWorkerOptions: MiniflareOptions = {
-			verbose: true,
+			verbose: logger.loggerLevel === "debug",
 			compatibilityFlags: ["nodejs_compat"],
 			modulesRoot: path.dirname(proxyWorkerPath),
 			modules: [{ type: "ESModule", path: proxyWorkerPath }],
@@ -94,7 +94,7 @@ export class ProxyController extends EventEmitter {
 			}),
 		};
 		const inspectorProxyWorkerOptions: MiniflareOptions = {
-			verbose: true,
+			verbose: logger.loggerLevel === "debug",
 			compatibilityFlags: ["nodejs_compat"],
 			modulesRoot: path.dirname(inspectorProxyWorkerPath),
 			modules: [{ type: "ESModule", path: inspectorProxyWorkerPath }],

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -301,6 +301,7 @@ export class ProxyController extends EventEmitter {
 		this.latestConfig = data.config;
 
 		void this.sendMessageToProxyWorker({ type: "pause" });
+		void this.sendMessageToInspectorProxyWorker({ type: "reloadStart" });
 	}
 	onReloadComplete(data: ReloadCompleteEvent) {
 		this.latestConfig = data.config;

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -386,7 +386,10 @@ export class ProxyController extends EventEmitter {
 		switch (message.type) {
 			case "runtime-websocket-error":
 				// TODO: consider sending proxyData again to trigger the InspectorProxyWorker to reconnect to the runtime
-				logger.error(message.error);
+				logger.error(
+					"[InspectorProxyWorker] 'runtime websocket' error",
+					message.error
+				);
 
 				break;
 			case "error":

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -86,6 +86,10 @@ export class ProxyController extends EventEmitter {
 					bindings: {
 						PROXY_CONTROLLER_AUTH_SECRET: this.secret,
 					},
+
+					// no need to use file-system, so don't
+					cache: false,
+					unsafeEphemeralDurableObjects: true,
 				},
 				{
 					name: "InspectorProxyWorker",
@@ -109,12 +113,14 @@ export class ProxyController extends EventEmitter {
 
 					unsafeDirectHost: this.latestConfig.dev?.inspector?.hostname,
 					unsafeDirectPort: this.latestConfig.dev?.inspector?.port ?? 0,
+
+					// no need to use file-system, so don't
+					cache: false,
+					unsafeEphemeralDurableObjects: true,
 				},
 			],
 
 			verbose: logger.loggerLevel === "debug",
-			cache: false,
-			unsafeEphemeralDurableObjects: true,
 
 			// log requests into the ProxyWorker (for local + remote mode)
 			log: new ProxyControllerLogger(castLogLevel(logger.loggerLevel), {

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -390,7 +390,7 @@ export class ProxyController extends EventEmitter {
 		switch (message.type) {
 			case "runtime-websocket-error":
 				// TODO: consider sending proxyData again to trigger the InspectorProxyWorker to reconnect to the runtime
-				logger.error(
+				logger.debug(
 					"[InspectorProxyWorker] 'runtime websocket' error",
 					message.error
 				);
@@ -507,16 +507,6 @@ export class ProxyControllerLogger extends WranglerLog {
 		// keep the ProxyWorker request logs if we're in debug mode
 		if (message.includes("/cdn-cgi/") && this.level < LogLevel.DEBUG) return;
 		super.log(message);
-	}
-
-	// TODO: remove this override when miniflare is fixed https://jira.cfdata.org/browse/DEVX-983
-	error(message: Error) {
-		try {
-			super.error(message);
-		} catch {
-			// miniflare shouldn't throw in logger.error
-			// for now, ignore errors from the logger
-		}
 	}
 }
 

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -71,7 +71,10 @@ export class ProxyController extends EventEmitter {
 					modulesRoot: path.dirname(proxyWorkerPath),
 					modules: [{ type: "ESModule", path: proxyWorkerPath }],
 					durableObjects: {
-						DURABLE_OBJECT: "ProxyWorker",
+						DURABLE_OBJECT: {
+							className: "ProxyWorker",
+							unsafePreventEviction: true,
+						},
 					},
 					serviceBindings: {
 						PROXY_CONTROLLER: async (req): Promise<Response> => {
@@ -97,7 +100,10 @@ export class ProxyController extends EventEmitter {
 					modulesRoot: path.dirname(inspectorProxyWorkerPath),
 					modules: [{ type: "ESModule", path: inspectorProxyWorkerPath }],
 					durableObjects: {
-						DURABLE_OBJECT: "InspectorProxyWorker",
+						DURABLE_OBJECT: {
+							className: "InspectorProxyWorker",
+							unsafePreventEviction: true,
+						},
 					},
 					serviceBindings: {
 						PROXY_CONTROLLER: async (req): Promise<Response> => {

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -240,6 +240,8 @@ export class ProxyController extends EventEmitter {
 	): Promise<void> {
 		if (this._torndown) return;
 
+		// Don't do any async work here. Enqueue the message with the mutex immediately.
+
 		try {
 			await this.runtimeMessageMutex.runWith(async () => {
 				assert(this.proxyWorker, "proxyWorker should already be instantiated");

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -492,12 +492,12 @@ export class ProxyController extends EventEmitter {
 }
 
 export class ProxyControllerLogger extends WranglerLog {
-	info(message: string) {
+	log(message: string) {
 		// filter out request logs being handled by the ProxyWorker
 		// the requests log remaining are handled by the UserWorker
 		// keep the ProxyWorker request logs if we're in debug mode
-		if (message.includes("/cdn-cgi/") && this.level !== LogLevel.DEBUG) return;
-		super.info(message);
+		if (message.includes("/cdn-cgi/") && this.level < LogLevel.DEBUG) return;
+		super.log(message);
 	}
 
 	// TODO: remove this override when miniflare is fixed https://jira.cfdata.org/browse/DEVX-983

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -144,7 +144,7 @@ export type ProxyData = {
 	userWorkerUrl: UrlOriginParts;
 	userWorkerInspectorUrl: UrlOriginAndPathnameParts;
 	userWorkerInnerUrlOverrides: Partial<UrlOriginParts>;
-	headers: Record<string, string>;
+	headers: Record<string, string | undefined>;
 	liveReload?: boolean;
 	proxyLogsToController?: boolean;
 };

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -138,4 +138,5 @@ export type ProxyData = {
 	userWorkerInnerUrlOverrides: Partial<UrlOriginParts>;
 	headers: Record<string, string>;
 	liveReload?: boolean;
+	proxyLogsToController?: boolean;
 };

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -119,7 +119,7 @@ export function serialiseError(e: unknown): SerializedError {
 			message: e.message,
 			name: e.name,
 			stack: e.stack,
-			cause: serialiseError(e.cause),
+			cause: e.cause && serialiseError(e.cause),
 		};
 	} else {
 		return { message: String(e) };

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -74,7 +74,6 @@ export type ReadyEvent = {
 	type: "ready";
 
 	proxyWorker: Miniflare;
-	inspectorProxyWorker: Miniflare;
 };
 
 // ProxyWorker

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -6,19 +6,27 @@ import type { Miniflare } from "miniflare";
 export type TeardownEvent = {
 	type: "teardown";
 };
-export type ErrorEvent = {
+export type ErrorEvent =
+	| BaseErrorEvent<
+			| "ConfigController"
+			| "BundlerController"
+			| "LocalRuntimeController"
+			| "RemoteRuntimeController"
+			| "ProxyWorker"
+			| "InspectorProxyWorker"
+	  >
+	| BaseErrorEvent<
+			"ProxyController",
+			{ config?: StartDevWorkerOptions; bundle?: EsbuildBundle }
+	  >;
+export type BaseErrorEvent<Source = string, Data = undefined> = {
 	type: "error";
 	reason: string;
-	cause: Error;
-	source:
-		| "ConfigController"
-		| "BundlerController"
-		| "LocalRuntimeController"
-		| "RemoteRuntimeController"
-		| "ProxyController"
-		| "ProxyWorker"
-		| "InspectorProxyWorker";
+	cause: Error | SerializedError;
+	source: Source;
+	data: Data;
 };
+
 export function castErrorCause(cause: unknown) {
 	if (cause instanceof Error) return cause;
 

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -87,10 +87,14 @@ export type ProxyWorkerOutgoingRequestBody =
 
 // InspectorProxyWorker
 export * from "./devtools";
-export type InspectorProxyWorkerIncomingWebSocketMessage = {
-	type: ReloadCompleteEvent["type"];
-	proxyData: ProxyData;
-};
+export type InspectorProxyWorkerIncomingWebSocketMessage =
+	| {
+			type: ReloadStartEvent["type"];
+	  }
+	| {
+			type: ReloadCompleteEvent["type"];
+			proxyData: ProxyData;
+	  };
 export type InspectorProxyWorkerOutgoingWebsocketMessage =
 	// Relayed Chrome DevTools Protocol Messages
 	| DevToolsEvent<"Runtime.consoleAPICalled">

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -421,7 +421,7 @@ function DevSession(props: DevSessionProps) {
 			bindings={props.bindings}
 			workerDefinitions={workerDefinitions}
 			assetPaths={props.assetPaths}
-			initialPort={0} // hard-code for userworker, DevEnv-ProxyWorker now uses this prop value
+			initialPort={undefined} // hard-code for userworker, DevEnv-ProxyWorker now uses this prop value
 			initialIp={"127.0.0.1"} // hard-code for userworker, DevEnv-ProxyWorker now uses this prop value
 			rules={props.rules}
 			inspectorPort={props.inspectorPort}

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -289,6 +289,7 @@ function DevSession(props: DevSessionProps) {
 			props.initialIp,
 			props.initialPort,
 			props.localProtocol,
+			props.localUpstream,
 			props.inspectorPort,
 			props.liveReload,
 		]

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -277,6 +277,10 @@ function DevSession(props: DevSessionProps) {
 				inspector: {
 					port: props.inspectorPort,
 				},
+				urlOverrides: {
+					secure: props.localProtocol === "https",
+					hostname: props.localUpstream,
+				},
 				liveReload: props.liveReload,
 			},
 		}),

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -383,6 +383,13 @@ function DevSession(props: DevSessionProps) {
 		finalPort,
 		proxyData
 	) => {
+		// at this point (in the layers of onReady callbacks), we have devEnv in scope
+		// so rewrite the onReady params to be the ip/port of the ProxyWorker instead of the UserWorker
+		const { proxyWorker } = await devEnv.proxy.ready.promise;
+		const url = await proxyWorker.ready;
+		finalIp = url.hostname;
+		finalPort = parseInt(url.port);
+
 		if (process.send) {
 			process.send(
 				JSON.stringify({
@@ -403,13 +410,6 @@ function DevSession(props: DevSessionProps) {
 		}
 
 		if (props.onReady) {
-			// at this point (in the layers of onReady callbacks), we have devEnv in scope
-			// so rewrite the onReady params to be the ip/port of the ProxyWorker instead of the UserWorker
-			const { proxyWorker } = await devEnv.proxy.ready.promise;
-			const url = await proxyWorker.ready;
-			finalIp = url.hostname;
-			finalPort = parseInt(url.port);
-
 			props.onReady(finalIp, finalPort, proxyData);
 		}
 	};

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -174,6 +174,7 @@ function useLocalWorker(props: LocalProps) {
 					userWorkerInnerUrlOverrides: {
 						protocol: props.localProtocol,
 						hostname: props.localUpstream,
+						port: props.localUpstream ? "" : undefined, // `localUpstream` was essentially `host`, not `hostname`, so if it was set delete the `port`
 					},
 					headers: {}, // no headers needed in local-mode
 					liveReload: props.liveReload,

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -25,7 +25,7 @@ export interface LocalProps {
 	bindings: CfWorkerInit["bindings"];
 	workerDefinitions: WorkerRegistry | undefined;
 	assetPaths: AssetPaths | undefined;
-	initialPort: number;
+	initialPort: number | undefined;
 	initialIp: string;
 	rules: Config["rules"];
 	inspectorPort: number;

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -157,8 +157,6 @@ function useLocalWorker(props: LocalProps) {
 			const newServer = new MiniflareServer();
 			miniflareServerRef.current = server = newServer;
 			server.addEventListener("reloaded", async (event) => {
-				await maybeRegisterLocalWorker(event, props.name);
-
 				const proxyData: ProxyData = {
 					userWorkerUrl: {
 						protocol: event.url.protocol,

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -177,6 +177,9 @@ function useLocalWorker(props: LocalProps) {
 					},
 					headers: {}, // no headers needed in local-mode
 					liveReload: props.liveReload,
+					// in local mode, the logs are already being printed to the console by workerd but only for workers written in "module" format
+					// workers written in "service-worker" format still need to proxy logs to the ProxyController
+					proxyLogsToController: props.format === "service-worker",
 				};
 
 				props.onReady?.(

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -157,6 +157,8 @@ function useLocalWorker(props: LocalProps) {
 			const newServer = new MiniflareServer();
 			miniflareServerRef.current = server = newServer;
 			server.addEventListener("reloaded", async (event) => {
+				await maybeRegisterLocalWorker(event, props.name);
+
 				const proxyData: ProxyData = {
 					userWorkerUrl: {
 						protocol: event.url.protocol,

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -409,7 +409,7 @@ function buildSitesOptions({ assetPaths }: ConfigBundle) {
 	}
 }
 
-function handleRuntimeStdio(stdout: Readable, stderr: Readable) {
+export function handleRuntimeStdio(stdout: Readable, stderr: Readable) {
 	// ASSUMPTION: each chunk is a whole message from workerd
 	// This may not hold across OSes/architectures, but it seems to work on macOS M-line
 	// I'm going with this simple approach to avoid complicating this too early

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -421,6 +421,9 @@ export function handleRuntimeStdio(stdout: Readable, stderr: Readable) {
 		isAddressInUse(chunk: string) {
 			return chunk.includes("Address already in use; toString() = ");
 		},
+		isWarning(chunk: string) {
+			return /\.c\+\+:\d+: warning:/.test(chunk);
+		},
 	};
 
 	stdout.on("data", (chunk: Buffer | string) => {
@@ -438,6 +441,11 @@ export function handleRuntimeStdio(stdout: Readable, stderr: Readable) {
 			// so send it to the debug logs which are discarded unless
 			// the user explicitly sets a logLevel indicating they care
 			logger.debug(chunk);
+		}
+
+		// known case: warnings are not info, log them as such
+		else if (classifiers.isWarning(chunk)) {
+			logger.warn(chunk);
 		}
 
 		// anything not exlicitly handled above should be logged as info (via stdout)
@@ -472,6 +480,11 @@ export function handleRuntimeStdio(stdout: Readable, stderr: Readable) {
 			// so send it to the debug logs which are discarded unless
 			// the user explicitly sets a logLevel indicating they care
 			logger.debug(chunk);
+		}
+
+		// known case: warnings are not errors, log them as such
+		else if (classifiers.isWarning(chunk)) {
+			logger.warn(chunk);
 		}
 
 		// anything not exlicitly handled above should be logged as an error (via stderr)

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -139,16 +139,6 @@ export class WranglerLog extends Log {
 		}
 		super.warn(message);
 	}
-
-	// TODO: remove this override when miniflare is fixed https://jira.cfdata.org/browse/DEVX-983
-	error(message: Error) {
-		try {
-			super.error(message);
-		} catch {
-			// miniflare shouldn't throw in logger.error
-			// for now, ignore errors from the logger
-		}
-	}
 }
 
 export const DEFAULT_WORKER_NAME = "worker";

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -420,7 +420,10 @@ export function handleRuntimeStdio(stdout: Readable, stderr: Readable) {
 			const containsLlvmSymbolizerWarning = chunk.includes(
 				"Not symbolizing stack traces because $LLVM_SYMBOLIZER is not set"
 			);
-			const containsHexStack = /stack:( [a-f\d]{9}){3,}/.test(chunk);
+			// Matches stack traces from workerd
+			//  - on unix: groups of 9 hex digits separated by spaces
+			//  - on windows: groups of 12 hex digits, or a single digit 0, separated by spaces
+			const containsHexStack = /stack:( (0|[a-f\d]{4,})){3,}/.test(chunk);
 
 			return containsLlvmSymbolizerWarning || containsHexStack;
 		},

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -110,10 +110,10 @@ export interface ConfigBundle {
 export class WranglerLog extends Log {
 	#warnedCompatibilityDateFallback = false;
 
-	info(message: string) {
+	log(message: string) {
 		// Hide request logs for external Durable Objects proxy worker
 		if (message.includes(EXTERNAL_DURABLE_OBJECTS_WORKER_NAME)) return;
-		super.info(message);
+		super.log(message);
 	}
 
 	warn(message: string) {

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -82,6 +82,11 @@ export default {
 }
 `;
 
+type SpecificPort = Exclude<number, 0>;
+type RandomConsistentPort = 0; // random port, but consistent across reloads
+type RandomDifferentPort = undefined; // random port, but different across reloads
+type Port = SpecificPort | RandomConsistentPort | RandomDifferentPort;
+
 export interface ConfigBundle {
 	// TODO(soon): maybe rename some of these options, check proposed API Google Docs
 	name: string | undefined;
@@ -93,7 +98,7 @@ export interface ConfigBundle {
 	bindings: CfWorkerInit["bindings"];
 	workerDefinitions: WorkerRegistry | undefined;
 	assetPaths: AssetPaths | undefined;
-	initialPort: number;
+	initialPort: Port;
 	initialIp: string;
 	rules: Config["rules"];
 	inspectorPort: number;

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -306,6 +306,7 @@ export function useWorker(
 				});
 			}
 			*/
+
 			const proxyData: ProxyData = {
 				userWorkerUrl: {
 					protocol: "https:",
@@ -321,6 +322,7 @@ export function useWorker(
 				userWorkerInnerUrlOverrides: {}, // we did not permit overriding request.url in remote mode
 				headers: { "cf-workers-preview-token": workerPreviewToken.value },
 				liveReload: false, // liveReload currently disabled in remote-mode, but will be supported with startDevWorker
+				proxyLogsToController: true,
 			};
 
 			onReady?.(props.host || "localhost", props.port, proxyData);
@@ -433,6 +435,7 @@ export async function startRemoteServer(props: RemoteProps) {
 				userWorkerInnerUrlOverrides: {}, // we did not permit overriding request.url in remote mode
 				headers: { "cf-workers-preview-token": previewToken.value },
 				liveReload: false, // liveReload currently disabled in remote-mode, but will be supported with startDevWorker
+				proxyLogsToController: true,
 			};
 
 			props.onReady?.(ip, port, proxyData);

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -14,6 +14,7 @@ import {
 	requireApiToken,
 	saveAccountToCache,
 } from "../user";
+import { getAccessToken } from "../user/access";
 import {
 	createPreviewSession,
 	createWorkerPreview,
@@ -306,6 +307,7 @@ export function useWorker(
 				});
 			}
 			*/
+			const accessToken = await getAccessToken(workerPreviewToken.host);
 
 			const proxyData: ProxyData = {
 				userWorkerUrl: {
@@ -320,7 +322,10 @@ export function useWorker(
 					pathname: workerPreviewToken.inspectorUrl.pathname,
 				},
 				userWorkerInnerUrlOverrides: {}, // there is no analagous prop for this option because we did not permit overriding request.url in remote mode
-				headers: { "cf-workers-preview-token": workerPreviewToken.value },
+				headers: {
+					"cf-workers-preview-token": workerPreviewToken.value,
+					Cookie: accessToken && `CF_Authorization=${accessToken}`,
+				},
 				liveReload: false, // liveReload currently disabled in remote-mode, but will be supported with startDevWorker
 				proxyLogsToController: true,
 			};
@@ -419,7 +424,9 @@ export async function startRemoteServer(props: RemoteProps) {
 		localProtocol: props.localProtocol,
 		localPort: props.port,
 		ip: props.ip,
-		onReady: (ip, port) => {
+		onReady: async (ip, port) => {
+			const accessToken = await getAccessToken(previewToken.host);
+
 			const proxyData: ProxyData = {
 				userWorkerUrl: {
 					protocol: "https:",
@@ -433,7 +440,10 @@ export async function startRemoteServer(props: RemoteProps) {
 					pathname: previewToken.inspectorUrl.pathname,
 				},
 				userWorkerInnerUrlOverrides: {}, // there is no analagous prop for this option because we did not permit overriding request.url in remote mode
-				headers: { "cf-workers-preview-token": previewToken.value },
+				headers: {
+					"cf-workers-preview-token": previewToken.value,
+					Cookie: accessToken && `CF_Authorization=${accessToken}`,
+				},
 				liveReload: false, // liveReload currently disabled in remote-mode, but will be supported with startDevWorker
 				proxyLogsToController: true,
 			};

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -319,7 +319,7 @@ export function useWorker(
 					port: workerPreviewToken.inspectorUrl.port.toString(),
 					pathname: workerPreviewToken.inspectorUrl.pathname,
 				},
-				userWorkerInnerUrlOverrides: {}, // we did not permit overriding request.url in remote mode
+				userWorkerInnerUrlOverrides: {}, // there is no analagous prop for this option because we did not permit overriding request.url in remote mode
 				headers: { "cf-workers-preview-token": workerPreviewToken.value },
 				liveReload: false, // liveReload currently disabled in remote-mode, but will be supported with startDevWorker
 				proxyLogsToController: true,
@@ -432,7 +432,7 @@ export async function startRemoteServer(props: RemoteProps) {
 					port: previewToken.inspectorUrl.port.toString(),
 					pathname: previewToken.inspectorUrl.pathname,
 				},
-				userWorkerInnerUrlOverrides: {}, // we did not permit overriding request.url in remote mode
+				userWorkerInnerUrlOverrides: {}, // there is no analagous prop for this option because we did not permit overriding request.url in remote mode
 				headers: { "cf-workers-preview-token": previewToken.value },
 				liveReload: false, // liveReload currently disabled in remote-mode, but will be supported with startDevWorker
 				proxyLogsToController: true,

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -396,6 +396,8 @@ export async function startLocalServer(
 	return new Promise<{ stop: () => Promise<void> }>((resolve, reject) => {
 		const server = new MiniflareServer();
 		server.addEventListener("reloaded", async (event) => {
+			await maybeRegisterLocalWorker(event, props.name);
+
 			const proxyData: ProxyData = {
 				userWorkerUrl: {
 					protocol: event.url.protocol,

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -410,6 +410,7 @@ export async function startLocalServer(
 				userWorkerInnerUrlOverrides: {
 					protocol: props.localProtocol,
 					hostname: props.localUpstream,
+					port: props.localUpstream ? "" : undefined, // `localUpstream` was essentially `host`, not `hostname`, so if it was set delete the `port`
 				},
 				headers: {},
 				liveReload: props.liveReload,

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -196,7 +196,7 @@ export async function startDevServer(
 
 		return {
 			stop: async () => {
-				await Promise.all([stop(), stopWorkerRegistry()]);
+				await Promise.all([stop(), stopWorkerRegistry(), devEnv.teardown()]);
 			},
 			// TODO: inspectorUrl,
 		};
@@ -245,9 +245,7 @@ export async function startDevServer(
 		});
 		return {
 			stop: async () => {
-				stop();
-				await stopWorkerRegistry();
-				await devEnv.teardown();
+				await Promise.all([stop(), stopWorkerRegistry(), devEnv.teardown()]);
 			},
 			// TODO: inspectorUrl,
 		};

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -396,8 +396,6 @@ export async function startLocalServer(
 	return new Promise<{ stop: () => Promise<void> }>((resolve, reject) => {
 		const server = new MiniflareServer();
 		server.addEventListener("reloaded", async (event) => {
-			await maybeRegisterLocalWorker(event, props.name);
-
 			const proxyData: ProxyData = {
 				userWorkerUrl: {
 					protocol: event.url.protocol,

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -2,7 +2,6 @@ import * as path from "node:path";
 import * as util from "node:util";
 import chalk from "chalk";
 import onExit from "signal-exit";
-import tmp from "tmp-promise";
 import { DevEnv, type StartDevWorkerOptions } from "../api";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { getBundleType } from "../deployment-bundle/bundle-type";

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -413,6 +413,9 @@ export async function startLocalServer(
 				},
 				headers: {},
 				liveReload: props.liveReload,
+				// in local mode, the logs are already being printed to the console by workerd but only for workers written in "module" format
+				// workers written in "service-worker" format still need to proxy logs to the ProxyController
+				proxyLogsToController: props.format === "service-worker",
 			};
 
 			props.onReady?.(event.url.hostname, parseInt(event.url.port), proxyData);

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -259,7 +259,7 @@ export class InspectorProxyWorker implements DurableObject {
 		}
 	};
 
-	runtimeAbortController = new AbortController();
+	runtimeAbortController = new AbortController(); // will abort the in-flight websocket upgrade request to the remote runtime
 	runtimeKeepAliveInterval: number | null = null;
 	async reconnectRuntimeWebSocket() {
 		assert(this.proxyData, "Expected this.proxyData to be defined");

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -71,6 +71,14 @@ export class InspectorProxyWorker implements DurableObject {
 	runtimeMessageBuffer: (DevToolsCommandResponses | DevToolsEvents)[] = [];
 
 	async fetch(req: Request) {
+		const url = new URL(req.url);
+
+		// temp: respond with the origin until miniflare supports mf.getWorker(...).getUrl()
+		if (url.pathname === "/cdn-cgi/get-url") {
+			this.sendDebugLog("InspectorProxyWorker.ts:", url.href);
+			return new Response(url.origin);
+		}
+
 		if (
 			req.headers.get("Authorization") === this.env.PROXY_CONTROLLER_AUTH_SECRET
 		) {

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -218,9 +218,13 @@ export class InspectorProxyWorker implements DurableObject {
 
 		if (
 			!this.websockets.devtoolsHasFileSystemAccess &&
-			msg.params.sourceMapURL !== undefined
+			msg.params.sourceMapURL !== undefined &&
+			// Don't try to find a sourcemap for e.g. node-internal: scripts
+			msg.params.url.startsWith("file:")
 		) {
 			const url = new URL(msg.params.sourceMapURL, msg.params.url);
+			// Check for file: in case msg.params.sourceMapURL has a different
+			// protocol (e.g. data). In that case we should ignore this file
 			if (url.protocol === "file:") {
 				msg.params.sourceMapURL = url.href.replace("file:", "wrangler-file:");
 			}

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -208,8 +208,11 @@ export class InspectorProxyWorker implements DurableObject {
 			| DevToolsEvents;
 		this.sendDebugLog("RUNTIME INCOMING MESSAGE", msg);
 
+		if (isDevToolsEvent(msg, "Runtime.exceptionThrown")) {
+			this.sendProxyControllerMessage(event.data);
+		}
 		if (
-			isDevToolsEvent(msg, "Runtime.exceptionThrown") ||
+			this.proxyData?.proxyLogsToController &&
 			isDevToolsEvent(msg, "Runtime.consoleAPICalled")
 		) {
 			this.sendProxyControllerMessage(event.data);

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -111,7 +111,7 @@ export class ProxyWorker implements DurableObject {
 			const innerUrl = new URL(request.url);
 			Object.assign(innerUrl, proxyData.userWorkerInnerUrlOverrides);
 			headers.set("MF-Original-URL", innerUrl.href);
-			headers.set("MF-Disable-Pretty-Error", "true");
+			headers.set("MF-Disable-Pretty-Error", "true"); // disables the UserWorker miniflare instance from rendering the pretty error -- instead the ProxyWorker miniflare instance will intercept the json error response and render the pretty error page
 
 			// merge proxyData headers with the request headers
 			for (const [key, value] of Object.entries(proxyData.headers ?? {})) {

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -108,10 +108,10 @@ export class ProxyWorker implements DurableObject {
 			Object.assign(userWorkerUrl, proxyData.userWorkerUrl);
 
 			// set request.url in the UserWorker
-			// this will no longer disable miniflare's pretty error page in the UserWorker after https://github.com/cloudflare/miniflare/pull/689
 			const innerUrl = new URL(request.url);
 			Object.assign(innerUrl, proxyData.userWorkerInnerUrlOverrides);
 			headers.set("MF-Original-URL", innerUrl.href);
+			headers.set("MF-Disable-Pretty-Error", "true");
 
 			// merge proxyData headers with the request headers
 			for (const [key, value] of Object.entries(proxyData.headers ?? {})) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -961,7 +961,7 @@ importers:
         version: 5.23.0
       wrangler:
         specifier: ^3.5.1
-        version: link:../wrangler
+        version: 3.14.0
 
   packages/prerelease-registry:
     dependencies:
@@ -1526,7 +1526,7 @@ importers:
         version: 6.5.1
       wrangler:
         specifier: ^3.0.0
-        version: link:../wrangler
+        version: 3.14.0
 
 packages:
 
@@ -3561,7 +3561,6 @@ packages:
     resolution: {integrity: sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==}
     dependencies:
       mime: 3.0.0
-    dev: false
 
   /@cloudflare/kv-asset-handler@0.3.0:
     resolution: {integrity: sha512-9CB/MKf/wdvbfkUdfrj+OkEwZ5b7rws0eogJ4293h+7b6KX5toPwym+VQKmILafNB9YiehqY0DlNrDcDhdWHSQ==}
@@ -3822,7 +3821,6 @@ packages:
       esbuild: '*'
     dependencies:
       esbuild: 0.17.19
-    dev: false
 
   /@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19):
     resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
@@ -3832,7 +3830,6 @@ packages:
       esbuild: 0.17.19
       escape-string-regexp: 4.0.0
       rollup-plugin-node-polyfills: 0.2.1
-    dev: false
 
   /@esbuild/android-arm64@0.16.17:
     resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
@@ -8116,7 +8113,6 @@ packages:
 
   /blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
-    dev: false
 
   /blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
@@ -10643,7 +10639,6 @@ packages:
 
   /estree-walker@0.6.1:
     resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
-    dev: false
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -13609,7 +13604,6 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
-    dev: false
 
   /magic-string@0.30.3:
     resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
@@ -14519,7 +14513,6 @@ packages:
   /node-forge@1.3.0:
     resolution: {integrity: sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==}
     engines: {node: '>= 6.13.0'}
-    dev: false
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -16366,19 +16359,16 @@ packages:
       estree-walker: 0.6.1
       magic-string: 0.25.9
       rollup-pluginutils: 2.8.2
-    dev: false
 
   /rollup-plugin-node-polyfills@0.2.1:
     resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
     dependencies:
       rollup-plugin-inject: 3.0.2
-    dev: false
 
   /rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
       estree-walker: 0.6.1
-    dev: false
 
   /rollup@3.25.1:
     resolution: {integrity: sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==}
@@ -16513,7 +16503,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       node-forge: 1.3.0
-    dev: false
 
   /semiver@1.1.0:
     resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
@@ -16897,7 +16886,6 @@ packages:
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
-    dev: false
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -18557,6 +18545,32 @@ packages:
       '@cloudflare/workerd-windows-64': 1.20231030.0
     dev: false
 
+  /wrangler@3.14.0:
+    resolution: {integrity: sha512-4vzw11yG1/KXpYKbumvRJ61Iyhm/yKXb/ayOw/2xiIRdKdpsfN9/796d2l525+CDaGwZWswpLENe6ZMS0p/Ghg==}
+    engines: {node: '>=16.13.0'}
+    hasBin: true
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.2.0
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      chokidar: 3.5.3
+      esbuild: 0.17.19
+      miniflare: 3.20231016.0(supports-color@9.2.2)
+      nanoid: 3.3.6
+      path-to-regexp: 6.2.0
+      selfsigned: 2.1.1
+      source-map: 0.6.1
+      source-map-support: 0.5.21
+      xxhash-wasm: 1.0.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -18706,7 +18720,6 @@ packages:
 
   /xxhash-wasm@1.0.1:
     resolution: {integrity: sha512-Lc9CTvDrH2vRoiaUzz25q7lRaviMhz90pkx6YxR9EPYtF99yOJnv2cB+CQ0hp/TLoqrUsk8z/W2EN31T568Azw==}
-    dev: false
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -961,7 +961,7 @@ importers:
         version: 5.23.0
       wrangler:
         specifier: ^3.5.1
-        version: 3.14.0
+        version: link:../wrangler
 
   packages/prerelease-registry:
     dependencies:
@@ -1526,7 +1526,7 @@ importers:
         version: 6.5.1
       wrangler:
         specifier: ^3.0.0
-        version: 3.14.0
+        version: link:../wrangler
 
 packages:
 
@@ -3561,6 +3561,7 @@ packages:
     resolution: {integrity: sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==}
     dependencies:
       mime: 3.0.0
+    dev: false
 
   /@cloudflare/kv-asset-handler@0.3.0:
     resolution: {integrity: sha512-9CB/MKf/wdvbfkUdfrj+OkEwZ5b7rws0eogJ4293h+7b6KX5toPwym+VQKmILafNB9YiehqY0DlNrDcDhdWHSQ==}
@@ -3821,6 +3822,7 @@ packages:
       esbuild: '*'
     dependencies:
       esbuild: 0.17.19
+    dev: false
 
   /@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19):
     resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
@@ -3830,6 +3832,7 @@ packages:
       esbuild: 0.17.19
       escape-string-regexp: 4.0.0
       rollup-plugin-node-polyfills: 0.2.1
+    dev: false
 
   /@esbuild/android-arm64@0.16.17:
     resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
@@ -8113,6 +8116,7 @@ packages:
 
   /blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+    dev: false
 
   /blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
@@ -10639,6 +10643,7 @@ packages:
 
   /estree-walker@0.6.1:
     resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+    dev: false
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -13604,6 +13609,7 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: false
 
   /magic-string@0.30.3:
     resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
@@ -14513,6 +14519,7 @@ packages:
   /node-forge@1.3.0:
     resolution: {integrity: sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==}
     engines: {node: '>= 6.13.0'}
+    dev: false
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -16359,16 +16366,19 @@ packages:
       estree-walker: 0.6.1
       magic-string: 0.25.9
       rollup-pluginutils: 2.8.2
+    dev: false
 
   /rollup-plugin-node-polyfills@0.2.1:
     resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
     dependencies:
       rollup-plugin-inject: 3.0.2
+    dev: false
 
   /rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
       estree-walker: 0.6.1
+    dev: false
 
   /rollup@3.25.1:
     resolution: {integrity: sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==}
@@ -16503,6 +16513,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       node-forge: 1.3.0
+    dev: false
 
   /semiver@1.1.0:
     resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
@@ -16886,6 +16897,7 @@ packages:
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
+    dev: false
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -18545,32 +18557,6 @@ packages:
       '@cloudflare/workerd-windows-64': 1.20231030.0
     dev: false
 
-  /wrangler@3.14.0:
-    resolution: {integrity: sha512-4vzw11yG1/KXpYKbumvRJ61Iyhm/yKXb/ayOw/2xiIRdKdpsfN9/796d2l525+CDaGwZWswpLENe6ZMS0p/Ghg==}
-    engines: {node: '>=16.13.0'}
-    hasBin: true
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.2.0
-      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
-      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
-      blake3-wasm: 2.1.5
-      chokidar: 3.5.3
-      esbuild: 0.17.19
-      miniflare: 3.20231016.0(supports-color@9.2.2)
-      nanoid: 3.3.6
-      path-to-regexp: 6.2.0
-      selfsigned: 2.1.1
-      source-map: 0.6.1
-      source-map-support: 0.5.21
-      xxhash-wasm: 1.0.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -18720,6 +18706,7 @@ packages:
 
   /xxhash-wasm@1.0.1:
     resolution: {integrity: sha512-Lc9CTvDrH2vRoiaUzz25q7lRaviMhz90pkx6YxR9EPYtF99yOJnv2cB+CQ0hp/TLoqrUsk8z/W2EN31T568Azw==}
+    dev: false
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16546,7 +16546,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       miniflare:
-        specifier: 3.20231002.1
-        version: 3.20231002.1
+        specifier: 3.20231025.1
+        version: link:../../packages/miniflare
       undici:
         specifier: ^5.23.0
         version: 5.23.0
@@ -3663,15 +3663,6 @@ packages:
       marked: 0.3.19
     dev: false
 
-  /@cloudflare/workerd-darwin-64@1.20231002.0:
-    resolution: {integrity: sha512-sgtjzVO/wtI/6S7O0bk4zQAv2xlvqOxB18AXzlit6uXgbYFGeQedRHjhKVMOacGmWEnM4C3ir/fxJGsc3Pyxng==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@cloudflare/workerd-darwin-64@1.20231030.0:
     resolution: {integrity: sha512-J4PQ9utPxLya9yHdMMx3AZeC5M/6FxcoYw6jo9jbDDFTy+a4Gslqf4Im9We3aeOEdPXa3tgQHVQOSelJSZLhIw==}
     engines: {node: '>=16'}
@@ -3679,15 +3670,6 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: false
-    optional: true
-
-  /@cloudflare/workerd-darwin-arm64@1.20231002.0:
-    resolution: {integrity: sha512-dv8nztYFaTYYgBpyy80vc4hdMYv9mhyNbvBsZywm8S7ivcIpzogi0UKkGU4E/G0lYK6W3WtwTBqwRe+pXJ1+Ww==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@cloudflare/workerd-darwin-arm64@1.20231030.0:
@@ -3699,15 +3681,6 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-64@1.20231002.0:
-    resolution: {integrity: sha512-UG8SlLcGzaQDSSw6FR4+Zf408925wkLOCAi8w5qEoFYu3g4Ef7ZenstesCOsyWL7qBDKx0/iwk6+a76W5IHI0Q==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@cloudflare/workerd-linux-64@1.20231030.0:
     resolution: {integrity: sha512-2HUeRTvoCC17fxE0qdBeR7J9dO8j4A8ZbdcvY8pZxdk+zERU6+N03RTbk/dQMU488PwiDvcC3zZqS4gwLfVT8g==}
     engines: {node: '>=16'}
@@ -3717,15 +3690,6 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-arm64@1.20231002.0:
-    resolution: {integrity: sha512-GPaa66ZSq1gK09r87c5CJbHIApcIU//LVHz3rnUxK0//00YCwUuGUUK1dn/ylg+fVqDQxIDmH+ABnobBanvcDA==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@cloudflare/workerd-linux-arm64@1.20231030.0:
     resolution: {integrity: sha512-4/GK5zHh+9JbUI6Z5xTCM0ZmpKKHk7vu9thmHjUxtz+o8Ne9DoD7DlDvXQWgMF6XGaTubDWyp3ttn+Qv8jDFuQ==}
     engines: {node: '>=16'}
@@ -3733,15 +3697,6 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: false
-    optional: true
-
-  /@cloudflare/workerd-windows-64@1.20231002.0:
-    resolution: {integrity: sha512-ybIy+sCme0VO0RscndXvqWNBaRMUOc8vhi+1N2h/KDsKfNLsfEQph+XWecfKzJseUy1yE2rV1xei3BaNmaa6vg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@cloudflare/workerd-windows-64@1.20231030.0:
@@ -7759,6 +7714,7 @@ packages:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
     dependencies:
       printable-characters: 1.0.42
+    dev: false
 
   /assert@2.0.0:
     resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
@@ -8387,6 +8343,7 @@ packages:
       tslib: 2.5.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
     patched: true
 
   /capnpc-ts@0.7.0:
@@ -9099,6 +9056,7 @@ packages:
 
   /data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
+    dev: false
 
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
@@ -11320,6 +11278,7 @@ packages:
     dependencies:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
+    dev: false
 
   /get-stream@4.1.0:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
@@ -14216,28 +14175,6 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /miniflare@3.20231002.1:
-    resolution: {integrity: sha512-4xJ8FezJkQqHzCm71lovb9L/wJ0VV/odMFf5CIxfLTunsx97kTIlZnhS6aHuvcbzdztbWp1RR71K/1qFUHdpdQ==}
-    engines: {node: '>=16.13'}
-    dependencies:
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      capnp-ts: 0.7.0(patch_hash=l4yimnxyvkiyj6alnps2ec3sii)
-      exit-hook: 2.2.1
-      glob-to-regexp: 0.4.1
-      source-map-support: 0.5.21
-      stoppable: 1.1.0
-      undici: 5.23.0
-      workerd: 1.20231002.0
-      ws: 8.14.2
-      youch: 3.2.3
-      zod: 3.22.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -15506,6 +15443,7 @@ packages:
 
   /printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
+    dev: false
 
   /prism-react-renderer@1.3.5(react@18.2.0):
     resolution: {integrity: sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==}
@@ -16976,6 +16914,7 @@ packages:
     dependencies:
       as-table: 1.0.55
       get-source: 2.0.12
+    dev: false
 
   /standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -17001,6 +16940,7 @@ packages:
   /stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
+    dev: false
 
   /stream-shift@1.0.1:
     resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
@@ -18531,19 +18471,6 @@ packages:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
 
-  /workerd@1.20231002.0:
-    resolution: {integrity: sha512-NFuUQBj30ZguDoPZ6bL40hINiu8aP2Pvxr/3xAdhWOwVFLuObPOiSdQ8qm4JYZ7jovxWjWE4Z7VR2avjIzEksQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20231002.0
-      '@cloudflare/workerd-darwin-arm64': 1.20231002.0
-      '@cloudflare/workerd-linux-64': 1.20231002.0
-      '@cloudflare/workerd-linux-arm64': 1.20231002.0
-      '@cloudflare/workerd-windows-64': 1.20231002.0
-    dev: true
-
   /workerd@1.20231030.0:
     resolution: {integrity: sha512-+FSW+d31f8RrjHanFf/R9A+Z0csf3OtsvzdPmAKuwuZm/5HrBv83cvG9fFeTxl7/nI6irUUXIRF9xcj/NomQzQ==}
     engines: {node: '>=16'}
@@ -18826,6 +18753,7 @@ packages:
       cookie: 0.5.0
       mustache: 4.2.0
       stacktracey: 2.1.8
+    dev: false
 
   /z-schema@5.0.3:
     resolution: {integrity: sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==}


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR is for all changes made since Milestone 1 was first merged in #3960

Notable commits:
- bedbe4eb fix: don't show logs to ProxyWorker(s) unless log level is debug
  - fixes #4168 
- 76f90edf fix: show console.log's in remote mode remote inspector websocket upgrade request required auth headers so use `fetch` with `Upgrade: websocket` header instead of `new WebSocket`
  - fixes #4165 
- 1271a1ae use miniflare verbose mode only if debug log level
  - should reduce "scary logs" noise
- 7198a81b register ProxyWorker with DevRegistry instead of UserWorker
- f09c51dc Revert "register ProxyWorker with DevRegistry"
  - this commit has been applied+reverted and will be reapplied in Milestone 2 due to its dependence on the new `bindings` shape
  - it is an optimisation for the devregistry and functionally behaves the same
- 1a9e2f54 use single Miniflare instance for (Inspector)ProxyWorker
  - fixes [DEVX-929](https://jira.cfdata.org/browse/DEVX-929)
- 997d77db port: clear remote runtime logs upon UserWorker restarts
  - this forward-ports [this change](https://github.com/cloudflare/workers-sdk/pull/4235)
- 6129d965 default unstable_dev inspectorPort to 0
  - this is a more sane default for unstable_dev which is used most in test suites and therefore most likely run in parallel
- 7ac5efd7 parallelise cleanup to minimise chance of hanging
  - previously, sequential cleanups fail to fully cleanup if earlier steps in the sequence fail
- 974216e2 ensure InspectorProxyWorker unsafeDirectPort is set
  - `undefined` disables the inspector – we should implement a separate option to explicitly enable/disable the inspector in Miniflare
- 001c542d don't use file-system for (Inspector)ProxyWorker DOs
  - the DOs don't use storage so we can tell Miniflare to not bother setting up the tmp dirs
- 3fea2685 prevent eviction of the Durable Objects with (Inspector)ProxyWorker
  - Durable Object eviction was implemented and shipped during this work which caused the in-memory state to disappear across requests (interferring with pause/play control messages) – since these DOs are for local development, we can disable eviction entirely
- 183db24c ready event should await proxyWorker.setOptions
  - workaround for miniflare bug
- 7f768e6d remove miniflare workaround for parallel requests
  - removes a previous workaround
- f72497e6 considerations for race between control messages and user fetches
  - this guarantees the order of requests for control messages and `worker.fetch` requests which are more likely to run into a race condition over the async http boundary than eye-ball requests
- 0845c9df use port: undefined vs 0 for UserWorker to force different port across reloads to workaround workerd bug on Windows
  - this is a workaround for https://github.com/cloudflare/workerd/issues/1376
- 217d8ba5 Don't try to parse node internals
  - this fixes an issue with devtools not working introduced by https://github.com/cloudflare/workerd/pull/1294
- a49cc8a0 only proxy consoleAPICalled events in remote mode
- a1d5afa2 enable consoleAPICalled events proxying if local mode AND service-worker format
  - these 2 commits account for workerd now printing console.log's itself since https://github.com/cloudflare/workerd/pull/1294

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): linked above
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
