### PR TITLE
chore: temporarily disable sentry error reporting

### DIFF
--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -68,7 +68,6 @@ jobs:
           NODE_ENV: "production"
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
-          SENTRY_DSN: "https://9edbb8417b284aa2bbead9b4c318918b@sentry10.cfdata.org/583"
           CI_OS: ${{ runner.os }}
 
       - name: Pack miniflare

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -67,7 +67,6 @@ jobs:
           # this is the "test/staging" key for sparrow analytics
           SPARROW_SOURCE_KEY: "5adf183f94b3436ba78d67f506965998"
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
-          SENTRY_DSN: "https://9edbb8417b284aa2bbead9b4c318918b@sentry10.cfdata.org/583"
           ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
         working-directory: packages/wrangler
 
@@ -112,7 +111,6 @@ jobs:
           NODE_ENV: "production"
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
-          SENTRY_DSN: "https://9edbb8417b284aa2bbead9b4c318918b@sentry10.cfdata.org/583"
           CI_OS: ${{ runner.os }}
 
       - name: Build & Publish Prerelease Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
-          SENTRY_DSN: "https://9edbb8417b284aa2bbead9b4c318918b@sentry10.cfdata.org/583"
 
           NODE_ENV: "production"
           # This is the "production" key for sparrow analytics.


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR temporarily disables Sentry error reporting whilst we discuss what errors/metadata we want to be sending. 

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: no code changes
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: no user facing changes (aside from fewer error report popups I guess?)
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: no user facing changes

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
