### PR TITLE
ci: only deploy Workers when pushing to special branches

### DIFF
--- a/.github/workflows/worker-deploy-edge-preview-authenticated-proxy.yml
+++ b/.github/workflows/worker-deploy-edge-preview-authenticated-proxy.yml
@@ -1,16 +1,16 @@
-name: Error Formatting Worker
+name: Deploy Edge Preview Authenticated Proxy Worker (production)
 
+# On a push to `deploy-worker/edge-preview-authenticated-proxy`, on Cloudflare,
+# deploy to production.
 on:
   push:
     branches:
-      - main
-    paths:
-      - "packages/format-errors/**"
+      - deploy-worker/edge-preview-authenticated-proxy
 
 jobs:
-  publish_worker:
+  deploy_worker:
     if: ${{ github.repository_owner == 'cloudflare' }}
-    name: Publish Worker
+    name: Deploy Edge Preview Authenticated Proxy (production)
     runs-on: ubuntu-latest
 
     steps:
@@ -18,33 +18,37 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+
+      - name: Use pnpm 8.8.0
+        uses: pnpm/action-setup@v2
         with:
           version: 8.8.0
+
       - name: Use Node.js 16.18
         uses: actions/setup-node@v3
         with:
           node-version: 16.18
           cache: "pnpm"
 
-      - name: Install workerd Dependencies
+      - name: Install workerd dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update
           sudo apt-get install -y libc++1
-      - name: Install NPM Dependencies
+
+      - name: Install NPM dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build wrangler
+      - name: Build tools and libraries
         run: pnpm run build
         env:
           NODE_ENV: "production"
           CI_OS: ${{ runner.os }}
 
-      - name: Build & Publish Worker
-        run: pnpm run publish
+      - name: Build & deploy Worker
+        run: pnpm run deploy
         env:
           NODE_ENV: "production"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        working-directory: packages/format-errors
+        working-directory: packages/edge-preview-authenticated-proxy

--- a/.github/workflows/worker-format-errors-deploy.yml
+++ b/.github/workflows/worker-format-errors-deploy.yml
@@ -1,51 +1,54 @@
-name: Edge Preview Authenticated Proxy Worker
+name: Deploy Format Errors Worker (production)
 
+# On a push to `deploy-worker/format-errors`, on Cloudflare,
+# deploy to production.
 on:
   push:
     branches:
-      - main
-    paths:
-      - "packages/edge-preview-authenticated-proxy/**"
+      - deploy-worker/format-errors
 
 jobs:
-  publish_worker:
+  deploy_worker:
     if: ${{ github.repository_owner == 'cloudflare' }}
-    name: Publish Worker
+    name: Deploy Format Errors Worker (production)
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Checkout repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+
+      - name: Use pnpm 8.8.0
+        uses: pnpm/action-setup@v2
         with:
           version: 8.8.0
+
       - name: Use Node.js 16.18
         uses: actions/setup-node@v3
         with:
           node-version: 16.18
           cache: "pnpm"
 
-      - name: Install workerd Dependencies
+      - name: Install workerd dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update
           sudo apt-get install -y libc++1
 
-      - name: Install NPM Dependencies
+      - name: Install NPM dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build wrangler
+      - name: Build tools and libraries
         run: pnpm run build
         env:
           NODE_ENV: "production"
           CI_OS: ${{ runner.os }}
 
-      - name: Build & Publish Worker
-        run: pnpm run publish
+      - name: Build & deploy Worker
+        run: pnpm run deploy
         env:
           NODE_ENV: "production"
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        working-directory: packages/edge-preview-authenticated-proxy
+        working-directory: packages/format-errors

--- a/.github/workflows/worker-playground-preview-deploy-production.yml
+++ b/.github/workflows/worker-playground-preview-deploy-production.yml
@@ -1,49 +1,52 @@
-name: Playground Preview Worker
+name: Deploy Playground Preview Worker (production)
 
+# On a push to `deploy-worker/playground-preview-worker`, on Cloudflare,
+# deploy to production.
 on:
   push:
     branches:
-      - main
-    paths:
-      - "packages/playground-preview-worker/**"
+      - deploy-worker/playground-preview-worker
 
 jobs:
-  publish_worker:
+  deploy_worker:
     if: ${{ github.repository_owner == 'cloudflare' }}
-    name: Publish Worker
+    name: Deploy Playground Preview Worker (production)
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Checkout repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+
+      - name: Use pnpm 8.8.0
+        uses: pnpm/action-setup@v2
         with:
           version: 8.8.0
+
       - name: Use Node.js 16.18
         uses: actions/setup-node@v3
         with:
           node-version: 16.18
           cache: "pnpm"
 
-      - name: Install workerd Dependencies
+      - name: Install workerd dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update
           sudo apt-get install -y libc++1
 
-      - name: Install NPM Dependencies
+      - name: Install NPM dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build wrangler
+      - name: Build tools and libraries
         run: pnpm run build
         env:
           NODE_ENV: "production"
           CI_OS: ${{ runner.os }}
 
-      - name: Build & Publish Worker
+      - name: Build & deploy Worker
         run: pnpm run deploy
         env:
           NODE_ENV: "production"

