### PR TITLE
Stop deploying edge-preview-authenticated-proxy on every merge

### DIFF
--- a/.github/workflows/edge-preview-authenticated-proxy.yml
+++ b/.github/workflows/edge-preview-authenticated-proxy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'packages/edge-preview-authenticated-proxy/**'
+
 jobs:
   publish_worker:
     if: ${{ github.repository_owner == 'cloudflare' }}


### PR DESCRIPTION
Previously we were deploying `edge-preview-authenticated-proxy` every time a PR was merged to `main`. We now instead only trigger this workflow run when that push to main includes changes to the `packages/edge-preview-authenticated-proxy` directory.