### PR TITLE
[wrangler] fix: ensure API failures without `messages` logged correctly

### DIFF
--- a/.changeset/fifty-crabs-flow.md
+++ b/.changeset/fifty-crabs-flow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: ensure API failures without additional messages logged correctly

--- a/packages/wrangler/src/__tests__/cfetch-utils.test.ts
+++ b/packages/wrangler/src/__tests__/cfetch-utils.test.ts
@@ -78,4 +78,22 @@ describe("throwFetchError", () => {
 			],
 		});
 	});
+
+	it("should include api errors without messages", async () => {
+		msw.use(
+			rest.get("*/user", (req, res, ctx) => {
+				return res(
+					ctx.json({
+						result: null,
+						success: false,
+						errors: [{ code: 10000, message: "error" }],
+					})
+				);
+			})
+		);
+		await expect(runWrangler("whoami")).rejects.toMatchObject({
+			text: "A request to the Cloudflare API (/user) failed.",
+			notes: [{ text: "error [code: 10000]" }],
+		});
+	});
 });

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -13,7 +13,7 @@ export interface FetchResult<ResponseType = unknown> {
 	success: boolean;
 	result: ResponseType;
 	errors: FetchError[];
-	messages: string[];
+	messages?: string[];
 	result_info?: unknown;
 }
 
@@ -168,7 +168,7 @@ function throwFetchError(
 		text: `A request to the Cloudflare API (${resource}) failed.`,
 		notes: [
 			...response.errors.map((err) => ({ text: renderError(err) })),
-			...response.messages.map((text) => ({ text })),
+			...(response.messages?.map((text) => ({ text })) ?? []),
 		],
 	});
 	// add the first error code directly to this error


### PR DESCRIPTION
Fixes #4694.

**What this PR solves / how to test:**

This PR ensures API failures with a `messages` property are logged correctly. Our `FetchResult` type had incorrectly assumed these would always be included in a response.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a regression

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
