### PR TITLE
Implements wrangler deploy/dev support for Python.

### DIFF
--- a/.changeset/smooth-goats-watch.md
+++ b/.changeset/smooth-goats-watch.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feature: implemented Python support in Wrangler
+
+Python Workers are now supported by `wrangler deploy` and `wrangler dev`.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -601,7 +601,6 @@ let maybeInstanceRegistry:
 export function _initialiseInstanceRegistry() {
 	return (maybeInstanceRegistry = new Map());
 }
-
 export class Miniflare {
 	#previousSharedOpts?: PluginSharedOptions;
 	#sharedOpts: PluginSharedOptions;

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -240,6 +240,77 @@ describe("basic dev tests", () => {
 	});
 });
 
+describe("basic dev python tests", () => {
+	let worker: DevWorker;
+
+	beforeEach(async () => {
+		worker = await makeWorker();
+		await worker.seed((workerName) => ({
+			"wrangler.toml": dedent`
+					name = "${workerName}"
+					main = "index.py"
+					compatibility_date = "2023-01-01"
+			`,
+			"index.py": dedent`
+				from js import Response
+				def fetch(request):
+					return Response.new('py hello world')`,
+			"package.json": dedent`
+					{
+						"name": "${workerName}",
+						"version": "0.0.0",
+						"private": true
+					}
+					`,
+		}));
+	});
+
+	it.only("can run and modify python worker during dev session (local)", async () => {
+		await worker.runDevSession("", async (session) => {
+			const { text } = await retry(
+				(s) => s.status !== 200,
+				async () => {
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(text).toMatchInlineSnapshot('"py hello world"');
+
+			await worker.seed({
+				"index.py": dedent`
+					from js import Response
+					def fetch(request):
+						return Response.new('Updated Python Worker value')`,
+			});
+
+			const { text: text2 } = await retry(
+				(s) => s.status !== 200 || s.text === "py hello world",
+				async () => {
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(text2).toMatchInlineSnapshot('"Updated Python Worker value"');
+
+			await worker.seed((workerName) => ({
+				"wrangler.toml": dedent`
+						name = "${workerName}"
+						main = "index.py"
+						compatibility_date = "2023-01-01"
+				`,
+			}));
+			const { text: text3 } = await retry(
+				(s) => s.status !== 200 || s.text === "Updated Python Worker value",
+				async () => {
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(text3).toMatchInlineSnapshot('"Updated Python Worker value"');
+		});
+	});
+});
+
 describe("dev registry", () => {
 	let a: DevWorker;
 	let b: DevWorker;

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8775,6 +8775,46 @@ export default{
 		});
 	});
 
+	describe("python", () => {
+		it("should upload python module defined in wrangler.toml", async () => {
+			writeWranglerToml({
+				main: "index.py"
+			});
+			await fs.promises.writeFile("index.py", "from js import Response;\ndef fetch(request):\n return Response.new('hello')");
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedMainModule: "index.py"
+			});
+
+			await runWrangler("deploy");
+			expect(std.out).toMatchInlineSnapshot(`
+			"Total Upload: xx KiB / gzip: xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Deployment ID: Galaxy-Class"
+		`);
+		});
+
+		it("should upload python module specified in CLI args", async () => {
+			writeWranglerToml();
+			await fs.promises.writeFile("index.py", "from js import Response;\ndef fetch(request):\n return Response.new('hello')");
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedMainModule: "index.py"
+			});
+
+			await runWrangler("deploy index.py");
+			expect(std.out).toMatchInlineSnapshot(`
+			"Total Upload: xx KiB / gzip: xx KiB
+			Uploaded test-name (TIMINGS)
+			Published test-name (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Deployment ID: Galaxy-Class"
+		`);
+		});
+	});
+
 	describe("hyperdrive", () => {
 		it("should upload hyperdrive bindings", async () => {
 			writeWranglerToml({

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -41,7 +41,6 @@ import type {
 import type { ValidatorFn } from "./validation-helpers";
 
 const ENGLISH = new Intl.ListFormat("en");
-
 /**
  * Validate the given `rawConfig` object that was loaded from `configPath`.
  *

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -25,6 +25,8 @@ export function toMimeType(type: CfModuleType): string {
 			return "application/octet-stream";
 		case "text":
 			return "text/plain";
+		case "python":
+			return "text/x-python";
 		default:
 			throw new TypeError("Unsupported module: " + type);
 	}

--- a/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
+++ b/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
@@ -20,6 +20,17 @@ export default async function guessWorkerFormat(
 	hint: CfScriptFormat | undefined,
 	tsconfig?: string | undefined
 ): Promise<CfScriptFormat> {
+	const parsedEntryPath = path.parse(entryFile);
+	if (parsedEntryPath.ext == ".py") {
+		logger.warn(
+			`The entrypoint ${path.relative(
+				process.cwd(),
+				entryFile
+			)} defines a Python worker, support for Python workers is currently experimental.`
+		);
+		return "python";
+	}
+
 	const result = await esbuild.build({
 		...COMMON_ESBUILD_OPTIONS,
 		entryPoints: [entryFile],

--- a/packages/wrangler/src/deployment-bundle/run-custom-build.ts
+++ b/packages/wrangler/src/deployment-bundle/run-custom-build.ts
@@ -38,7 +38,7 @@ export async function runCustomBuild(
 		assertEntryPointExists(
 			expectedEntryAbsolute,
 			expectedEntryRelative,
-			`The entry-point file at "${expectedEntryRelative}" was not found.`
+			`The entry-point file at "${expectedEntryAbsolute}" was not found.`
 		);
 	}
 }

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -4,7 +4,7 @@ import type { Json } from "miniflare";
 /**
  * The type of Worker
  */
-export type CfScriptFormat = "modules" | "service-worker";
+export type CfScriptFormat = "modules" | "service-worker" | "python";
 
 /**
  * A module type.
@@ -14,7 +14,8 @@ export type CfModuleType =
 	| "commonjs"
 	| "compiled-wasm"
 	| "text"
-	| "buffer";
+	| "buffer"
+	| "python";
 
 /**
  * An imported module.

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -4,6 +4,7 @@ import { getEntry } from "./deployment-bundle/entry";
 import { UserError } from "./errors";
 import { logger } from "./logger";
 import type { Config } from "./config";
+import { CfScriptFormat } from "./deployment-bundle/worker";
 
 // Currently includes bindings & rules for declaring modules
 
@@ -147,7 +148,7 @@ function writeDTSFile({
 }: {
 	envTypeStructure: string[];
 	modulesTypeStructure: string[];
-	formatType: "modules" | "service-worker";
+	formatType: CfScriptFormat;
 }) {
 	const wranglerOverrideDTSPath = findUpSync("worker-configuration.d.ts");
 	try {


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR implements `wrangler deploy index.py` and `wrangler deploy` (with a wrangler.toml that defines `main = "index.py"`). This means Python Workers can be deployed using Wrangler.

Tested manually via:

```
$ cat $PWD/index.py
from js import Response
def fetch(request):
  return Response.new('Updated Python Worker value')
$ pnpm run --filter wrangler start dev $PWD/index.py --compatibility-flag experimental
```

Also using tests:

```
$ cd packages/wrangler
$ pnpm test # added --testNamePattern=\"can run and modify python worker during dev session (local)\" --silent=false in packages.json
$ pnpm test:e2e
```

I included an e2e test for `dev` but I couldn't run it locally. Other e2e tests fail locally for me too so I guess I just have something misconfigured. Help appreciated in getting it working.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
