### PR TITLE
Added support for configuring Sippy with GCS provider in Wrangler

### DIFF
--- a/.changeset/tame-melons-boil.md
+++ b/.changeset/tame-melons-boil.md
@@ -6,6 +6,6 @@ feature: adds support for configuring Sippy with Google Cloud Storage (GCS) prov
 
 Sippy (https://developers.cloudflare.com/r2/data-migration/sippy/) now supports Google Cloud Storage.
 This change updates the `wrangler r2 sippy` commands to take a provider (AWS or GCS) and appropriate configuration arguments.
-If you don't specify a provide then the command will enter an interactive flow for the user to set the configuration.
+If you don't specify `--provider` argument then the command will enter an interactive flow for the user to set the configuration.
 Note that this is a breaking change from the previous behaviour where you could configure AWS as the provider without explictly specifying the `--provider` argument.
 (This breaking change is allowed in a minor release because the Sippy feature and `wrangler r2 sippy` commands are marked as beta.)

--- a/.changeset/tame-melons-boil.md
+++ b/.changeset/tame-melons-boil.md
@@ -2,4 +2,6 @@
 "wrangler": minor
 ---
 
-Added support for configuring Sippy with GCS provider.
+feature: adds support for configuring Sippy with Google Cloud Storage (GCS) provider.
+
+Sippy (https://developers.cloudflare.com/r2/data-migration/sippy/) now supports Google Cloud Storage.

--- a/.changeset/tame-melons-boil.md
+++ b/.changeset/tame-melons-boil.md
@@ -5,3 +5,7 @@
 feature: adds support for configuring Sippy with Google Cloud Storage (GCS) provider.
 
 Sippy (https://developers.cloudflare.com/r2/data-migration/sippy/) now supports Google Cloud Storage.
+This change updates the `wrangler r2 sippy` commands to take a provider (AWS or GCS) and appropriate configuration arguments.
+If you don't specify a provide then the command will enter an interactive flow for the user to set the configuration.
+Note that this is a breaking change from the previous behaviour where you could configure AWS as the provider without explictly specifying the `--provider` argument.
+(This breaking change is allowed in a minor release because the Sippy feature and `wrangler r2 sippy` commands are marked as beta.)

--- a/.changeset/tame-melons-boil.md
+++ b/.changeset/tame-melons-boil.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Added support for configuring Sippy with GCS provider.

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -345,6 +345,33 @@ describe("r2", () => {
 					);
 				});
 
+				it("should enable sippy on GCS for the given bucket", async () => {
+					setIsTTY(false);
+
+					msw.use(
+						rest.put(
+							"*/accounts/some-account-id/r2/buckets/testBucket/sippy",
+							async (request, response, context) => {
+								expect(await request.json()).toEqual({
+									private_key: "gcs-private-key",
+									bucket: "gcsBucket",
+									client_email: "gcs-client-email",
+									provider: "GCS",
+									r2_access_key: "some-secret",
+									r2_key_id: "some-key",
+								});
+								return response.once(context.json(createFetchResult({})));
+							}
+						)
+					);
+					await runWrangler(
+						"r2 bucket sippy enable testBucket --r2-key-id=some-key --r2-secret-access-key=some-secret --provider=GCS --client-email=gcs-client-email --private-key=gcs-private-key --bucket=gcsBucket"
+					);
+					expect(std.out).toMatchInlineSnapshot(
+						`"✨ Successfully enabled Sippy on the 'testBucket' bucket."`
+					);
+				});
+
 				it("should error if no bucket name is given", async () => {
 					await expect(
 						runWrangler("r2 bucket sippy enable")

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -263,18 +263,29 @@ export async function deleteR2Sippy(
 /**
  * Enable sippy on the bucket with the given name
  */
+export type SippyConfig =
+	| {
+			provider: "AWS";
+			zone: string | undefined;
+			bucket: string;
+			key_id: string;
+			access_key: string;
+			r2_key_id: string;
+			r2_access_key: string;
+	  }
+	| {
+			provider: "GCS";
+			bucket: string;
+			client_email: string;
+			private_key: string;
+			r2_key_id: string;
+			r2_access_key: string;
+	  };
+
 export async function putR2Sippy(
 	accountId: string,
 	bucketName: string,
-	config: {
-		provider: "AWS";
-		zone: string | undefined;
-		bucket: string;
-		key_id: string;
-		access_key: string;
-		r2_key_id: string;
-		r2_access_key: string;
-	},
+	config: SippyConfig,
 	jurisdiction?: string
 ): Promise<void> {
 	const headers: HeadersInit = {};

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -260,32 +260,34 @@ export async function deleteR2Sippy(
 	);
 }
 
+export type R2Credentials = {
+	bucket: string;
+	r2_key_id: string;
+	r2_access_key: string;
+};
+
+export type SippyPutConfig = R2Credentials &
+	(
+		| {
+				provider: "AWS";
+				zone: string | undefined;
+				key_id: string;
+				access_key: string;
+		  }
+		| {
+				provider: "GCS";
+				client_email: string;
+				private_key: string;
+		  }
+	);
+
 /**
  * Enable sippy on the bucket with the given name
  */
-export type SippyConfig =
-	| {
-			provider: "AWS";
-			zone: string | undefined;
-			bucket: string;
-			key_id: string;
-			access_key: string;
-			r2_key_id: string;
-			r2_access_key: string;
-	  }
-	| {
-			provider: "GCS";
-			bucket: string;
-			client_email: string;
-			private_key: string;
-			r2_key_id: string;
-			r2_access_key: string;
-	  };
-
 export async function putR2Sippy(
 	accountId: string,
 	bucketName: string,
-	config: SippyConfig,
+	config: SippyPutConfig,
 	jurisdiction?: string
 ): Promise<void> {
 	const headers: HeadersInit = {};

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -21,7 +21,6 @@ import {
 	putR2Object,
 	usingLocalBucket,
 } from "./helpers";
-
 import * as Sippy from "./sippy";
 import type { CommonYargsArgv } from "../yargs-types";
 import type { R2PutOptions } from "@cloudflare/workers-types/experimental";

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -16,14 +16,13 @@ import {
 	createR2Bucket,
 	deleteR2Bucket,
 	deleteR2Object,
-	deleteR2Sippy,
 	getR2Object,
-	getR2Sippy,
 	listR2Buckets,
 	putR2Object,
-	putR2Sippy,
 	usingLocalBucket,
 } from "./helpers";
+
+import * as Sippy from "./sippy";
 import type { CommonYargsArgv } from "../yargs-types";
 import type { R2PutOptions } from "@cloudflare/workers-types/experimental";
 
@@ -521,127 +520,20 @@ export function r2(r2Yargs: CommonYargsArgv) {
 						.command(
 							"enable <name>",
 							"Enable Sippy on an R2 bucket",
-							(yargs) =>
-								yargs
-									.positional("name", {
-										describe: "The name of the bucket",
-										type: "string",
-										demandOption: true,
-									})
-									.option("jurisdiction", {
-										describe: "The jurisdiction where the bucket exists",
-										alias: "J",
-										requiresArg: true,
-										type: "string",
-									})
-									.option("provider", {
-										choices: ["AWS"],
-										default: "AWS",
-										implies: [
-											"bucket",
-											"key-id",
-											"secret-access-key",
-											"r2-key-id",
-											"r2-secret-access-key",
-										],
-									})
-									.option("bucket", {
-										description: "The name of the upstream bucket",
-										string: true,
-									})
-									.option("region", {
-										description: "The region of the upstream bucket",
-										string: true,
-									})
-									.option("key-id", {
-										description:
-											"The secret access key id for the upstream bucket",
-										string: true,
-									})
-									.option("secret-access-key", {
-										description:
-											"The secret access key for the upstream bucket",
-										string: true,
-									})
-									.option("r2-key-id", {
-										description: "The secret access key id for this R2 bucket",
-										string: true,
-									})
-									.option("r2-secret-access-key", {
-										description: "The secret access key for this R2 bucket",
-										string: true,
-									}),
-
-							async (args) => {
-								const config = readConfig(args.config, args);
-								const accountId = await requireAuth(config);
-
-								await putR2Sippy(
-									accountId,
-									args.name,
-									{
-										provider: "AWS",
-										zone: args["region"],
-										bucket: args.bucket ?? "",
-										key_id: args["key-id"] ?? "",
-										access_key: args["secret-access-key"] ?? "",
-										r2_key_id: args["r2-key-id"] ?? "",
-										r2_access_key: args["r2-secret-access-key"] ?? "",
-									},
-									args.jurisdiction
-								);
-							}
+							Sippy.EnableOptions,
+							Sippy.EnableHandler
 						)
 						.command(
 							"disable <name>",
 							"Disable Sippy on an R2 bucket",
-							(yargs) =>
-								yargs
-									.positional("name", {
-										describe: "The name of the bucket",
-										type: "string",
-										demandOption: true,
-									})
-									.option("jurisdiction", {
-										describe: "The jurisdiction where the bucket exists",
-										alias: "J",
-										requiresArg: true,
-										type: "string",
-									}),
-							async (args) => {
-								const config = readConfig(args.config, args);
-								const accountId = await requireAuth(config);
-
-								await deleteR2Sippy(accountId, args.name, args.jurisdiction);
-							}
+							Sippy.DisableOptions,
+							Sippy.DisableHandler
 						)
 						.command(
 							"get <name>",
 							"Check the status of Sippy on an R2 bucket",
-							(yargs) =>
-								yargs
-									.positional("name", {
-										describe: "The name of the bucket",
-										type: "string",
-										demandOption: true,
-									})
-									.option("jurisdiction", {
-										describe: "The jurisdiction where the bucket exists",
-										alias: "J",
-										requiresArg: true,
-										type: "string",
-									}),
-							async (args) => {
-								const config = readConfig(args.config, args);
-								const accountId = await requireAuth(config);
-
-								const sippyBucket = await getR2Sippy(
-									accountId,
-									args.name,
-									args.jurisdiction
-								);
-								logger.log(`Sippy upstream bucket: ${sippyBucket}.`);
-							}
+							Sippy.GetOptions,
+							Sippy.GetHandler
 						);
 				}
 			);

--- a/packages/wrangler/src/r2/sippy.ts
+++ b/packages/wrangler/src/r2/sippy.ts
@@ -1,0 +1,240 @@
+import { readConfig } from "../config";
+import { prompt } from "../dialogs";
+import { UserError } from "../errors";
+import { logger } from "../logger";
+import { APIError, readFileSync } from "../parse";
+import { requireAuth } from "../user";
+import { deleteR2Sippy, getR2Sippy, putR2Sippy } from "./helpers";
+
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+import type { SippyConfig } from "./helpers";
+
+export function EnableOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			describe: "The name of the bucket",
+			type: "string",
+			demandOption: true,
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		})
+		.option("provider", {
+			choices: ["AWS", "GCS"],
+		})
+		.option("bucket", {
+			description: "The name of the upstream bucket",
+			string: true,
+		})
+		.option("region", {
+			description: "(AWS provider only) The region of the upstream bucket",
+			string: true,
+		})
+		.option("key-id", {
+			description:
+				"(AWS provider only) The secret access key id for the upstream bucket",
+			string: true,
+		})
+		.option("secret-access-key", {
+			description:
+				"(AWS provider only) The secret access key for the upstream bucket",
+			string: true,
+		})
+		.option("service-account-key-file", {
+			description:
+				"(GCS provider only) The path to your Google Cloud service account key JSON file",
+			string: true,
+		})
+		.option("client-email", {
+			description:
+				"(GCS provider only) The client email for your Google Cloud service account key",
+			string: true,
+		})
+		.option("private-key", {
+			description:
+				"(GCS provider only) The private key for your Google Cloud service account key",
+			string: true,
+		})
+		.option("r2-key-id", {
+			description: "The secret access key id for this R2 bucket",
+			string: true,
+		})
+		.option("r2-secret-access-key", {
+			description: "The secret access key for this R2 bucket",
+			string: true,
+		});
+}
+
+export async function EnableHandler(
+	args: StrictYargsOptionsToInterface<typeof EnableOptions>
+) {
+	const isInteractive = process.stdin.isTTY;
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	if (isInteractive) {
+		if (!args.provider) {
+			args.provider = await prompt(
+				"Enter the cloud storage provider of your bucket (AWS or GCS):"
+			);
+		}
+
+		if (!args.bucket) {
+			args.bucket = await prompt(
+				`Enter the name of your ${args.provider} bucket:`
+			);
+		}
+
+		if (args.provider == "AWS") {
+			if (!args.region) {
+				args.region = await prompt(
+					"Enter the AWS region where your S3 bucket is located (example: us-west-2):"
+				);
+			}
+			if (!args.keyId) {
+				args.keyId = await prompt(
+					"Enter your AWS Access Key ID (requires read and list access):"
+				);
+			}
+			if (!args.secretAccessKey) {
+				args.secretAccessKey = await prompt(
+					"Enter your AWS Secret Access Key:"
+				);
+			}
+		} else if (args.provider == "GCS") {
+			if (
+				!(args.clientEmail && args.privateKey) &&
+				!args.serviceAccountKeyFile
+			) {
+				args.serviceAccountKeyFile = await prompt(
+					"Enter the path to your Google Cloud service account key JSON file:"
+				);
+			}
+		}
+		if (!args.r2KeyId) {
+			args.r2KeyId = await prompt(
+				"Enter your R2 Access Key ID (requires read and write access):"
+			);
+		}
+		if (!args.r2SecretAccessKey) {
+			args.r2SecretAccessKey = await prompt("Enter your R2 Secret Access Key:");
+		}
+	}
+
+	let sippyConfig = {
+		bucket: args.bucket ?? "",
+		r2_key_id: args.r2KeyId ?? "",
+		r2_access_key: args.r2SecretAccessKey ?? "",
+	} as SippyConfig;
+
+	if (args.provider == "AWS") {
+		if (!(args.keyId && args.secretAccessKey)) {
+			throw new UserError(
+				`Error: must provide --key_id and --secret_access_key.`
+			);
+		}
+		sippyConfig = {
+			...sippyConfig,
+			provider: "AWS",
+			zone: args.region,
+			key_id: args.keyId,
+			access_key: args.secretAccessKey,
+		};
+	} else if (args.provider == "GCS") {
+		if (args.serviceAccountKeyFile) {
+			const serviceAccount = JSON.parse(
+				readFileSync(args.serviceAccountKeyFile)
+			);
+			if ("client_email" in serviceAccount && "private_key" in serviceAccount) {
+				args.clientEmail = serviceAccount["client_email"];
+				args.privateKey = serviceAccount["private_key"];
+			}
+		}
+		if (!(args.clientEmail && args.privateKey)) {
+			throw new UserError(
+				`Error: must provide --service-account-key-file or --client_email and --private_key.`
+			);
+		}
+		args.privateKey = args.privateKey.replace(/\\n/g, "\n");
+		sippyConfig = {
+			...sippyConfig,
+			provider: "GCS",
+			client_email: args.clientEmail,
+			private_key: args.privateKey,
+		};
+	}
+
+	await putR2Sippy(accountId, args.name, sippyConfig, args.jurisdiction);
+
+	logger.log(`✨ Successfully enabled Sippy on the '${args.name}' bucket.`);
+}
+
+export function GetOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			describe: "The name of the bucket",
+			type: "string",
+			demandOption: true,
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		});
+}
+
+const NO_SUCH_OBJECT_KEY = 10007;
+export async function GetHandler(
+	args: StrictYargsOptionsToInterface<typeof GetOptions>
+) {
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	try {
+		const sippyBucket = await getR2Sippy(
+			accountId,
+			args.name,
+			args.jurisdiction
+		);
+		logger.log(`Sippy upstream bucket: ${sippyBucket}.`);
+	} catch (e) {
+		if (e instanceof APIError && "code" in e && e.code == NO_SUCH_OBJECT_KEY) {
+			logger.log(`No Sippy configuration found for the '${args.name}' bucket.`);
+		} else {
+			throw e;
+		}
+	}
+}
+
+export function DisableOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			describe: "The name of the bucket",
+			type: "string",
+			demandOption: true,
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		});
+}
+
+export async function DisableHandler(
+	args: StrictYargsOptionsToInterface<typeof DisableOptions>
+) {
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	await deleteR2Sippy(accountId, args.name, args.jurisdiction);
+
+	logger.log(`✨ Successfully disabled Sippy on the '${args.name}' bucket.`);
+}

