### PR TITLE
[wrangler] Support ai bindings in getBindingsProxy

### DIFF
--- a/.changeset/odd-kids-notice.md
+++ b/.changeset/odd-kids-notice.md
@@ -2,4 +2,6 @@
 "wrangler": patch
 ---
 
-Expose AI bindings to the `getBindingsProxy` utility function.
+feature: Expose AI bindings to `getBindingsProxy`.
+
+The `getBindingsProxy` utility function will now contain entries for any AI bindings specified in `wrangler.toml`.

--- a/.changeset/odd-kids-notice.md
+++ b/.changeset/odd-kids-notice.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Expose AI bindings to the `getBindingsProxy` utility function.

--- a/packages/wrangler/src/api/integrations/bindings/index.ts
+++ b/packages/wrangler/src/api/integrations/bindings/index.ts
@@ -118,7 +118,10 @@ async function getMiniflareOptionsFromConfig(
 				script: "",
 				modules: true,
 				...bindingOptions,
-				serviceBindings,
+				serviceBindings: {
+					...serviceBindings,
+					...bindingOptions.serviceBindings,
+				},
 			},
 			externalDurableObjectWorker,
 		],


### PR DESCRIPTION
Fixes #4793.

**What this PR solves / how to test:**

This PR adds support for AI bindings to `getBindingsProxy`. 

A proxy object was already getting added to the miniflare binding options, but as a [service binding](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/dev/miniflare.ts#L352). `getBindingsProxy` was then clobbering that definition with its own service binding definitions. 

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ x ] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
