### PR TITLE
During the pages validation, show `MAX_ASSET_SIZE` consistently as per docs

### DIFF
--- a/.changeset/itchy-knives-share.md
+++ b/.changeset/itchy-knives-share.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+During the pages validation, show `MAX_ASSET_SIZE` consistently as per docs
+
+During the pages validation, if a file is bigger than `MAX_ASSET_SIZE`
+and error is displayed to the user saying that the maximum allowed size
+for a file is 26.2 MB, this format is inconsistent with the pages documentation
+(https://developers.cloudflare.com/pages/platform/limits/#file-size)
+which mentions that the maximum limit is 25 MiB, this inconsistency might lead to
+confusion, fix the error message so that it is consistent with the docs

--- a/packages/wrangler/src/pages/validate.tsx
+++ b/packages/wrangler/src/pages/validate.tsx
@@ -94,7 +94,8 @@ export const validate = async (args: {
 					if (filestat.size > MAX_ASSET_SIZE) {
 						throw new FatalError(
 							`Error: Pages only supports files up to ${prettyBytes(
-								MAX_ASSET_SIZE
+								MAX_ASSET_SIZE,
+								{ binary: true }
 							)} in size\n${name} is ${prettyBytes(filestat.size)} in size`,
 							1
 						);


### PR DESCRIPTION
resolves  #4519