### PR TITLE
[playground-preview-worker] Reject /.update-preview-token requests from regular browsing contexts

### DIFF
--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -41,6 +41,11 @@ describe("Preview Worker", () => {
 			{
 				method: "GET",
 				redirect: "manual",
+				// These are forbidden headers, but undici currently allows setting them
+				headers: {
+					"Sec-Fetch-Dest": "iframe",
+					Referer: "https://workers.cloudflare.com/",
+				},
 			}
 		);
 		expect(resp.headers.get("location")).toMatchInlineSnapshot(


### PR DESCRIPTION
Fixes VULN-49261

**What this PR solves / how to test:**

This PR fixes a vulnerability that allowed Workers Playground preview instances to be accessed from outside of playground contexts.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: No changelog for playground-preview-worker
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: no relevant docs