### PR TITLE
Warn about AI in dev local

### DIFF
--- a/.changeset/proud-readers-cough.md
+++ b/.changeset/proud-readers-cough.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+add warnings about ai and verctorize bindings not being supported locally

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -179,7 +179,7 @@ function useLocalWorker(props: LocalProps) {
 				"Vectorize bindings are not currently supported in local mode. Please use --remote if you are working with them."
 			);
 		}
-	}, [props.bindings.ai, props.bindings.vectorize])
+	}, [props.bindings.ai, props.bindings.vectorize]);
 
 	useEffect(() => {
 		const abortController = new AbortController();

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -167,21 +167,6 @@ function useLocalWorker(props: LocalProps) {
 	}, [props.bindings.durable_objects?.bindings]);
 
 	useEffect(() => {
-		if (props.bindings.ai) {
-			logger.warn(
-				"Workers AI is not currently supported in local mode. Please use --remote to work with it."
-			);
-		}
-
-		if (!props.bindings.ai && props.bindings.vectorize?.length) {
-			// TODO: add local support for Vectorize bindings (https://github.com/cloudflare/workers-sdk/issues/4360)
-			logger.warn(
-				"Vectorize bindings are not currently supported in local mode. Please use --remote if you are working with them."
-			);
-		}
-	}, [props.bindings.ai, props.bindings.vectorize]);
-
-	useEffect(() => {
 		const abortController = new AbortController();
 
 		if (!props.bundle || !props.format) return;

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -167,6 +167,21 @@ function useLocalWorker(props: LocalProps) {
 	}, [props.bindings.durable_objects?.bindings]);
 
 	useEffect(() => {
+		if (props.bindings.ai) {
+			logger.warn(
+				"Workers AI is not currently supported in local mode. Please use --remote to work with it."
+			);
+		}
+
+		if (!props.bindings.ai && props.bindings.vectorize?.length) {
+			// TODO: add local support for Vectorize bindings (https://github.com/cloudflare/workers-sdk/issues/4360)
+			logger.warn(
+				"Vectorize bindings are not currently supported in local mode. Please use --remote if you are working with them."
+			);
+		}
+	}, [props.bindings.ai, props.bindings.vectorize])
+
+	useEffect(() => {
 		const abortController = new AbortController();
 
 		if (!props.bundle || !props.format) return;

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -396,6 +396,19 @@ async function buildMiniflareOptions(
 		logger.warn("Miniflare 3 does not support CRON triggers yet, ignoring...");
 	}
 
+	if (config.bindings.ai) {
+		logger.warn(
+			"Workers AI is not currently supported in local mode. Please use --remote to work with it."
+		);
+	}
+
+	if (!config.bindings.ai && config.bindings.vectorize?.length) {
+		// TODO: add local support for Vectorize bindings (https://github.com/cloudflare/workers-sdk/issues/4360)
+		logger.warn(
+			"Vectorize bindings are not currently supported in local mode. Please use --remote if you are working with them."
+		);
+	}
+
 	const upstream =
 		typeof config.localUpstream === "string"
 			? `${config.localProtocol}://${config.localUpstream}`


### PR DESCRIPTION
Result:
![Screenshot 2023-11-16 at 12 52 25](https://github.com/cloudflare/workers-sdk/assets/61631103/95b2c63b-3d54-40e6-a9e9-e37073d1f623)

![Screenshot 2023-11-16 at 12 49 31](https://github.com/cloudflare/workers-sdk/assets/61631103/ca24f9bf-850b-4db7-80a6-a42e1f6c5466)

As you can see anyways we do say "your workerd has access to the following bindings" which is not really correct and might be confusing to people as @pi0 mentioned here: https://github.com/cloudflare/workers-sdk/issues/4360#issuecomment-1813262660

We could change that by tweaking the `printBindings` function:
https://github.com/cloudflare/workers-sdk/blob/46a35e07d103ee21589169f91ee68218e6050246/packages/wrangler/src/config/index.ts#L81

So that it is aware whether is run in invoked in local mode so that we don't even show the bindings or show them with a warning or something like that.

I started looking into it but I was afraid that it could be a bit of a controversial change (also the function [generates a single text message and logs it in one go](https://github.com/cloudflare/workers-sdk/blob/46a35e07d103ee21589169f91ee68218e6050246/packages/wrangler/src/config/index.ts#L413-L425) making it harder to for example print some text yellow, etc...).

If anyone has any opinion please let me know 🙂, I'd be happy to tweak `printBindings` as an addition to the changes in this PR or as a replacement of them (if we might want to show the warnings in the bindings text itself).