### PR TITLE
[wrangler] fix: stop rebuild attempts when sources are missing (#3886)

### DIFF
--- a/.changeset/hip-files-count.md
+++ b/.changeset/hip-files-count.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+fix: Intermittent errors during watch rebuilds mitigated

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -371,7 +371,10 @@ export const Handler = async ({
 		watch([workerScriptPath], {
 			persistent: true,
 			ignoreInitial: true,
-		}).on("all", async () => {
+		}).on("all", async (event) => {
+			if (event === "unlink") {
+				return;
+			}
 			await runBuild();
 		});
 	} else if (usingFunctions) {
@@ -539,8 +542,11 @@ export const Handler = async ({
 			watch([routesJSONPath], {
 				persistent: true,
 				ignoreInitial: true,
-			}).on("all", async () => {
+			}).on("all", async (event) => {
 				try {
+					if (event === "unlink") {
+						return;
+					}
 					/**
 					 * Watch for _routes.json file changes and validate file each time.
 					 * If file is valid proceed to running the build.


### PR DESCRIPTION
Fixes #3886.

**What this PR solves / how to test:**

As I've been working on a site using sveltekit and its adapter-cloudflare alongside workers-sdk I've been seeing lots of errors in the console (as those in the issue linked above) referring to missing files. This is due to rebuilds of the worker file being triggered on all file changes, including "unlink" events, which with lots of build pipelines happen at the beginning of a build.

In effect this means that we watch files for change, notice that a file has been deleted, and then try to rebuild, although we can guarantee that at this point the build will file, since the watched file no longer exists, and instead we should just hold on a few seconds until the build finishes and the "add" or "change" event is emitted.

**Author has addressed the following:**

This PR updates the behaviour of the dev.ts' worker script building to ignore "unlink" events on the worker file as well as the route files, so rebuilds are only triggered on events which add or modify said files. This means that no more `ENOENT` errors for missing `_worker.js` or `_routes.json` when watching for changes.

- Tests
  - [ ] Included
  - [x] Not necessary because: Removes intermittent errors during development watch experience which doesn't seem to be tested for.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): #3886
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
