### PR TITLE
fix: don't report invalid `format-errors` input

### DIFF
--- a/packages/format-errors/src/index.ts
+++ b/packages/format-errors/src/index.ts
@@ -155,8 +155,16 @@ export default {
 				},
 			},
 		});
+
+		// Validate payload outside of Sentry/metrics reporting
+		let payload: Payload;
 		try {
-			const payload = PayloadSchema.parse(await request.json());
+			payload = PayloadSchema.parse(await request.json());
+		} catch {
+			return new Response("Invalid payload", { status: 400 });
+		}
+
+		try {
 			return handlePrettyErrorRequest(payload);
 		} catch (e) {
 			sentry.captureException(e);


### PR DESCRIPTION
**What this PR solves / how to test:**

Previously, invalid input to the `format-errors` worker was reported as an internal server error. As with #4904, this is a user error that the service can't do anything about. This PR 

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: `format-errors` currently has no tests, we can add some once we've landed the new Vitest pool work.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: change to an internal worker
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: change to an internal worker

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
