### PR TITLE
[playground-preview-worker] fix: fallback to returning stack trace if `format-errors` broken

### DIFF
--- a/packages/playground-preview-worker/src/middleware/definitions/json.module.template
+++ b/packages/playground-preview-worker/src/middleware/definitions/json.module.template
@@ -13,15 +13,22 @@ const jsonError = async (request, env, _ctx, middlewareCtx) => {
   } catch (e) {
     console.error(e);
     const error = reduceError(e);
-    return fetch('https://format-errors.devprod.cloudflare.dev', {
-      method: 'POST',
-      body: JSON.stringify({
-        error,
-        url: request.url,
-        method: request.method,
-        headers: Object.fromEntries(request.headers.entries())
-      })
-    });
+    try {
+      const errorRes = await fetch(
+        'https://format-errors.devprod.cloudflare.dev',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            error,
+            url: request.url,
+            method: request.method,
+            headers: Object.fromEntries(request.headers.entries()),
+          }),
+        }
+      );
+      if (errorRes.ok) return errorRes;
+    } catch {}
+    return new Response(error.stack ?? error.message);
   }
 };
 


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR ensures that if the `format-errors` worker is unavailable or returns a non 200 response, we just return the stack trace unformatted. Note `format-errors` returns a 200 response even though we're technically returning an error page:

https://github.com/cloudflare/workers-sdk/blob/3e7cd6e40816c5c6ab28163508a6ba9729c6de73/packages/format-errors/src/index.ts#L117-L119

This change means the user still sees their error, even if it doesn't look as pretty. We'll want to apply a similar change to the internal Quick Editor middleware.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: would ideally include, but mocking this `fetch` is pretty tricky in the current testing setup. This should be easier with the new Vitest environment.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: changing internal worker
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: changing internal worker

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
