### PR TITLE
C3: update the solidStart logic to work with their latest (beta-2) implementation

### DIFF
--- a/.changeset/giant-sloths-check.md
+++ b/.changeset/giant-sloths-check.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+update the solidStart logic to work with their latest (beta-2) implementation

--- a/.prettierignore
+++ b/.prettierignore
@@ -37,3 +37,9 @@ fixtures/**/dist/**
 
 # Miniflare shouldn't be formatted with the root `prettier` version
 packages/miniflare
+
+# In the C3 templates, in particular framework templates, we want to be able to
+# use any format that the framework authors prefer/use in their own templates,
+# so let's ignore all the c3 template files, exlcuding the c3.ts ones
+packages/create-cloudflare/templates/**/*.*
+!packages/create-cloudflare/templates/**/c3.ts

--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -124,6 +124,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
+			unsupportedOSs: ["win32"],
 		},
 		svelte: {
 			expectResponseToContain: "SvelteKit app",

--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -124,7 +124,6 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 			],
 			testCommitMessage: true,
 			timeout: LONG_TIMEOUT,
-			quarantine: true,
 		},
 		svelte: {
 			expectResponseToContain: "SvelteKit app",

--- a/packages/create-cloudflare/templates/solid/c3.ts
+++ b/packages/create-cloudflare/templates/solid/c3.ts
@@ -15,18 +15,6 @@ const generate = async (ctx: C3Context) => {
 	logRaw("");
 };
 
-const configure = async (ctx: C3Context) => {
-	// Install the pages adapter
-	const pkg = "solid-start-cloudflare-pages";
-	await installPackages([pkg], {
-		dev: true,
-		startText: "Adding the Cloudflare Pages adapter",
-		doneText: `${brandColor(`installed`)} ${dim(pkg)}`,
-	});
-
-	updateStatus(`Adding the Cloudflare Pages adapter to vite config`);
-};
-
 const config: TemplateConfig = {
 	configVersion: 1,
 	id: "solid",
@@ -37,12 +25,12 @@ const config: TemplateConfig = {
 		ts: { path: "./ts" },
 	},
 	generate,
-	configure,
 	transformPackageJson: async () => ({
 		scripts: {
 			"pages:dev": `wrangler pages dev ${await compatDateFlag()} --proxy 3000 -- ${npm} run dev`,
-			"pages:deploy": `${npm} run build && wrangler pages deploy ./dist/public`,
+			"pages:deploy": `${npm} run build && wrangler pages deploy ./dist`,
 		},
 	}),
+	compatibilityFlags: ["nodejs_compat"],
 };
 export default config;

--- a/packages/create-cloudflare/templates/solid/c3.ts
+++ b/packages/create-cloudflare/templates/solid/c3.ts
@@ -31,6 +31,7 @@ const config: TemplateConfig = {
 			"pages:deploy": `${npm} run build && wrangler pages deploy ./dist`,
 		},
 	}),
+	devCommand: ['dev'],
 	compatibilityFlags: ["nodejs_compat"],
 };
 export default config;

--- a/packages/create-cloudflare/templates/solid/c3.ts
+++ b/packages/create-cloudflare/templates/solid/c3.ts
@@ -31,7 +31,7 @@ const config: TemplateConfig = {
 			"pages:deploy": `${npm} run build && wrangler pages deploy ./dist`,
 		},
 	}),
-	devCommand: ['dev'],
+	devScript: "dev",
 	compatibilityFlags: ["nodejs_compat"],
 };
 export default config;

--- a/packages/create-cloudflare/templates/solid/c3.ts
+++ b/packages/create-cloudflare/templates/solid/c3.ts
@@ -27,7 +27,7 @@ const config: TemplateConfig = {
 	generate,
 	transformPackageJson: async () => ({
 		scripts: {
-			"pages:dev": `wrangler pages dev ${await compatDateFlag()} --proxy 3000 -- ${npm} run dev`,
+			"pages:preview": `${npm} run build && npx wrangler pages dev dist ${await compatDateFlag()} --compatibility-flag nodejs_compat`,
 			"pages:deploy": `${npm} run build && wrangler pages deploy ./dist`,
 		},
 	}),

--- a/packages/create-cloudflare/templates/solid/js/vite.config.js
+++ b/packages/create-cloudflare/templates/solid/js/vite.config.js
@@ -1,7 +1,12 @@
-import cloudflare from "solid-start-cloudflare-pages";
-import solid from "solid-start/vite";
-import { defineConfig } from "vite";
+import { defineConfig } from "@solidjs/start/config";
 
 export default defineConfig({
-	plugins: [solid({ adapter: cloudflare({}) })],
+    start: {
+        server: {
+            preset: "cloudflare-pages",
+            rollupConfig: {
+                external: ["node:async_hooks"]
+            },
+        }
+    }
 });

--- a/packages/create-cloudflare/templates/solid/ts/vite.config.ts
+++ b/packages/create-cloudflare/templates/solid/ts/vite.config.ts
@@ -1,7 +1,12 @@
-import cloudflare from "solid-start-cloudflare-pages";
-import solid from "solid-start/vite";
-import { defineConfig } from "vite";
+import { defineConfig } from "@solidjs/start/config";
 
 export default defineConfig({
-	plugins: [solid({ adapter: cloudflare({}) })],
+    start: {
+        server: {
+            preset: "cloudflare-pages",
+            rollupConfig: {
+                external: ["node:async_hooks"]
+            },
+        }
+    }
 });


### PR DESCRIPTION
The creation of solidStart applications is currently broken in C3 after their beta-2 bump (for example see the failing workflows here: https://github.com/cloudflare/workers-sdk/pull/4682)

This PR addresses this making solidStart apps work again
