### PR TITLE
make the workerd compatibility date retrieval more stable by fetching it directly from the npm registry

### DIFF
--- a/.changeset/lucky-ghosts-sell.md
+++ b/.changeset/lucky-ghosts-sell.md
@@ -2,4 +2,4 @@
 "create-cloudflare": patch
 ---
 
-make the workerd compatibility retrieval more stable (by always performing it with npm)
+make the workerd compatibility date retrieval more stable by fetching it directly from the npm registry

--- a/.changeset/lucky-ghosts-sell.md
+++ b/.changeset/lucky-ghosts-sell.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+make the workerd compatibility retrieval more stable (by always performing it with npm)

--- a/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/command.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "cross-spawn";
 import { detectPackageManager } from "helpers/packages";
+import { Response, fetch } from "undici";
 import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
 import whichPMRuns from "which-pm-runs";
 import {
@@ -14,6 +15,7 @@ import {
 let spawnResultCode = 0;
 let spawnStdout: string | undefined = undefined;
 let spawnStderr: string | undefined = undefined;
+let fetchResult: Response | undefined = undefined;
 
 describe("Command Helpers", () => {
 	afterEach(() => {
@@ -21,6 +23,7 @@ describe("Command Helpers", () => {
 		spawnResultCode = 0;
 		spawnStdout = undefined;
 		spawnStderr = undefined;
+		fetchResult = undefined;
 	});
 
 	beforeEach(() => {
@@ -48,6 +51,20 @@ describe("Command Helpers", () => {
 
 			return { spawn: mockedSpawn };
 		});
+
+		// Mock out the undici fetch function
+		vi.mock("undici", async () => {
+			const actual = (await vi.importActual("undici")) as Record<
+				string,
+				unknown
+			>;
+			const mockedFetch = vi.fn().mockImplementation(() => {
+				return fetchResult;
+			});
+
+			return { ...actual, fetch: mockedFetch };
+		});
+
 		vi.mock("which-pm-runs");
 		vi.mocked(whichPMRuns).mockReturnValue({ name: "npm", version: "8.3.1" });
 
@@ -160,31 +177,31 @@ describe("Command Helpers", () => {
 
 	describe("getWorkerdCompatibilityDate()", () => {
 		test("normal flow", async () => {
-			spawnStdout = "2.20250110.5";
+			fetchResult = new Response(
+				JSON.stringify({
+					"dist-tags": { latest: "2.20250110.5" },
+				})
+			);
 			const date = await getWorkerdCompatibilityDate();
-			expectSilentSpawnWith("npm info workerd dist-tags.latest");
+			expect(fetch).toHaveBeenCalledWith("https://registry.npmjs.org/workerd");
 			expect(date).toBe("2025-01-10");
 		});
 
 		test("empty result", async () => {
-			spawnStdout = "";
+			fetchResult = new Response(
+				JSON.stringify({
+					"dist-tags": { latest: "" },
+				})
+			);
 			const date = await getWorkerdCompatibilityDate();
-			expectSilentSpawnWith("npm info workerd dist-tags.latest");
+			expect(fetch).toHaveBeenCalledWith("https://registry.npmjs.org/workerd");
 			expect(date).toBe("2023-05-18");
 		});
 
-		test("verbose output (e.g. yarn or debug mode)", async () => {
-			spawnStdout =
-				"Debugger attached.\nyarn info v1.22.19\n2.20250110.5\n✨  Done in 0.83s.";
-			const date = await getWorkerdCompatibilityDate();
-			expectSilentSpawnWith("npm info workerd dist-tags.latest");
-			expect(date).toBe("2025-01-10");
-		});
-
 		test("command failed", async () => {
-			spawnResultCode = 1;
+			fetchResult = new Response("Unknown error");
 			const date = await getWorkerdCompatibilityDate();
-			expectSilentSpawnWith("npm info workerd dist-tags.latest");
+			expect(fetch).toHaveBeenCalledWith("https://registry.npmjs.org/workerd");
 			expect(date).toBe("2023-05-18");
 		});
 	});

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -381,9 +381,9 @@ export const listAccounts = async () => {
  * @returns The latest compatibility date for workerd in the form "YYYY-MM-DD"
  */
 export async function getWorkerdCompatibilityDate() {
-	const { npm } = detectPackageManager();
-
-	return runCommand([npm, "info", "workerd", "dist-tags.latest"], {
+	// the following command is run using npm regardless of the currently used package manager, this makes the
+	// command more stable and it doesn't really have any effect in regards to the currently used package manager
+	return runCommand(["npm", "info", "workerd", "dist-tags.latest"], {
 		silent: true,
 		captureOutput: true,
 		startText: "Retrieving current workerd compatibility date",

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -1,6 +1,6 @@
 import { existsSync, rmSync } from "fs";
 import path from "path";
-import { endSection, stripAnsi, warn } from "@cloudflare/cli";
+import { endSection, stripAnsi } from "@cloudflare/cli";
 import { brandColor, dim } from "@cloudflare/cli/colors";
 import { isInteractive, spinner } from "@cloudflare/cli/interactive";
 import { spawn } from "cross-spawn";

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -1,10 +1,11 @@
 import { existsSync, rmSync } from "fs";
 import path from "path";
-import { endSection, stripAnsi } from "@cloudflare/cli";
+import { endSection, stripAnsi, warn } from "@cloudflare/cli";
 import { brandColor, dim } from "@cloudflare/cli/colors";
 import { isInteractive, spinner } from "@cloudflare/cli/interactive";
 import { spawn } from "cross-spawn";
 import { getFrameworkCli } from "frameworks/index";
+import { fetch } from "undici";
 import { quoteShellArgs } from "../common";
 import { detectPackageManager } from "./packages";
 import type { PagesGeneratorContext } from "types";
@@ -381,23 +382,36 @@ export const listAccounts = async () => {
  * @returns The latest compatibility date for workerd in the form "YYYY-MM-DD"
  */
 export async function getWorkerdCompatibilityDate() {
-	// the following command is run using npm regardless of the currently used package manager, this makes the
-	// command more stable and it doesn't really have any effect in regards to the currently used package manager
-	return runCommand(["npm", "info", "workerd", "dist-tags.latest"], {
-		silent: true,
-		captureOutput: true,
+	const { compatDate: workerdCompatibilityDate } = await printAsyncStatus<{
+		compatDate: string;
+		isFallback: boolean;
+	}>({
+		useSpinner: true,
 		startText: "Retrieving current workerd compatibility date",
-		transformOutput: (result) => {
-			// The format of the workerd version is `major.yyyymmdd.patch`.
-			const match = result.match(/\d+\.(\d{4})(\d{2})(\d{2})\.\d+/);
+		doneText: ({ compatDate, isFallback }) =>
+			`${brandColor("compatibility date")}${
+				isFallback ? dim(" Could not find workerd date, falling back to") : ""
+			} ${dim(compatDate)}`,
+		async promise() {
+			try {
+				const resp = await fetch("https://registry.npmjs.org/workerd");
+				const workerdNpmInfo = (await resp.json()) as {
+					"dist-tags": { latest: string };
+				};
+				const result = workerdNpmInfo["dist-tags"].latest;
 
-			if (!match) {
-				throw new Error("Could not find workerd date");
-			}
-			const [, year, month, date] = match;
-			return `${year}-${month}-${date}`;
+				// The format of the workerd version is `major.yyyymmdd.patch`.
+				const match = result.match(/\d+\.(\d{4})(\d{2})(\d{2})\.\d+/);
+
+				if (match) {
+					const [, year, month, date] = match ?? [];
+					return { compatDate: `${year}-${month}-${date}`, isFallback: false };
+				}
+			} catch {}
+
+			return { compatDate: "2023-05-18", isFallback: true };
 		},
-		fallbackOutput: () => "2023-05-18",
-		doneText: (output) => `${brandColor("compatibility date")} ${dim(output)}`,
 	});
+
+	return workerdCompatibilityDate;
 }


### PR DESCRIPTION
It seems like the workerd compatibility retrieval can have some issues with different package managers (or at least with `yarn`):
- https://github.com/cloudflare/workers-sdk/actions/runs/7211842007/job/19748508606?pr=4602#step:4:65
- https://github.com/cloudflare/workers-sdk/actions/runs/7250601828/job/19751164094?pr=4604#step:4:65
- https://github.com/cloudflare/workers-sdk/actions/runs/7246672804/job/19747293009?pr=4617#step:4:65
- https://github.com/cloudflare/workers-sdk/actions/runs/7246765792/job/19742158656?pr=4618#step:4:65
- https://github.com/cloudflare/workers-sdk/actions/runs/7260941093/job/19781139701?pr=4629#step:4:65

The changes here make this more stable by always using fetching the date directly from the npm registry instead
