### PR TITLE
fix: remove confusing `--local` messaging from `wrangler pages dev`

### DIFF
--- a/.changeset/ten-dancers-wonder.md
+++ b/.changeset/ten-dancers-wonder.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: remove confusing `--local` messaging from `wrangler pages dev`
+
+Running `wrangler pages dev` would previously log a warning saying `--local is no longer required` even though `--local` was never set. This change removes this warning.

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -4,10 +4,13 @@ import { describe, it, beforeAll, afterAll } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages Functions", () => {
-	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
+	let ip: string,
+		port: number,
+		stop: (() => Promise<unknown>) | undefined,
+		getOutput: () => string;
 
 	beforeAll(async () => {
-		({ ip, port, stop } = await runWranglerPagesDev(
+		({ ip, port, stop, getOutput } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
 			[
@@ -92,6 +95,13 @@ describe("Pages Functions", () => {
 		const response = await fetch(`http://${ip}:${port}/next`);
 		const text = await response.text();
 		expect(text).toContain("<h1>An asset</h1>");
+	});
+
+	it("doesn't warn about local mode", async ({ expect }) => {
+		// Regression test for https://github.com/cloudflare/workers-sdk/issues/4210
+		expect(getOutput()).not.toContain(
+			"--local is no longer required and will be removed in a future version"
+		);
 	});
 
 	describe("can mount a plugin", () => {

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -152,7 +152,7 @@ export async function unstable_dev(
 		_: [],
 		$0: "",
 		remote: !local,
-		local,
+		local: undefined,
 		experimentalLocal: undefined,
 		d1Databases,
 		disableDevRegistry,


### PR DESCRIPTION
Fixes #4210.

**What this PR solves / how to test:**

Running `wrangler pages dev` would previously log a warning saying `--local is no longer required` even though `--local` was never set. This change removes this warning. To test this, run `wrangler pages dev` and make sure `--local is no longer required` doesn't appear.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: removing old messaging

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
