### PR TITLE
[wrangler] Perform old-asset-ttl in parallel

### DIFF
--- a/.changeset/nervous-crews-drum.md
+++ b/.changeset/nervous-crews-drum.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+fix: perform old-asset-ttl in parallel
+
+Expires old assets using Promise.all
+Fixes #4414


### PR DESCRIPTION
* Rather than expiring each asset synchronously, use Promise.all

Fixes #4414

**What this PR solves / how to test:** Run multiple `deploy` with `--old-asset-ttl N` set.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: Existing functionality covers this
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): #4414 #3384 #3385
  - [ ] Not necessary because:

