### PR TITLE
fix: only deploy `format-errors` worker when files change

### DIFF
--- a/.github/workflows/format-errors.yml
+++ b/.github/workflows/format-errors.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "packages/format-errors/**"
+
 jobs:
   publish_worker:
     if: ${{ github.repository_owner == 'cloudflare' }}


### PR DESCRIPTION
**What this PR solves / how to test:**

Previously, we were re-deploying the `format-errors` worker on every merge to `main`, even if no changes were made to it. This is probably fine, but our other workers (`edge-preview-authenticated-proxy` and `playground-preview-worker`) have `paths` filters to only deploy when their source changes. This PR adds a `paths` filter for `format-errors` so we only deploy it when we've made changes.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: changing GitHub Actions workflow
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: no user facing changes
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: no user facing changes

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
