### PR TITLE
Revert "feat(workers): allow namespaced scripts to be used as Worker tail consumers"

### DIFF
--- a/.changeset/thin-pears-repeat.md
+++ b/.changeset/thin-pears-repeat.md
@@ -1,5 +1,0 @@
----
-"wrangler": patch
----
-
-[Workers] Allow namespace to be specified for a tail script

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -4772,7 +4772,6 @@ describe("normalizeAndValidateConfig()", () => {
 							// these are valid
 							{ service: "tail_listener" },
 							{ service: "listener_two", environment: "production" },
-							{ service: "listener_three", namespace: "a-dispatch-namespace" },
 						],
 					} as unknown as RawConfig,
 					undefined,

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -5135,7 +5135,6 @@ addEventListener('fetch', event => {});`
 				tail_consumers: [
 					{ service: "listener " },
 					{ service: "test-listener", environment: "production" },
-					{ service: "namespaced-listener", namespace: "a-dispatch-namespace" },
 				],
 			});
 			await fs.promises.writeFile("index.js", `export default {};`);
@@ -5144,7 +5143,6 @@ addEventListener('fetch', event => {});`
 				expectedTailConsumers: [
 					{ service: "listener " },
 					{ service: "test-listener", environment: "production" },
-					{ service: "namespaced-listener", namespace: "a-dispatch-namespace" },
 				],
 			});
 

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -734,10 +734,8 @@ export type ConfigModuleRuleType =
 export type TailConsumer = {
 	/** The name of the service tail events will be forwarded to. */
 	service: string;
-	/** (Optional) The environment of the service. */
+	/** (Optional) The environt of the service. */
 	environment?: string;
-	/** (Optional) The dispatch namespace the Tail Worker script belongs to (if any). */
-	namespace?: string;
 };
 
 export interface DispatchNamespaceOutbound {

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -247,7 +247,6 @@ export interface CfPlacement {
 export interface CfTailConsumer {
 	service: string;
 	environment?: string;
-	namespace?: string;
 }
 
 export interface CfUserLimits {


### PR DESCRIPTION
Reverts cloudflare/workers-sdk#3845