--- a/.github/workflows/worker-playground-preview-deploy-testing.yml
+++ b/.github/workflows/worker-playground-preview-deploy-testing.yml
@@ -1,50 +1,58 @@
-name: Playground Worker tests
+name: Deploy Playground Preview Worker (testing)
 
+# On a push to `main`, on Cloudflare, where there are changes to the files in this worker's package,
+# or an update to a PR, on Cloudflare, labelled as `playground-worker`,
+# deploy to testing and then run the end-to-end tests against this deployment.
 on:
   push:
     branches:
       - main
-      - changeset-release/main
+    paths:
+      - "packages/playground-preview-worker/**"
+
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
-  repository_dispatch:
 
 jobs:
   e2e-test:
-    if: github.repository_owner == 'cloudflare' && (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains(github.event.*.labels.*.name, 'playground-worker' )) || (github.event_name == 'pull_request' && github.head_ref == 'changeset-release/main'))
-    name: "Playground Worker Test"
+    if: github.repository_owner == 'cloudflare' && (github.event_name != 'pull_request' || contains(github.event.*.labels.*.name, 'playground-worker'))
+    name: "Deploy Playground Preview Worker (testing)"
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout Repo
+      - name: Checkout repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+
+      - name: Use pnpm 8.8.0
+        uses: pnpm/action-setup@v2
         with:
           version: 8.8.0
-      - name: Use Node.js 18
+
+      - name: Use Node.js 16.18
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16.18
           cache: "pnpm"
 
-      - name: Install workerd Dependencies
+      - name: Install workerd dependencies
         if: ${{ runner.os == 'Linux' }}
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update
           sudo apt-get install -y libc++1
 
-      - name: Install NPM Dependencies
+      - name: Install NPM dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run builds
+      - name: Build tools and libraries
         run: pnpm run build
         env:
           NODE_ENV: "production"
           CI_OS: ${{ runner.os }}
 
-      - name: Build & Publish Testing Playground Worker
+      - name: Build & deploy Worker
         run: pnpm run deploy:testing
         env:
           NODE_ENV: "production"
@@ -52,7 +60,7 @@ jobs:
         working-directory: packages/playground-preview-worker
 
       - name: Run tests & collect coverage
-        run: pnpm run test:ci
+        run: pnpm run test:e2e
         env:
           TMP_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TMP_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/edge-preview-authenticated-proxy/package.json
+++ b/packages/edge-preview-authenticated-proxy/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"check:lint": "eslint .",
-		"publish": "wrangler deploy",
+		"deploy": "wrangler deploy",
 		"start": "wrangler dev",
 		"test": "vitest run",
 		"type:tests": "tsc -p ./tests/tsconfig.json",

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"check:lint": "eslint .",
-		"publish": "wrangler deploy",
+		"deploy": "wrangler deploy",
 		"build": "wrangler build",
 		"start": "wrangler dev"
 	},

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -9,8 +9,7 @@
 		"deploy": "wrangler -j deploy",
 		"deploy:testing": "wrangler -j deploy -e testing",
 		"start": "wrangler -j dev",
-		"test": "vitest run",
-		"test:ci": "vitest run"
+		"test:e2e": "vitest run"
 	},
 	"dependencies": {
 		"hono": "^3.3.2",

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -1,12 +1,5 @@
 import { fetch } from "undici";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-
-function removeUUID(str: string) {
-	return str.replace(
-		/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/g,
-		"00000000-0000-0000-0000-000000000000"
-	);
-}
+import { beforeAll, describe, expect, it } from "vitest";
 
 const REMOTE = "https://playground-testing.devprod.cloudflare.dev";
 const PREVIEW_REMOTE =


### PR DESCRIPTION
Previously every push to `main` that contained changes to a Worker package would cause that Worker to be deploy "to production". This meant that we had to be very careful about merging PRs that touch these Workers files.

Now production deployment is only run for a Worker on a push to its special deployment branch (e.g. `deploy-worker/playground-preview-worker`). This allows us to land PRs to `main` and then collect up changes to release in a single go by updating the special deployment branch in a controlled way. Moreover it is also easy to see what changes will be released by looking at the difference between `main` and the deployment branch for the Worker package directory.

The three workers in this repo now follow this pattern:

- edge-preview-authenticated-proxy
- format-errors
- playground-preview-worker

The overhead is that to trigger a release one will need to do something like:

```
git switch main
git pull
git switch deploy-worker/playground-preview-worker
git reset --hard main
git push
```

(Or if you want you could create and merge a PR from `main` to the deployment branch in Github, if CLI commands were not your thing.)

Note that we will add branch protection rules to prevent unauthorised users from deploying Workers.

![Screenshot 2024-01-30 at 14 43 48](https://github.com/cloudflare/workers-sdk/assets/15655/0dd5c7e1-4a6e-45ca-a438-b758bc9b140d)


In addition, the Playground Preview Worker has end-to-end tests that are run on every push to the `main` branch, and also any PRs that have the "playground-worker" label. For these tests the Worker is deployed to the testing environment before running the tests against this deployment.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: update to CI configuration
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: internal update to CI configuration
- Associated docs
  - [ ] **TBD - need to update our release docs when this PR lands**
  - [ ] Not necessary because:
