### PR TITLE
remove C3 prerelease comment which overrides the wrangler one and add the c3 prerelease to the original comment

### DIFF
--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -90,6 +90,10 @@ jobs:
             npm install https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-cloudflare-pages-shared-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
             ```
 
+            ```sh
+            npm install https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_WRANGLER }}/npm-package-create-cloudflare-${{ env.WORKFLOW_RUN_PR_FOR_WRANGLER }}
+            ```
+
             Note that these links will no longer work once [the GitHub Actions artifact expires](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).
 
             </details>
@@ -97,17 +101,3 @@ jobs:
             ---
 
             ${{ env.RUNTIME_VERSIONS }}
-
-      - name: "Comment on PR with C3 link"
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          number: ${{ env.WORKFLOW_RUN_PR_FOR_CREATE-CLOUDFLARE }}
-          message: |
-            A create-cloudflare (C3) prerelease is available for testing.
-            You can use `npx` with this latest build directly:
-
-            ```sh
-            npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/${{ env.WORKFLOW_RUN_ID_FOR_CREATE_CLOUDFLARE }}/npm-package-create-cloudflare-${{ env.WORKFLOW_RUN_PR_FOR_CREATE_CLOUDFLARE }}
-            ```
-
-            Note that these links will no longer work once [the GitHub Actions artifact expires](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).


### PR DESCRIPTION
Adding a new sticky comment seems to delete the previous one so we cannot have two sticky prerelease comments, fix this by:
 - removing the C3 prerelease comment job
 - add the C3 prerelease to the existing comment (in the same exact way as the other packages are added)
 
 > [!Note]
 > I personally think that the prerelease comment needs to be updated to appropriately list the various packages, I did attempt to do that in #4090 but abandoned it given the pushbacks, I'd like to merge this PR asap to restore the proper comment (with the c3 prerelease package) and potentially consider later a restructuring of the comment's content