### PR TITLE
fix: correctly find the latest version of create-cloudflare

### DIFF
--- a/.changeset/strange-bikes-run.md
+++ b/.changeset/strange-bikes-run.md
@@ -1,0 +1,20 @@
+---
+"create-cloudflare": patch
+---
+
+fix: correctly find the latest version of create-cloudflare
+
+When create-cloudflare starts up, it checks to see if the version being run
+is the latest available on npm.
+
+Previously this check used `npm info` to look up the version.
+But was prone to failing if that command returned additional unexpected output
+such as warnings.
+
+Now we make a fetch request to the npm REST API directly for the latest version,
+which does not have the problem of unexpected warnings.
+
+Since the same approach is used to compute the latest version of workerd, the
+function to do this has been put into a helper.
+
+Fixes #4729

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -122,7 +122,7 @@ export const parseArgs = async (argv: string[]): Promise<Partial<C3Args>> => {
 const showMoreInfoNote = () => {
 	const c3CliArgsDocsPage =
 		"https://developers.cloudflare.com/pages/get-started/c3/#cli-arguments";
-	console.log(
+	console.error(
 		`\nFor more information regarding how to invoke C3 please visit ${c3CliArgsDocsPage}`
 	);
 };

--- a/packages/create-cloudflare/src/helpers/cli.ts
+++ b/packages/create-cloudflare/src/helpers/cli.ts
@@ -1,6 +1,11 @@
 import { updateStatus, warn } from "@cloudflare/cli";
+import { blue } from "@cloudflare/cli/colors";
+import { spinner, spinnerFrames } from "@cloudflare/cli/interactive";
 import Haikunator from "haikunator";
 import open from "open";
+import semver from "semver";
+import { version } from "../../package.json";
+import { getLatestPackageVersion } from "./latestPackageVersion";
 
 /**
  * An extremely simple wrapper around the open command.
@@ -17,6 +22,27 @@ export async function openInBrowser(url: string): Promise<void> {
 		warn("Failed to open browser");
 	});
 }
+
+// Detects if a newer version of c3 is available by comparing the version
+// specified in package.json with the `latest` tag from npm
+export const isUpdateAvailable = async () => {
+	// Use a spinner when running this check since it may take some time
+	const s = spinner(spinnerFrames.vertical, blue);
+	s.start("Checking if a newer version is available");
+	try {
+		const latestVersion = await getLatestPackageVersion("create-cloudflare");
+		return (
+			// Don't auto-update to major versions
+			semver.diff(latestVersion, version) !== "major" &&
+			semver.gt(latestVersion, version)
+		);
+	} catch {
+		s.update("Failed to read latest version from npm.");
+		return false;
+	} finally {
+		s.stop();
+	}
+};
 
 export const C3_DEFAULTS = {
 	projectName: new Haikunator().haikunate({ tokenHex: true }),

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -5,8 +5,8 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { isInteractive, spinner } from "@cloudflare/cli/interactive";
 import { spawn } from "cross-spawn";
 import { getFrameworkCli } from "frameworks/index";
-import { fetch } from "undici";
 import { quoteShellArgs } from "../common";
+import { getLatestPackageVersion } from "./latestPackageVersion";
 import { detectPackageManager } from "./packages";
 import type { C3Context } from "types";
 
@@ -406,14 +406,12 @@ export async function getWorkerdCompatibilityDate() {
 			} ${dim(compatDate)}`,
 		async promise() {
 			try {
-				const resp = await fetch("https://registry.npmjs.org/workerd");
-				const workerdNpmInfo = (await resp.json()) as {
-					"dist-tags": { latest: string };
-				};
-				const result = workerdNpmInfo["dist-tags"].latest;
+				const latestWorkerdVersion = await getLatestPackageVersion("workerd");
 
 				// The format of the workerd version is `major.yyyymmdd.patch`.
-				const match = result.match(/\d+\.(\d{4})(\d{2})(\d{2})\.\d+/);
+				const match = latestWorkerdVersion.match(
+					/\d+\.(\d{4})(\d{2})(\d{2})\.\d+/
+				);
 
 				if (match) {
 					const [, year, month, date] = match ?? [];

--- a/packages/create-cloudflare/src/helpers/latestPackageVersion.ts
+++ b/packages/create-cloudflare/src/helpers/latestPackageVersion.ts
@@ -1,0 +1,14 @@
+import { fetch } from "undici";
+
+type NpmInfoResponse = {
+	"dist-tags": { latest: string };
+};
+
+/**
+ * Get the latest version of an npm package by making a request to the npm REST API.
+ */
+export async function getLatestPackageVersion(packageSpecifier: string) {
+	const resp = await fetch(`https://registry.npmjs.org/${packageSpecifier}`);
+	const npmInfo = (await resp.json()) as NpmInfoResponse;
+	return npmInfo["dist-tags"].latest;
+}


### PR DESCRIPTION
When create-cloudflare starts up, it checks to see if the version being run is the latest available on npm.

**What this PR solves / how to test:**

Previously this check used `npm info` to look up the version. But was prone to failing if that command returned additional unexpected output such as warnings.

Now we make a fetch request to the npm REST API directly for the latest version, which does not have the problem of unexpected warnings.

Since the same approach is used to compute the latest version of workerd, the function to do this has been put into a helper.

Fixes #4729

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: no user facing change
