### PR TITLE
Gradual Rollouts `versions upload` (experimental) command

### DIFF
--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -66,6 +66,7 @@ import {
 	validateScopeKeys,
 } from "./user";
 import { vectorize } from "./vectorize/index";
+import { versionsUploadHandler, versionsUploadOptions } from "./versions";
 import { whoami } from "./whoami";
 import { asJson } from "./yargs-types";
 import type { Config } from "./config";
@@ -714,6 +715,16 @@ export function createCLIParser(argv: string[]) {
 			}
 		}
 	);
+
+	// versions
+	wrangler.command("versions", false, (versionYargs) => {
+		return versionYargs.command(
+			"upload",
+			"Upload a Worker for Gradual Rollouts [beta]",
+			versionsUploadOptions,
+			versionsUploadHandler
+		);
+	});
 
 	wrangler.exitProcess(false);
 

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -217,6 +217,11 @@ export function createCLIParser(argv: string[]) {
 			describe: `Experimental: Support wrangler.json`,
 			type: "boolean",
 		})
+		.option("experimental-gradual-rollouts", {
+			describe: `Experimental: Support Gradual Rollouts`,
+			type: "boolean",
+			hidden: true,
+		})
 		.check((args) => {
 			// Grab locally specified env params from `.env` file
 			const loaded = loadDotEnv(".env", args.env);
@@ -717,14 +722,19 @@ export function createCLIParser(argv: string[]) {
 	);
 
 	// versions
-	wrangler.command("versions", false, (versionYargs) => {
-		return versionYargs.command(
-			"upload",
-			"Upload a Worker for Gradual Rollouts [beta]",
-			versionsUploadOptions,
-			versionsUploadHandler
-		);
-	});
+	const experimentalGradualRollouts = argv.includes(
+		"--experimental-gradual-rollouts"
+	);
+	if (experimentalGradualRollouts) {
+		wrangler.command("versions", false, (versionYargs) => {
+			return versionYargs.command(
+				"upload",
+				"Upload a Worker for Gradual Rollouts [beta]",
+				versionsUploadOptions,
+				versionsUploadHandler
+			);
+		});
+	}
 
 	wrangler.exitProcess(false);
 

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -64,7 +64,8 @@ export type EventNames =
 	| "run pages dev"
 	| "view docs"
 	| "view deployments"
-	| "rollback deployments";
+	| "rollback deployments"
+	| "upload worker version";
 
 /**
  * Send a metrics event, with no extra properties, to Cloudflare, if usage tracking is enabled.

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -1,0 +1,1157 @@
+import assert from "node:assert";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { URLSearchParams } from "node:url";
+import chalk from "chalk";
+import { fetchListResult, fetchResult } from "../cfetch";
+import { printBindings } from "../config";
+import { bundleWorker } from "../deployment-bundle/bundle";
+import {
+	printBundleSize,
+	printOffendingDependencies,
+} from "../deployment-bundle/bundle-reporter";
+import { getBundleType } from "../deployment-bundle/bundle-type";
+import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
+import {
+	findAdditionalModules,
+	writeAdditionalModules,
+} from "../deployment-bundle/find-additional-modules";
+import {
+	createModuleCollector,
+	getWrangler1xLegacyModuleReferences,
+} from "../deployment-bundle/module-collection";
+import { addHyphens } from "../deployments";
+import { confirm } from "../dialogs";
+import { getMigrationsToUpload } from "../durable";
+import { logger } from "../logger";
+import { getMetricsUsageHeaders } from "../metrics";
+import { ParseError } from "../parse";
+import { getWranglerTmpDir } from "../paths";
+import { getQueue, putConsumer } from "../queues/client";
+import { getWorkersDevSubdomain } from "../routes";
+import { syncAssets } from "../sites";
+import {
+	getSourceMappedString,
+	maybeRetrieveFileSourceMap,
+} from "../sourcemap";
+import { getZoneForRoute } from "../zones";
+import type { FetchError } from "../cfetch";
+import type { Config } from "../config";
+import type {
+	Route,
+	ZoneIdRoute,
+	ZoneNameRoute,
+	CustomDomainRoute,
+	Rule,
+} from "../config/environment";
+import type { Entry } from "../deployment-bundle/entry";
+import type { CfWorkerInit, CfPlacement } from "../deployment-bundle/worker";
+import type { PutConsumerBody } from "../queues/client";
+import type { AssetPaths } from "../sites";
+import type { RetrieveSourceMapFunction } from "../sourcemap";
+
+type Props = {
+	config: Config;
+	accountId: string | undefined;
+	entry: Entry;
+	rules: Config["rules"];
+	name: string | undefined;
+	env: string | undefined;
+	compatibilityDate: string | undefined;
+	compatibilityFlags: string[] | undefined;
+	assetPaths: AssetPaths | undefined;
+	vars: Record<string, string> | undefined;
+	defines: Record<string, string> | undefined;
+	triggers: string[] | undefined;
+	routes: string[] | undefined;
+	legacyEnv: boolean | undefined;
+	jsxFactory: string | undefined;
+	jsxFragment: string | undefined;
+	tsconfig: string | undefined;
+	isWorkersSite: boolean;
+	minify: boolean | undefined;
+	nodeCompat: boolean | undefined;
+	outDir: string | undefined;
+	dryRun: boolean | undefined;
+	noBundle: boolean | undefined;
+	keepVars: boolean | undefined;
+	logpush: boolean | undefined;
+	oldAssetTtl: number | undefined;
+	projectRoot: string | undefined;
+};
+
+type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;
+
+export type CustomDomain = {
+	id: string;
+	zone_id: string;
+	zone_name: string;
+	hostname: string;
+	service: string;
+	environment: string;
+};
+type UpdatedCustomDomain = CustomDomain & { modified: boolean };
+type ConflictingCustomDomain = CustomDomain & {
+	external_dns_record_id?: string;
+	external_cert_id?: string;
+};
+
+export type CustomDomainChangeset = {
+	added: CustomDomain[];
+	removed: CustomDomain[];
+	updated: UpdatedCustomDomain[];
+	conflicting: ConflictingCustomDomain[];
+};
+
+function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const scriptStartupErrorRegex = /startup/i;
+
+function errIsScriptSize(err: unknown): err is { code: 10027 } {
+	if (!err) return false;
+
+	// 10027 = workers.api.error.script_too_large
+	if ((err as { code: number }).code === 10027) {
+		return true;
+	}
+
+	return false;
+}
+
+function errIsStartupErr(err: unknown): err is ParseError & { code: 10021 } {
+	if (!err) return false;
+
+	// 10021 = validation error
+	// no explicit error code for more granular errors than "invalid script"
+	// but the error will contain a string error message directly from the
+	// validator.
+	// the error always SHOULD look like "Script startup exceeded CPU limit."
+	// (or the less likely "Script startup exceeded memory limits.")
+	if (
+		(err as { code: number }).code === 10021 &&
+		err instanceof ParseError &&
+		scriptStartupErrorRegex.test(err.notes[0]?.text)
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+function renderRoute(route: Route): string {
+	let result = "";
+	if (typeof route === "string") {
+		result = route;
+	} else {
+		result = route.pattern;
+		const isCustomDomain = Boolean(
+			"custom_domain" in route && route.custom_domain
+		);
+		if (isCustomDomain && "zone_id" in route) {
+			result += ` (custom domain - zone id: ${route.zone_id})`;
+		} else if (isCustomDomain && "zone_name" in route) {
+			result += ` (custom domain - zone name: ${route.zone_name})`;
+		} else if (isCustomDomain) {
+			result += ` (custom domain)`;
+		} else if ("zone_id" in route) {
+			result += ` (zone id: ${route.zone_id})`;
+		} else if ("zone_name" in route) {
+			result += ` (zone name: ${route.zone_name})`;
+		}
+	}
+	return result;
+}
+
+// publishing to custom domains involves a few more steps than just updating
+// the routing table, and thus the api implementing it is fairly defensive -
+// it will error eagerly on conflicts against existing domains or existing
+// managed DNS records
+
+// however, you can pass params to override the errors. to know if we should
+// override the current state, we generate a "changeset" of required actions
+// to get to the state we want (specified by the list of custom domains). the
+// changeset returns an "updated" collection (existing custom domains
+// connected to other scripts) and a "conflicting" collection (the requested
+// custom domains that have a managed, conflicting DNS record preventing the
+// host's use as a custom domain). with this information, we can prompt to
+// the user what will occur if we create the custom domains requested, and
+// add the override param if they confirm the action
+//
+// if a user does not confirm that they want to override, we skip publishing
+// to these custom domains, but continue on through the rest of the
+// deploy stage
+async function publishCustomDomains(
+	workerUrl: string,
+	accountId: string,
+	domains: Array<RouteObject>
+): Promise<string[]> {
+	const config = {
+		override_scope: true,
+		override_existing_origin: false,
+		override_existing_dns_record: false,
+	};
+	const origins = domains.map((domainRoute) => {
+		return {
+			hostname: domainRoute.pattern,
+			zone_id: "zone_id" in domainRoute ? domainRoute.zone_id : undefined,
+			zone_name: "zone_name" in domainRoute ? domainRoute.zone_name : undefined,
+		};
+	});
+
+	const fail = () => {
+		return [
+			domains.length > 1
+				? `Publishing to ${domains.length} Custom Domains was skipped, fix conflicts and try again`
+				: `Publishing to Custom Domain "${domains[0].pattern}" was skipped, fix conflict and try again`,
+		];
+	};
+
+	if (!process.stdout.isTTY) {
+		// running in non-interactive mode.
+		// existing origins / dns records are not indicative of errors,
+		// so we aggressively update rather than aggressively fail
+		config.override_existing_origin = true;
+		config.override_existing_dns_record = true;
+	} else {
+		// get a changeset for operations required to achieve a state with the requested domains
+		const changeset = await fetchResult<CustomDomainChangeset>(
+			`${workerUrl}/domains/changeset?replace_state=true`,
+			{
+				method: "POST",
+				body: JSON.stringify(origins),
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+
+		const updatesRequired = changeset.updated.filter(
+			(domain) => domain.modified
+		);
+		if (updatesRequired.length > 0) {
+			// find out which scripts the conflict domains are already attached to
+			// so we can provide that in the confirmation prompt
+			const existing = await Promise.all(
+				updatesRequired.map((domain) =>
+					fetchResult<CustomDomain>(
+						`/accounts/${accountId}/workers/domains/records/${domain.id}`
+					)
+				)
+			);
+			const existingRendered = existing
+				.map(
+					(domain) =>
+						`\t• ${domain.hostname} (used as a domain for "${domain.service}")`
+				)
+				.join("\n");
+			const message = `Custom Domains already exist for these domains:
+${existingRendered}
+Update them to point to this script instead?`;
+			if (!(await confirm(message))) return fail();
+			config.override_existing_origin = true;
+		}
+
+		if (changeset.conflicting.length > 0) {
+			const conflicitingRendered = changeset.conflicting
+				.map((domain) => `\t• ${domain.hostname}`)
+				.join("\n");
+			const message = `You already have DNS records that conflict for these Custom Domains:
+${conflicitingRendered}
+Update them to point to this script instead?`;
+			if (!(await confirm(message))) return fail();
+			config.override_existing_dns_record = true;
+		}
+	}
+
+	// deploy to domains
+	await fetchResult(`${workerUrl}/domains/records`, {
+		method: "PUT",
+		body: JSON.stringify({ ...config, origins }),
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+
+	return domains.map((domain) => renderRoute(domain));
+}
+
+export default async function deploy(props: Props): Promise<void> {
+	// TODO: warn if git/hg has uncommitted changes
+	const { config, accountId, name } = props;
+	if (accountId && name) {
+		try {
+			const serviceMetaData = await fetchResult(
+				`/accounts/${accountId}/workers/services/${name}`
+			);
+			const { default_environment } = serviceMetaData as {
+				default_environment: {
+					script: { last_deployed_from: "dash" | "wrangler" | "api" };
+				};
+			};
+
+			if (default_environment.script.last_deployed_from === "dash") {
+				logger.warn(
+					`You are about to publish a Workers Service that was last published via the Cloudflare Dashboard.\nEdits that have been made via the dashboard will be overridden by your local code and config.`
+				);
+				if (!(await confirm("Would you like to continue?"))) {
+					return;
+				}
+			} else if (default_environment.script.last_deployed_from === "api") {
+				logger.warn(
+					`You are about to publish a Workers Service that was last updated via the script API.\nEdits that have been made via the script API will be overridden by your local code and config.`
+				);
+				if (!(await confirm("Would you like to continue?"))) {
+					return;
+				}
+			}
+		} catch (e) {
+			// code: 10090, message: workers.api.error.service_not_found
+			// is thrown from the above fetchResult on the first deploy of a Worker
+			if ((e as { code?: number }).code !== 10090) {
+				throw e;
+			}
+		}
+	}
+
+	if (!(props.compatibilityDate || config.compatibility_date)) {
+		const compatibilityDateStr = `${new Date().getFullYear()}-${(
+			new Date().getMonth() +
+			1 +
+			""
+		).padStart(2, "0")}-${(new Date().getDate() + "").padStart(2, "0")}`;
+
+		throw new Error(`A compatibility_date is required when publishing. Add the following to your wrangler.toml file:.
+    \`\`\`
+    compatibility_date = "${compatibilityDateStr}"
+    \`\`\`
+    Or you could pass it in your terminal as \`--compatibility-date ${compatibilityDateStr}\`
+See https://developers.cloudflare.com/workers/platform/compatibility-dates for more information.`);
+	}
+
+	const triggers = props.triggers || config.triggers?.crons;
+	const routes =
+		props.routes ?? config.routes ?? (config.route ? [config.route] : []) ?? [];
+	const routesOnly: Array<Route> = [];
+	const customDomainsOnly: Array<RouteObject> = [];
+	for (const route of routes) {
+		if (typeof route !== "string" && route.custom_domain) {
+			if (route.pattern.includes("*")) {
+				throw new Error(
+					`Cannot use "${route.pattern}" as a Custom Domain; wildcard operators (*) are not allowed`
+				);
+			}
+			if (route.pattern.includes("/")) {
+				throw new Error(
+					`Cannot use "${route.pattern}" as a Custom Domain; paths are not allowed`
+				);
+			}
+			customDomainsOnly.push(route);
+		} else {
+			routesOnly.push(route);
+		}
+	}
+
+	// deployToWorkersDev defaults to true only if there aren't any routes defined
+	const deployToWorkersDev = config.workers_dev ?? routes.length === 0;
+
+	const jsxFactory = props.jsxFactory || config.jsx_factory;
+	const jsxFragment = props.jsxFragment || config.jsx_fragment;
+	const keepVars = props.keepVars || config.keep_vars;
+
+	const minify = props.minify ?? config.minify;
+
+	const legacyNodeCompat = props.nodeCompat ?? config.node_compat;
+	if (legacyNodeCompat) {
+		logger.warn(
+			"Enabling Node.js compatibility mode for built-ins and globals. This is experimental and has serious tradeoffs. Please see https://github.com/ionic-team/rollup-plugin-node-polyfills/ for more details."
+		);
+	}
+
+	const compatibilityFlags =
+		props.compatibilityFlags ?? config.compatibility_flags;
+	const nodejsCompat = compatibilityFlags.includes("nodejs_compat");
+	assert(
+		!(legacyNodeCompat && nodejsCompat),
+		"The `nodejs_compat` compatibility flag cannot be used in conjunction with the legacy `--node-compat` flag. If you want to use the Workers runtime Node.js compatibility features, please remove the `--node-compat` argument from your CLI command or `node_compat = true` from your config file."
+	);
+
+	// Warn if user tries minify or node-compat with no-bundle
+	if (props.noBundle && minify) {
+		logger.warn(
+			"`--minify` and `--no-bundle` can't be used together. If you want to minify your Worker and disable Wrangler's bundling, please minify as part of your own bundling process."
+		);
+	}
+
+	if (props.noBundle && legacyNodeCompat) {
+		logger.warn(
+			"`--node-compat` and `--no-bundle` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process."
+		);
+	}
+
+	const scriptName = props.name;
+	assert(
+		scriptName,
+		'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+	);
+
+	assert(
+		!config.site || config.site.bucket,
+		"A [site] definition requires a `bucket` field with a path to the site's assets directory."
+	);
+
+	if (props.outDir) {
+		// we're using a custom output directory,
+		// so let's first ensure it exists
+		mkdirSync(props.outDir, { recursive: true });
+		// add a README
+		const readmePath = path.join(props.outDir, "README.md");
+		writeFileSync(
+			readmePath,
+			`This folder contains the built output assets for the worker "${scriptName}" generated at ${new Date().toISOString()}.`
+		);
+	}
+
+	const destination =
+		props.outDir ?? getWranglerTmpDir(props.projectRoot, "deploy");
+	const envName = props.env ?? "production";
+
+	const start = Date.now();
+	const notProd = Boolean(!props.legacyEnv && props.env);
+	const workerName = notProd ? `${scriptName} (${envName})` : scriptName;
+	const workerUrl = notProd
+		? `/accounts/${accountId}/workers/services/${scriptName}/environments/${envName}`
+		: `/accounts/${accountId}/workers/scripts/${scriptName}`;
+
+	let available_on_subdomain: boolean | undefined = undefined; // we'll set this later
+	let deploymentId: string | null = null;
+
+	const { format } = props.entry;
+
+	if (
+		!props.isWorkersSite &&
+		Boolean(props.assetPaths) &&
+		format === "service-worker"
+	) {
+		throw new Error(
+			"You cannot use the service-worker format with an `assets` directory yet. For information on how to migrate to the module-worker format, see: https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/"
+		);
+	}
+
+	if (config.wasm_modules && format === "modules") {
+		throw new Error(
+			"You cannot configure [wasm_modules] with an ES module worker. Instead, import the .wasm module directly in your code"
+		);
+	}
+
+	if (config.text_blobs && format === "modules") {
+		throw new Error(
+			"You cannot configure [text_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure `[rules]` in your wrangler.toml"
+		);
+	}
+
+	if (config.data_blobs && format === "modules") {
+		throw new Error(
+			"You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure `[rules]` in your wrangler.toml"
+		);
+	}
+	try {
+		if (props.noBundle) {
+			// if we're not building, let's just copy the entry to the destination directory
+			const destinationDir =
+				typeof destination === "string" ? destination : destination.path;
+			mkdirSync(destinationDir, { recursive: true });
+			writeFileSync(
+				path.join(destinationDir, path.basename(props.entry.file)),
+				readFileSync(props.entry.file, "utf-8")
+			);
+		}
+
+		const entryDirectory = path.dirname(props.entry.file);
+		const moduleCollector = createModuleCollector({
+			wrangler1xLegacyModuleReferences: getWrangler1xLegacyModuleReferences(
+				entryDirectory,
+				props.entry.file
+			),
+			entry: props.entry,
+			// `moduleCollector` doesn't get used when `props.noBundle` is set, so
+			// `findAdditionalModules` always defaults to `false`
+			findAdditionalModules: config.find_additional_modules ?? false,
+			rules: props.rules,
+		});
+
+		const { modules, dependencies, resolvedEntryPointPath, bundleType } =
+			props.noBundle
+				? await noBundleWorker(props.entry, props.rules, props.outDir)
+				: await bundleWorker(
+						props.entry,
+						typeof destination === "string" ? destination : destination.path,
+						{
+							bundle: true,
+							additionalModules: [],
+							moduleCollector,
+							serveAssetsFromWorker:
+								!props.isWorkersSite && Boolean(props.assetPaths),
+							doBindings: config.durable_objects.bindings,
+							jsxFactory,
+							jsxFragment,
+							tsconfig: props.tsconfig ?? config.tsconfig,
+							minify,
+							legacyNodeCompat,
+							nodejsCompat,
+							define: { ...config.define, ...props.defines },
+							checkFetch: false,
+							assets: config.assets,
+							// enable the cache when publishing
+							bypassAssetCache: false,
+							services: config.services,
+							// We don't set workerDefinitions here,
+							// because we don't want to apply the dev-time
+							// facades on top of it
+							workerDefinitions: undefined,
+							// We want to know if the build is for development or publishing
+							// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
+							targetConsumer: "deploy",
+							local: false,
+							projectRoot: props.projectRoot,
+						}
+				  );
+
+		// Add modules to dependencies for size warning
+		for (const module of modules) {
+			const modulePath =
+				module.filePath === undefined
+					? module.name
+					: path.relative("", module.filePath);
+			const bytesInOutput =
+				typeof module.content === "string"
+					? Buffer.byteLength(module.content)
+					: module.content.byteLength;
+			dependencies[modulePath] = { bytesInOutput };
+		}
+
+		const content = readFileSync(resolvedEntryPointPath, {
+			encoding: "utf-8",
+		});
+
+		// durable object migrations
+		const migrations = !props.dryRun
+			? await getMigrationsToUpload(scriptName, {
+					accountId,
+					config,
+					legacyEnv: props.legacyEnv,
+					env: props.env,
+			  })
+			: undefined;
+
+		const assets = await syncAssets(
+			accountId,
+			// When we're using the newer service environments, we wouldn't
+			// have added the env name on to the script name. However, we must
+			// include it in the kv namespace name regardless (since there's no
+			// concept of service environments for kv namespaces yet).
+			scriptName + (!props.legacyEnv && props.env ? `-${props.env}` : ""),
+			props.assetPaths,
+			false,
+			props.dryRun,
+			props.oldAssetTtl
+		);
+
+		const bindings: CfWorkerInit["bindings"] = {
+			kv_namespaces: (config.kv_namespaces || []).concat(
+				assets.namespace
+					? { binding: "__STATIC_CONTENT", id: assets.namespace }
+					: []
+			),
+			send_email: config.send_email,
+			vars: { ...config.vars, ...props.vars },
+			wasm_modules: config.wasm_modules,
+			browser: config.browser,
+			ai: config.ai,
+			text_blobs: {
+				...config.text_blobs,
+				...(assets.manifest &&
+					format === "service-worker" && {
+						__STATIC_CONTENT_MANIFEST: "__STATIC_CONTENT_MANIFEST",
+					}),
+			},
+			data_blobs: config.data_blobs,
+			durable_objects: config.durable_objects,
+			queues: config.queues.producers?.map((producer) => {
+				return { binding: producer.binding, queue_name: producer.queue };
+			}),
+			r2_buckets: config.r2_buckets,
+			d1_databases: config.d1_databases,
+			vectorize: config.vectorize,
+			constellation: config.constellation,
+			hyperdrive: config.hyperdrive,
+			services: config.services,
+			analytics_engine_datasets: config.analytics_engine_datasets,
+			dispatch_namespaces: config.dispatch_namespaces,
+			mtls_certificates: config.mtls_certificates,
+			logfwdr: config.logfwdr,
+			unsafe: {
+				bindings: config.unsafe.bindings,
+				metadata: config.unsafe.metadata,
+				capnp: config.unsafe.capnp,
+			},
+		};
+
+		if (assets.manifest) {
+			modules.push({
+				name: "__STATIC_CONTENT_MANIFEST",
+				filePath: undefined,
+				content: JSON.stringify(assets.manifest),
+				type: "text",
+			});
+		}
+
+		// The upload API only accepts an empty string or no specified placement for the "off" mode.
+		const placement: CfPlacement | undefined =
+			config.placement?.mode === "smart" ? { mode: "smart" } : undefined;
+
+		const entryPointName = path.basename(resolvedEntryPointPath);
+		const worker: CfWorkerInit = {
+			name: scriptName,
+			main: {
+				name: entryPointName,
+				filePath: resolvedEntryPointPath,
+				content: content,
+				type: bundleType,
+			},
+			bindings,
+			migrations,
+			modules,
+			compatibility_date: props.compatibilityDate ?? config.compatibility_date,
+			compatibility_flags: compatibilityFlags,
+			usage_model: config.usage_model,
+			keepVars,
+			logpush: props.logpush !== undefined ? props.logpush : config.logpush,
+			placement,
+			tail_consumers: config.tail_consumers,
+			limits: config.limits,
+		};
+
+		// As this is not deterministic for testing, we detect if in a jest environment and run asynchronously
+		// We do not care about the timing outside of testing
+		const bundleSizePromise = printBundleSize(
+			{ name: path.basename(resolvedEntryPointPath), content: content },
+			modules
+		);
+		if (process.env.JEST_WORKER_ID !== undefined) await bundleSizePromise;
+		else void bundleSizePromise;
+
+		const withoutStaticAssets = {
+			...bindings,
+			kv_namespaces: config.kv_namespaces,
+			text_blobs: config.text_blobs,
+		};
+
+		// mask anything that was overridden in cli args
+		// so that we don't log potential secrets into the terminal
+		const maskedVars = { ...withoutStaticAssets.vars };
+		for (const key of Object.keys(maskedVars)) {
+			if (maskedVars[key] !== config.vars[key]) {
+				// This means it was overridden in cli args
+				// so let's mask it
+				maskedVars[key] = "(hidden)";
+			}
+		}
+
+		printBindings({ ...withoutStaticAssets, vars: maskedVars });
+
+		if (!props.dryRun) {
+			await ensureQueuesExist(config);
+
+			// Upload the script so it has time to propagate.
+			// We can also now tell whether available_on_subdomain is set
+			try {
+				const result = await fetchResult<{
+					available_on_subdomain: boolean;
+					id: string | null;
+					etag: string | null;
+					pipeline_hash: string | null;
+					mutable_pipeline_id: string | null;
+					deployment_id: string | null;
+				}>(
+					workerUrl,
+					{
+						method: "PUT",
+						body: createWorkerUploadForm(worker),
+						headers: await getMetricsUsageHeaders(config.send_metrics),
+					},
+					new URLSearchParams({
+						include_subdomain_availability: "true",
+						// pass excludeScript so the whole body of the
+						// script doesn't get included in the response
+						excludeScript: "true",
+					})
+				);
+
+				available_on_subdomain = result.available_on_subdomain;
+				deploymentId = addHyphens(result.deployment_id) ?? result.deployment_id;
+
+				if (config.first_party_worker) {
+					// Print some useful information returned after publishing
+					// Not all fields will be populated for every worker
+					// These fields are likely to be scraped by tools, so do not rename
+					if (result.id) logger.log("Worker ID: ", result.id);
+					if (result.etag) logger.log("Worker ETag: ", result.etag);
+					if (result.pipeline_hash)
+						logger.log("Worker PipelineHash: ", result.pipeline_hash);
+					if (result.mutable_pipeline_id)
+						logger.log(
+							"Worker Mutable PipelineID (Development ONLY!):",
+							result.mutable_pipeline_id
+						);
+				}
+			} catch (err) {
+				helpIfErrorIsSizeOrScriptStartup(err, dependencies);
+
+				// Apply source mapping to validation startup errors if possible
+				if (
+					err instanceof ParseError &&
+					"code" in err &&
+					err.code === 10021 /* validation error */ &&
+					err.notes.length > 0
+				) {
+					const maybeNameToFilePath = (moduleName: string) => {
+						// If this is a service worker, always return the entrypoint path.
+						// Service workers can't have additional JavaScript modules.
+						if (bundleType === "commonjs") return resolvedEntryPointPath;
+						// Similarly, if the name matches the entrypoint, return its path
+						if (moduleName === entryPointName) return resolvedEntryPointPath;
+						// Otherwise, return the file path of the matching module (if any)
+						for (const module of modules) {
+							if (moduleName === module.name) return module.filePath;
+						}
+					};
+					const retrieveSourceMap: RetrieveSourceMapFunction = (moduleName) =>
+						maybeRetrieveFileSourceMap(maybeNameToFilePath(moduleName));
+
+					err.notes[0].text = getSourceMappedString(
+						err.notes[0].text,
+						retrieveSourceMap
+					);
+				}
+
+				throw err;
+			}
+		}
+	} finally {
+		if (typeof destination !== "string") {
+			// this means we're using a temp dir,
+			// so let's clean up before we proceed
+			destination.remove();
+		}
+	}
+
+	if (props.dryRun) {
+		logger.log(`--dry-run: exiting now.`);
+		return;
+	}
+	assert(accountId, "Missing accountId");
+
+	const uploadMs = Date.now() - start;
+	const deployments: Promise<string[]>[] = [];
+
+	if (deployToWorkersDev) {
+		// Deploy to a subdomain of `workers.dev`
+		const userSubdomain = await getWorkersDevSubdomain(accountId);
+		const scriptURL =
+			props.legacyEnv || !props.env
+				? `${scriptName}.${userSubdomain}.workers.dev`
+				: `${envName}.${scriptName}.${userSubdomain}.workers.dev`;
+		if (!available_on_subdomain) {
+			// Enable the `workers.dev` subdomain.
+			deployments.push(
+				fetchResult(`${workerUrl}/subdomain`, {
+					method: "POST",
+					body: JSON.stringify({ enabled: true }),
+					headers: {
+						"Content-Type": "application/json",
+					},
+				})
+					.then(() => [scriptURL])
+					// Add a delay when the subdomain is first created.
+					// This is to prevent an issue where a negative cache-hit
+					// causes the subdomain to be unavailable for 30 seconds.
+					// This is a temporary measure until we fix this on the edge.
+					.then(async (url) => {
+						await sleep(3000);
+						return url;
+					})
+			);
+		} else {
+			deployments.push(Promise.resolve([scriptURL]));
+		}
+	} else {
+		if (available_on_subdomain) {
+			// Disable the workers.dev deployment
+			await fetchResult(`${workerUrl}/subdomain`, {
+				method: "POST",
+				body: JSON.stringify({ enabled: false }),
+				headers: {
+					"Content-Type": "application/json",
+				},
+			});
+		} else if (routes.length !== 0) {
+			// if you get to this point it's because
+			// you're trying to deploy a worker to a custom
+			// domain that's already bound to another worker.
+			// so this thing is about finding workers that have
+			// bindings to the routes you're trying to deploy to.
+			//
+			// the logic is kinda similar (read: duplicated) from publishRoutesFallback,
+			// except here we know we have a good API token or whatever so we don't need
+			// to bother with all the error handling tomfoolery.
+			const routesWithOtherBindings: Record<string, string[]> = {};
+			for (const route of routes) {
+				const zone = await getZoneForRoute(route);
+				if (!zone) {
+					continue;
+				}
+
+				const routePattern = typeof route === "string" ? route : route.pattern;
+				const routesInZone = await fetchListResult<{
+					pattern: string;
+					script: string;
+				}>(`/zones/${zone.id}/workers/routes`);
+
+				routesInZone.forEach(({ script, pattern }) => {
+					if (pattern === routePattern && script !== scriptName) {
+						if (!(script in routesWithOtherBindings)) {
+							routesWithOtherBindings[script] = [];
+						}
+
+						routesWithOtherBindings[script].push(pattern);
+					}
+				});
+			}
+
+			if (Object.keys(routesWithOtherBindings).length > 0) {
+				let errorMessage =
+					"Can't deploy a worker to routes that are assigned to another worker.\n";
+
+				for (const worker in routesWithOtherBindings) {
+					const assignedRoutes = routesWithOtherBindings[worker];
+					errorMessage += `"${worker}" is already assigned to routes:\n${assignedRoutes.map(
+						(r) => `  - ${chalk.underline(r)}\n`
+					)}`;
+				}
+
+				const resolution =
+					"Unassign other workers from the routes you want to deploy to, and then try again.";
+				const dashLink = `Visit ${chalk.blue(
+					chalk.underline(
+						`https://dash.cloudflare.com/${accountId}/workers/overview`
+					)
+				)} to unassign a worker from a route.`;
+
+				throw new Error(`${errorMessage}\n${resolution}\n${dashLink}`);
+			}
+		}
+	}
+
+	logger.log("Uploaded", workerName, formatTime(uploadMs));
+
+	// Update routing table for the script.
+	if (routesOnly.length > 0) {
+		deployments.push(
+			publishRoutes(routesOnly, { workerUrl, scriptName, notProd }).then(() => {
+				if (routesOnly.length > 10) {
+					return routesOnly
+						.slice(0, 9)
+						.map((route) => renderRoute(route))
+						.concat([`...and ${routesOnly.length - 10} more routes`]);
+				}
+				return routesOnly.map((route) => renderRoute(route));
+			})
+		);
+	}
+
+	// Update custom domains for the script
+	if (customDomainsOnly.length > 0) {
+		deployments.push(
+			publishCustomDomains(workerUrl, accountId, customDomainsOnly)
+		);
+	}
+
+	// Configure any schedules for the script.
+	// TODO: rename this to `schedules`?
+	if (triggers && triggers.length) {
+		deployments.push(
+			fetchResult(`${workerUrl}/schedules`, {
+				// Note: PUT will override previous schedules on this script.
+				method: "PUT",
+				body: JSON.stringify(triggers.map((cron) => ({ cron }))),
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}).then(() => triggers.map((trigger) => `schedule: ${trigger}`))
+		);
+	}
+
+	if (config.queues.consumers && config.queues.consumers.length) {
+		deployments.push(...updateQueueConsumers(config));
+	}
+
+	const targets = await Promise.all(deployments);
+	const deployMs = Date.now() - start - uploadMs;
+
+	if (deployments.length > 0) {
+		logger.log("Published", workerName, formatTime(deployMs));
+		for (const target of targets.flat()) {
+			// Append protocol only on workers.dev domains
+			logger.log(
+				" ",
+				(target.endsWith("workers.dev") ? "https://" : "") + target
+			);
+		}
+	} else {
+		logger.log("No deploy targets for", workerName, formatTime(deployMs));
+	}
+
+	logger.log("Current Deployment ID:", deploymentId);
+}
+
+export function helpIfErrorIsSizeOrScriptStartup(
+	err: unknown,
+	dependencies: { [path: string]: { bytesInOutput: number } }
+) {
+	if (errIsScriptSize(err)) {
+		printOffendingDependencies(dependencies);
+	} else if (errIsStartupErr(err)) {
+		const youFailed =
+			"Your Worker failed validation because it exceeded startup limits.";
+		const heresWhy =
+			"To ensure fast responses, we place constraints on Worker startup -- like how much CPU it can use, or how long it can take.";
+		const heresTheProblem =
+			"Your Worker failed validation, which means it hit one of these startup limits.";
+		const heresTheSolution =
+			"Try reducing the amount of work done during startup (outside the event handler), either by removing code or relocating it inside the event handler.";
+		logger.warn(
+			[youFailed, heresWhy, heresTheProblem, heresTheSolution].join("\n")
+		);
+	}
+}
+
+function formatTime(duration: number) {
+	return `(${(duration / 1000).toFixed(2)} sec)`;
+}
+
+/**
+ * Associate the newly deployed Worker with the given routes.
+ */
+async function publishRoutes(
+	routes: Route[],
+	{
+		workerUrl,
+		scriptName,
+		notProd,
+	}: { workerUrl: string; scriptName: string; notProd: boolean }
+): Promise<string[]> {
+	try {
+		return await fetchResult(`${workerUrl}/routes`, {
+			// Note: PUT will delete previous routes on this script.
+			method: "PUT",
+			body: JSON.stringify(
+				routes.map((route) =>
+					typeof route !== "object" ? { pattern: route } : route
+				)
+			),
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+	} catch (e) {
+		if (isAuthenticationError(e)) {
+			// An authentication error is probably due to a known issue,
+			// where the user is logged in via an API token that does not have "All Zones".
+			return await publishRoutesFallback(routes, { scriptName, notProd });
+		} else {
+			throw e;
+		}
+	}
+}
+
+/**
+ * Try updating routes for the Worker using a less optimal zone-based API.
+ *
+ * Compute match zones to the routes, then for each route attempt to connect it to the Worker via the zone.
+ */
+async function publishRoutesFallback(
+	routes: Route[],
+	{ scriptName, notProd }: { scriptName: string; notProd: boolean }
+) {
+	if (notProd) {
+		throw new Error(
+			"Service environments combined with an API token that doesn't have 'All Zones' permissions is not supported.\n" +
+				"Either turn off service environments by setting `legacy_env = true`, creating an API token with 'All Zones' permissions, or logging in via OAuth"
+		);
+	}
+	logger.warn(
+		"The current authentication token does not have 'All Zones' permissions.\n" +
+			"Falling back to using the zone-based API endpoint to update each route individually.\n" +
+			"Note that there is no access to routes associated with zones that the API token does not have permission for.\n" +
+			"Existing routes for this Worker in such zones will not be deleted."
+	);
+
+	const deployedRoutes: string[] = [];
+
+	// Collect the routes (and their zones) that will be deployed.
+	const activeZones = new Map<string, string>();
+	const routesToDeploy = new Map<string, string>();
+	for (const route of routes) {
+		const zone = await getZoneForRoute(route);
+		if (zone) {
+			activeZones.set(zone.id, zone.host);
+			routesToDeploy.set(
+				typeof route === "string" ? route : route.pattern,
+				zone.id
+			);
+		}
+	}
+
+	// Collect the routes that are already deployed.
+	const allRoutes = new Map<string, string>();
+	const alreadyDeployedRoutes = new Set<string>();
+	for (const [zone, host] of activeZones) {
+		try {
+			for (const { pattern, script } of await fetchListResult<{
+				pattern: string;
+				script: string;
+			}>(`/zones/${zone}/workers/routes`)) {
+				allRoutes.set(pattern, script);
+				if (script === scriptName) {
+					alreadyDeployedRoutes.add(pattern);
+				}
+			}
+		} catch (e) {
+			if (isAuthenticationError(e)) {
+				e.notes.push({
+					text: `This could be because the API token being used does not have permission to access the zone "${host}" (${zone}).`,
+				});
+			}
+			throw e;
+		}
+	}
+
+	// Deploy each route that is not already deployed.
+	for (const [routePattern, zoneId] of routesToDeploy.entries()) {
+		if (allRoutes.has(routePattern)) {
+			const knownScript = allRoutes.get(routePattern);
+			if (knownScript === scriptName) {
+				// This route is already associated with this worker, so no need to hit the API.
+				alreadyDeployedRoutes.delete(routePattern);
+				continue;
+			} else {
+				throw new Error(
+					`The route with pattern "${routePattern}" is already associated with another worker called "${knownScript}".`
+				);
+			}
+		}
+
+		const { pattern } = await fetchResult<{ pattern: string }>(
+			`/zones/${zoneId}/workers/routes`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					pattern: routePattern,
+					script: scriptName,
+				}),
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+
+		deployedRoutes.push(pattern);
+	}
+
+	if (alreadyDeployedRoutes.size) {
+		logger.warn(
+			"Previously deployed routes:\n" +
+				"The following routes were already associated with this worker, and have not been deleted:\n" +
+				[...alreadyDeployedRoutes.values()].map((route) => ` - "${route}"\n`) +
+				"If these routes are not wanted then you can remove them in the dashboard."
+		);
+	}
+
+	return deployedRoutes;
+}
+
+export function isAuthenticationError(e: unknown): e is ParseError {
+	return e instanceof ParseError && (e as { code?: number }).code === 10000;
+}
+
+async function ensureQueuesExist(config: Config) {
+	const producers = (config.queues.producers || []).map(
+		(producer) => producer.queue
+	);
+	const consumers = (config.queues.consumers || []).map(
+		(consumer) => consumer.queue
+	);
+
+	const queueNames = producers.concat(consumers);
+	for (const queue of queueNames) {
+		try {
+			await getQueue(config, queue);
+		} catch (err) {
+			const queueErr = err as FetchError;
+			if (queueErr.code === 11000) {
+				// queue_not_found
+				throw new Error(
+					`Queue "${queue}" does not exist. To create it, run: wrangler queues create ${queue}`
+				);
+			}
+			throw err;
+		}
+	}
+}
+
+function updateQueueConsumers(config: Config): Promise<string[]>[] {
+	const consumers = config.queues.consumers || [];
+	return consumers.map((consumer) => {
+		const body: PutConsumerBody = {
+			dead_letter_queue: consumer.dead_letter_queue,
+			settings: {
+				batch_size: consumer.max_batch_size,
+				max_retries: consumer.max_retries,
+				max_wait_time_ms: consumer.max_batch_timeout
+					? 1000 * consumer.max_batch_timeout
+					: undefined,
+				max_concurrency: consumer.max_concurrency,
+			},
+		};
+
+		if (config.name === undefined) {
+			// TODO: how can we reliably get the current script name?
+			throw new Error("Script name is required to update queue consumers");
+		}
+		const scriptName = config.name;
+		const envName = undefined; // TODO: script environment for wrangler deploy?
+		return putConsumer(config, consumer.queue, scriptName, envName, body).then(
+			() => [`Consumer for ${consumer.queue}`]
+		);
+	});
+}
+
+async function noBundleWorker(
+	entry: Entry,
+	rules: Rule[],
+	outDir: string | undefined
+) {
+	const modules = await findAdditionalModules(entry, rules);
+	if (outDir) {
+		await writeAdditionalModules(modules, outDir);
+	}
+
+	return {
+		modules,
+		dependencies: {} as { [path: string]: { bytesInOutput: number } },
+		resolvedEntryPointPath: entry.file,
+		bundleType: getBundleType(entry.format),
+	};
+}

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -188,13 +188,6 @@ export async function versionsUploadHandler(
 ) {
 	await printWranglerBanner();
 
-	// Check for deprecated `wrangler publish` command
-	if (args._[0] === "publish") {
-		logger.warn(
-			"`wrangler publish` is deprecated and will be removed in the next major version.\nPlease use `wrangler deploy` instead, which accepts exactly the same arguments."
-		);
-	}
-
 	const configPath =
 		args.config || (args.script && findWranglerToml(path.dirname(args.script)));
 	const projectRoot = configPath && path.dirname(configPath);

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -170,12 +170,13 @@ export function versionsUploadOptions(yargs: CommonYargsArgv) {
 			})
 			// args only for `versions upload`, not `deploy`
 			.option("tag", {
-				describe: "A tag for this Worker Version",
+				describe: "A tag for this Worker Gradual Rollouts Version",
 				type: "string",
 				requiresArg: true,
 			})
 			.option("message", {
-				describe: "A descriptive message for this Worker Version",
+				describe:
+					"A descriptive message for this Worker Gradual Rollouts Version",
 				type: "string",
 				requiresArg: true,
 			})

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -168,6 +168,17 @@ export function versionsUploadOptions(yargs: CommonYargsArgv) {
 				default: false,
 				type: "boolean",
 			})
+			// args only for `versions upload`, not `deploy`
+			.option("tag", {
+				describe: "A tag for this Worker Version",
+				type: "string",
+				requiresArg: true,
+			})
+			.option("message", {
+				describe: "A descriptive message for this Worker Version",
+				type: "string",
+				requiresArg: true,
+			})
 	);
 }
 
@@ -234,5 +245,8 @@ export async function versionsUploadHandler(
 		noBundle: !(args.bundle ?? !config.no_bundle),
 		keepVars: args.keepVars,
 		projectRoot,
+
+		tag: args.tag,
+		message: args.message,
 	});
 }

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -1,0 +1,325 @@
+import path from "node:path";
+import chalk from "chalk";
+import { fetchResult } from "../cfetch";
+import { findWranglerToml, readConfig } from "../config";
+import { getEntry } from "../deployment-bundle/entry";
+import {
+	getRules,
+	getScriptName,
+	isLegacyEnv,
+	printWranglerBanner,
+} from "../index";
+import { logger } from "../logger";
+import * as metrics from "../metrics";
+import { getAssetPaths, getSiteAssetPaths } from "../sites";
+import { requireAuth } from "../user";
+import { collectKeyValues } from "../utils/collectKeyValues";
+import deploy from "./deploy";
+import type { Config } from "../config";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+async function standardPricingWarning(
+	accountId: string | undefined,
+	config: Config
+) {
+	try {
+		const { standard, reason } = await fetchResult<{
+			standard: boolean;
+			reason: string;
+		}>(`/accounts/${accountId}/workers/standard`);
+
+		if (!standard && reason !== "enterprise without override") {
+			logger.log(
+				chalk.blue(
+					`🚧 New Workers Standard pricing is now available. Please visit the dashboard to view details and opt-in to new pricing: https://dash.cloudflare.com/${accountId}/workers/standard/opt-in.`
+				)
+			);
+			if (config.limits?.cpu_ms !== undefined) {
+				logger.warn(
+					"The `limits` defined in wrangler.toml can only be applied to scripts opted into Workers Standard pricing. Agree to the new pricing details to set limits for your script."
+				);
+			}
+			return;
+		}
+		if (standard && config.usage_model !== undefined) {
+			logger.warn(
+				"The `usage_model` defined in wrangler.toml is no longer used because you have opted into Workers Standard pricing. Please remove this setting from your wrangler.toml and use the dashboard to configure the usage model for your script."
+			);
+			return;
+		}
+		// Ignore 404 errors for the enablement check
+	} catch {}
+}
+
+export function deployOptions(yargs: CommonYargsArgv) {
+	return (
+		yargs
+			.positional("script", {
+				describe: "The path to an entry point for your worker",
+				type: "string",
+				requiresArg: true,
+			})
+			.option("name", {
+				describe: "Name of the worker",
+				type: "string",
+				requiresArg: true,
+			})
+			// We want to have a --no-bundle flag, but yargs requires that
+			// we also have a --bundle flag (that it adds the --no to by itself)
+			// So we make a --bundle flag, but hide it, and then add a --no-bundle flag
+			// that's visible to the user but doesn't "do" anything.
+			.option("bundle", {
+				describe: "Run wrangler's compilation step before publishing",
+				type: "boolean",
+				hidden: true,
+			})
+			.option("no-bundle", {
+				describe: "Skip internal build steps and directly deploy Worker",
+				type: "boolean",
+				default: false,
+			})
+			.option("outdir", {
+				describe: "Output directory for the bundled worker",
+				type: "string",
+				requiresArg: true,
+			})
+			.option("format", {
+				choices: ["modules", "service-worker"] as const,
+				describe: "Choose an entry type",
+				deprecated: true,
+				hidden: true,
+			})
+			.option("compatibility-date", {
+				describe: "Date to use for compatibility checks",
+				type: "string",
+				requiresArg: true,
+			})
+			.option("compatibility-flags", {
+				describe: "Flags to use for compatibility checks",
+				alias: "compatibility-flag",
+				type: "string",
+				requiresArg: true,
+				array: true,
+			})
+			.option("latest", {
+				describe: "Use the latest version of the worker runtime",
+				type: "boolean",
+				default: false,
+			})
+			.option("experimental-public", {
+				describe: "Static assets to be served",
+				type: "string",
+				requiresArg: true,
+				deprecated: true,
+				hidden: true,
+			})
+			.option("public", {
+				describe: "Static assets to be served",
+				type: "string",
+				requiresArg: true,
+				deprecated: true,
+				hidden: true,
+			})
+			.option("assets", {
+				describe: "Static assets to be served",
+				type: "string",
+				requiresArg: true,
+			})
+			.option("site", {
+				describe: "Root folder of static assets for Workers Sites",
+				type: "string",
+				requiresArg: true,
+			})
+			.option("site-include", {
+				describe:
+					"Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.",
+				type: "string",
+				requiresArg: true,
+				array: true,
+			})
+			.option("site-exclude", {
+				describe:
+					"Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.",
+				type: "string",
+				requiresArg: true,
+				array: true,
+			})
+			.option("var", {
+				describe:
+					"A key-value pair to be injected into the script as a variable",
+				type: "string",
+				requiresArg: true,
+				array: true,
+			})
+			.option("define", {
+				describe: "A key-value pair to be substituted in the script",
+				type: "string",
+				requiresArg: true,
+				array: true,
+			})
+			.option("triggers", {
+				describe: "cron schedules to attach",
+				alias: ["schedule", "schedules"],
+				type: "string",
+				requiresArg: true,
+				array: true,
+			})
+			.option("routes", {
+				describe: "Routes to upload",
+				alias: "route",
+				type: "string",
+				requiresArg: true,
+				array: true,
+			})
+			.option("jsx-factory", {
+				describe: "The function that is called for each JSX element",
+				type: "string",
+				requiresArg: true,
+			})
+			.option("jsx-fragment", {
+				describe: "The function that is called for each JSX fragment",
+				type: "string",
+				requiresArg: true,
+			})
+			.option("tsconfig", {
+				describe: "Path to a custom tsconfig.json file",
+				type: "string",
+				requiresArg: true,
+			})
+			.option("minify", {
+				describe: "Minify the Worker",
+				type: "boolean",
+			})
+			.option("node-compat", {
+				describe: "Enable Node.js compatibility",
+				type: "boolean",
+			})
+			.option("dry-run", {
+				describe: "Don't actually deploy",
+				type: "boolean",
+			})
+			.option("keep-vars", {
+				describe:
+					"Stop wrangler from deleting vars that are not present in the wrangler.toml\nBy default Wrangler will remove all vars and replace them with those found in the wrangler.toml configuration.\nIf your development approach is to modify vars after deployment via the dashboard you may wish to set this flag.",
+				default: false,
+				type: "boolean",
+			})
+			.option("legacy-env", {
+				type: "boolean",
+				describe: "Use legacy environments",
+				hidden: true,
+			})
+			.option("logpush", {
+				type: "boolean",
+				describe:
+					"Send Trace Events from this worker to Workers Logpush.\nThis will not configure a corresponding Logpush job automatically.",
+			})
+			.option("old-asset-ttl", {
+				describe:
+					"Expire old assets in given seconds rather than immediate deletion.",
+				type: "number",
+			})
+	);
+}
+
+export async function deployHandler(
+	args: StrictYargsOptionsToInterface<typeof deployOptions>
+) {
+	await printWranglerBanner();
+
+	// Check for deprecated `wrangler publish` command
+	if (args._[0] === "publish") {
+		logger.warn(
+			"`wrangler publish` is deprecated and will be removed in the next major version.\nPlease use `wrangler deploy` instead, which accepts exactly the same arguments."
+		);
+	}
+
+	const configPath =
+		args.config || (args.script && findWranglerToml(path.dirname(args.script)));
+	const projectRoot = configPath && path.dirname(configPath);
+	const config = readConfig(configPath, args);
+	const entry = await getEntry(args, config, "deploy");
+	await metrics.sendMetricsEvent(
+		"deploy worker script",
+		{
+			usesTypeScript: /\.tsx?$/.test(entry.file),
+		},
+		{
+			sendMetrics: config.send_metrics,
+		}
+	);
+
+	if (args.public) {
+		throw new Error("The --public field has been renamed to --assets");
+	}
+	if (args.experimentalPublic) {
+		throw new Error(
+			"The --experimental-public field has been renamed to --assets"
+		);
+	}
+
+	if ((args.assets || config.assets) && (args.site || config.site)) {
+		throw new Error("Cannot use Assets and Workers Sites in the same Worker.");
+	}
+
+	if (args.assets) {
+		logger.warn(
+			"The --assets argument is experimental and may change or break at any time"
+		);
+	}
+	if (args.latest) {
+		logger.warn(
+			"Using the latest version of the Workers runtime. To silence this warning, please choose a specific version of the runtime with --compatibility-date, or add a compatibility_date to your wrangler.toml.\n"
+		);
+	}
+
+	const cliVars = collectKeyValues(args.var);
+	const cliDefines = collectKeyValues(args.define);
+
+	const accountId = args.dryRun ? undefined : await requireAuth(config);
+
+	const assetPaths =
+		args.assets || config.assets
+			? getAssetPaths(config, args.assets)
+			: getSiteAssetPaths(
+					config,
+					args.site,
+					args.siteInclude,
+					args.siteExclude
+			  );
+	await standardPricingWarning(accountId, config);
+	await deploy({
+		config,
+		accountId,
+		name: getScriptName(args, config),
+		rules: getRules(config),
+		entry,
+		env: args.env,
+		compatibilityDate: args.latest
+			? new Date().toISOString().substring(0, 10)
+			: args.compatibilityDate,
+		compatibilityFlags: args.compatibilityFlags,
+		vars: cliVars,
+		defines: cliDefines,
+		triggers: args.triggers,
+		jsxFactory: args.jsxFactory,
+		jsxFragment: args.jsxFragment,
+		tsconfig: args.tsconfig,
+		routes: args.routes,
+		assetPaths,
+		legacyEnv: isLegacyEnv(config),
+		minify: args.minify,
+		nodeCompat: args.nodeCompat,
+		isWorkersSite: Boolean(args.site || config.site),
+		outDir: args.outdir,
+		dryRun: args.dryRun,
+		noBundle: !(args.bundle ?? !config.no_bundle),
+		keepVars: args.keepVars,
+		logpush: args.logpush,
+		oldAssetTtl: args.oldAssetTtl,
+		projectRoot,
+	});
+}

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -201,7 +201,7 @@ export async function versionsUploadHandler(
 	const config = readConfig(configPath, args);
 	const entry = await getEntry(args, config, "deploy");
 	await metrics.sendMetricsEvent(
-		"deploy worker script",
+		"upload worker version",
 		{
 			usesTypeScript: /\.tsx?$/.test(entry.file),
 		},

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -445,20 +445,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					})
 				);
 
