### PR TITLE
[wrangler] fix: include messages from API in errors

### DIFF
--- a/.changeset/stupid-frogs-obey.md
+++ b/.changeset/stupid-frogs-obey.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: include messages from API in errors

--- a/packages/wrangler/src/__tests__/cfetch-utils.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-utils.test.ts
@@ -1,4 +1,9 @@
+import { rest } from "msw";
 import { hasMorePages } from "../cfetch";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { createFetchResult, msw } from "./helpers/msw";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
 
 /**
 hasMorePages is a function that returns a boolean based on the result_info object returned from the cloudflare v4 API - if the current page is less than the total number of pages, it returns true, otherwise false.
@@ -34,5 +39,43 @@ describe("hasMorePages", () => {
 				total_count: 100,
 			})
 		).toBe(false);
+	});
+});
+
+describe("throwFetchError", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+
+	it("should include api errors and messages in error", async () => {
+		msw.use(
+			rest.get("*/user", (req, res, ctx) => {
+				return res(
+					ctx.json(
+						createFetchResult(
+							null,
+							false,
+							[
+								{ code: 10001, message: "error one" },
+								{ code: 10002, message: "error two" },
+							],
+							["message one", "message two"]
+						)
+					)
+				);
+			})
+		);
+		await expect(runWrangler("whoami")).rejects.toMatchObject({
+			text: "A request to the Cloudflare API (/user) failed.",
+			notes: [
+				{ text: "error one [code: 10001]" },
+				{ text: "error two [code: 10002]" },
+				{ text: "message one" },
+				{ text: "message two" },
+				{
+					text: "\nIf you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose",
+				},
+			],
+		});
 	});
 });

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -166,9 +166,10 @@ function throwFetchError(
 ): never {
 	const error = new ParseError({
 		text: `A request to the Cloudflare API (${resource}) failed.`,
-		notes: response.errors.map((err) => ({
-			text: renderError(err),
-		})),
+		notes: [
+			...response.errors.map((err) => ({ text: renderError(err) })),
+			...response.messages.map((text) => ({ text })),
+		],
 	});
 	// add the first error code directly to this error
 	// so consumers can use it for specific behaviour


### PR DESCRIPTION
Fixes #2775.

**What this PR solves / how to test:**

This PR ensures we display any `messages` returned from the API in our error messages. These might include additional information useful for debugging.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: change to how Wrangler reports errors

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
