### PR TITLE
Improve fixture test stability

### DIFF
--- a/fixtures/additional-modules/test/index.test.ts
+++ b/fixtures/additional-modules/test/index.test.ts
@@ -52,7 +52,7 @@ describe("find_additional_modules dev", () => {
 			path.join(tmpDir, "wrangler.toml")
 		);
 
-		worker = await runWranglerDev(tmpDir, ["--port=0"]);
+		worker = await runWranglerDev(tmpDir, ["--port=0", "--inspector-port=0"]);
 	});
 	afterAll(async () => {
 		await worker.stop();

--- a/fixtures/external-durable-objects-app/tests/index.test.ts
+++ b/fixtures/external-durable-objects-app/tests/index.test.ts
@@ -38,6 +38,7 @@ describe.skip("Pages Functions", () => {
 				"public",
 				"--do=PAGES_REFERENCED_DO=MyDurableObject@a",
 				"--port=0",
+				"--inspector-port=0",
 			],
 			{
 				stdio: ["ignore", "ignore", "ignore", "ipc"],

--- a/fixtures/import-wasm-example/tests/index.test.ts
+++ b/fixtures/import-wasm-example/tests/index.test.ts
@@ -9,6 +9,7 @@ describe("wrangler correctly imports wasm files with npm resolution", () => {
 	beforeAll(async () => {
 		({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
 			"--port=0",
+			"--inspector-port=0",
 		]));
 	});
 

--- a/fixtures/node-app-pages/tests/index.test.ts
+++ b/fixtures/node-app-pages/tests/index.test.ts
@@ -10,7 +10,7 @@ describe("Pages Dev", () => {
 		const { ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--node-compat", "--port=0"]
+			["--node-compat", "--port=0", "--inspector-port=0"]
 		);
 		try {
 			const response = await fetch(`http://${ip}:${port}/stripe`);

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -15,6 +15,7 @@ describe("Pages Functions", () => {
 				"--binding=OTHER_NAME=THING=WITH=EQUALS",
 				"--r2=BUCKET",
 				"--port=0",
+				"--inspector-port=0",
 			]
 		));
 	});

--- a/fixtures/pages-functions-wasm-app/tests/index.test.ts
+++ b/fixtures/pages-functions-wasm-app/tests/index.test.ts
@@ -10,7 +10,7 @@ describe("Pages Functions with wasm module imports", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0"]
+			["--port=0", "--inspector-port=0"]
 		));
 	});
 

--- a/fixtures/pages-functions-with-routes-app/tests/index.test.ts
+++ b/fixtures/pages-functions-with-routes-app/tests/index.test.ts
@@ -10,7 +10,7 @@ describe("Pages Functions with custom _routes.json", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0"]
+			["--port=0", "--inspector-port=0"]
 		));
 	});
 

--- a/fixtures/pages-plugin-mounted-on-root-app/tests/index.test.ts
+++ b/fixtures/pages-plugin-mounted-on-root-app/tests/index.test.ts
@@ -12,7 +12,7 @@ describe("Pages Functions", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			path.resolve(__dirname, ".."),
 			"public",
-			["--port=0"]
+			["--port=0", "--inspector-port=0"]
 		));
 	});
 

--- a/fixtures/pages-simple-assets/tests/index.test.ts
+++ b/fixtures/pages-simple-assets/tests/index.test.ts
@@ -10,7 +10,7 @@ describe("Pages Functions", async () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0"]
+			["--port=0", "--inspector-port=0"]
 		));
 	});
 

--- a/fixtures/pages-workerjs-and-functions-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-and-functions-app/tests/index.test.ts
@@ -10,7 +10,7 @@ describe("Pages project with `_worker.js` and `/functions` directory", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0"]
+			["--port=0", "--inspector-port=0"]
 		));
 	});
 

