### PR TITLE
[wrangler] fix: include additional modules in `largest dependencies` warning

### DIFF
--- a/.changeset/small-fishes-tan.md
+++ b/.changeset/small-fishes-tan.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: include additional modules in `largest dependencies` warning
+
+If your Worker fails to deploy because it's too large, Wrangler will display of list of your Worker's largest dependencies. Previously, this just included JavaScript dependencies. This change ensures additional module dependencies (e.g. WebAssembly, text blobs, etc.) are included when computing this list.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8114,15 +8114,25 @@ export default{
 				)
 			);
 
+			fs.writeFileSync(
+				"add.wasm",
+				"AGFzbQEAAAABBwFgAn9/AX8DAgEABwcBA2FkZAAACgkBBwAgACABagsACgRuYW1lAgMBAAA=",
+				"base64"
+			);
+			fs.writeFileSync("message.txt", "👋");
 			fs.writeFileSync("dependency.js", `export const thing = "a string dep";`);
 
 			fs.writeFileSync(
 				"index.js",
-				`import { thing } from "./dependency";
+				`
+				import addModule from "./add.wasm";
+				import message from "./message.txt";
+				import { thing } from "./dependency";
 
         export default {
           async fetch() {
-            return new Response('response plus ' + thing);
+          	const instance = new WebAssembly.Instance(addModule);
+          	return Response.json({ add: instance.exports.add(1, 2), message, thing });
           }
         }`
 			);
@@ -8150,10 +8160,12 @@ export default{
 			  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
 
 			",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mHere are the 2 largest dependencies included in your script:[0m
+			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mHere are the 4 largest dependencies included in your script:[0m
 
 			  - index.js - xx KiB
+			  - add.wasm - xx KiB
 			  - dependency.js - xx KiB
+			  - message.txt - xx KiB
 			  If these are unnecessary, consider removing them
 
 			",

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -518,6 +518,19 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						}
 				  );
 
+		// Add modules to dependencies for size warning
+		for (const module of modules) {
+			const modulePath =
+				module.filePath === undefined
+					? module.name
+					: path.relative("", module.filePath);
+			const bytesInOutput =
+				typeof module.content === "string"
+					? Buffer.byteLength(module.content)
+					: module.content.byteLength;
+			dependencies[modulePath] = { bytesInOutput };
+		}
+
 		const content = readFileSync(resolvedEntryPointPath, {
 			encoding: "utf-8",
 		});
@@ -1137,7 +1150,7 @@ async function noBundleWorker(
 
 	return {
 		modules,
-		dependencies: {},
+		dependencies: {} as { [path: string]: { bytesInOutput: number } },
 		resolvedEntryPointPath: entry.file,
 		bundleType: getBundleType(entry.format),
 	};


### PR DESCRIPTION
Fixes #4663.

**What this PR solves / how to test:**

If your Worker fails to deploy because it's too large, Wrangler will display of list of your Worker's largest dependencies. Previously, this just included JavaScript dependencies. This change ensures additional module dependencies (e.g. WebAssembly, text blobs, etc.) are included when computing this list. To test this, run `wrangler deploy` on a worker that imports a large dependency (e.g. a massive text file). The logged error should include the path to the text file.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: improving error messaging

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
