### PR TITLE
[miniflare] fix: remove `__STATIC_CONTENT_MANIFEST` from module worker `env`

### DIFF
--- a/.changeset/soft-chairs-share.md
+++ b/.changeset/soft-chairs-share.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: remove `__STATIC_CONTENT_MANIFEST` from module worker `env`
+
+When using Workers Sites with a module worker, the asset manifest must be imported from the `__STATIC_CONTENT_MANIFEST` virtual module. Miniflare provided this module, but also erroneously added `__STATIC_CONTENT_MANIFEST` to the `env` object too. Whilst this didn't break anything locally, it could cause users to develop Workers that ran locally, but not when deployed. This change ensures `env` doesn't contain `__STATIC_CONTENT_MANIFEST`.

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -146,5 +146,4 @@ export const KV_PLUGIN: Plugin<
 	},
 };
 
-export { maybeGetSitesManifestModule } from "./sites";
 export { KV_PLUGIN_NAME };

--- a/packages/miniflare/src/plugins/kv/sites.ts
+++ b/packages/miniflare/src/plugins/kv/sites.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import fs from "fs/promises";
 import path from "path";
 import SCRIPT_KV_SITES from "worker:kv/sites";
-import { Service, Worker_Binding, Worker_Module } from "../../runtime";
+import { Service, Worker_Binding } from "../../runtime";
 import { globsToRegExps } from "../../shared";
 import {
 	SharedBindings,
@@ -100,17 +100,6 @@ export async function getSitesNodeBindings(
 		[SiteBindings.KV_NAMESPACE_SITE]: kProxyNodeBinding,
 		[SiteBindings.JSON_SITE_MANIFEST]: __STATIC_CONTENT_MANIFEST,
 	};
-}
-
-export function maybeGetSitesManifestModule(
-	bindings: Worker_Binding[]
-): Worker_Module | undefined {
-	for (const binding of bindings) {
-		if (binding.name === SiteBindings.JSON_SITE_MANIFEST) {
-			assert("json" in binding && binding.json !== undefined);
-			return { name: SiteBindings.JSON_SITE_MANIFEST, text: binding.json };
-		}
-	}
 }
 
 export function getSitesServices(options: SitesOptions): Service[] {

--- a/packages/miniflare/test/fixtures/sites/modules.ts
+++ b/packages/miniflare/test/fixtures/sites/modules.ts
@@ -2,8 +2,22 @@ import { getAssetFromKV } from "@cloudflare/kv-asset-handler";
 import manifestJSON from "__STATIC_CONTENT_MANIFEST";
 const manifest = JSON.parse(manifestJSON);
 
-export default <ExportedHandler<{ __STATIC_CONTENT: KVNamespace }>>{
+export default <
+	ExportedHandler<{
+		__STATIC_CONTENT: KVNamespace;
+		__STATIC_CONTENT_MANIFEST?: undefined;
+	}>
+>{
 	async fetch(request, env, ctx) {
+		if (
+			"__STATIC_CONTENT_MANIFEST" in env ||
+			env.__STATIC_CONTENT_MANIFEST !== undefined
+		) {
+			return new Response(
+				"Expected __STATIC_CONTENT_MANIFEST to be undefined",
+				{ status: 500 }
+			);
+		}
 		return await getAssetFromKV(
 			{
 				request,


### PR DESCRIPTION
Fixes #4374.

**What this PR solves / how to test:**

When using Workers Sites with a module worker, the asset manifest must be imported from the `__STATIC_CONTENT_MANIFEST` virtual module. Miniflare provided this module, but also erroneously added `__STATIC_CONTENT_MANIFEST` to the `env` object too. Whilst this didn't break anything locally, it could cause users to develop Workers that ran locally, but not when deployed. This change ensures `env` doesn't contain `__STATIC_CONTENT_MANIFEST`.

To test this, run `wrangler dev` in `fixtures/sites-app` and verify `__STATIC_CONTENT_MANIFEST` doesn't appear in the `env` object.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: this was erroneous local only behaviour

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
