### PR TITLE
[miniflare] feat: expose `rows_read`/`rows_written` in D1 `meta`

### DIFF
--- a/.changeset/late-clocks-reply.md
+++ b/.changeset/late-clocks-reply.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+---
+
+feat: expose `rows_read` and `rows_written` in D1 result `meta`
+
+`rows_read`/`rows_written` contain the number of rows read from/written to the database engine when executing a query respectively. These numbers may be greater than the number of rows returned from/inserted by a query. These numbers form billing metrics when your Worker is deployed. See https://developers.cloudflare.com/d1/platform/pricing/#billing-metrics for more details.

--- a/packages/miniflare/src/workers/d1/database.worker.ts
+++ b/packages/miniflare/src/workers/d1/database.worker.ts
@@ -37,8 +37,10 @@ interface D1SuccessResponse {
 		duration: number;
 		changes: number;
 		last_row_id: number;
-		changed_db?: boolean;
-		size_after?: number;
+		changed_db: boolean;
+		size_after: number;
+		rows_read: number;
+		rows_written: number;
 	};
 }
 interface D1FailureResponse {
@@ -143,6 +145,8 @@ export class D1DatabaseObject extends MiniflareDurableObject {
 				last_row_id: afterChanges.lastRowId,
 				changed_db: changed,
 				size_after: afterSize,
+				rows_read: cursor.rowsRead,
+				rows_written: cursor.rowsWritten,
 			},
 		};
 	};

--- a/packages/miniflare/src/workers/shared/sql.worker.ts
+++ b/packages/miniflare/src/workers/shared/sql.worker.ts
@@ -29,6 +29,9 @@ export interface TypedSqlStorage {
 export interface TypedSqlStorageCursor<R extends TypedResult = TypedResult> {
 	raw(): IterableIterator<R[keyof R][]>;
 	[Symbol.iterator](): IterableIterator<R>;
+	readonly columnNames: string[];
+	readonly rowsRead: number;
+	readonly rowsWritten: number;
 }
 export interface TypedSqlStorageStatement<
 	P extends TypedValue[] = TypedValue[],

--- a/packages/miniflare/test/plugins/d1/suite.ts
+++ b/packages/miniflare/test/plugins/d1/suite.ts
@@ -229,6 +229,8 @@ test("D1PreparedStatement: run", async (t) => {
 			last_row_id: result.meta.last_row_id,
 			served_by: "miniflare.db",
 			size_after: result.meta.size_after,
+			rows_read: 3,
+			rows_written: 0,
 		},
 	});
 
@@ -251,6 +253,8 @@ test("D1PreparedStatement: run", async (t) => {
 			last_row_id: 4,
 			served_by: "miniflare.db",
 			size_after: result.meta.size_after,
+			rows_read: 2,
+			rows_written: 2,
 		},
 	});
 
@@ -282,6 +286,8 @@ test("D1PreparedStatement: run", async (t) => {
 			last_row_id: 5,
 			served_by: "miniflare.db",
 			size_after: result.meta.size_after,
+			rows_read: 1,
+			rows_written: 1,
 		},
 	});
 });
@@ -309,6 +315,8 @@ test("D1PreparedStatement: all", async (t) => {
 			last_row_id: result.meta.last_row_id,
 			served_by: "miniflare.db",
 			size_after: result.meta.size_after,
+			rows_read: 3,
+			rows_written: 0,
 		},
 	});
 


### PR DESCRIPTION
Fixes #4671.

**What this PR solves / how to test:**

This PR exposes `rows_read`/`rows_written` in the `meta` object of D1 responses. This matches production behaviour. `rows_read`/`rows_written` contain the number of rows read from/written to the database engine when executing a query respectively. These numbers may be greater than the number of rows returned from/inserted by a query. These numbers form billing metrics when your Worker is deployed. See https://developers.cloudflare.com/d1/platform/pricing/#billing-metrics and https://github.com/cloudflare/workerd/pull/979 for more details. To test this, run `wrangler dev` on a Worker using D1 databases. Observe `rows_read` and `rows_written` are now included in `meta`.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: matching existing production behaviour

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
