### PR TITLE
refactor(pages-shared): Store asset key instead of body in preservation cache

### DIFF
--- a/.changeset/fifty-owls-study.md
+++ b/.changeset/fifty-owls-study.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/pages-shared": patch
+---
+
+refactor: Store asset key instead of body in preservation cache
+
+- Add HTTP method to cache key to prevent returning null bodies in cached GET requests that follow a HEAD request
+- Only write unchanged assets to preservation cache every 24-36 hours instead of on every request


### PR DESCRIPTION
Fixes # BANDAOPS-41

**What this PR solves / how to test:**

Stores assetKey in preservation cache rather than the actual asset so that we don't write rarely used bytes to cache. Also now only writes to cache once rather than on every request.

Tested in RC and ensured preservation cache still serves correctly

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

