### PR TITLE
[prerelease-registry]: add failed response.text to response to help diagnose why 403s are returned

### DIFF
--- a/packages/prerelease-registry/functions/routes/[repo]/runs/[[path]].ts
+++ b/packages/prerelease-registry/functions/routes/[repo]/runs/[[path]].ts
@@ -9,13 +9,13 @@ export const onRequestGet: PagesFunction<
 	const { repo, path } = params;
 
 	if (!Array.isArray(path) || !repos.includes(repo as string)) {
-		return new Response(`path: "${path}", repo: "${repo}"`, { status: 404 });
+		return Response.json({ path, repo }, { status: 404 });
 	}
 
 	const runID = parseInt(path[0]);
 	const name = path[1];
 	if (isNaN(runID) || name === undefined)
-		return new Response(`runID: "${runID}", name: "${name}"`, { status: 404 });
+		return Response.json({ path, runID, name }, { status: 404 });
 
 	const gitHubFetch = generateGitHubFetch(env);
 


### PR DESCRIPTION
4th and hopefully final time... This time just adding `response.text()` to the data returned but decided to respond with JSON since it was getting a bit long returning strings

Adding extra info to the response body when returning a 404 to aid debugging #4804.

**What this PR solves / how to test:**

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: does not affect our end-user products
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: does not affect our end-user products
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: does not affect our end-user products

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
