### PR TITLE
[C3] Ensure `ts` is defined

### DIFF
--- a/.changeset/fresh-rockets-vanish.md
+++ b/.changeset/fresh-rockets-vanish.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: Ensure C3 can be used to create TypeScript workers

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -1,9 +1,15 @@
 import { ConfirmPrompt, SelectPrompt, TextPrompt } from "@clack/core";
 import ansiEscapes from "ansi-escapes";
-import logUpdate from "log-update";
+import { createLogUpdate } from "log-update";
 import { blue, bold, brandColor, dim, gray } from "./colors";
 import { cancel, newline, shapes, space, status } from "./index";
 import type { ChalkInstance } from "chalk";
+
+const wideStdout = Object.assign(process.stdout, {
+	columns: Number.MAX_SAFE_INTEGER,
+});
+
+const logUpdate = createLogUpdate(wideStdout);
 
 export type Arg = string | boolean | string[] | undefined;
 const grayBar = gray(shapes.bar);

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -5,11 +5,9 @@ import { blue, bold, brandColor, dim, gray } from "./colors";
 import { cancel, newline, shapes, space, status } from "./index";
 import type { ChalkInstance } from "chalk";
 
-const wideStdout = Object.assign(process.stdout, {
-	columns: Number.MAX_SAFE_INTEGER,
-});
+process.stdout.columns = 300;
 
-const logUpdate = createLogUpdate(wideStdout);
+const logUpdate = createLogUpdate(process.stdout);
 
 export type Arg = string | boolean | string[] | undefined;
 const grayBar = gray(shapes.bar);

--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -140,6 +140,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			],
 			testCommitMessage: true,
 			unsupportedOSs: ["win32"],
