### PR TITLE
fix: create required parent directories for `wrangler r2 object get`

### DIFF
--- a/.changeset/perfect-students-pull.md
+++ b/.changeset/perfect-students-pull.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: automatically create required directories for `wrangler r2 object get`
+
+Previously, if you tried to use `wrangler r2 object get` with an object name containing a `/` or used the `--file` flag with a path containing a `/`, and the specified directory didn't exist, Wrangler would throw an `ENOENT` error. This change ensures Wrangler automatically creates required parent directories if they don't exist.

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -295,6 +295,15 @@ describe("r2", () => {
 		`);
 		});
 
+		it("should download R2 object from bucket into directory", async () => {
+			await runWrangler(
+				`r2 object get bucketName-object-test/wormhole-img.png --file ./a/b/c/wormhole-img.png`
+			);
+			expect(fs.readFileSync("a/b/c/wormhole-img.png", "utf8")).toBe(
+				"wormhole-img.png"
+			);
+		});
+
 		it("should upload R2 object to bucket", async () => {
 			fs.writeFileSync("wormhole-img.png", "passageway");
 			await runWrangler(

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -1,5 +1,6 @@
 import { Blob } from "node:buffer";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import * as stream from "node:stream";
 import { ReadableStream } from "node:stream/web";
 import prettyBytes from "pretty-bytes";
@@ -109,7 +110,13 @@ export function r2(r2Yargs: CommonYargsArgv) {
 							logger.log(`Downloading "${key}" from "${fullBucketName}".`);
 						}
 
-						const output = file ? fs.createWriteStream(file) : process.stdout;
+						let output: stream.Writable;
+						if (file) {
+							fs.mkdirSync(path.dirname(file), { recursive: true });
+							output = fs.createWriteStream(file);
+						} else {
+							output = process.stdout;
+						}
 						if (objectGetYargs.local) {
 							await usingLocalBucket(
 								objectGetYargs.persistTo,


### PR DESCRIPTION
Fixes #2721.

**What this PR solves / how to test:**

Previously, if you tried to use `wrangler r2 object get` with an object name containing a `/` or used the `--file` flag with a path containing a `/`, and the specified directory didn't exist, Wrangler would throw an `ENOENT` error. This change ensures Wrangler automatically creates required parent directories if they don't exist.

To test, run `wrangler r2 object get <bucket-name>/<object-name>` with an `<object-name>` containing a `/`, or run with the `--file <output-file>` flag with `<output-file>` containing a `/`.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: expected behaviour for existing functionality

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
