### PR TITLE
C3: Bump  to 6.0.3

### DIFF
--- a/.changeset/wet-geckos-turn.md
+++ b/.changeset/wet-geckos-turn.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+C3: Bumped `create-svelte` from `5.3.3` to `6.0.3`

--- a/packages/create-cloudflare/src/frameworks/package.json
+++ b/packages/create-cloudflare/src/frameworks/package.json
@@ -15,7 +15,7 @@
 		"create-react-app": "5.0.1",
 		"create-remix": "2.4.0",
 		"create-solid": "0.3.10",
-		"create-svelte": "5.3.3",
+		"create-svelte": "6.0.3",
 		"create-vue": "3.9.0",
 		"gatsby": "5.12.12",
 		"nuxi": "3.10.0"


### PR DESCRIPTION
Fixes #4623.

**What this PR solves / how to test:**

**Author has addressed the following:**

Bumps `create-svelte` to a new major version. This clears up an issue we're seeing where the latest version of `@sveltejs/adapter-cloudflare` expects the latest major version of `sveltekit` and fails to install.

- Tests
  - [ ] Included
  - [ x ] Not necessary because: Just a package bump, existing coverage is fine.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ x ] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
