### PR TITLE
[wrangler] feat: source map logged strings

### DIFF
--- a/.changeset/lazy-gifts-train.md
+++ b/.changeset/lazy-gifts-train.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+feat: apply source mapping to logged strings
+
+Previously, Wrangler would only apply source mapping to uncaught exceptions. This meant if you caught an exception and logged its stack trace, the call sites would reference built JavaScript files as opposed to source files. This change looks for stack traces in logged messages, and tries to source map them.
+
+Note source mapping is only applied when outputting logs. `Error#stack` does not return a source mapped stack trace. This means the actual runtime value of `new Error().stack` and the output from `console.log(new Error().stack)` may be different.

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -1,5 +1,6 @@
-import { now } from "./dep";
 import { randomBytes } from "isomorphic-random-example";
+import { now } from "./dep";
+import { logErrors } from "./log";
 
 console.log("startup log");
 
@@ -23,6 +24,8 @@ export default {
 			new Map([...request.headers]),
 			request.cf
 		);
+
+		logErrors();
 
 		await fetch(new URL("http://example.com"));
 		await fetch(

--- a/fixtures/worker-app/src/log.ts
+++ b/fixtures/worker-app/src/log.ts
@@ -1,0 +1,12 @@
+// Make sure built JavaScript file doesn't use the same line numbers
+interface Output {
+	thing: 42;
+}
+
+export function logErrors(): Output {
+	console.log(new Error("logged error one"));
+	console.log(new Error("logged error two").stack);
+	console.log({ error: new Error("logged error three") });
+
+	return { thing: 42 };
+}

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -29,6 +29,17 @@ describe("'wrangler dev' correctly renders pages", () => {
 		const output = getOutput();
 		expect(output).toContain("startup log");
 		expect(output).toContain("request log");
+
+		// Check logged strings are source mapped
+		expect(output).toMatch(
+			/Error: logged error one.+fixtures\/worker-app\/src\/log.ts:7:14/s
+		);
+		expect(output).toMatch(
+			/Error: logged error two.+fixtures\/worker-app\/src\/log.ts:8:14/s
+		);
+		expect(output).toMatch(
+			/Error: logged error three.+fixtures\/worker-app\/src\/log.ts:9:23/s
+		);
 	});
 
 	it("uses `workerd` condition when bundling", async ({ expect }) => {

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -41,12 +41,12 @@
 		"miniflare": "bootstrap.js"
 	},
 	"dependencies": {
+		"@cspotcode/source-map-support": "0.8.1",
 		"acorn": "^8.8.0",
 		"acorn-walk": "^8.2.0",
 		"capnp-ts": "^0.7.0",
 		"exit-hook": "^2.2.1",
 		"glob-to-regexp": "^0.4.1",
-		"source-map-support": "0.5.21",
 		"stoppable": "^1.1.0",
 		"undici": "^5.22.1",
 		"workerd": "1.20231030.0",

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import type { UrlAndMap } from "source-map-support";
+import type { UrlAndMap } from "@cspotcode/source-map-support";
 import { z } from "zod";
 import { Request, Response } from "../../../http";
 import { Log } from "../../../shared";
@@ -49,7 +49,7 @@ interface SourceFile {
 }
 
 // Try to read a file from the file-system, returning undefined if not found
-function maybeGetDiskFile(filePath: string): SourceFile | undefined {
+function maybeGetDiskFile(filePath: string): Required<SourceFile> | undefined {
 	try {
 		const contents = fs.readFileSync(filePath, "utf8");
 		return { path: filePath, contents };

--- a/packages/miniflare/test/test-shared/asserts.ts
+++ b/packages/miniflare/test/test-shared/asserts.ts
@@ -18,9 +18,9 @@ export function isWithin(
 	);
 }
 
-export function escapeRegexp(value: string): RegExp {
+export function escapeRegexpComponent(value: string): string {
 	// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping
-	return new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function flaky(

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -102,6 +102,7 @@
 	},
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "^0.2.0",
+		"@cspotcode/source-map-support": "0.8.1",
 		"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
 		"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
 		"blake3-wasm": "^2.1.5",
@@ -113,7 +114,6 @@
 		"resolve.exports": "^2.0.2",
 		"selfsigned": "^2.0.1",
 		"source-map": "0.6.1",
-		"source-map-support": "0.5.21",
 		"xxhash-wasm": "^1.0.1"
 	},
 	"devDependencies": {

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -12,6 +12,8 @@ export const EXTERNAL_DEPENDENCIES = [
 	// todo - bundle miniflare too
 	"selfsigned",
 	"source-map",
+	// CommonJS module using `module.require()` which isn't provided by `esbuild`
+	"@cspotcode/source-map-support",
 	"@esbuild-plugins/node-globals-polyfill",
 	"@esbuild-plugins/node-modules-polyfill",
 	"chokidar",

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -8,6 +8,7 @@ import {
 	isAllowedSourcePath,
 } from "../api/startDevWorker/bundle-allowed-paths";
 import { logger } from "../logger";
+import { getSourceMappedString } from "../sourcemap";
 import type { EsbuildBundle } from "../dev/use-esbuild";
 import type Protocol from "devtools-protocol";
 import type { RawSourceMap } from "source-map";
@@ -57,6 +58,9 @@ export function logConsoleMessage(
 			case "undefined":
 			case "symbol":
 			case "bigint":
+				if (typeof ro.value === "string") {
+					ro.value = getSourceMappedString(ro.value);
+				}
 				args.push(ro.value);
 				break;
 			case "function":

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -7,6 +7,7 @@ import { ModuleTypeToRuleType } from "../deployment-bundle/module-collection";
 import { withSourceURLs } from "../deployment-bundle/source-url";
 import { getHttpsOptions } from "../https-options";
 import { logger } from "../logger";
+import { getSourceMappedString } from "../sourcemap";
 import { updateCheck } from "../update-check";
 import type { Config } from "../config";
 import type {
@@ -462,7 +463,7 @@ export function handleRuntimeStdio(stdout: Readable, stderr: Readable) {
 
 		// anything not exlicitly handled above should be logged as info (via stdout)
 		else {
-			logger.info(chunk);
+			logger.info(getSourceMappedString(chunk));
 		}
 	});
 
@@ -501,7 +502,7 @@ export function handleRuntimeStdio(stdout: Readable, stderr: Readable) {
 
 		// anything not exlicitly handled above should be logged as an error (via stderr)
 		else {
-			logger.error(chunk);
+			logger.error(getSourceMappedString(chunk));
 		}
 	});
 }

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -2,6 +2,41 @@ import assert from "node:assert";
 import type Protocol from "devtools-protocol";
 
 let sourceMappingPrepareStackTrace: typeof Error.prepareStackTrace;
+function getSourceMappingPrepareStackTrace(): NonNullable<
+	typeof Error.prepareStackTrace
+> {
+	if (sourceMappingPrepareStackTrace !== undefined) {
+		return sourceMappingPrepareStackTrace;
+	}
+
+	// `source-map-support` will only modify `Error.prepareStackTrace` if this
+	// is the first time `install()` has been called. This is governed by a
+	// module level variable: `errorFormatterInstalled`. To ensure we're not
+	// affecting external user's use of this package, and so
+	// `Error.prepareStackTrace` is always updated, load a fresh copy, by
+	// resetting then restoring the `require` cache.
+	const originalSupport = require.cache["source-map-support"];
+	delete require.cache["source-map-support"];
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports,@typescript-eslint/no-var-requires
+	const support: typeof import("source-map-support") = require("source-map-support");
+	require.cache["source-map-support"] = originalSupport;
+
+	const originalPrepareStackTrace = Error.prepareStackTrace;
+	support.install({
+		environment: "node",
+		// Don't add Node `uncaughtException` handler
+		handleUncaughtExceptions: false,
+		// Don't hook Node `require` function
+		hookRequire: false,
+		// Make sure we're using fresh copies of files each time we source map
+		emptyCacheBetweenOperations: true,
+	});
+	sourceMappingPrepareStackTrace = Error.prepareStackTrace;
+	assert(sourceMappingPrepareStackTrace !== undefined);
+	Error.prepareStackTrace = originalPrepareStackTrace;
+
+	return sourceMappingPrepareStackTrace;
+}
 
 export function getSourceMappedStack(
 	details: Protocol.Runtime.ExceptionDetails
@@ -12,72 +47,164 @@ export function getSourceMappedStack(
 	// mapping without parsing the stack, so just return the description as is
 	if (callFrames === undefined) return description;
 
-	if (sourceMappingPrepareStackTrace === undefined) {
-		// `source-map-support` will only modify `Error.prepareStackTrace` if this
-		// is the first time `install()` has been called. This is governed by a
-		// module level variable: `errorFormatterInstalled`. To ensure we're not
-		// affecting external user's use of this package, and so
-		// `Error.prepareStackTrace` is always updated, load a fresh copy, by
-		// resetting then restoring the `require` cache.
-		const originalSupport = require.cache["source-map-support"];
-		delete require.cache["source-map-support"];
-		// eslint-disable-next-line @typescript-eslint/consistent-type-imports,@typescript-eslint/no-var-requires
-		const support: typeof import("source-map-support") = require("source-map-support");
-		require.cache["source-map-support"] = originalSupport;
-
-		const originalPrepareStackTrace = Error.prepareStackTrace;
-		support.install({
-			environment: "node",
-			// Don't add Node `uncaughtException` handler
-			handleUncaughtExceptions: false,
-			// Don't hook Node `require` function
-			hookRequire: false,
-			// Make sure we're using fresh copies of files each time we source map
-			emptyCacheBetweenOperations: true,
-		});
-		sourceMappingPrepareStackTrace = Error.prepareStackTrace;
-		assert(sourceMappingPrepareStackTrace !== undefined);
-		Error.prepareStackTrace = originalPrepareStackTrace;
-	}
-
 	const nameMessage = details.exception?.description?.split("\n")[0] ?? "";
 	const colonIndex = nameMessage.indexOf(":");
 	const error = new Error(nameMessage.substring(colonIndex + 2));
 	error.name = nameMessage.substring(0, colonIndex);
-	const callSites = callFrames.map((frame) => new CallSite(frame));
-	return sourceMappingPrepareStackTrace(error, callSites);
+	const callSites = callFrames.map(callFrameToCallSite);
+	return getSourceMappingPrepareStackTrace()(error, callSites);
 }
 
+function callFrameToCallSite(frame: Protocol.Runtime.CallFrame): CallSite {
+	return new CallSite({
+		typeName: null,
+		functionName: frame.functionName,
+		methodName: null,
+		fileName: frame.url,
+		lineNumber: frame.lineNumber + 1,
+		columnNumber: frame.columnNumber + 1,
+		native: false,
+	});
+}
+
+const placeholderError = new Error();
+export function getSourceMappedString(value: string): string {
+	// We could use `.replace()` here with a function replacer, but
+	// `getSourceMappingPrepareStackTrace()` clears its source map caches between
+	// operations. It's likely call sites in this `value` will share source maps,
+	// so instead we find all call sites, source map them together, then replace.
+	// Note this still works if there are multiple instances of the same call site
+	// (e.g. stack overflow error), as the final `.replace()`s will only replace
+	// the first instance. If they replace the value with itself, all instances
+	// of the call site would've been replaced with the same thing.
+	const callSiteLines = Array.from(value.matchAll(CALL_SITE_REGEXP));
+	const callSites = callSiteLines.map(lineMatchToCallSite);
+	const sourceMappedStackTrace: string = getSourceMappingPrepareStackTrace()(
+		placeholderError,
+		callSites
+	);
+	const sourceMappedCallSiteLines = sourceMappedStackTrace.split("\n").slice(1);
+	for (let i = 0; i < callSiteLines.length; i++) {
+		value = value.replace(
+			callSiteLines[i][0],
+			sourceMappedCallSiteLines[i].substring(4) // Trim indent from stack
+		);
+	}
+	return value;
+}
+
+// Adapted from `node-stack-trace`:
+/*!
+ * Copyright (c) 2011 Felix Geisendörfer (felix@debuggable.com)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+const CALL_SITE_REGEXP =
+	/at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/g;
+function lineMatchToCallSite(lineMatch: RegExpMatchArray): CallSite {
+	let object: string | null = null;
+	let method: string | null = null;
+	let functionName: string | null = null;
+	let typeName: string | null = null;
+	let methodName: string | null = null;
+	const isNative = lineMatch[5] === "native";
+
+	if (lineMatch[1]) {
+		functionName = lineMatch[1];
+		let methodStart = functionName.lastIndexOf(".");
+		if (functionName[methodStart - 1] == ".") methodStart--;
+		if (methodStart > 0) {
+			object = functionName.substring(0, methodStart);
+			method = functionName.substring(methodStart + 1);
+			const objectEnd = object.indexOf(".Module");
+			if (objectEnd > 0) {
+				functionName = functionName.substring(objectEnd + 1);
+				object = object.substring(0, objectEnd);
+			}
+		}
+	}
+
+	if (method) {
+		typeName = object;
+		methodName = method;
+	}
+
+	if (method === "<anonymous>") {
+		methodName = null;
+		functionName = null;
+	}
+
+	return new CallSite({
+		typeName,
+		functionName,
+		methodName,
+		fileName: lineMatch[2] || null,
+		lineNumber: parseInt(lineMatch[3]) || null,
+		columnNumber: parseInt(lineMatch[4]) || null,
+		native: isNative,
+	});
+}
+
+export interface CallSiteOptions {
+	typeName: string | null;
+	functionName: string | null;
+	methodName: string | null;
+	fileName: string | null;
+	lineNumber: number | null;
+	columnNumber: number | null;
+	native: boolean;
+}
+
+// https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+// This class supports the subset of options implemented by `node-stack-trace`:
+// https://github.com/felixge/node-stack-trace/blob/4c41a4526e74470179b3b6dd5d75191ca8c56c17/index.js
 export class CallSite implements NodeJS.CallSite {
-	constructor(private readonly frame: Protocol.Runtime.CallFrame) {}
+	constructor(private readonly opts: CallSiteOptions) {}
 
 	getThis(): unknown {
 		return null;
 	}
 	getTypeName(): string | null {
-		return null;
+		return this.opts.typeName;
 	}
 	// eslint-disable-next-line @typescript-eslint/ban-types
 	getFunction(): Function | undefined {
 		return undefined;
 	}
 	getFunctionName(): string | null {
-		return this.frame.functionName;
+		return this.opts.functionName;
 	}
 	getMethodName(): string | null {
-		return null;
+		return this.opts.methodName;
 	}
 	getFileName(): string | undefined {
-		return this.frame.url;
+		return this.opts.fileName ?? undefined;
 	}
 	getScriptNameOrSourceURL(): string | null {
-		return this.frame.url;
+		return this.opts.fileName;
 	}
 	getLineNumber(): number | null {
-		return this.frame.lineNumber + 1;
+		return this.opts.lineNumber;
 	}
 	getColumnNumber(): number | null {
-		return this.frame.columnNumber + 1;
+		return this.opts.columnNumber;
 	}
 	getEvalOrigin(): string | undefined {
 		return undefined;
@@ -89,7 +216,7 @@ export class CallSite implements NodeJS.CallSite {
 		return false;
 	}
 	isNative(): boolean {
-		return false;
+		return this.opts.native;
 	}
 	isConstructor(): boolean {
 		return false;

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -15,11 +15,11 @@ function getSourceMappingPrepareStackTrace(): NonNullable<
 	// affecting external user's use of this package, and so
 	// `Error.prepareStackTrace` is always updated, load a fresh copy, by
 	// resetting then restoring the `require` cache.
-	const originalSupport = require.cache["source-map-support"];
-	delete require.cache["source-map-support"];
+	const originalSupport = require.cache["@cspotcode/source-map-support"];
+	delete require.cache["@cspotcode/source-map-support"];
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports,@typescript-eslint/no-var-requires
-	const support: typeof import("source-map-support") = require("source-map-support");
-	require.cache["source-map-support"] = originalSupport;
+	const support: typeof import("@cspotcode/source-map-support") = require("@cspotcode/source-map-support");
+	require.cache["@cspotcode/source-map-support"] = originalSupport;
 
 	const originalPrepareStackTrace = Error.prepareStackTrace;
 	support.install({
@@ -28,6 +28,7 @@ function getSourceMappingPrepareStackTrace(): NonNullable<
 		handleUncaughtExceptions: false,
 		// Don't hook Node `require` function
 		hookRequire: false,
+		redirectConflictingLibrary: false,
 		// Make sure we're using fresh copies of files each time we source map
 		emptyCacheBetweenOperations: true,
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,6 +782,9 @@ importers:
 
   packages/miniflare:
     dependencies:
+      '@cspotcode/source-map-support':
+        specifier: 0.8.1
+        version: 0.8.1
       acorn:
         specifier: ^8.8.0
         version: 8.10.0
@@ -797,9 +800,6 @@ importers:
       glob-to-regexp:
         specifier: ^0.4.1
         version: 0.4.1
-      source-map-support:
-        specifier: 0.5.21
-        version: 0.5.21
       stoppable:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1234,6 +1234,9 @@ importers:
       '@cloudflare/kv-asset-handler':
         specifier: ^0.2.0
         version: 0.2.0
+      '@cspotcode/source-map-support':
+        specifier: 0.8.1
+        version: 0.8.1
       '@esbuild-plugins/node-globals-polyfill':
         specifier: ^0.2.3
         version: 0.2.3(esbuild@0.17.19)
@@ -1267,9 +1270,6 @@ importers:
       source-map:
         specifier: 0.6.1
         version: 0.6.1
-      source-map-support:
-        specifier: 0.5.21
-        version: 0.5.21
       xxhash-wasm:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1563,7 +1563,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
     dev: true
 
   /@ava/typescript@4.1.0:
@@ -1664,7 +1664,7 @@ packages:
     dependencies:
       '@babel/types': 7.22.19
       '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
       jsesc: 2.5.2
     dev: true
 
@@ -1674,7 +1674,7 @@ packages:
     dependencies:
       '@babel/types': 7.22.5
       '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
       jsesc: 2.5.2
     dev: true
 
@@ -3772,7 +3772,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
-    dev: true
 
   /@emotion/hash@0.9.1:
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
@@ -5188,32 +5187,20 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.0
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
     dev: true
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/set-array@1.1.0:
     resolution: {integrity: sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==}
     engines: {node: '>=6.0.0'}
     dev: true
 
-  /@jridgewell/sourcemap-codec@1.4.14:
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: true
-
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
-  /@jridgewell/trace-mapping@0.3.17:
-    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.19:
     resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
@@ -5227,7 +5214,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /@jspm/core@2.0.1:
     resolution: {integrity: sha512-Lg3PnLp0QXpxwLIAuuJboLeRaIhrgJjeuh797QADg3xz8wGLugQOS5DpsE8A6i6Adgzf+bacllkKZG3J0tGfDw==}
@@ -8249,6 +8235,7 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
 
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -16871,6 +16858,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+    dev: true
 
   /source-map-url@0.4.1:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==}


### PR DESCRIPTION
Fixes #3383 and closes #3739.

**What this PR solves / how to test:**

Previously, Wrangler would only apply source mapping to uncaught exceptions. This meant if you caught an exception and logged its stack trace, the call sites would reference built JavaScript files as opposed to source files. This change looks for stack traces in logged messages, and tries to source map them.

Note source mapping is only applied when outputting logs. `Error#stack` does not return a source mapped stack trace. This means the actual runtime value of `new Error().stack` and the output from `console.log(new Error().stack)` may be different.

To test this, run the following worker with `wrangler dev`:

```ts
interface Env {
}

export default <ExportedHandler<Env>>{
  fetch() {
    console.log(new Error("1"));
    console.log(new Error("2").stack);
    console.log({ error: new Error("3").stack });
  }
}
```

Note how source mapping is applied in all cases.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
