### PR TITLE
implement `getBindingsProxy` utility

### DIFF
--- a/.changeset/dull-jobs-deliver.md
+++ b/.changeset/dull-jobs-deliver.md
@@ -4,7 +4,7 @@
 
 Add new `getBindingsProxy` utility to the wrangler package
 
-The new utility is part of wrangler's js api (it is not part of the wrangler CLI) and its use is to provide proxy objects to bindings, such objects can be used in nodejs code as if they were actual bindings
+The new utility is part of wrangler's JS API (it is not part of the wrangler CLI) and its use is to provide proxy objects to bindings, such objects can be used in Node.js code as if they were actual bindings
 
 The utility reads the `wrangler.toml` file present in the current working directory in order to discern what bindings should be available (a `wrangler.json` file can be used too, as well as config files with custom paths).
 

--- a/.changeset/dull-jobs-deliver.md
+++ b/.changeset/dull-jobs-deliver.md
@@ -1,0 +1,42 @@
+---
+"wrangler": minor
+---
+
+Add new `getBindingsProxy` utility to the wrangler package
+
+The new utility is part of wrangler's js api (it is not part of the wrangler CLI) and its use is to provide proxy objects to bindings, such objects can be used in nodejs code as if they were actual bindings
+
+The utility reads the `wrangler.toml` file present in the current working directory in order to discern what bindings should be available (a `wrangler.json` file can be used too, as well as config files with custom paths).
+
+## Example
+
+Assuming that in the current working directory there is a `wrangler.toml` file with the following
+content:
+
+```
+[[kv_namespaces]]
+binding = "MY_KV"
+id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+The utility could be used in a nodejs script in the following way:
+
+```js
+import { getBindingsProxy } from "wrangler";
+
+// we use the utility to get the bindings proxies
+const { bindings, dispose } = await getBindingsProxy();
+
+// we get access to the KV binding proxy
+const myKv = bindings.MY_KV;
+// we can then use the proxy in the same exact way we'd use the
+// KV binding in the workerd runtime, without any API discrepancies
+const kvValue = await myKv.get("my-kv-key");
+
+console.log(`
+    KV Value = ${kvValue}
+`);
+
+// we need to dispose of the underlying child process in order for this nodejs script to properly terminate
+await dispose();
+```

--- a/fixtures/get-bindings-proxy/custom-toml/path/test-toml
+++ b/fixtures/get-bindings-proxy/custom-toml/path/test-toml
@@ -1,0 +1,7 @@
+name = "get-bindings-proxy-fixture"
+main = "src/index.ts"
+compatibility_date = "2023-11-21"
+
+[vars]
+MY_VAR = "my-var-value-from-a-custom-toml"
+MY_JSON_VAR = { test = true, customToml = true }

--- a/fixtures/get-bindings-proxy/package.json
+++ b/fixtures/get-bindings-proxy/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "get-bindings-proxy-fixture",
+	"private": true,
+	"description": "A test for the getBindingsProxy utility",
+	"scripts": {
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"type:tests": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "^4.20221111.1",
+		"wrangler": "workspace:*"
+	}
+}

--- a/fixtures/get-bindings-proxy/tests/index.test.ts
+++ b/fixtures/get-bindings-proxy/tests/index.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import {
+	type UnstableDevWorker,
+	unstable_dev,
+	getBindingsProxy,
+} from "wrangler";
+import {
+	R2Bucket,
+	type KVNamespace,
+	Fetcher,
+	D1Database,
+	DurableObjectNamespace,
+} from "@cloudflare/workers-types";
+import { readdir, rm } from "fs/promises";
+import path from "path";
+
+type Bindings = {
+	MY_VAR: string;
+	MY_JSON_VAR: Object;
+	MY_SERVICE_A: Fetcher;
+	MY_SERVICE_B: Fetcher;
+	MY_KV: KVNamespace;
+	MY_DO_A: DurableObjectNamespace;
+	MY_DO_B: DurableObjectNamespace;
+	MY_BUCKET: R2Bucket;
+	MY_D1: D1Database;
+};
+
+const wranglerTomlFilePath = path.join(__dirname, "..", "wrangler.toml");
+
+describe("getBindingsProxy", () => {
+	let devWorkers: UnstableDevWorker[];
+
+	beforeAll(async () => {
+		devWorkers = await startWorkers();
+
+		await rm(path.join(__dirname, "..", ".wrangler"), {
+			force: true,
+			recursive: true,
+		});
+	});
+
+	afterAll(async () => {
+		await Promise.allSettled(devWorkers.map((i) => i.stop()));
+	});
+
+	it("correctly obtains var bindings", async () => {
+		const { bindings, dispose } = await getBindingsProxy<Bindings>({
+			configPath: wranglerTomlFilePath,
+		});
+		const { MY_VAR, MY_JSON_VAR } = bindings;
+		expect(MY_VAR).toEqual("my-var-value");
+		expect(MY_JSON_VAR).toEqual({
+			test: true,
+		});
+		await dispose();
+	});
+
+	it("correctly reads a toml from a custom path", async () => {
+		const { bindings, dispose } = await getBindingsProxy<Bindings>({
+			configPath: path.join(
+				__dirname,
+				"..",
+				"custom-toml",
+				"path",
+				"test-toml"
+			),
+		});
+		const { MY_VAR, MY_JSON_VAR } = bindings;
+		expect(MY_VAR).toEqual("my-var-value-from-a-custom-toml");
+		expect(MY_JSON_VAR).toEqual({
+			test: true,
+			customToml: true,
+		});
+		await dispose();
+	});
+
+	it("correctly reads a json config file", async () => {
+		const { bindings, dispose } = await getBindingsProxy<Bindings>({
+			configPath: path.join(__dirname, "..", "wrangler.json"),
+		});
+		const { MY_VAR, MY_JSON_VAR } = bindings;
+		expect(MY_VAR).toEqual("my-var-value-from-a-json-config-file");
+		expect(MY_JSON_VAR).toEqual({
+			test: true,
+			fromJson: true,
+		});
+		await dispose();
+	});
+
+	it("provides service bindings to external local workers", async () => {
+		const { bindings, dispose } = await getBindingsProxy<Bindings>({
+			configPath: wranglerTomlFilePath,
+		});
+		const { MY_SERVICE_A, MY_SERVICE_B } = bindings;
+		await testServiceBinding(MY_SERVICE_A, "Hello World from hello-worker-a");
+		await testServiceBinding(MY_SERVICE_B, "Hello World from hello-worker-b");
+		await dispose();
+	});
+
+	it("correctly obtains functioning KV bindings", async () => {
+		const { bindings, dispose } = await getBindingsProxy<Bindings>({
+			configPath: wranglerTomlFilePath,
+		});
+		const { MY_KV } = bindings;
+		let numOfKeys = (await MY_KV.list()).keys.length;
+		expect(numOfKeys).toBe(0);
+		await MY_KV.put("my-key", "my-value");
+		numOfKeys = (await MY_KV.list()).keys.length;
+		expect(numOfKeys).toBe(1);
+		const value = await MY_KV.get("my-key");
+		expect(value).toBe("my-value");
+		await dispose();
+	});
+
+	it("correctly obtains functioning DO bindings (provided by external local workers)", async () => {
+		const { bindings, dispose } = await getBindingsProxy<Bindings>({
+			configPath: wranglerTomlFilePath,
+		});
+		const { MY_DO_A, MY_DO_B } = bindings;
+		await testDoBinding(MY_DO_A, "Hello from DurableObject A");
+		await testDoBinding(MY_DO_B, "Hello from DurableObject B");
+		await dispose();
+	});
+
+	it("correctly obtains functioning R2 bindings", async () => {
+		const { bindings, dispose } = await getBindingsProxy<Bindings>({
+			configPath: wranglerTomlFilePath,
+		});
+		const { MY_BUCKET } = bindings;
+		let numOfObjects = (await MY_BUCKET.list()).objects.length;
+		expect(numOfObjects).toBe(0);
+		await MY_BUCKET.put("my-object", "my-value");
+		numOfObjects = (await MY_BUCKET.list()).objects.length;
+		expect(numOfObjects).toBe(1);
+		const value = await MY_BUCKET.get("my-object");
+		expect(await value?.text()).toBe("my-value");
+		await dispose();
+	});
+
+	it("correctly obtains functioning D1 bindings", async () => {
+		const { bindings, dispose } = await getBindingsProxy<Bindings>({
+			configPath: wranglerTomlFilePath,
+		});
+		const { MY_D1 } = bindings;
+		await MY_D1.exec(
+			`CREATE TABLE IF NOT EXISTS users ( id integer PRIMARY KEY AUTOINCREMENT, name text NOT NULL )`
+		);
+		const stmt = MY_D1.prepare("insert into users (name) values (?1)");
+		await MY_D1.batch([
+			stmt.bind("userA"),
+			stmt.bind("userB"),
+			stmt.bind("userC"),
+		]);
+		const { results } = await MY_D1.prepare(
+			"SELECT name FROM users LIMIT 5"
+		).all();
+		expect(results).toEqual([
+			{ name: "userA" },
+			{ name: "userB" },
+			{ name: "userC" },
+		]);
+		await dispose();
+	});
+});
+
+/**
+ * Starts all the workers present in the `workers` directory using `unstable_dev`
+ *
+ * @returns the workers' UnstableDevWorker instances
+ */
+async function startWorkers(): Promise<UnstableDevWorker[]> {
+	const workersDirPath = path.join(__dirname, "..", "workers");
+	const workers = await readdir(workersDirPath);
+	return await Promise.all(
+		workers.map((workerName) => {
+			const workerPath = path.join(workersDirPath, workerName);
+			return unstable_dev(path.join(workerPath, "index.ts"), {
+				config: path.join(workerPath, "wrangler.toml"),
+			});
+		})
+	);
+}
+
+async function testServiceBinding(binding: Fetcher, expectedResponse: string) {
+	const resp = await binding.fetch("http://0.0.0.0");
+	const respText = await resp.text();
+	expect(respText).toBe(expectedResponse);
+}
+
+async function testDoBinding(
+	binding: DurableObjectNamespace,
+	expectedResponse: string
+) {
+	const durableObjectId = binding.idFromName("__my-do__");
+	const doStub = binding.get(durableObjectId);
+	const doResp = await doStub.fetch("http://0.0.0.0");
+	const doRespText = await doResp.text();
+	expect(doRespText).toBe(expectedResponse);
+}

--- a/fixtures/get-bindings-proxy/tsconfig.json
+++ b/fixtures/get-bindings-proxy/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"include": [
+		"workers/hello-worker-a",
+		"module-worker-b",
+		"service-worker-a",
+		"module-worker-c",
+		"module-worker-d",
+		"pages-functions-app"
+	],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "CommonJS",
+		"lib": ["ES2020"],
+		"types": ["@cloudflare/workers-types"]
+	}
+}

--- a/fixtures/get-bindings-proxy/vitest.config.ts
+++ b/fixtures/get-bindings-proxy/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		testTimeout: 25_000,
+		hookTimeout: 25_000,
+		teardownTimeout: 25_000,
+		useAtomics: true,
+	},
+});

--- a/fixtures/get-bindings-proxy/workers/do-worker-a/index.ts
+++ b/fixtures/get-bindings-proxy/workers/do-worker-a/index.ts
@@ -1,0 +1,11 @@
+export default {
+	async fetch(): Promise<Response> {
+		return new Response("Hello World from do-worker-a");
+	},
+};
+
+export class DurableObjectClass {
+	async fetch() {
+		return new Response("Hello from DurableObject A");
+	}
+}

--- a/fixtures/get-bindings-proxy/workers/do-worker-a/wrangler.toml
+++ b/fixtures/get-bindings-proxy/workers/do-worker-a/wrangler.toml
@@ -1,0 +1,5 @@
+name = "do-worker-a"
+
+[[durable_objects.bindings]]
+name = "MY_DO"
+class_name = "DurableObjectClass"

--- a/fixtures/get-bindings-proxy/workers/do-worker-b/index.ts
+++ b/fixtures/get-bindings-proxy/workers/do-worker-b/index.ts
@@ -1,0 +1,11 @@
+export default {
+	async fetch(): Promise<Response> {
+		return new Response("Hello World from do-worker-a");
+	},
+};
+
+export class DurableObjectClass {
+	async fetch() {
+		return new Response("Hello from DurableObject B");
+	}
+}

--- a/fixtures/get-bindings-proxy/workers/do-worker-b/wrangler.toml
+++ b/fixtures/get-bindings-proxy/workers/do-worker-b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "do-worker-b"
+
+[[durable_objects.bindings]]
+name = "MY_DO"
+class_name = "DurableObjectClass"

--- a/fixtures/get-bindings-proxy/workers/hello-worker-a/index.ts
+++ b/fixtures/get-bindings-proxy/workers/hello-worker-a/index.ts
@@ -1,0 +1,5 @@
+export default {
+	fetch() {
+		return new Response("Hello World from hello-worker-a");
+	},
+};

--- a/fixtures/get-bindings-proxy/workers/hello-worker-a/wrangler.toml
+++ b/fixtures/get-bindings-proxy/workers/hello-worker-a/wrangler.toml
@@ -1,0 +1,1 @@
+name = "hello-worker-a"

--- a/fixtures/get-bindings-proxy/workers/hello-worker-b/index.ts
+++ b/fixtures/get-bindings-proxy/workers/hello-worker-b/index.ts
@@ -1,0 +1,5 @@
+export default {
+	fetch() {
+		return new Response("Hello World from hello-worker-b");
+	},
+};

--- a/fixtures/get-bindings-proxy/workers/hello-worker-b/wrangler.toml
+++ b/fixtures/get-bindings-proxy/workers/hello-worker-b/wrangler.toml
@@ -1,0 +1,1 @@
+name = "hello-worker-b"

--- a/fixtures/get-bindings-proxy/wrangler.json
+++ b/fixtures/get-bindings-proxy/wrangler.json
@@ -1,0 +1,11 @@
+{
+	"name": "get-bindings-proxy-fixture",
+	"main": "src/index.ts",
+	"vars": {
+		"MY_VAR": "my-var-value-from-a-json-config-file",
+		"MY_JSON_VAR": {
+			"test": true,
+			"fromJson": true
+		}
+	}
+}

--- a/fixtures/get-bindings-proxy/wrangler.toml
+++ b/fixtures/get-bindings-proxy/wrangler.toml
@@ -1,0 +1,31 @@
+name = "get-bindings-proxy-fixture"
+main = "src/index.ts"
+compatibility_date = "2023-11-21"
+
+services = [
+  { binding = "MY_SERVICE_A", service = "hello-worker-a" },
+  { binding = "MY_SERVICE_B", service = "hello-worker-b" }
+]
+
+[vars]
+MY_VAR = "my-var-value"
+MY_JSON_VAR = { test = true }
+
+[[kv_namespaces]]
+binding = "MY_KV"
+id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+[[r2_buckets]]
+binding = "MY_BUCKET"
+bucket_name = "my-bucket"
+
+[durable_objects]
+bindings = [
+  { name = "MY_DO_A", script_name = "do-worker-a", class_name = "DurableObjectClass" },
+  { name = "MY_DO_B", script_name = "do-worker-b", class_name = "DurableObjectClass" }
+]
+
+[[d1_databases]]
+binding = "MY_D1"
+database_name = "test-db"
+database_id = "000000000-0000-0000-0000-000000000000"

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -10,3 +10,4 @@ export {
 	deleteMTlsCertificate,
 } from "./mtls-certificate";
 export * from "./startDevWorker";
+export * from "./integrations";

--- a/packages/wrangler/src/api/integrations/bindings/index.ts
+++ b/packages/wrangler/src/api/integrations/bindings/index.ts
@@ -1,0 +1,151 @@
+import { Miniflare } from "miniflare";
+import { readConfig } from "../../../config";
+import { getBindings } from "../../../dev";
+import { getBoundRegisteredWorkers } from "../../../dev-registry";
+import { buildMiniflareBindingOptions } from "../../../dev/miniflare";
+import { getServiceBindings } from "./services";
+import type { MiniflareOptions } from "miniflare";
+
+/**
+ * Options for the `getBindingsProxy` utility
+ */
+export type GetBindingsProxyOptions = {
+	/**
+	 * The path to the config object to use (default `wrangler.toml`)
+	 */
+	configPath?: string;
+	/**
+	 * Flag to indicate the utility to read a json config file (`wrangler.json`)
+	 * instead of the toml one (`wrangler.toml`)
+	 *
+	 * Note: this feature is experimental
+	 */
+	experimentalJsonConfig?: boolean;
+	/**
+	 * Indicates if and where to persist the bindings data, if not present or `true` it defaults to the same location
+	 * used by wrangler v3: `.wrangler/state/v3` (so that the same data can be easily used by the caller and wrangler).
+	 * If `false` is specified no data is persisted on the filesystem.
+	 */
+	persist?: boolean | { path: string };
+};
+
+/**
+ * Result of the `getBindingsProxy` utility
+ */
+export type BindingsProxy<Bindings = Record<string, unknown>> = {
+	/**
+	 * Object containing the various proxies
+	 */
+	bindings: Bindings;
+	/**
+	 * Function used to dispose of the child process providing the bindings implementation
+	 */
+	dispose: () => Promise<void>;
+};
+
+/**
+ * By reading from a `wrangler.toml` file this function generates proxy binding objects that can be
+ * used to simulate the interaction with bindings during local development in a Node.js environment
+ *
+ * @param options The various options that can tweak this function's behavior
+ * @returns An Object containing the generated proxies alongside other related utilities
+ */
+export async function getBindingsProxy<Bindings = Record<string, unknown>>(
+	options: GetBindingsProxyOptions = {}
+): Promise<BindingsProxy<Bindings>> {
+	const miniflareOptions = await getMiniflareOptionsFromConfig(options);
+
+	const mf = new Miniflare({
+		script: "",
+		modules: true,
+		...(miniflareOptions as Record<string, unknown>),
+	});
+
+	const bindings: Bindings = await mf.getBindings();
+
+	return {
+		bindings,
+		dispose: () => mf.dispose(),
+	};
+}
+
+async function getMiniflareOptionsFromConfig(
+	opts: GetBindingsProxyOptions
+): Promise<Partial<MiniflareOptions>> {
+	const rawConfig = readConfig(opts.configPath, {
+		experimentalJsonConfig: opts.experimentalJsonConfig,
+	});
+
+	// getBindingsProxy doesn't currently support selecting an environment
+	const env = undefined;
+
+	const bindings = getBindings(rawConfig, env, true, {});
+
+	const workerDefinitions = await getBoundRegisteredWorkers({
+		services: bindings.services,
+		durableObjects: rawConfig["durable_objects"],
+	});
+
+	const { bindingOptions, externalDurableObjectWorker } =
+		buildMiniflareBindingOptions({
+			name: undefined,
+			bindings,
+			workerDefinitions,
+			queueConsumers: undefined,
+			serviceBindings: {},
+		});
+
+	const persistOptions = getMiniflarePersistOptions(opts.persist);
+
+	const serviceBindings = await getServiceBindings(bindings.services);
+
+	const options: MiniflareOptions = {
+		workers: [
+			{
+				script: "",
+				modules: true,
+				...bindingOptions,
+				serviceBindings,
+			},
+			externalDurableObjectWorker,
+		],
+		...persistOptions,
+	};
+
+	return options;
+}
+
+/**
+ * Get the persist option properties to pass to miniflare
+ *
+ * @param persist The user provided persistence option
+ * @returns an object containing the properties to pass to miniflare
+ */
+function getMiniflarePersistOptions(
+	persist: GetBindingsProxyOptions["persist"]
+): Pick<
+	MiniflareOptions,
+	"kvPersist" | "durableObjectsPersist" | "r2Persist" | "d1Persist"
+> {
+	if (persist === false) {
+		// the user explicitly asked for no persistance
+		return {
+			kvPersist: false,
+			durableObjectsPersist: false,
+			r2Persist: false,
+			d1Persist: false,
+		};
+	}
+
+	const defaultPersistPath = ".wrangler/state/v3";
+
+	const persistPath =
+		typeof persist === "object" ? persist.path : defaultPersistPath;
+
+	return {
+		kvPersist: `${persistPath}/kv`,
+		durableObjectsPersist: `${persistPath}/do`,
+		r2Persist: `${persistPath}/r2`,
+		d1Persist: `${persistPath}/d1`,
+	};
+}

--- a/packages/wrangler/src/api/integrations/bindings/services.ts
+++ b/packages/wrangler/src/api/integrations/bindings/services.ts
@@ -28,30 +28,20 @@ export async function getServiceBindings(
 		return;
 	}
 
-	const [foundServices, _missingServices] = services.reduce(
-		([found, missing], { binding: bindingName, service: serviceName }) => {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const service = registeredWorkers![serviceName];
-			return service
-				? [
-						[...found, { bindingName, serviceName, workerDefinition: service }],
-						missing,
-				  ]
-				: [found, [...missing, { bindingName }]];
-		},
-		[[], []] as [
-			AvailableBindingInfo[],
-			Pick<AvailableBindingInfo, "bindingName">[]
-		]
-	);
+  const foundServices: AvailableBindingInfo[] = [];
+  const _missingServices: Pick<AvailableBindingInfo, "bindingName">[] = [];
+  for (const {binding: bindingName, service: serviceName} of services) {
+     const worker = registeredWorkers[serviceName]
+     if (worker) {
+       foundServices.push({ bindingName, serviceName, workerDefinition: worker });
+     } else {
+       _missingServices.push({bindingName});
+  }
 
-	const serviceBindings = foundServices.reduce((acc, bindingInfo) => {
-		return {
-			...acc,
-			[bindingInfo.bindingName]: getServiceBindingProxyFetch(bindingInfo),
-		};
-	}, {} as ServiceBindings);
-
+	const serviceBindings: ServiceBindings = {};
+	for(bindingInfo of foundServices) {
+			serviceBindings[bindingInfo.bindingName] = getServiceBindingProxyFetch(bindingInfo);
+	}
 	return serviceBindings;
 }
 

--- a/packages/wrangler/src/api/integrations/bindings/services.ts
+++ b/packages/wrangler/src/api/integrations/bindings/services.ts
@@ -1,7 +1,7 @@
 import { Response } from "miniflare";
 import { fetch, type Request } from "undici";
 import { getRegisteredWorkers } from "../../../dev-registry";
-import type { WorkerDefinition, WorkerRegistry } from "../../../dev-registry";
+import type { WorkerDefinition } from "../../../dev-registry";
 import type { RequestInit } from "undici";
 
 /**
@@ -23,14 +23,7 @@ export async function getServiceBindings(
 		return;
 	}
 
-	let registeredWorkers: WorkerRegistry | undefined;
-
-	try {
-		registeredWorkers = await getRegisteredWorkers();
-	} catch {
-		/* */
-	}
-
+	const registeredWorkers = await maybeGetRegisteredWorkers();
 	if (!registeredWorkers) {
 		return;
 	}
@@ -105,4 +98,12 @@ function getServiceBindingProxyFetch({
 			);
 		}
 	};
+}
+
+async function maybeGetRegisteredWorkers() {
+	try {
+		return await getRegisteredWorkers();
+	} catch {
+		return undefined;
+	}
 }

--- a/packages/wrangler/src/api/integrations/bindings/services.ts
+++ b/packages/wrangler/src/api/integrations/bindings/services.ts
@@ -1,0 +1,108 @@
+import { Response } from "miniflare";
+import { fetch, type Request } from "undici";
+import { getRegisteredWorkers } from "../../../dev-registry";
+import type { WorkerDefinition, WorkerRegistry } from "../../../dev-registry";
+import type { RequestInit } from "undici";
+
+/**
+ * Gets service bindings that proxy requests to external workers running locally, so that they
+ * can be passed to miniflare and used to fetch from such workers by the next app.
+ *
+ * @param services the services requested by the user
+ * @returns the service bindings ready to be passed to miniflare
+ */
+export async function getServiceBindings(
+	services:
+		| {
+				binding: string;
+				service: string;
+		  }[]
+		| undefined = []
+): Promise<ServiceBindings | undefined> {
+	if (services.length === 0) {
+		return;
+	}
+
+	let registeredWorkers: WorkerRegistry | undefined;
+
+	try {
+		registeredWorkers = await getRegisteredWorkers();
+	} catch {
+		/* */
+	}
+
+	if (!registeredWorkers) {
+		return;
+	}
+
+	const [foundServices, _missingServices] = services.reduce(
+		([found, missing], { binding: bindingName, service: serviceName }) => {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const service = registeredWorkers![serviceName];
+			return service
+				? [
+						[...found, { bindingName, serviceName, workerDefinition: service }],
+						missing,
+				  ]
+				: [found, [...missing, { bindingName }]];
+		},
+		[[], []] as [
+			AvailableBindingInfo[],
+			Pick<AvailableBindingInfo, "bindingName">[]
+		]
+	);
+
+	const serviceBindings = foundServices.reduce((acc, bindingInfo) => {
+		return {
+			...acc,
+			[bindingInfo.bindingName]: getServiceBindingProxyFetch(bindingInfo),
+		};
+	}, {} as ServiceBindings);
+
+	return serviceBindings;
+}
+
+type ServiceBindings = Record<string, (_req: Request) => Promise<Response>>;
+
+type AvailableBindingInfo = {
+	bindingName: string;
+	serviceName: string;
+	workerDefinition: WorkerDefinition;
+};
+
+/**
+ * Given all the relevant information about a service binding and its relative worker definition this
+ * function generates a proxy fetch that takes requests targeted to the service and proxies them to it
+ *
+ * @param availableBindingInfo the binding information to be used to create a proxy to an external service
+ * @returns the binding proxy (in the form of a nodejs fetch method)
+ */
+function getServiceBindingProxyFetch({
+	workerDefinition,
+	bindingName,
+	serviceName,
+}: AvailableBindingInfo) {
+	const { protocol, host, port } = workerDefinition;
+
+	const getExternalUrl = (request: Request) => {
+		const newUrl = new URL(request.url);
+		if (protocol) newUrl.protocol = protocol;
+		if (host) newUrl.host = host;
+		if (port) newUrl.port = `${port}`;
+		return newUrl;
+	};
+
+	return async (request: Request) => {
+		const newUrl = getExternalUrl(request);
+		try {
+			const resp = await fetch(newUrl, request as RequestInit);
+			const respBody = await resp.arrayBuffer();
+			return new Response(respBody, resp as unknown as Response);
+		} catch {
+			return new Response(
+				`Error: Unable to fetch from external service (${serviceName} bound with ${bindingName} binding), please make sure that the service is still running with \`wrangler dev\``,
+				{ status: 500 }
+			);
+		}
+	};
+}