+			unsupportedPms: ["npm"],
 		},
 		vue: {
 			expectResponseToContain: "Vite App",

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -23,7 +23,7 @@ type WorkerTestConfig = Omit<RunnerConfig, "ctx"> & {
 	template: string;
 };
 describe
-	.skipIf(frameworkToTest || isQuarantineMode())
+	.skipIf(frameworkToTest || isQuarantineMode() || process.platform === "win32")
 	.concurrent(`E2E: Workers templates`, () => {
 		const workerTemplates: WorkerTestConfig[] = [
 			{

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -1,12 +1,9 @@
 import { join } from "path";
-import {
-	describe,
-	expect,
-	test,
-	afterEach,
-	beforeEach,
-	beforeAll,
-} from "vitest";
+import { retry } from "helpers/command";
+import { readToml } from "helpers/files";
+import { fetch } from "undici";
+import { describe, expect, test, beforeAll } from "vitest";
+import { deleteWorker } from "../scripts/common";
 import { frameworkToTest } from "./frameworkToTest";
 import {
 	isQuarantineMode,
@@ -14,49 +11,78 @@ import {
 	runC3,
 	testProjectDir,
 } from "./helpers";
+import type { RunnerConfig } from "./helpers";
 import type { Suite, TestContext } from "vitest";
 
-/*
-Areas for future improvement:
-- Make these actually e2e by verifying that deployment works
-*/
+const TEST_TIMEOUT = 1000 * 60 * 5;
 
-// Note: skipIf(frameworkToTest) makes it so that all the worker tests are
-//       skipped in case we are testing a specific framework
-//       (since no worker template implements a framework application)
-describe.skipIf(frameworkToTest || isQuarantineMode())(
-	"E2E: Workers templates",
-	() => {
-		const { getPath, clean } = testProjectDir("workers");
+type WorkerTestConfig = Omit<RunnerConfig, "ctx"> & {
+	expectResponseToContain?: string;
+	timeout?: number;
+	name?: string;
+	template: string;
+};
+describe
+	.skipIf(frameworkToTest || isQuarantineMode())
+	.concurrent(`E2E: Workers templates`, () => {
+		const workerTemplates: WorkerTestConfig[] = [
+			{
+				expectResponseToContain: "Hello World!",
+				template: "hello-world",
+			},
+			{
+				template: "common",
+				expectResponseToContain: "Try making requests to:",
+			},
+			{
+				template: "chatgptPlugin",
+				name: "chat-gpt-plugin",
+				expectResponseToContain: "SwaggerUI",
+				promptHandlers: [],
+			},
+			{
+				template: "queues",
+				// Skipped for now, since C3 does not yet support resource creation
+				// expectResponseToContain:
+			},
+			{
+				template: "scheduled",
+				// Skipped for now, since it's not possible to test scheduled events on deployed Workers
+				// expectResponseToContain:
+			},
+			{
+				template: "openapi",
+				expectResponseToContain: "SwaggerUI",
+				promptHandlers: [],
+			},
+		];
 
 		beforeAll((ctx) => {
 			recreateLogFolder(ctx as Suite);
 		});
 
-		beforeEach((ctx) => {
-			const template = ctx.meta.name;
-			clean(template);
-		});
-
-		afterEach((ctx) => {
-			const template = ctx.meta.name;
-			clean(template);
-		});
-
-		const runCli = async (template: string, ctx: TestContext) => {
-			const projectPath = getPath(template.toLowerCase());
-
-			const argv = [
+		const runCli = async (
+			framework: string,
+			projectPath: string,
+			{ ctx, argv = [], promptHandlers = [] }: RunnerConfig
+		) => {
+			const args = [
 				projectPath,
 				"--type",
-				template,
-				"--no-ts",
-				"--no-deploy",
+				framework,
+				"--deploy",
+				"--no-open",
 				"--no-git",
-				"--wrangler-defaults",
 			];
 
-			await runC3({ ctx, argv });
+			args.push(...argv);
+
+			const { output } = await runC3({
+				ctx,
+				argv: args,
+				promptHandlers,
+				outputPrefix: `[${framework}]`,
+			});
 
 			// Relevant project files should have been created
 			expect(projectPath).toExist();
@@ -69,19 +95,102 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 
 			const wranglerPath = join(projectPath, "node_modules/wrangler");
 			expect(wranglerPath).toExist();
+
+			const tomlPath = join(projectPath, "wrangler.toml");
+			expect(tomlPath).toExist();
+
+			const config = readToml(tomlPath) as { main: string };
+
+			expect(join(projectPath, config.main)).toExist();
+
+			return { output };
 		};
 
-		describe.each([
-			"hello-world",
-			"common",
-			"chatgptPlugin",
-			"queues",
-			"scheduled",
-			"openapi",
-		])("%s", async (name) => {
-			test(name, async (ctx) => {
-				await runCli(name, ctx);
+		const runCliWithDeploy = async (
+			template: WorkerTestConfig,
+			projectPath: string,
+			ctx: TestContext
+		) => {
+			const { argv, overrides, promptHandlers, expectResponseToContain } =
+				template;
+
+			const { output } = await runCli(template.template, projectPath, {
+				ctx,
+				overrides,
+				promptHandlers,
+				argv: [...(argv ?? [])],
 			});
-		});
-	}
-);
+
+			if (expectResponseToContain) {
+				// Verify deployment
+				const deployedUrlRe =
+					/deployment is ready at: (https:\/\/.+\.(workers)\.dev)/;
+
+				const match = output.match(deployedUrlRe);
+				if (!match || !match[1]) {
+					expect(false, "Couldn't find deployment url in C3 output").toBe(true);
+					return;
+				}
+
+				const projectUrl = match[1];
+
+				await retry({ times: 5 }, async () => {
+					await new Promise((resolve) => setTimeout(resolve, 1000)); // wait a second
+					const res = await fetch(projectUrl);
+					const body = await res.text();
+					if (!body.includes(expectResponseToContain)) {
+						throw new Error(
+							`(${template}) Deployed page (${projectUrl}) didn't contain expected string: "${expectResponseToContain}"`
+						);
+					}
+				});
+			}
+		};
+
+		workerTemplates
+			.flatMap<WorkerTestConfig>((template) =>
+				template.promptHandlers
+					? [template]
+					: [
+							{
+								...template,
+								name: `${template.name ?? template.template}-ts`,
+								promptHandlers: [
+									{
+										matcher: /Do you want to use TypeScript\?/,
+										input: ["y"],
+									},
+								],
+							},
+
+							{
+								...template,
+								name: `${template.name ?? template.template}-js`,
+								promptHandlers: [
+									{
+										matcher: /Do you want to use TypeScript\?/,
+										input: ["n"],
+									},
+								],
+							},
+					  ]
+			)
+			.forEach((template) => {
+				const name = template.name ?? template.template;
+				test(
+					name,
+					async (ctx) => {
+						const { getPath, getName, clean } = testProjectDir("workers");
+						const projectPath = getPath(name);
+						const projectName = getName(name);
+						try {
+							await runCliWithDeploy(template, projectPath, ctx);
+						} finally {
+							clean(name);
+							await deleteWorker(projectName);
+						}
+					},
+					{ retry: 1, timeout: template.timeout || TEST_TIMEOUT }
+				);
+			});
+	});

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -49,6 +49,7 @@
 		"@cloudflare/eslint-config-worker": "*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20230419.0",
+		"@iarna/toml": "^3.0.0",
 		"@types/command-exists": "^1.2.0",
 		"@types/cross-spawn": "^6.0.2",
 		"@types/dns2": "^2.0.3",

--- a/packages/create-cloudflare/src/helpers/files.ts
+++ b/packages/create-cloudflare/src/helpers/files.ts
@@ -1,5 +1,6 @@
 import fs, { existsSync } from "fs";
 import { crash } from "@cloudflare/cli";
+import TOML from "@iarna/toml";
 import { getWorkerdCompatibilityDate } from "./command";
 import type { PagesGeneratorContext } from "types";
 
@@ -22,6 +23,11 @@ export const readFile = (path: string) => {
 export const readJSON = (path: string) => {
 	const contents = readFile(path);
 	return contents ? JSON.parse(contents) : contents;
+};
+
+export const readToml = (path: string) => {
+	const contents = readFile(path);
+	return contents ? TOML.parse(contents) : contents;
 };
 
 export const writeJSON = (path: string, object: object, stringifySpace = 2) => {

--- a/packages/create-cloudflare/src/templateMap.ts
+++ b/packages/create-cloudflare/src/templateMap.ts
@@ -23,11 +23,11 @@ export const templateMap: Record<string, TemplateConfig> = {
 	},
 	scheduled: {
 		label: "Scheduled Worker (Cron Trigger)",
-		handler: runWorkersGenerator,
+		handler: (args) => runWorkersGenerator({ ...args, deploy: false }),
 	},
 	queues: {
 		label: "Queue consumer & producer Worker",
-		handler: runWorkersGenerator,
+		handler: (args) => runWorkersGenerator({ ...args, deploy: false }),
 	},
 	chatgptPlugin: {
 		label: `ChatGPT plugin`,

--- a/packages/create-cloudflare/src/workers.ts
+++ b/packages/create-cloudflare/src/workers.ts
@@ -46,7 +46,7 @@ export const runWorkersGenerator = async (args: C3Args) => {
 		ctx.args.ts = false;
 	}
 
-	await processArgument<boolean>(ctx.args, "ts", {
+	ctx.args.ts = await processArgument<boolean>(ctx.args, "ts", {
 		type: "confirm",
 		question: "Do you want to use TypeScript?",
 		label: "typescript",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,6 +608,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20230419.0
         version: 4.20230821.0
+      '@iarna/toml':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/command-exists':
         specifier: ^1.2.0
         version: 1.2.0


### PR DESCRIPTION
Closes #4599 

**What this PR solves / how to test:**

This fixes a bug introduced in 3.8.2 where the result of `processArgument` for `ts wasn't being used. See https://github.com/cloudflare/workers-sdk/pull/4470/commits/01e2542ba8b3badadebc73547a9e3744de4e2f9c

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: C3 doesn't currently have a way to test interactive prompting, which is the only way to write a regression test for this. It should, and expanding Wrangler's support for interactive prompt testing to support C3 should be a prompt followup
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: Bugfix

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
