### PR TITLE
[prerelease-registry]: add in-scope vars to more 404s to differentiat…

### DIFF
--- a/packages/prerelease-registry/functions/utils/getArtifactForWorkflowRun.ts
+++ b/packages/prerelease-registry/functions/utils/getArtifactForWorkflowRun.ts
@@ -38,10 +38,16 @@ export const getArtifactForWorkflowRun = async ({
 		);
 		if (!artifactsResponse.ok) {
 			if (artifactsResponse.status >= 500) {
-				return new Response(null, { status: 502 });
+				return new Response(
+					`artifactsResponse.status: ${artifactsResponse.status}, repo: "${repo}", runID: ${runID}`,
+					{ status: 502 }
+				);
 			}
 
-			return new Response(null, { status: 404 });
+			return new Response(
+				`artifactsResponse.status: ${artifactsResponse.status}, repo: "${repo}", runID: ${runID}`,
+				{ status: 404 }
+			);
 		}
 
 		const { artifacts } = (await artifactsResponse.json()) as {
@@ -51,15 +57,27 @@ export const getArtifactForWorkflowRun = async ({
 		const artifact = artifacts.find(
 			(artifactCandidate) => artifactCandidate.name === name
 		);
-		if (artifact === undefined) return new Response(null, { status: 404 });
+		if (artifact === undefined)
+			return new Response(
+				`artifact === undefined, name: "${name}", artifacts.length: ${artifacts.length}`,
+				{
+					status: 404,
+				}
+			);
 
 		const zipResponse = await gitHubFetch(artifact.archive_download_url);
 		if (!zipResponse.ok) {
 			if (zipResponse.status >= 500) {
-				return new Response(null, { status: 502 });
+				return new Response(
+					`zipResponse.status: ${zipResponse.status}, artifact.archive_download_url: "${artifact.archive_download_url}"`,
+					{ status: 502 }
+				);
 			}
 
-			return new Response(null, { status: 404 });
+			return new Response(
+				`zipResponse.status: ${zipResponse.status}, artifact.archive_download_url: "${artifact.archive_download_url}"`,
+				{ status: 404 }
+			);
 		}
 
 		const zip = new JSZip();
@@ -68,7 +86,8 @@ export const getArtifactForWorkflowRun = async ({
 		const files = zip.files;
 		const fileNames = Object.keys(files);
 		const tgzFileName = fileNames.find((fileName) => fileName.endsWith(".tgz"));
-		if (tgzFileName === undefined) return new Response(null, { status: 404 });
+		if (tgzFileName === undefined)
+			return new Response(`fileNames: ${fileNames}`, { status: 404 });
 
 		const tgzBlob = await files[tgzFileName].async("blob");
 		const response = new Response(tgzBlob, {
@@ -79,6 +98,6 @@ export const getArtifactForWorkflowRun = async ({
 
 		return response;
 	} catch (thrown) {
-		return new Response(null, { status: 500 });
+		return new Response(String(thrown), { status: 500 });
 	}
 };


### PR DESCRIPTION
3rd time lucky...

Adding extra info to the response body when returning a 404 to aid debugging #4804.

**What this PR solves / how to test:**

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: does not affect our end-user products
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: does not affect our end-user products
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: does not affect our end-user products

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
