### PR TITLE
Improve DX with `node:*` modules

### DIFF
--- a/.changeset/chatty-balloons-impress.md
+++ b/.changeset/chatty-balloons-impress.md
@@ -4,7 +4,7 @@
 
 feat: Support runtime-agnostic polyfills
 
-Previously, Wrangler treated any imports of `node:*` modules as build-time errors (unless one of the two Node.JS compatibility modes was enabled). This is sometimes overly aggressive, since those imports are often not hit at runtime (for instance, it was impossible to write a library that worked across Node.JS and Workers, using Node packages only when running in Node). Here's an example of a function that would cause Wrangler to fail to build:
+Previously, Wrangler treated any imports of `node:*` modules as build-time errors (unless one of the two Node.js compatibility modes was enabled). This is sometimes overly aggressive, since those imports are often not hit at runtime (for instance, it was impossible to write a library that worked across Node.JS and Workers, using Node packages only when running in Node). Here's an example of a function that would cause Wrangler to fail to build:
 
 ```ts
 export function randomBytes(length: number) {

--- a/.changeset/chatty-balloons-impress.md
+++ b/.changeset/chatty-balloons-impress.md
@@ -1,0 +1,44 @@
+---
+"wrangler": minor
+---
+
+feat: Support runtime-agnostic polyfills
+
+Previously, Wrangler treated any imports of `node:*` modules as build-time errors (unless one of the two Node.JS compatibility modes was enabled). This is sometimes overly aggressive, since those imports are often not hit at runtime (for instance, it was impossible to write a library that worked across Node.JS and Workers, using Node packages only when running in Node). Here's an example of a function that would cause Wrangler to fail to build:
+
+```ts
+export function randomBytes(length: number) {
+	if (navigator.userAgent !== "Cloudflare-Workers") {
+		return new Uint8Array(require("node:crypto").randomBytes(length));
+	} else {
+		return crypto.getRandomValues(new Uint8Array(length));
+	}
+}
+```
+
+This function _should_ work in both Workers and Node, since it gates Node-specific functionality behind a user agent check, and falls back to the built-in Workers crypto API. Instead, Wrangler detected the `node:crypto` import and failed with the following error:
+
+```
+✘ [ERROR] Could not resolve "node:crypto"
+
+    src/randomBytes.ts:5:36:
+      5 │ ... return new Uint8Array(require('node:crypto').randomBytes(length));
+        ╵                                   ~~~~~~~~~~~~~
+
+  The package "node:crypto" wasn't found on the file system but is built into node.
+  Add "node_compat = true" to your wrangler.toml file to enable Node.js compatibility.
+```
+
+This change turns that Wrangler build failure into a warning, which users can choose to ignore if they know the import of `node:*` APIs is safe (because it will never trigger at runtime, for instance):
+
+```
+▲ [WARNING] The package "node:crypto" wasn't found on the file system but is built into node.
+
+  Your Worker may throw errors at runtime unless you enable the "nodejs_compat"
+  compatibility flag. Refer to
+  https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.
+  Imported from:
+   - src/randomBytes.ts
+```
+
+However, in a lot of cases, it's possible to know at _build_ time whether the import is safe. This change also injects `navigator.userAgent` into `esbuild`'s bundle settings as a predefined constant, which means that `esbuild` can tree-shake away imports of `node:*` APIs that are guaranteed not to be hit at runtime, supressing the warning entirely.

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert";
+import { mkdir, writeFile, readFile } from "node:fs/promises";
+import path from "node:path";
+import dedent from "ts-dedent";
+import { bundleWorker } from "../deployment-bundle/bundle";
+import { noopModuleCollector } from "../deployment-bundle/module-collection";
+import { isNavigatorDefined } from "../navigator-user-agent";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runInTempDir } from "./helpers/run-in-tmp";
+
+/*
+ * This file contains inline comments with the word "javascript"
+ * This signals to a compatible editor extension that the template string
+ * contents should be syntax-highlighted as JavaScript. One such extension
+ * is zjcompt.es6-string-javascript, but there are others.
+ */
+
+async function seedFs(files: Record<string, string>): Promise<void> {
+	for (const [location, contents] of Object.entries(files)) {
+		await mkdir(path.dirname(location), { recursive: true });
+		await writeFile(location, contents);
+	}
+}
+
+describe("isNavigatorDefined", () => {
+	test("default", () => {
+		expect(isNavigatorDefined(undefined)).toBe(false);
+	});
+
+	test("modern date", () => {
+		expect(isNavigatorDefined("2024-01-01")).toBe(true);
+	});
+
+	test("old date", () => {
+		expect(isNavigatorDefined("2000-01-01")).toBe(false);
+	});
+
+	test("switch date", () => {
+		expect(isNavigatorDefined("2022-03-21")).toBe(true);
+	});
+
+	test("before date", () => {
+		expect(isNavigatorDefined("2022-03-20")).toBe(false);
+	});
+
+	test("old date, but with flag", () => {
+		expect(isNavigatorDefined("2000-01-01", ["global_navigator"])).toBe(true);
+	});
+
+	test("old date, with disable flag", () => {
+		expect(isNavigatorDefined("2000-01-01", ["no_global_navigator"])).toBe(
+			false
+		);
+	});
+
+	test("new date, but with disable flag", () => {
+		expect(isNavigatorDefined("2024-01-01", ["no_global_navigator"])).toBe(
+			false
+		);
+	});
+
+	test("new date, with enable flag", () => {
+		expect(isNavigatorDefined("2024-01-01", ["global_navigator"])).toBe(true);
+	});
+
+	test("errors with disable and enable flags specified", () => {
+		try {
+			isNavigatorDefined("2024-01-01", [
+				"no_global_navigator",
+				"global_navigator",
+			]);
+			assert(false, "Unreachable");
+		} catch (e) {
+			expect(e).toMatchInlineSnapshot(
+				`[AssertionError: Can't both enable and disable a flag]`
+			);
+		}
+	});
+});
+
+// Does bundleWorker respect the value of `defineNavigatorUserAgent`?
+describe("defineNavigatorUserAgent is respected", () => {
+	runInTempDir();
+	const std = mockConsoleMethods();
+
+	it("defineNavigatorUserAgent = false, navigator preserved", async () => {
+		await seedFs({
+			"src/index.js": dedent/* javascript */ `
+			function randomBytes(length) {
+				if (navigator.userAgent !== "Cloudflare-Workers") {
+					return new Uint8Array(require("node:crypto").randomBytes(length));
+				} else {
+					return crypto.getRandomValues(new Uint8Array(length));
+				}
+			}
+			export default {
+				async fetch(request, env) {
+					return new Response(randomBytes(10))
+				},
+			};
+		`,
+		});
+
+		await bundleWorker(
+			{
+				file: path.resolve("src/index.js"),
+				directory: process.cwd(),
+				format: "modules",
+				moduleRoot: path.dirname(path.resolve("src/index.js")),
+			},
+			path.resolve("dist"),
+			{
+				bundle: true,
+				additionalModules: [],
+				moduleCollector: noopModuleCollector,
+				serveAssetsFromWorker: false,
+				doBindings: [],
+				define: {},
+				checkFetch: false,
+				targetConsumer: "deploy",
+				local: true,
+				projectRoot: process.cwd(),
+				defineNavigatorUserAgent: false,
+			}
+		);
+
+		// Build time warning that the dynamic import of `require("node:crypto")` may not be safe
+		expect(std.warn).toMatchInlineSnapshot(`
+		"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe package \\"node:crypto\\" wasn't found on the file system but is built into node.[0m
+
+		  Your Worker may throw errors at runtime unless you enable the \\"nodejs_compat\\" compatibility flag.
+		  Refer to [4mhttps://developers.cloudflare.com/workers/runtime-apis/nodejs/[0m for more details. Imported
+		  from:
+		   - src/index.js
+
+		"
+	`);
+		const fileContents = await readFile("dist/index.js", "utf8");
+
+		// navigator.userAgent should have been preserved as-is
+		expect(fileContents).toContain("navigator.userAgent");
+	});
+
+	it("defineNavigatorUserAgent = true, navigator treeshaken", async () => {
+		await seedFs({
+			"src/index.js": dedent/* javascript */ `
+			function randomBytes(length) {
+				if (navigator.userAgent !== "Cloudflare-Workers") {
+					return new Uint8Array(require("node:crypto").randomBytes(length));
+				} else {
+					return crypto.getRandomValues(new Uint8Array(length));
+				}
+			}
+			export default {
+				async fetch(request, env) {
+					return new Response(randomBytes(10))
+				},
+			};
+		`,
+		});
+
+		await bundleWorker(
+			{
+				file: path.resolve("src/index.js"),
+				directory: process.cwd(),
+				format: "modules",
+				moduleRoot: path.dirname(path.resolve("src/index.js")),
+			},
+			path.resolve("dist"),
+			{
+				bundle: true,
+				additionalModules: [],
+				moduleCollector: noopModuleCollector,
+				serveAssetsFromWorker: false,
+				doBindings: [],
+				define: {},
+				checkFetch: false,
+				targetConsumer: "deploy",
+				local: true,
+				projectRoot: process.cwd(),
+				defineNavigatorUserAgent: true,
+			}
+		);
+
+		// Build time warning is suppressed, because esbuild treeshakes the relevant code path
+		expect(std.warn).toMatchInlineSnapshot(`""`);
+
+		const fileContents = await readFile("dist/index.js", "utf8");
+
+		// navigator.userAgent should have been defined, and so should not be present in the bundle
+		expect(fileContents).not.toContain("navigator.userAgent");
+	});
+});

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { mkdir, writeFile, readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import dedent from "ts-dedent";
 import { bundleWorker } from "../deployment-bundle/bundle";

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -413,7 +413,7 @@ export default {
 		);
 	});
 
