### PR TITLE
fix: ensure logs containing `at ` not truncated to `at [object Object]`

### DIFF
--- a/.changeset/sharp-rivers-carry.md
+++ b/.changeset/sharp-rivers-carry.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: ensure logs containing `at ` not truncated to `at [object Object]`
+
+Previously, logs containing `at ` were always treated as stack trace call sites requiring source mapping. This change updates the call site detection to avoid false positives.

--- a/fixtures/worker-app/src/log.ts
+++ b/fixtures/worker-app/src/log.ts
@@ -8,5 +8,9 @@ export function logErrors(): Output {
 	console.log(new Error("logged error two").stack);
 	console.log({ error: new Error("logged error three") });
 
+	console.log("some normal text to log");
+	console.log("text with at in the middle");
+	console.log("more text with    at in the middle");
+
 	return { thing: 42 };
 }

--- a/fixtures/worker-app/src/log.ts
+++ b/fixtures/worker-app/src/log.ts
@@ -7,6 +7,7 @@ export function logErrors(): Output {
 	console.log(new Error("logged error one"));
 	console.log(new Error("logged error two").stack);
 	console.log({ error: new Error("logged error three") });
+	console.log({ nested: { error: new Error("logged error four").stack } });
 
 	console.log("some normal text to log");
 	console.log("text with at in the middle");

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -35,16 +35,16 @@ describe("'wrangler dev' correctly renders pages", () => {
 
 		// Check logged strings are source mapped
 		expect(output).toMatch(
-			/Error: logged error one.+fixtures\/worker-app\/src\/log\.ts:7:14/s
+			/Error: logged error one\n.+at logErrors.+fixtures\/worker-app\/src\/log\.ts:7:14/
 		);
 		expect(output).toMatch(
-			/Error: logged error two.+fixtures\/worker-app\/src\/log\.ts:8:14/s
+			/Error: logged error two\n.+at logErrors.+fixtures\/worker-app\/src\/log\.ts:8:14/
 		);
 		expect(output).toMatch(
-			/Error: logged error three.+fixtures\/worker-app\/src\/log\.ts:9:23/s
+			/Error: logged error three\n.+at logErrors.+fixtures\/worker-app\/src\/log\.ts:9:23/
 		);
 		expect(output).toMatch(
-			/Error: logged error four.+fixtures\/worker-app\/src\/log\.ts:10:33/s
+			/Error: logged error four\\n' \+\n.+at logErrors.+fixtures\/worker-app\/src\/log\.ts:10:33/
 		);
 
 		// Regression test for https://github.com/cloudflare/workers-sdk/issues/4668

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -35,13 +35,16 @@ describe("'wrangler dev' correctly renders pages", () => {
 
 		// Check logged strings are source mapped
 		expect(output).toMatch(
-			/Error: logged error one.+fixtures\/worker-app\/src\/log.ts:7:14/s
+			/Error: logged error one.+fixtures\/worker-app\/src\/log\.ts:7:14/s
 		);
 		expect(output).toMatch(
-			/Error: logged error two.+fixtures\/worker-app\/src\/log.ts:8:14/s
+			/Error: logged error two.+fixtures\/worker-app\/src\/log\.ts:8:14/s
 		);
 		expect(output).toMatch(
-			/Error: logged error three.+fixtures\/worker-app\/src\/log.ts:9:23/s
+			/Error: logged error three.+fixtures\/worker-app\/src\/log\.ts:9:23/s
+		);
+		expect(output).toMatch(
+			/Error: logged error four.+fixtures\/worker-app\/src\/log\.ts:10:33/s
 		);
 
 		// Regression test for https://github.com/cloudflare/workers-sdk/issues/4668

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -43,6 +43,11 @@ describe("'wrangler dev' correctly renders pages", () => {
 		expect(output).toMatch(
 			/Error: logged error three.+fixtures\/worker-app\/src\/log.ts:9:23/s
 		);
+
+		// Regression test for https://github.com/cloudflare/workers-sdk/issues/4668
+		expect(output).toContain("some normal text to log");
+		expect(output).toContain("text with at in the middle");
+		expect(output).toContain("more text with    at in the middle");
 	});
 
 	it("renders pretty error after logging", async ({ expect }) => {

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -151,12 +151,12 @@ export function getSourceMappedString(
 		if (callSites[i].getFileName() === undefined) continue;
 
 		const callSiteLine = callSiteLines[i][0];
-		const callSiteAtIndex = callSiteLine.indexOf("    at");
+		const callSiteAtIndex = callSiteLine.indexOf("at");
 		assert(callSiteAtIndex !== -1); // Matched against `CALL_SITE_REGEXP`
 		const callSiteLineLeftPad = callSiteLine.substring(0, callSiteAtIndex);
 		value = value.replace(
 			callSiteLine,
-			callSiteLineLeftPad + sourceMappedCallSiteLines[i]
+			callSiteLineLeftPad + sourceMappedCallSiteLines[i].trimStart()
 		);
 	}
 	return value;
@@ -186,8 +186,10 @@ export function getSourceMappedString(
  */
 
 const CALL_SITE_REGEXP =
+	// Validation errors from `wrangler deploy` have a 2 space indent, whereas
+	// regular stack traces have a 4 space indent.
 	// eslint-disable-next-line no-control-regex
-	/^(?:\s+(?:\x1B\[32m)?'?)? {4}at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/gm;
+	/^(?:\s+(?:\x1B\[32m)?'?)? {2,4}at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/gm;
 function lineMatchToCallSite(lineMatch: RegExpMatchArray): CallSite {
 	let object: string | null = null;
 	let method: string | null = null;

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -189,7 +189,7 @@ const CALL_SITE_REGEXP =
 	// Validation errors from `wrangler deploy` have a 2 space indent, whereas
 	// regular stack traces have a 4 space indent.
 	// eslint-disable-next-line no-control-regex
-	/^(?:\s+(?:\x1B\[32m)?'?)? {2,4}at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/gm;
+	/^(?:\s+(?:\x1B\[\d+m)?'?)? {2,4}at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/gm;
 function lineMatchToCallSite(lineMatch: RegExpMatchArray): CallSite {
 	let object: string | null = null;
 	let method: string | null = null;

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -144,11 +144,13 @@ export function getSourceMappedString(
 		callSites
 	);
 	const sourceMappedCallSiteLines = sourceMappedStackTrace.split("\n").slice(1);
+
 	for (let i = 0; i < callSiteLines.length; i++) {
-		value = value.replace(
-			callSiteLines[i][0],
-			sourceMappedCallSiteLines[i].substring(4) // Trim indent from stack
-		);
+		// If a call site doesn't have a file name, it's likely invalid, so don't
+		// apply source mapping (see cloudflare/workers-sdk#4668)
+		if (callSites[i].getFileName() === undefined) continue;
+
+		value = value.replace(callSiteLines[i][0], sourceMappedCallSiteLines[i]);
 	}
 	return value;
 }
@@ -177,7 +179,7 @@ export function getSourceMappedString(
  */
 
 const CALL_SITE_REGEXP =
-	/at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/g;
+	/ {4}at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/g;
 function lineMatchToCallSite(lineMatch: RegExpMatchArray): CallSite {
 	let object: string | null = null;
 	let method: string | null = null;

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -150,7 +150,14 @@ export function getSourceMappedString(
 		// apply source mapping (see cloudflare/workers-sdk#4668)
 		if (callSites[i].getFileName() === undefined) continue;
 
-		value = value.replace(callSiteLines[i][0], sourceMappedCallSiteLines[i]);
+		const callSiteLine = callSiteLines[i][0];
+		const callSiteAtIndex = callSiteLine.indexOf("    at");
+		assert(callSiteAtIndex !== -1); // Matched against `CALL_SITE_REGEXP`
+		const callSiteLineLeftPad = callSiteLine.substring(0, callSiteAtIndex);
+		value = value.replace(
+			callSiteLine,
+			callSiteLineLeftPad + sourceMappedCallSiteLines[i]
+		);
 	}
 	return value;
 }
@@ -179,7 +186,8 @@ export function getSourceMappedString(
  */
 
 const CALL_SITE_REGEXP =
-	/ {4}at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/g;
+	// eslint-disable-next-line no-control-regex
+	/^(?:\s+(?:\x1B\[32m)?'?)? {4}at (?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/gm;
 function lineMatchToCallSite(lineMatch: RegExpMatchArray): CallSite {
 	let object: string | null = null;
 	let method: string | null = null;


### PR DESCRIPTION
Fixes #4668.

**What this PR solves / how to test:**

Previously, logs containing `at ` were always treated as stack trace call sites requiring source mapping. This change updates the call site detection to avoid false positives, by requiring an indent of 4 spaces and a valid file name. We aren't able to rely on newlines here, as we support source mapping with `console.log({ stack: new Error("oopps").stack })`. In this case, the `value` passed to `getSourceMappedString()` contains ANSI colour codes and looks something like...

```
{
  value: '{\n' +
    "  stack: \x1B[32m'Error: oopps\\n'\x1B[39m +\n" +
    "    \x1B[32m'    at Object.fetch (file:///Users/bcoll/.wrangler/tmp/dev-Bzz87I/index.js:53:26)\\n'\x1B[39m +\n" +
    "    \x1B[32m'    at __facade_modules_fetch__ (file:///Users/bcoll/.wrangler/tmp/dev-Bzz87I/index.js:111:46)\\n'\x1B[39m +\n" +
    "    \x1B[32m'    at __facade_invokeChain__ (file:///Users/bcoll/.wrangler/tmp/dev-Bzz87I/index.js:39:10)\\n'\x1B[39m +\n" +
    "    \x1B[32m'    at Object.next (file:///Users/bcoll/.wrangler/tmp/dev-Bzz87I/index.js:36:14)\\n'\x1B[39m +\n" +
    "    \x1B[32m'    at jsonError (file:///Users/bcoll/.wrangler/tmp/dev-Bzz87I/index.js:69:32)\\n'\x1B[39m +\n" +
    "    \x1B[32m'    at __facade_invokeChain__ (file:///Users/bcoll/.wrangler/tmp/dev-Bzz87I/index.js:39:10)\\n'\x1B[39m +\n" +
    "    \x1B[32m'    at __facade_invoke__ (file:///Users/bcoll/.wrangler/tmp/dev-Bzz87I/index.js:42:10)\\n'\x1B[39m +\n" +
    "    \x1B[32m'    at Object.fetch (file:///Users/bcoll/.wrangler/tmp/dev-Bzz87I/index.js:162:14)'\x1B[39m\n" +
    '}'
}
```

To test this, run `wrangler dev` in `fixtures/worker-app` and make a request to `http://localhost:8787`. You should see all `console.log()`s correctly logged in the output.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a regression

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
