### PR TITLE
amend broken cd instruction

### DIFF
--- a/.changeset/three-horses-talk.md
+++ b/.changeset/three-horses-talk.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+amend broken cd instruction

--- a/packages/create-cloudflare/src/common.ts
+++ b/packages/create-cloudflare/src/common.ts
@@ -254,9 +254,9 @@ export const printSummary = async (ctx: PagesGeneratorContext) => {
 	const dirRelativePath = relative(ctx.originalCWD, ctx.project.path);
 
 	const nextSteps = [
-		...(dirRelativePath
+		dirRelativePath
 			? [`Navigate to the new directory`, `cd ${dirRelativePath}`]
-			: []),
+			: [],
 		[
 			`Run the development server`,
 			quoteShellArgs([


### PR DESCRIPTION
Fixing the broken `cd` instruction we get at the end of the build process:
![Screenshot 2023-12-12 at 19 46 00](https://github.com/cloudflare/workers-sdk/assets/61631103/8841d567-1992-48d3-b566-7463fc55da82)

(introduced in https://github.com/cloudflare/workers-sdk/pull/4579)