### PR TITLE
Add info about `node:${module}` syntax for nodejs_compat

### DIFF
--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -7717,7 +7717,7 @@ export default{
 			expect(
 				esbuild.formatMessagesSync(err?.errors ?? [], { kind: "error" }).join()
 			).toMatch(
-				/The package "path" wasn't found on the file system but is built into node\.\s+Add "node_compat = true" to your wrangler\.toml file to enable Node.js compatibility\./
+				/The package "path" wasn't found on the file system but is built into node\.\s+Add "node_compat = true" to your wrangler\.toml file and make sure to prefix the module name with "node:" to enable Node.js compatibility\./
 			);
 		});
 

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -437,7 +437,7 @@ export default {
 			'The package "node:async_hooks" wasn\'t found on the file system but is built into node.'
 		);
 		expect(std.err).toContain(
-			'Add the "nodejs_compat" compatibility flag to your Pages project to enable Node.js compatibility.'
+			'Add the "nodejs_compat" compatibility flag to your Pages project and make sure to prefix the module name with "node:" to enable Node.js compatibility.'
 		);
 	});
 

--- a/packages/wrangler/src/deployment-bundle/build-failures.ts
+++ b/packages/wrangler/src/deployment-bundle/build-failures.ts
@@ -30,7 +30,7 @@ export function rewriteNodeCompatBuildFailure(
 				forPages
 					? 'Add the "nodejs_compat" compatibility flag to your Pages project'
 					: 'Add "node_compat = true" to your wrangler.toml file'
-			} to enable Node.js compatibility.`;
+			} and make sure to prefix the module name with "node:" to enable Node.js compatibility.`;
 
 			error.notes = [
 				{


### PR DESCRIPTION
**What this PR solves / how to test:**

This updates the error message to point the user that they might be missing `node:` in the module name for the imports, even if they enabled `nodejs_compat` in their project.

I'm open to changing the wording. This I did on a whim after receiving support from @KianNH on Discord which I thought might be worth highlighting in the error message.

It's about this error message from the CLI:

<img width="806" alt="image" src="https://github.com/cloudflare/workers-sdk/assets/25948390/f87be0e9-ea3f-4a23-a388-e4b4cf981a4a">

It can still occur when `nodejs_compat` is enabled but the imported package is not in the intended format - `node:{moduleName}`

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: It's a docs change.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: It's a docs change.
- Associated docs
  - [ ] Issue(s)/PR(s):
 https://developers.cloudflare.com/workers/runtime-apis/nodejs/
  - [x] Not necessary because: it's a message change.

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
