### PR TITLE
[miniflare] fix: add `miniflare` `bin` entry

### DIFF
--- a/.changeset/loud-taxis-drop.md
+++ b/.changeset/loud-taxis-drop.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: add `miniflare` `bin` entry
+
+Miniflare 3 doesn't include a CLI anymore, but should log a useful error stating this when running `npx miniflare`. We had a script for this, but it wasn't correctly hooked up. :facepalm: This change makes sure the required `bin` entry exists.

--- a/packages/miniflare/bootstrap.js
+++ b/packages/miniflare/bootstrap.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const { Log } = require(".");
 
 const log = new Log();

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -37,6 +37,9 @@
 		"lint:fix": "pnpm run lint -- --fix",
 		"types:build": "node scripts/types.mjs tsconfig.json && node scripts/types.mjs src/workers/tsconfig.json"
 	},
+	"bin": {
+		"miniflare": "bootstrap.js"
+	},
 	"dependencies": {
 		"acorn": "^8.8.0",
 		"acorn-walk": "^8.2.0",


### PR DESCRIPTION
Fixes #4355

**What this PR solves / how to test:**

Miniflare 3 doesn't include a CLI anymore, but should log a useful error stating this when running `npx miniflare`. We had a script for this, but it wasn't correctly hooked up. :facepalm: To test this, run `npx miniflare` in the `packages/wrangler` directory.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: small change to add a `bin` entry to`miniflare`'s `package.json`
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: already have migration docs suggesting users use `npx wrangler dev`

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
