### PR TITLE
fix: pages-shared: Only apply early hints to html assets

### DIFF
--- a/.changeset/silly-llamas-flow.md
+++ b/.changeset/silly-llamas-flow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/pages-shared": patch
+---
+
+fix(pages-shared): Only apply early hints to html assets

--- a/.changeset/silly-llamas-flow.md
+++ b/.changeset/silly-llamas-flow.md
@@ -2,4 +2,4 @@
 "@cloudflare/pages-shared": patch
 ---
 
-fix(pages-shared): Only apply early hints to html assets
+fix: Only apply early hints to html assets

--- a/packages/pages-shared/__tests__/asset-server/handler.test.ts
+++ b/packages/pages-shared/__tests__/asset-server/handler.test.ts
@@ -513,7 +513,7 @@ describe("asset-server handler", () => {
 		}
 
 		expect(earlyHintsRes.headers.get("link")).toMatchInlineSnapshot(
-			`"</a.png>; rel=\\"preload\\"; as=image, </b.png>; rel=\\"preload\\"; as=image"`
+			`"</a.png>; rel="preload"; as=image, </b.png>; rel="preload"; as=image"`
 		);
 
 		// Do it again, but this time ensure that we didn't write to cache again
@@ -534,7 +534,7 @@ describe("asset-server handler", () => {
 		}
 
 		expect(earlyHintsRes2.headers.get("link")).toMatchInlineSnapshot(
-			`"</a.png>; rel=\\"preload\\"; as=image, </b.png>; rel=\\"preload\\"; as=image"`
+			`"</a.png>; rel="preload"; as=image, </b.png>; rel="preload"; as=image"`
 		);
 	});
 });