-				if (config.first_party_worker) {
-					// Print some useful information returned after publishing
-					// Not all fields will be populated for every worker
-					// These fields are likely to be scraped by tools, so do not rename
-					if (result.id) logger.log("Worker ID: ", result.id);
-					if (result.etag) logger.log("Worker ETag: ", result.etag);
-					if (result.pipeline_hash)
-						logger.log("Worker PipelineHash: ", result.pipeline_hash);
-					if (result.mutable_pipeline_id)
-						logger.log(
-							"Worker Mutable PipelineID (Development ONLY!):",
-							result.mutable_pipeline_id
-						);
-				}
+				logger.log("Worker Version ID:", result.id);
 			} catch (err) {
 				helpIfErrorIsSizeOrScriptStartup(err, dependencies);
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -210,14 +210,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	const destination =
 		props.outDir ?? getWranglerTmpDir(props.projectRoot, "deploy");
-	const envName = props.env ?? "production";
 
 	const start = Date.now();
 	const workerName = scriptName;
 	const workerUrl = `/accounts/${accountId}/workers/scripts/${scriptName}/versions`;
-
-	let available_on_subdomain: boolean | undefined = undefined; // we'll set this later
-	let deploymentId: string | null = null;
 
 	const { format } = props.entry;
 
@@ -448,9 +444,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						excludeScript: "true",
 					})
 				);
