### PR TITLE
[prerelease-registry]: add in-scope vars to all 404s to differentiate…

### DIFF
--- a/packages/prerelease-registry/functions/routes/[repo]/prs/[[path]].ts
+++ b/packages/prerelease-registry/functions/routes/[repo]/prs/[[path]].ts
@@ -27,7 +27,7 @@ export const onRequestGet: PagesFunction<
 	const pullRequestID = parseInt(path[0]);
 	const name = path[1];
 	if (isNaN(pullRequestID) || name === undefined)
-		return new Response(`pullRequestID: "${pullRequestID}", name: "${name}"`, {
+		return new Response(`pullRequestID: ${pullRequestID}, name: "${name}"`, {
 			status: 404,
 		});
 
@@ -48,7 +48,7 @@ export const onRequestGet: PagesFunction<
 			}
 
 			return new Response(
-				`pullRequestsResponse.ok: "${pullRequestsResponse.ok}"`,
+				`pullRequestsResponse.ok: ${pullRequestsResponse.ok}, pullRequestsResponse.status: ${pullRequestsResponse.status}, repo: "${repo}", pullRequestID: ${pullRequestID}`,
 				{ status: 404 }
 			);
 		}
@@ -71,7 +71,7 @@ export const onRequestGet: PagesFunction<
 			}
 
 			return new Response(
-				`workflowRunsResponse.ok: "${workflowRunsResponse.ok}"`,
+				`workflowRunsResponse.ok: ${workflowRunsResponse.ok}, workflowRunsResponse.status: ${workflowRunsResponse.status}, repo: "${repo}", branch: "${branch}"`,
 				{ status: 404 }
 			);
 		}
@@ -87,7 +87,9 @@ export const onRequestGet: PagesFunction<
 				workflowRunCandidate.workflow_id === WORKFLOW_ID
 		);
 		if (workflowRun === undefined)
-			return new Response("workflowRun === undefined", { status: 404 });
+			return new Response(`workflowRun === undefined, sha: "${sha}"`, {
+				status: 404,
+			});
 
 		return getArtifactForWorkflowRun({
 			repo: repo as string,
@@ -97,6 +99,6 @@ export const onRequestGet: PagesFunction<
 			waitUntil,
 		});
 	} catch (thrown) {
-		return new Response(null, { status: 500 });
+		return new Response(String(thrown), { status: 500 });
 	}
 };


### PR DESCRIPTION
Adding extra info to the response body when returning a 404 to aid debugging #4804.

This adds more to what was added in #4806 – the vars that were in-scope of the condition that caused the 404 response

**What this PR solves / how to test:**

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: does not affect our end-user products
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: does not affect our end-user products
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: does not affect our end-user products

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
