### PR TITLE
[prerelease-registry]: add extra info to all 404s to differentiate 

### DIFF
--- a/packages/prerelease-registry/functions/routes/[repo]/prs/[[path]].ts
+++ b/packages/prerelease-registry/functions/routes/[repo]/prs/[[path]].ts
@@ -21,13 +21,15 @@ export const onRequestGet: PagesFunction<
 	const { repo, path } = params;
 
 	if (!Array.isArray(path) || !repos.includes(repo as string)) {
-		return new Response(null, { status: 404 });
+		return new Response(`path: "${path}", repo: "${repo}"`, { status: 404 });
 	}
 
 	const pullRequestID = parseInt(path[0]);
 	const name = path[1];
 	if (isNaN(pullRequestID) || name === undefined)
-		return new Response(null, { status: 404 });
+		return new Response(`pullRequestID: "${pullRequestID}", name: "${name}"`, {
+			status: 404,
+		});
 
 	const gitHubFetch = generateGitHubFetch(env);
 
@@ -45,7 +47,10 @@ export const onRequestGet: PagesFunction<
 				return new Response(null, { status: 502 });
 			}
 
-			return new Response(null, { status: 404 });
+			return new Response(
+				`pullRequestsResponse.ok: "${pullRequestsResponse.ok}"`,
+				{ status: 404 }
+			);
 		}
 
 		const {
@@ -65,7 +70,10 @@ export const onRequestGet: PagesFunction<
 				return new Response(null, { status: 502 });
 			}
 
-			return new Response(null, { status: 404 });
+			return new Response(
+				`workflowRunsResponse.ok: "${workflowRunsResponse.ok}"`,
+				{ status: 404 }
+			);
 		}
 
 		const { workflow_runs: workflowRuns } =
@@ -78,7 +86,8 @@ export const onRequestGet: PagesFunction<
 				workflowRunCandidate.head_sha === sha &&
 				workflowRunCandidate.workflow_id === WORKFLOW_ID
 		);
-		if (workflowRun === undefined) return new Response(null, { status: 404 });
+		if (workflowRun === undefined)
+			return new Response("workflowRun === undefined", { status: 404 });
 
 		return getArtifactForWorkflowRun({
 			repo: repo as string,

--- a/packages/prerelease-registry/functions/routes/[repo]/runs/[[path]].ts
+++ b/packages/prerelease-registry/functions/routes/[repo]/runs/[[path]].ts
@@ -9,13 +9,13 @@ export const onRequestGet: PagesFunction<
 	const { repo, path } = params;
 
 	if (!Array.isArray(path) || !repos.includes(repo as string)) {
-		return new Response(null, { status: 404 });
+		return new Response(`path: "${path}", repo: "${repo}"`, { status: 404 });
 	}
 
 	const runID = parseInt(path[0]);
 	const name = path[1];
 	if (isNaN(runID) || name === undefined)
-		return new Response(null, { status: 404 });
+		return new Response(`runID: "${runID}", name: "${name}"`, { status: 404 });
 
 	const gitHubFetch = generateGitHubFetch(env);
 


### PR DESCRIPTION
Adding extra info to the response body when returning a 404 to aid debugging #4804.

**What this PR solves / how to test:**

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: does not affect our end-user products
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: does not affect our end-user products
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: does not affect our end-user products

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
