### PR TITLE
[wrangler@2] fix: pin `workerd` to `1.20230404.0`

### DIFF
--- a/.changeset/cyan-yaks-rule.md
+++ b/.changeset/cyan-yaks-rule.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: pin `workerd` to `1.20230404.0`

--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -35,6 +35,10 @@ async function runLongLivedWrangler(command: string[], cwd: string) {
 		(resolve) => (resolveReadyPromise = resolve)
 	);
 
+	if (!command.includes("--inspector-port")) {
+		command.push("--inspector-port", "0");
+	}
+
 	const wranglerProcess = fork(
 		"../../packages/wrangler/bin/wrangler.js",
 		command,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4265,9 +4265,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230717.0.tgz",
-			"integrity": "sha512-NVwwAYEIJmXGnQRnrCig2i4XAYFwPPFD+324fvQGWqUyfvBXKDYF3Jkw92ZginwdojYU1W+2l2qP7t6JE9Sw0g==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230404.0.tgz",
+			"integrity": "sha512-W36JJLz3XLktBv+Huw37eZhiHvXp8XZ+1LsbUqU2O5Y0OXUzVhxhtdPSHgxvjfwo83zxnWuSS3uGKl6ex8Xm/Q==",
 			"cpu": [
 				"x64"
 			],
@@ -4281,9 +4281,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230717.0.tgz",
-			"integrity": "sha512-toK0AadC35j0AiaXPYUq7yrAwPJR+5GLLXOXguHq5DHPqzzgD5pB9e4zlIKD+b09FAAEB6lO/k/eJSMYF/lfzA==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230404.0.tgz",
+			"integrity": "sha512-cEpLgMwNmUpXVPjTJEd+WXgzSt9l4cTJpaNyEouAHrH99cStt21iIgkVctnef9bpPqzLoIZf2LUaPKu2H85/Ig==",
 			"cpu": [
 				"arm64"
 			],
@@ -4297,9 +4297,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230717.0.tgz",
-			"integrity": "sha512-nxpfVzMkNLNa4hOvZ+Y7JHY13UkRf7or5tcQCRtfJ5sEhtCVGdfsOosQGnzw9G+045JUk0EKEY+gqNPRnt5u2w==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230404.0.tgz",
+			"integrity": "sha512-XMXUuZKTfWW60EKLYy0DJJSEKF8/q1EupYa2nldIp2i6gprhndXxOe3WR4inWB+XAMcppUXO0VgwAV6tTvgOvg==",
 			"cpu": [
 				"x64"
 			],
@@ -4313,9 +4313,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230717.0.tgz",
-			"integrity": "sha512-jWVSJmOP0bMJ23xNONqP5x6TEDS9h/4nr0d0gULMpkfh6W9qNZNLpF8urNanXOqTM9p6rX55aBvzXsHs8Jctqw==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230404.0.tgz",
+			"integrity": "sha512-4+mnzlnlYe66LusX0HeS5TNV4FN64QSMD/WuahbFPpxg41t/iBD4T8KrRYvz0PjIhNzt8wqxymHbL1Coo+La5Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -4329,9 +4329,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230717.0.tgz",
-			"integrity": "sha512-y9Ys8j22LMHaMdy31OyaV7Qz1Xca8MhzpBlpX4Ay6saECXYP1DZHHwtcW8pBqBU2zyGfEkErBQhyH130SSHFJg==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230404.0.tgz",
+			"integrity": "sha512-LRuLa6dqYlFGSfeqYV+f0J2llUTQ5nuWDrp77pqSHgJlqFFEX2qlZ0wJIAxulvK5Vz/O05WvmpdV9HJwrlj3VQ==",
 			"cpu": [
 				"x64"
 			],
@@ -7171,9 +7171,9 @@
 			}
 		},
 		"node_modules/@miniflare/tre": {
-			"version": "3.0.0-next.13",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.13.tgz",
-			"integrity": "sha512-FogtwZUmUqico28dTdrFd2BF2wyMMheUw3MI9MDSSYNqRUGiNw8cJopHRMjo7OoO3dq6F5D01HwqMMZvSA1ZFA==",
+			"version": "3.0.0-next.14",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.14.tgz",
+			"integrity": "sha512-qT2gnua5fhWv7DUHtrOXMv3AZfNarc0wZJ1q6jbXdMpSA7aQtyr06lE9t1+Nb8TBqxpz8wHArXxMAtIWjfrzYA==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -7188,7 +7188,7 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "^1.20230404.0",
+				"workerd": "1.20230404.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
@@ -43437,9 +43437,9 @@
 			"link": true
 		},
 		"node_modules/workerd": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230717.0.tgz",
