### PR TITLE
Update issue template bug description field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -52,7 +52,7 @@ body:
     attributes:
       label: Describe the Bug
       description: Please describe the bug and include steps to reproduce.
-      placeholder: |
+      value: |
         ### Observed behavior
         Please describe.
 


### PR DESCRIPTION
Fixes N/A.

**What this PR solves / how to test:** Fixes previous update to the issue template (https://github.com/cloudflare/workers-sdk/pull/4865) to include the content of the "Describe the bug" field as pre-filled value rather than a placeholder.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: just changing issue template
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: just changing issue template
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: just changing issue template

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
