### PR TITLE
Fix typos in CORS headers for edge-preview workers

### DIFF
--- a/packages/edge-preview-authenticated-proxy/src/index.ts
+++ b/packages/edge-preview-authenticated-proxy/src/index.ts
@@ -22,7 +22,7 @@ class HttpError extends Error {
 				status: this.status,
 				headers: {
 					"Access-Control-Allow-Origin": "*",
-					"Access-Control-Allow-Method": "GET,PUT,POST",
+					"Access-Control-Allow-Methods": "GET,PUT,POST",
 				},
 			}
 		);
@@ -170,7 +170,7 @@ async function handleRawHttp(request: Request, url: URL) {
 		return new Response(null, {
 			headers: {
 				"Access-Control-Allow-Origin": request.headers.get("Origin") ?? "",
-				"Access-Control-Allow-Method": "*",
+				"Access-Control-Allow-Methods": "*",
 				"Access-Control-Allow-Credentials": "true",
 				"Access-Control-Allow-Headers":
 					request.headers.get("Access-Control-Request-Headers") ??
@@ -218,7 +218,7 @@ async function handleRawHttp(request: Request, url: URL) {
 		headers: {
 			...rawHeaders,
 			"Access-Control-Allow-Origin": request.headers.get("Origin") ?? "",
-			"Access-Control-Allow-Method": "*",
+			"Access-Control-Allow-Methods": "*",
 			"Access-Control-Allow-Credentials": "true",
 			"cf-ew-status": workerResponse.status.toString(),
 			"Access-Control-Expose-Headers": "*",
@@ -328,7 +328,7 @@ async function handleTokenExchange(url: URL) {
 	return Response.json(session, {
 		headers: {
 			"Access-Control-Allow-Origin": "*",
-			"Access-Control-Allow-Method": "POST",
+			"Access-Control-Allow-Methods": "POST",
 		},
 	});
 }

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -293,4 +293,19 @@ describe("Raw HTTP preview", () => {
 
 		expect(resp.headers.get("Access-Control-Allow-Headers")).toBe("foo");
 	});
+
+	it("should allow arbitrary methods in cross-origin requests", async () => {
+		const resp = await worker.fetch(
+			`https://0000.rawhttp.devprod.cloudflare.dev`,
+			{
+				method: "OPTIONS",
+				headers: {
+					"Access-Control-Request-Method": "PUT",
+					origin: "https://cloudflare.dev",
+				},
+			}
+		);
+
+		expect(resp.headers.get("Access-Control-Allow-Methods")).toBe("*");
+	});
 });

--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -39,7 +39,7 @@ export class HttpError extends Error {
 				status: this.status,
 				headers: {
 					"Access-Control-Allow-Origin": "*",
-					"Access-Control-Allow-Method": "GET,PUT,POST",
+					"Access-Control-Allow-Methods": "GET,PUT,POST",
 				},
 			}
 		);
@@ -174,7 +174,7 @@ async function handleRawHttp(request: Request, url: URL, env: Env) {
 		headers: {
 			...rawHeaders,
 			"Access-Control-Allow-Origin": request.headers.get("Origin") ?? "",
-			"Access-Control-Allow-Method": "*",
+			"Access-Control-Allow-Methods": "*",
 			"Access-Control-Allow-Credentials": "true",
 			"cf-ew-status": workerResponse.status.toString(),
 			"Access-Control-Expose-Headers": "*",
@@ -321,7 +321,7 @@ app.all(`${previewDomain}/*`, async (c) => {
 		return new Response(null, {
 			headers: {
 				"Access-Control-Allow-Origin": c.req.headers.get("Origin") ?? "",
-				"Access-Control-Allow-Method": "*",
+				"Access-Control-Allow-Methods": "*",
 				"Access-Control-Allow-Credentials": "true",
 				"Access-Control-Allow-Headers":
 					c.req.headers.get("Access-Control-Request-Headers") ?? "x-cf-token",

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -175,4 +175,17 @@ describe("Raw HTTP preview", () => {
 
 		expect(resp.headers.get("Access-Control-Allow-Headers")).toBe("foo");
 	});
+
+	it("should allow arbitrary methods in cross-origin requests", async () => {
+		const resp = await fetch(PREVIEW_REMOTE, {
+			method: "OPTIONS",
+			headers: {
+				"Access-Control-Request-Method": "PUT",
+				origin: "https://cloudflare.dev",
+				"cf-raw-http": "true",
+			},
+		});
+
+		expect(resp.headers.get("Access-Control-Allow-Methods")).toBe("*");
+	});
 });


### PR DESCRIPTION
**What this PR solves / how to test:**

This fixes an issue that caused requests made in the HTTP tab of Quick Editor and Playground to get blocked by CORS errors if they used a method other than GET or POST. We had inadvertently been sending the incorrect CORS header (singular `Access-Control-Allow-Method` instead of [`Access-Control-Allow-Methods`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods)).

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: No changelogs for affected packages
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: N/A

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
