### PR TITLE
Prometheus metrics

### DIFF
--- a/packages/edge-preview-authenticated-proxy/package.json
+++ b/packages/edge-preview-authenticated-proxy/package.json
@@ -14,6 +14,7 @@
 		"@cloudflare/eslint-config-worker": "*",
 		"@cloudflare/workers-types": "^4.20230321.0",
 		"cookie": "^0.5.0",
+    "promjs": "^0.4.2",
 		"toucan-js": "^3.1.0",
 		"wrangler": "workspace:*",
 		"@types/cookie": "^0.5.1"

--- a/packages/edge-preview-authenticated-proxy/worker-configuration.d.ts
+++ b/packages/edge-preview-authenticated-proxy/worker-configuration.d.ts
@@ -4,6 +4,7 @@ interface Env {
 	PREVIEW: "preview.devprod.cloudflare.dev";
 	RAW_HTTP: "rawhttp.devprod.cloudflare.dev";
 	// Secrets
+	PROMETHEUS_TOKEN: string;
 	SENTRY_ACCESS_CLIENT_SECRET: string;
 	SENTRY_ACCESS_CLIENT_ID: string;
 	TOKEN_LOOKUP: KVNamespace;

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -12,6 +12,7 @@
 		"@cloudflare/eslint-config-worker": "*",
 		"@cloudflare/workers-types": "^4.20230321.0",
 		"mustache": "^4.2.0",
+    "promjs": "^0.4.2",
 		"toucan-js": "^3.2.3",
 		"tsconfig": "*",
 		"typescript": "^5.0.2",

--- a/packages/format-errors/src/index.ts
+++ b/packages/format-errors/src/index.ts
@@ -1,7 +1,9 @@
+import prom from "promjs";
 import { Toucan } from "toucan-js";
 import { z } from "zod";
 import Youch from "./Youch";
 export interface Env {
+	PROMETHEUS_TOKEN: string;
 	SENTRY_ACCESS_CLIENT_SECRET: string;
 	SENTRY_ACCESS_CLIENT_ID: string;
 	SENTRY_DSN: string;
@@ -122,6 +124,14 @@ export default {
 		env: Env,
 		ctx: ExecutionContext
 	): Promise<Response> {
+		const registry = prom();
+		const requestCounter = registry.create(
+			"counter",
+			"devprod_format_errors_request_total",
+			"Request counter for DevProd's format-errors service"
+		);
+		requestCounter.inc();
+
 		const sentry = new Toucan({
 			dsn: env.SENTRY_DSN,
 			context: ctx,
@@ -149,6 +159,13 @@ export default {
 			return handlePrettyErrorRequest(payload);
 		} catch (e) {
 			sentry.captureException(e);
+			const errorCounter = registry.create(
+				"counter",
+				"devprod_format_errors_error_total",
+				"Error counter for DevProd's format-errors service"
+			);
+			errorCounter.inc();
+
 			return Response.json(
 				{
 					error: "UnexpectedError",
@@ -157,6 +174,16 @@ export default {
 				{
 					status: 500,
 				}
+			);
+		} finally {
+			ctx.waitUntil(
+				fetch("https://workers-logging.cfdata.org/prometheus", {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${env.PROMETHEUS_TOKEN}`,
+					},
+					body: registry.metrics(),
+				})
 			);
 		}
 	},

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -21,6 +21,7 @@
 		"@types/cookie": "^0.5.1",
 		"cookie": "^0.5.0",
 		"itty-router": "^4.0.13",
+		"promjs": "^0.4.2",
 		"toucan-js": "^3.2.2",
 		"undici": "^5.23.0",
 		"wrangler": "^3.5.1"

--- a/packages/playground-preview-worker/worker-configuration.d.ts
+++ b/packages/playground-preview-worker/worker-configuration.d.ts
@@ -6,6 +6,7 @@ type Env = {
 	workersDev: string;
 	// Secrets
 	API_TOKEN: string;
+	PROMETHEUS_TOKEN: string;
 	SENTRY_ACCESS_CLIENT_SECRET: string;
 	SENTRY_ACCESS_CLIENT_ID: string;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -737,6 +737,9 @@ importers:
       cookie:
         specifier: ^0.5.0
         version: 0.5.0
+      promjs:
+        specifier: ^0.4.2
+        version: 0.4.2
       toucan-js:
         specifier: ^3.1.0
         version: 3.2.2(patch_hash=dxprwy4mawdnq3drjhp7shhm2m)
@@ -992,6 +995,9 @@ importers:
       itty-router:
         specifier: ^4.0.13
         version: 4.0.17
+      promjs:
+        specifier: ^0.4.2
+        version: 0.4.2
       toucan-js:
         specifier: ^3.2.2
         version: 3.2.2(patch_hash=dxprwy4mawdnq3drjhp7shhm2m)
@@ -15769,6 +15775,10 @@ packages:
       retry: 0.12.0
     dev: false
     optional: true
+
+  /promjs@0.4.2:
+    resolution: {integrity: sha512-qvHcTU9xwEieFOf2Qnf5JYPKkdJU2lRbJfJvJspw6XpnoH7VPmNfnJJnOLPfN8ODJMBLRt8wEPVjxyyn0Or6RQ==}
+    dev: true
 
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,6 +785,9 @@ importers:
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
+      promjs:
+        specifier: ^0.4.2
+        version: 0.4.2
       toucan-js:
         specifier: ^3.2.3
         version: 3.2.3


### PR DESCRIPTION
Fixes [DEVX-1090](https://jira.cfdata.org/browse/DEVX-1090), [DEVX-1091](https://jira.cfdata.org/browse/DEVX-1091), [DEVX-1092](https://jira.cfdata.org/browse/DEVX-1092)

**What this PR solves / how to test:**

Adds prometheus counter metrics for requests and errors for the `edge-preview-authenticated-proxy`, `format-errors`, `playground-preview-worker` workers

Decisions made during implementation:
- metric name format: `<team-name>_<service-name>_[request|error]_total` where service-name is the original kebab-case (hyphenated) name even amongst a snake_case metric name
- no labels (i.e. for request pathname) have been added – we can choose to do so later

Still TODO:
- [x] add `PROMETHEUS_TOKEN` secret to `edge-preview-authenticated-proxy`
- [x] add `PROMETHEUS_TOKEN` secret to `format-errors`
- [x] add `PROMETHEUS_TOKEN` secret to `playground-preview-worker`

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: no tests for sentry and this is a minor addition to the sentry codepath
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: changeset not applied to worker deployments
- Associated docs
  - [x] Issue(s)/PR(s): linked above
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
