### PR TITLE
[wrangler] fix: prevent zombie `workerd` processes

### DIFF
--- a/.changeset/metal-houses-drop.md
+++ b/.changeset/metal-houses-drop.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: prevent zombie `workerd` processes
+
+Previously, running `wrangler dev` would leave behind "zombie" `workerd` processes. These processes prevented the same port being bound if `wrangler dev` was restarted and sometimes consumed lots of CPU time. This change ensures all `workerd` processes are killed when `wrangler dev` is shutdown.
+
+To clean-up existing zombie processes, run `pkill -KILL workerd` on macOS/Linux or `taskkill /f /im workerd.exe` on Windows.

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -765,13 +765,17 @@ export async function main(argv: string[]): Promise<void> {
 		}
 		throw e;
 	} finally {
-		await closeSentry();
 		// In the bootstrapper script `bin/wrangler.js`, we open an IPC channel, so
 		// IPC messages from this process are propagated through the bootstrapper.
 		// Make sure this channel is closed once it's no longer needed, so we can
 		// cleanly exit. Note, we don't want to disconnect if this file was imported
 		// in Jest, as that would stop communication with the test runner.
 		if (typeof jest === "undefined") process.disconnect?.();
+
+		// Close Sentry after disconnecting the IPC channel. Doing this before leads
+		// to hanging `workerd` processes.
+		// TODO(soon): work out why
+		await closeSentry();
 	}
 }
 


### PR DESCRIPTION
Fixes #4612.
Fixes #4131.
Fixes cloudflare/workers-rs#425.

**What this PR solves / how to test:**

Previously, running `wrangler dev` would leave behind "zombie" `workerd` processes. These processes prevented the same port being bound if `wrangler dev` was restarted and sometimes consumed lots of CPU time. This PR ensures all `workerd` processes are killed when `wrangler dev` is shutdown.

Massive thank you to @ezg27 for identifying that commenting out `await closeSentry()` fixes the issue. I'm still not quite sure why this is happening. This is what I've observed:

- This issue only occurs in production builds (when the `SENTRY_DSN` environment variable is set during the build)
- Starting `wrangler-dist/cli.js` directly rather than through the `bin/wrangler.js` bootstrapper fixes the issue
- Removing `, "ipc"` from... https://github.com/cloudflare/workers-sdk/blob/a6a4e8a4981f390709ae7519225a02cd981059b4/packages/wrangler/bin/wrangler.js#L65 ...fixes the issue
- Swapping the order of the `await closeSentry()` and `process.disconnect?.()` fixes the issue

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: this fix doesn't appear to work when spawning `wrangler` via `shellac` (likely not a `shellac` problem), so we can't use our existing E2E testing framework to write tests for this. Given this is affecting lots of users, I'd prefer we get a fix out now, then investigate/test this later.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a regression

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
