### PR TITLE
cloudchamber: add internal module insertion

### DIFF
--- a/.changeset/tender-owls-wink.md
+++ b/.changeset/tender-owls-wink.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Cloudchamber command shows json error message on load account if --json specified
+
+If the user specifies a json option, we should see a more detailed error on why `loadAccount` failed.

--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ dist
 wrangler-dist/
 miniflare-dist
 packages/wrangler/wrangler.toml
+packages/wrangler/src/cloudchamber/internal
 packages/prerelease-registry/_worker.bundle
 packages/wranglerjs-compat-webpack-plugin/lib
 .wrangler-1-cache

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,9 @@
 /packages/wrangler/src/api/d1/ @cloudflare/d1 @cloudflare/wrangler
 /packages/wrangler/src/d1/ @cloudflare/d1 @cloudflare/wrangler
 
+# Cloudchamber ownership
+/packages/wrangler/src/cloudchamber/ @cloudflare/cloudchamber @cloudflare/wrangler
+
 # C3 ownership
 /packages/create-cloudflare/ @cloudflare/c3
 

--- a/packages/wrangler/src/cloudchamber/client/core/OpenAPI.ts
+++ b/packages/wrangler/src/cloudchamber/client/core/OpenAPI.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import { Agent } from "undici";
 import type { ApiRequestOptions } from "./ApiRequestOptions";
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
@@ -16,10 +17,11 @@ export type OpenAPIConfig = {
 	PASSWORD?: string | Resolver<string>;
 	HEADERS?: Headers | Resolver<Headers>;
 	ENCODE_PATH?: (path: string) => string;
+	AGENT?: Agent;
 };
 
 export const OpenAPI: OpenAPIConfig = {
-	BASE: "https://api.cloudflare.com/client/v4/accounts/<account-tag>/cloudchamber",
+	BASE: "",
 	VERSION: "1.0.0",
 	WITH_CREDENTIALS: false,
 	CREDENTIALS: "include",

--- a/packages/wrangler/src/cloudchamber/client/core/request.ts
+++ b/packages/wrangler/src/cloudchamber/client/core/request.ts
@@ -4,10 +4,10 @@
 import { fetch, FormData, Headers, RequestInit, Response } from "undici";
 import { ApiError } from "./ApiError";
 import { CancelablePromise } from "./CancelablePromise";
+import { type OpenAPIConfig } from "./OpenAPI";
 import type { ApiRequestOptions } from "./ApiRequestOptions";
 import type { ApiResult } from "./ApiResult";
 import type { OnCancel } from "./CancelablePromise";
-import type { OpenAPIConfig } from "./OpenAPI";
 
 const isDefined = <T>(
 	value: T | null | undefined
@@ -213,6 +213,7 @@ export const sendRequest = async (
 		body: body ?? formData,
 		method: options.method,
 		signal: controller.signal,
+		dispatcher: config.AGENT ?? undefined,
 	};
 
 	if (config.WITH_CREDENTIALS) {

--- a/packages/wrangler/src/cloudchamber/index.ts
+++ b/packages/wrangler/src/cloudchamber/index.ts
@@ -8,10 +8,22 @@ import { sshCommand } from "./ssh/ssh";
 import type { CommonYargsArgvJSON, CommonYargsOptions } from "../yargs-types";
 import type { CommandModule } from "yargs";
 
+function internalCommands(args: CommonYargsArgvJSON) {
+	try {
+		// Add dynamically an internal module that we can attach internal commands
+		// eslint-disable-next-line @typescript-eslint/no-var-requires
+		const cloudchamberInternalRequireEntry = require("./internal/index");
+		return cloudchamberInternalRequireEntry.internalCommands(args);
+	} catch {
+		return args;
+	}
+}
+
 export const cloudchamber = (
 	yargs: CommonYargsArgvJSON,
 	subHelp: CommandModule<CommonYargsOptions, CommonYargsOptions>
 ) => {
+	yargs = internalCommands(yargs);
 	return yargs
 		.command(
 			"delete [deploymentId]",


### PR DESCRIPTION
**What this PR solves / how to test:**
We like to use wrangler for internal usage of the Cloudchamber API and we would like to have a "dynamic" way of inserting internal CC commands into `wrangler cloudchamber`.

Let us know if this is a good way to do it; I personally like this solution as it adds a way for us to insert internal modules without us patching Wrangler or maintaining a fork.

- Tests
  - [ ] Included
  - [x] Not necessary because: It's already tested on compile time and by running a single cloudchamber command.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [] Not necessary because: doesn't affect in any way users.
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: it's for enabling internal use-cases.

I'm also adding CODEOWNERS for Cloudchamber and a few nits that we found like adding a https undici Agent in the OpenAPI's fetch. 
