### PR TITLE
[wrangler] fix: don't require auth for `wrangler r2 object --local` operations

### DIFF
--- a/.changeset/funny-otters-sing.md
+++ b/.changeset/funny-otters-sing.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: don't require auth for `wrangler r2 object --local` operations
+
+Previously, Wrangler would ask you to login when reading or writing from local R2 buckets. This change ensures no login prompt is displayed, as authentication isn't required for these operations.

--- a/packages/wrangler/src/__tests__/helpers/mock-account-id.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-account-id.ts
@@ -1,8 +1,5 @@
 import { reinitialiseAuthTokens } from "../../user";
 
-const ORIGINAL_CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
-const ORIGINAL_CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
-
 /**
  * Mock the API token so that we don't need to read it from user configuration files.
  *
@@ -12,6 +9,7 @@ const ORIGINAL_CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
 export function mockApiToken({
 	apiToken = "some-api-token",
 }: { apiToken?: string | null } = {}) {
+	const ORIGINAL_CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
 	beforeEach(() => {
 		if (apiToken === null) {
 			delete process.env.CLOUDFLARE_API_TOKEN;
@@ -22,7 +20,12 @@ export function mockApiToken({
 		reinitialiseAuthTokens();
 	});
 	afterEach(() => {
-		process.env.CLOUDFLARE_API_TOKEN = ORIGINAL_CLOUDFLARE_API_TOKEN;
+		if (ORIGINAL_CLOUDFLARE_API_TOKEN === undefined) {
+			// `process.env`'s assigned property values are coerced to strings
+			delete process.env.CLOUDFLARE_API_TOKEN;
+		} else {
+			process.env.CLOUDFLARE_API_TOKEN = ORIGINAL_CLOUDFLARE_API_TOKEN;
+		}
 	});
 }
 
@@ -35,14 +38,22 @@ export function mockApiToken({
 export function mockAccountId({
 	accountId = "some-account-id",
 }: { accountId?: string | null } = {}) {
+	const ORIGINAL_CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
 	beforeEach(() => {
 		if (accountId === null) {
 			delete process.env.CLOUDFLARE_ACCOUNT_ID;
 		} else {
 			process.env.CLOUDFLARE_ACCOUNT_ID = accountId;
 		}
+		// Now we have updated the environment, we must reinitialize the user auth state.
+		reinitialiseAuthTokens();
 	});
 	afterEach(() => {
-		process.env.CLOUDFLARE_ACCOUNT_ID = ORIGINAL_CLOUDFLARE_ACCOUNT_ID;
+		if (ORIGINAL_CLOUDFLARE_ACCOUNT_ID === undefined) {
+			// `process.env`'s assigned property values are coerced to strings
+			delete process.env.CLOUDFLARE_ACCOUNT_ID;
+		} else {
+			process.env.CLOUDFLARE_ACCOUNT_ID = ORIGINAL_CLOUDFLARE_ACCOUNT_ID;
+		}
 	});
 }

--- a/packages/wrangler/src/__tests__/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages-deployment-tail.test.ts
@@ -22,6 +22,15 @@ import type WebSocket from "ws";
 
 describe("pages deployment tail", () => {
 	runInTempDir();
+
+	// This `afterEach()` must come before `mockAccountId()` and `mockApiToken()`.
+	// Closing the sockets will trigger an authenticated fetch call which would
+	// otherwise fail.
+	afterEach(() => {
+		mockWebSockets.forEach((ws) => ws.close());
+		mockWebSockets.splice(0);
+	});
+
 	mockAccountId();
 	mockApiToken();
 	const std = mockConsoleMethods();
@@ -40,11 +49,6 @@ describe("pages deployment tail", () => {
 	});
 	afterAll(() => {
 		delete process.env.CF_PAGES;
-	});
-
-	afterEach(() => {
-		mockWebSockets.forEach((ws) => ws.close());
-		mockWebSockets.splice(0);
 	});
 
 	/**

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -30,18 +30,21 @@ describe("tail", () => {
 		mockWs.useOriginal = false;
 	});
 
+	// This `afterEach()` must come before `mockAccountId()` and `mockApiToken()`.
+	// Closing the sockets will trigger an authenticated fetch call which would
+	// otherwise fail.
+	afterEach(() => {
+		mockWebSockets.forEach((ws) => ws.close());
+		mockWebSockets.splice(0);
+		clearDialogs();
+	});
+
 	beforeEach(() => msw.use(...mswSucessScriptHandlers));
 	runInTempDir();
 	mockAccountId();
 	mockApiToken();
 
 	const std = mockConsoleMethods();
-
-	afterEach(() => {
-		mockWebSockets.forEach((ws) => ws.close());
-		mockWebSockets.splice(0);
-		clearDialogs();
-	});
 
 	/**
 	 * Interaction with the tailing API, including tail creation,

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -96,7 +96,6 @@ export function r2(r2Yargs: CommonYargsArgv) {
 					},
 					async (objectGetYargs) => {
 						const config = readConfig(objectGetYargs.config, objectGetYargs);
-						const accountId = await requireAuth(config);
 						const { objectPath, pipe, jurisdiction } = objectGetYargs;
 						const { bucket, key } = bucketAndKeyFromObjectPath(objectPath);
 						let fullBucketName = bucket;
@@ -135,6 +134,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 								}
 							);
 						} else {
+							const accountId = await requireAuth(config);
 							const input = await getR2Object(
 								accountId,
 								bucket,
@@ -228,7 +228,6 @@ export function r2(r2Yargs: CommonYargsArgv) {
 						await printWranglerBanner();
 
 						const config = readConfig(objectPutYargs.config, objectPutYargs);
-						const accountId = await requireAuth(config);
 						const {
 							objectPath,
 							file,
@@ -336,6 +335,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 								}
 							);
 						} else {
+							const accountId = await requireAuth(config);
 							await putR2Object(
 								accountId,
 								bucket,
@@ -382,7 +382,6 @@ export function r2(r2Yargs: CommonYargsArgv) {
 						await printWranglerBanner();
 
 						const config = readConfig(args.config, args);
-						const accountId = await requireAuth(config);
 						const { bucket, key } = bucketAndKeyFromObjectPath(objectPath);
 						let fullBucketName = bucket;
 						if (jurisdiction !== undefined) {
@@ -401,6 +400,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 								(r2Bucket) => r2Bucket.delete(key)
 							);
 						} else {
+							const accountId = await requireAuth(config);
 							await deleteR2Object(accountId, bucket, key, jurisdiction);
 						}
 


### PR DESCRIPTION
**What this PR solves / how to test:**

Previously, Wrangler would ask you to login when reading or writing from local R2 buckets. This change ensures no login prompt is displayed, as authentication isn't required for these operations. To test this, run `wrangler logout`, then `wrangler r2 object put TEST_BUCKET/a.txt --file <local_file> --local` and observe the object is written without a login prompt.

This PR also fixes an issue with `mockApiToken()` and `mockAccountId()` where they weren't correctly unsetting API tokens in `afterEach()` hooks. This was causing some tail tests to erroneously pass.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a bug in user expectations

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
