### PR TITLE
Add workers ai usage warning in local mode

### DIFF
--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -507,6 +507,12 @@ async function buildMiniflareOptions(
 		logger.warn("Miniflare 3 does not support CRON triggers yet, ignoring...");
 	}
 
+	if (config.bindings.ai) {
+		logger.warn(
+			"Workers AI will incur usage charges in local mode."
+		);
+	}
+
 	if (config.bindings.vectorize?.length) {
 		// TODO: add local support for Vectorize bindings (https://github.com/cloudflare/workers-sdk/issues/4360)
 		logger.warn(


### PR DESCRIPTION
**What this PR solves / how to test:**
Adds workers ai usage warning in local mode

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
