### PR TITLE
test: add test for `--local-protocol=https`

### DIFF
--- a/fixtures/worker-app/tests/https.test.ts
+++ b/fixtures/worker-app/tests/https.test.ts
@@ -1,0 +1,33 @@
+import { resolve } from "path";
+import { Agent, fetch } from "undici";
+import { describe, it, beforeAll, afterAll } from "vitest";
+import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
+
+describe("'wrangler dev' starts HTTPS server", () => {
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
+
+	beforeAll(async () => {
+		({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
+			"--port=0",
+			"--inspector-port=0",
+			"--local-protocol=https",
+		]));
+	});
+
+	afterAll(async () => {
+		await stop?.();
+	});
+
+	it("allows access over HTTPS", async ({ expect }) => {
+		const dispatcher = new Agent({
+			// `wrangler dev` will generate a self-signed certificate. By default,
+			// Node will reject these. Therefore, we need to use a custom
+			// dispatcher that accepts "invalid" certificates.
+			connect: { rejectUnauthorized: false },
+		});
+		const response = await fetch(`https://${ip}:${port}/random`, {
+			dispatcher,
+		});
+		expect(response.ok).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #4644.

**What this PR solves / how to test:**

When triaging #4644, we realised we didn't have integration tests for the `--local-protocol` flag. It looks like this flag is working correctly, but having a test means we shouldn't need to worry about this breaking in the future. 🙂 

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: just adding a test to validate existing behaviour
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: just adding a test to validate existing behaviour

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
