### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,17 +1,26 @@
 * @cloudflare/wrangler
 
+# Wrangler core ownership
 /packages/wrangler/CHANGELOG.md @cloudflare/wrangler-admins
 
+# Miniflare ownership
+/packages/miniflare/CHANGELOG.md @cloudflare/wrangler-admins
+
+# Pages ownership
 /packages/pages-shared/ @cloudflare/pages
+/packages/pages-shared/CHANGELOG.md @cloudflare/wrangler-admins
 /packages/wrangler/pages/ @cloudflare/pages @cloudflare/wrangler
 /packages/wrangler/src/api/pages/ @cloudflare/pages @cloudflare/wrangler
 /packages/wrangler/src/pages/ @cloudflare/pages @cloudflare/wrangler
 /packages/wrangler/src/__tests__/pages/ @cloudflare/pages @cloudflare/wrangler
 
+# D1 ownership
 /packages/wrangler/src/api/d1/ @cloudflare/d1 @cloudflare/wrangler
 /packages/wrangler/src/d1/ @cloudflare/d1 @cloudflare/wrangler
 
+# C3 ownership
 /packages/create-cloudflare/ @cloudflare/c3
+/packages/create-cloudflare/CHANGELOG.md @cloudflare/wrangler-admins
 
 # Owners intentionally left blank on these shared directories
 # to avoid noisy review requests


### PR DESCRIPTION
Fixes: N/A.

**What this PR solves / how to test:** Per internal discussion, we want to move towards an opt-out package release model to streamline `workers-sdk` releases. In this model, workers-sdk releases will be managed by the @cloudflare/wrangler and @cloudflare/wrangler-admins teams, and feature teams will need to explicitly opt-out of release. This PR is to update CODEOWNERS to reflect the proposed change.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: this is only a change to code ownership and there aren't tests associated with this
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: this is only a change to code ownership
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: this is only a change to code ownership

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
