### PR TITLE
Improve module collection warnings

### DIFF
--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -7256,13 +7256,16 @@ addEventListener('fetch', event => {});`
 			);
 			// and the warnings because fallthrough was not explicitly set
 			expect(std.warn).toMatchInlineSnapshot(`
-			        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe module rule at position 1 ({\\"type\\":\\"Text\\",\\"globs\\":[\\"**/*.other\\"]}) has the same type as a previous rule (at position 0, {\\"type\\":\\"Text\\",\\"globs\\":[\\"**/*.file\\"]}). This rule will be ignored. To use the previous rule, add \`fallthrough = true\` to allow this one to also be used, or \`fallthrough = false\` to silence this warning.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe module rule {\\"type\\":\\"Text\\",\\"globs\\":[\\"**/*.file\\"]} does not have a fallback, the following rules will be ignored:[0m
 
+			   {\\"type\\":\\"Text\\",\\"globs\\":[\\"**/*.other\\"]}
+			   {\\"type\\":\\"Text\\",\\"globs\\":[\\"**/*.txt\\",\\"**/*.html\\"]} (DEFAULT)
 
-			        [33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe default module rule {\\"type\\":\\"Text\\",\\"globs\\":[\\"**/*.txt\\",\\"**/*.html\\"]} has the same type as a previous rule (at position 0, {\\"type\\":\\"Text\\",\\"globs\\":[\\"**/*.file\\"]}). This rule will be ignored. To use the previous rule, add \`fallthrough = true\` to allow the default one to also be used, or \`fallthrough = false\` to silence this warning.[0m
+			  Add \`fallthrough = true\` to rule to allow next rule to be used or \`fallthrough = false\` to slience
+			  this warning
 
-			        "
-		      `);
+			"
+		`);
 		});
 
 		describe("inject process.env.NODE_ENV", () => {

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -7261,7 +7261,7 @@ addEventListener('fetch', event => {});`
 			   {\\"type\\":\\"Text\\",\\"globs\\":[\\"**/*.other\\"]}
 			   {\\"type\\":\\"Text\\",\\"globs\\":[\\"**/*.txt\\",\\"**/*.html\\"]} (DEFAULT)
 
-			  Add \`fallthrough = true\` to rule to allow next rule to be used or \`fallthrough = false\` to slience
+			  Add \`fallthrough = true\` to rule to allow next rule to be used or \`fallthrough = false\` to silence
 			  this warning
 
 			"

--- a/packages/wrangler/src/deployment-bundle/rules.ts
+++ b/packages/wrangler/src/deployment-bundle/rules.ts
@@ -25,19 +25,19 @@ export function parseRules(userRules: Rule[] = []): ParsedRules {
 	const rules: Rule[] = [...userRules, ...DEFAULT_MODULE_RULES];
 
 	const completedRuleLocations: Record<string, number> = {};
-	const redudantRules: Record<string, RedundantRule[]> = {};
+	const redundantRules: Record<string, RedundantRule[]> = {};
 	let index = 0;
 	const rulesToRemove: Rule[] = [];
 	for (const rule of rules) {
 		if (rule.type in completedRuleLocations) {
 			if (rules[completedRuleLocations[rule.type]].fallthrough !== false) {
-				if (rule.type in redudantRules) {
-					redudantRules[rule.type].push({
+				if (rule.type in redundantRules) {
+					redundantRules[rule.type].push({
 						index,
 						default: index >= userRules.length,
 					});
 				} else {
-					redudantRules[rule.type] = [
+					redundantRules[rule.type] = [
 						{ index, default: index >= userRules.length },
 					];
 				}
@@ -52,7 +52,7 @@ export function parseRules(userRules: Rule[] = []): ParsedRules {
 	}
 
 	for (const completedRuleType in completedRuleLocations) {
-		const r = redudantRules[completedRuleType];
+		const r = redundantRules[completedRuleType];
 		if (r) {
 			const completedRuleIndex = completedRuleLocations[completedRuleType];
 			let warning = `The ${
@@ -67,7 +67,7 @@ export function parseRules(userRules: Rule[] = []): ParsedRules {
 				}`;
 			}
 
-			warning += `\n\nAdd \`fallthrough = true\` to rule to allow next rule to be used or \`fallthrough = false\` to slience this warning`;
+			warning += `\n\nAdd \`fallthrough = true\` to rule to allow next rule to be used or \`fallthrough = false\` to silence this warning`;
 
 			logger.warn(warning);
 		}


### PR DESCRIPTION
Fixes #682

Changes module collection warnings from
```
▲ [WARNING] The module rule at position 1 ({"type":"Text","globs":["**/*.other"]}) has the same type as a previous rule (at position 0, {"type":"Text","globs":["**/*.file"]}). This rule will be ignored. To use the previous rule, add `fallthrough = true` to allow this one to also be used, or `fallthrough = false` to silence this warning.


▲ [WARNING] The default module rule {"type":"Text","globs":["**/*.txt","**/*.html"]} has the same type as a previous rule (at position 0, {"type":"Text","globs":["**/*.file"]}). This rule will be ignored. To use the previous rule, add `fallthrough = true` to allow the default one to also be used, or `fallthrough = false` to silence this warning.
```
to

```
▲ [WARNING] The module rule {"type":"Text","globs":["**/*.file"]} does not have a fallback, the following rules will be ignored:

   {"type":"Text","globs":["**/*.other"]}
   {"type":"Text","globs":["**/*.txt","**/*.html"]} (DEFAULT)

  Add `fallthrough = true` to rule to allow next rule to be used or `fallthrough = false` to
  slience this warning
```

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: Small wording change, not sure this warrants a changeset
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: Module collection warnings are not documented

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
