### PR TITLE
fix: ensure that Origin header is rewritten as necessary

### DIFF
--- a/.changeset/selfish-starfishes-cry.md
+++ b/.changeset/selfish-starfishes-cry.md
@@ -1,0 +1,17 @@
+---
+"miniflare": patch
+---
+
+fix: ensure that Origin header is rewritten as necessary
+
+The `wrangler dev` command puts the Worker under test behind a proxy server.
+This proxy server should be transparent to the client and the Worker, which
+means that the `Request` arriving at the Worker with the correct `url` property,
+and `Host` and `Origin` headers.
+Previously we fixed the `Host` header but missed the `Origin` header which is
+only added to a request under certain circumstances, such as cross-origin requests.
+
+This change fixes the `Origin` header as well, so that it is rewritten, when it exists,
+to use the `origin` of the `url` property.
+
+Fixes #4761

--- a/fixtures/pages-d1-shim/tests/index.test.ts
+++ b/fixtures/pages-d1-shim/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "child_process";
-import { readFileSync } from "fs";
+import { mkdtempSync, readFileSync, realpathSync } from "fs";
 import { tmpdir } from "os";
 import * as path from "path";
 import { join } from "path";
@@ -9,8 +9,10 @@ describe("Pages D1 shim", () => {
 	it("builds functions with D1 binding, without the shim", async ({
 		expect,
 	}) => {
-		const dir = tmpdir();
-		const file = join(dir, "./d1-pages.js");
+		const tempDir = realpathSync(
+			mkdtempSync(join(tmpdir(), "pages-d1-shim-tests"))
+		);
+		const file = join(tempDir, "./d1-pages.js");
 
 		execSync(
 			`npx wrangler pages functions build --outfile ${file} --bindings="{\\"d1_databases\\":{\\"FOO\\":{}}}"`,

--- a/fixtures/pages-workerjs-directory/tests/index.test.ts
+++ b/fixtures/pages-workerjs-directory/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path, { join, resolve } from "node:path";
 import { fetch } from "undici";
@@ -8,7 +8,9 @@ import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages _worker.js/ directory", () => {
 	it("should support non-bundling with 'dev'", async ({ expect }) => {
-		const tmpDir = join(tmpdir(), Math.random().toString(36).slice(2));
+		const tmpDir = realpathSync(
+			mkdtempSync(join(tmpdir(), "worker-directory-tests"))
+		);
 
 		const { ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
@@ -67,8 +69,10 @@ describe("Pages _worker.js/ directory", () => {
 	});
 
 	it("should bundle", async ({ expect }) => {
-		const dir = tmpdir();
-		const file = join(dir, "_worker.bundle");
+		const tempDir = realpathSync(
+			mkdtempSync(join(tmpdir(), "worker-bundle-tests"))
+		);
+		const file = join(tempDir, "_worker.bundle");
 
 		execSync(
 			`npx wrangler pages functions build --build-output-directory public --outfile ${file} --bindings="{\\"d1_databases\\":{\\"D1\\":{}}}"`,

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -36,7 +36,9 @@ export default {
 
 		console.log("end of request");
 		return new Response(
-			`${request.url} ${now()} ${request.headers.get("Host")}`
+			`${request.url} ${now()} HOST:${request.headers.get(
+				"Host"
+			)} ORIGIN:${request.headers.get("Origin")}`
 		);
 	},
 

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -45,8 +45,7 @@ function getUserRequest(
 	const originalUrl = request.headers.get(CoreHeaders.ORIGINAL_URL);
 	let url = new URL(originalUrl ?? request.url);
 
-	// The `upstreamHost` is used to override the `Host` header on the request being handled.
-	let upstreamHost: string | undefined;
+	let rewriteHeadersFromOriginalUrl = false;
 
 	// If the request is signed by a proxy server then we can use the Host and Origin from the ORIGINAL_URL.
 	// The shared secret is required to prevent a malicious user being able to change the headers without permission.
@@ -60,7 +59,7 @@ function getUserRequest(
 			secretFromHeader.byteLength === configuredSecret?.byteLength &&
 			crypto.subtle.timingSafeEqual(secretFromHeader, configuredSecret)
 		) {
-			upstreamHost = url.host;
+			rewriteHeadersFromOriginalUrl = true;
 		} else {
 			throw new HttpError(
 				400,
@@ -77,7 +76,7 @@ function getUserRequest(
 		// Remove leading slash, so we resolve relative to `upstream`'s path
 		if (path.startsWith("/")) path = `./${path.substring(1)}`;
 		url = new URL(path, upstreamUrl);
-		upstreamHost = url.host;
+		rewriteHeadersFromOriginalUrl = true;
 	}
 
 	// Note when constructing new `Request`s from `request`, we must always pass
@@ -92,14 +91,15 @@ function getUserRequest(
 	if (request.cf === undefined) {
 		request = new Request(request, { cf: env[CoreBindings.JSON_CF_BLOB] });
 	}
-	if (upstreamHost !== undefined) {
-		request.headers.set("Host", upstreamHost);
+
+	if (rewriteHeadersFromOriginalUrl) {
+		request.headers.set("Host", url.host);
+		// Only rewrite Origin header if there is already one
 		if (request.headers.has("Origin")) {
-			// The request contained an Origin header, so replace with a rewritten one based on the original URL
-			request.headers.delete('Origin');
 			request.headers.set('Origin', url.origin);
 		}
 	}
+
 	request.headers.delete(CoreHeaders.PROXY_SHARED_SECRET);
 	request.headers.delete(CoreHeaders.ORIGINAL_URL);
 	request.headers.delete(CoreHeaders.DISABLE_PRETTY_ERROR);

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -96,7 +96,7 @@ function getUserRequest(
 		request.headers.set("Host", url.host);
 		// Only rewrite Origin header if there is already one
 		if (request.headers.has("Origin")) {
-			request.headers.set('Origin', url.origin);
+			request.headers.set("Origin", url.origin);
 		}
 	}
 

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -48,8 +48,8 @@ function getUserRequest(
 	// The `upstreamHost` is used to override the `Host` header on the request being handled.
 	let upstreamHost: string | undefined;
 
-	// If the request is signed by an upstream proxy then we can use the one from the ORIGINAL_URL.
-	// The shared secret is required to prevent a malicious user being able to change the host header without permission.
+	// If the request is signed by a proxy server then we can use the Host and Origin from the ORIGINAL_URL.
+	// The shared secret is required to prevent a malicious user being able to change the headers without permission.
 	const proxySharedSecret = request.headers.get(
 		CoreHeaders.PROXY_SHARED_SECRET
 	);
@@ -94,6 +94,11 @@ function getUserRequest(
 	}
 	if (upstreamHost !== undefined) {
 		request.headers.set("Host", upstreamHost);
+		if (request.headers.has("Origin")) {
+			// The request contained an Origin header, so replace with a rewritten one based on the original URL
+			request.headers.delete('Origin');
+			request.headers.set('Origin', url.origin);
+		}
 	}
 	request.headers.delete(CoreHeaders.PROXY_SHARED_SECRET);
 	request.headers.delete(CoreHeaders.ORIGINAL_URL);


### PR DESCRIPTION
The `wrangler dev` command puts the Worker under test behind a proxy server. This proxy server should be transparent to the client and the Worker, which means that the `Request` arriving at the Worker with the correct `url` property, and `Host` and `Origin` headers.

Previously we fixed the `Host` header but missed the `Origin` header which is only added to a request under certain circumstances, such as cross-origin requests.

**What this PR solves / how to test:**

This change fixes the `Origin` header as well, so that it is rewritten, when it exists, to use the `origin` of the `url` property.

A nice way to test this is to simply clone the reproduction from #4761 - https://github.com/Le0Developer/wrangler-host-header-repro, then replace the local Miniflare with the pre-release one from this PR.

Fixes #4761 

**Author has addressed the following:**

- Tests
  - [x] Included (updated worker-app fixture tests)
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: no user facing change
