### PR TITLE
Assert `workerd` version pinned

### DIFF
--- a/.github/extract-runtime-versions.mjs
+++ b/.github/extract-runtime-versions.mjs
@@ -45,6 +45,15 @@ const miniflarePackage = JSON.parse(miniflarePackageJson);
 const miniflareVersion = miniflarePackage.version;
 const workerdVersionConstraint = miniflarePackage.dependencies.workerd;
 
+// Fail if workerd isn't pinned (constraint doesn't start with a number)
+if (!/^[0-9]/.test(workerdVersionConstraint)) {
+	const quoted = JSON.stringify(workerdVersionConstraint);
+	console.error(
+		`\`miniflare\`'s \`workerd\` version constraint ${quoted} is not pinned`
+	);
+	process.exitCode = 1;
+}
+
 // 3. Load `workerd` `package.json`, getting `workerd` version
 const miniflareRequire = module.createRequire(miniflarePackageJsonPath);
 const workerdMainPath = miniflareRequire.resolve("workerd");


### PR DESCRIPTION
Closes DEVX-1049

**What this PR solves / how to test:**

This PR ensures `miniflare`'s `workerd` version is pinned as part of CI. Specifically, the `Create Pull Request Prerelease` job will fail here...

https://github.com/cloudflare/workers-sdk/blob/70f634c563cc26e94df11d038faa0d4bae576f48/.github/workflows/create-pullrequest-prerelease.yml#L45-L46

...if `workerd` isn't pinned.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: internal change to CI
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: internal change to CI

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