--- a/packages/wrangler/src/api/integrations/bindings/services.ts
+++ b/packages/wrangler/src/api/integrations/bindings/services.ts
@@ -28,19 +28,22 @@ export async function getServiceBindings(
 		return;
 	}
 
-  const foundServices: AvailableBindingInfo[] = [];
-  const _missingServices: Pick<AvailableBindingInfo, "bindingName">[] = [];
-  for (const {binding: bindingName, service: serviceName} of services) {
-     const worker = registeredWorkers[serviceName]
-     if (worker) {
-       foundServices.push({ bindingName, serviceName, workerDefinition: worker });
-     } else {
-       _missingServices.push({bindingName});
-  }
+	const foundServices: AvailableBindingInfo[] = [];
+	for (const { binding: bindingName, service: serviceName } of services) {
+		const worker = registeredWorkers[serviceName];
+		if (worker) {
+			foundServices.push({
+				bindingName,
+				serviceName,
+				workerDefinition: worker,
+			});
+		}
+	}
 
 	const serviceBindings: ServiceBindings = {};
-	for(bindingInfo of foundServices) {
-			serviceBindings[bindingInfo.bindingName] = getServiceBindingProxyFetch(bindingInfo);
+	for (const bindingInfo of foundServices) {
+		serviceBindings[bindingInfo.bindingName] =
+			getServiceBindingProxyFetch(bindingInfo);
 	}
 	return serviceBindings;
 }

--- a/packages/wrangler/src/api/integrations/index.ts
+++ b/packages/wrangler/src/api/integrations/index.ts
@@ -1,0 +1,1 @@
+export * from "./bindings";

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -26,3 +26,5 @@ if (typeof jest === "undefined" && require.main === module) {
  */
 export { unstable_dev, unstable_pages, unstable_DevEnv };
 export type { UnstableDevWorker, UnstableDevOptions };
+
+export * from "./api/integrations";

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -29,7 +29,7 @@ export type {
 export function readConfig<CommandArgs>(
 	configPath: string | undefined,
 	// Include command specific args as well as the wrangler global flags
-	args: CommandArgs & OnlyCamelCase<CommonYargsOptions>
+	args: CommandArgs & Partial<OnlyCamelCase<CommonYargsOptions>>
 ): Config {
 	let rawConfig: RawConfig = {};
 	if (!configPath) {

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -29,7 +29,8 @@ export type {
 export function readConfig<CommandArgs>(
 	configPath: string | undefined,
 	// Include command specific args as well as the wrangler global flags
-	args: CommandArgs & Partial<OnlyCamelCase<CommonYargsOptions>>
+	args: CommandArgs &
+		Pick<OnlyCamelCase<CommonYargsOptions>, "experimentalJsonConfig">
 ): Config {
 	let rawConfig: RawConfig = {};
 	if (!configPath) {

--- a/packages/wrangler/src/dev-registry.ts
+++ b/packages/wrangler/src/dev-registry.ts
@@ -18,7 +18,7 @@ let terminator: HttpTerminator;
 
 export type WorkerRegistry = Record<string, WorkerDefinition>;
 
-type WorkerDefinition = {
+export type WorkerDefinition = {
 	port: number | undefined;
 	protocol: "http" | "https" | undefined;
 	host: string | undefined;

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -846,7 +846,7 @@ function getBindingsAndAssetPaths(args: StartDevOptions, configParam: Config) {
 	return { assetPaths, bindings };
 }
 
-function getBindings(
+export function getBindings(
 	configParam: Config,
 	env: string | undefined,
 	local: boolean,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/get-bindings-proxy:
+    devDependencies:
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20221111.1
+        version: 4.20231025.0
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/import-wasm-example:
     dependencies:
       import-wasm-static:
@@ -1018,7 +1030,7 @@ importers:
         version: 5.23.0
       wrangler:
         specifier: ^3.5.1
-        version: link:../wrangler
+        version: 3.23.0
 
   packages/prerelease-registry:
     dependencies:
@@ -1598,7 +1610,7 @@ importers:
         version: 6.5.1
       wrangler:
         specifier: ^3.0.0
-        version: link:../wrangler
+        version: 3.23.0
 
 packages:
 
@@ -3637,7 +3649,6 @@ packages:
     resolution: {integrity: sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==}
     dependencies:
       mime: 3.0.0
-    dev: false
 
   /@cloudflare/kv-asset-handler@0.3.0:
     resolution: {integrity: sha512-9CB/MKf/wdvbfkUdfrj+OkEwZ5b7rws0eogJ4293h+7b6KX5toPwym+VQKmILafNB9YiehqY0DlNrDcDhdWHSQ==}
@@ -3745,7 +3756,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workerd-darwin-arm64@1.20231218.0:
@@ -3754,7 +3764,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workerd-linux-64@1.20231218.0:
@@ -3763,7 +3772,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workerd-linux-arm64@1.20231218.0:
@@ -3772,7 +3780,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workerd-windows-64@1.20231218.0:
@@ -3781,7 +3788,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@cloudflare/workers-types@3.18.0:
@@ -3852,7 +3858,6 @@ packages:
       esbuild: '*'
     dependencies:
       esbuild: 0.17.19
-    dev: false
 
   /@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19):
     resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
@@ -3862,7 +3867,6 @@ packages:
       esbuild: 0.17.19
       escape-string-regexp: 4.0.0
       rollup-plugin-node-polyfills: 0.2.1
-    dev: false
 
   /@esbuild/android-arm64@0.16.17:
     resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
@@ -7856,7 +7860,6 @@ packages:
     resolution: {integrity: sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==}
     dependencies:
       printable-characters: 1.0.42
-    dev: false
 
   /assert@2.0.0:
     resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
@@ -8214,7 +8217,6 @@ packages:
 
   /blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
-    dev: false
 
   /blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
@@ -8506,7 +8508,6 @@ packages:
       tslib: 2.5.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
     patched: true
 
   /capnpc-ts@0.7.0:
@@ -9217,7 +9218,6 @@ packages:
 
   /data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
-    dev: false
 
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
@@ -10783,7 +10783,6 @@ packages:
 
   /estree-walker@0.6.1:
     resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
-    dev: false
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -11474,7 +11473,6 @@ packages:
     dependencies:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
-    dev: false
 
   /get-stream@4.1.0:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
@@ -13793,7 +13791,6 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
-    dev: false
 
   /magic-string@0.30.3:
     resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
@@ -14421,6 +14418,29 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /miniflare@3.20231218.2:
+    resolution: {integrity: sha512-rCUI2OjqCf3fZVdmSX4DOZQRzSDvHp/oL2vjER/cvJEdWSYiqRxDp2oO7A7JcEo1/Y+kPa5VQ1pFfdZpjBcpFg==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      capnp-ts: 0.7.0(patch_hash=l4yimnxyvkiyj6alnps2ec3sii)
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      stoppable: 1.1.0
+      undici: 5.28.2
+      workerd: 1.20231218.0
+      ws: 8.14.2
+      youch: 3.2.3
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -14739,7 +14759,6 @@ packages:
   /node-forge@1.3.0:
     resolution: {integrity: sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==}
     engines: {node: '>= 6.13.0'}
-    dev: false
 
   /node-gyp@10.0.1:
     resolution: {integrity: sha512-gg3/bHehQfZivQVfqIyy8wTdSymF9yTyP4CJifK73imyNMU8AIGQE2pUa7dNWfmMeG9cDVF2eehiRMv0LC1iAg==}
@@ -15755,7 +15774,6 @@ packages:
 
   /printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
-    dev: false
 
   /prism-react-renderer@1.3.5(react@18.2.0):
     resolution: {integrity: sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==}
@@ -16652,19 +16670,16 @@ packages:
       estree-walker: 0.6.1
       magic-string: 0.25.9
       rollup-pluginutils: 2.8.2
-    dev: false
 
   /rollup-plugin-node-polyfills@0.2.1:
     resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
     dependencies:
       rollup-plugin-inject: 3.0.2
-    dev: false
 
   /rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
     dependencies:
       estree-walker: 0.6.1
-    dev: false
 
   /rollup@3.25.1:
     resolution: {integrity: sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==}
@@ -16799,7 +16814,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       node-forge: 1.3.0
-    dev: false
 
   /semiver@1.1.0:
     resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
@@ -17182,7 +17196,6 @@ packages:
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
-    dev: false
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -17270,7 +17283,6 @@ packages:
     dependencies:
       as-table: 1.0.55
       get-source: 2.0.12
-    dev: false
 
   /standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -17296,7 +17308,6 @@ packages:
   /stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
-    dev: false
 
   /stream-shift@1.0.1:
     resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
@@ -18865,7 +18876,33 @@ packages:
       '@cloudflare/workerd-linux-64': 1.20231218.0
       '@cloudflare/workerd-linux-arm64': 1.20231218.0
       '@cloudflare/workerd-windows-64': 1.20231218.0
-    dev: false
+
+  /wrangler@3.23.0:
+    resolution: {integrity: sha512-mOWPL02/popoF6jjb4TT8au4yvo8VFu6O6/IwcRN74rlgwaGS0XvlkFtbofBGAdDUHAh5DXkuoPNS871mXNuJg==}
+    engines: {node: '>=16.17.0'}
+    hasBin: true
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.2.0
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      chokidar: 3.5.3
+      esbuild: 0.17.19
+      miniflare: 3.20231218.2
+      nanoid: 3.3.6
+      path-to-regexp: 6.2.0
+      resolve: 1.22.8
+      resolve.exports: 2.0.2
+      selfsigned: 2.1.1
+      source-map: 0.6.1
+      xxhash-wasm: 1.0.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: true
 
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -19016,7 +19053,6 @@ packages:
 
   /xxhash-wasm@1.0.1:
     resolution: {integrity: sha512-Lc9CTvDrH2vRoiaUzz25q7lRaviMhz90pkx6YxR9EPYtF99yOJnv2cB+CQ0hp/TLoqrUsk8z/W2EN31T568Azw==}
-    dev: false
 
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -19136,7 +19172,6 @@ packages:
       cookie: 0.5.0
       mustache: 4.2.0
       stacktracey: 2.1.8
-    dev: false
 
   /z-schema@5.0.3:
     resolution: {integrity: sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==}


### PR DESCRIPTION
This PR introduces a new `getBindingsProxy` that can be used externally to get a proxy to Miniflare bindings that integrate well with wrangler (e.g. with the toml file and the local registry)

You can see a demo of what this would look like here: [getBindingsProxy-poc-demo](https://github.com/dario-piotrowicz/getBindingsProxy-poc-demo)

> [!NOTE]
> Initially the utility was going to have two alternative argument APIs, one in which it would accept inline bindings (to use for Pages application) and one in which the bindings would instead be read from the `wrangler.toml` file (to use for Workers applications).
>
> We're currently considering if maybe it would be better to have this utility simply always only read the bindings from the `wrangler.toml` file (it would be a simpler API for users to use and for us to implement and maintain).
>
> I am not sure if both APIs will be implemented or if only the toml one will, regardless I'm scoping this PR only to the toml implementation, since the inline one could be then added afterwords as an additive non-breaking change anyways, so there is really no harm in reducing the PR's scope

___

To address:

- [x] implement passing the `persist` option ~~, also, maybe we should just enable the utility to get the miniflare options and pass them to it as they are?~~[^1]
- ~~[ ] Implement utilities to get all the bindings of a certain type (e.g. `getD1Bindings`, etc...)~~[^2]
- ~~[ ] to give maximum flexibility to users, maybe in the return object we should return the miniflare instance itself?~~[^1]
- ~~[ ] implement ai fetcher (if possible) to enable workers-ai bindings to be used locally~~[^2]
- [x] Add testing for the utility
- ~~[ ] support reading env variables/secrets from `.dev.vars`~~[^2]
- [x] make sure the utility can also read `wrangler.json` files (to do here if it's simple or in a followup PR otherwise)
- [x] add proper tsdocs comments to the utility and its options

[^1]: The fact that miniflare is used under the hood should be transparent to users, they shouldn't need to be aware of this, especially if/when in the future this utility uses `startDevWorker` or whatever else layer of abstraction (as discussed with @RamIdeas). 

[^2]: Let's get this working with the classic/simple bindings and add things incrementally in followup PRs (incrementally iterating over this in non breaking manners looks to me like the way to go instead of trying to nail every single aspect right out of the gate) 