### PR TITLE
[wrangler] fix: check permissions on authentication error with API token set

### DIFF
--- a/.changeset/strange-eels-search.md
+++ b/.changeset/strange-eels-search.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: suggest checking permissions on authentication error with API token set

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8324,6 +8324,9 @@ export default{
 		  Authentication error [code: 10000]
 
 
+		📎 It looks like you've set a custom API token with an environment variable.
+		Please ensure it has the correct permissions for this operation.
+
 		Getting User settings...
 		👋 You are logged in with an API Token, associated with the email user@example.com!
 		┌───────────────┬────────────┐

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8324,7 +8324,7 @@ export default{
 		  Authentication error [code: 10000]
 
 
-		📎 It looks like you've set a custom API token with an environment variable.
+		📎 It looks like you are authenticating Wrangler via a custom API token set in an environment variable.
 		Please ensure it has the correct permissions for this operation.
 
 		Getting User settings...

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -1,6 +1,7 @@
 import module from "node:module";
 import os from "node:os";
 import TOML from "@iarna/toml";
+import chalk from "chalk";
 import { ProxyAgent, setGlobalDispatcher } from "undici";
 import makeCLI from "yargs";
 import { version as wranglerVersion } from "../package.json";
@@ -56,7 +57,13 @@ import {
 import { tailOptions, tailHandler } from "./tail";
 import { generateTypes } from "./type-generation";
 import { printWranglerBanner } from "./update-check";
-import { listScopes, login, logout, validateScopeKeys } from "./user";
+import {
+	getAuthFromEnv,
+	listScopes,
+	login,
+	logout,
+	validateScopeKeys,
+} from "./user";
 import { vectorize } from "./vectorize/index";
 import { whoami } from "./whoami";
 
@@ -724,6 +731,13 @@ export async function main(argv: string[]): Promise<void> {
 			await createCLIParser([...argv, "--help"]).parse();
 		} else if (isAuthenticationError(e)) {
 			logger.log(formatMessage(e));
+			const envAuth = getAuthFromEnv();
+			if (envAuth !== undefined && "apiToken" in envAuth) {
+				const message =
+					"📎 It looks like you've set a custom API token with an environment variable.\n" +
+					"Please ensure it has the correct permissions for this operation.\n";
+				logger.log(chalk.yellow(message));
+			}
 			await whoami();
 		} else if (e instanceof ParseError) {
 			e.notes.push({

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -734,7 +734,7 @@ export async function main(argv: string[]): Promise<void> {
 			const envAuth = getAuthFromEnv();
 			if (envAuth !== undefined && "apiToken" in envAuth) {
 				const message =
-					"📎 It looks like you've set a custom API token with an environment variable.\n" +
+					"📎 It looks like you are authenticating Wrangler via a custom API token set in an environment variable.\n" +
 					"Please ensure it has the correct permissions for this operation.\n";
 				logger.log(chalk.yellow(message));
 			}


### PR DESCRIPTION
Fixes #4078.

**What this PR solves / how to test:**

The API tokens set with the `CLOUDFLARE_API_TOKEN` environment variable may not include all required permissions for Wrangler. This change ensures the error message for authentication errors includes a suggestion to check token permissions. Ideally, authentication errors would inclusion the name of the required permission that was missing, but they don't. 🙁 

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: this is an improvement to error messaging

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
