### PR TITLE
fix: only include reportable playground errors in metrics

### DIFF
--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -367,12 +367,15 @@ app.onError((e, c) => {
 	const sentry = c.get("sentry");
 	const registry = c.get("prometheus");
 
-	const errorCounter = registry.create(
-		"counter",
-		"devprod_playground_preview_worker_error_total",
-		"Error counter for DevProd's playground-preview-worker service"
-	);
-	errorCounter.inc();
+	// Only include reportable `HttpError`s or any other error in error metrics
+	if (!(e instanceof HttpError) || e.reportable) {
+		const errorCounter = registry.create(
+			"counter",
+			"devprod_playground_preview_worker_error_total",
+			"Error counter for DevProd's playground-preview-worker service"
+		);
+		errorCounter.inc();
+	}
 
 	return handleException(e, sentry);
 });


### PR DESCRIPTION
**What this PR solves / how to test:**

Previously, we were marking all requests that threw `HttpError`s as "errored". This change ensures only `reportable` errors are included in metrics.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: we don't have tests for our metrics reporting
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: change to internal metrics reporting
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: change to internal metrics reporting

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
