### PR TITLE
fix: ensure upstream_protocol is passed to the Worker

### DIFF
--- a/.changeset/giant-kings-heal.md
+++ b/.changeset/giant-kings-heal.md
@@ -1,0 +1,21 @@
+---
+"wrangler": patch
+---
+
+fix: ensure upstream_protocol is passed to the Worker
+
+In `wrangler dev` it is possible to set the `upstream_protocol`,
+which is the protocol under which the User Worker believes it has been
+requested, as recorded in the `request.url` that can be used for
+forwarding on requests to the origin.
+
+Previously, it was not being passed to `wrangler dev` in local mode.
+Instead it was always set to `http`.
+
+Note that setting `upstream_protocol` to `http` is not supported in
+`wrangler dev` remote mode, which is the case since Wrangler v2.0.
+
+This setting now defaults to `https` in remote mode (since that is the only option),
+and to the same as `local_protocol` in local mode.
+
+Fixes #4539

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -22,12 +22,10 @@ export default {
 			return new Response(request.url);
 		}
 
-		console.log(
-			request.method,
-			request.url,
-			new Map([...request.headers]),
-			request.cf
-		);
+		console.log("METHOD =", request.method);
+		console.log("URL = ", request.url);
+		console.log("HEADERS =", new Map([...request.headers]));
+		console.log("CF =", request.cf);
 
 		logErrors();
 

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -33,7 +33,7 @@ describe("normalizeAndValidateConfig()", () => {
 				ip: process.platform === "win32" ? "127.0.0.1" : "localhost",
 				local_protocol: "http",
 				port: undefined, // the default of 8787 is set at runtime
-				upstream_protocol: "https",
+				upstream_protocol: "http",
 				host: undefined,
 			},
 			cloudchamber: {},

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -748,12 +748,12 @@ describe("wrangler dev", () => {
 	});
 
 	describe("upstream-protocol", () => {
-		it("should default upstream-protocol to `https`", async () => {
+		it("should default upstream-protocol to `https` if remote mode", async () => {
 			writeWranglerToml({
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
+			await runWrangler("dev --remote");
 			expect((Dev as jest.Mock).mock.calls[0][0].upstreamProtocol).toEqual(
 				"https"
 			);
@@ -762,24 +762,52 @@ describe("wrangler dev", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should warn if `--upstream-protocol=http` is used", async () => {
+		it("should warn if `--upstream-protocol=http` is used in remote mode", async () => {
 			writeWranglerToml({
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --upstream-protocol=http");
+			await runWrangler("dev --upstream-protocol=http --remote");
 			expect((Dev as jest.Mock).mock.calls[0][0].upstreamProtocol).toEqual(
 				"http"
 			);
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`
-			        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mSetting upstream-protocol to http is not currently implemented.[0m
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mSetting upstream-protocol to http is not currently supported for remote mode.[0m
 
-			          If this is required in your project, please add your use case to the following issue:
-			          [4mhttps://github.com/cloudflare/workers-sdk/issues/583[0m.
+			  If this is required in your project, please add your use case to the following issue:
+			  [4mhttps://github.com/cloudflare/workers-sdk/issues/583[0m.
 
-			        "
-		      `);
+			"
+		`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should default upstream-protocol to local-protocol if local mode", async () => {
+			writeWranglerToml({
+				main: "index.js",
+			});
+			fs.writeFileSync("index.js", `export default {};`);
+			await runWrangler("dev --local-protocol=https");
+			expect((Dev as jest.Mock).mock.calls[0][0].upstreamProtocol).toEqual(
+				"https"
+			);
+			expect(std.out).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should default upstream-protocol to http if no local-protocol in local mode", async () => {
+			writeWranglerToml({
+				main: "index.js",
+			});
+			fs.writeFileSync("index.js", `export default {};`);
+			await runWrangler("dev");
+			expect((Dev as jest.Mock).mock.calls[0][0].upstreamProtocol).toEqual(
+				"http"
+			);
+			expect(std.out).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -215,11 +215,10 @@ export interface DevConfig {
 	/**
 	 * Protocol that wrangler dev forwards requests on
 	 *
-	 * Setting this to `http` is not currently implemented.
+	 * Setting this to `http` is not currently implemented for remote mode.
 	 * See https://github.com/cloudflare/workers-sdk/issues/583
 	 *
-	 * @default `https`
-	 * @todo this needs to be implemented https://github.com/cloudflare/workers-sdk/issues/583
+	 * @default `https` in remote mode; same as local_protocol in local mode.
 	 */
 	upstream_protocol: "https" | "http";
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -756,9 +756,9 @@ async function validateDevServerSettings(
 	}
 	const upstreamProtocol =
 		args.upstreamProtocol ?? config.dev.upstream_protocol;
-	if (upstreamProtocol === "http") {
+	if (upstreamProtocol === "http" && args.remote) {
 		logger.warn(
-			"Setting upstream-protocol to http is not currently implemented.\n" +
+			"Setting upstream-protocol to http is not currently supported for remote mode.\n" +
 				"If this is required in your project, please add your use case to the following issue:\n" +
 				"https://github.com/cloudflare/workers-sdk/issues/583."
 		);

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -441,6 +441,7 @@ function DevSession(props: DevSessionProps) {
 			queueConsumers={props.queueConsumers}
 			localProtocol={"http"} // hard-code for userworker, DevEnv-ProxyWorker now uses this prop value
 			localUpstream={props.localUpstream}
+			upstreamProtocol={props.upstreamProtocol}
 			inspect={props.inspect}
 			onReady={announceAndOnReady}
 			enablePagesAssetsServiceBinding={props.enablePagesAssetsServiceBinding}

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -38,6 +38,7 @@ export interface LocalProps {
 	crons: Config["triggers"]["crons"];
 	queueConsumers: Config["queues"]["consumers"];
 	localProtocol: "http" | "https";
+	upstreamProtocol: "http" | "https";
 	localUpstream: string | undefined;
 	inspect: boolean;
 	onReady:
@@ -93,6 +94,7 @@ export async function localPropsToConfigBundle(
 		queueConsumers: props.queueConsumers,
 		localProtocol: props.localProtocol,
 		localUpstream: props.localUpstream,
+		upstreamProtocol: props.upstreamProtocol,
 		inspect: props.inspect,
 		serviceBindings,
 	};
@@ -177,7 +179,7 @@ function useLocalWorker(props: LocalProps) {
 						pathname: `/core:user:${props.name ?? DEFAULT_WORKER_NAME}`,
 					},
 					userWorkerInnerUrlOverrides: {
-						protocol: props.localProtocol,
+						protocol: props.upstreamProtocol,
 						hostname: props.localUpstream,
 						port: props.localUpstream ? "" : undefined, // `localUpstream` was essentially `host`, not `hostname`, so if it was set delete the `port`
 					},

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -112,6 +112,7 @@ export interface ConfigBundle {
 	queueConsumers: Config["queues"]["consumers"];
 	localProtocol: "http" | "https";
 	localUpstream: string | undefined;
+	upstreamProtocol: "http" | "https";
 	inspect: boolean;
 	serviceBindings: Record<string, (_request: Request) => Promise<Response>>;
 }
@@ -564,7 +565,7 @@ async function buildMiniflareOptions(
 
 	const upstream =
 		typeof config.localUpstream === "string"
-			? `${config.localProtocol}://${config.localUpstream}`
+			? `${config.upstreamProtocol}://${config.localUpstream}`
 			: undefined;
 
 	const sourceOptions = await buildSourceOptions(config);

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -95,7 +95,7 @@ export async function startDevServer(
 				port: props.inspectorPort,
 			},
 			urlOverrides: {
-				secure: props.localProtocol === "https",
+				secure: props.upstreamProtocol === "https",
 				hostname: props.localUpstream,
 			},
 			liveReload: props.liveReload,
@@ -168,6 +168,7 @@ export async function startDevServer(
 			queueConsumers: props.queueConsumers,
 			localProtocol: props.localProtocol,
 			localUpstream: props.localUpstream,
+			upstreamProtocol: props.upstreamProtocol,
 			inspect: true,
 			onReady: async (ip, port, proxyData) => {
 				// at this point (in the layers of onReady callbacks), we have devEnv in scope
@@ -412,7 +413,7 @@ export async function startLocalServer(
 					pathname: `/core:user:${props.name ?? DEFAULT_WORKER_NAME}`,
 				},
 				userWorkerInnerUrlOverrides: {
-					protocol: props.localProtocol,
+					protocol: props.upstreamProtocol,
 					hostname: props.localUpstream,
 					port: props.localUpstream ? "" : undefined, // `localUpstream` was essentially `host`, not `hostname`, so if it was set delete the `port`
 				},


### PR DESCRIPTION
**What this PR solves:**

In `wrangler dev` it is possible to set the `upstream_protocol`, which is the protocol under which the User Worker believes it has been requested, as recorded in the `request.url` that can be used for forwarding on requests to the origin.

This setting defaults to `https`. Previously, it was not being passed to `wrangler dev` in local mode. Instead it was always set to `http`.

Note that setting `upstream_protocol` to `http` is not supported in `wrangler dev` remote mode, which is the case since Wrangler v2.0.

Fixes #4539

**How to test:**

Using the build of Wrangler from this PR run `wrangler dev` on a simple worker as follows:

```ts
export default {
  fetch(request: Request) {
    return new Response(request.url);
  }
}
```

Note that the response will be a URL that has `https` as its protocol (e.g. `https://localhost:8787`).

Then run the same worker with `wrangler dev --upstream-protocol=http`. Now the response will have a URL that has `http` as the protocol.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: bug fix - no docs changes needed.

