### PR TITLE
Change dev registry and inspector server to use 127.0.0.1 instead of all interfaces

### DIFF
--- a/.changeset/warm-dryers-double.md
+++ b/.changeset/warm-dryers-double.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Change dev registry and inspector server to listen on 127.0.0.1 instead of all interfaces

--- a/packages/wrangler/src/__tests__/api-devregistry.test.ts
+++ b/packages/wrangler/src/__tests__/api-devregistry.test.ts
@@ -41,7 +41,7 @@ describe("multi-worker testing", () => {
 	});
 
 	it("parentWorker and childWorker should be added devRegistry", async () => {
-		const resp = await fetch("http://localhost:6284/workers");
+		const resp = await fetch("http://127.0.0.1:6284/workers");
 		if (resp) {
 			const parsedResp = (await resp.json()) as {
 				parent: unknown;

--- a/packages/wrangler/src/__tests__/unstableDev.test.ts
+++ b/packages/wrangler/src/__tests__/unstableDev.test.ts
@@ -23,7 +23,7 @@ describe("unstable devRegistry testing", () => {
 			mode: "local",
 			durableObjects: [{ name: "testing", className: "testing" }],
 		});
-		const resp = await fetch("http://localhost:6284/workers");
+		const resp = await fetch("http://127.0.0.1:6284/workers");
 		if (resp) {
 			const parsedResp = (await resp.json()) as {
 				test: unknown;
@@ -35,7 +35,7 @@ describe("unstable devRegistry testing", () => {
 	it("should not restart the devRegistry if the devRegistry already start", async () => {
 		await startWorkerRegistry();
 
-		await fetch("http://localhost:6284/workers/init", {
+		await fetch("http://127.0.0.1:6284/workers/init", {
 			method: "POST",
 			body: JSON.stringify({}),
 		});
@@ -48,7 +48,7 @@ describe("unstable devRegistry testing", () => {
 			durableObjects: [{ name: "testing", className: "testing" }],
 		});
 
-		const resp = await fetch("http://localhost:6284/workers");
+		const resp = await fetch("http://127.0.0.1:6284/workers");
 		if (resp) {
 			const parsedResp = (await resp.json()) as {
 				test: unknown;

--- a/packages/wrangler/src/dev-registry.ts
+++ b/packages/wrangler/src/dev-registry.ts
@@ -1,5 +1,5 @@
-import http from "http";
 import net from "net";
+import { createServer } from "node:http";
 import bodyParser from "body-parser";
 import express from "express";
 import { createHttpTerminator } from "http-terminator";
@@ -7,11 +7,11 @@ import { fetch } from "undici";
 import { logger } from "./logger";
 
 import type { Config } from "./config";
-import type { Server } from "http";
 import type { HttpTerminator } from "http-terminator";
+import type { Server } from "node:http";
 
-const DEV_REGISTRY_PORT = "6284";
-const DEV_REGISTRY_HOST = `http://localhost:${DEV_REGISTRY_PORT}`;
+const DEV_REGISTRY_PORT = 6284;
+const DEV_REGISTRY_HOST = `http://127.0.0.1:${DEV_REGISTRY_PORT}`;
 
 let server: Server | null;
 let terminator: HttpTerminator;
@@ -48,7 +48,7 @@ async function isPortAvailable() {
 				netServer.close();
 				resolve(true);
 			});
-		netServer.listen(DEV_REGISTRY_PORT);
+		netServer.listen(DEV_REGISTRY_PORT, "127.0.0.1");
 	});
 }
 
@@ -80,9 +80,9 @@ export async function startWorkerRegistry() {
 				workers = {};
 				res.json(null);
 			});
-		server = http.createServer(app);
+		server = createServer(app);
 		terminator = createHttpTerminator({ server });
-		server.listen(DEV_REGISTRY_PORT);
+		server.listen(DEV_REGISTRY_PORT, "127.0.0.1");
 
 		/**
 		 * The registry server may have already been started by another wrangler process.

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -125,7 +125,7 @@ export default function useInspector(props: InspectorProps) {
 					case "/json/list":
 						{
 							res.setHeader("Content-Type", "application/json");
-							const localHost = `localhost:${props.port}/ws`;
+							const localHost = `127.0.0.1:${props.port}/ws`;
 							const devtoolsFrontendUrl = `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=${localHost}`;
 							const devtoolsFrontendUrlCompat = `devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=${localHost}`;
 							res.end(
@@ -252,7 +252,7 @@ export default function useInspector(props: InspectorProps) {
 				timeout: 2000,
 				abortSignal: abortController.signal,
 			});
-			server.listen(props.port);
+			server.listen(props.port, "127.0.0.1");
 		}
 		startInspectorProxy().catch((err) => {
 			if ((err as { code: string }).code !== "ABORT_ERR") {
@@ -862,7 +862,7 @@ export const openInspector = async (
 ) => {
 	const query = new URLSearchParams();
 	query.set("theme", "systemPreferred");
-	query.set("ws", `localhost:${inspectorPort}/ws`);
+	query.set("ws", `127.0.0.1:${inspectorPort}/ws`);
 	if (worker) query.set("domain", worker);
 	query.set("debugger", "true");
 	const url = `https://devtools.devprod.cloudflare.dev/js_app?${query.toString()}`;


### PR DESCRIPTION
Fixes #4430

The dev registry and inspector server listen on all interfaces when running `wrangler dev`, this might not be desired by users who use `--ip` to prevent listening beyond `localhost`. This PR will will make the dev registry and inspector server use `127.0.0.1`

- Tests
  - [ ] Included
  - [ ] Not necessary because: 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: Not a change that is user facing or affects user behavior

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
