### PR TITLE
Try to URL decode hyperdrive passwords before sending them to API

### DIFF
--- a/.changeset/stupid-turkeys-enjoy.md
+++ b/.changeset/stupid-turkeys-enjoy.md
@@ -1,0 +1,5 @@
+---
+"wrangler": major
+---
+
+Try URL decoding hyperdrive passwords in create

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -151,6 +151,30 @@ describe("hyperdrive commands", () => {
 	`);
 	});
 
+	it("should handle creating a hyperdrive config if the password is URL encoded", async () => {
+		mockHyperdriveRequest();
+		await runWrangler(
+			"hyperdrive create test123 --connection-string='postgresql://test:a%23%3F81n%287@foo.us-east-2.aws.neon.tech/neondb'"
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+		"🚧 Creating 'test123'
+		✅ Created new Hyperdrive config
+		 {
+		  \\"id\\": \\"7a040c1eee714e91a30ea6707a2d125c\\",
+		  \\"name\\": \\"test123\\",
+		  \\"origin\\": {
+		    \\"host\\": \\"foo.us-east-2.aws.neon.tech\\",
+		    \\"port\\": 5432,
+		    \\"database\\": \\"neondb\\",
+		    \\"user\\": \\"test\\"
+		  },
+		  \\"caching\\": {
+		    \\"disabled\\": false
+		  }
+		}"
+	`);
+	});
+
 	it("should handle listing configs", async () => {
 		mockHyperdriveRequest();
 		await runWrangler("hyperdrive list");

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -80,7 +80,7 @@ export async function handler(
 				scheme: url.protocol.replace(":", ""),
 				database: url.pathname.replace("/", ""),
 				user: url.username,
-				password: url.password,
+				password: decodeIfURLEncoded(url.password),
 			},
 			caching: { disabled: args.cachingDisabled ?? false },
 		});
@@ -88,5 +88,15 @@ export async function handler(
 			`✅ Created new Hyperdrive config\n`,
 			JSON.stringify(database, null, 2)
 		);
+	}
+}
+
+function decodeIfURLEncoded(str: string): string {
+	try {
+		const decoded = decodeURIComponent(str);
+		return str === decoded ? str : decoded;
+	} catch (e) {
+		logger.error(`Error while trying to decode password`, e);
+		return str;
 	}
 }


### PR DESCRIPTION
Fixes #SQC-153

**What this PR solves / how to test:**

Small change, adds utility function to try to URL password before hitting the API in the create method. Some customers might use characters in their connection string that are URL encoded.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
