### PR TITLE
update next pages:dev script

### DIFF
--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -146,12 +146,13 @@ const config: FrameworkConfig = {
 		const nextOnPagesScope = isNpmOrBun ? "@cloudflare/" : "";
 		const nextOnPagesCommand = `${nextOnPagesScope}next-on-pages`;
 		const pmCommand = isNpmOrBun ? npx : npm;
-		const pagesDeployCommand = isNpm ? "npm run" : isBun ? "bun" : pmCommand;
+		const pmRun = isNpm ? "npm run" : isBun ? "bun" : pmCommand;
 		return {
 			"pages:build": `${pmCommand} ${nextOnPagesCommand}`,
-			"pages:deploy": `${pagesDeployCommand} pages:build && wrangler pages deploy .vercel/output/static`,
+			"pages:deploy": `${pmRun} pages:build && wrangler pages deploy .vercel/output/static`,
 			"pages:watch": `${pmCommand} ${nextOnPagesCommand} --watch`,
-			"pages:dev": `${pmCommand} wrangler pages dev .vercel/output/static ${await compatDateFlag()} --compatibility-flag=nodejs_compat`,
+			"wrangler:pages:dev": `${pmCommand} wrangler pages dev .vercel/output/static ${await compatDateFlag()} --compatibility-flag=nodejs_compat`,
+			"pages:dev": `${pmRun} pages:watch & sleep 15 && ${pmRun} wrangler:pages:dev`,
 		};
 	},
 	testFlags: [


### PR DESCRIPTION
This is not a proper solution at all, but soon the `pages:dev` script should be replaced with a `pages:preview` one and for local development developers should just use the standard dev command (as per the [recommended workflow](https://github.com/cloudflare/next-on-pages/tree/main/internal-packages/next-dev#recommended-workflow)), so I am not sure if we should invest more time in trying to make `pages:dev` better now or add this simple stopgap until we're ready [finalize next-dev](https://github.com/cloudflare/next-on-pages/issues/527)