### PR TITLE
[wrangler] fix: throw helpful error if email validation required

### DIFF
--- a/.changeset/serious-seals-sneeze.md
+++ b/.changeset/serious-seals-sneeze.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: throw helpful error if email validation required
+
+Previously, Wrangler would display the raw API error message and code if email validation was required during `wrangler deploy`. This change ensures a helpful error message is displayed instead, prompting users to check their emails or visit the dashboard for a verification link.

--- a/packages/wrangler/src/cfetch/errors.ts
+++ b/packages/wrangler/src/cfetch/errors.ts
@@ -1,0 +1,23 @@
+import { ParseError } from "../parse";
+
+export interface FetchError {
+	code: number;
+	message: string;
+	error_chain?: FetchError[];
+}
+
+function buildDetailedError(message: string, ...extra: string[]) {
+	return new ParseError({
+		text: message,
+		notes: extra.map((text) => ({ text })),
+	});
+}
+
+export function maybeThrowFriendlyError(error: FetchError) {
+	if (error.message === "workers.api.error.email_verification_required") {
+		throw buildDetailedError(
+			"Please verify your account's email address and try again.",
+			"Check your email for a verification link, or login to https://dash.cloudflare.com and request a new one."
+		);
+	}
+}

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -1,16 +1,14 @@
 import { URLSearchParams } from "node:url";
 import { logger } from "../logger";
 import { ParseError } from "../parse";
+import { maybeThrowFriendlyError } from "./errors";
 import { fetchInternal, performApiFetch } from "./internal";
+import type { FetchError } from "./errors";
 import type { RequestInit } from "undici";
 
 // Check out https://api.cloudflare.com/ for API docs.
 
-export interface FetchError {
-	code: number;
-	message: string;
-	error_chain?: FetchError[];
-}
+export type { FetchError };
 export interface FetchResult<ResponseType = unknown> {
 	success: boolean;
 	result: ResponseType;
@@ -164,6 +162,8 @@ function throwFetchError(
 	resource: string,
 	response: FetchResult<unknown>
 ): never {
+	for (const error of response.errors) maybeThrowFriendlyError(error);
+
 	const error = new ParseError({
 		text: `A request to the Cloudflare API (${resource}) failed.`,
 		notes: response.errors.map((err) => ({


### PR DESCRIPTION
Fixes #4187.

**What this PR solves / how to test:**

Previously, Wrangler would display the raw API error message and code if email validation was required during `wrangler deploy`. This change ensures a helpful error message is displayed instead, prompting users to check their emails or visit the dashboard for a verification link. To test this, try run `wrangler deploy` using a `workers.dev` subdomain on an account without a verified email. (I assume you've got one of those lying around! 😛)

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: just changing the error message for existing behaviour

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
