### PR TITLE
[wrangler] fix: prevent repeated reloads with circular service bindings

### DIFF
--- a/.changeset/gorgeous-turkeys-wait.md
+++ b/.changeset/gorgeous-turkeys-wait.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: prevent repeated reloads with circular service bindings
+
+`wrangler@3.19.0` introduced a bug where starting multiple `wrangler dev` sessions with service bindings to each other resulted in a reload loop. This change ensures Wrangler only reloads when dependent `wrangler dev` sessions start/stop.

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -1,3 +1,4 @@
+import type { CfDurableObject } from "../../deployment-bundle/worker";
 import type { EsbuildBundle } from "../../dev/use-esbuild";
 import type { DevToolsEvent } from "./devtools";
 import type { StartDevWorkerOptions } from "./types";
@@ -147,4 +148,5 @@ export type ProxyData = {
 	headers: Record<string, string | undefined>;
 	liveReload?: boolean;
 	proxyLogsToController?: boolean;
+	internalDurableObjects?: CfDurableObject[];
 };

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -27,7 +27,7 @@ import { logger } from "../logger";
 import openInBrowser from "../open-in-browser";
 import { getWranglerTmpDir } from "../paths";
 import { openInspector } from "./inspect";
-import { Local } from "./local";
+import { Local, maybeRegisterLocalWorker } from "./local";
 import { Remote } from "./remote";
 import { useEsbuild } from "./use-esbuild";
 import { validateDevProps } from "./validate-dev-props";
@@ -386,6 +386,14 @@ function DevSession(props: DevSessionProps) {
 		const url = await proxyWorker.ready;
 		finalIp = url.hostname;
 		finalPort = parseInt(url.port);
+
+		if (props.local) {
+			await maybeRegisterLocalWorker(
+				url,
+				props.name,
+				proxyData.internalDurableObjects
+			);
+		}
 
 		if (process.send) {
 			process.send(

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -177,6 +177,12 @@ export async function startDevServer(
 				ip = url.hostname;
 				port = parseInt(url.port);
 
+				await maybeRegisterLocalWorker(
+					url,
+					props.name,
+					proxyData.internalDurableObjects
+				);
+
 				props.onReady?.(ip, port, proxyData);
 
 				// temp: fake these events by calling the handler directly
@@ -393,8 +399,6 @@ export async function startLocalServer(
 	return new Promise<{ stop: () => Promise<void> }>((resolve, reject) => {
 		const server = new MiniflareServer();
 		server.addEventListener("reloaded", async (event) => {
-			await maybeRegisterLocalWorker(event, props.name);
-
 			const proxyData: ProxyData = {
 				userWorkerUrl: {
 					protocol: event.url.protocol,
@@ -420,6 +424,7 @@ export async function startLocalServer(
 				// in local mode, the logs are already being printed to the console by workerd but only for workers written in "module" format
 				// workers written in "service-worker" format still need to proxy logs to the ProxyController
 				proxyLogsToController: props.format === "service-worker",
+				internalDurableObjects: event.internalDurableObjects,
 			};
 
 			props.onReady?.(event.url.hostname, parseInt(event.url.port), proxyData);


### PR DESCRIPTION
Fixes #4673.

**What this PR solves / how to test:**

`wrangler@3.19.0` introduced a bug where starting multiple `wrangler dev` sessions with service bindings to each other resulted in a reload loop. This change ensures Wrangler only reloads when dependent `wrangler dev` sessions start/stop, by registering workers in the dev registry with the URL of the proxy worker, not the user worker.

Using the user worker URL meant that when a dependent service was started, the original service picked up the change and restarted its user worker getting a new port. The original service registered this new port, which was picked up by the dependent service which itself restarted its user worker on a new port. This created a reload loop.

We're planning to slightly change how dev registry registration works as part of the later WaaL milestones. This should also help prevent these sorts of issues.

To test this, add the following to `fixtures/service-bindings-app`...

```toml
[[services]]
binding = "AYY"
service = 'a'
```

...then run `pnpm dev` in `fixtures/serivce-bindings-app`. Both `wrangler dev` sessions should start up without entering into a reload loop.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: we currently skip most of our dev registry tests because of flakiness in CI. Once #4241 lands, we should re-enable these tests, including coverage for circular bindings like this.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a regression

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
