### PR TITLE
Stop deploying playground-preview-worker on every merge

### DIFF
--- a/.github/workflows/playground-preview-worker.yml
+++ b/.github/workflows/playground-preview-worker.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/playground-preview-worker/**'
+
 jobs:
   publish_worker:
     if: ${{ github.repository_owner == 'cloudflare' }}


### PR DESCRIPTION
Previously we were deploying `playground-preview-worker` every time a PR was merged to `main`. We now instead only trigger this workflow run when that push to `main` includes changes to the `packages/playground-preview-worker` directory.