### PR TITLE
fix: ensure unused KV and Cache blobs cleaned up

### DIFF
--- a/.changeset/slow-pants-fetch.md
+++ b/.changeset/slow-pants-fetch.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+fix: ensure unused KV and Cache blobs cleaned up
+
+When storing data in KV, Cache and R2, Miniflare uses both an SQL database and separate blob store. When writing a key/value pair, a blob is created for the new value and the old blob for the previous value (if any) is deleted. A few months ago, we introduced a change that prevented old blobs being deleted for KV and Cache. R2 was unaffected. This shouldn't have caused any problems, but could lead to persistence directories growing unnecessarily as they filled up with garbage blobs. This change ensures garbage blobs are deleted.
+
+Note existing garbage will not be cleaned up. If you'd like to do this, download this Node script (https://gist.github.com/mrbbot/68787e19dcde511bd99aa94997b39076). If you're using the default Wrangler persistence directory, run `node gc.mjs kv .wrangler/state/v3/kv <namespace_id_1> <namespace_id_2> ...` and `node gc.mjs cache .wrangler/state/v3/cache default named:<cache_name_1> named:<cache_name_2> ...` with each of your KV namespace IDs (not binding names) and named caches.

--- a/packages/miniflare/src/workers/shared/keyvalue.worker.ts
+++ b/packages/miniflare/src/workers/shared/keyvalue.worker.ts
@@ -52,7 +52,7 @@ CREATE INDEX IF NOT EXISTS _mf_entries_expiration_idx ON _mf_entries(expiration)
 `;
 function sqlStmts(db: TypedSql) {
 	const stmtGetBlobIdByKey = db.stmt<Pick<Row, "key">, Pick<Row, "blob_id">>(
-		"SELECT blob_id FROM _mf_entries WHERE :key"
+		"SELECT blob_id FROM _mf_entries WHERE key = :key"
 	);
 	const stmtPut = db.stmt<Row>(
 		`INSERT OR REPLACE INTO _mf_entries (key, blob_id, expiration, metadata)

--- a/packages/miniflare/test/plugins/cache/index.spec.ts
+++ b/packages/miniflare/test/plugins/cache/index.spec.ts
@@ -55,6 +55,18 @@ async function getControlStub(
 	return stub;
 }
 
+function sqlStmts(object: MiniflareDurableObjectControlStub) {
+	return {
+		getBlobIdByKey: async (key: string): Promise<string | undefined> => {
+			const rows = await object.sqlQuery<{ blob_id: string }>(
+				"SELECT blob_id FROM _mf_entries WHERE key = ?",
+				key
+			);
+			return rows[0]?.blob_id;
+		},
+	};
+}
+
 test.beforeEach(async (t) => {
 	t.context.caches = await t.context.mf.getCaches();
 
@@ -229,6 +241,31 @@ test("match respects Range header", async (t) => {
 	);
 	assert(res !== undefined);
 	t.is(res.status, 416);
+});
+test("put overrides existing responses", async (t) => {
+	const cache = t.context.caches.default;
+	const defaultObject = t.context.defaultObject;
+	const stmts = sqlStmts(defaultObject);
+
+	const resToCache = (body: string) =>
+		new Response(body, { headers: { "Cache-Control": "max-age=3600" } });
+
+	const key = "http://localhost/cache-override";
+	await cache.put(key, resToCache("body1"));
+	const blobId = await stmts.getBlobIdByKey(key);
+	assert(blobId !== undefined);
+	await cache.put(key, resToCache("body2"));
+	const res = await cache.match(key);
+	t.is(await res?.text(), "body2");
+
+	// Check deletes old blob
+	await defaultObject.waitForFakeTasks();
+	t.is(await defaultObject.getBlob(blobId), null);
+
+	// Check created new blob
+	const newBlobId = await stmts.getBlobIdByKey(key);
+	assert(newBlobId !== undefined);
+	t.not(blobId, newBlobId);
 });
 
 // Note this macro must be used with `test.serial` to avoid races.


### PR DESCRIPTION
**What this PR solves / how to test:**

cloudflare/miniflare#656 introduced a bug in the SQL statement used for getting the old blob ID of entries to delete when overriding keys. This meant if a key was overridden, the old blob pointed to by that key was not deleted. This lead to an accumulation of garbage when `kvPersist` and `cachePersist` were enabled. This shouldn't have caused any problems, but could lead to persistence directories growing unnecessarily as they filled up with garbage blobs. This change ensures garbage blobs are deleted, and adds some regression tests to prevent this happening again.

Note existing garbage will not be cleaned up. If you'd like to do this, download this Node script (https://gist.github.com/mrbbot/68787e19dcde511bd99aa94997b39076). If you're using the default Wrangler persistence directory, run `node gc.mjs kv .wrangler/state/v3/kv <namespace_id_1> <namespace_id_2> ...` and `node gc.mjs cache .wrangler/state/v3/cache default named:<cache_name_1> named:<cache_name_2> ...` with each of your KV namespace IDs (not binding names) and named caches.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a bug in Miniflare's underlying storage implementation

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
