### PR TITLE
fix: validate `Host`/`Origin` headers in magic proxy and `InspectorProxyWorker`

### DIFF
--- a/.changeset/wise-seas-press.md
+++ b/.changeset/wise-seas-press.md
@@ -1,0 +1,8 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+fix: validate `Host` and `Orgin` headers where appropriate
+
+`Host` and `Origin` headers are now checked when connecting to the inspector and Miniflare's magic proxy. If these don't match what's expected, the request will fail.

--- a/packages/miniflare/test/plugins/core/proxy/client.spec.ts
+++ b/packages/miniflare/test/plugins/core/proxy/client.spec.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { Blob } from "buffer";
+import http from "http";
 import { text } from "stream/consumers";
 import { ReadableStream } from "stream/web";
 import util from "util";
@@ -185,7 +186,7 @@ test("ProxyClient: stack traces don't include internal implementation", async (t
 
 	const mf = new Miniflare({
 		modules: true,
-		script: `export class DurableObject {}    
+		script: `export class DurableObject {}
     export default {
       fetch() { return new Response(null, { status: 404 }); }
     }`,
@@ -270,9 +271,32 @@ test("ProxyClient: can `JSON.stringify()` proxies", async (t) => {
 test("ProxyServer: prevents unauthorised access", async (t) => {
 	const mf = new Miniflare({ script: nullScript });
 	t.teardown(() => mf.dispose());
-
 	const url = await mf.ready;
-	const res = await fetch(url, { headers: { "MF-Op": "GET" } });
+
+	// Check validates `Host` header
+	const statusPromise = new DeferredPromise<number>();
+	const req = http.get(
+		url,
+		{ setHost: false, headers: { "MF-Op": "GET", Host: "localhost" } },
+		(res) => statusPromise.resolve(res.statusCode ?? 0)
+	);
+	req.on("error", (error) => statusPromise.reject(error));
+	t.is(await statusPromise, 401);
+
+	// Check validates `MF-Op-Secret` header
+	let res = await fetch(url, {
+		headers: { "MF-Op": "GET" }, // (missing)
+	});
+	t.is(res.status, 401);
+	await res.arrayBuffer(); // (drain)
+	res = await fetch(url, {
+		headers: { "MF-Op": "GET", "MF-Op-Secret": "aaaa" }, // (too short)
+	});
+	t.is(res.status, 401);
+	await res.arrayBuffer(); // (drain)
+	res = await fetch(url, {
+		headers: { "MF-Op": "GET", "MF-Op-Secret": "a".repeat(32) }, // (wrong)
+	});
 	t.is(res.status, 401);
 	await res.arrayBuffer(); // (drain)
 });

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -67,7 +67,8 @@ export class ProxyController extends EventEmitter {
 			workers: [
 				{
 					name: "ProxyWorker",
-					compatibilityFlags: ["nodejs_compat"],
+					// `url_standard` required to parse IPv6 hostnames correctly
+					compatibilityFlags: ["nodejs_compat", "url_standard"],
 					modulesRoot: path.dirname(proxyWorkerPath),
 					modules: [{ type: "ESModule", path: proxyWorkerPath }],
 					durableObjects: {
@@ -96,7 +97,8 @@ export class ProxyController extends EventEmitter {
 				},
 				{
 					name: "InspectorProxyWorker",
-					compatibilityFlags: ["nodejs_compat"],
+					// `url_standard` required to parse IPv6 hostnames correctly
+					compatibilityFlags: ["nodejs_compat", "url_standard"],
 					modulesRoot: path.dirname(inspectorProxyWorkerPath),
 					modules: [{ type: "ESModule", path: inspectorProxyWorkerPath }],
 					durableObjects: {


### PR DESCRIPTION
**What this PR solves / how to test:**

`Host` and `Origin` headers are now checked when connecting to the inspector and Miniflare's magic proxy. If these don't match what's expected, the request will fail. To test this, host DevTools on a different networked computer, and try to connect to the local `wrangler dev` server from that. The request should fail. Connecting from the hosted devtools and local devtools should succeed. Miniflare's test suite should succeed too.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: this shouldn't affect regular use

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