-
-				available_on_subdomain = result.available_on_subdomain;
-				deploymentId = addHyphens(result.deployment_id) ?? result.deployment_id;
 
 				if (config.first_party_worker) {
 					// Print some useful information returned after publishing

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -19,7 +19,6 @@ import {
 	createModuleCollector,
 	getWrangler1xLegacyModuleReferences,
 } from "../deployment-bundle/module-collection";
-import { addHyphens } from "../deployments";
 import { confirm } from "../dialogs";
 import { getMigrationsToUpload } from "../durable";
 import { logger } from "../logger";
@@ -35,7 +34,7 @@ import type { FetchError } from "../cfetch";
 import type { Config } from "../config";
 import type { Rule } from "../config/environment";
 import type { Entry } from "../deployment-bundle/entry";
-import type { CfWorkerInit, CfPlacement } from "../deployment-bundle/worker";
+import type { CfPlacement, CfWorkerInit } from "../deployment-bundle/worker";
 import type { RetrieveSourceMapFunction } from "../sourcemap";
 
 type Props = {
@@ -494,7 +493,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	assert(accountId, "Missing accountId");
 
 	const uploadMs = Date.now() - start;
-	const deployments: Promise<string[]>[] = [];
 
 	logger.log("Uploaded", workerName, formatTime(uploadMs));
 }


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR implements the new Gradual Rollouts `versions upload` command for internal-use only. Therefore, it is hidden from the help output.

The command is _essentially_ the same as `deploy` and, for now, has been duplicated so as not to touch the deploy command implementation at all and, while we agree on the differences, the diff should be more readable this way. The PR is marked as draft and will be refactored to abstracted functions of shared implementation at a granular level before being marked as ready for review. This should allow internal use of the prerelease builds before going through that effort.

Please find the prerelease build instructions in a bot comment below. Specifically for this command you can run:

```sh
npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/7575284748/npm-package-wrangler-4744 versions upload
```

> [!IMPORTANT]  
> The URL in the command above will be updated as commits/changes are validated. Please refer back here for the latest stable prerelease build.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: beta command hidden behind a flag `–experimental-gradual-rollouts`
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: no user facing changes
- Associated docs
  - [x] Issue(s)/PR(s): https://docs.google.com/document/d/1Kn0EpTXzu2ANMznbEehBVRCkhYky1WbFEc9K79OIfBc
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
