### PR TITLE
use proper env variable for C3 prerelease comment

### DIFF
--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -101,7 +101,7 @@ jobs:
       - name: "Comment on PR with C3 link"
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ env.WORKFLOW_RUN_PR_FOR_CREATE_CLOUDFLARE }}
+          number: ${{ env.WORKFLOW_RUN_PR_FOR_CREATE-CLOUDFLARE }}
           message: |
             A create-cloudflare (C3) prerelease is available for testing.
             You can use `npx` with this latest build directly:


### PR DESCRIPTION
The variable name has a dash instead of an underscore

([source](https://github.com/cloudflare/workers-sdk/blob/18a4dd92456f955ccbb35567a88475beafda01c0/.github/workflows/create-pullrequest-prerelease.yml#L110))
 ([example run](https://github.com/cloudflare/workers-sdk/actions/runs/7035882053/job/19147287700#step:6:28)) 