### PR TITLE
[wrangler] fix: ensure dev server doesn't change request URLs

### DIFF
--- a/.changeset/serious-lemons-carry.md
+++ b/.changeset/serious-lemons-carry.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: ensure dev server doesn't change request URLs
+
+Previously, Wrangler's dev server could change incoming request URLs unexpectedly (e.g. rewriting `http://localhost:8787//test` to `http://localhost:8787/test`). This change ensures URLs are passed through without modification.
+
+Fixes #4743.

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -18,6 +18,9 @@ export default {
 		const { pathname } = new URL(request.url);
 		if (pathname === "/random") return new Response(hexEncode(randomBytes(8)));
 		if (pathname === "/error") throw new Error("Oops!");
+		if (request.headers.get("X-Test-URL") !== null) {
+			return new Response(request.url);
+		}
 
 		console.log(
 			request.method,

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -78,7 +78,7 @@ describe("'wrangler dev' correctly renders pages", () => {
 	});
 
 	it("passes through URL unchanged", async ({ expect }) => {
-		const url = `http://${ip}:${port}//thing`;
+		const url = `http://${ip}:${port}//thing?a=1`;
 		const response = await fetch(url, {
 			headers: { "X-Test-URL": "true" },
 		});

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -76,4 +76,13 @@ describe("'wrangler dev' correctly renders pages", () => {
 		const text = await response.text();
 		expect(text).toMatch(/[0-9a-f]{16}/); // 8 hex bytes
 	});
+
+	it("passes through URL unchanged", async ({ expect }) => {
+		const url = `http://${ip}:${port}//thing`;
+		const response = await fetch(url, {
+			headers: { "X-Test-URL": "true" },
+		});
+		const text = await response.text();
+		expect(text).toBe(url);
+	});
 });

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -57,15 +57,6 @@ export class ProxyController extends EventEmitter {
 				? getHttpsOptions()
 				: undefined;
 
-		const compatibilityFlags: string[] = [
-			"nodejs_compat",
-			// Required to parse IPv6 hostnames correctly
-			"url_standard",
-			// Required to parse `DurableObjectStub#fetch()` URLs correctly,
-			// cause of https://github.com/cloudflare/workers-sdk/issues/4743
-			"durable_object_fetch_requires_full_url",
-		];
-
 		const proxyWorkerOptions: MiniflareOptions = {
 			host: this.latestConfig.dev?.server?.hostname,
 			port: this.latestConfig.dev?.server?.port,
@@ -76,7 +67,8 @@ export class ProxyController extends EventEmitter {
 			workers: [
 				{
 					name: "ProxyWorker",
-					compatibilityFlags,
+					compatibilityDate: "2023-12-18",
+					compatibilityFlags: ["nodejs_compat"],
 					modulesRoot: path.dirname(proxyWorkerPath),
 					modules: [{ type: "ESModule", path: proxyWorkerPath }],
 					durableObjects: {
@@ -105,7 +97,8 @@ export class ProxyController extends EventEmitter {
 				},
 				{
 					name: "InspectorProxyWorker",
-					compatibilityFlags,
+					compatibilityDate: "2023-12-18",
+					compatibilityFlags: ["nodejs_compat"],
 					modulesRoot: path.dirname(inspectorProxyWorkerPath),
 					modules: [{ type: "ESModule", path: inspectorProxyWorkerPath }],
 					durableObjects: {

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -57,6 +57,15 @@ export class ProxyController extends EventEmitter {
 				? getHttpsOptions()
 				: undefined;
 
+		const compatibilityFlags: string[] = [
+			"nodejs_compat",
+			// Required to parse IPv6 hostnames correctly
+			"url_standard",
+			// Required to parse `DurableObjectStub#fetch()` URLs correctly,
+			// cause of https://github.com/cloudflare/workers-sdk/issues/4743
+			"durable_object_fetch_requires_full_url",
+		];
+
 		const proxyWorkerOptions: MiniflareOptions = {
 			host: this.latestConfig.dev?.server?.hostname,
 			port: this.latestConfig.dev?.server?.port,
@@ -67,8 +76,7 @@ export class ProxyController extends EventEmitter {
 			workers: [
 				{
 					name: "ProxyWorker",
-					// `url_standard` required to parse IPv6 hostnames correctly
-					compatibilityFlags: ["nodejs_compat", "url_standard"],
+					compatibilityFlags,
 					modulesRoot: path.dirname(proxyWorkerPath),
 					modules: [{ type: "ESModule", path: proxyWorkerPath }],
 					durableObjects: {
@@ -97,8 +105,7 @@ export class ProxyController extends EventEmitter {
 				},
 				{
 					name: "InspectorProxyWorker",
-					// `url_standard` required to parse IPv6 hostnames correctly
-					compatibilityFlags: ["nodejs_compat", "url_standard"],
+					compatibilityFlags,
 					modulesRoot: path.dirname(inspectorProxyWorkerPath),
 					modules: [{ type: "ESModule", path: inspectorProxyWorkerPath }],
 					durableObjects: {


### PR DESCRIPTION
Fixes #4743.

**What this PR solves / how to test:**

This PR ensures URLs aren't modified when requests pass through Wrangler's proxy server. Specifically, it ensures this `DurableObjectStub#fetch()`...

https://github.com/cloudflare/workers-sdk/blob/54ea6a53bd1f222308135ed96bbb16a019302382/packages/wrangler/templates/startDevWorker/ProxyWorker.ts#L31

...preserves the URL, by enabling the `durable_object_fetch_requires_full_url` compatibility flag in the proxy workers. This flag disables `workerd`'s legacy behaviour of resolving this URL relative to `http://fake-host` and leaves the URL untouched. To test this, run `wrangler dev` against a worker that logs its incoming URL, e.g.

```js
export default {
  async fetch(request, env, ctx) {
    console.log(request.url);
    return new Response("body");
  }
}
```

...then run `curl http://localhost:8787//test`. You should see `http://localhost:8787//test` in the `wrangler dev` session's output, including the `//`.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a regression

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
