### PR TITLE
Exclude standardPricingWarning from dryrun

### DIFF
--- a/.changeset/twelve-coins-hear.md
+++ b/.changeset/twelve-coins-hear.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: do not attempt login during dry-run
+
+The "standard pricing" warning was attempting to make an API call that was causing a login attempt even when on a dry-run.
+Now this warning is disabled during dry-runs.
+
+Fixes #4723

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -293,10 +293,9 @@ export async function deployHandler(
 					args.siteInclude,
 					args.siteExclude
 			  );
-	
-	if (!args.dryRun)
-		await standardPricingWarning(accountId, config);
-	
+
+	if (!args.dryRun) await standardPricingWarning(accountId, config);
+
 	await deploy({
 		config,
 		accountId,

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -293,7 +293,10 @@ export async function deployHandler(
 					args.siteInclude,
 					args.siteExclude
 			  );
-	await standardPricingWarning(accountId, config);
+	
+	if (!args.dryRun)
+		await standardPricingWarning(accountId, config);
+	
 	await deploy({
 		config,
 		accountId,


### PR DESCRIPTION
That way we do not need authentication for dryrun, again.

Fixes #4723

**What this PR solves / how to test:**

Install wrangler, don't login (or logout) run a dryRun deploy, see that you are asked to login. Install PR, see that you are no longer required to login when doing a dryRun deploy.

**Author has addressed the following:**

- Tests
  - [x] Not necessary because: fixes a non-tested bug
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because: trivial fix
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: trivial bug

