### PR TITLE
Update Next.js template to support bindings

### DIFF
--- a/packages/create-cloudflare/src/__tests__/workers-types.test.ts
+++ b/packages/create-cloudflare/src/__tests__/workers-types.test.ts
@@ -1,7 +1,11 @@
 import { existsSync, readdirSync } from "fs";
+import {
+	addWorkersTypesToTsConfig,
+	getLatestTypesEntrypoint,
+} from "helpers/command";
 import { readFile, writeFile } from "helpers/files";
 import { describe, expect, test, vi, afterEach, beforeEach } from "vitest";
-import * as workers from "../workers";
+
 import { createTestContext } from "./helpers";
 import type { Dirent } from "fs";
 import type { PagesGeneratorContext } from "types";
@@ -35,7 +39,7 @@ describe("getLatestTypesEntrypoint", () => {
 			() => [...mockWorkersTypesDirListing] as unknown as Dirent[]
 		);
 
-		const entrypoint = workers.getLatestTypesEntrypoint(ctx);
+		const entrypoint = getLatestTypesEntrypoint(ctx);
 		expect(entrypoint).toBe("2023-07-01");
 	});
 
@@ -44,14 +48,14 @@ describe("getLatestTypesEntrypoint", () => {
 			throw new Error("ENOENT: no such file or directory");
 		});
 
-		const entrypoint = workers.getLatestTypesEntrypoint(ctx);
+		const entrypoint = getLatestTypesEntrypoint(ctx);
 		expect(entrypoint).toBe(null);
 	});
 
 	test("empty directory", async () => {
 		vi.mocked(readdirSync).mockImplementation(() => []);
 
-		const entrypoint = workers.getLatestTypesEntrypoint(ctx);
+		const entrypoint = getLatestTypesEntrypoint(ctx);
 		expect(entrypoint).toBe(null);
 	});
 
@@ -60,12 +64,12 @@ describe("getLatestTypesEntrypoint", () => {
 			() => ["foo", "bar"] as unknown as Dirent[]
 		);
 
-		const entrypoint = workers.getLatestTypesEntrypoint(ctx);
+		const entrypoint = getLatestTypesEntrypoint(ctx);
 		expect(entrypoint).toBe(null);
 	});
 });
 
