### PR TITLE
More wrangler init --from-dash improvements

### DIFF
--- a/.changeset/early-lizards-knock.md
+++ b/.changeset/early-lizards-knock.md
@@ -1,0 +1,8 @@
+---
+"create-cloudflare": patch
+---
+
+Minor improvements when using the `--existing-script scriptName` flag:
+
+- Format the type as "Pre-existing Worker (from Dashboard)"
+- Defaults the project name to `scriptName`

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -13,6 +13,7 @@ const leftT = gray(shapes.leftT);
 export type Option = {
 	label: string;
 	value: string;
+	hidden?: boolean;
 };
 
 export type BasePromptConfig = {
@@ -69,7 +70,6 @@ export const inputPrompt = async (promptConfig: PromptConfig) => {
 	if (promptConfig.type === "select") {
 		prompt = new SelectPrompt({
 			...promptConfig,
-			options: (promptConfig as SelectPromptConfig).options,
 			initialValue: String(promptConfig.defaultValue),
 			render() {
 				return dispatchRender(this);
@@ -187,7 +187,10 @@ const getSelectRenderers = (config: SelectPromptConfig) => {
 
 		return [
 			`${blCorner} ${bold(question)} ${dim(helpText)}`,
-			`${options.map(renderOption).join(`\n`)}`,
+			`${options
+				.filter((o) => !o.hidden)
+				.map(renderOption)
+				.join(`\n`)}`,
 			``, // extra line for readability
 		];
 	};

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -92,9 +92,9 @@ export const runCli = async (args: Partial<C3Args>) => {
 		}
 	}
 
-	const templateOptions = Object.entries(templateMap)
-		.filter(([_, { hidden }]) => !hidden)
-		.map(([value, { label }]) => ({ value, label }));
+	const templateOptions = Object.entries(templateMap).map(
+		([value, { label, hidden }]) => ({ value, label, hidden })
+	);
 
 	const type = await processArgument<string>(args, "type", {
 		type: "select",

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -72,11 +72,15 @@ export const runLatest = async () => {
 export const runCli = async (args: Partial<C3Args>) => {
 	printBanner();
 
+	const defaultName = args.existingScript
+		? args.existingScript
+		: C3_DEFAULTS.projectName;
+
 	const projectName = await processArgument<string>(args, "projectName", {
 		type: "text",
 		question: `In which directory do you want to create your application?`,
 		helpText: "also used as application name",
-		defaultValue: C3_DEFAULTS.projectName,
+		defaultValue: defaultName,
 		label: "dir",
 		validate: (value) =>
 			validateProjectDirectory(String(value) || C3_DEFAULTS.projectName, args),

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -72,9 +72,7 @@ export const runLatest = async () => {
 export const runCli = async (args: Partial<C3Args>) => {
 	printBanner();
 
-	const defaultName = args.existingScript
-		? args.existingScript
-		: C3_DEFAULTS.projectName;
+	const defaultName = args.existingScript || C3_DEFAULTS.projectName;
 
 	const projectName = await processArgument<string>(args, "projectName", {
 		type: "text",


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR improves the `wrangler init --from-dash` workflow by:
- Displaying a label for the pre-existing type (currently says `type: undefined`)
- Defaulting the project name to the name of the pre-existing script

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ x ] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
