### PR TITLE
Extend error handling of proxy request errors in ProxyWorker

### DIFF
--- a/.changeset/few-houses-wait.md
+++ b/.changeset/few-houses-wait.md
@@ -2,4 +2,8 @@
 "wrangler": patch
 ---
 
-Previously, when running `wrangler dev`, requests inflight during a UserWorker reload (due to config or source file changes) would fail. Now, if those inflight requests are GET or HEAD requests, they will be reproxied against the new UserWorker. This adds to the guarantee that requests made during local development reach the latest worker.
+fix: inflight requests to UserWorker which failed across reloads are now retried
+
+Previously, when running `wrangler dev`, requests inflight during a UserWorker reload (due to config or source file changes) would fail.
+
+Now, if those inflight requests are GET or HEAD requests, they will be reproxied against the new UserWorker. This adds to the guarantee that requests made during local development reach the latest worker.

--- a/.changeset/few-houses-wait.md
+++ b/.changeset/few-houses-wait.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Previously, when running `wrangler dev`, requests inflight during a UserWorker reload (due to config or source file changes) would fail. Now, if those inflight requests are GET or HEAD requests, they will be reproxied against the new UserWorker. This adds to the guarantee that requests made during local development reach the latest worker.

--- a/fixtures/dev-env/tests/index.test.ts
+++ b/fixtures/dev-env/tests/index.test.ts
@@ -230,7 +230,7 @@ describe("startDevWorker: ProxyController", () => {
 		fireAndForgetFakeUserWorkerChanges({
 			mfOpts: run.mfOpts,
 			config: run.config,
-			script: run.mfOpts.script.replace("1", "2"),
+			script: run.mfOpts.script.replace("body:1", "body:2"),
 		});
 
 		res = await run.worker.fetch("http://dummy");
@@ -295,7 +295,7 @@ describe("startDevWorker: ProxyController", () => {
 		fireAndForgetFakeUserWorkerChanges({
 			mfOpts: run.mfOpts,
 			config: run.config,
-			script: run.mfOpts.script.replace("1", "2"),
+			script: run.mfOpts.script.replace("body:1", "body:2"),
 		});
 		await executionContextClearedPromise;
 	});
@@ -598,5 +598,54 @@ describe("startDevWorker: ProxyController", () => {
 		await expect(res.text()).resolves.toBe(
 			"URL: https://mybank.co.uk/test/path/2"
 		);
+	});
+
+	test("inflight requests are retried during UserWorker reloads", async () => {
+		// to simulate inflight requests failing during UserWorker reloads,
+		// we will use a UserWorker with a longish `await setTimeout(...)`
+		// so that we can guarantee the race condition is hit
+		// when workerd is eventually terminated
+
+		const run = await fakeStartUserWorker({
+			script: `
+				export default {
+					async fetch(request) {
+            const url = new URL(request.url);
+
+            if (url.pathname === '/long') {
+              await new Promise(r => setTimeout(r, 30_000));
+            }
+						return new Response("UserWorker:1");
+					}
+				}
+			`,
+		});
+
+		res = await run.worker.fetch("http://dummy/short"); // implicitly waits for UserWorker:1 to be ready
+		await expect(res.text()).resolves.toBe("UserWorker:1");
+
+		const inflightDuringReloads = run.worker.fetch("http://dummy/long");
+
+		// this will cause workerd for UserWorker:1 to terminate (eventually, but soon)
+		fireAndForgetFakeUserWorkerChanges({
+			mfOpts: run.mfOpts,
+			config: run.config,
+			script: run.mfOpts.script.replace("UserWorker:1", "UserWorker:2"), // change response so it can be identified
+		});
+
+		res = await run.worker.fetch("http://dummy/short"); // implicitly waits for UserWorker:2 to be ready
+		await expect(res.text()).resolves.toBe("UserWorker:2");
+
+		// this will cause workerd for UserWorker:2 to terminate (eventually, but soon)
+		fireAndForgetFakeUserWorkerChanges({
+			mfOpts: run.mfOpts,
+			config: run.config,
+			script: run.mfOpts.script
+				.replace("UserWorker:1", "UserWorker:3") // change response so it can be identified
+				.replace("30_000", "0"), // remove the long wait as we won't reload this UserWorker
+		});
+
+		res = await inflightDuringReloads;
+		await expect(res.text()).resolves.toBe("UserWorker:3");
 	});
 });

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -41,17 +41,3 @@ export function urlFromParts(
 
 	return url;
 }
