### PR TITLE
fix the include section in the c3-e2e-dependabot yml indentation

### DIFF
--- a/.github/workflows/c3-e2e-dependabot.yml
+++ b/.github/workflows/c3-e2e-dependabot.yml
@@ -75,10 +75,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         pm: [npm, pnpm, bun, yarn]
-      # include a single windows test with pnpm
-      include:
-        - os: windows-latest
-          pm: pnpm
+        # include a single windows test with pnpm
+        include:
+          - os: windows-latest
+            pm: pnpm
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
The indentation of the `include` field in the c3-e2e-dependabot yml is wrong, making the workflow not take effect:
https://github.com/cloudflare/workers-sdk/actions/runs/7207803909/workflow#L79

(sorry it's my bad, I missed this in https://github.com/cloudflare/workers-sdk/pull/4576 😓 🙇 )