### PR TITLE
[D1] Add user friendly D1 validation error messages for `dev --remote` and `deploy`

### DIFF
--- a/.changeset/fair-shoes-melt.md
+++ b/.changeset/fair-shoes-melt.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-add user friendly error messages for d1 validation errors
+fix: ensure d1 validation errors render user friendly messages

--- a/.changeset/fair-shoes-melt.md
+++ b/.changeset/fair-shoes-melt.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+add user friendly error messages for d1 validation errors

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -719,8 +719,13 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				) {
 					err.preventReport();
 
-					if(err.notes[0].text === "binding DB of type d1 must have a valid `id` specified [code: 10021]") {
-						throw new UserError("You must use a real database in the database_id configuration. You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here: https://developers.cloudflare.com/d1/configuration/local-development");
+					if (
+						err.notes[0].text ===
+						"binding DB of type d1 must have a valid `id` specified [code: 10021]"
+					) {
+						throw new UserError(
+							"You must use a real database in the database_id configuration. You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here: https://developers.cloudflare.com/d1/configuration/local-development"
+						);
 					}
 
 					const maybeNameToFilePath = (moduleName: string) => {

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -719,6 +719,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				) {
 					err.preventReport();
 
+					if(err.notes[0].text === "binding DB of type d1 must have a valid `id` specified [code: 10021]") {
+						throw new UserError("You must use a real database in the database_id configuration. You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here: https://developers.cloudflare.com/d1/configuration/local-development");
+					}
+
 					const maybeNameToFilePath = (moduleName: string) => {
 						// If this is a service worker, always return the entrypoint path.
 						// Service workers can't have additional JavaScript modules.

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -684,20 +684,25 @@ function handleUserFriendlyError(error: FetchError, accountId?: string) {
 	}
 
 	switch(error.code) {
-		// code 10021 happens when the provided preview database
-		// id does not actually exist
+		// code 10021 is a validation error
 		case 10021: {
-			const errorMessage =
-			"Error: You must use a real database in the preview_database_id configuration.";
-			const solutionMessage =
-				"You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here:";
-			const documentationLink = `https://developers.cloudflare.com/d1/configuration/local-development`;
+			// if it is the following message, give a more user friendly
+			// error, otherwise do not handle this error in this function
+			if(error.message === "binding DB of type d1 must have a valid `id` specified") {
+				const errorMessage =
+				"Error: You must use a real database in the preview_database_id configuration.";
+				const solutionMessage =
+					"You can find your databases using 'wrangler d1 list', or read how to develop locally with D1 here:";
+				const documentationLink = `https://developers.cloudflare.com/d1/configuration/local-development`;
 
-			logger.error(
-				`${errorMessage}\n${solutionMessage}\n${documentationLink}`
-			);
+				logger.error(
+					`${errorMessage}\n${solutionMessage}\n${documentationLink}`
+				);
 
-			return true;
+				return true;
+			}
+
+			return false;
 		}
 
 		// for error 10063 (workers.dev subdomain required)

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -37,7 +37,7 @@ import type {
 	CfPreviewToken,
 } from "./create-worker-preview";
 import type { EsbuildBundle } from "./use-esbuild";
-import { FetchError } from "../cfetch";
+import type { FetchError } from "../cfetch";
 
 interface RemoteProps {
 	name: string | undefined;

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -37,7 +37,7 @@ import type {
 	CfPreviewToken,
 } from "./create-worker-preview";
 import type { EsbuildBundle } from "./use-esbuild";
-import type { FetchError } from "../cfetch";
+import type { ParseError } from "../parse";
 
 interface RemoteProps {
 	name: string | undefined;
@@ -676,19 +676,19 @@ function ChooseAccount(props: {
  * messages, does not perform any logic other than logging errors.
  * @returns if the error was handled or not
  */
-function handleUserFriendlyError(error: FetchError, accountId?: string) {
+function handleUserFriendlyError(error: ParseError, accountId?: string) {
 	// simulate aborts as handled errors by this function, but don't
 	// log anything
-	if ((error.code as unknown as string) === "ABORT_ERR") {
+	if ((error as unknown as { code: string }).code === "ABORT_ERR") {
 		return true;
 	}
 
-	switch(error.code) {
+	switch((error as unknown as { code: number }).code) {
 		// code 10021 is a validation error
 		case 10021: {
 			// if it is the following message, give a more user friendly
 			// error, otherwise do not handle this error in this function
-			if(error.message === "binding DB of type d1 must have a valid `id` specified") {
+			if(error.notes[0].text === "binding DB of type d1 must have a valid `id` specified [code: 10021]") {
 				const errorMessage =
 				"Error: You must use a real database in the preview_database_id configuration.";
 				const solutionMessage =


### PR DESCRIPTION
Fixes #4590.

**What this PR solves / how to test:** Adds a user friendly error message mapping for code 10021, specifically when the database id mapping is invalid.

**Author has addressed the following:** I have also moved out some repeated error mappings in the `remote.ts` file to a shared function.

- Tests
  - [ ] Included
  - [X] Not necessary because: Error messages.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [X] Included
  - [ ] Not necessary because: 
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [X] Not necessary because: Error messages.

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