--- a/packages/pages-shared/__tests__/asset-server/rulesEngine.test.ts
+++ b/packages/pages-shared/__tests__/asset-server/rulesEngine.test.ts
@@ -4,8 +4,12 @@ import { generateRulesMatcher, replacer } from "../../asset-server/rulesEngine";
 describe("rules engine", () => {
 	test("it should match simple pathname hosts", () => {
 		const matcher = generateRulesMatcher({ "/test": 1, "/some%20page": 2 });
-		expect(matcher({ request: new Request("/test") })).toEqual([1]);
-		expect(matcher({ request: new Request("/some page") })).toEqual([2]);
+		expect(
+			matcher({ request: new Request("https://example.com/test") })
+		).toEqual([1]);
+		expect(
+			matcher({ request: new Request("https://example.com/some page") })
+		).toEqual([2]);
 	});
 
 	test("it should match cross-host requests", () => {
@@ -36,7 +40,9 @@ describe("rules engine", () => {
 			"/$~.%20/!+-/[bo|%7Bo%7D]...()": 1,
 		});
 		expect(
-			matcher({ request: new Request("/$~. \\!+-/[bo|{o}]...()") })
+			matcher({
+				request: new Request("https://example.com/$~. \\!+-/[bo|{o}]...()"),
+			})
 		).toEqual([1]);
 	});
 
@@ -52,21 +58,24 @@ describe("rules engine", () => {
 			},
 			(match, replacements) => replacer(match, replacements)
 		);
-		expect(matcher({ request: new Request("/foo/test/yes") })).toEqual([
-			"1/yes",
-			"2/test/yes",
-		]);
-		expect(matcher({ request: new Request("/foo/test/") })).toEqual([
-			"1/",
-			"2/test/",
-		]);
-		expect(matcher({ request: new Request("/foo/test") })).toEqual(["2/test"]);
-		expect(matcher({ request: new Request("/foo/") })).toEqual(["2/"]);
-		expect(matcher({ request: new Request("/foo") })).toEqual([]);
-		expect(matcher({ request: new Request("/blog/123/tricycle") })).toEqual([
-			"3/tricycle/123",
-			"4/123/tricycle",
-		]);
+		expect(
+			matcher({ request: new Request("https://example.com/foo/test/yes") })
+		).toEqual(["1/yes", "2/test/yes"]);
+		expect(
+			matcher({ request: new Request("https://example.com/foo/test/") })
+		).toEqual(["1/", "2/test/"]);
+		expect(
+			matcher({ request: new Request("https://example.com/foo/test") })
+		).toEqual(["2/test"]);
+		expect(
+			matcher({ request: new Request("https://example.com/foo/") })
+		).toEqual(["2/"]);
+		expect(
+			matcher({ request: new Request("https://example.com/foo") })
+		).toEqual([]);
+		expect(
+			matcher({ request: new Request("https://example.com/blog/123/tricycle") })
+		).toEqual(["3/tricycle/123", "4/123/tricycle"]);
 		expect(
 			matcher({ request: new Request("https://my.pages.dev/magic") })
 		).toEqual(["5/my/dev/magic"]);

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -667,5 +667,5 @@ function isPreview(url: URL): boolean {
  * Content-Type header
  */
 function isHTMLContentType(contentType?: string | null) {
-	return contentType?.startsWith("text/html") || false;
+	return contentType?.toLowerCase().startsWith("text/html") || false;
 }

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -328,7 +328,10 @@ export async function generateHandler<
 			...Object.fromEntries(extraHeaders.entries()),
 		});
 
-		if (earlyHintsCache) {
+		if (
+			earlyHintsCache &&
+			isHTMLContentType(response.headers.get("Content-Type"))
+		) {
 			const preEarlyHintsHeaders = new Headers(headers);
 
 			// "Early Hints cache entries are keyed by request URI and ignore query strings."
@@ -347,65 +350,70 @@ export async function generateHandler<
 				}
 			} else {
 				if (setMetrics) setMetrics({ earlyHintsResult: "notused-miss" });
-			}
 
-			const clonedResponse = response.clone();
+				const clonedResponse = response.clone();
 
-			if (waitUntil) {
-				waitUntil(
-					(async () => {
-						try {
-							const links: { href: string; rel: string; as?: string }[] = [];
+				if (waitUntil) {
+					waitUntil(
+						(async () => {
+							try {
+								const links: { href: string; rel: string; as?: string }[] = [];
 
-							const transformedResponse = new HTMLRewriter()
-								.on("link[rel~=preconnect],link[rel~=preload]", {
-									element(element) {
-										for (const [attributeName] of element.attributes) {
-											if (
-												!ALLOWED_EARLY_HINT_LINK_ATTRIBUTES.includes(
-													attributeName.toLowerCase()
-												)
-											) {
-												return;
+								const transformedResponse = new HTMLRewriter()
+									.on("link[rel~=preconnect],link[rel~=preload]", {
+										element(element) {
+											for (const [attributeName] of element.attributes) {
+												if (
+													!ALLOWED_EARLY_HINT_LINK_ATTRIBUTES.includes(
+														attributeName.toLowerCase()
+													)
+												) {
+													return;
+												}
 											}
-										}
 
-										const href = element.getAttribute("href") || undefined;
-										const rel = element.getAttribute("rel") || undefined;
-										const as = element.getAttribute("as") || undefined;
-										if (href && !href.startsWith("data:") && rel) {
-											links.push({ href, rel, as });
-										}
-									},
-								})
-								.transform(clonedResponse);
+											const href = element.getAttribute("href") || undefined;
+											const rel = element.getAttribute("rel") || undefined;
+											const as = element.getAttribute("as") || undefined;
+											if (href && !href.startsWith("data:") && rel) {
+												links.push({ href, rel, as });
+											}
+										},
+									})
+									.transform(clonedResponse);
 
-							// Needed to actually execute the HTMLRewriter handlers
-							await transformedResponse.text();
+								// Needed to actually execute the HTMLRewriter handlers
+								await transformedResponse.text();
 
-							links.forEach(({ href, rel, as }) => {
-								let link = `<${href}>; rel="${rel}"`;
-								if (as) {
-									link += `; as=${as}`;
+								links.forEach(({ href, rel, as }) => {
+									let link = `<${href}>; rel="${rel}"`;
+									if (as) {
+										link += `; as=${as}`;
+									}
+									preEarlyHintsHeaders.append("Link", link);
+								});
+
+								const linkHeader = preEarlyHintsHeaders.get("Link");
+								if (linkHeader) {
+									await earlyHintsCache.put(
+										earlyHintsCacheKey,
+										new Response(null, {
+											headers: {
+												Link: linkHeader,
+												"Cache-Control": "max-age=2592000", // 30 days
+											},
+										})
+									);
 								}
-								preEarlyHintsHeaders.append("Link", link);
-							});
-
-							const linkHeader = preEarlyHintsHeaders.get("Link");
-							if (linkHeader) {
-								await earlyHintsCache.put(
-									earlyHintsCacheKey,
-									new Response(null, { headers: { Link: linkHeader } })
-								);
+							} catch (err) {
+								// Nbd if we fail here in the deferred 'waitUntil' work. We're probably trying to parse a malformed page or something.
+								// Totally fine to skip over any errors.
+								// If we need to debug something, you can uncomment the following:
+								// logError(err)
 							}
-						} catch (err) {
-							// Nbd if we fail here in the deferred 'waitUntil' work. We're probably trying to parse a malformed page or something.
-							// Totally fine to skip over any errors.
-							// If we need to debug something, you can uncomment the following:
-							// logError(err)
-						}
-					})()
-				);
+						})()
+					);
+				}
 			}
 		} else {
 			if (setMetrics) setMetrics({ earlyHintsResult: "disabled" });
@@ -553,7 +561,7 @@ export async function generateHandler<
 			}
 
 			if (
-				asset.contentType.startsWith("text/html") &&
+				isHTMLContentType(asset.contentType) &&
 				metadata.analytics?.version === ANALYTICS_VERSION
 			) {
 				return new HTMLRewriter()
@@ -652,4 +660,12 @@ function isPreview(url: URL): boolean {
 		return url.hostname.split(".").length > 3 ? true : false;
 	}
 	return false;
+}
+
+/**
+ * Whether or not the passed in string looks like an HTML
+ * Content-Type header
+ */
+function isHTMLContentType(contentType?: string | null) {
+	return contentType?.startsWith("text/html") || false;
 }

--- a/packages/pages-shared/environment-polyfills/miniflare.ts
+++ b/packages/pages-shared/environment-polyfills/miniflare.ts
@@ -1,11 +1,13 @@
 import { polyfill } from ".";
 
 export default async () => {
+	const { HTMLRewriter } = await import("@miniflare/html-rewriter");
 	const mf = await import("miniflare");
 	polyfill({
 		fetch: mf.fetch,
 		Headers: mf.Headers,
 		Request: mf.Request,
 		Response: mf.Response,
+		HTMLRewriter: HTMLRewriter,
 	});
 };

--- a/packages/pages-shared/environment-polyfills/types.ts
+++ b/packages/pages-shared/environment-polyfills/types.ts
@@ -27,6 +27,7 @@ export type PolyfilledRuntimeEnvironment = {
 	Headers: typeof Headers;
 	Request: typeof Request;
 	Response: typeof Response;
+	HTMLRewriter: typeof HTMLRewriter;
 };
 
 export {

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -22,11 +22,13 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@miniflare/storage-memory": "^2.14.2",
 		"@cloudflare/workers-types": "^4.20240419.0",
-		"@types/service-worker-mock": "^2.0.1",
+		"@miniflare/cache": "^2.14.2",
+		"@miniflare/core": "^2.14.2",
+		"@miniflare/html-rewriter": "^2.14.2",
 		"concurrently": "^7.3.0",
-		"glob": "^8.0.3",
-		"service-worker-mock": "^2.0.5"
+		"glob": "^8.0.3"
 	},
 	"workers-sdk": {
 		"prerelease": true

--- a/packages/pages-shared/vite.setup.ts
+++ b/packages/pages-shared/vite.setup.ts
@@ -1,3 +1,11 @@
-import makeServiceWorkerEnv from "service-worker-mock";
+import { fetch, Headers, Request, Response } from "@miniflare/core";
+import { HTMLRewriter } from "@miniflare/html-rewriter";
+import { polyfill } from "./environment-polyfills";
 
-Object.assign(globalThis, makeServiceWorkerEnv());
+polyfill({
+	fetch,
+	Headers,
+	Request,
+	Response,
+	HTMLRewriter,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1174,18 +1174,24 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20240419.0
         version: 4.20240419.0
-      '@types/service-worker-mock':
-        specifier: ^2.0.1
-        version: 2.0.1
+      '@miniflare/cache':
+        specifier: ^2.14.2
+        version: 2.14.2
+      '@miniflare/core':
+        specifier: ^2.14.2
+        version: 2.14.2
+      '@miniflare/html-rewriter':
+        specifier: ^2.14.2
+        version: 2.14.2
+      '@miniflare/storage-memory':
+        specifier: ^2.14.2
+        version: 2.14.2
       concurrently:
         specifier: ^7.3.0
         version: 7.3.0
       glob:
         specifier: ^8.0.3
         version: 8.0.3
-      service-worker-mock:
-        specifier: ^2.0.5
-        version: 2.0.5
 
   packages/playground-preview-worker:
     dependencies:
@@ -5636,6 +5642,10 @@ packages:
       - supports-color
     dev: false
 
+  /@iarna/toml@2.2.5:
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+    dev: true
+
   /@iarna/toml@3.0.0:
     resolution: {integrity: sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==}
     dev: true
@@ -6069,6 +6079,73 @@ packages:
 
   /@microsoft/tsdoc@0.14.2:
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
+    dev: true
+
+  /@miniflare/cache@2.14.2:
+    resolution: {integrity: sha512-XH218Y2jxSOfxG8EyuprBKhI/Fn6xLrb9A39niJBlzpiKXqr8skl/sy/sUL5tfvqEbEnqDagGne8zEcjM+1fBg==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/core': 2.14.2
+      '@miniflare/shared': 2.14.2
+      http-cache-semantics: 4.1.1
+      undici: 5.28.2
+    dev: true
+
+  /@miniflare/core@2.14.2:
+    resolution: {integrity: sha512-n/smm5ZTg7ilGM4fxO7Gxhbe573oc8Za06M3b2fO+lPWqF6NJcEKdCC+sJntVFbn3Cbbd2G1ChISmugPfmlCkQ==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@iarna/toml': 2.2.5
+      '@miniflare/queues': 2.14.2
+      '@miniflare/shared': 2.14.2
+      '@miniflare/watcher': 2.14.2
+      busboy: 1.6.0
+      dotenv: 10.0.0
+      kleur: 4.1.5
+      set-cookie-parser: 2.6.0
+      undici: 5.28.2
+      urlpattern-polyfill: 4.0.3
+    dev: true
+
+  /@miniflare/html-rewriter@2.14.2:
+    resolution: {integrity: sha512-tu0kd9bj38uZ04loHb3sMI8kzUzZPgPOAJEdS9zmdSPh0uOkjCDf/TEkKsDdv2OFysyb0DRsIrwhPqCTIrPf1Q==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/core': 2.14.2
+      '@miniflare/shared': 2.14.2
+      html-rewriter-wasm: 0.4.1
+      undici: 5.28.2
+    dev: true
+
+  /@miniflare/queues@2.14.2:
+    resolution: {integrity: sha512-OylkRs4lOWKvGnX+Azab3nx+1qwC87M36/hkgAU1RRvVDCOxOrYLvNLUczFfgmgMBwpYsmmW8YOIASlI3p4Qgw==}
+    engines: {node: '>=16.7'}
+    dependencies:
+      '@miniflare/shared': 2.14.2
+    dev: true
+
+  /@miniflare/shared@2.14.2:
+    resolution: {integrity: sha512-dDnYIztz10zDQjaFJ8Gy9UaaBWZkw3NyhFdpX6tAeyPA/2lGvkftc42MYmNi8s5ljqkZAtKgWAJnSf2K75NCJw==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@types/better-sqlite3': 7.6.8
+      kleur: 4.1.5
+      npx-import: 1.1.4
+      picomatch: 2.3.1
+    dev: true
+
+  /@miniflare/storage-memory@2.14.2:
+    resolution: {integrity: sha512-9Wtz9mayHIY0LDsfpMGx+/sfKCq3eAQJzYY+ju1tTEaKR0sVAuO51wu0wbyldsjj9OcBcd2X32iPbIa7KcSZQQ==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/shared': 2.14.2
+    dev: true
+
+  /@miniflare/watcher@2.14.2:
+    resolution: {integrity: sha512-/TL0np4uYDl+6MdseDApZmDdlJ6Y7AY5iDY0TvUQJG9nyBoCjX6w0Zn4SiKDwO6660rPtSqZ5c7HzbPhGb5vsA==}
+    engines: {node: '>=16.13'}
+    dependencies:
+      '@miniflare/shared': 2.14.2
     dev: true
 
   /@mswjs/cookies@0.2.2:
@@ -7206,6 +7283,12 @@ packages:
       '@babel/types': 7.22.19
     dev: true
 
+  /@types/better-sqlite3@7.6.8:
+    resolution: {integrity: sha512-ASndM4rdGrzk7iXXqyNC4fbwt4UEjpK0i3j4q4FyeQrLAthfB6s7EF135ZJE0qQxtKIMFwmyT6x0switET7uIw==}
+    dependencies:
+      '@types/node': 18.16.10
+    dev: true
+
   /@types/body-parser@1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
@@ -7553,10 +7636,6 @@ packages:
     dependencies:
       '@types/mime': 1.3.2
       '@types/node': 18.16.10
-    dev: true
-
-  /@types/service-worker-mock@2.0.1:
-    resolution: {integrity: sha512-LqaP0QmgppRF7YEaqx4amoazHNXaX5bIFDAu62LnWIc5ku0HbgqlPKroQstAu8WsdmWIqEfI9VGlP8Skkq+m5A==}
     dev: true
 
   /@types/set-cookie-parser@2.4.2:
@@ -9663,6 +9742,13 @@ packages:
       run-applescript: 5.0.0
     dev: true
 
+  /busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+    dependencies:
+      streamsearch: 1.1.0
+    dev: true
+
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -11047,6 +11133,11 @@ packages:
   /dotenv-expand@10.0.0:
     resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
     engines: {node: '>=12'}
+    dev: true
+
+  /dotenv@10.0.0:
+    resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
+    engines: {node: '>=10'}
     dev: true
 
   /dotenv@16.0.0:
@@ -13499,6 +13590,10 @@ packages:
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
+  /html-rewriter-wasm@0.4.1:
+    resolution: {integrity: sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q==}
     dev: true
 
   /http-cache-semantics@4.1.0:
@@ -16630,6 +16725,15 @@ packages:
       set-blocking: 2.0.0
     dev: true
 
+  /npx-import@1.1.4:
+    resolution: {integrity: sha512-3ShymTWOgqGyNlh5lMJAejLuIv3W1K3fbI5Ewc6YErZU3Sp0PqsNs8UIU1O8z5+KVl/Du5ag56Gza9vdorGEoA==}
+    dependencies:
+      execa: 6.1.0
+      parse-package-name: 1.0.0
+      semver: 7.5.4
+      validate-npm-package-name: 4.0.0
+    dev: true
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -17119,6 +17223,10 @@ packages:
   /parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+    dev: true
+
+  /parse-package-name@1.0.0:
+    resolution: {integrity: sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==}
     dev: true
 
   /parserlib@1.1.1:
@@ -19181,6 +19289,11 @@ packages:
       mixme: 0.5.4
     dev: true
 
+  /streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+    dev: true
+
   /strict-event-emitter@0.2.8:
     resolution: {integrity: sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==}
     dependencies:
@@ -20097,6 +20210,13 @@ packages:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
+  /undici@5.28.2:
+    resolution: {integrity: sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==}
+    engines: {node: '>=14.0'}
+    dependencies:
+      '@fastify/busboy': 2.1.0
+    dev: true
+
   /undici@5.28.3:
     resolution: {integrity: sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==}
     engines: {node: '>=14.0'}
@@ -20322,6 +20442,10 @@ packages:
     deprecated: now available as @ungap/url-search-params
     dev: true
 
+  /urlpattern-polyfill@4.0.3:
+    resolution: {integrity: sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==}
+    dev: true
+
   /use-sync-external-store@1.2.0(react@18.2.0):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
@@ -20398,6 +20522,13 @@ packages:
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
+    dev: true
+
+  /validate-npm-package-name@4.0.0:
+    resolution: {integrity: sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      builtins: 5.0.1
     dev: true
 
   /validate-npm-package-name@5.0.0:


### PR DESCRIPTION
Fixes BANDAOPS-60

This is mostly based off #2574 that was reverted in #2645 due to `wrangler pages dev` failing.
This no longer appears to be causing issues with `wrangler pages dev` in my testing.

Also tested in rc to ensure Link headers still show up when they should

**What this PR solves / how to test:**
Only applies early hints to html assets

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