--- a/fixtures/pages-workerjs-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-app/tests/index.test.ts
@@ -33,7 +33,7 @@ describe("Pages _worker.js", () => {
 		const { ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"./workerjs-test",
-			["--no-bundle=false", "--port=0"]
+			["--no-bundle=false", "--port=0", "--inspector-port=0"]
 		);
 		try {
 			await expect(
@@ -50,7 +50,7 @@ describe("Pages _worker.js", () => {
 		const { ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"./workerjs-test",
-			["--bundle", "--port=0"]
+			["--bundle", "--port=0", "--inspector-port=0"]
 		);
 		try {
 			await expect(

--- a/fixtures/pages-workerjs-directory/tests/index.test.ts
+++ b/fixtures/pages-workerjs-directory/tests/index.test.ts
@@ -15,6 +15,7 @@ describe("Pages _worker.js/ directory", () => {
 			"public",
 			[
 				"--port=0",
+				"--inspector-port=0",
 				`--persist-to=${tmpDir}`,
 				"--d1=D1",
 				"--d1=PUT=elsewhere",

--- a/fixtures/pages-workerjs-wasm-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-wasm-app/tests/index.test.ts
@@ -10,7 +10,7 @@ describe("Pages Advanced Mode with wasm module imports", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0"]
+			["--port=0", "--inspector-port=0"]
 		));
 	});
 

--- a/fixtures/pages-workerjs-with-routes-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-with-routes-app/tests/index.test.ts
@@ -10,7 +10,7 @@ describe("Pages Advanced Mode with custom _routes.json", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0"]
+			["--port=0", "--inspector-port=0"]
 		));
 	});
 

--- a/fixtures/pages-ws-app/tests/index.test.ts
+++ b/fixtures/pages-ws-app/tests/index.test.ts
@@ -22,7 +22,15 @@ describe.skip("Pages Functions", () => {
 		});
 		wranglerProcess = fork(
 			path.join("..", "..", "packages", "wrangler", "bin", "wrangler.js"),
-			["pages", "dev", "--port=0", "--proxy=8791", "--", "pnpm run server"],
+			[
+				"pages",
+				"dev",
+				"--port=0",
+				"--inspector-port=0",
+				"--proxy=8791",
+				"--",
+				"pnpm run server",
+			],
 			{
 				cwd: path.resolve(__dirname, ".."),
 			}

--- a/fixtures/remix-pages-app/tests/index.test.ts
+++ b/fixtures/remix-pages-app/tests/index.test.ts
@@ -19,7 +19,7 @@ describe("Remix", () => {
 		({ ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--port=0"]
+			["--port=0", "--inspector-port=0"]
 		));
 	});
 

--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -74,7 +74,7 @@ async function runLongLivedWrangler(command: string[], cwd: string) {
 			separator,
 		].join("\n");
 		rejectReadyPromise(new Error(message));
-	}, 10_000);
+	}, 20_000);
 
 	async function stop() {
 		return new Promise((resolve, reject) => {

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -12,7 +12,7 @@ describe("'wrangler dev' correctly renders pages", () => {
 	beforeAll(async () => {
 		({ ip, port, stop, getOutput } = await runWranglerDev(
 			resolve(__dirname, ".."),
-			["--local", "--port=0"]
+			["--local", "--port=0", "--inspector-port=0"]
 		));
 	});
 


### PR DESCRIPTION
Some fixture tests explicitly set `port: 0` to allow for parallel execution with other tests. This avoided running into a race condition with other tests for the main port. Before startDevWorker Milestone 1, when losing the race for the default inspector port 9229, the inspector proxy server would just fail to start and not cause the proxy server to fail to start. Now the ProxyWorker and InspectorProxyWorker start in the same Miniflare/workerd instance, so if the InspectorProxyWorker tries to bind to a port that is already bound, the ProxyWorker would be blocked from starting also. Considering these tests already make concessions for a random main port, they should also set a random inspector port. Further, these tests don't actually use the inspector at all, so for now there's no need for the inspector to be on a known port. In the future, we will need to expose what port the inspector is accessible on – even for users – via stdout.

I've also increased the timeout in `runLongLivedWrangler` because I saw [sometimes the Miniflare instance did successfully start up but the timeout failed the test anyway](https://github.com/cloudflare/workers-sdk/actions/runs/6973799366/job/18981755173)

- Tests
  - [ ] Included
  - [x] Not necessary because: improving existing tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: no user-facing changes
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: no user-facing changes

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
