### PR TITLE
fix: make `worker-app` test more reliable

### DIFF
--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -33,6 +33,7 @@ export default {
 			new Request("http://example.com", { method: "POST", body: "foo" })
 		);
 
+		console.log("end of request");
 		return new Response(
 			`${request.url} ${now()} ${request.headers.get("Host")}`
 		);


### PR DESCRIPTION
**What this PR solves / how to test:**

I've observed the `worker-app` tests flaking quite a bit recently. I think this is because logs aren't being flushed fast enough. This PR waits for up to 5s for a log logged at the end of the request to appear, ensuring all assertions run once all request logs have been flushed.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: fixing existing tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: change to internal tests
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: change to internal tests

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
