### PR TITLE
[wranger] fix: createMetadataObject to use logging levels (#4265)

### DIFF
--- a/.changeset/wet-lemons-wash.md
+++ b/.changeset/wet-lemons-wash.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/pages-shared": patch
+"wrangler": patch
+---
+
+Less verbose warnings from header and redirect parsing

--- a/.changeset/wet-lemons-wash.md
+++ b/.changeset/wet-lemons-wash.md
@@ -3,4 +3,4 @@
 "wrangler": patch
 ---
 
-Less verbose warnings from header and redirect parsing
+fix: Use appropriate logging levels when parsing headers and redirects in `wrangler pages dev`.

--- a/packages/pages-shared/metadata-generator/createMetadataObject.ts
+++ b/packages/pages-shared/metadata-generator/createMetadataObject.ts
@@ -15,13 +15,21 @@ import type {
 	ParsedRedirects,
 } from "./types";
 
+const noopLogger = {
+	debug: (_message: string) => {},
+	log: (_message: string) => {},
+	info: (_message: string) => {},
+	warn: (_message: string) => {},
+	error: (_error: Error) => {},
+};
+
 export function createMetadataObject({
 	redirects,
 	headers,
 	webAnalyticsToken,
 	deploymentId,
 	failOpen,
-	logger = (_message: string) => {},
+	logger = noopLogger,
 }: {
 	redirects?: ParsedRedirects;
 	headers?: ParsedHeaders;
@@ -51,15 +59,17 @@ function constructRedirects({
 	const num_valid = redirects.rules.length;
 	const num_invalid = redirects.invalid.length;
 
-	logger(
+	logger.log(
 		`Parsed ${num_valid} valid redirect rule${num_valid === 1 ? "" : "s"}.`
 	);
 
 	if (num_invalid > 0) {
-		logger(`Found invalid redirect lines:`);
+		logger.warn(`Found invalid redirect lines:`);
 		for (const { line, lineNumber, message } of redirects.invalid) {
-			if (line) logger(`  - ${lineNumber ? `#${lineNumber}: ` : ""}${line}`);
-			logger(`    ${message}`);
+			if (line) {
+				logger.warn(`  - ${lineNumber ? `#${lineNumber}: ` : ""}${line}`);
+			}
+			logger.warn(`    ${message}`);
 		}
 	}
 
@@ -81,8 +91,8 @@ function constructRedirects({
 				};
 				continue;
 			} else {
-				logger(
-					`Info: the redirect rule ${rule.from} → ${rule.status} ${rule.to} could be made more performant by bringing it above any lines with splats or placeholders.`
+				logger.info(
+					`The redirect rule ${rule.from} → ${rule.status} ${rule.to} could be made more performant by bringing it above any lines with splats or placeholders.`
 				);
 			}
 		}
@@ -112,13 +122,17 @@ function constructHeaders({
 	const num_valid = headers.rules.length;
 	const num_invalid = headers.invalid.length;
 
-	logger(`Parsed ${num_valid} valid header rule${num_valid === 1 ? "" : "s"}.`);
+	logger.log(
+		`Parsed ${num_valid} valid header rule${num_valid === 1 ? "" : "s"}.`
+	);
 
 	if (num_invalid > 0) {
-		logger(`Found invalid header lines:`);
+		logger.warn(`Found invalid header lines:`);
 		for (const { line, lineNumber, message } of headers.invalid) {
-			if (line) logger(`  - ${lineNumber ? `#${lineNumber}: ` : ""} ${line}`);
-			logger(`    ${message}`);
+			if (line) {
+				logger.warn(`  - ${lineNumber ? `#${lineNumber}: ` : ""} ${line}`);
+			}
+			logger.warn(`    ${message}`);
 		}
 	}
 

--- a/packages/pages-shared/metadata-generator/types.ts
+++ b/packages/pages-shared/metadata-generator/types.ts
@@ -87,4 +87,10 @@ export type Metadata = {
 	failOpen?: boolean;
 };
 
-export type Logger = (message: string) => void;
+export interface Logger {
+	debug: (message: string) => void;
+	log: (message: string) => void;
+	info: (message: string) => void;
+	warn: (message: string) => void;
+	error: (error: Error) => void;
+}

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -7,6 +7,7 @@ import { watch } from "chokidar";
 import { getType } from "mime";
 import { fetch, Request, Response } from "miniflare";
 import { hashFile } from "../pages/hash";
+import type { Logger } from "../logger";
 import type { Metadata } from "@cloudflare/pages-shared/asset-server/metadata";
 import type {
 	ParsedHeaders,
@@ -14,12 +15,6 @@ import type {
 } from "@cloudflare/pages-shared/metadata-generator/types";
 import type { Request as WorkersRequest } from "@cloudflare/workers-types/experimental";
 import type { RequestInit } from "miniflare";
-
-interface Logger {
-	log: (message: string) => void;
-	warn: (message: string) => void;
-	error: (error: Error) => void;
-}
 
 export interface Options {
 	log: Logger;
@@ -109,7 +104,7 @@ async function generateAssetsFetch(
 	let metadata = createMetadataObject({
 		redirects,
 		headers,
-		logger: log.warn.bind(log),
+		logger: log,
 	});
 
 	watch([headersFile, redirectsFile], { persistent: true }).on(
@@ -133,7 +128,7 @@ async function generateAssetsFetch(
 			metadata = createMetadataObject({
 				redirects,
 				headers,
-				logger: log.warn,
+				logger: log,
 			});
 		}
 	);


### PR DESCRIPTION
Relates to #4265.

**What this PR solves / how to test:**
createMetadataObject previously only received a single logging function set to warn. This PR updates it to receive a full Logger object, and updates it to use the various levels correctly.

Previously messages such as `[WARNING] Parsed 2 valid header rules.` were output to the console, whereas with this fix they're no longer warnings, and therefore can be muted with `--log-level=info`.

Additionally, `wrangler/src/miniflare-cli/assets.ts` was defining its own Logger interface but is now loading the interface from the `logger.ts` file.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: Covered by existing tests.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): https://github.com/cloudflare/workers-sdk/issues/4265
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
