### PR TITLE
[wrangler] fix: reset inspector execution contexts on reload

### DIFF
--- a/.changeset/three-carpets-kick.md
+++ b/.changeset/three-carpets-kick.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: show up-to-date sources in DevTools when saving source files
+
+Previously, DevTools would never refresh source contents after opening a file, even if it was updated on-disk. This could cause issues with step-through debugging as breakpoints set in source files would map to incorrect locations in bundled Worker code. This change ensures DevTools' source cache is cleared on each reload, preventing outdated sources from being displayed.

--- a/fixtures/dev-env/vitest.config.ts
+++ b/fixtures/dev-env/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -293,6 +293,13 @@ export class InspectorProxyWorker implements DurableObject {
 
 		this.sendDebugLog("NEW RUNTIME WEBSOCKET", runtimeWebSocketUrl);
 
+		// Make sure DevTools re-fetches script contents,
+		// and uses the newly created execution context
+		this.sendDevToolsMessage({
+			method: "Runtime.executionContextsCleared",
+			params: undefined,
+		});
+
 		const upgrade = await fetch(runtimeWebSocketUrl, {
 			headers: {
 				...this.proxyData.headers,


### PR DESCRIPTION
Fixes #4640.
Alternative fix to https://github.com/cloudflare/workers-sdk/pull/4331.

**What this PR solves / how to test:**

I wasn't able to reproduce any of the issues from #4640 on the latest version of `wrangler`. These were reported on `wrangler@3.17.1+` which was before we properly landed WaaL milestone 1. It's possible these regressions were from an earlier version of the WaaL work? In any case, this PR attempts to fix a related issue of caching script contents that could break breakpoint debugging: https://github.com/cloudflare/workers-sdk/pull/4331.

Previously, DevTools would never refresh source contents after opening a file, even if it was updated on-disk. This could cause issues with step-through debugging as breakpoints set in source files would map to incorrect locations in bundled Worker code. This change ensures we clean up old execution contexts by sending [`Runtime.executionContextsCleared`](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#event-executionContextsCleared) whenever the user worker is restarted. This causes DevTools to re-fetch source contents, and makes local mode behave more like remote mode with its long-lived inspector session.

This PR also ensures we actually run the WaaL tests in CI. Previously, these were being skipped because of a missing `vitest.config.ts` file.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: ensuring behaviour matches user expectations

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
