### PR TITLE
fix no-non-null-assertion warnings coming the wrangler/src/cloudchamber

### DIFF
--- a/packages/eslint-config-worker/index.js
+++ b/packages/eslint-config-worker/index.js
@@ -55,6 +55,7 @@ module.exports = {
 				"@typescript-eslint/no-empty-function": "off",
 				"@typescript-eslint/no-explicit-any": "error",
 				"@typescript-eslint/no-floating-promises": "error",
+				"@typescript-eslint/no-non-null-assertion": "error",
 				"@typescript-eslint/no-unused-vars": "off",
 				"import/order": [
 					"error",

--- a/packages/wrangler/src/cloudchamber/cli/deployments.ts
+++ b/packages/wrangler/src/cloudchamber/cli/deployments.ts
@@ -137,6 +137,7 @@ export async function listDeploymentsAndChoose(
 		})),
 		label: "deployment",
 	});
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	return deployments.find((d) => d.id === deployment)!;
 }
 

--- a/packages/wrangler/src/cloudchamber/cli/index.ts
+++ b/packages/wrangler/src/cloudchamber/cli/index.ts
@@ -266,7 +266,7 @@ async function waitForPlacementInstance(deployment: DeploymentV2) {
 			}
 
 			return (
-				newDeployment.current_placement.id !== deployment.current_placement!.id
+				newDeployment.current_placement.id !== deployment.current_placement?.id
 			);
 		})
 	);
@@ -283,11 +283,13 @@ async function waitForPlacementInstance(deployment: DeploymentV2) {
 	updateStatus(
 		"Assigned placement in " + idToLocationName(deployment.location.name)
 	);
-	log(
-		`${brandColor("assigned placement")} ${dim(
-			`version ${d.current_placement!.deployment_version}`
-		)}\n`
-	);
+	if (d.current_placement?.deployment_version) {
+		log(
+			`${brandColor("assigned placement")} ${dim(
+				`version ${d.current_placement.deployment_version}`
+			)}\n`
+		);
+	}
 	deployment.current_placement = d.current_placement;
 }
 

--- a/packages/wrangler/src/cloudchamber/cli/locations.ts
+++ b/packages/wrangler/src/cloudchamber/cli/locations.ts
@@ -100,6 +100,7 @@ export async function getLocation(
 
 	const pops = locationToPops[location];
 	if (pops.length === 1) {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		return pops.pop()!.location;
 	}
 

--- a/packages/wrangler/src/cloudchamber/ssh/ssh.ts
+++ b/packages/wrangler/src/cloudchamber/ssh/ssh.ts
@@ -185,8 +185,8 @@ async function tryToRetrieveAllDefaultSSHKeyPaths(): Promise<string[]> {
  */
 async function tryToRetrieveADefaultPath(): Promise<string> {
 	const paths = await tryToRetrieveAllDefaultSSHKeyPaths();
-	if (paths.length === 0) return "";
-	return paths.pop()!;
+	const path = paths.pop();
+	return path ?? "";
 }
 
 /**


### PR DESCRIPTION
In all PRs we're getting this no-non-null-assertion warnings from cloudchamber, so I figured I could create a quick PR to clean them up

I'm also changing the rule to error so that we avoid these type of warnings (we already went through something like this with @1000hz, I think I remember we agreed on not using eslint warnings since they can indeed create unnecessary noise) (https://github.com/cloudflare/workers-sdk/pull/3833)