-			"integrity": "sha512-MTKF2u3pfqfpGlyaYe9BfZm8IoUwhQNe2vMWECYtv6Z8cGPJujVxcRe27ZT4l/G5lRijnnVeP3Ns3mMS9fjMsw==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230404.0.tgz",
+			"integrity": "sha512-tTiWZkJXetNmahmVZL1AcFH/U1cp9MMYRcQNBD1RjTSGh/v8VlKlEKTp4Ss6EdItvPNKQqsE7s/6y/TrblTI7g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -43449,11 +43449,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20230717.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230717.0",
-				"@cloudflare/workerd-linux-64": "1.20230717.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230717.0",
-				"@cloudflare/workerd-windows-64": "1.20230717.0"
+				"@cloudflare/workerd-darwin-64": "1.20230404.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20230404.0",
+				"@cloudflare/workerd-linux-64": "1.20230404.0",
+				"@cloudflare/workerd-linux-arm64": "1.20230404.0",
+				"@cloudflare/workerd-windows-64": "1.20230404.0"
 			}
 		},
 		"node_modules/workers-analytics-engine-template": {
@@ -45509,7 +45509,7 @@
 				"@cloudflare/workers-types": "^4.20221111.1",
 				"@iarna/toml": "^3.0.0",
 				"@microsoft/api-extractor": "^7.28.3",
-				"@miniflare/tre": "3.0.0-next.13",
+				"@miniflare/tre": "3.0.0-next.14",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",
@@ -59476,37 +59476,37 @@
 			}
 		},
 		"@cloudflare/workerd-darwin-64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230717.0.tgz",
