### PR TITLE
Revert "build(deps): bump hono from 3.5.6 to 3.11.7 (#4608)"

### DIFF
--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -13,7 +13,7 @@
 		"test:ci": "vitest run"
 	},
 	"dependencies": {
-		"hono": "^3.11.7",
+		"hono": "^3.3.2",
 		"zod": "^3.22.3"
 	},
 	"devDependencies": {

--- a/packages/turbo-r2-archive/package.json
+++ b/packages/turbo-r2-archive/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@hono/zod-validator": "^0.1.8",
-		"hono": "^3.11.7",
+		"hono": "^3.5.6",
 		"zod": "^3.22.3"
 	},
 	"devDependencies": {

--- a/packages/workers-playground/package.json
+++ b/packages/workers-playground/package.json
@@ -33,7 +33,7 @@
 		"csstype": "^3.1.2",
 		"es-module-lexer": "^1.3.0",
 		"glob-to-regexp": "^0.4.1",
-		"hono": "^3.11.7",
+		"hono": "^3.3.2",
 		"lz-string": "^1.5.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,8 +1016,8 @@ importers:
   packages/playground-preview-worker:
     dependencies:
       hono:
-        specifier: ^3.11.7
-        version: 3.11.7
+        specifier: ^3.3.2
+        version: 3.5.6
       zod:
         specifier: ^3.22.3
         version: 3.22.3
@@ -1112,10 +1112,10 @@ importers:
     dependencies:
       '@hono/zod-validator':
         specifier: ^0.1.8
-        version: 0.1.8(hono@3.11.7)(zod@3.22.3)
+        version: 0.1.8(hono@3.5.6)(zod@3.22.3)
       hono:
-        specifier: ^3.11.7
-        version: 3.11.7
+        specifier: ^3.5.6
+        version: 3.5.6
       zod:
         specifier: ^3.22.3
         version: 3.22.3
@@ -1196,8 +1196,8 @@ importers:
         specifier: ^0.4.1
         version: 0.4.1
       hono:
-        specifier: ^3.11.7
-        version: 3.11.7
+        specifier: ^3.3.2
+        version: 3.5.6
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0
@@ -5108,13 +5108,13 @@ packages:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
 
-  /@hono/zod-validator@0.1.8(hono@3.11.7)(zod@3.22.3):
+  /@hono/zod-validator@0.1.8(hono@3.5.6)(zod@3.22.3):
     resolution: {integrity: sha512-/Kd/p/dUVKM7/1TY3jafTV+ngwEh3fOLmXCJQKb9esWsCom5WOJaNmZYv8jeRhyipu1xBvmN5jceRA3Ev3rmQw==}
     peerDependencies:
       hono: 3.*
       zod: ^3.19.1
     dependencies:
-      hono: 3.11.7
+      hono: 3.5.6
       zod: 3.22.3
     dev: false
 
@@ -12473,8 +12473,8 @@ packages:
     resolution: {integrity: sha512-Yu+q/XWr2fFQ11tHxPq4p4EiNkb2y+lAacJNhAdRXVfRIcDH6gi7htWFnnlIzvqHMHoWeIsfXlNAjZInpAOJDA==}
     dev: true
 
-  /hono@3.11.7:
-    resolution: {integrity: sha512-TcfAq7IdipF+9coxnuzYlSSBXbm9mTyWjjagLCv/2ampboNcKJdi+XCK5G48mHQtpI5+9Rj3J4FfcGgw9vzIww==}
+  /hono@3.5.6:
+    resolution: {integrity: sha512-ycTOpIZJ6yLbjzoE+ojsesC7G7ZXfGSoCIDyvqmzlHc5Mk4Aj48Ed9R5g7gw3v7rOkS81pjcYIvWef/karq1iA==}
     engines: {node: '>=16.0.0'}
     dev: false
 


### PR DESCRIPTION
This reverts commit 14e64e97f06d1a0ebdefa8df7bd14f38b7de0ae3.

This bump to the Hono library broke playground-preview-worker tests, which were not run on the PR.

Fixes # [insert GH or internal issue number(s)].

**What this PR solves / how to test:**

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
