### PR TITLE
chore: bump vite and vitest to latest versions

### DIFF
--- a/fixtures/additional-modules/test/index.test.ts
+++ b/fixtures/additional-modules/test/index.test.ts
@@ -167,33 +167,33 @@ describe("find_additional_modules deploy", () => {
 		const bundledEntry = await fs.readFile(bundledEntryPath, "utf8");
 		expect(bundledEntry).toMatchInlineSnapshot(`
 			"// src/index.ts
-			import common from \\"./common.cjs\\";
+			import common from "./common.cjs";
 
 			// src/dep.ts
-			var dep_default = \\"bundled\\";
+			var dep_default = "bundled";
 
 			// src/index.ts
-			import text from \\"./text.txt\\";
+			import text from "./text.txt";
 			var src_default = {
 			  async fetch(request) {
 			    const url = new URL(request.url);
-			    if (url.pathname === \\"/dep\\") {
+			    if (url.pathname === "/dep") {
 			      return new Response(dep_default);
 			    }
-			    if (url.pathname === \\"/text\\") {
+			    if (url.pathname === "/text") {
 			      return new Response(text);
 			    }
-			    if (url.pathname === \\"/common\\") {
+			    if (url.pathname === "/common") {
 			      return new Response(common);
 			    }
-			    if (url.pathname === \\"/dynamic\\") {
-			      return new Response((await import(\\"./dynamic.js\\")).default);
+			    if (url.pathname === "/dynamic") {
+			      return new Response((await import("./dynamic.js")).default);
 			    }
-			    if (url.pathname.startsWith(\\"/lang/\\")) {
-			      const language = \\"./lang/\\" + url.pathname.substring(\\"/lang/\\".length) + \\".js\\";
+			    if (url.pathname.startsWith("/lang/")) {
+			      const language = "./lang/" + url.pathname.substring("/lang/".length) + ".js";
 			      return new Response((await import(language)).default.hello);
 			    }
-			    return new Response(\\"Not Found\\", { status: 404 });
+			    return new Response("Not Found", { status: 404 });
 			  }
 			};
 			export {

--- a/fixtures/interactive-dev-tests/vitest.config.ts
+++ b/fixtures/interactive-dev-tests/vitest.config.ts
@@ -6,7 +6,7 @@ export default mergeConfig(
 	defineProject({
 		test: {
 			// `node-pty` doesn't work inside worker threads
-			threads: false,
+			pool: "forks",
 		},
 	})
 );

--- a/fixtures/local-mode-tests/tests/module.test.ts
+++ b/fixtures/local-mode-tests/tests/module.test.ts
@@ -42,18 +42,18 @@ describe("module worker", () => {
 
 		const text = await resp.text();
 		expect(text).toMatchInlineSnapshot(`
-		"{
-		  \\"VAR1\\": \\"value1\\",
-		  \\"VAR2\\": 123,
-		  \\"VAR3\\": {
-		    \\"abc\\": \\"def\\"
-		  },
-		  \\"VAR4\\": \\"https://google.com\\",
-		  \\"text\\": \\"Here be some text\\",
-		  \\"data\\": \\"Here be some data\\",
-		  \\"NODE_ENV\\": \\"local-testing\\"
-		}"
-	`);
+			"{
+			  "VAR1": "value1",
+			  "VAR2": 123,
+			  "VAR3": {
+			    "abc": "def"
+			  },
+			  "VAR4": "https://google.com",
+			  "text": "Here be some text",
+			  "data": "Here be some data",
+			  "NODE_ENV": "local-testing"
+			}"
+		`);
 	});
 	describe("header parsing", () => {
 		it.concurrent("should return Hi by default", async () => {

--- a/fixtures/local-mode-tests/tests/sw.test.ts
+++ b/fixtures/local-mode-tests/tests/sw.test.ts
@@ -33,18 +33,18 @@ describe("service worker", () => {
 
 		const text = await resp.text();
 		expect(text).toMatchInlineSnapshot(`
-    "{
-      \\"VAR1\\": \\"value1\\",
-      \\"VAR2\\": 123,
-      \\"VAR3\\": {
-        \\"abc\\": \\"def\\"
-      },
-      \\"text\\": \\"Here be some text\\",
-      \\"data\\": \\"Here be some data\\",
-      \\"TEXT\\": \\"Here be some text\\",
-      \\"DATA\\": \\"Here be some data\\",
-      \\"NODE_ENV\\": \\"local-testing\\"
-    }"
-  `);
+			"{
+			  "VAR1": "value1",
+			  "VAR2": 123,
+			  "VAR3": {
+			    "abc": "def"
+			  },
+			  "text": "Here be some text",
+			  "data": "Here be some data",
+			  "TEXT": "Here be some text",
+			  "DATA": "Here be some data",
+			  "NODE_ENV": "local-testing"
+			}"
+		`);
 	});
 });

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
 		"prettier-plugin-packagejson": "^2.2.18",
 		"rimraf": "^5.0.1",
 		"typescript": "^4.8.4",
-		"vite": "^4.0.4",
-		"vitest": "^0.34.6"
+		"vite": "^5.0.12",
+		"vitest": "^1.2.2"
 	},
 	"devDependencies": {
 		"@actions/artifact": "^2.0.1",

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -20,7 +20,7 @@ import type {
 	SpawnOptionsWithoutStdio,
 } from "child_process";
 import type { WriteStream } from "fs";
-import type { Suite, TestContext } from "vitest";
+import type { Suite, TaskContext } from "vitest";
 
 export const C3_E2E_PREFIX = "tmp-e2e-c3";
 
@@ -192,7 +192,7 @@ export const waitForExit = async (
 	};
 };
 
-export const createTestLogStream = (ctx: TestContext) => {
+export const createTestLogStream = (ctx: TaskContext) => {
 	// The .ansi extension allows for editor extensions that format ansi terminal codes
 	const fileName = `${normalizeTestName(ctx)}.ansi`;
 	return createWriteStream(join(getLogPath(ctx.task.suite), fileName), {
@@ -220,7 +220,7 @@ const getLogPath = (suite: Suite) => {
 	return join("./.e2e-logs/", process.env.TEST_PM as string, suiteFilename);
 };
 
-const normalizeTestName = (ctx: TestContext) => {
+const normalizeTestName = (ctx: TaskContext) => {
 	const baseName = ctx.task.name
 		.toLowerCase()
 		.replace(/\s+/g, "_") // replace any whitespace with `_`

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -114,7 +114,7 @@ compatibility_date = "2023-01-01"
 		);
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"Error\\",\\"message\\":\\"Invalid URL\\"}"'
+			`"{"error":"Error","message":"Invalid URL"}"`
 		);
 	});
 	it("should allow tokens > 4096 bytes", async () => {
@@ -197,7 +197,7 @@ compatibility_date = "2023-01-01"
 		);
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"Error\\",\\"message\\":\\"Invalid URL\\"}"'
+			`"{"error":"Error","message":"Invalid URL"}"`
 		);
 	});
 	it("should reject invalid remote url", async () => {
@@ -208,7 +208,7 @@ compatibility_date = "2023-01-01"
 		);
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"Error\\",\\"message\\":\\"Invalid URL\\"}"'
+			`"{"error":"Error","message":"Invalid URL"}"`
 		);
 	});
 

--- a/packages/pages-shared/__tests__/asset-server/responses.test.ts
+++ b/packages/pages-shared/__tests__/asset-server/responses.test.ts
@@ -42,7 +42,7 @@ describe("stripLeadingDoubleSlashes", () => {
 			`"/foo//bar"`
 		);
 		expect(stripLeadingDoubleSlashes("/foo/\\/bar")).toMatchInlineSnapshot(
-			`"/foo/\\\\/bar"`
+			`"/foo/\\/bar"`
 		);
 		expect(stripLeadingDoubleSlashes("/%09foo")).toMatchInlineSnapshot(
 			`"/foo"`

--- a/packages/workers.new/tests/__snapshots__/index.test.ts.snap
+++ b/packages/workers.new/tests/__snapshots__/index.test.ts.snap
@@ -9,7 +9,7 @@ exports[`worker > templates list 1`] = `
 <style>
 	body {
 		margin: 2rem 10rem;
-		font-family: \\"Inter\\", sans-serif;
+		font-family: "Inter", sans-serif;
 	}
 	h1{
 		text-align: center;
@@ -100,173 +100,173 @@ exports[`worker > templates list 1`] = `
 
 </style>
 <body>
-	<nav class=\\"nav\\">
-		<a href=\\"https://workers.cloudflare.com\\">
-			<img src=\\"https://imagedelivery.net/T24Zz2DP7HaLOEAdMToO-g/70363224-4bee-4f48-a775-06ffdfbc6d00/public\\" height=\\"50\\" alt=\\"Cloudflare Workers\\" />
+	<nav class="nav">
+		<a href="https://workers.cloudflare.com">
+			<img src="https://imagedelivery.net/T24Zz2DP7HaLOEAdMToO-g/70363224-4bee-4f48-a775-06ffdfbc6d00/public" height="50" alt="Cloudflare Workers" />
 		</a>
-		<a href=\\"https://developers.cloudflare.com/workers\\">Documentation</a>
+		<a href="https://developers.cloudflare.com/workers">Documentation</a>
 	</nav>
-	<p class=\\"heading\\">Cloudflare Workers Templates</p>
-	<p class=\\"subheading\\">Ready to use templates to start building applications on Cloudflare Workers.</p>
+	<p class="heading">Cloudflare Workers Templates</p>
+	<p class="subheading">Ready to use templates to start building applications on Cloudflare Workers.</p>
 	<ul>
 		<li>
-				<p class=\\"card-title\\"> Image Sharing Website with Pages Functions </p>
-				<p class=\\"title\\">pages-image-sharing</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/pages-image-sharing\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-image-sharing\\">Deploy with Workers</a></span>
+				<p class="card-title"> Image Sharing Website with Pages Functions </p>
+				<p class="title">pages-image-sharing</p>
+				<span class="link"><a target="_blank" href="https://workers.new/pages-image-sharing">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-image-sharing">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Stream + Stripe Checkout </p>
-				<p class=\\"title\\">stream/auth/stripe</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/auth/stripe\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/auth/stripe\\">Deploy with Workers</a></span>
+				<p class="card-title"> Stream + Stripe Checkout </p>
+				<p class="title">stream/auth/stripe</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/auth/stripe">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/auth/stripe">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Workers Durable Objects counter </p>
-				<p class=\\"title\\">worker-durable-objects</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/worker-durable-objects\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-durable-objects\\">Deploy with Workers</a></span>
+				<p class="card-title"> Workers Durable Objects counter </p>
+				<p class="title">worker-durable-objects</p>
+				<span class="link"><a target="_blank" href="https://workers.new/worker-durable-objects">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-durable-objects">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Workers D1 </p>
-				<p class=\\"title\\">worker-d1</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/d1\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1\\">Deploy with Workers</a></span>
+				<p class="card-title"> Workers D1 </p>
+				<p class="title">worker-d1</p>
+				<span class="link"><a target="_blank" href="https://workers.new/d1">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-d1">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Workers Router </p>
-				<p class=\\"title\\">worker-router</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/router\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-router\\">Deploy with Workers</a></span>
+				<p class="card-title"> Workers Router </p>
+				<p class="title">worker-router</p>
+				<span class="link"><a target="_blank" href="https://workers.new/router">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-router">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Workers TypeScript </p>
-				<p class=\\"title\\">worker-typescript</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/typescript\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript\\">Deploy with Workers</a></span>
+				<p class="card-title"> Workers TypeScript </p>
+				<p class="title">worker-typescript</p>
+				<span class="link"><a target="_blank" href="https://workers.new/typescript">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-typescript">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Workers WebSocket </p>
-				<p class=\\"title\\">worker-websocket</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/websocket\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-websocket\\">Deploy with Workers</a></span>
+				<p class="card-title"> Workers WebSocket </p>
+				<p class="title">worker-websocket</p>
+				<span class="link"><a target="_blank" href="https://workers.new/websocket">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-websocket">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Workers Wordle example </p>
-				<p class=\\"title\\">worker-example-wordle</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/example-wordle\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-wordle\\">Deploy with Workers</a></span>
+				<p class="card-title"> Workers Wordle example </p>
+				<p class="title">worker-example-wordle</p>
+				<span class="link"><a target="_blank" href="https://workers.new/example-wordle">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-wordle">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Workers Request Scheduler </p>
-				<p class=\\"title\\">worker-example-request-scheduler</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/example-request-scheduler\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-request-scheduler\\">Deploy with Workers</a></span>
+				<p class="card-title"> Workers Request Scheduler </p>
+				<p class="title">worker-example-request-scheduler</p>
+				<span class="link"><a target="_blank" href="https://workers.new/example-request-scheduler">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-example-request-scheduler">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Workers WebSocket Durable Objects </p>
-				<p class=\\"title\\">worker-websocket-durable-objects</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/websocket-durable-objects\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-websocket-durable-objects\\">Deploy with Workers</a></span>
+				<p class="card-title"> Workers WebSocket Durable Objects </p>
+				<p class="title">worker-websocket-durable-objects</p>
+				<span class="link"><a target="_blank" href="https://workers.new/websocket-durable-objects">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-websocket-durable-objects">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Workers Worktop </p>
-				<p class=\\"title\\">worker-worktop</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/worktop\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-worktop\\">Deploy with Workers</a></span>
+				<p class="card-title"> Workers Worktop </p>
+				<p class="title">worker-worktop</p>
+				<span class="link"><a target="_blank" href="https://workers.new/worktop">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-worktop">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Pages Functions CORS </p>
-				<p class=\\"title\\">pages-functions-cors</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/pages-functions-cors\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-functions-cors\\">Deploy with Workers</a></span>
+				<p class="card-title"> Pages Functions CORS </p>
+				<p class="title">pages-functions-cors</p>
+				<span class="link"><a target="_blank" href="https://workers.new/pages-functions-cors">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-functions-cors">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Pages Plugin static forms </p>
-				<p class=\\"title\\">pages-plugin-static-forms</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/pages-plugin-static-forms\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-plugin-static-forms\\">Deploy with Workers</a></span>
+				<p class="card-title"> Pages Plugin static forms </p>
+				<p class="title">pages-plugin-static-forms</p>
+				<span class="link"><a target="_blank" href="https://workers.new/pages-plugin-static-forms">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-plugin-static-forms">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Pages Example Forum app </p>
-				<p class=\\"title\\">pages-example-forum-app</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/pages-example-forum-app\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-example-forum-app\\">Deploy with Workers</a></span>
+				<p class="card-title"> Pages Example Forum app </p>
+				<p class="title">pages-example-forum-app</p>
+				<span class="link"><a target="_blank" href="https://workers.new/pages-example-forum-app">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/pages-example-forum-app">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Cloudflare Stream Player </p>
-				<p class=\\"title\\">stream/playback/stream-player</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/stream-player\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/stream-player\\">Deploy with Workers</a></span>
+				<p class="card-title"> Cloudflare Stream Player </p>
+				<p class="title">stream/playback/stream-player</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/stream-player">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/stream-player">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Cloudflare Stream + Video.js </p>
-				<p class=\\"title\\">stream/playback/video-js</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/video-js\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/video-js\\">Deploy with Workers</a></span>
+				<p class="card-title"> Cloudflare Stream + Video.js </p>
+				<p class="title">stream/playback/video-js</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/video-js">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/video-js">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Cloudflare Stream + Vidstack </p>
-				<p class=\\"title\\">stream/playback/vidstack</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/vidstack\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/vidstack\\">Deploy with Workers</a></span>
+				<p class="card-title"> Cloudflare Stream + Vidstack </p>
+				<p class="title">stream/playback/vidstack</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/vidstack">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/vidstack">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Cloudflare Stream + hls.js </p>
-				<p class=\\"title\\">stream/playback/hls-js</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/hls-js\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/hls-js\\">Deploy with Workers</a></span>
+				<p class="card-title"> Cloudflare Stream + hls.js </p>
+				<p class="title">stream/playback/hls-js</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/hls-js">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/hls-js">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Cloudflare Stream + dash.js </p>
-				<p class=\\"title\\">stream/playback/dash-js</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/dash-js\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/dash-js\\">Deploy with Workers</a></span>
+				<p class="card-title"> Cloudflare Stream + dash.js </p>
+				<p class="title">stream/playback/dash-js</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/dash-js">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/dash-js">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Cloudflare Stream + Shaka Player </p>
-				<p class=\\"title\\">stream/playback/shaka-player</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/shaka-player\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/shaka-player\\">Deploy with Workers</a></span>
+				<p class="card-title"> Cloudflare Stream + Shaka Player </p>
+				<p class="title">stream/playback/shaka-player</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/shaka-player">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/playback/shaka-player">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Direct Creator Uploads to Cloudflare Stream </p>
-				<p class=\\"title\\">stream/upload/direct-creator-uploads</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/direct-creator-uploads\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads\\">Deploy with Workers</a></span>
+				<p class="card-title"> Direct Creator Uploads to Cloudflare Stream </p>
+				<p class="title">stream/upload/direct-creator-uploads</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/direct-creator-uploads">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Direct Creator Uploads to Cloudflare Stream, using TUS </p>
-				<p class=\\"title\\">stream/upload/direct-creator-uploads-tus</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/direct-creator-uploads-tus\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads-tus\\">Deploy with Workers</a></span>
+				<p class="card-title"> Direct Creator Uploads to Cloudflare Stream, using TUS </p>
+				<p class="title">stream/upload/direct-creator-uploads-tus</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/direct-creator-uploads-tus">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/upload/direct-creator-uploads-tus">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Stream live video (using WHIP) and playback (using WHEP) over WebRTC with Cloudflare Stream </p>
-				<p class=\\"title\\">stream/webrtc</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/webrtc\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/webrtc\\">Deploy with Workers</a></span>
+				<p class="card-title"> Stream live video (using WHIP) and playback (using WHEP) over WebRTC with Cloudflare Stream </p>
+				<p class="title">stream/webrtc</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/webrtc">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/webrtc">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Stream live video (using WHIP) over WebRTC with Cloudflare Stream </p>
-				<p class=\\"title\\">stream/webrtc</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/webrtc-whip\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/webrtc\\">Deploy with Workers</a></span>
+				<p class="card-title"> Stream live video (using WHIP) over WebRTC with Cloudflare Stream </p>
+				<p class="title">stream/webrtc</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/webrtc-whip">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/webrtc">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Play live video (using WHEP) over WebRTC with Cloudflare Stream </p>
-				<p class=\\"title\\">stream/webrtc</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/webrtc-whep\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/webrtc\\">Deploy with Workers</a></span>
+				<p class="card-title"> Play live video (using WHEP) over WebRTC with Cloudflare Stream </p>
+				<p class="title">stream/webrtc</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/webrtc-whep">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/webrtc">Deploy with Workers</a></span>
 				</li>
 <li>
-				<p class=\\"card-title\\"> Example of using Cloudflare Stream Signed URLs with public content </p>
-				<p class=\\"title\\">stream/auth/signed-urls-public-content</p>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://workers.new/stream/signed-urls-public-content\\">Open with StackBlitz</a></span>
-				<span class=\\"link\\"><a target=\\"_blank\\" href=\\"https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/auth/signed-urls-public-content\\">Deploy with Workers</a></span>
+				<p class="card-title"> Example of using Cloudflare Stream Signed URLs with public content </p>
+				<p class="title">stream/auth/signed-urls-public-content</p>
+				<span class="link"><a target="_blank" href="https://workers.new/stream/signed-urls-public-content">Open with StackBlitz</a></span>
+				<span class="link"><a target="_blank" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/stream/auth/signed-urls-public-content">Deploy with Workers</a></span>
 				</li>
 	</ul>
-	<p class=\\"subheading\\">Want to contribute a template? <a class=\\"url\\" href=\\"https://github.com/cloudflare/workers-sdk/tree/main/templates\\"> Send a PR to the Wrangler repository.</a></p>
+	<p class="subheading">Want to contribute a template? <a class="url" href="https://github.com/cloudflare/workers-sdk/tree/main/templates"> Send a PR to the Wrangler repository.</a></p>
 </body>
 </html>
 "

--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -44,7 +44,7 @@ describe("r2", () => {
 			$ ${WRANGLER} r2 object put ${`${bucketName}/testr2`} --file test-r2.txt --content-type text/html
 		`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"Creating object \\"testr2\\" in bucket \\"wrangler-smoke-test-bucket\\".
+			"Creating object "testr2" in bucket "wrangler-smoke-test-bucket".
 			Upload complete."
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
@@ -55,7 +55,7 @@ describe("r2", () => {
 			$ ${WRANGLER} r2 object get ${`${bucketName}/testr2`} --file test-r2o.txt
 		`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"Downloading \\"testr2\\" from \\"wrangler-smoke-test-bucket\\".
+			"Downloading "testr2" from "wrangler-smoke-test-bucket".
 			Download complete."
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
@@ -66,7 +66,7 @@ describe("r2", () => {
 		const { stdout, stderr } =
 			await run`$ ${WRANGLER} r2 object delete ${`${bucketName}/testr2`}`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"Deleting object \\"testr2\\" from bucket \\"wrangler-smoke-test-bucket\\".
+			"Deleting object "testr2" from bucket "wrangler-smoke-test-bucket".
 			Delete complete."
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
@@ -79,12 +79,12 @@ describe("r2", () => {
 			}
     `;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"Downloading \\"testr2\\" from \\"wrangler-smoke-test-bucket\\".
+			"Downloading "testr2" from "wrangler-smoke-test-bucket".
 			If you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose"
 		`);
 		expect(normalize(stderr)).toMatchInlineSnapshot(`
 			"X [ERROR] The specified key does not exist.
-			🪵  Logs were written to \\"<LOG>\\""
+			🪵  Logs were written to "<LOG>""
 		`);
 	});
 
@@ -108,12 +108,12 @@ describe("r2", () => {
 			}
 		`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"Creating object \\"testr2\\" in bucket \\"wrangler-smoke-test-bucket\\".
+			"Creating object "testr2" in bucket "wrangler-smoke-test-bucket".
 			If you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose"
 		`);
 		expect(normalize(stderr)).toMatchInlineSnapshot(`
 			"X [ERROR] The specified bucket does not exist.
-			🪵  Logs were written to \\"<LOG>\\""
+			🪵  Logs were written to "<LOG>""
 		`);
 	});
 });

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -63,7 +63,7 @@
 		"test": "pnpm run assert-git-version && jest",
 		"test:ci": "pnpm run test --coverage",
 		"test:debug": "pnpm run test --silent=false --verbose=true",
-		"test:e2e": "vitest --test-timeout 240000 --single-thread --dir ./e2e --retry 2 run",
+		"test:e2e": "vitest --test-timeout 240000 --poolOptions.threads.singleThread --dir ./e2e --retry 2 run",
 		"test:watch": "pnpm run test --testTimeout=50000 --watch",
 		"type:tests": "tsc -p ./src/__tests__/tsconfig.json && tsc -p ./e2e/tsconfig.json"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,11 +68,11 @@ importers:
         specifier: ^4.8.4
         version: 4.9.5
       vite:
-        specifier: ^4.0.4
-        version: 4.3.9(@types/node@20.1.7)
+        specifier: ^5.0.12
+        version: 5.0.12(@types/node@20.1.7)
       vitest:
-        specifier: ^0.34.6
-        version: 0.34.6
+        specifier: ^1.2.2
+        version: 1.2.2(@types/node@20.1.7)
     devDependencies:
       '@actions/artifact':
         specifier: ^2.0.1
@@ -769,7 +769,7 @@ importers:
         version: 5.28.2
       vite-tsconfig-paths:
         specifier: ^4.0.8
-        version: 4.2.0(typescript@5.0.3)(vite@4.3.9)
+        version: 4.2.0(typescript@5.0.3)(vite@5.0.12)
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1391,7 +1391,7 @@ importers:
     optionalDependencies:
       fsevents:
         specifier: ~2.3.2
-        version: 2.3.2
+        version: 2.3.3
     devDependencies:
       '@cloudflare/ai':
         specifier: ^1.0.35
@@ -4107,6 +4107,14 @@ packages:
       rollup-plugin-node-polyfills: 0.2.1
     dev: false
 
+  /@esbuild/aix-ppc64@0.19.12:
+    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/android-arm64@0.16.17:
     resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
     engines: {node: '>=12'}
@@ -4149,6 +4157,14 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.19.12:
+    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
     optional: true
 
   /@esbuild/android-arm@0.16.17:
@@ -4195,6 +4211,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.19.12:
+    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/android-x64@0.16.17:
     resolution: {integrity: sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==}
     engines: {node: '>=12'}
@@ -4237,6 +4261,14 @@ packages:
     os: [android]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.19.12:
+    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
     optional: true
 
   /@esbuild/darwin-arm64@0.16.17:
@@ -4283,6 +4315,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.19.12:
+    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/darwin-x64@0.16.17:
     resolution: {integrity: sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==}
     engines: {node: '>=12'}
@@ -4325,6 +4365,14 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.19.12:
+    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.16.17:
@@ -4371,6 +4419,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.19.12:
+    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.16.17:
     resolution: {integrity: sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==}
     engines: {node: '>=12'}
@@ -4413,6 +4469,14 @@ packages:
     os: [freebsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.19.12:
+    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-arm64@0.16.17:
@@ -4459,6 +4523,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.19.12:
+    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-arm@0.16.17:
     resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
     engines: {node: '>=12'}
@@ -4501,6 +4573,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.19.12:
+    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-ia32@0.16.17:
@@ -4547,6 +4627,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.19.12:
+    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-loong64@0.16.17:
     resolution: {integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==}
     engines: {node: '>=12'}
@@ -4589,6 +4677,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.19.12:
+    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-mips64el@0.16.17:
@@ -4635,6 +4731,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.19.12:
+    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.16.17:
     resolution: {integrity: sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==}
     engines: {node: '>=12'}
@@ -4677,6 +4781,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.19.12:
+    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-riscv64@0.16.17:
@@ -4723,6 +4835,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.19.12:
+    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-s390x@0.16.17:
     resolution: {integrity: sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==}
     engines: {node: '>=12'}
@@ -4765,6 +4885,14 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.19.12:
+    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@esbuild/linux-x64@0.16.17:
@@ -4811,6 +4939,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.19.12:
+    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.16.17:
     resolution: {integrity: sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==}
     engines: {node: '>=12'}
@@ -4853,6 +4989,14 @@ packages:
     os: [netbsd]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.19.12:
+    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
     optional: true
 
   /@esbuild/openbsd-x64@0.16.17:
@@ -4899,6 +5043,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.19.12:
+    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/sunos-x64@0.16.17:
     resolution: {integrity: sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==}
     engines: {node: '>=12'}
@@ -4941,6 +5093,14 @@ packages:
     os: [sunos]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.19.12:
+    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
     optional: true
 
   /@esbuild/win32-arm64@0.16.17:
@@ -4987,6 +5147,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64@0.19.12:
+    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-ia32@0.16.17:
     resolution: {integrity: sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==}
     engines: {node: '>=12'}
@@ -5031,6 +5199,14 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.19.12:
+    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-x64@0.16.17:
     resolution: {integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==}
     engines: {node: '>=12'}
@@ -5073,6 +5249,14 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.19.12:
+    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.42.0):
@@ -6266,6 +6450,97 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /@rollup/rollup-android-arm-eabi@4.9.6:
+    resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.9.6:
+    resolution: {integrity: sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.9.6:
+    resolution: {integrity: sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.9.6:
+    resolution: {integrity: sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.9.6:
+    resolution: {integrity: sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.9.6:
+    resolution: {integrity: sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.9.6:
+    resolution: {integrity: sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.9.6:
+    resolution: {integrity: sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.9.6:
+    resolution: {integrity: sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.9.6:
+    resolution: {integrity: sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.9.6:
+    resolution: {integrity: sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.9.6:
+    resolution: {integrity: sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.9.6:
+    resolution: {integrity: sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@rushstack/eslint-patch@1.2.0:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: true
@@ -6620,7 +6895,7 @@ packages:
   /@types/acorn@4.0.6:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
     dev: true
 
   /@types/argparse@1.0.38:
@@ -6681,16 +6956,6 @@ packages:
       '@types/node': 18.16.10
       '@types/responselike': 1.0.0
     dev: true
-
-  /@types/chai-subset@1.3.3:
-    resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
-    dependencies:
-      '@types/chai': 4.3.5
-    dev: false
-
-  /@types/chai@4.3.5:
-    resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
-    dev: false
 
   /@types/command-exists@1.2.0:
     resolution: {integrity: sha512-ugsxEJfsCuqMLSuCD4PIJkp5Uk2z6TCMRCgYVuhRo5cYQY3+1xXTQkSlPtkpGHuvWMjS2KTeVQXxkXRACMbM6A==}
@@ -6754,12 +7019,14 @@ packages:
   /@types/estree-jsx@1.0.0:
     resolution: {integrity: sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
     dev: true
 
   /@types/estree@1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
-    dev: true
+
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
   /@types/express-serve-static-core@4.17.29:
     resolution: {integrity: sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==}
@@ -7976,41 +8243,42 @@ packages:
       - supports-color
     dev: true
 
-  /@vitest/expect@0.34.6:
-    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
+  /@vitest/expect@1.2.2:
+    resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
     dependencies:
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
+      '@vitest/spy': 1.2.2
+      '@vitest/utils': 1.2.2
       chai: 4.3.10
     dev: false
 
-  /@vitest/runner@0.34.6:
-    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
+  /@vitest/runner@1.2.2:
+    resolution: {integrity: sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==}
     dependencies:
-      '@vitest/utils': 0.34.6
-      p-limit: 4.0.0
+      '@vitest/utils': 1.2.2
+      p-limit: 5.0.0
       pathe: 1.1.1
     dev: false
 
-  /@vitest/snapshot@0.34.6:
-    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
+  /@vitest/snapshot@1.2.2:
+    resolution: {integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==}
     dependencies:
-      magic-string: 0.30.3
+      magic-string: 0.30.5
       pathe: 1.1.1
       pretty-format: 29.7.0
     dev: false
 
-  /@vitest/spy@0.34.6:
-    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+  /@vitest/spy@1.2.2:
+    resolution: {integrity: sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==}
     dependencies:
-      tinyspy: 2.1.1
+      tinyspy: 2.2.0
     dev: false
 
-  /@vitest/utils@0.34.6:
-    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
+  /@vitest/utils@1.2.2:
+    resolution: {integrity: sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==}
     dependencies:
       diff-sequences: 29.6.3
-      loupe: 2.3.6
+      estree-walker: 3.0.3
+      loupe: 2.3.7
       pretty-format: 29.7.0
     dev: false
 
@@ -8123,7 +8391,6 @@ packages:
   /acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
@@ -9370,7 +9637,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -10860,6 +11127,36 @@ packages:
       '@esbuild/win32-x64': 0.18.20
     dev: true
 
+  /esbuild@0.19.12:
+    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.19.12
+      '@esbuild/android-arm': 0.19.12
+      '@esbuild/android-arm64': 0.19.12
+      '@esbuild/android-x64': 0.19.12
+      '@esbuild/darwin-arm64': 0.19.12
+      '@esbuild/darwin-x64': 0.19.12
+      '@esbuild/freebsd-arm64': 0.19.12
+      '@esbuild/freebsd-x64': 0.19.12
+      '@esbuild/linux-arm': 0.19.12
+      '@esbuild/linux-arm64': 0.19.12
+      '@esbuild/linux-ia32': 0.19.12
+      '@esbuild/linux-loong64': 0.19.12
+      '@esbuild/linux-mips64el': 0.19.12
+      '@esbuild/linux-ppc64': 0.19.12
+      '@esbuild/linux-riscv64': 0.19.12
+      '@esbuild/linux-s390x': 0.19.12
+      '@esbuild/linux-x64': 0.19.12
+      '@esbuild/netbsd-x64': 0.19.12
+      '@esbuild/openbsd-x64': 0.19.12
+      '@esbuild/sunos-x64': 0.19.12
+      '@esbuild/win32-arm64': 0.19.12
+      '@esbuild/win32-ia32': 0.19.12
+      '@esbuild/win32-x64': 0.19.12
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -11569,7 +11866,7 @@ packages:
   /estree-util-attach-comments@2.1.0:
     resolution: {integrity: sha512-rJz6I4L0GaXYtHpoMScgDIwM0/Vwbu5shbMeER596rB2D1EWF6+Gj0e0UKzJPZrpoOc87+Q2kgVFHfjAymIqmw==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
     dev: true
 
   /estree-util-build-jsx@2.2.0:
@@ -11612,6 +11909,12 @@ packages:
   /estree-walker@3.0.1:
     resolution: {integrity: sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==}
     dev: true
+
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.0
+    dev: false
 
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -11699,6 +12002,21 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
     dev: true
+
+  /execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+    dev: false
 
   /exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
@@ -12243,8 +12561,8 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -12364,6 +12682,11 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
     dev: true
+
+  /get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+    dev: false
 
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -12861,6 +13184,11 @@ packages:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
     dev: true
+
+  /human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+    dev: false
 
   /hyphenate-style-name@1.0.4:
     resolution: {integrity: sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==}
@@ -13495,7 +13823,7 @@ packages:
   /is-reference@3.0.0:
     resolution: {integrity: sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
     dev: true
 
   /is-regex@1.1.4:
@@ -13526,7 +13854,6 @@ packages:
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
 
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -13952,7 +14279,7 @@ packages:
       sane: 4.1.0(supports-color@9.2.2)
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13973,7 +14300,7 @@ packages:
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /jest-leak-detector@29.7.0:
@@ -14512,9 +14839,12 @@ packages:
     engines: {node: '>= 12.13.0'}
     dev: true
 
-  /local-pkg@0.4.3:
-    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
+  /local-pkg@0.5.0:
+    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.4.2
+      pkg-types: 1.0.3
     dev: false
 
   /localforage@1.10.0:
@@ -14657,6 +14987,13 @@ packages:
 
   /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
+    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
+    dependencies:
+      get-func-name: 2.0.2
+    dev: false
+
+  /loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
     dependencies:
       get-func-name: 2.0.2
     dev: false
@@ -14730,7 +15067,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -14999,7 +15335,6 @@ packages:
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-    dev: true
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -15204,7 +15539,7 @@ packages:
     resolution: {integrity: sha512-WWp3bf7xT9MppNuw3yPjpnOxa8cj5ACivEzXJKu0WwnjBYfzaBvIAT9KfeyI0Qkll+bfQtfftSwdgTH6QhTOKw==}
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       estree-util-visit: 1.2.0
       micromark-util-types: 1.0.2
       uvu: 0.5.6
@@ -15341,7 +15676,6 @@ packages:
   /mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
-    dev: true
 
   /mimic-function@5.0.0:
     resolution: {integrity: sha512-RBfQ+9X9DpXdEoK7Bu+KeEU6vFhumEIiXKWECPzRBmDserEq4uR2b/VCm0LwpMSosoq2k+Zuxj/GzOr0Fn6h/g==}
@@ -15600,6 +15934,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /nanoid@3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   /nanomatch@1.2.13(supports-color@9.2.2):
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
     engines: {node: '>=0.10.0'}
@@ -15844,7 +16183,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       path-key: 4.0.0
-    dev: true
 
   /npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
@@ -15969,7 +16307,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       mimic-fn: 4.0.0
-    dev: true
 
   /open@7.4.2:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
@@ -16066,7 +16403,7 @@ packages:
     resolution: {integrity: sha512-Ux1J4NUqC6tZayBqLN1kUlDAEvLiQlli/53sSddU4IN+h+3xxnv2HmRSMpVSvr1hvJzotfMs3ERvETGK+f4OwA==}
     engines: {node: '>= 4.0'}
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /os-tmpdir@1.0.2:
@@ -16131,6 +16468,14 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       yocto-queue: 1.0.0
+    dev: true
+
+  /p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: false
 
   /p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -16416,7 +16761,6 @@ packages:
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
-    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -16662,6 +17006,14 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+
+  /postcss@8.4.33:
+    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
@@ -17676,7 +18028,30 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
+    dev: true
+
+  /rollup@4.9.6:
+    resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.9.6
+      '@rollup/rollup-android-arm64': 4.9.6
+      '@rollup/rollup-darwin-arm64': 4.9.6
+      '@rollup/rollup-darwin-x64': 4.9.6
+      '@rollup/rollup-linux-arm-gnueabihf': 4.9.6
+      '@rollup/rollup-linux-arm64-gnu': 4.9.6
+      '@rollup/rollup-linux-arm64-musl': 4.9.6
+      '@rollup/rollup-linux-riscv64-gnu': 4.9.6
+      '@rollup/rollup-linux-x64-gnu': 4.9.6
+      '@rollup/rollup-linux-x64-musl': 4.9.6
+      '@rollup/rollup-win32-arm64-msvc': 4.9.6
+      '@rollup/rollup-win32-ia32-msvc': 4.9.6
+      '@rollup/rollup-win32-x64-msvc': 4.9.6
+      fsevents: 2.3.3
 
   /rsvp@4.8.5:
     resolution: {integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==}
@@ -17996,6 +18371,11 @@ packages:
     resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
     engines: {node: '>=14'}
 
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: false
+
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
@@ -18294,8 +18674,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /std-env@3.4.3:
-    resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
+  /std-env@3.7.0:
+    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
     dev: false
 
   /stoppable@1.1.0:
@@ -18466,7 +18846,6 @@ packages:
   /strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
-    dev: true
 
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -18484,8 +18863,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  /strip-literal@1.0.1:
-    resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
+  /strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
     dependencies:
       acorn: 8.11.3
     dev: false
@@ -18666,8 +19045,8 @@ packages:
     resolution: {integrity: sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==}
     dev: true
 
-  /tinybench@2.5.0:
-    resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
+  /tinybench@2.6.0:
+    resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
     dev: false
 
   /tinycolor2@1.6.0:
@@ -18681,13 +19060,13 @@ packages:
       tinycolor2: 1.6.0
     dev: true
 
-  /tinypool@0.7.0:
-    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+  /tinypool@0.8.2:
+    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /tinyspy@2.1.1:
-    resolution: {integrity: sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==}
+  /tinyspy@2.2.0:
+    resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -18932,7 +19311,7 @@ packages:
       '@esbuild-kit/core-utils': 3.3.2
       '@esbuild-kit/esm-loader': 2.6.5
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /tty-table@2.8.13:
@@ -19560,20 +19939,20 @@ packages:
       - terser
     dev: true
 
-  /vite-node@0.34.6(@types/node@18.16.10):
-    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
-    engines: {node: '>=v14.18.0'}
+  /vite-node@1.2.2(@types/node@20.1.7):
+    resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4(supports-color@9.2.2)
-      mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.3.9(@types/node@18.16.10)
+      vite: 5.0.12(@types/node@20.1.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -19591,7 +19970,7 @@ packages:
       vite: 4.3.9(@types/node@20.1.7)
     dev: true
 
-  /vite-tsconfig-paths@4.2.0(typescript@5.0.3)(vite@4.3.9):
+  /vite-tsconfig-paths@4.2.0(typescript@5.0.3)(vite@5.0.12):
     resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
     peerDependencies:
       vite: '*'
@@ -19602,44 +19981,11 @@ packages:
       debug: 4.3.4(supports-color@9.2.2)
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.0.3)
-      vite: 4.3.9(@types/node@20.1.7)
+      vite: 5.0.12(@types/node@20.1.7)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
-
-  /vite@4.3.9(@types/node@18.16.10):
-    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.16.10
-      esbuild: 0.17.19
-      postcss: 8.4.24
-      rollup: 3.25.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
 
   /vite@4.3.9(@types/node@20.1.7):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
@@ -19671,23 +20017,59 @@ packages:
       postcss: 8.4.24
       rollup: 3.25.1
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
+    dev: true
 
-  /vitest@0.34.6:
-    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
-    engines: {node: '>=v14.18.0'}
+  /vite@5.0.12(@types/node@20.1.7):
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.1.7
+      esbuild: 0.19.12
+      postcss: 8.4.33
+      rollup: 4.9.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  /vitest@1.2.2(@types/node@20.1.7):
+    resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
       happy-dom: '*'
       jsdom: '*'
-      playwright: '*'
-      safaridriver: '*'
-      webdriverio: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/node':
         optional: true
       '@vitest/browser':
         optional: true
@@ -19697,39 +20079,32 @@ packages:
         optional: true
       jsdom:
         optional: true
-      playwright:
-        optional: true
-      safaridriver:
-        optional: true
-      webdriverio:
-        optional: true
     dependencies:
-      '@types/chai': 4.3.5
-      '@types/chai-subset': 1.3.3
-      '@types/node': 18.16.10
-      '@vitest/expect': 0.34.6
-      '@vitest/runner': 0.34.6
-      '@vitest/snapshot': 0.34.6
-      '@vitest/spy': 0.34.6
-      '@vitest/utils': 0.34.6
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
+      '@types/node': 20.1.7
+      '@vitest/expect': 1.2.2
+      '@vitest/runner': 1.2.2
+      '@vitest/snapshot': 1.2.2
+      '@vitest/spy': 1.2.2
+      '@vitest/utils': 1.2.2
+      acorn-walk: 8.3.2
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4(supports-color@9.2.2)
-      local-pkg: 0.4.3
-      magic-string: 0.30.3
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
       pathe: 1.1.1
       picocolors: 1.0.0
-      std-env: 3.4.3
-      strip-literal: 1.0.1
-      tinybench: 2.5.0
-      tinypool: 0.7.0
-      vite: 4.3.9(@types/node@18.16.10)
-      vite-node: 0.34.6(@types/node@18.16.10)
+      std-env: 3.7.0
+      strip-literal: 1.3.0
+      tinybench: 2.6.0
+      tinypool: 0.8.2
+      vite: 5.0.12(@types/node@20.1.7)
+      vite-node: 1.2.2(@types/node@20.1.7)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -20018,7 +20393,7 @@ packages:
     dependencies:
       xdg-portable: 10.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /xdg-portable@10.6.0:
@@ -20027,7 +20402,7 @@ packages:
     dependencies:
       os-paths: 7.4.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /xdm@2.1.0:

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -13,6 +13,8 @@ export default defineConfig({
 		testTimeout: 50_000,
 		hookTimeout: 50_000,
 		teardownTimeout: 50_000,
-		useAtomics: true,
+		poolOptions: {
+			useAtomics: true,
+		},
 	},
 });


### PR DESCRIPTION
Closes #4798 

**What this PR solves / how to test:**

In attempting to update Vitest in a dependabot PR, we noticed that there were a mix of versions of Vitest and that there would be some tricky parts to bumping the version. Moreover updating to the latest Vitest requires updating Vite as a transitive dependency, and we have a direct dependency on this too.

This work here brings everything to the latest versions and aligns it across the repository.

The update to Vitest had some breaking changes to a number of tests and configuration files have been fixed accordingly.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: it is an internal chore.
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: it is an internal chore.
