### PR TITLE
[wrangler] fix: require worker name for rollback

### DIFF
--- a/.changeset/tasty-experts-protect.md
+++ b/.changeset/tasty-experts-protect.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: require worker name for rollback
+
+Previously, Wrangler would fail with a cryptic error if you tried to run `wrangler rollback` outside of a directory containing a Wrangler configuration file with a `name` defined. This change validates that a worker name is defined, and allows you to set it from the command line using the `--name` flag.

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { rest } from "msw";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -15,6 +16,12 @@ import { mswSuccessDeployments } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import writeWranglerToml from "./helpers/write-wrangler-toml";
+
+function isFileNotFound(e: unknown) {
+	return (
+		typeof e === "object" && e !== null && "code" in e && e.code === "ENOENT"
+	);
+}
 
 describe("deployments", () => {
 	const std = mockConsoleMethods();
@@ -34,6 +41,13 @@ describe("deployments", () => {
 			...mswSuccessDeploymentScriptMetadata,
 			...mswSuccessDeploymentDetails
 		);
+	});
+	afterEach(() => {
+		try {
+			fs.unlinkSync("wrangler.toml");
+		} catch (e) {
+			if (!isFileNotFound(e)) throw e;
+		}
 	});
 
 	it("should log a help message for deployments command", async () => {
@@ -71,24 +85,24 @@ describe("deployments", () => {
 			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
 
-			Deployment ID: Constitution-Class
+			Deployment ID: Constitution-Class-tag:test-name
 			Created on:    2021-01-01T00:00:00.000000Z
 			Author:        Jean-Luc-Picard@federation.org
 			Source:        Upload from Wrangler 🤠
 
-			Deployment ID: Intrepid-Class
+			Deployment ID: Intrepid-Class-tag:test-name
 			Created on:    2021-02-02T00:00:00.000000Z
 			Author:        Kathryn-Janeway@federation.org
 			Source:        Rollback from Wrangler 🤠
 			Rollback from: MOCK-DEPLOYMENT-ID-1111
 			Message:       Rolled back for this version
 
-			Deployment ID: 3mEgaU1T-Intrepid-someThing
+			Deployment ID: 3mEgaU1T-Intrepid-someThing-tag:test-name
 			Created on:    2021-02-03T00:00:00.000000Z
 			Author:        Kathryn-Janeway@federation.org
 			Source:        Wrangler 🤠
 
-			Deployment ID: Galaxy-Class
+			Deployment ID: Galaxy-Class-tag:test-name
 			Created on:    2021-01-04T00:00:00.000000Z
 			Author:        Jean-Luc-Picard@federation.org
 			Source:        Rollback from Wrangler 🤠
@@ -103,24 +117,24 @@ describe("deployments", () => {
 			"🚧\`wrangler deployments\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
 
-			Deployment ID: Constitution-Class
+			Deployment ID: Constitution-Class-tag:something-else
 			Created on:    2021-01-01T00:00:00.000000Z
 			Author:        Jean-Luc-Picard@federation.org
 			Source:        Upload from Wrangler 🤠
 
-			Deployment ID: Intrepid-Class
+			Deployment ID: Intrepid-Class-tag:something-else
 			Created on:    2021-02-02T00:00:00.000000Z
 			Author:        Kathryn-Janeway@federation.org
 			Source:        Rollback from Wrangler 🤠
 			Rollback from: MOCK-DEPLOYMENT-ID-1111
 			Message:       Rolled back for this version
 
-			Deployment ID: 3mEgaU1T-Intrepid-someThing
+			Deployment ID: 3mEgaU1T-Intrepid-someThing-tag:something-else
 			Created on:    2021-02-03T00:00:00.000000Z
 			Author:        Kathryn-Janeway@federation.org
 			Source:        Wrangler 🤠
 
-			Deployment ID: Galaxy-Class
+			Deployment ID: Galaxy-Class-tag:something-else
 			Created on:    2021-01-04T00:00:00.000000Z
 			Author:        Jean-Luc-Picard@federation.org
 			Source:        Rollback from Wrangler 🤠
@@ -220,8 +234,8 @@ describe("deployments", () => {
 					rest.put(
 						"*/accounts/:accountID/workers/scripts/:scriptName",
 						(req, res, ctx) => {
-							expect(req.url.searchParams.get("rollback_to")).toBe(
-								"3mEgaU1T-Intrepid-someThing"
+							expect(req.url.searchParams.get("rollback_to")).toMatch(
+								/^3mEgaU1T-Intrepid-someThing-tag:/
 							);
 
 							requests.count++;
@@ -266,12 +280,13 @@ describe("deployments", () => {
 					result: "",
 				});
 
-				await runWrangler("rollback 3mEgaU1T-Intrepid-someThing");
+				writeWranglerToml();
+				await runWrangler("rollback 3mEgaU1T-Intrepid-someThing-tag:test-name");
 				expect(std.out).toMatchInlineSnapshot(`
 			"🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
 
-			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing
+			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing-tag:test-name
 			Current Deployment ID: galactic_mission_alpha"
 		`);
 
@@ -284,7 +299,8 @@ describe("deployments", () => {
 					result: false,
 				});
 
-				await runWrangler("rollback 3mEgaU1T-Intrpid-someThing");
+				writeWranglerToml();
+				await runWrangler("rollback 3mEgaU1T-Intrpid-someThing-tag:test-name");
 				expect(std.out).toMatchInlineSnapshot(`
 			"🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 			"
@@ -296,7 +312,8 @@ describe("deployments", () => {
 			it("should skip prompt automatically in rollback if in a non-TTY environment", async () => {
 				setIsTTY(false);
 
-				await runWrangler("rollback 3mEgaU1T-Intrepid-someThing");
+				writeWranglerToml();
+				await runWrangler("rollback 3mEgaU1T-Intrepid-someThing-tag:test-name");
 				expect(std.out).toMatchInlineSnapshot(`
 			"🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
@@ -305,7 +322,7 @@ describe("deployments", () => {
 			? Please provide a message for this rollback (120 characters max)
 			🤖 Using default value in non-interactive context:
 
-			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing
+			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing-tag:test-name
 			Current Deployment ID: galactic_mission_alpha"
 		`);
 
@@ -313,14 +330,15 @@ describe("deployments", () => {
 			});
 
 			it("should skip prompt automatically in rollback if message flag is provided", async () => {
+				writeWranglerToml();
 				await runWrangler(
-					`rollback 3mEgaU1T-Intrepid-someThing --message "test"`
+					`rollback 3mEgaU1T-Intrepid-someThing-tag:test-name --message "test"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
 			"🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
 
-			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing
+			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing-tag:test-name
 			Current Deployment ID: galactic_mission_alpha"
 		`);
 
@@ -328,14 +346,15 @@ describe("deployments", () => {
 			});
 
 			it("should skip prompt automatically in rollback with empty message", async () => {
+				writeWranglerToml();
 				await runWrangler(
-					`rollback 3mEgaU1T-Intrepid-someThing --message "test"`
+					`rollback 3mEgaU1T-Intrepid-someThing-tag:test-name --message "test"`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
 			"🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
 
-			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing
+			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing-tag:test-name
 			Current Deployment ID: galactic_mission_alpha"
 		`);
 
@@ -353,12 +372,44 @@ describe("deployments", () => {
 					result: "",
 				});
 
+				writeWranglerToml();
 				await runWrangler("rollback");
 				expect(std.out).toMatchInlineSnapshot(`
 			"🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
 
-			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing
+			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing-tag:test-name
+			Current Deployment ID: galactic_mission_alpha"
+		`);
+
+				expect(requests.count).toEqual(1);
+			});
+
+			it("should require a worker name", async () => {
+				await expect(runWrangler("rollback")).rejects.toMatchInlineSnapshot(
+					`[Error: Required Worker name missing. Please specify the Worker name in wrangler.toml, or pass it as an argument with \`--name\`]`
+				);
+
+				expect(requests.count).toEqual(0);
+			});
+
+			it("should automatically rollback to previous deployment with specified name", async () => {
+				mockConfirm({
+					text: "This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, R2, KV, etc.).",
+					result: true,
+				});
+
+				mockPrompt({
+					text: "Please provide a message for this rollback (120 characters max)",
+					result: "",
+				});
+
+				await runWrangler("rollback --name something-else");
+				expect(std.out).toMatchInlineSnapshot(`
+			"🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
+
+
+			Successfully rolled back to Deployment ID: 3mEgaU1T-Intrepid-someThing-tag:something-else
 			Current Deployment ID: galactic_mission_alpha"
 		`);
 

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/deployments.ts
@@ -1,8 +1,8 @@
 import { rest } from "msw";
 import { createFetchResult } from "../index";
 
-const latestDeployment = {
-	id: "Galaxy-Class",
+const latestDeployment = (scriptTag: string) => ({
+	id: `Galaxy-Class-${scriptTag}`,
 	number: "1701-E",
 	annotations: {
 		"workers/triggered_by": "rollback",
@@ -16,21 +16,22 @@ const latestDeployment = {
 		modified_on: "2021-01-04T00:00:00.000000Z",
 	},
 	resources: {
-		script: "MOCK-TAG",
+		script: scriptTag,
 		bindings: [],
 	},
-};
+});
 export const mswSuccessDeployments = [
 	rest.get(
 		"*/accounts/:accountId/workers/deployments/by-script/:scriptTag",
-		(_, response, context) =>
-			response.once(
+		(request, response, context) => {
+			const scriptTag = String(request.params["scriptTag"]);
+			return response.once(
 				context.json(
 					createFetchResult({
-						latest: latestDeployment,
+						latest: latestDeployment(scriptTag),
 						items: [
 							{
-								id: "Constitution-Class",
+								id: `Constitution-Class-${scriptTag}`,
 								number: "1701-E",
 								annotations: {
 									"workers/triggered_by": "upload",
@@ -44,7 +45,7 @@ export const mswSuccessDeployments = [
 								},
 							},
 							{
-								id: "Intrepid-Class",
+								id: `Intrepid-Class-${scriptTag}`,
 								number: "NCC-74656",
 								annotations: {
 									"workers/triggered_by": "rollback",
@@ -60,7 +61,7 @@ export const mswSuccessDeployments = [
 								},
 							},
 							{
-								id: "3mEgaU1T-Intrepid-someThing",
+								id: `3mEgaU1T-Intrepid-someThing-${scriptTag}`,
 								number: "NCC-74656",
 								metadata: {
 									author_id: "Kathryn-Jane-Gamma-6-0-7-3",
@@ -70,23 +71,25 @@ export const mswSuccessDeployments = [
 									modified_on: "2021-02-03T00:00:00.000000Z",
 								},
 							},
-							latestDeployment,
+							latestDeployment(scriptTag),
 						],
 					})
 				)
-			)
+			);
+		}
 	),
 ];
 
 export const mswSuccessDeploymentScriptMetadata = [
 	rest.get(
 		"*/accounts/:accountId/workers/services/:scriptName",
-		(_, res, ctx) => {
+		(req, res, ctx) => {
+			const tag = `tag:${req.params["scriptName"]}`;
 			return res.once(
 				ctx.json(
 					createFetchResult({
 						default_environment: {
-							script: { last_deployed_from: "wrangler", tag: "MOCK-TAG" },
+							script: { last_deployed_from: "wrangler", tag },
 						},
 					})
 				)
@@ -98,12 +101,13 @@ export const mswSuccessDeploymentScriptMetadata = [
 export const mswSuccessDeploymentScriptAPI = [
 	rest.get(
 		"*/accounts/:accountId/workers/services/:scriptName",
-		(_, res, ctx) => {
+		(req, res, ctx) => {
+			const tag = `tag:${req.params["scriptName"]}`;
 			return res.once(
 				ctx.json(
 					createFetchResult({
 						default_environment: {
-							script: { last_deployed_from: "api", tag: "MOCK-TAG" },
+							script: { last_deployed_from: "api", tag },
 						},
 					})
 				)

--- a/packages/wrangler/src/deployments.ts
+++ b/packages/wrangler/src/deployments.ts
@@ -55,12 +55,6 @@ export async function deployments(
 	scriptName: string | undefined,
 	{ send_metrics: sendMetrics }: { send_metrics?: Config["send_metrics"] } = {}
 ) {
-	if (!scriptName) {
-		throw new Error(
-			"Required Worker name missing. Please specify the Worker name in wrangler.toml, or pass it as an argument with `--name`"
-		);
-	}
-
 	await metrics.sendMetricsEvent(
 		"view deployments",
 		{ view: scriptName ? "single" : "all" },
@@ -162,7 +156,7 @@ export async function rollbackDeployment(
 
 		if (deploys.length < 2) {
 			throw new Error(
-				"Cannot rollback to previous deployment since there are less than 2 deployemnts"
+				"Cannot rollback to previous deployment since there are less than 2 deployments"
 			);
 		}
 
@@ -341,6 +335,11 @@ export async function commonDeploymentCMDSetup(
 	);
 
 	logger.log(`${deploymentsWarning}\n`);
+	if (!scriptName) {
+		throw new Error(
+			"Required Worker name missing. Please specify the Worker name in wrangler.toml, or pass it as an argument with `--name`"
+		);
+	}
 
 	return { accountId, scriptName, config };
 }

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -664,6 +664,10 @@ export function createCLIParser(argv: string[]) {
 					type: "string",
 					default: undefined,
 				})
+				.option("name", {
+					describe: "The name of your worker",
+					type: "string",
+				})
 				.epilogue(rollbackWarning),
 		async (rollbackYargs) => {
 			const { accountId, scriptName, config } = await commonDeploymentCMDSetup(


### PR DESCRIPTION
Fixes #3372.

**What this PR solves / how to test:**

Previously, Wrangler would fail with a cryptic error if you tried to run `wrangler rollback` outside of a directory containing a Wrangler configuration file with a `name` defined. This change validates that a worker name is defined, and allows you to set it from the command line using the `--name` flag. To test this, try to run `wrangler rollback` in a directory without a `wrangler.toml`. This should fail, but running `wrangler rollback --name <NAME_TO_VALID_WORKER>` should succeed.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): https://github.com/cloudflare/cloudflare-docs/pull/12204
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