-	it("should error at Node.js imports when the `nodejs_compat` compatibility flag is not set", async () => {
+	it("should warn at Node.js imports when the `nodejs_compat` compatibility flag is not set", async () => {
 		mkdirSync("functions");
 		writeFileSync(
 			"functions/hello.js",
@@ -428,17 +428,18 @@ export default {
 		);
 
 		await expect(
-			runWrangler(`pages functions build --outfile=public/_worker.bundle`)
-		).rejects.toThrowErrorMatchingInlineSnapshot(`
-		"Build failed with 1 error:
-		hello.js:2:36: ERROR: Could not resolve \\"node:async_hooks\\""
+			await runWrangler(`pages functions build --outfile=public/_worker.bundle`)
+		);
+		expect(std.warn).toMatchInlineSnapshot(`
+		"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe package \\"node:async_hooks\\" wasn't found on the file system but is built into node.[0m
+
+		  Your Worker may throw errors at runtime unless you enable the \\"nodejs_compat\\" compatibility flag.
+		  Refer to [4mhttps://developers.cloudflare.com/workers/runtime-apis/nodejs/[0m for more details. Imported
+		  from:
+		   - hello.js
+
+		"
 	`);
-		expect(std.err).toContain(
-			'The package "node:async_hooks" wasn\'t found on the file system but is built into node.'
-		);
-		expect(std.err).toContain(
-			'Add the "nodejs_compat" compatibility flag to your Pages project and make sure to prefix the module name with "node:" to enable Node.js compatibility.'
-		);
 	});
 
 	it("should compile a _worker.js/ directory", async () => {

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -5,6 +5,7 @@ import { File, FormData } from "undici";
 import { fetchResult } from "../../cfetch";
 import { FatalError } from "../../errors";
 import { logger } from "../../logger";
+import { isNavigatorDefined } from "../../navigator-user-agent";
 import { buildFunctions } from "../../pages/buildFunctions";
 import { MAX_DEPLOYMENT_ATTEMPTS } from "../../pages/constants";
 import {
@@ -23,8 +24,7 @@ import { getPagesTmpDir } from "../../pages/utils";
 import { validate } from "../../pages/validate";
 import { createUploadWorkerBundleContents } from "./create-worker-bundle-contents";
 import type { BundleResult } from "../../deployment-bundle/bundle";
-import type { Project, Deployment } from "@cloudflare/types";
-import { isNavigatorDefined } from "../../navigator-user-agent";
+import type { Deployment, Project } from "@cloudflare/types";
 
 interface PagesDeployOptions {
 	/**

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -23,7 +23,8 @@ import { getPagesTmpDir } from "../../pages/utils";
 import { validate } from "../../pages/validate";
 import { createUploadWorkerBundleContents } from "./create-worker-bundle-contents";
 import type { BundleResult } from "../../deployment-bundle/bundle";
-import type { Deployment, Project } from "@cloudflare/types";
+import type { Project, Deployment } from "@cloudflare/types";
+import { isNavigatorDefined } from "../../navigator-user-agent";
 
 interface PagesDeployOptions {
 	/**
@@ -143,6 +144,10 @@ export async function deploy({
 	const nodejsCompat =
 		deploymentConfig.compatibility_flags?.includes("nodejs_compat");
 
+	const defineNavigatorUserAgent = isNavigatorDefined(
+		deploymentConfig.compatibility_date,
+		deploymentConfig.compatibility_flags
+	);
 	/**
 	 * Evaluate if this is an Advanced Mode or Pages Functions project. If Advanced Mode, we'll
 	 * go ahead and upload `_worker.js` as is, but if Pages Functions, we need to attempt to build
@@ -175,6 +180,7 @@ export async function deploy({
 				routesOutputPath,
 				local: false,
 				nodejsCompat,
+				defineNavigatorUserAgent,
 			});
 
 			builtFunctions = readFileSync(
@@ -254,6 +260,7 @@ export async function deploy({
 			workerJSDirectory: _workerPath,
 			buildOutputDirectory: directory,
 			nodejsCompat,
+			defineNavigatorUserAgent,
 		});
 	} else if (_workerJS) {
 		if (bundle) {
@@ -270,6 +277,7 @@ export async function deploy({
 				watch: false,
 				onEnd: () => {},
 				nodejsCompat,
+				defineNavigatorUserAgent,
 			});
 		} else {
 			await checkRawWorker(_workerPath, () => {});

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -26,6 +26,7 @@ import { getMigrationsToUpload } from "../durable";
 import { UserError } from "../errors";
 import { logger } from "../logger";
 import { getMetricsUsageHeaders } from "../metrics";
+import { isNavigatorDefined } from "../navigator-user-agent";
 import { APIError, ParseError } from "../parse";
 import { getWranglerTmpDir } from "../paths";
 import { getQueue, putConsumer } from "../queues/client";
@@ -54,7 +55,6 @@ import type {
 import type { PutConsumerBody } from "../queues/client";
 import type { AssetPaths } from "../sites";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
-import { isNavigatorDefined } from "../navigator-user-agent";
 
 type Props = {
 	config: Config;

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -54,6 +54,7 @@ import type {
 import type { PutConsumerBody } from "../queues/client";
 import type { AssetPaths } from "../sites";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
+import { isNavigatorDefined } from "../navigator-user-agent";
 
 type Props = {
 	config: Config;
@@ -520,8 +521,25 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 							targetConsumer: "deploy",
 							local: false,
 							projectRoot: props.projectRoot,
+							defineNavigatorUserAgent: isNavigatorDefined(
+								props.compatibilityDate ?? config.compatibility_date,
+								props.compatibilityFlags ?? config.compatibility_flags
+							),
 						}
 				  );
+
+		// Add modules to dependencies for size warning
+		for (const module of modules) {
+			const modulePath =
+				module.filePath === undefined
+					? module.name
+					: path.relative("", module.filePath);
+			const bytesInOutput =
+				typeof module.content === "string"
+					? Buffer.byteLength(module.content)
+					: module.content.byteLength;
+			dependencies[modulePath] = { bytesInOutput };
+		}
 
 		// Add modules to dependencies for size warning
 		for (const module of modules) {

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -328,7 +328,7 @@ export async function bundleWorker(
 			...(legacyNodeCompat
 				? [NodeGlobalsPolyfills({ buffer: true }), NodeModulesPolyfills()]
 				: []),
-			...(nodejsCompat ? [nodejsCompatPlugin] : []),
+			nodejsCompatPlugin(!!nodejsCompat),
 			cloudflareInternalPlugin,
 			buildResultPlugin,
 			...(plugins || []),

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -312,6 +312,7 @@ export async function bundleWorker(
 		conditions: BUILD_CONDITIONS,
 		...(process.env.NODE_ENV && {
 			define: {
+				"navigator.userAgent": `"Cloudflare-Workers"`,
 				// use process.env["NODE_ENV" + ""] so that esbuild doesn't replace it
 				// when we do a build of wrangler. (re: https://github.com/cloudflare/workers-sdk/issues/1477)
 				"process.env.NODE_ENV": `"${process.env["NODE_ENV" + ""]}"`,

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -86,6 +86,7 @@ export type BundleOptions = {
 	forPages?: boolean;
 	local: boolean;
 	projectRoot: string | undefined;
+	defineNavigatorUserAgent: boolean;
 };
 
 /**
@@ -124,6 +125,7 @@ export async function bundleWorker(
 		forPages,
 		local,
 		projectRoot,
+		defineNavigatorUserAgent,
 	}: BundleOptions
 ): Promise<BundleResult> {
 	// We create a temporary directory for any one-off files we
@@ -312,7 +314,9 @@ export async function bundleWorker(
 		conditions: BUILD_CONDITIONS,
 		...(process.env.NODE_ENV && {
 			define: {
-				"navigator.userAgent": `"Cloudflare-Workers"`,
+				...(defineNavigatorUserAgent
+					? { "navigator.userAgent": `"Cloudflare-Workers"` }
+					: {}),
 				// use process.env["NODE_ENV" + ""] so that esbuild doesn't replace it
 				// when we do a build of wrangler. (re: https://github.com/cloudflare/workers-sdk/issues/1477)
 				"process.env.NODE_ENV": `"${process.env["NODE_ENV" + ""]}"`,

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -1,13 +1,64 @@
+import chalk from "chalk";
+import { logger } from "../../logger";
 import type { Plugin } from "esbuild";
+
+// Infinite loop detection
+const seen = new Set();
+
+// Prevent multiple warnings per package
+const warnedPackaged = new Map();
 
 /**
  * An esbuild plugin that will mark any `node:...` imports as external.
  */
-export const nodejsCompatPlugin: Plugin = {
+export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
+	silenceWarnings
+) => ({
 	name: "nodejs_compat imports plugin",
 	setup(pluginBuild) {
-		pluginBuild.onResolve({ filter: /node:.*/ }, () => {
-			return { external: true };
+		pluginBuild.onResolve(
+			{ filter: /node:.*/ },
+			async ({ path, kind, resolveDir, ...opts }) => {
+				if (seen.has(`${path}:${kind}:${resolveDir}:${opts.importer}`)) {
+					return;
+				}
+
+				seen.add(`${path}:${kind}:${resolveDir}:${opts.importer}`);
+				// Try to resolve this import as a normal package
+				const result = await pluginBuild.resolve(path, {
+					kind,
+					resolveDir,
+					importer: opts.importer,
+				});
+
+				if (result.errors.length > 0) {
+					// esbuild couldn't resolve the package
+					// We should warn the user, but not fail the build
+					if (!warnedPackaged.has(path)) {
+						warnedPackaged.set(path, [opts.importer]);
+					} else {
+						warnedPackaged.set(path, [
+							...warnedPackaged.get(path),
+							opts.importer,
+						]);
+					}
+					return { external: true };
+				}
+				// This is a normal package—don't treat it specially
+				return result;
+			}
+		);
+		// Wait until the build finishes to log warnings, so that all files which import a package
+		// can be collated
+		pluginBuild.onEnd(() => {
+			if (!silenceWarnings)
+				warnedPackaged.forEach((importers: string[], path: string) => {
+					logger.warn(
+						`The package "${path}" wasn't found on the file system but is built into node.
+Your Worker may throw errors at runtime unless you enable the "nodejs_compat" compatibility flag. Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details. Imported from:
+${importers.map((i) => ` - ${chalk.blue(i)}`).join("\n")}`
+					);
+				});
 		});
 	},
-};
+});

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -1,4 +1,3 @@
-import { readFile } from "fs/promises";
 import chalk from "chalk";
 import { logger } from "../../logger";
 import type { Plugin } from "esbuild";
@@ -35,23 +34,6 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 				if (result.errors.length > 0) {
 					// esbuild couldn't resolve the package
 					// We should warn the user, but not fail the build
-
-					// First, check whether the importer has specifically silenced warnings for this import
-					const importer = await readFile(opts.importer, "utf8");
-
-					const allowlistedModules =
-						/\/\/ wrangler-allowlist (".*?")\w*\n/.exec(importer);
-					if (allowlistedModules?.[1]) {
-						// Remove quotes
-						const modules = allowlistedModules[1]
-							.split(" ")
-							.map((m) => m.slice(1, -1));
-
-						// Disable warnings for this node:* module in this file
-						if (modules.includes(path)) {
-							return { external: true };
-						}
-					}
 
 					if (!warnedPackaged.has(path)) {
 						warnedPackaged.set(path, [opts.importer]);

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -1,3 +1,4 @@
+import { readFile } from "fs/promises";
 import chalk from "chalk";
 import { logger } from "../../logger";
 import type { Plugin } from "esbuild";
@@ -34,6 +35,24 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 				if (result.errors.length > 0) {
 					// esbuild couldn't resolve the package
 					// We should warn the user, but not fail the build
+
+					// First, check whether the importer has specifically silenced warnings for this import
+					const importer = await readFile(opts.importer, "utf8");
+
+					const allowlistedModules =
+						/\/\/ wrangler-allowlist (".*?")\w*\n/.exec(importer);
+					if (allowlistedModules?.[1]) {
+						// Remove quotes
+						const modules = allowlistedModules[1]
+							.split(" ")
+							.map((m) => m.slice(1, -1));
+
+						// Disable warnings for this node:* module in this file
+						if (modules.includes(path)) {
+							return { external: true };
+						}
+					}
+
 					if (!warnedPackaged.has(path)) {
 						warnedPackaged.set(path, [opts.importer]);
 					} else {

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -1,7 +1,7 @@
+import { relative } from "path";
 import chalk from "chalk";
 import { logger } from "../../logger";
 import type { Plugin } from "esbuild";
-import { relative } from "path";
 
 // Infinite loop detection
 const seen = new Set();
@@ -17,6 +17,8 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 ) => ({
 	name: "nodejs_compat imports plugin",
 	setup(pluginBuild) {
+		seen.clear();
+		warnedPackaged.clear();
 		pluginBuild.onResolve(
 			{ filter: /node:.*/ },
 			async ({ path, kind, resolveDir, ...opts }) => {

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -24,6 +24,7 @@ import {
 	unregisterWorker,
 } from "../dev-registry";
 import { logger } from "../logger";
+import { isNavigatorDefined } from "../navigator-user-agent";
 import openInBrowser from "../open-in-browser";
 import { getWranglerTmpDir } from "../paths";
 import { openInspector } from "./inspect";
@@ -41,7 +42,6 @@ import type { EnablePagesAssetsServiceBindingOptions } from "../miniflare-cli/ty
 import type { EphemeralDirectory } from "../paths";
 import type { AssetPaths } from "../sites";
 import type { EsbuildBundle } from "./use-esbuild";
-import { isNavigatorDefined } from "../navigator-user-agent";
 
 /**
  * This hooks establishes a connection with the dev registry,

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -41,6 +41,7 @@ import type { EnablePagesAssetsServiceBindingOptions } from "../miniflare-cli/ty
 import type { EphemeralDirectory } from "../paths";
 import type { AssetPaths } from "../sites";
 import type { EsbuildBundle } from "./use-esbuild";
+import { isNavigatorDefined } from "../navigator-user-agent";
 
 /**
  * This hooks establishes a connection with the dev registry,
@@ -354,6 +355,10 @@ function DevSession(props: DevSessionProps) {
 		experimentalLocal: props.experimentalLocal,
 		projectRoot: props.projectRoot,
 		onBundleStart,
+		defineNavigatorUserAgent: isNavigatorDefined(
+			props.compatibilityDate,
+			props.compatibilityFlags
+		),
 	});
 	useEffect(() => {
 		if (bundle) onReloadStart(bundle);

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -33,6 +33,7 @@ import type { WorkerRegistry } from "../dev-registry";
 import type { DevProps } from "./dev";
 import type { LocalProps } from "./local";
 import type { EsbuildBundle } from "./use-esbuild";
+import { isNavigatorDefined } from "../navigator-user-agent";
 
 export async function startDevServer(
 	props: DevProps & {
@@ -139,6 +140,10 @@ export async function startDevServer(
 		local: props.local,
 		doBindings: props.bindings.durable_objects?.bindings ?? [],
 		projectRoot: props.projectRoot,
+		defineNavigatorUserAgent: isNavigatorDefined(
+			props.compatibilityDate,
+			props.compatibilityFlags
+		),
 	});
 
 	if (props.local) {
@@ -290,6 +295,7 @@ async function runEsbuild({
 	local,
 	doBindings,
 	projectRoot,
+	defineNavigatorUserAgent,
 }: {
 	entry: Entry;
 	destination: string;
@@ -313,6 +319,7 @@ async function runEsbuild({
 	local: boolean;
 	doBindings: DurableObjectBindings;
 	projectRoot: string | undefined;
+	defineNavigatorUserAgent: boolean;
 }): Promise<EsbuildBundle> {
 	if (noBundle) {
 		additionalModules = dedupeModulesByName([
@@ -359,6 +366,7 @@ async function runEsbuild({
 					testScheduled,
 					doBindings,
 					projectRoot,
+					defineNavigatorUserAgent,
 			  })
 			: undefined;
 

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -19,6 +19,7 @@ import {
 	stopWorkerRegistry,
 } from "../dev-registry";
 import { logger } from "../logger";
+import { isNavigatorDefined } from "../navigator-user-agent";
 import { getWranglerTmpDir } from "../paths";
 import { localPropsToConfigBundle, maybeRegisterLocalWorker } from "./local";
 import { DEFAULT_WORKER_NAME, MiniflareServer } from "./miniflare";
@@ -33,7 +34,6 @@ import type { WorkerRegistry } from "../dev-registry";
 import type { DevProps } from "./dev";
 import type { LocalProps } from "./local";
 import type { EsbuildBundle } from "./use-esbuild";
-import { isNavigatorDefined } from "../navigator-user-agent";
 
 export async function startDevServer(
 	props: DevProps & {

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -58,6 +58,7 @@ export function useEsbuild({
 	experimentalLocal,
 	projectRoot,
 	onBundleStart,
+	defineNavigatorUserAgent,
 }: {
 	entry: Entry;
 	destination: string | undefined;
@@ -84,6 +85,7 @@ export function useEsbuild({
 	experimentalLocal: boolean | undefined;
 	projectRoot: string | undefined;
 	onBundleStart: () => void;
+	defineNavigatorUserAgent: boolean;
 }): EsbuildBundle | undefined {
 	const [bundle, setBundle] = useState<EsbuildBundle>();
 	const { exit } = useApp();
@@ -190,6 +192,7 @@ export function useEsbuild({
 							plugins: [onEnd],
 							local,
 							projectRoot,
+							defineNavigatorUserAgent,
 					  })
 					: undefined;
 

--- a/packages/wrangler/src/navigator-user-agent.ts
+++ b/packages/wrangler/src/navigator-user-agent.ts
@@ -5,8 +5,10 @@ export function isNavigatorDefined(
 	compatibility_flags: string[] = []
 ) {
 	assert(
-		compatibility_flags.includes("global_navigator") &&
-			compatibility_flags.includes("no_global_navigator"),
+		!(
+			compatibility_flags.includes("global_navigator") &&
+			compatibility_flags.includes("no_global_navigator")
+		),
 		"Can't both enable and disable a flag"
 	);
 	if (compatibility_flags.includes("global_navigator")) {
@@ -15,5 +17,5 @@ export function isNavigatorDefined(
 	if (compatibility_flags.includes("no_global_navigator")) {
 		return false;
 	}
-	return !compatibility_date || compatibility_date >= "2022-03-21";
+	return !!compatibility_date && compatibility_date >= "2022-03-21";
 }

--- a/packages/wrangler/src/navigator-user-agent.ts
+++ b/packages/wrangler/src/navigator-user-agent.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert";
+
+export function isNavigatorDefined(
+	compatibility_date: string | undefined,
+	compatibility_flags: string[] = []
+) {
+	assert(
+		compatibility_flags.includes("global_navigator") &&
+			compatibility_flags.includes("no_global_navigator"),
+		"Can't both enable and disable a flag"
+	);
+	if (compatibility_flags.includes("global_navigator")) {
+		return true;
+	}
+	if (compatibility_flags.includes("no_global_navigator")) {
+		return false;
+	}
+	return !compatibility_date || compatibility_date >= "2022-03-21";
+}

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -21,6 +21,7 @@ import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
+import { isNavigatorDefined } from "../navigator-user-agent";
 
 export type PagesBuildArgs = StrictYargsOptionsToInterface<typeof Options>;
 
@@ -126,6 +127,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 			plugin,
 			nodejsCompat,
 			legacyNodeCompat,
+			defineNavigatorUserAgent,
 		} = validatedArgs;
 
 		try {
@@ -151,6 +153,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 				nodejsCompat,
 				routesOutputPath,
 				local: false,
+				defineNavigatorUserAgent,
 			});
 		} catch (e) {
 			if (e instanceof FunctionsNoRoutesError) {
@@ -188,6 +191,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 			nodejsCompat,
 			legacyNodeCompat,
 			workerScriptPath,
+			defineNavigatorUserAgent,
 		} = validatedArgs;
 
 		/**
@@ -200,6 +204,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 					workerJSDirectory: workerScriptPath,
 					buildOutputDirectory,
 					nodejsCompat,
+					defineNavigatorUserAgent,
 				});
 			} else {
 				/**
@@ -216,6 +221,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 					sourcemap,
 					watch,
 					nodejsCompat,
+					defineNavigatorUserAgent,
 				});
 			}
 		} else {
@@ -240,6 +246,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 					nodejsCompat,
 					routesOutputPath,
 					local: false,
+					defineNavigatorUserAgent,
 				});
 			} catch (e) {
 				if (e instanceof FunctionsNoRoutesError) {
@@ -278,7 +285,7 @@ type WorkerBundleArgs = Omit<PagesBuildArgs, "nodeCompat"> & {
 	buildOutputDirectory: string;
 	legacyNodeCompat: boolean;
 	nodejsCompat: boolean;
-
+	defineNavigatorUserAgent: boolean;
 	workerScriptPath: string;
 };
 type PluginArgs = Omit<
@@ -289,6 +296,7 @@ type PluginArgs = Omit<
 	outdir: string;
 	legacyNodeCompat: boolean;
 	nodejsCompat: boolean;
+	defineNavigatorUserAgent: boolean;
 };
 
 type ValidatedArgs = WorkerBundleArgs | PluginArgs;
@@ -357,6 +365,10 @@ const validateArgs = (args: PagesBuildArgs): ValidatedArgs => {
 		);
 	}
 	const nodejsCompat = !!args.compatibilityFlags?.includes("nodejs_compat");
+	const defineNavigatorUserAgent = isNavigatorDefined(
+		args.compatibilityDate,
+		args.compatibilityFlags
+	);
 	if (legacyNodeCompat && nodejsCompat) {
 		throw new UserError(
 			"The `nodejs_compat` compatibility flag cannot be used in conjunction with the legacy `--node-compat` flag. If you want to use the Workers runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command."
@@ -404,5 +416,6 @@ We looked for the Functions directory (${basename(
 		workerScriptPath,
 		nodejsCompat,
 		legacyNodeCompat,
+		defineNavigatorUserAgent,
 	} as ValidatedArgs;
 };

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -5,6 +5,7 @@ import { writeAdditionalModules } from "../deployment-bundle/find-additional-mod
 import { FatalError, UserError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
+import { isNavigatorDefined } from "../navigator-user-agent";
 import { buildFunctions } from "./buildFunctions";
 import {
 	EXIT_CODE_FUNCTIONS_NO_ROUTES_ERROR,
@@ -21,7 +22,6 @@ import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
-import { isNavigatorDefined } from "../navigator-user-agent";
 
 export type PagesBuildArgs = StrictYargsOptionsToInterface<typeof Options>;
 

--- a/packages/wrangler/src/pages/buildFunctions.ts
+++ b/packages/wrangler/src/pages/buildFunctions.ts
@@ -38,6 +38,7 @@ export async function buildFunctions({
 		getPagesTmpDir(),
 		`./functionsRoutes-${Math.random()}.mjs`
 	),
+	defineNavigatorUserAgent,
 }: Partial<
 	Pick<
 		PagesBuildArgs,
@@ -61,6 +62,7 @@ export async function buildFunctions({
 	// Allow `routesModule` to be fixed, so we don't create a new file in the
 	// temporary directory each time
 	routesModule?: string;
+	defineNavigatorUserAgent: boolean;
 }) {
 	RUNNING_BUILDERS.forEach(
 		(runningBuilder) => runningBuilder.stop && runningBuilder.stop()
@@ -117,6 +119,7 @@ export async function buildFunctions({
 			legacyNodeCompat,
 			functionsDirectory: absoluteFunctionsDirectory,
 			local,
+			defineNavigatorUserAgent,
 		});
 	} else {
 		bundle = await buildWorkerFromFunctions({
@@ -133,6 +136,7 @@ export async function buildFunctions({
 			buildOutputDirectory,
 			legacyNodeCompat,
 			nodejsCompat,
+			defineNavigatorUserAgent,
 		});
 	}
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -33,6 +33,7 @@ import type {
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
 import type { RoutesJSONSpec } from "./functions/routes-transformation";
+import { isNavigatorDefined } from "../navigator-user-agent";
 
 /*
  * DURABLE_OBJECTS_BINDING_REGEXP matches strings like:
@@ -304,6 +305,10 @@ export const Handler = async ({
 	let scriptPath = "";
 
 	const nodejsCompat = compatibilityFlags?.includes("nodejs_compat");
+	const defineNavigatorUserAgent = isNavigatorDefined(
+		compatibilityDate,
+		compatibilityFlags
+	);
 	let modules: CfModule[] = [];
 
 	if (usingWorkerDirectory) {
@@ -312,6 +317,7 @@ export const Handler = async ({
 				workerJSDirectory: workerScriptPath,
 				buildOutputDirectory: directory ?? ".",
 				nodejsCompat,
+				defineNavigatorUserAgent,
 			});
 			modules = bundleResult.modules;
 			scriptPath = bundleResult.resolvedEntryPointPath;
@@ -360,6 +366,7 @@ export const Handler = async ({
 						sourcemap: true,
 						watch: false,
 						onEnd: () => scriptReadyResolve(),
+						defineNavigatorUserAgent,
 					});
 				} catch (e: unknown) {
 					logger.warn("Failed to bundle _worker.js.", e);
@@ -416,6 +423,7 @@ export const Handler = async ({
 					nodejsCompat,
 					local: true,
 					routesModule,
+					defineNavigatorUserAgent,
 				});
 				await metrics.sendMetricsEvent("build pages functions");
 			};

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -9,6 +9,7 @@ import { esbuildAliasExternalPlugin } from "../deployment-bundle/esbuild-plugins
 import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
+import { isNavigatorDefined } from "../navigator-user-agent";
 import { getBasePath } from "../paths";
 import * as shellquote from "../utils/shell-quote";
 import { buildFunctions } from "./buildFunctions";
@@ -33,7 +34,6 @@ import type {
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
 import type { RoutesJSONSpec } from "./functions/routes-transformation";
-import { isNavigatorDefined } from "../navigator-user-agent";
 
 /*
  * DURABLE_OBJECTS_BINDING_REGEXP matches strings like:

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -23,6 +23,7 @@ export function buildPluginFromFunctions({
 	legacyNodeCompat,
 	functionsDirectory,
 	local,
+	defineNavigatorUserAgent,
 }: Options) {
 	const entry: Entry = {
 		file: resolve(getBasePath(), "templates/pages-template-plugin.ts"),
@@ -107,5 +108,6 @@ export function buildPluginFromFunctions({
 		forPages: true,
 		local,
 		projectRoot: getPagesProjectRoot(),
+		defineNavigatorUserAgent,
 	});
 }

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -31,6 +31,7 @@ export type Options = {
 	nodejsCompat?: boolean;
 	functionsDirectory: string;
 	local: boolean;
+	defineNavigatorUserAgent: boolean;
 };
 
 export function buildWorkerFromFunctions({
@@ -47,6 +48,7 @@ export function buildWorkerFromFunctions({
 	nodejsCompat,
 	functionsDirectory,
 	local,
+	defineNavigatorUserAgent,
 }: Options) {
 	const entry: Entry = {
 		file: resolve(getBasePath(), "templates/pages-template-worker.ts"),
@@ -158,6 +160,7 @@ export function buildWorkerFromFunctions({
 		forPages: true,
 		local,
 		projectRoot: getPagesProjectRoot(),
+		defineNavigatorUserAgent,
 	});
 }
 
@@ -178,6 +181,7 @@ export type RawOptions = {
 	nodejsCompat?: boolean;
 	local: boolean;
 	additionalModules?: CfModule[];
+	defineNavigatorUserAgent: boolean;
 };
 
 /**
@@ -203,6 +207,7 @@ export function buildRawWorker({
 	nodejsCompat,
 	local,
 	additionalModules = [],
+	defineNavigatorUserAgent,
 }: RawOptions) {
 	const entry: Entry = {
 		file: workerScriptPath,
@@ -252,6 +257,7 @@ export function buildRawWorker({
 		forPages: true,
 		local,
 		projectRoot: getPagesProjectRoot(),
+		defineNavigatorUserAgent,
 	});
 }
 
@@ -259,10 +265,12 @@ export async function traverseAndBuildWorkerJSDirectory({
 	workerJSDirectory,
 	buildOutputDirectory,
 	nodejsCompat,
+	defineNavigatorUserAgent,
 }: {
 	workerJSDirectory: string;
 	buildOutputDirectory: string;
 	nodejsCompat?: boolean;
+	defineNavigatorUserAgent: boolean;
 }): Promise<BundleResult> {
 	const entrypoint = resolve(join(workerJSDirectory, "index.js"));
 
@@ -297,6 +305,7 @@ export async function traverseAndBuildWorkerJSDirectory({
 		onEnd: () => {},
 		nodejsCompat,
 		additionalModules,
+		defineNavigatorUserAgent,
 	});
 
 	return {

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -23,6 +23,7 @@ import { getMigrationsToUpload } from "../durable";
 import { UserError } from "../errors";
 import { logger } from "../logger";
 import { getMetricsUsageHeaders } from "../metrics";
+import { isNavigatorDefined } from "../navigator-user-agent";
 import { ParseError } from "../parse";
 import { getWranglerTmpDir } from "../paths";
 import { getQueue } from "../queues/client";
@@ -294,6 +295,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 							targetConsumer: "deploy",
 							local: false,
 							projectRoot: props.projectRoot,
+							defineNavigatorUserAgent: isNavigatorDefined(
+								props.compatibilityDate ?? config.compatibility_date,
+								props.compatibilityFlags ?? config.compatibility_flags
+							),
 						}
 				  );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,7 +820,7 @@ importers:
         version: 8.49.0
       eslint-config-turbo:
         specifier: latest
-        version: 1.10.15(eslint@8.49.0)
+        version: 1.12.3(eslint@8.49.0)
       eslint-plugin-import:
         specifier: 2.26.x
         version: 2.26.0(@typescript-eslint/parser@6.7.2)(eslint@8.49.0)
@@ -3956,17 +3956,8 @@ packages:
       marked: 0.3.19
     dev: false
 
-  /@cloudflare/workerd-darwin-64@1.20231025.0:
-    resolution: {integrity: sha512-MYRYTbSl+tjGg6su7savlLIb8cOcKJfdGpA+WdtgqT2OF7O+89Lag0l1SA/iyVlUkT31Jc6OLHqvzsXgmg+niQ==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@cloudflare/workerd-darwin-64@1.20231030.0:
-    resolution: {integrity: sha512-J4PQ9utPxLya9yHdMMx3AZeC5M/6FxcoYw6jo9jbDDFTy+a4Gslqf4Im9We3aeOEdPXa3tgQHVQOSelJSZLhIw==}
+  /@cloudflare/workerd-darwin-64@1.20240129.0:
+    resolution: {integrity: sha512-DfVVB5IsQLVcWPJwV019vY3nEtU88c2Qu2ST5SQxqcGivZ52imagLRK0RHCIP8PK4piSiq90qUC6ybppUsw8eg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -3974,17 +3965,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-darwin-arm64@1.20231025.0:
-    resolution: {integrity: sha512-BszjtBDR84TVa6oWe74dePJSAukWlTmLw9zR4KeWuwZLJGV7RMm6AmwGStetjnwZrecZaaOFELfBCAHtsebV0Q==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@cloudflare/workerd-darwin-arm64@1.20231030.0:
-    resolution: {integrity: sha512-WSJJjm11Del4hSneiNB7wTXGtBXI4QMCH9l5qf4iT5PAW8cESGcCmdHtWDWDtGAAGcvmLT04KNvmum92vRKKQQ==}
+  /@cloudflare/workerd-darwin-arm64@1.20240129.0:
+    resolution: {integrity: sha512-t0q8ABkmumG1zRM/MZ/vIv/Ysx0vTAXnQAPy/JW5aeQi/tqrypXkO9/NhPc0jbF/g/hIPrWEqpDgEp3CB7Da7Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -3992,17 +3974,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-64@1.20231025.0:
-    resolution: {integrity: sha512-AT9dxgKXOa9xZxZ3k2a432axPJJ58KpoNWnPiPYGpuAuLoWnfcYwwh6mr9sZVcTdAdTAK9Xu9c81tp0YABanUw==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@cloudflare/workerd-linux-64@1.20231030.0:
-    resolution: {integrity: sha512-2HUeRTvoCC17fxE0qdBeR7J9dO8j4A8ZbdcvY8pZxdk+zERU6+N03RTbk/dQMU488PwiDvcC3zZqS4gwLfVT8g==}
+  /@cloudflare/workerd-linux-64@1.20240129.0:
+    resolution: {integrity: sha512-sFV1uobHgDI+6CKBS/ZshQvOvajgwl6BtiYaH4PSFSpvXTmRx+A9bcug+6BnD+V4WgwxTiEO2iR97E1XuwDAVw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -4010,17 +3983,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-arm64@1.20231025.0:
-    resolution: {integrity: sha512-EIjex5o2k80YZWPix1btGybL/vNZ3o6vqKX9ptS0JcFkHV5aFX5/kcMwSBRjiIC+w04zVjmGQx3N1Vh3njuncg==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@cloudflare/workerd-linux-arm64@1.20231030.0:
-    resolution: {integrity: sha512-4/GK5zHh+9JbUI6Z5xTCM0ZmpKKHk7vu9thmHjUxtz+o8Ne9DoD7DlDvXQWgMF6XGaTubDWyp3ttn+Qv8jDFuQ==}
+  /@cloudflare/workerd-linux-arm64@1.20240129.0:
+    resolution: {integrity: sha512-O7q7htHaFRp8PgTqNJx1/fYc3+LnvAo6kWWB9a14C5OWak6AAZk42PNpKPx+DXTmGvI+8S1+futBGUeJ8NPDXg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -4028,17 +3992,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-windows-64@1.20231025.0:
-    resolution: {integrity: sha512-7vtq0mO22A2v0OOsKXa760r9a84Gg8CK0gDu5uNWlj6hojmt011iz7jJt76I7oo/XrVwVlVfu69GnA3ljx6U8w==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@cloudflare/workerd-windows-64@1.20231030.0:
-    resolution: {integrity: sha512-fb/Jgj8Yqy3PO1jLhk7mTrHMkR8jklpbQFud6rL/aMAn5d6MQbaSrYOCjzkKGp0Zng8D2LIzSl+Fc0C9Sggxjg==}
+  /@cloudflare/workerd-windows-64@1.20240129.0:
+    resolution: {integrity: sha512-YqGno0XSqqqkDmNoGEX6M8kJlI2lEfWntbTPVtHaZlaXVR9sWfoD7TEno0NKC95cXFz+ioyFLbgbOdnfWwmVAA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -8397,6 +8352,7 @@ packages:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
     dependencies:
       printable-characters: 1.0.42
+    dev: false
 
   /assert@2.0.0:
     resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
@@ -9097,6 +9053,7 @@ packages:
       tslib: 2.5.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
     patched: true
 
   /capnpc-ts@0.7.0:
@@ -9853,6 +9810,7 @@ packages:
 
   /data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
+    dev: false
 
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
@@ -10760,13 +10718,13 @@ packages:
       eslint: 8.49.0
     dev: true
 
-  /eslint-config-turbo@1.10.15(eslint@8.49.0):
-    resolution: {integrity: sha512-76mpx2x818JZE26euen14utYcFDxOahZ9NaWA+6Xa4pY2ezVKVschuOxS96EQz3o3ZRSmcgBOapw/gHbN+EKxQ==}
+  /eslint-config-turbo@1.12.3(eslint@8.49.0):
+    resolution: {integrity: sha512-Q46MEOiNJpJWC3Et5/YEuIYYhbOieS04yZwQOinO2hpZw3folEXV+hbwVo8M+ap/q8gtpjIWiRMZ1A4QxmhEqQ==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
       eslint: 8.49.0
-      eslint-plugin-turbo: 1.10.15(eslint@8.49.0)
+      eslint-plugin-turbo: 1.12.3(eslint@8.49.0)
     dev: false
 
   /eslint-import-resolver-node@0.3.7:
@@ -11193,8 +11151,8 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-turbo@1.10.15(eslint@8.49.0):
-    resolution: {integrity: sha512-Tv4QSKV/U56qGcTqS/UgOvb9HcKFmWOQcVh3HEaj7of94lfaENgfrtK48E2CckQf7amhKs1i+imhCsNCKjkQyA==}
+  /eslint-plugin-turbo@1.12.3(eslint@8.49.0):
+    resolution: {integrity: sha512-7hEyxa+oP898EFNoxVenHlH8jtBwV1hbbIkdQWgqDcB0EmVNGVEZkYRo5Hm6BuMAjR433B+NISBJdj0bQo4/Lg==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
@@ -12142,6 +12100,7 @@ packages:
     dependencies:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
+    dev: false
 
   /get-stream@4.1.0:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
@@ -15122,28 +15081,6 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /miniflare@3.20231025.1:
-    resolution: {integrity: sha512-zwvu/f6eivBBF2shuom5DibnZjGSxt6FiC8sZlj+CcqTRss1D2ZHYD09odhAZLY9DYXE0orBFkJKnIDx/QmYdQ==}
-    engines: {node: '>=16.13'}
-    dependencies:
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      capnp-ts: 0.7.0(patch_hash=l4yimnxyvkiyj6alnps2ec3sii)
-      exit-hook: 2.2.1
-      glob-to-regexp: 0.4.1
-      source-map-support: 0.5.21
-      stoppable: 1.1.0
-      undici: 5.23.0
-      workerd: 1.20231025.0
-      ws: 8.14.2
-      youch: 3.2.3
-      zod: 3.22.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -16491,6 +16428,7 @@ packages:
 
   /printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
+    dev: false
 
   /prism-react-renderer@1.3.5(react@18.2.0):
     resolution: {integrity: sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==}
@@ -18020,6 +17958,7 @@ packages:
     dependencies:
       as-table: 1.0.55
       get-source: 2.0.12
+    dev: false
 
   /standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -18045,6 +17984,7 @@ packages:
   /stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
+    dev: false
 
   /stream-shift@1.0.1:
     resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
@@ -19636,21 +19576,8 @@ packages:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
 
-  /workerd@1.20231025.0:
-    resolution: {integrity: sha512-W1PFtpMFfvmm+ozBf+u70TE3Pviv7WA4qzDeejHDC4z+PFDq4+3KJCkgffaGBO86h+akWO0hSsc0uXL2zAqofQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20231025.0
-      '@cloudflare/workerd-darwin-arm64': 1.20231025.0
-      '@cloudflare/workerd-linux-64': 1.20231025.0
-      '@cloudflare/workerd-linux-arm64': 1.20231025.0
-      '@cloudflare/workerd-windows-64': 1.20231025.0
-    dev: true
-
-  /workerd@1.20231030.0:
-    resolution: {integrity: sha512-+FSW+d31f8RrjHanFf/R9A+Z0csf3OtsvzdPmAKuwuZm/5HrBv83cvG9fFeTxl7/nI6irUUXIRF9xcj/NomQzQ==}
+  /workerd@1.20240129.0:
+    resolution: {integrity: sha512-t4pnsmjjk/u+GdVDgH2M1AFmJaBUABshYK/vT/HNrAXsHSwN6VR8Yqw0JQ845OokO34VLkuUtYQYyxHHKpdtsw==}
     engines: {node: '>=16'}
     hasBin: true
     requiresBuild: true
@@ -19943,6 +19870,7 @@ packages:
       cookie: 0.5.0
       mustache: 4.2.0
       stacktracey: 2.1.8
+    dev: false
 
   /z-schema@5.0.3:
     resolution: {integrity: sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,7 +820,7 @@ importers:
         version: 8.49.0
       eslint-config-turbo:
         specifier: latest
-        version: 1.12.2(eslint@8.49.0)
+        version: 1.10.15(eslint@8.49.0)
       eslint-plugin-import:
         specifier: 2.26.x
         version: 2.26.0(@typescript-eslint/parser@6.7.2)(eslint@8.49.0)
@@ -3956,8 +3956,17 @@ packages:
       marked: 0.3.19
     dev: false
 
-  /@cloudflare/workerd-darwin-64@1.20240129.0:
-    resolution: {integrity: sha512-DfVVB5IsQLVcWPJwV019vY3nEtU88c2Qu2ST5SQxqcGivZ52imagLRK0RHCIP8PK4piSiq90qUC6ybppUsw8eg==}
+  /@cloudflare/workerd-darwin-64@1.20231025.0:
+    resolution: {integrity: sha512-MYRYTbSl+tjGg6su7savlLIb8cOcKJfdGpA+WdtgqT2OF7O+89Lag0l1SA/iyVlUkT31Jc6OLHqvzsXgmg+niQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@cloudflare/workerd-darwin-64@1.20231030.0:
+    resolution: {integrity: sha512-J4PQ9utPxLya9yHdMMx3AZeC5M/6FxcoYw6jo9jbDDFTy+a4Gslqf4Im9We3aeOEdPXa3tgQHVQOSelJSZLhIw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -3965,8 +3974,17 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-darwin-arm64@1.20240129.0:
-    resolution: {integrity: sha512-t0q8ABkmumG1zRM/MZ/vIv/Ysx0vTAXnQAPy/JW5aeQi/tqrypXkO9/NhPc0jbF/g/hIPrWEqpDgEp3CB7Da7Q==}
+  /@cloudflare/workerd-darwin-arm64@1.20231025.0:
+    resolution: {integrity: sha512-BszjtBDR84TVa6oWe74dePJSAukWlTmLw9zR4KeWuwZLJGV7RMm6AmwGStetjnwZrecZaaOFELfBCAHtsebV0Q==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@cloudflare/workerd-darwin-arm64@1.20231030.0:
+    resolution: {integrity: sha512-WSJJjm11Del4hSneiNB7wTXGtBXI4QMCH9l5qf4iT5PAW8cESGcCmdHtWDWDtGAAGcvmLT04KNvmum92vRKKQQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -3974,8 +3992,17 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-64@1.20240129.0:
-    resolution: {integrity: sha512-sFV1uobHgDI+6CKBS/ZshQvOvajgwl6BtiYaH4PSFSpvXTmRx+A9bcug+6BnD+V4WgwxTiEO2iR97E1XuwDAVw==}
+  /@cloudflare/workerd-linux-64@1.20231025.0:
+    resolution: {integrity: sha512-AT9dxgKXOa9xZxZ3k2a432axPJJ58KpoNWnPiPYGpuAuLoWnfcYwwh6mr9sZVcTdAdTAK9Xu9c81tp0YABanUw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@cloudflare/workerd-linux-64@1.20231030.0:
+    resolution: {integrity: sha512-2HUeRTvoCC17fxE0qdBeR7J9dO8j4A8ZbdcvY8pZxdk+zERU6+N03RTbk/dQMU488PwiDvcC3zZqS4gwLfVT8g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -3983,8 +4010,17 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-arm64@1.20240129.0:
-    resolution: {integrity: sha512-O7q7htHaFRp8PgTqNJx1/fYc3+LnvAo6kWWB9a14C5OWak6AAZk42PNpKPx+DXTmGvI+8S1+futBGUeJ8NPDXg==}
+  /@cloudflare/workerd-linux-arm64@1.20231025.0:
+    resolution: {integrity: sha512-EIjex5o2k80YZWPix1btGybL/vNZ3o6vqKX9ptS0JcFkHV5aFX5/kcMwSBRjiIC+w04zVjmGQx3N1Vh3njuncg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@cloudflare/workerd-linux-arm64@1.20231030.0:
+    resolution: {integrity: sha512-4/GK5zHh+9JbUI6Z5xTCM0ZmpKKHk7vu9thmHjUxtz+o8Ne9DoD7DlDvXQWgMF6XGaTubDWyp3ttn+Qv8jDFuQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -3992,8 +4028,17 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-windows-64@1.20240129.0:
-    resolution: {integrity: sha512-YqGno0XSqqqkDmNoGEX6M8kJlI2lEfWntbTPVtHaZlaXVR9sWfoD7TEno0NKC95cXFz+ioyFLbgbOdnfWwmVAA==}
+  /@cloudflare/workerd-windows-64@1.20231025.0:
+    resolution: {integrity: sha512-7vtq0mO22A2v0OOsKXa760r9a84Gg8CK0gDu5uNWlj6hojmt011iz7jJt76I7oo/XrVwVlVfu69GnA3ljx6U8w==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@cloudflare/workerd-windows-64@1.20231030.0:
+    resolution: {integrity: sha512-fb/Jgj8Yqy3PO1jLhk7mTrHMkR8jklpbQFud6rL/aMAn5d6MQbaSrYOCjzkKGp0Zng8D2LIzSl+Fc0C9Sggxjg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -8352,7 +8397,6 @@ packages:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
     dependencies:
       printable-characters: 1.0.42
-    dev: false
 
   /assert@2.0.0:
     resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
@@ -9053,7 +9097,6 @@ packages:
       tslib: 2.5.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
     patched: true
 
   /capnpc-ts@0.7.0:
@@ -9810,7 +9853,6 @@ packages:
 
   /data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
-    dev: false
 
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
@@ -10718,13 +10760,13 @@ packages:
       eslint: 8.49.0
     dev: true
 
-  /eslint-config-turbo@1.12.2(eslint@8.49.0):
-    resolution: {integrity: sha512-JHTGtDQuISBEWIorHenu5AeX1nv16NiDgDVRi1i0VyeYw0SiVh+lSQbv4BawXSnG1nOFpjbopAQdZvdB3PwXbQ==}
+  /eslint-config-turbo@1.10.15(eslint@8.49.0):
+    resolution: {integrity: sha512-76mpx2x818JZE26euen14utYcFDxOahZ9NaWA+6Xa4pY2ezVKVschuOxS96EQz3o3ZRSmcgBOapw/gHbN+EKxQ==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
       eslint: 8.49.0
-      eslint-plugin-turbo: 1.12.2(eslint@8.49.0)
+      eslint-plugin-turbo: 1.10.15(eslint@8.49.0)
     dev: false
 
   /eslint-import-resolver-node@0.3.7:
@@ -11151,8 +11193,8 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-turbo@1.12.2(eslint@8.49.0):
-    resolution: {integrity: sha512-/l0aGvZRzK1LMRTibRd6ZbEEuD5TtGotDTkZpxSIWA1FI764pWVvQduQMKBaRuz7aTuAo0WxatD8v1scK+qRWw==}
+  /eslint-plugin-turbo@1.10.15(eslint@8.49.0):
+    resolution: {integrity: sha512-Tv4QSKV/U56qGcTqS/UgOvb9HcKFmWOQcVh3HEaj7of94lfaENgfrtK48E2CckQf7amhKs1i+imhCsNCKjkQyA==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
@@ -12100,7 +12142,6 @@ packages:
     dependencies:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
-    dev: false
 
   /get-stream@4.1.0:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
@@ -15081,6 +15122,28 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /miniflare@3.20231025.1:
+    resolution: {integrity: sha512-zwvu/f6eivBBF2shuom5DibnZjGSxt6FiC8sZlj+CcqTRss1D2ZHYD09odhAZLY9DYXE0orBFkJKnIDx/QmYdQ==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      capnp-ts: 0.7.0(patch_hash=l4yimnxyvkiyj6alnps2ec3sii)
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      source-map-support: 0.5.21
+      stoppable: 1.1.0
+      undici: 5.23.0
+      workerd: 1.20231025.0
+      ws: 8.14.2
+      youch: 3.2.3
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -16428,7 +16491,6 @@ packages:
 
   /printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
-    dev: false
 
   /prism-react-renderer@1.3.5(react@18.2.0):
     resolution: {integrity: sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==}
@@ -17958,7 +18020,6 @@ packages:
     dependencies:
       as-table: 1.0.55
       get-source: 2.0.12
-    dev: false
 
   /standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -17984,7 +18045,6 @@ packages:
   /stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
-    dev: false
 
   /stream-shift@1.0.1:
     resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
@@ -19576,8 +19636,21 @@ packages:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
 
-  /workerd@1.20240129.0:
-    resolution: {integrity: sha512-t4pnsmjjk/u+GdVDgH2M1AFmJaBUABshYK/vT/HNrAXsHSwN6VR8Yqw0JQ845OokO34VLkuUtYQYyxHHKpdtsw==}
+  /workerd@1.20231025.0:
+    resolution: {integrity: sha512-W1PFtpMFfvmm+ozBf+u70TE3Pviv7WA4qzDeejHDC4z+PFDq4+3KJCkgffaGBO86h+akWO0hSsc0uXL2zAqofQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20231025.0
+      '@cloudflare/workerd-darwin-arm64': 1.20231025.0
+      '@cloudflare/workerd-linux-64': 1.20231025.0
+      '@cloudflare/workerd-linux-arm64': 1.20231025.0
+      '@cloudflare/workerd-windows-64': 1.20231025.0
+    dev: true
+
+  /workerd@1.20231030.0:
+    resolution: {integrity: sha512-+FSW+d31f8RrjHanFf/R9A+Z0csf3OtsvzdPmAKuwuZm/5HrBv83cvG9fFeTxl7/nI6irUUXIRF9xcj/NomQzQ==}
     engines: {node: '>=16'}
     hasBin: true
     requiresBuild: true
@@ -19870,7 +19943,6 @@ packages:
       cookie: 0.5.0
       mustache: 4.2.0
       stacktracey: 2.1.8
-    dev: false
 
   /z-schema@5.0.3:
     resolution: {integrity: sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==}


### PR DESCRIPTION
Fixes  #4050

**What this PR solves / how to test:**

Previously, importing `node:*` modules would fail at build time if neither nodejs compat mode was enabled. This PR changes the build time error into a build time warning, which will support writing runtime-agnostic code that conditionally imports NodeJS APIs only in a NodeJS environment.

Additionally, it adds the `navigator.userAgent` constant to esbuild's bundle settings. This means that as long as users are feature detecting with `navigator.userAgent`, `esbuild` will tree-shake away the Node.JS code, and they won't see warnings.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): In progress, coming with a larger update to the bundling docs
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
