### PR TITLE
[wrangler] fix: listen on loopback for wrangler dev port check and login

### DIFF
--- a/.changeset/smart-owls-jog.md
+++ b/.changeset/smart-owls-jog.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: listen on loopback for wrangler dev port check and login
+
+Avoid listening on the wildcard address by default to reduce the attacker's
+surface and avoid firewall prompts on macOS.
+
+Relates to #4430.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -879,12 +879,12 @@ describe("wrangler dev", () => {
 			writeWranglerToml({
 				main: "index.js",
 				dev: {
-					ip: "1.2.3.4",
+					ip: "::1",
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWrangler("dev");
-			expect((Dev as jest.Mock).mock.calls[0][0].initialIp).toEqual("1.2.3.4");
+			expect((Dev as jest.Mock).mock.calls[0][0].initialIp).toEqual("::1");
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
@@ -894,12 +894,14 @@ describe("wrangler dev", () => {
 			writeWranglerToml({
 				main: "index.js",
 				dev: {
-					ip: "1.2.3.4",
+					ip: "::1",
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --ip=5.6.7.8");
-			expect((Dev as jest.Mock).mock.calls[0][0].initialIp).toEqual("5.6.7.8");
+			await runWrangler("dev --ip=127.0.0.1");
+			expect((Dev as jest.Mock).mock.calls[0][0].initialIp).toEqual(
+				"127.0.0.1"
+			);
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/dev/proxy.ts
+++ b/packages/wrangler/src/dev/proxy.ts
@@ -154,7 +154,7 @@ export async function startPreviewServer({
 			accessTokenRef,
 		});
 
-		await waitForPortToBeAvailable(port, {
+		await waitForPortToBeAvailable(port, ip, {
 			retryPeriod: 200,
 			timeout: 2000,
 			abortSignal: abortController.signal,
@@ -295,7 +295,7 @@ export function usePreviewServer({
 			return;
 		}
 
-		waitForPortToBeAvailable(port, {
+		waitForPortToBeAvailable(port, ip, {
 			retryPeriod: 200,
 			timeout: 2000,
 			abortSignal: abortController.signal,
@@ -636,9 +636,13 @@ function createStreamHandler(
  */
 export async function waitForPortToBeAvailable(
 	port: number,
+	host: string,
 	options: { retryPeriod: number; timeout: number; abortSignal: AbortSignal }
 ): Promise<void> {
 	return new Promise((resolve, reject) => {
+		if (host === "*") {
+			host = "0.0.0.0";
+		}
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		options.abortSignal.addEventListener("abort", () => {
 			const abortError = new Error("waitForPortToBeAvailable() aborted");
@@ -686,7 +690,7 @@ export async function waitForPortToBeAvailable(
 					doReject(err);
 				}
 			});
-			server.listen(port, () =>
+			server.listen(port, host, () =>
 				terminator
 					.terminate()
 					.then(doResolve, () =>

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1014,7 +1014,7 @@ export async function login(
 			}
 		});
 
-		server.listen(8976);
+		server.listen(8976, "localhost");
 	});
 	if (props?.browser) {
 		logger.log(`Opening a link in your default browser: ${urlToOpen}`);


### PR DESCRIPTION
The `wrangler dev` port availability check triggers a firewall prompt on macOS while it briefly opens and closes listeners. The OAuth callback server from `wrangler login` has the same issue.

Fix both cases by listening on the loopback address only by default.

Fixed some new test failures by using locally available IP addresses:

    wrangler:test:   ● wrangler dev › ip › should use to `ip` from `wrangler.toml`, if available
    wrangler:test:     listen EADDRNOTAVAIL: address not available 1.2.3.4:8787
    wrangler:test:
    wrangler:test:   ● wrangler dev › ip › should use --ip command line arg, if provided
    wrangler:test:     listen EADDRNOTAVAIL: address not available 5.6.7.8:8787

Relates to #4430

___
Note: the test suite still has many problems with listening on the wildcard address, for example `fixtures/pages-ws-app/server/index.ts`. Find more issues with: `git grep -ne '\.listen('`

**What this PR solves / how to test:**

Run `wrangler dev`, `wrangler dev --remote`, and `wrangler login`. Both should not trip a macOS "Accept incoming connections" firewall dialog. The `wrangler dev --remote --ip "*"` option should continue to work.

While `wrangler dev` has a shortlived socket, `wrangler login` listens for some more time. You can check this with `lsof -nPiTCP -sTCP:LISTEN` on macOS or `ss -tlpn` on Linux.


**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: non-critical functionality.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: bugfix.

<!--
**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->