--- a/packages/wrangler/src/r2/sippy.ts
+++ b/packages/wrangler/src/r2/sippy.ts
@@ -5,12 +5,11 @@ import { logger } from "../logger";
 import { APIError, readFileSync } from "../parse";
 import { requireAuth } from "../user";
 import { deleteR2Sippy, getR2Sippy, putR2Sippy } from "./helpers";
-
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
-import type { SippyConfig } from "./helpers";
+import type { SippyPutConfig } from "./helpers";
 
 export function EnableOptions(yargs: CommonYargsArgv) {
 	return yargs
@@ -79,34 +78,23 @@ export async function EnableHandler(
 	const accountId = await requireAuth(config);
 
 	if (isInteractive) {
-		if (!args.provider) {
-			args.provider = await prompt(
-				"Enter the cloud storage provider of your bucket (AWS or GCS):"
-			);
-		}
-
-		if (!args.bucket) {
-			args.bucket = await prompt(
-				`Enter the name of your ${args.provider} bucket:`
-			);
-		}
+		args.provider ??= await prompt(
+			"Enter the cloud storage provider of your bucket (AWS or GCS):"
+		);
+		args.bucket ??= await prompt(
+			`Enter the name of your ${args.provider} bucket:`
+		);
 
 		if (args.provider == "AWS") {
-			if (!args.region) {
-				args.region = await prompt(
-					"Enter the AWS region where your S3 bucket is located (example: us-west-2):"
-				);
-			}
-			if (!args.keyId) {
-				args.keyId = await prompt(
-					"Enter your AWS Access Key ID (requires read and list access):"
-				);
-			}
-			if (!args.secretAccessKey) {
-				args.secretAccessKey = await prompt(
-					"Enter your AWS Secret Access Key:"
-				);
-			}
+			args.region ??= await prompt(
+				"Enter the AWS region where your S3 bucket is located (example: us-west-2):"
+			);
+			args.keyId ??= await prompt(
+				"Enter your AWS Access Key ID (requires read and list access):"
+			);
+			args.secretAccessKey ??= await prompt(
+				"Enter your AWS Secret Access Key:"
+			);
 		} else if (args.provider == "GCS") {
 			if (
 				!(args.clientEmail && args.privateKey) &&
@@ -117,21 +105,17 @@ export async function EnableHandler(
 				);
 			}
 		}
-		if (!args.r2KeyId) {
-			args.r2KeyId = await prompt(
-				"Enter your R2 Access Key ID (requires read and write access):"
-			);
-		}
-		if (!args.r2SecretAccessKey) {
-			args.r2SecretAccessKey = await prompt("Enter your R2 Secret Access Key:");
-		}
+		args.r2KeyId ??= await prompt(
+			"Enter your R2 Access Key ID (requires read and write access):"
+		);
+		args.r2SecretAccessKey ??= await prompt("Enter your R2 Secret Access Key:");
 	}
 
 	let sippyConfig = {
 		bucket: args.bucket ?? "",
 		r2_key_id: args.r2KeyId ?? "",
 		r2_access_key: args.r2SecretAccessKey ?? "",
-	} as SippyConfig;
+	} as SippyPutConfig;
 
 	if (args.provider == "AWS") {
 		if (!(args.keyId && args.secretAccessKey)) {

--- a/packages/wrangler/src/r2/sippy.ts
+++ b/packages/wrangler/src/r2/sippy.ts
@@ -150,7 +150,7 @@ export async function EnableHandler(
 	if (args.provider == "AWS") {
 		if (!(args.keyId && args.secretAccessKey)) {
 			throw new UserError(
-				`Error: must provide --key_id and --secret_access_key.`
+				`Error: must provide --key-id and --secret-access-key.`
 			);
 		}
 		sippyConfig = {
@@ -172,7 +172,7 @@ export async function EnableHandler(
 		}
 		if (!(args.clientEmail && args.privateKey)) {
 			throw new UserError(
-				`Error: must provide --service-account-key-file or --client_email and --private_key.`
+				`Error: must provide --service-account-key-file or --client-email and --private-key.`
 			);
 		}
 		args.privateKey = args.privateKey.replace(/\\n/g, "\n");

--- a/packages/wrangler/src/r2/sippy.ts
+++ b/packages/wrangler/src/r2/sippy.ts
@@ -11,6 +11,9 @@ import type {
 } from "../yargs-types";
 import type { SippyPutConfig } from "./helpers";
 
+const NO_SUCH_OBJECT_KEY = 10007;
+const SIPPY_PROVIDER_CHOICES = ["AWS", "GCS"];
+
 export function EnableOptions(yargs: CommonYargsArgv) {
 	return yargs
 		.positional("name", {
@@ -25,7 +28,7 @@ export function EnableOptions(yargs: CommonYargsArgv) {
 			type: "string",
 		})
 		.option("provider", {
-			choices: ["AWS", "GCS"],
+			choices: SIPPY_PROVIDER_CHOICES,
 		})
 		.option("bucket", {
 			description: "The name of the upstream bucket",
@@ -81,9 +84,18 @@ export async function EnableHandler(
 		args.provider ??= await prompt(
 			"Enter the cloud storage provider of your bucket (AWS or GCS):"
 		);
+		if (!args.provider) {
+			throw new UserError("Must specify a cloud storage provider.");
+		}
+		if (!SIPPY_PROVIDER_CHOICES.includes(args.provider)) {
+			throw new UserError("Cloud storage provider must be: AWS or GCS");
+		}
 		args.bucket ??= await prompt(
 			`Enter the name of your ${args.provider} bucket:`
 		);
+		if (!args.bucket) {
+			throw new UserError(`Must specify ${args.provider} bucket name.`);
+		}
 
 		if (args.provider == "AWS") {
 			args.region ??= await prompt(
@@ -92,9 +104,15 @@ export async function EnableHandler(
 			args.keyId ??= await prompt(
 				"Enter your AWS Access Key ID (requires read and list access):"
 			);
+			if (!args.keyId) {
+				throw new UserError("Must specify an AWS Access Key ID.");
+			}
 			args.secretAccessKey ??= await prompt(
 				"Enter your AWS Secret Access Key:"
 			);
+			if (!args.secretAccessKey) {
+				throw new UserError("Must specify an AWS Secret Access Key.");
+			}
 		} else if (args.provider == "GCS") {
 			if (
 				!(args.clientEmail && args.privateKey) &&
@@ -103,12 +121,24 @@ export async function EnableHandler(
 				args.serviceAccountKeyFile = await prompt(
 					"Enter the path to your Google Cloud service account key JSON file:"
 				);
+				if (!args.serviceAccountKeyFile) {
+					throw new UserError(
+						"Must specify the path to a service account key JSON file."
+					);
+				}
 			}
 		}
+
 		args.r2KeyId ??= await prompt(
 			"Enter your R2 Access Key ID (requires read and write access):"
 		);
+		if (!args.r2KeyId) {
+			throw new UserError("Must specify an R2 Access Key ID.");
+		}
 		args.r2SecretAccessKey ??= await prompt("Enter your R2 Secret Access Key:");
+		if (!args.r2SecretAccessKey) {
+			throw new UserError("Must specify an R2 Secret Access Key.");
+		}
 	}
 
 	let sippyConfig = {
@@ -174,7 +204,6 @@ export function GetOptions(yargs: CommonYargsArgv) {
 		});
 }
 
-const NO_SUCH_OBJECT_KEY = 10007;
 export async function GetHandler(
 	args: StrictYargsOptionsToInterface<typeof GetOptions>
 ) {


### PR DESCRIPTION
 Added support for configuring Sippy with GCS provider in Wrangler. Enabling Sippy now prompts if parameters are not present

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): https://github.com/cloudflare/cloudflare-docs/pull/12652
