### PR TITLE
[wrangler] Backport recent inspector proxy server changes to V2

### DIFF
--- a/.changeset/warm-dryers-double.md
+++ b/.changeset/warm-dryers-double.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Change dev registry and inspector server to listen on 127.0.0.1 instead of all interfaces

--- a/.changeset/wise-seas-press.md
+++ b/.changeset/wise-seas-press.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: validate `Host` and `Orgin` headers where appropriate
+
+`Host` and `Origin` headers are now checked when connecting to the inspector proxy. If these don't match what's expected, the request will fail.

--- a/packages/wrangler/src/__tests__/api-devregistry.test.ts
+++ b/packages/wrangler/src/__tests__/api-devregistry.test.ts
@@ -40,7 +40,7 @@ describe("multi-worker testing", () => {
 	});
 
 	it("parentWorker and childWorker should be added devRegistry", async () => {
-		const resp = await fetch("http://localhost:6284/workers");
+		const resp = await fetch("http://127.0.0.1:6284/workers");
 		if (resp) {
 			const parsedResp = (await resp.json()) as {
 				parent: unknown;

--- a/packages/wrangler/src/dev-registry.ts
+++ b/packages/wrangler/src/dev-registry.ts
@@ -1,5 +1,5 @@
-import http from "http";
 import net from "net";
+import { createServer } from "node:http";
 import bodyParser from "body-parser";
 import express from "express";
 import { createHttpTerminator } from "http-terminator";
@@ -7,11 +7,11 @@ import { fetch } from "undici";
 import { logger } from "./logger";
 
 import type { Config } from "./config";
-import type { Server } from "http";
 import type { HttpTerminator } from "http-terminator";
+import type { Server } from "node:http";
 
-const DEV_REGISTRY_PORT = "6284";
-const DEV_REGISTRY_HOST = `http://localhost:${DEV_REGISTRY_PORT}`;
+const DEV_REGISTRY_PORT = 6284;
+const DEV_REGISTRY_HOST = `http://127.0.0.1:${DEV_REGISTRY_PORT}`;
 
 let server: Server | null;
 let terminator: HttpTerminator;
@@ -48,7 +48,7 @@ async function isPortAvailable() {
 				netServer.close();
 				resolve(true);
 			});
-		netServer.listen(DEV_REGISTRY_PORT);
+		netServer.listen(DEV_REGISTRY_PORT, "127.0.0.1");
 	});
 }
 
@@ -80,9 +80,9 @@ export async function startWorkerRegistry() {
 				workers = {};
 				res.json(null);
 			});
-		server = http.createServer(app);
+		server = createServer(app);
 		terminator = createHttpTerminator({ server });
-		server.listen(DEV_REGISTRY_PORT);
+		server.listen(DEV_REGISTRY_PORT, "127.0.0.1");
 
 		/**
 		 * The registry server may have already been started by another wrangler process.

--- a/packages/wrangler/src/inspect.ts
+++ b/packages/wrangler/src/inspect.ts
@@ -110,7 +110,7 @@ export default function useInspector(props: InspectorProps) {
 					case "/json/list":
 						{
 							res.setHeader("Content-Type", "application/json");
-							const localHost = `localhost:${props.port}/ws`;
+							const localHost = `127.0.0.1:${props.port}/ws`;
 							const devtoolsFrontendUrl = `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=${localHost}`;
 							const devtoolsFrontendUrlCompat = `devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=${localHost}`;
 							res.end(
@@ -197,7 +197,7 @@ export default function useInspector(props: InspectorProps) {
 				timeout: 2000,
 				abortSignal: abortController.signal,
 			});
-			server.listen(props.port);
+			server.listen(props.port, "127.0.0.1");
 		}
 		startInspectorProxy().catch((err) => {
 			if ((err as { code: string }).code !== "ABORT_ERR") {
@@ -844,7 +844,7 @@ export const openInspector = async (
 ) => {
 	const query = new URLSearchParams();
 	query.set("theme", "systemPreferred");
-	query.set("ws", `localhost:${inspectorPort}/ws`);
+	query.set("ws", `127.0.0.1:${inspectorPort}/ws`);
 	if (worker) query.set("domain", worker);
 	const url = `https://devtools.devprod.cloudflare.dev/js_app?${query.toString()}`;
 	const errorMessage =


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR backports some changes we recently made to the Wrangler 3's inspector proxy to Wrangler 2. Specifically, the inspector server now listens on local interfaces by default, and validates incoming `Host`/`Origin` headers.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: these changes have already landed in v3, and we're just backporting them over to a version that's just receiving security updates
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: v2 is no longer documented

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
