### PR TITLE
fix: open browser to correct url pressing `b`

### DIFF
--- a/.changeset/heavy-dogs-serve.md
+++ b/.changeset/heavy-dogs-serve.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: open browser to correct url pressing `b` in `--remote` mode
+
+This change ensures Wrangler doesn't try to open `http://*` when `*` is used as the dev server's hostname. Instead, Wrangler will now open `http://127.0.0.1`.

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -534,7 +534,7 @@ function useHotkeys(props: {
 					break;
 				// open browser
 				case "b": {
-					if (ip === "0.0.0.0") {
+					if (ip === "0.0.0.0" || ip === "*") {
 						await openInBrowser(`${localProtocol}://127.0.0.1:${port}`);
 						return;
 					}


### PR DESCRIPTION
**What this PR solves / how to test:**

This change ensures Wrangler doesn't try to open `http://*` when `*` is used as the dev server's hostname. Instead, Wrangler will now open `http://127.0.0.1`.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: this is expected behaviour of the `b` hotkey

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
