### PR TITLE
Create a custom not-found edge route for next applications using the app router

### DIFF
--- a/.changeset/calm-bulldogs-bake.md
+++ b/.changeset/calm-bulldogs-bake.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Create a custom not-found edge route for next applications using the app router

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -1,5 +1,5 @@
-import { mkdirSync } from "fs";
-import { updateStatus, warn } from "@cloudflare/cli";
+import { existsSync, mkdirSync } from "fs";
+import { crash, updateStatus, warn } from "@cloudflare/cli";
 import { brandColor, dim } from "@cloudflare/cli/colors";
 import { processArgument } from "helpers/args";
 import { installPackages, runFrameworkGenerator } from "helpers/command";
@@ -18,6 +18,8 @@ import {
 	apiAppDirHelloTs,
 	apiPagesDirHelloJs,
 	apiPagesDirHelloTs,
+	appDirNotFoundJs,
+	appDirNotFoundTs,
 } from "./templates";
 import type { C3Args, FrameworkConfig, PagesGeneratorContext } from "types";
 
@@ -53,26 +55,40 @@ const getApiTemplate = (
 const configure = async (ctx: PagesGeneratorContext) => {
 	const projectName = ctx.project.name;
 
-	// Add a compatible function handler example
-	const path = probePaths(
-		[
+	let probedPath = "";
+	try {
+		probedPath = probePaths([
 			`${projectName}/pages/api`,
 			`${projectName}/src/pages/api`,
 			`${projectName}/src/app/api`,
 			`${projectName}/app/api`,
 			`${projectName}/src/app`,
 			`${projectName}/app`,
-		],
-		"Could not find the `/api` or `/app` directory"
-	);
+		]);
+	} catch {
+		crash("Could not find the `/api` or `/app` directory");
+	}
+
+	const path = probedPath;
 
 	// App directory template may not generate an API route handler, so we update the path to add an `api` directory.
 	const apiPath = path.replace(/\/app$/, "/app/api");
 
-	const [handlerPath, handlerFile] = getApiTemplate(
-		apiPath,
-		usesTypescript(projectName)
-	);
+	const usesTs = usesTypescript(projectName);
+
+	const appDirPath = getAppDirPath(projectName);
+	if (appDirPath) {
+		// Add a custom app not-found edge route as recommended in next-on-pages
+		const notFoundPath = `${appDirPath}/not-found.${usesTs ? "tsx" : "js"}`;
+		if (!existsSync(notFoundPath)) {
+			const notFoundContent = usesTs ? appDirNotFoundTs : appDirNotFoundJs;
+			writeFile(notFoundPath, notFoundContent);
+			updateStatus("Created a custom edge not-found route");
+		}
+	}
+
+	// Add a compatible function handler example
+	const [handlerPath, handlerFile] = getApiTemplate(apiPath, usesTs);
 	writeFile(handlerPath, handlerFile);
 	updateStatus("Created an example API route handler");
 
@@ -167,3 +183,11 @@ const config: FrameworkConfig = {
 	compatibilityFlags: ["nodejs_compat"],
 };
 export default config;
+
+const getAppDirPath = (projectName: string) => {
+	try {
+		return probePaths([`${projectName}/src/app`, `${projectName}/app`]);
+	} catch {
+		return null;
+	}
+};

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -45,3 +45,127 @@ export async function GET(request) {
   return new Response(JSON.stringify({ name: 'John Doe' }))
 }
 `;
+
+// Simplified and adjusted version of the Next.js built-in not-found component (https://github.com/vercel/next.js/blob/1c65c5575/packages/next/src/client/components/not-found-error.tsx)
+export const appDirNotFoundJs = `
+export const runtime = "edge";
+
+export default function NotFound() {
+  return (
+    <>
+      <title>404: This page could not be found.</title>
+      <div style={styles.error}>
+        <div>
+          <style
+            dangerouslySetInnerHTML={{
+              __html: \`body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}\`,
+            }}
+          />
+          <h1 className="next-error-h1" style={styles.h1}>
+            404
+          </h1>
+          <div style={styles.desc}>
+            <h2 style={styles.h2}>This page could not be found.</h2>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+const styles = {
+  error: {
+    fontFamily:
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
+    height: "100vh",
+    textAlign: "center",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  desc: {
+    display: "inline-block",
+  },
+
+  h1: {
+    display: "inline-block",
+    margin: "0 20px 0 0",
+    padding: "0 23px 0 0",
+    fontSize: 24,
+    fontWeight: 500,
+    verticalAlign: "top",
+    lineHeight: "49px",
+  },
+
+  h2: {
+    fontSize: 14,
+    fontWeight: 400,
+    lineHeight: "49px",
+    margin: 0,
+  },
+};
+`;
+
+// Simplified and adjusted version of the Next.js built-in not-found component (https://github.com/vercel/next.js/blob/1c65c5575/packages/next/src/client/components/not-found-error.tsx)
+export const appDirNotFoundTs = `
+export const runtime = "edge";
+
+export default function NotFound() {
+  return (
+    <>
+      <title>404: This page could not be found.</title>
+      <div style={styles.error}>
+        <div>
+          <style
+            dangerouslySetInnerHTML={{
+              __html: \`body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}\`,
+            }}
+          />
+          <h1 className="next-error-h1" style={styles.h1}>
+            404
+          </h1>
+          <div style={styles.desc}>
+            <h2 style={styles.h2}>This page could not be found.</h2>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+const styles = {
+  error: {
+    fontFamily:
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
+    height: "100vh",
+    textAlign: "center",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  desc: {
+    display: "inline-block",
+  },
+
+  h1: {
+    display: "inline-block",
+    margin: "0 20px 0 0",
+    padding: "0 23px 0 0",
+    fontSize: 24,
+    fontWeight: 500,
+    verticalAlign: "top",
+    lineHeight: "49px",
+  },
+
+  h2: {
+    fontSize: 14,
+    fontWeight: 400,
+    lineHeight: "49px",
+    margin: 0,
+  },
+} as const;
+`;

--- a/packages/create-cloudflare/src/helpers/files.ts
+++ b/packages/create-cloudflare/src/helpers/files.ts
@@ -35,19 +35,15 @@ export const writeJSON = (path: string, object: object, stringifySpace = 2) => {
 };
 
 // Probes a list of paths and returns the first one that exists
-// If one isn't found, throws an error with the given message
-export const probePaths = (
-	paths: string[],
-	errorMsg = "Failed to find required file."
-) => {
+// If one isn't found, throws an error
+export const probePaths = (paths: string[]) => {
 	for (const path of paths) {
 		if (existsSync(path)) {
 			return path;
 		}
 	}
 
-	crash(errorMsg);
-	process.exit(1); // hack to make typescript happy
+	throw new Error("Failed to find required file.");
 };
 
 export const usesTypescript = (projectRoot = ".") => {


### PR DESCRIPTION
This PR generates a `not-found` custom edge route for users creating next-on-pages applications that use the app router.

Having such route is not mandatory but it helps avoiding a gotcha that can trip people over: https://github.com/cloudflare/next-on-pages/blob/56391355c3028737a4b0069a5126ccaec24e53b1/packages/next-on-pages/docs/gotchas.md#not-found

___

> [!WARNING]
> this can't yet be merged, it has to wait for the next next-on-pages release
> otherwise the changes here will make the pages:build script fail with the following error:
> ![Screenshot 2023-12-18 at 18 02 08](https://github.com/cloudflare/workers-sdk/assets/61631103/5f802d36-ae74-48f0-82ac-e754b92800cf)
> also the eslint plugin needs to be updated to reflect that non-static not-found routes are ok now, otherwise people
> opting to use the plugin would get the following error:
> ![Screenshot 2023-12-18 at 18 03 35](https://github.com/cloudflare/workers-sdk/assets/61631103/bc79d5f2-10af-44e4-a6ed-4f887df2acf9)
