### PR TITLE
fix: init from dash using explicit usage model for standard accounts

### DIFF
--- a/.changeset/heavy-cherries-fetch.md
+++ b/.changeset/heavy-cherries-fetch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: init from dash specifying explicit usage model in wrangler.toml for standard users


### PR DESCRIPTION
**What this PR solves / how to test:**

Fixes a bug where users with the standard usage model would have an explicit usage model defined in their `wrangler.toml` when they initialized a Worker from dash. Testing can be done by building and then running `wrangler init --from-dash [worker] -y --no-delegate-c3` on an account that has opted into the new standard pricing and ensuring there is no usage model defined in the config.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: this is a bug fix to match existing defined behavior

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
