### PR TITLE
improve the c3 dependabot workflow

### DIFF
--- a/.github/get-c3-dependabot-bumped-framework.cjs
+++ b/.github/get-c3-dependabot-bumped-framework.cjs
@@ -1,0 +1,26 @@
+const { execSync } = require("child_process");
+
+module.exports = function () {
+	const diff = execSync(
+		"git diff HEAD~2 packages/create-cloudflare/src/frameworks/package.json"
+	).toString();
+
+	const changedPackages = diff
+		.match(/-\s*".*?":\s".*?",?/g)
+		.map((match) => match.match(/-\s*"(.*)":/)?.[1])
+		.filter(Boolean);
+
+	if (changedPackages.length === 0) {
+		console.warn("No changes detected!");
+		return null;
+	} else if (changedPackages.length > 1) {
+		console.warn(
+			`More then one package has changed (${changedPackages.join(
+				", "
+			)}), that's not currently supported`
+		);
+		throw new Error("More than one package bump detected");
+	} else {
+		return changedPackages[0];
+	}
+};

--- a/.github/workflows/c3-e2e-dependabot.yml
+++ b/.github/workflows/c3-e2e-dependabot.yml
@@ -3,9 +3,9 @@
 name: C3 E2E Tests (Dependabot)
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
-      - packages/create-cloudflare/**
+      - .changeset/c3-frameworks-update-*.md
 
 env:
   node-version: 18.17.1
@@ -23,45 +23,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 3
           ref: ${{ github.head_ref }}
-      - name: Get PR description as string
-        id: get-pr-description
-        run: |
-          str=$(sed 's/`/\`/g' <<EOF
-            ${{ github.event.pull_request.body }}
-          EOF
-          )
-          echo 'result<<EOF' >> $GITHUB_OUTPUT
-          echo $str >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
       - name: detect-bumped-framework
         id: detect
         uses: actions/github-script@v6
         with:
           result-encoding: string
           script: |
-            const json = require('./packages/create-cloudflare/src/frameworks/package.json')
-            const frameworkCliPackages = Object.values(json.frameworkCliMap);
-
-            const body = `${{ steps.get-pr-description.outputs.result }}`;
-
-            // Official semver regex: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-            const semverRegexStr = '(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?';
-
-            const frameworkCliRegex = new RegExp(
-              `(?:^|\\s+)Bumps\\s+\\[(${frameworkCliPackages.join(
-                '|'
-              )})\\]\\(.*?\\)\\s+from\\s+${semverRegexStr}\\s+to\\s+${semverRegexStr}`
-            );
-
-            const bumpedFrameworkCli = body.match(frameworkCliRegex)?.[1];
-
-            if(!bumpedFrameworkCli) {
-              throw new Error('Error: Failed to determine framework cli to test');
-            }
-
-            return bumpedFrameworkCli;
+            const getBumpedFrameworkCli = require('.github/get-c3-dependabot-bumped-framework.cjs');
+            return getBumpedFrameworkCli();
 
   # For dependabot versioning PRs we only want to run the e2es for the specifically bumped
   # framework (this is both for optimization and in order to reduce unnecessary flakiness)


### PR DESCRIPTION
improve the c3 dependabot testing workflow by
 - externalizing js code inlined in yml files
 - not relying on dependabot PR descriptions which can potentially create issues and be unreliability
 
 ___
 
 This PR should fix the recent issue we've had with the c3 dependabot workflow failing to detect the bumped framework (see: https://github.com/cloudflare/workers-sdk/actions/runs/7385419011/job/20090141538?pr=4678#step:3:324)
