### PR TITLE
[D1] add rows read/written to `wrangler d1 info` output

### DIFF
--- a/.changeset/four-students-joke.md
+++ b/.changeset/four-students-joke.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: add rows written/read in the last 24 hours to `wrangler d1 info` output

--- a/packages/wrangler/src/d1/info.tsx
+++ b/packages/wrangler/src/d1/info.tsx
@@ -63,6 +63,8 @@ export const Handler = withConfig<HandlerOptions>(
 											sum {
 												readQueries
 												writeQueries
+												rowsRead
+												rowsWritten
 										}
 										dimensions {
 												datetimeHour
@@ -90,16 +92,25 @@ export const Handler = withConfig<HandlerOptions>(
 				},
 			});
 
-			const metrics = { readQueries: 0, writeQueries: 0 };
+			const metrics = {
+				readQueries: 0,
+				writeQueries: 0,
+				rowsRead: 0,
+				rowsWritten: 0,
+			};
 			if (graphqlResult) {
 				graphqlResult.data?.viewer?.accounts[0]?.d1AnalyticsAdaptiveGroups?.forEach(
 					(row) => {
 						metrics.readQueries += row?.sum?.readQueries ?? 0;
 						metrics.writeQueries += row?.sum?.writeQueries ?? 0;
+						metrics.rowsRead += row?.sum?.rowsRead ?? 0;
+						metrics.rowsWritten += row?.sum?.rowsWritten ?? 0;
 					}
 				);
-				output.read_queries_24h = metrics.readQueries;
-				output.write_queries_24h = metrics.writeQueries;
+				output.readQueries24h = metrics.readQueries;
+				output.writeQueries24h = metrics.writeQueries;
+				output.rowsRead24h = metrics.rowsRead;
+				output.rowsWritten24h = metrics.rowsWritten;
 			}
 		}
 
@@ -113,7 +124,12 @@ export const Handler = withConfig<HandlerOptions>(
 				let value;
 				if (k === "database_size") {
 					value = prettyBytes(Number(v));
-				} else if (k === "read_queries_24h" || k === "write_queries_24h") {
+				} else if (
+					k === "readQueries24h" ||
+					k === "writeQueries24h" ||
+					k === "rowsRead24h" ||
+					k === "rowsWritten24h"
+				) {
 					value = v.toLocaleString();
 				} else {
 					value = v;

--- a/packages/wrangler/src/d1/info.tsx
+++ b/packages/wrangler/src/d1/info.tsx
@@ -107,10 +107,10 @@ export const Handler = withConfig<HandlerOptions>(
 						metrics.rowsWritten += row?.sum?.rowsWritten ?? 0;
 					}
 				);
-				output.readQueries24h = metrics.readQueries;
-				output.writeQueries24h = metrics.writeQueries;
-				output.rowsRead24h = metrics.rowsRead;
-				output.rowsWritten24h = metrics.rowsWritten;
+				output.read_queries_24h = metrics.readQueries;
+				output.write_queries_24h = metrics.writeQueries;
+				output.rows_read_24h = metrics.rowsRead;
+				output.rows_written_24h = metrics.rowsWritten;
 			}
 		}
 
@@ -125,10 +125,10 @@ export const Handler = withConfig<HandlerOptions>(
 				if (k === "database_size") {
 					value = prettyBytes(Number(v));
 				} else if (
-					k === "readQueries24h" ||
-					k === "writeQueries24h" ||
-					k === "rowsRead24h" ||
-					k === "rowsWritten24h"
+					k === "read_queries_24h" ||
+					k === "write_queries_24h" ||
+					k === "rows_read_24h" ||
+					k === "rows_written_24h"
 				) {
 					value = v.toLocaleString();
 				} else {

--- a/packages/wrangler/src/d1/types.ts
+++ b/packages/wrangler/src/d1/types.ts
@@ -44,6 +44,8 @@ export interface D1Metrics {
 	sum?: {
 		readQueries?: number;
 		writeQueries?: number;
+		rowsRead?: number;
+		rowsWritten?: number;
 		queryBatchResponseBytes?: number;
 	};
 	quantiles?: {


### PR DESCRIPTION
This PR adds `rowsRead` and `rowsWritten` to `wrangler d1 info <NAME>` output:
```
 npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/7249340037/npm-package-wrangler-4621 d1 info northwind
✔ Select an account › D1
┌───────────────────┬──────────────────────────────────────┐
│                   │ d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06 │
├───────────────────┼──────────────────────────────────────┤
│ name              │ northwind                            │
├───────────────────┼──────────────────────────────────────┤
│ created_at        │ 2023-05-23T08:33:54.590Z             │
├───────────────────┼──────────────────────────────────────┤
│ version           │ beta                                 │
├───────────────────┼──────────────────────────────────────┤
│ num_tables        │ 13                                   │
├───────────────────┼──────────────────────────────────────┤
│ running_in_region │ WEUR                                 │
├───────────────────┼──────────────────────────────────────┤
│ database_size     │ 33.1 MB                              │
├───────────────────┼──────────────────────────────────────┤
│ readQueries24h    │ 2,035                                │
├───────────────────┼──────────────────────────────────────┤
│ writeQueries24h   │ 0                                    │
├───────────────────┼──────────────────────────────────────┤
│ rowsRead24h       │ 609,744,286                          │
├───────────────────┼──────────────────────────────────────┤
│ rowsWritten24h    │ 0                                    │
└───────────────────┴──────────────────────────────────────┘
```