### PR TITLE
[wrangler] Allow empty strings in secret:bulk

### DIFF
--- a/.changeset/eleven-carrots-happen.md
+++ b/.changeset/eleven-carrots-happen.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: allow empty strings in secret:bulk upload
+
+Previously, the `secret:bulk` command would fail if any of the secrets in the secret.json file were empty strings and they already existed remotely.

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -736,6 +736,7 @@ describe("wrangler secret", () => {
 				JSON.stringify({
 					"secret-name-2": "secret_text",
 					"secret-name-3": "secret_text",
+					"secret-name-4": "",
 				})
 			);
 
@@ -761,6 +762,7 @@ describe("wrangler secret", () => {
 										},
 										{ type: "secret_text", name: "secret-name-1" },
 										{ type: "secret_text", name: "secret-name-2" },
+										{ type: "secret_text", name: "secret-name-4" },
 									],
 								})
 							)
@@ -795,6 +797,7 @@ describe("wrangler secret", () => {
 									name: "secret-name-3",
 									text: "secret_text",
 								},
+								{ type: "secret_text", name: "secret-name-4", text: "" },
 							],
 						});
 						expect(parsedSettings).not.toHaveProperty(["bindings", 0, "text"]);
@@ -811,9 +814,10 @@ describe("wrangler secret", () => {
 					"🌀 Creating the secrets for the Worker \\"script-name\\"
 					✨ Successfully created secret for key: secret-name-2
 					✨ Successfully created secret for key: secret-name-3
+					✨ Successfully created secret for key: secret-name-4
 
 					Finished processing secrets JSON file:
-					✨ 2 secrets successfully uploaded"
+					✨ 3 secrets successfully uploaded"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -452,7 +452,7 @@ export const secretBulkHandler = async (secretBulkArgs: SecretBulkArgs) => {
 			// secrets that currently exist for the worker but are not provided for bulk update
 			// are inherited over with other binding types
 			return (
-				binding.type !== "secret_text" || !content[binding.name] === undefined
+				binding.type !== "secret_text" || content[binding.name] === undefined
 			);
 		})
 		.map((binding) => ({ type: binding.type, name: binding.name }));

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -451,7 +451,9 @@ export const secretBulkHandler = async (secretBulkArgs: SecretBulkArgs) => {
 		.filter((binding) => {
 			// secrets that currently exist for the worker but are not provided for bulk update
 			// are inherited over with other binding types
-			return binding.type !== "secret_text" || !content[binding.name];
+			return (
+				binding.type !== "secret_text" || !content[binding.name] === undefined
+			);
 		})
 		.map((binding) => ({ type: binding.type, name: binding.name }));
 	// secrets to upload are provided as bindings in their full form


### PR DESCRIPTION
**What this PR solves / how to test:**
Previously when running `secret:bulk` with a `secret.json` containing a variable with an empty string as value the bulk operation would fail. This was due to the check for a falsy value when merging instead of comparing to `undefined` to make sure all specified values are excluded. The old other check would keep both the current value and the new value in the merged list which would then be rejected by the settings API as it doesn't allow the same key to be present multiple times.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: just a small fix

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
