### PR TITLE
fix: include request url and headers in pretty error page

### DIFF
--- a/.changeset/tiny-sloths-kneel.md
+++ b/.changeset/tiny-sloths-kneel.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: include request url and headers in pretty error page
+
+This change ensures Miniflare's pretty error page includes the URL and headers of the incoming request, rather than Miniflare's internal request for the page.

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -259,7 +259,7 @@ export async function handlePrettyErrorRequest(
 	// `cause` is usually more useful than the error itself, display that instead
 	// TODO(someday): would be nice if we could display both
 	const youch = new Youch(error.cause ?? error, {
-		url: request.url,
+		url: request.cf?.prettyErrorOriginalUrl ?? request.url,
 		method: request.method,
 		headers: Object.fromEntries(request.headers),
 	});

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -82,19 +82,13 @@ function maybePrettifyError(request: Request, response: Response, env: Env) {
 		return response;
 	}
 
-	// Forward `Accept` and `User-Agent` headers if defined
-	const accept = request.headers.get("Accept");
-	const userAgent = request.headers.get("User-Agent");
-	const headers = new Headers();
-	if (accept !== null) headers.set("Accept", accept);
-	if (userAgent !== null) headers.set("User-Agent", userAgent);
-
 	return env[CoreBindings.SERVICE_LOOPBACK].fetch(
 		"http://localhost/core/error",
 		{
 			method: "POST",
-			headers,
+			headers: request.headers,
 			body: response.body,
+			cf: { prettyErrorOriginalUrl: request.url },
 		}
 	);
 }


### PR DESCRIPTION
**What this PR solves / how to test:**

This change ensures Miniflare's pretty error page includes the URL and headers of the incoming request, rather than Miniflare's internal request from `workerd` to the loopback server.

The request URL has been incorrect since the pretty error page was introduced into version 3 (cloudflare/miniflare#436). The request headers have been incorrect since (cloudflare/miniflare#681). This change also adds some tests to prevent this regressing again.

To test, run `wrangler dev` with a worker that throws an unhandled exception and visit the page in your browser. The reported request URL should match the browser's URL, and the headers should match headers sent by the browser.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: expected behaviour for the pretty error page

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