-describe("updateTsConfig", () => {
+describe("addWorkersTypesToTsConfig", () => {
 	let ctx: PagesGeneratorContext;
 
 	beforeEach(() => {
@@ -89,7 +93,7 @@ describe("updateTsConfig", () => {
 	});
 
 	test("happy path", async () => {
-		await workers.updateTsConfig(ctx);
+		await addWorkersTypesToTsConfig(ctx);
 
 		expect(vi.mocked(writeFile).mock.calls[0][1]).toEqual(
 			`{types: ["@cloudflare/workers-types/2023-07-01"]}`

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -20,6 +20,7 @@ import {
 	apiPagesDirHelloTs,
 	appDirNotFoundJs,
 	appDirNotFoundTs,
+	envDts,
 	nextConfig,
 } from "./templates";
 import type { C3Args, FrameworkConfig, PagesGeneratorContext } from "types";
@@ -94,6 +95,11 @@ const configure = async (ctx: PagesGeneratorContext) => {
 	writeFile(handlerPath, handlerFile);
 	updateStatus("Created an example API route handler");
 
+	if (usesTypescript(projectName)) {
+		writeFile(`${projectName}/env.d.ts`, envDts);
+		updateStatus("Created an env.d.ts file for the Cloudflare types");
+	}
+
 	const installEslintPlugin = await shouldInstallNextOnPagesEslintPlugin(ctx);
 
 	if (installEslintPlugin) {
@@ -113,7 +119,7 @@ const configure = async (ctx: PagesGeneratorContext) => {
 		doneText: `${brandColor(`installed`)} ${dim(packages.join(", "))}`,
 	});
 
-	writeFile(path, nextConfig);
+	writeFile(`${ctx.project.path}/next.config.js`, nextConfig);
 };
 
 export const shouldInstallNextOnPagesEslintPlugin = async (

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -20,6 +20,7 @@ import {
 	apiPagesDirHelloTs,
 	appDirNotFoundJs,
 	appDirNotFoundTs,
+	nextConfig,
 } from "./templates";
 import type { C3Args, FrameworkConfig, PagesGeneratorContext } from "types";
 
@@ -111,6 +112,8 @@ const configure = async (ctx: PagesGeneratorContext) => {
 		startText: "Adding the Cloudflare Pages adapter",
 		doneText: `${brandColor(`installed`)} ${dim(packages.join(", "))}`,
 	});
+
+	writeFile(path, nextConfig);
 };
 
 export const shouldInstallNextOnPagesEslintPlugin = async (

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -26,6 +26,7 @@ import {
 	appDirNotFoundTs,
 	envDts,
 	nextConfig,
+	readme,
 } from "./templates";
 import type { C3Args, FrameworkConfig, PagesGeneratorContext } from "types";
 
@@ -112,6 +113,9 @@ const configure = async (ctx: PagesGeneratorContext) => {
 
 	writeFile(`${ctx.project.path}/next.config.js`, nextConfig);
 	updateStatus("Updated the next.config.js file");
+
+	writeFile(`${ctx.project.path}/README.md`, readme);
+	updateStatus("Updated the README file");
 
 	await addDevDependencies(projectName, usesTs, ctx, installEslintPlugin);
 };

--- a/packages/create-cloudflare/src/frameworks/next/index.ts
+++ b/packages/create-cloudflare/src/frameworks/next/index.ts
@@ -166,12 +166,13 @@ const config: FrameworkConfig = {
 		const nextOnPagesScope = isNpmOrBun ? "@cloudflare/" : "";
 		const nextOnPagesCommand = `${nextOnPagesScope}next-on-pages`;
 		const pmCommand = isNpmOrBun ? npx : npm;
-		const pagesDeployCommand = isNpm ? "npm run" : isBun ? "bun" : pmCommand;
+		const pagesBuildRunCommand = `${
+			isNpm ? "npm run" : isBun ? "bun" : pmCommand
+		} pages:build`;
 		return {
 			"pages:build": `${pmCommand} ${nextOnPagesCommand}`,
-			"pages:deploy": `${pagesDeployCommand} pages:build && wrangler pages deploy .vercel/output/static`,
-			"pages:watch": `${pmCommand} ${nextOnPagesCommand} --watch`,
-			"pages:dev": `${pmCommand} wrangler pages dev .vercel/output/static ${await compatDateFlag()} --compatibility-flag=nodejs_compat`,
+			"pages:preview": `${pagesBuildRunCommand} && wrangler pages dev .vercel/output/static ${await compatDateFlag()} --compatibility-flag=nodejs_compat`,
+			"pages:deploy": `${pagesBuildRunCommand} && wrangler pages deploy .vercel/output/static`,
 		};
 	},
 	testFlags: [

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -1,14 +1,16 @@
-const bindings = `
+const handlerCode = `
 	// https://developers.cloudflare.com/workers/configuration/bindings/
 	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
 	// are exposed via process.env, as shown below:
 	//
-	// const myKv = process.env['MY_KV_NAMESPACE'];
-	// await myKv.put('foo', 'bar');
-	// const valueFromKv = await myKv.get('foo');
-	//
+	const myKv = process.env['MY_KV_NAMESPACE'];
+	await myKv.put('foo', 'bar');
+	const valueFromKv = await myKv.get('foo');
+
 	// Each binding must be configured in your project's next.config.js file:
 	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+
+	return new Response(JSON.stringify({ value: valueFromKv }))
 `;
 
 export const apiPagesDirHelloTs = `
@@ -21,9 +23,7 @@ export const config = {
 }
 
 export default async function handler(req: NextRequest) {
-${bindings}
-
-  return new Response(JSON.stringify({ name: 'John Doe' }))
+${handlerCode}
 }
 `;
 
@@ -35,9 +35,7 @@ export const config = {
 }
 
 export default async function handler(req) {
-${bindings}
-
-  return new Response(JSON.stringify({ name: 'John Doe' }))
+${handlerCode}
 }
 `;
 
@@ -49,10 +47,8 @@ import type { NextRequest } from 'next/server'
 export const runtime = 'edge'
 
 export async function GET(request: NextRequest) {
-${bindings}
+${handlerCode}
 
-
-  return new Response(JSON.stringify({ name: 'John Doe' }))
 }
 `;
 
@@ -62,9 +58,7 @@ export const apiAppDirHelloJs = `
 export const runtime = 'edge'
 
 export async function GET(request) {
-${bindings}
-
-  return new Response(JSON.stringify({ name: 'John Doe' }))
+${handlerCode}
 }
 `;
 

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -8,6 +8,17 @@ export const config = {
 }
 
 export default async function handler(req: NextRequest) {
+	// https://developers.cloudflare.com/workers/configuration/bindings/
+	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
+	// are exposed via process.env, as shown below:
+	//
+  // const myKv = process.env['MY_KV_NAMESPACE'];
+  // await myKv.put('foo', 'bar');
+  // const valueFromKv = await myKv.get('foo');
+	//
+  // Each binding must be configured in your project's next.config.js file:
+	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+
   return new Response(JSON.stringify({ name: 'John Doe' }))
 }
 `;
@@ -20,6 +31,17 @@ export const config = {
 }
 
 export default async function handler(req) {
+	// https://developers.cloudflare.com/workers/configuration/bindings/
+	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
+	// are exposed via process.env, as shown below:
+	//
+  // const myKv = process.env['MY_KV_NAMESPACE'];
+  // await myKv.put('foo', 'bar');
+  // const valueFromKv = await myKv.get('foo');
+	//
+  // Each binding must be configured in your project's next.config.js file:
+	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+
   return new Response(JSON.stringify({ name: 'John Doe' }))
 }
 `;
@@ -32,6 +54,18 @@ import type { NextRequest } from 'next/server'
 export const runtime = 'edge'
 
 export async function GET(request: NextRequest) {
+	// https://developers.cloudflare.com/workers/configuration/bindings/
+	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
+	// are exposed via process.env, as shown below:
+	//
+  // const myKv = process.env['MY_KV_NAMESPACE'];
+  // await myKv.put('foo', 'bar');
+  // const valueFromKv = await myKv.get('foo');
+	//
+  // Each binding must be configured in your project's next.config.js file:
+	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+
+
   return new Response(JSON.stringify({ name: 'John Doe' }))
 }
 `;
@@ -42,6 +76,17 @@ export const apiAppDirHelloJs = `
 export const runtime = 'edge'
 
 export async function GET(request) {
+	// https://developers.cloudflare.com/workers/configuration/bindings/
+	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
+	// are exposed via process.env, as shown below:
+	//
+  // const myKv = process.env['MY_KV_NAMESPACE'];
+  // await myKv.put('foo', 'bar');
+  // const valueFromKv = await myKv.get('foo');
+	//
+  // Each binding must be configured in your project's next.config.js file:
+	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+
   return new Response(JSON.stringify({ name: 'John Doe' }))
 }
 `;
@@ -169,3 +214,27 @@ const styles = {
   },
 } as const;
 `;
+
+
+export const nextConfig = `
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig
+
+// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+// This code ensures that bindings to resources like
+// KV, R2, Durable Objects, Queues, D1 are available in
+// local development when running the next dev command, which
+// runs a Node.js based local development server.
+if (process.env.NODE_ENV === 'development') {
+    import('@cloudflare/next-on-pages/__experimental__next-dev').then(({ setupDevBindings }) => {
+
+				// https://developers.cloudflare.com/workers/configuration/bindings/
+				// Each binding you want to expose via process.env must be configured via setupDevBindings()
+        setupDevBindings({
+            kvNamespaces: ['MY_KV_NAMESPACE'],
+        });
+    });
+}
+`

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -1,4 +1,4 @@
-const handlerCode = `  let responseText = 'hello world'
+const handlerCode = `  let responseText = 'Hello World'
 
   // In the edge runtime you can use Bindings that are available in your application
   // (for more details see:

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -191,12 +191,15 @@ const nextConfig = {}
 
 module.exports = nextConfig
 
+// Here we use the @cloudflare/next-on-pages next-dev module to allow us to use bindings during local development
+// (when running the application with \`next dev\`), for more information see:
+// https://github.com/dario-piotrowicz/next-on-pages/blob/8e93067/internal-packages/next-dev/README.md
 if (process.env.NODE_ENV === 'development') {
   import('@cloudflare/next-on-pages/next-dev').then(({ setupDevBindings }) => {
       setupDevBindings({
           bindings: {
-              // Add here the Cloudflare Bindings you want to have available during local development (with \`next dev\`)
-              // (for more details on Bindings see: https://developers.cloudflare.com/pages/functions/bindings/)
+              // Add here the Cloudflare Bindings you want to have available during local development,
+              // for more details on Bindings see: https://developers.cloudflare.com/pages/functions/bindings/)
               //
               // KV Example
               // MY_KV: {

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -1,10 +1,5 @@
 const handlerCode = `  let responseText = 'hello world'
 
-  // https://developers.cloudflare.com/workers/configuration/bindings/
-  // In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
-  // are exposed via process.env, as shown below:
-  //
-  //
   // In the edge runtime you can use Bindings that are available in your application
   // (for more details see:
   //    - https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -185,7 +185,6 @@ const styles = {
 } as const;
 `;
 
-
 export const nextConfig = `/** @type {import('next').NextConfig} */
 const nextConfig = {}
 

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -1,20 +1,25 @@
-const handlerCode = `
-	// https://developers.cloudflare.com/workers/configuration/bindings/
-	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
-	// are exposed via process.env, as shown below:
-	//
-	const myKv = process.env['MY_KV_NAMESPACE'];
-	await myKv.put('foo', 'bar');
-	const valueFromKv = await myKv.get('foo');
+const handlerCode = `  let responseText = 'hello world'
 
-	// Each binding must be configured in your project's next.config.js file:
-	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+  // https://developers.cloudflare.com/workers/configuration/bindings/
+  // In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
+  // are exposed via process.env, as shown below:
+  //
+  //
+  // In the edge runtime you can use Bindings that are available in your application
+  // (for more details see:
+  //    - https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+  //    - https://developers.cloudflare.com/pages/functions/bindings/
+  // )
+  //
+  // KV Example:
+  // const myKv = process.env.MY_KV
+  // await myKv.put('suffix', ' from a KV store!')
+  // const suffix = await myKv.get('suffix')
+  // responseText += suffix
 
-	return new Response(JSON.stringify({ value: valueFromKv }))
-`;
+  return new Response(responseText)`;
 
-export const apiPagesDirHelloTs = `
-// Next.js Edge API Routes: https://nextjs.org/docs/pages/building-your-application/routing/api-routes#edge-api-routes
+export const apiPagesDirHelloTs = `// Next.js Edge API Routes: https://nextjs.org/docs/pages/building-your-application/routing/api-routes#edge-api-routes
 
 import type { NextRequest } from 'next/server'
 
@@ -27,8 +32,7 @@ ${handlerCode}
 }
 `;
 
-export const apiPagesDirHelloJs = `
-// Next.js Edge API Routes: https://nextjs.org/docs/pages/building-your-application/routing/api-routes#edge-api-routes
+export const apiPagesDirHelloJs = `// Next.js Edge API Routes: https://nextjs.org/docs/pages/building-your-application/routing/api-routes#edge-api-routes
 
 export const config = {
   runtime: 'edge',
@@ -39,8 +43,7 @@ ${handlerCode}
 }
 `;
 
-export const apiAppDirHelloTs = `
-// Next.js Edge API Route Handlers: https://nextjs.org/docs/app/building-your-application/routing/router-handlers#edge-and-nodejs-runtimes
+export const apiAppDirHelloTs = `// Next.js Edge API Route Handlers: https://nextjs.org/docs/app/building-your-application/routing/router-handlers#edge-and-nodejs-runtimes
 
 import type { NextRequest } from 'next/server'
 
@@ -48,12 +51,10 @@ export const runtime = 'edge'
 
 export async function GET(request: NextRequest) {
 ${handlerCode}
-
 }
 `;
 
-export const apiAppDirHelloJs = `
-// Next.js Edge API Route Handlers: https://nextjs.org/docs/app/building-your-application/routing/router-handlers#edge-and-nodejs-runtimes
+export const apiAppDirHelloJs = `// Next.js Edge API Route Handlers: https://nextjs.org/docs/app/building-your-application/routing/router-handlers#edge-and-nodejs-runtimes
 
 export const runtime = 'edge'
 
@@ -63,8 +64,7 @@ ${handlerCode}
 `;
 
 // Simplified and adjusted version of the Next.js built-in not-found component (https://github.com/vercel/next.js/blob/1c65c5575/packages/next/src/client/components/not-found-error.tsx)
-export const appDirNotFoundJs = `
-export const runtime = "edge";
+export const appDirNotFoundJs = `export const runtime = "edge";
 
 export default function NotFound() {
   return (
@@ -125,8 +125,7 @@ const styles = {
 `;
 
 // Simplified and adjusted version of the Next.js built-in not-found component (https://github.com/vercel/next.js/blob/1c65c5575/packages/next/src/client/components/not-found-error.tsx)
-export const appDirNotFoundTs = `
-export const runtime = "edge";
+export const appDirNotFoundTs = `export const runtime = "edge";
 
 export default function NotFound() {
   return (
@@ -187,25 +186,40 @@ const styles = {
 `;
 
 
-export const nextConfig = `
-/** @type {import('next').NextConfig} */
+export const nextConfig = `/** @type {import('next').NextConfig} */
 const nextConfig = {}
 
 module.exports = nextConfig
 
-// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
-// This code ensures that bindings to resources like
-// KV, R2, Durable Objects, Queues, D1 are available in
-// local development when running the next dev command, which
-// runs a Node.js based local development server.
 if (process.env.NODE_ENV === 'development') {
-    import('@cloudflare/next-on-pages/__experimental__next-dev').then(({ setupDevBindings }) => {
-
-				// https://developers.cloudflare.com/workers/configuration/bindings/
-				// Each binding you want to expose via process.env must be configured via setupDevBindings()
-        setupDevBindings({
-            kvNamespaces: ['MY_KV_NAMESPACE'],
-        });
-    });
+  import('@cloudflare/next-on-pages/next-dev').then(({ setupDevBindings }) => {
+      setupDevBindings({
+          bindings: {
+              // Add here the Cloudflare Bindings you want to have available during local development (with \`next dev\`)
+              // (for more details on Bindings see: https://developers.cloudflare.com/pages/functions/bindings/)
+              //
+              // KV Example
+              // MY_KV: {
+              //   type: 'kv',
+              //   id: 'xxx',
+              // }
+          }
+      })
+  })
 }
+`;
+
+export const envDts = `declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      // Add here the Cloudflare Bindings you want to have available in your application
+      // (for more details on Bindings see: https://developers.cloudflare.com/pages/functions/bindings/)
+      //
+      // KV Example:
+      // MY_KV: KVNamespace
+    }
+  }
+}
+
+export {}
 `;

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -1,3 +1,16 @@
+const bindings = `
+	// https://developers.cloudflare.com/workers/configuration/bindings/
+	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
+	// are exposed via process.env, as shown below:
+	//
+	// const myKv = process.env['MY_KV_NAMESPACE'];
+	// await myKv.put('foo', 'bar');
+	// const valueFromKv = await myKv.get('foo');
+	//
+	// Each binding must be configured in your project's next.config.js file:
+	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+`;
+
 export const apiPagesDirHelloTs = `
 // Next.js Edge API Routes: https://nextjs.org/docs/pages/building-your-application/routing/api-routes#edge-api-routes
 
@@ -8,16 +21,7 @@ export const config = {
 }
 
 export default async function handler(req: NextRequest) {
-	// https://developers.cloudflare.com/workers/configuration/bindings/
-	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
-	// are exposed via process.env, as shown below:
-	//
-  // const myKv = process.env['MY_KV_NAMESPACE'];
-  // await myKv.put('foo', 'bar');
-  // const valueFromKv = await myKv.get('foo');
-	//
-  // Each binding must be configured in your project's next.config.js file:
-	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+${bindings}
 
   return new Response(JSON.stringify({ name: 'John Doe' }))
 }
@@ -31,16 +35,7 @@ export const config = {
 }
 
 export default async function handler(req) {
-	// https://developers.cloudflare.com/workers/configuration/bindings/
-	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
-	// are exposed via process.env, as shown below:
-	//
-  // const myKv = process.env['MY_KV_NAMESPACE'];
-  // await myKv.put('foo', 'bar');
-  // const valueFromKv = await myKv.get('foo');
-	//
-  // Each binding must be configured in your project's next.config.js file:
-	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+${bindings}
 
   return new Response(JSON.stringify({ name: 'John Doe' }))
 }
@@ -54,16 +49,7 @@ import type { NextRequest } from 'next/server'
 export const runtime = 'edge'
 
 export async function GET(request: NextRequest) {
-	// https://developers.cloudflare.com/workers/configuration/bindings/
-	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
-	// are exposed via process.env, as shown below:
-	//
-  // const myKv = process.env['MY_KV_NAMESPACE'];
-  // await myKv.put('foo', 'bar');
-  // const valueFromKv = await myKv.get('foo');
-	//
-  // Each binding must be configured in your project's next.config.js file:
-	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+${bindings}
 
 
   return new Response(JSON.stringify({ name: 'John Doe' }))
@@ -76,16 +62,7 @@ export const apiAppDirHelloJs = `
 export const runtime = 'edge'
 
 export async function GET(request) {
-	// https://developers.cloudflare.com/workers/configuration/bindings/
-	// In Next.js bindings to KV, R2, Durable Objects, Queues, D1 and more
-	// are exposed via process.env, as shown below:
-	//
-  // const myKv = process.env['MY_KV_NAMESPACE'];
-  // await myKv.put('foo', 'bar');
-  // const valueFromKv = await myKv.get('foo');
-	//
-  // Each binding must be configured in your project's next.config.js file:
-	// https://developers.cloudflare.com/pages/framework-guides/deploy-a-nextjs-site/#use-bindings-in-your-nextjs-application
+${bindings}
 
   return new Response(JSON.stringify({ name: 'John Doe' }))
 }
@@ -237,4 +214,4 @@ if (process.env.NODE_ENV === 'development') {
         });
     });
 }
-`
+`;

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -225,3 +225,62 @@ export const envDts = `declare global {
 
 export {}
 `;
+
+export const readme = `This is a [Next.js](https://nextjs.org/) project bootstrapped with [\`c3\`](https://developers.cloudflare.com/pages/get-started/c3).
+
+## Getting Started
+
+First, run the development server:
+
+\`\`\`bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+# or
+bun dev
+\`\`\`
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Cloudflare integration
+
+Besides the \`dev\` script mentioned above \`c3\` has added a few extra scripts that allow you to integrate the application with the [Cloudflare Pages](https://pages.cloudflare.com/) environment, these are:
+  - \`pages:build\` to build the application for Pages using the [\`@cloudflare/next-on-pages\`](https://github.com/cloudflare/next-on-pages) CLI
+  - \`pages:preview\` to locally preview your Pages application using the [Wrangler](https://developers.cloudflare.com/workers/wrangler/) CLI
+  - \`pages:deploy\` to deploy your Pages application using the [Wrangler](https://developers.cloudflare.com/workers/wrangler/) CLI
+
+> __Note:__ while the \`dev\` script is optimal for local development you should preview your Pages application as well (periodically or before deployments) in order to make sure that it can properly work in the Pages environment (for more details see the [\`@cloudflare/next-on-pages\` recommended workflow](https://github.com/cloudflare/next-on-pages/blob/05b6256/internal-packages/next-dev/README.md#recommended-workflow))
+
+### Bindings
+
+Cloudflare [Bindings](https://developers.cloudflare.com/pages/functions/bindings/) are what allows you to interact with resources available in the Cloudflare Platform.
+
+You can use bindings during development, when previewing locally your application and of course in the deployed application:
+
+- To use bindings in dev mode you need to define them in the \`next.config.js\` file under \`setupDevBindings\`, this mode uses the \`next-dev\` \`@cloudflare/next-on-pages\` submodule. For more details see its [documentation](https://github.com/cloudflare/next-on-pages/blob/05b6256/internal-packages/next-dev/README.md).
+
+- To use bindings in the preview mode you need to add them to the \`pages:preview\` script accordingly to the \`wrangler pages dev\` command. For more details see its [documentation](https://developers.cloudflare.com/workers/wrangler/commands/#dev-1) or the [Pages Bindings documentation](https://developers.cloudflare.com/pages/functions/bindings/).
+
+- To use bindings in the deployed application you will need to configure them in the Cloudflare [dashboard](https://dash.cloudflare.com/). For more details see the  [Pages Bindings documentation](https://developers.cloudflare.com/pages/functions/bindings/).
+
+#### KV Example
+
+\`c3\` has added for you an example showing how you can use a KV binding, in order to enable the example, search for lines containing the following comment:
+\`\`\`ts
+// KV Example:
+\`\`\`
+
+and uncomment the commented lines below it.
+
+After doing this you can run the \`dev\` script and visit the \`/api/hello\` route to see the example in action.
+
+To then enable such example also in preview mode add a \`kv\` in the \`pages:preview\` script like so:
+\`\`\`diff
+-    "pages:preview": "npm run pages:build && wrangler pages dev .vercel/output/static --compatibility-date=2023-12-18 --compatibility-flag=nodejs_compat",
++    "pages:preview": "npm run pages:build && wrangler pages dev .vercel/output/static --compatibility-date=2023-12-18 --compatibility-flag=nodejs_compat --kv MY_KV",
+\`\`\`
+
+Finally, if you also want to see the example work in the deployed application make sure to add a \`MY_KV\` binding to your Pages application in its [dashboard kv bindings settings section](https://dash.cloudflare.com/?to=/:account/pages/view/:pages-project/settings/functions#kv_namespace_bindings_section). After having configured it make sure to re-deploy your application.
+`;

--- a/packages/create-cloudflare/src/frameworks/next/templates.ts
+++ b/packages/create-cloudflare/src/frameworks/next/templates.ts
@@ -195,7 +195,7 @@ if (process.env.NODE_ENV === 'development') {
               // Add here the Cloudflare Bindings you want to have available during local development,
               // for more details on Bindings see: https://developers.cloudflare.com/pages/functions/bindings/)
               //
-              // KV Example
+              // KV Example:
               // MY_KV: {
               //   type: 'kv',
               //   id: 'xxx',


### PR DESCRIPTION
## What

Updates starter template that running `npm create cloudflare` and selecting Next.js creates, to make use of bindings proxy, as [implemented in `next-on-pages`](https://github.com/dario-piotrowicz/next-on-pages/blob/main/internal-packages/next-dev/README.md).

## Why

Provides a starting point that shows how to work with bindings in local dev, even when local dev server is in Node.js.

### Before merging

- [x] Why can't `next.config.js` file be written? https://github.com/cloudflare/workers-sdk/pull/4688/files#r1439845985
- [x] Release next-on-pages version where https://github.com/cloudflare/workers-sdk/pull/4688/files#diff-4dee5291b07de23139f615744ec0043e550865a2d726144daa7309df02c05bbaR77 is no longer experimental @dario-piotrowicz 
- [x] make sure that `@cloudflare/workers-types` is installed as a dev dependency for apps using TS
- [x] update package.json scripts, we want to have:
  - the standard Next.js scripts:
    - `dev` for local development
    - `build` for building the application
  - the pages scripts
     - `pages:preview` for previewing the pages app locally (basically the current `pages:dev`)
     - `pages:deploy` for deploying the pages app
     - `pages:build` for building the pages application (run as a pre-set by `pages:preview` and `pages:deploy`)
  - and we need to remove:
    - `pages:dev` (since users should just use `dev` now)
- [x] see if we can update jsonc `tsconfig.json` files (see [comment](https://github.com/cloudflare/workers-sdk/pull/4688/files#r1452603703))
- [x] update README
 
refs https://github.com/irvinebroque/next-bindings-test/pull/1
refs https://github.com/cloudflare/workers-sdk/pull/4523