### PR TITLE
Fix usage of patch API in bulk secrets update

### DIFF
--- a/.changeset/green-items-serve.md
+++ b/.changeset/green-items-serve.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix usage of patch API in bulk secrets update
+
+Only specifying the name and type of a binding instructs the patch API to copy the existing binding over - but we were including the contents of the binding as well. Normally that's OK, but there are some subtle differences between what you specify to _create_ a binding vs what it looks like once it's _created_, specifically for Durable Objects. So instead, we just use the simpler inheritance.

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -778,9 +778,8 @@ describe("wrangler secret", () => {
 						).formData();
 						const settings = formBody.get("settings");
 						expect(settings).not.toBeNull();
-						expect(
-							JSON.parse(formBody.get("settings") as string)
-						).toMatchObject({
+						const parsedSettings = JSON.parse(settings as string);
+						expect(parsedSettings).toMatchObject({
 							bindings: [
 								{ type: "plain_text", name: "env_var" },
 								{ type: "json", name: "another_var" },
@@ -797,6 +796,8 @@ describe("wrangler secret", () => {
 								},
 							],
 						});
+						expect(parsedSettings).not.toHaveProperty(["bindings", 0, "text"]);
+						expect(parsedSettings).not.toHaveProperty(["bindings", 1, "json"]);
 
 						return res(ctx.json(createFetchResult(null)));
 					}


### PR DESCRIPTION
Only specifying the name and type of a binding instructs the patch API to copy the existing binding over - but we were including the contents of the binding as well. Normally that's OK, but there are some subtle differences between what you specify to _create_ a binding vs what it looks like once it's _created_, specifically for Durable Objects. So instead, we just use the simpler inheritance.

Note that this depends on a not-yet-released EWC change to fix a separate bug in the patch API, and should hold until that makes it out

Fixes #4496, WC-1774