### PR TITLE
fix: ensure `miniflare`/`wrangler` can source map in the same process

### DIFF
--- a/.changeset/odd-fans-own.md
+++ b/.changeset/odd-fans-own.md
@@ -1,0 +1,8 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+fix: ensure `miniflare` and `wrangler` can source map in the same process
+
+Previously, if in a `wrangler dev` session you called `console.log()` and threw an unhandled error you'd see an error like `[ERR_ASSERTION]: The expression evaluated to a falsy value`. This change ensures you can do both of these things in the same session.

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -17,6 +17,7 @@ export default {
 
 		const { pathname } = new URL(request.url);
 		if (pathname === "/random") return new Response(hexEncode(randomBytes(8)));
+		if (pathname === "/error") throw new Error("Oops!");
 
 		console.log(
 			request.method,

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -45,6 +45,16 @@ describe("'wrangler dev' correctly renders pages", () => {
 		);
 	});
 
+	it("renders pretty error after logging", async ({ expect }) => {
+		// Regression test for https://github.com/cloudflare/workers-sdk/issues/4715
+		const response = await fetch(`http://${ip}:${port}/error`);
+		const text = await response.text();
+		expect(text).toContain("Oops!");
+		expect(response.headers.get("Content-Type")).toBe(
+			"text/html;charset=utf-8"
+		);
+	});
+
 	it("uses `workerd` condition when bundling", async ({ expect }) => {
 		const response = await fetch(`http://${ip}:${port}/random`);
 		const text = await response.text();

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -65,7 +65,6 @@
 		"@types/http-cache-semantics": "^4.0.1",
 		"@types/node": "^18.11.9",
 		"@types/rimraf": "^3.0.2",
-		"@types/source-map-support": "^0.5.6",
 		"@types/stoppable": "^1.1.1",
 		"@types/which": "^2.0.1",
 		"@types/ws": "^8.5.3",

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -274,3 +274,5 @@ export async function handlePrettyErrorRequest(
 		headers: { "Content-Type": "text/html;charset=utf-8" },
 	});
 }
+
+export { getFreshSourceMapSupport } from "./sourcemap";

--- a/packages/miniflare/src/plugins/core/errors/sourcemap.ts
+++ b/packages/miniflare/src/plugins/core/errors/sourcemap.ts
@@ -2,6 +2,40 @@ import assert from "assert";
 import type { Options } from "@cspotcode/source-map-support";
 import { parseStack } from "./callsite";
 
+// `source-map-support` will only modify `Error.prepareStackTrace` if this is
+// the first time `install()` has been called. This is governed by shared data
+// stored using a well-known symbol on `globalThis`. To ensure...
+//
+// a) `miniflare` and `wrangler` can have differing `install()` options
+// b) We're not affecting external user's use of this package
+// c) `Error.prepareStackTrace` is always updated on `install()`
+//
+// ...load a fresh copy, by resetting then restoring the `require` cache, and
+// overriding `Symbol.for()` to return a unique symbol.
+export function getFreshSourceMapSupport(): typeof import("@cspotcode/source-map-support") {
+	const resolvedSupportPath = require.resolve("@cspotcode/source-map-support");
+
+	const originalSymbolFor = Symbol.for;
+	const originalSupport = require.cache[resolvedSupportPath];
+	try {
+		Symbol.for = (key) => {
+			// Make sure we only override the expected symbol. If we upgrade this
+			// package, and new symbols are used, this assertion will fail in tests.
+			// We want to guard against `source-map-support/sharedData` changing to
+			// something else. If this new symbol *should* be shared across package
+			// instances, we'll need to add an
+			// `if (key === "...") return originalSymbolFor(key);` here.
+			assert.strictEqual(key, "source-map-support/sharedData");
+			return Symbol(key);
+		};
+		delete require.cache[resolvedSupportPath];
+		return require(resolvedSupportPath);
+	} finally {
+		Symbol.for = originalSymbolFor;
+		require.cache[resolvedSupportPath] = originalSupport;
+	}
+}
+
 const sourceMapInstallBaseOptions: Options = {
 	environment: "node",
 	// Don't add Node `uncaughtException` handler
@@ -30,18 +64,7 @@ let sourceMapper: SourceMapper;
 export function getSourceMapper(): SourceMapper {
 	if (sourceMapper !== undefined) return sourceMapper;
 
-	// `source-map-support` will only modify `Error.prepareStackTrace` if this is
-	// the first time `install()` has been called. This is governed by a module
-	// level variable: `errorFormatterInstalled`. To ensure we're not affecting
-	// external user's use of this package, and so `Error.prepareStackTrace` is
-	// always updated, load a fresh copy, by resetting then restoring the
-	// `require` cache.
-
-	const originalSupport = require.cache["@cspotcode/source-map-support"];
-	delete require.cache["@cspotcode/source-map-support"];
-	const support: typeof import("@cspotcode/source-map-support") = require("@cspotcode/source-map-support");
-	require.cache["@cspotcode/source-map-support"] = originalSupport;
-
+	const support = getFreshSourceMapSupport();
 	const originalPrepareStackTrace = Error.prepareStackTrace;
 	support.install(sourceMapInstallBaseOptions);
 	const prepareStackTrace = Error.prepareStackTrace;

--- a/packages/miniflare/src/plugins/index.ts
+++ b/packages/miniflare/src/plugins/index.ts
@@ -93,6 +93,7 @@ export {
 	ModuleDefinitionSchema,
 	SourceOptionsSchema,
 	ProxyClient,
+	getFreshSourceMapSupport,
 } from "./core";
 export type {
 	ModuleRuleType,

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -102,7 +102,6 @@
 	},
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "^0.2.0",
-		"@cspotcode/source-map-support": "0.8.1",
 		"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
 		"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
 		"blake3-wasm": "^2.1.5",
@@ -124,6 +123,7 @@
 		"@cloudflare/types": "^6.18.4",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20230914.0",
+		"@cspotcode/source-map-support": "0.8.1",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
 		"@sentry/node": "^7.86.0",

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -12,8 +12,6 @@ export const EXTERNAL_DEPENDENCIES = [
 	// todo - bundle miniflare too
 	"selfsigned",
 	"source-map",
-	// CommonJS module using `module.require()` which isn't provided by `esbuild`
-	"@cspotcode/source-map-support",
 	"@esbuild-plugins/node-globals-polyfill",
 	"@esbuild-plugins/node-modules-polyfill",
 	"chokidar",

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import fs from "node:fs";
 import url from "node:url";
+import { getFreshSourceMapSupport } from "miniflare";
 import type { Options } from "@cspotcode/source-map-support";
 import type Protocol from "devtools-protocol";
 
@@ -68,18 +69,9 @@ function getSourceMappingPrepareStackTrace(
 		return sourceMappingPrepareStackTrace;
 	}
 
-	// `source-map-support` will only modify `Error.prepareStackTrace` if this
-	// is the first time `install()` has been called. This is governed by a
-	// module level variable: `errorFormatterInstalled`. To ensure we're not
-	// affecting external user's use of this package, and so
-	// `Error.prepareStackTrace` is always updated, load a fresh copy, by
-	// resetting then restoring the `require` cache.
-	const originalSupport = require.cache["@cspotcode/source-map-support"];
-	delete require.cache["@cspotcode/source-map-support"];
-	// eslint-disable-next-line @typescript-eslint/consistent-type-imports,@typescript-eslint/no-var-requires
-	const support: typeof import("@cspotcode/source-map-support") = require("@cspotcode/source-map-support");
-	require.cache["@cspotcode/source-map-support"] = originalSupport;
-
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	const support: typeof import("@cspotcode/source-map-support") =
+		getFreshSourceMapSupport();
 	const originalPrepareStackTrace = Error.prepareStackTrace;
 	support.install({
 		environment: "node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,9 +870,6 @@ importers:
       '@types/rimraf':
         specifier: ^3.0.2
         version: 3.0.2
-      '@types/source-map-support':
-        specifier: ^0.5.6
-        version: 0.5.7
       '@types/stoppable':
         specifier: ^1.1.1
         version: 1.1.3
@@ -1255,9 +1252,6 @@ importers:
       '@cloudflare/kv-asset-handler':
         specifier: ^0.2.0
         version: 0.2.0
-      '@cspotcode/source-map-support':
-        specifier: 0.8.1
-        version: 0.8.1
       '@esbuild-plugins/node-globals-polyfill':
         specifier: ^0.2.3
         version: 0.2.3(esbuild@0.17.19)
@@ -1320,6 +1314,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20230914.0
         version: 4.20230914.0
+      '@cspotcode/source-map-support':
+        specifier: 0.8.1
+        version: 0.8.1
       '@iarna/toml':
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
Fixes #4715.

**What this PR solves / how to test:**

Previously, if in a `wrangler dev` session you called `console.log()` and threw an unhandled error you'd see an error like `[ERR_ASSERTION]: The expression evaluated to a falsy value`. This change ensures you can do both of these things in the same session.

This broke when we switched from `source-map-support` to `@cspotcode/source-map-support` as part of #4423. `@cspotcode/source-map-support` has some additional code to share state between different instances of the module. In particular, if the module was loaded once, future calls to any new instance's `install()` function wouldn't set `Error.prepareStackTrace`, leading to this assertion error in either Miniflare or Wrangler (depending on which one installed support first). We want each instance of the module to be completely isolated, so this PR overrides `Symbol.for()` while we're loading the module to ensure isolated "shared" data: https://github.com/cspotcode/node-source-map-support/blob/69baeb8ccbf9f2a342c8575f21ac81f5d711eb81/source-map-support.js#L45-L48. An assertion has been added to ensure this assumption holds when we upgrade the package.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a regression

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
