### PR TITLE
chore: change ignore list for node_modules to be less restrictive

### DIFF
--- a/.changeset/olive-tigers-scream.md
+++ b/.changeset/olive-tigers-scream.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Change the Cloudflare Pages deployment to only ignore node_modules folders in the root folder, instead of any folder called node_modules.

--- a/.changeset/olive-tigers-scream.md
+++ b/.changeset/olive-tigers-scream.md
@@ -2,4 +2,4 @@
 "wrangler": minor
 ---
 
-Change the Cloudflare Pages deployment to only ignore node_modules folders in the root folder, instead of any folder called node_modules.
+Add a .pagesignore alternative to the default ignore list to allow for uploading folders called node_modules.

--- a/packages/wrangler/src/pages/validate.tsx
+++ b/packages/wrangler/src/pages/validate.tsx
@@ -74,7 +74,7 @@ export const validate = async (args: {
 				return false;
 			}
 
-			return false;
+			return true;
 		});
 	}
 

--- a/packages/wrangler/src/pages/validate.tsx
+++ b/packages/wrangler/src/pages/validate.tsx
@@ -48,8 +48,8 @@ export const validate = async (args: {
 		"_headers",
 		"_routes.json",
 		"functions",
+		"node_modules",
 		"**/.DS_Store",
-		"**/node_modules",
 		"**/.git",
 	].map((pattern) => new Minimatch(pattern));
 

--- a/packages/wrangler/src/pages/validate.tsx
+++ b/packages/wrangler/src/pages/validate.tsx
@@ -63,7 +63,19 @@ export const validate = async (args: {
 			encoding: "utf-8"
 		});
 
-		return ignoreListContents.split('\n');
+		return ignoreListContents.split('\n').filter((line) => {
+			const trimmedLine = line.trim();
+
+			if(trimmedLine.length === 0) {
+				return false;
+			}
+
+			if(trimmedLine.startsWith('#')) {
+				return false;
+			}
+
+			return false;
+		});
 	}
 
 	const directory = resolve(args.directory);


### PR DESCRIPTION
Fixes #3615.

**What this PR solves / how to test:**
Currently, wrangler ignores _any_ folder that is named node_modules. While intentions are good, this is inherently very restrictive and should not be done. This PR changes the ignore list to only ignore the root folder's node_modules.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [X] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
