### PR TITLE
[wrangler] fix: report correct line/column numbers source mapping remote errors

### DIFF
--- a/.changeset/empty-islands-peel.md
+++ b/.changeset/empty-islands-peel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: report correct line and column numbers when source mapping errors with `wrangler dev --remote`

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -74,10 +74,10 @@ export class CallSite implements NodeJS.CallSite {
 		return this.frame.url;
 	}
 	getLineNumber(): number | null {
-		return this.frame.lineNumber;
+		return this.frame.lineNumber + 1;
 	}
 	getColumnNumber(): number | null {
-		return this.frame.columnNumber;
+		return this.frame.columnNumber + 1;
 	}
 	getEvalOrigin(): string | undefined {
 		return undefined;


### PR DESCRIPTION
**What this PR solves / how to test:**

When writing some new E2E tests for `wrangler dev (--remote)` I noticed the line/column numbers reported for uncaught errors were different between local and remote modes. It turns out the Chrome DevTools protocol reports line and column numbers 0-indexed, but `source-map-support` expects them to be 1-indexed. This meant https://github.com/cloudflare/workers-sdk/pull/3951/commits/d414ca9f60b29e1be78c4f4d34dd35e818d9a3b9 therefore broke `--remote` source mapping. 🙁 

To test this fix, run `wrangler dev --remote` in `fixtures/worker-app`, and replace the worker's `fetch()` handler with a `throw new Error()`. Make a request, then verify clicking the URL in your editor goes to the `new Error()`.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: coming soon with these new E2E tests 😁 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing incorrect behaviour

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