-
-export function urlPartsEqual(
-	partsA: Partial<URL> | undefined,
-	partsB: Partial<URL> | undefined,
-	baseA = "http://localhost",
-	baseB = baseA
-): boolean {
-	if (partsA === undefined || partsB === undefined) return partsA === partsB;
-
-	const urlA = urlFromParts(partsA, baseA);
-	const urlB = urlFromParts(partsB, baseB);
-
-	return urlA.href === urlB.href;
-}

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -41,3 +41,17 @@ export function urlFromParts(
 
 	return url;
 }
+
+export function urlPartsEqual(
+	partsA: Partial<URL> | undefined,
+	partsB: Partial<URL> | undefined,
+	baseA = "http://localhost",
+	baseB = baseA
+): boolean {
+	if (partsA === undefined || partsB === undefined) return partsA === partsB;
+
+	const urlA = urlFromParts(partsA, baseA);
+	const urlB = urlFromParts(partsB, baseB);
+
+	return urlA.href === urlB.href;
+}

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -139,34 +139,12 @@ export class ProxyWorker implements DurableObject {
 					// errors here are network errors or from response post-processing
 					// to catch only network errors, use the 2nd param of the fetch.then()
 
+					// we have crossed an async boundary, so proxyData may have changed
 					const newUserWorkerUrl =
 						this.proxyData && urlFromParts(this.proxyData.userWorkerUrl);
-					const downstreamUserWorkerChanged =
-						userWorkerUrl.href !== newUserWorkerUrl?.href;
-					const canRequestBeRetried =
-						request.method === "GET" || request.method === "HEAD"; // subset of idempotent requests which have no body
 
-					// if the downstream proxy has changed, requeue request and ignore errors
-					if (downstreamUserWorkerChanged) {
-						if (canRequestBeRetried) {
-							this.requestQueue.set(request, deferredResponse);
-						} else {
-							// if request cannot be retried, respond with 503 Service Unavailable
-							// important to note, this is not an (unexpected) error -- it is an acceptable flow of local development
-							// it would be incorrect to retry non-idempotent requests
-							// and would require cloning all body streams to avoid stream reuse (which is inefficient but not out of the question in the future)
-							// this is a good enough UX for now since it solves the most common GET use-case
-							deferredResponse.resolve(
-								new Response(
-									"Your worker restarted mid-request. Please try sending the request again. Only GET or HEAD requests are retried automatically.",
-									{
-										status: 503,
-										headers: { "Retry-After": "0" },
-									}
-								)
-							);
-						}
-					} else {
+					// only report errors if the downstream proxy has NOT changed
+					if (userWorkerUrl.href === newUserWorkerUrl?.href) {
 						void sendMessageToProxyController(this.env, {
 							type: "error",
 							error: {
@@ -178,6 +156,28 @@ export class ProxyWorker implements DurableObject {
 						});
 
 						deferredResponse.reject(error);
+					}
+
+					// if the request can be retried (subset of idempotent requests which have no body), requeue it
+					else if (request.method === "GET" || request.method === "HEAD") {
+						this.requestQueue.set(request, deferredResponse);
+					}
+
+					// if the request cannot be retried, respond with 503 Service Unavailable
+					// important to note, this is not an (unexpected) error -- it is an acceptable flow of local development
+					// it would be incorrect to retry non-idempotent requests
+					// and would require cloning all body streams to avoid stream reuse (which is inefficient but not out of the question in the future)
+					// this is a good enough UX for now since it solves the most common GET use-case
+					else {
+						deferredResponse.resolve(
+							new Response(
+								"Your worker restarted mid-request. Please try sending the request again. Only GET or HEAD requests are retried automatically.",
+								{
+									status: 503,
+									headers: { "Retry-After": "0" },
+								}
+							)
+						);
 					}
 				});
 		}


### PR DESCRIPTION
(Potentially) fixes #4562 

**What this PR solves / how to test:**

Before, the ProxyWorker had no resolution for errors that occur while requests are proxied and just logged the error to the terminal. This was because we expected inflight requests to be completed before workerd shuts down and therefore requests would only fail for unexpected reasons with no recovery strategy. But it seems, from reported issues, that requests are failing while the UserWorker is reloaded (workerd shuts down and a new workerd starts).

Now, given requests are known to fail during reloads, requests are now requeued (to retry) if they are GET or HEAD requests (because these are the subset of idempotent requests which have no body and _can safely_ be retried).

I managed to simulate the scenario with a worker which takes a while to respond to a request. And can confirm the test failed before these code changes and passes afterwards.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because: 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): #4562
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
