### PR TITLE
Pack miniflare for e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,23 @@ jobs:
           NODE_ENV: "production"
           CI_OS: ${{ runner.os }}
 
-      - name: Build Wrangler package for npm
+      - name: Pack Miniflare
+        run: pnpm pack --pack-destination $HOME
+        env:
+          NODE_ENV: "production"
+        working-directory: packages/miniflare
+
+      - name: Find Miniflare
+        shell: bash
+        id: "find-miniflare"
+        run: echo "dir=$(ls $HOME/miniflare-*.tgz)" >> $GITHUB_OUTPUT;
+
+      - name: Modify wrangler package.json miniflare dependency
+        run: cat <<< $(jq --tab ".dependencies.miniflare = \"$MINIFLARE_VERSION\"" packages/wrangler/package.json) > packages/wrangler/package.json
+        env:
+          MINIFLARE_VERSION: ${{ steps.find-miniflare.outputs.dir }}
+
+      - name: Pack Wrangler
         run: pnpm pack --pack-destination $HOME
         env:
           NODE_ENV: "production"
@@ -62,21 +78,10 @@ jobs:
         shell: bash
         id: "find-wrangler"
         run: echo "dir=$(ls $HOME/wrangler-*.tgz)" >> $GITHUB_OUTPUT;
-        env:
-          NODE_ENV: "production"
 
       - name: Run tests
         id: e2e-1
         continue-on-error: true
-        run: pnpm run --filter wrangler test:e2e
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER: pnpm --silent --package ${{ steps.find-wrangler.outputs.dir}} dlx wrangler
-          NODE_OPTIONS: "--max_old_space_size=8192"
-
-      - name: Retry tests
-        if: steps.e2e-1.outcome == 'failure'
         run: pnpm run --filter wrangler test:e2e
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -63,7 +63,7 @@
 		"test": "pnpm run assert-git-version && jest",
 		"test:ci": "pnpm run test --coverage",
 		"test:debug": "pnpm run test --silent=false --verbose=true",
-		"test:e2e": "vitest --test-timeout 240000 --single-thread --dir ./e2e run",
+		"test:e2e": "vitest --test-timeout 240000 --single-thread --dir ./e2e --retry 2 run",
 		"test:watch": "pnpm run test --runInBand --testTimeout=50000 --watch",
 		"type:tests": "tsc -p ./src/__tests__/tsconfig.json && tsc -p ./e2e/tsconfig.json"
 	},


### PR DESCRIPTION
Fixes e2e tests on Changesets PR

**What this PR solves / how to test:**

Previously, e2e tests on the changesets PR were trying to fetch an unreleased version of Miniflare from the npm registry. This ensure that they fetch the correct packed version of Miniflare.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: This is a fix for existing tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: Not user facing
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: Not user facing

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