-			"integrity": "sha512-NVwwAYEIJmXGnQRnrCig2i4XAYFwPPFD+324fvQGWqUyfvBXKDYF3Jkw92ZginwdojYU1W+2l2qP7t6JE9Sw0g==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20230404.0.tgz",
+			"integrity": "sha512-W36JJLz3XLktBv+Huw37eZhiHvXp8XZ+1LsbUqU2O5Y0OXUzVhxhtdPSHgxvjfwo83zxnWuSS3uGKl6ex8Xm/Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230717.0.tgz",
-			"integrity": "sha512-toK0AadC35j0AiaXPYUq7yrAwPJR+5GLLXOXguHq5DHPqzzgD5pB9e4zlIKD+b09FAAEB6lO/k/eJSMYF/lfzA==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20230404.0.tgz",
+			"integrity": "sha512-cEpLgMwNmUpXVPjTJEd+WXgzSt9l4cTJpaNyEouAHrH99cStt21iIgkVctnef9bpPqzLoIZf2LUaPKu2H85/Ig==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230717.0.tgz",
-			"integrity": "sha512-nxpfVzMkNLNa4hOvZ+Y7JHY13UkRf7or5tcQCRtfJ5sEhtCVGdfsOosQGnzw9G+045JUk0EKEY+gqNPRnt5u2w==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20230404.0.tgz",
+			"integrity": "sha512-XMXUuZKTfWW60EKLYy0DJJSEKF8/q1EupYa2nldIp2i6gprhndXxOe3WR4inWB+XAMcppUXO0VgwAV6tTvgOvg==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-linux-arm64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230717.0.tgz",
-			"integrity": "sha512-jWVSJmOP0bMJ23xNONqP5x6TEDS9h/4nr0d0gULMpkfh6W9qNZNLpF8urNanXOqTM9p6rX55aBvzXsHs8Jctqw==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20230404.0.tgz",
+			"integrity": "sha512-4+mnzlnlYe66LusX0HeS5TNV4FN64QSMD/WuahbFPpxg41t/iBD4T8KrRYvz0PjIhNzt8wqxymHbL1Coo+La5Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@cloudflare/workerd-windows-64": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230717.0.tgz",
-			"integrity": "sha512-y9Ys8j22LMHaMdy31OyaV7Qz1Xca8MhzpBlpX4Ay6saECXYP1DZHHwtcW8pBqBU2zyGfEkErBQhyH130SSHFJg==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20230404.0.tgz",
+			"integrity": "sha512-LRuLa6dqYlFGSfeqYV+f0J2llUTQ5nuWDrp77pqSHgJlqFFEX2qlZ0wJIAxulvK5Vz/O05WvmpdV9HJwrlj3VQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -61328,9 +61328,9 @@
 			}
 		},
 		"@miniflare/tre": {
-			"version": "3.0.0-next.13",
-			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.13.tgz",
-			"integrity": "sha512-FogtwZUmUqico28dTdrFd2BF2wyMMheUw3MI9MDSSYNqRUGiNw8cJopHRMjo7OoO3dq6F5D01HwqMMZvSA1ZFA==",
+			"version": "3.0.0-next.14",
+			"resolved": "https://registry.npmjs.org/@miniflare/tre/-/tre-3.0.0-next.14.tgz",
+			"integrity": "sha512-qT2gnua5fhWv7DUHtrOXMv3AZfNarc0wZJ1q6jbXdMpSA7aQtyr06lE9t1+Nb8TBqxpz8wHArXxMAtIWjfrzYA==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
@@ -61345,7 +61345,7 @@
 				"source-map-support": "0.5.21",
 				"stoppable": "^1.1.0",
 				"undici": "^5.13.0",
-				"workerd": "^1.20230404.0",
+				"workerd": "1.20230404.0",
 				"ws": "^8.11.0",
 				"youch": "^3.2.2",
 				"zod": "^3.20.6"
@@ -93879,16 +93879,16 @@
 			}
 		},
 		"workerd": {
-			"version": "1.20230717.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230717.0.tgz",
-			"integrity": "sha512-MTKF2u3pfqfpGlyaYe9BfZm8IoUwhQNe2vMWECYtv6Z8cGPJujVxcRe27ZT4l/G5lRijnnVeP3Ns3mMS9fjMsw==",
+			"version": "1.20230404.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20230404.0.tgz",
+			"integrity": "sha512-tTiWZkJXetNmahmVZL1AcFH/U1cp9MMYRcQNBD1RjTSGh/v8VlKlEKTp4Ss6EdItvPNKQqsE7s/6y/TrblTI7g==",
 			"dev": true,
 			"requires": {
-				"@cloudflare/workerd-darwin-64": "1.20230717.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20230717.0",
-				"@cloudflare/workerd-linux-64": "1.20230717.0",
-				"@cloudflare/workerd-linux-arm64": "1.20230717.0",
-				"@cloudflare/workerd-windows-64": "1.20230717.0"
+				"@cloudflare/workerd-darwin-64": "1.20230404.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20230404.0",
+				"@cloudflare/workerd-linux-64": "1.20230404.0",
+				"@cloudflare/workerd-linux-arm64": "1.20230404.0",
+				"@cloudflare/workerd-windows-64": "1.20230404.0"
 			}
 		},
 		"workers-analytics-engine-template": {
@@ -94109,7 +94109,7 @@
 				"@miniflare/core": "2.13.0",
 				"@miniflare/d1": "2.13.0",
 				"@miniflare/durable-objects": "2.13.0",
-				"@miniflare/tre": "3.0.0-next.13",
+				"@miniflare/tre": "3.0.0-next.14",
 				"@types/better-sqlite3": "^7.6.0",
 				"@types/busboy": "^1.5.0",
 				"@types/command-exists": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"postinstall": "patch-package",
 		"prettify": "prettier . --write --ignore-unknown",
 		"test": "npm run clean --workspace=wrangler && npm run bundle --workspace=wrangler && npm run test --workspace=packages/wrangler --workspace=packages/edge-preview-authenticated-proxy --workspace=packages/pages-shared --if-present && npx vitest",
-		"test:ci": "npm run test:ci --workspace=packages/wrangler --workspace=packages/pages-shared --if-present && npx vitest"
+		"test:ci": "npm run test:ci --workspace=packages/wrangler --workspace=packages/pages-shared --if-present && npx vitest --no-threads"
 	},
 	"dependencies": {
 		"@changesets/changelog-github": "^0.4.5",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -120,7 +120,7 @@
 		"@cloudflare/workers-types": "^4.20221111.1",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
-		"@miniflare/tre": "3.0.0-next.13",
+		"@miniflare/tre": "3.0.0-next.14",
 		"@types/better-sqlite3": "^7.6.0",
 		"@types/busboy": "^1.5.0",
 		"@types/command-exists": "^1.2.0",

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -948,5 +948,5 @@ export async function getMiniflare3(): Promise<
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 	typeof import("@miniflare/tre")
 > {
-	return (miniflare3Module ??= await npxImport("@miniflare/tre@3.0.0-next.13"));
+	return (miniflare3Module ??= await npxImport("@miniflare/tre@3.0.0-next.14"));
 }


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR aims to fix Wrangler 2's tests by pinning the version of `workerd` depended on by Miniflare 3.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: trying to get existing tests to pass
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: not user facing changes

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
