### PR TITLE
C3: Change default project type to hello world worker

### DIFF
--- a/.changeset/itchy-days-greet.md
+++ b/.changeset/itchy-days-greet.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Change the default project type to the hello world worker script.

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -63,7 +63,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 				promptHandlers: [
 					{
 						matcher: /What type of application do you want to create/,
-						input: [keys.down, keys.enter],
+						input: [keys.enter],
 					},
 					{
 						matcher: /Do you want to use TypeScript/,
@@ -130,7 +130,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 				promptHandlers: [
 					{
 						matcher: /What type of application do you want to create/,
-						input: [keys.down, keys.enter],
+						input: [keys.enter],
 					},
 					{
 						matcher: /Do you want to use git for version control/,

--- a/packages/create-cloudflare/src/helpers/cli.ts
+++ b/packages/create-cloudflare/src/helpers/cli.ts
@@ -20,7 +20,7 @@ export async function openInBrowser(url: string): Promise<void> {
 
 export const C3_DEFAULTS = {
 	projectName: new Haikunator().haikunate({ tokenHex: true }),
-	type: "webFramework",
+	type: "hello-world",
 	framework: "angular",
 	autoUpdate: true,
 	deploy: true,

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -298,7 +298,15 @@ const needsPackageManagerReset = (ctx: PagesGeneratorContext) => {
 export const npmInstall = async () => {
 	const { npm } = detectPackageManager();
 
-	await runCommand(`${npm} install`, {
+	const installCmd = [npm, "install"];
+
+	if (npm === "yarn" && process.env.VITEST) {
+		// Yarn can corrupt the cache if more than one instance is running at once,
+		// which is what we do in our tests.
+		installCmd.push("--mutex", "network");
+	}
+
+	await runCommand(installCmd, {
 		silent: true,
 		startText: "Installing dependencies",
 		doneText: `${brandColor("installed")} ${dim(`via \`${npm} install\``)}`,

--- a/packages/create-cloudflare/src/templateMap.ts
+++ b/packages/create-cloudflare/src/templateMap.ts
@@ -9,13 +9,13 @@ type TemplateConfig = {
 };
 
 export const templateMap: Record<string, TemplateConfig> = {
-	webFramework: {
-		label: "Website or web app",
-		handler: runPagesGenerator,
-	},
 	"hello-world": {
 		label: `"Hello World" Worker`,
 		handler: runWorkersGenerator,
+	},
+	webFramework: {
+		label: "Website or web app",
+		handler: runPagesGenerator,
 	},
 	common: {
 		label: "Example router & proxy Worker",


### PR DESCRIPTION
**What this PR solves / how to test:**
In a [previous change](https://github.com/cloudflare/workers-sdk/pull/4062/files) we changed the default project type from `hello-world` to `webFramework`. We received some feedback from the community that this makes the use case of creating a vanilla worker harder, and that it breaks examples/tutorials in our docs where we suggest using `--accept-defaults` for creating workers.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
