### PR TITLE
In pages functions avoid cloning the request when not necessary

### DIFF
--- a/.changeset/lucky-fans-repeat.md
+++ b/.changeset/lucky-fans-repeat.md
@@ -1,0 +1,15 @@
+---
+"wrangler": patch
+---
+
+fix: Remove `request.clone()` from Pages functions when possible
+
+When using the `/functions` directory requests get cloned unconditionally, such request bodies
+can not be read causing workerd errors regarding unused streams and wasted memory.
+
+These changes prevent `request.clone()` for routes containing a single handler, resolving the
+above issue for such simple type of routes.
+
+Routes with multiple handlers (with middlewares for example) sill generate clones unconditionally,
+such routes cannot be amended in a non breaking way, so they will be amended at a later time before
+a new major release of wrangler.

--- a/fixtures/pages-functions-request-clone/README.md
+++ b/fixtures/pages-functions-request-clone/README.md
@@ -1,0 +1,35 @@
+# Request Cloning
+
+This route + tests is for testing the `request.clone()` call that is currently causing workerd
+runtime errors: https://github.com/cloudflare/workers-sdk/issues/3259
+
+The cloning should be in the next wrangler major release, optimally alongside with this route + tests
+
+## Why can't we fix it in a patch release
+
+The issue is caused by the `request.clone()` that we perform in `pages-template-workers.ts`
+we did remove it when there is a single handler, but we can't remove it when there are multiple
+handlers because more than one could try reading the request body.
+
+For example, the following code would break if we were to unconditionally remove the `.clone()` call:
+
+```
+// functions/_middleware.ts
+
+export const onRequest = async ({ request, next }) => {
+  console.log(await request.text())
+  return next()
+}
+```
+
+```
+// functions/foo.ts
+
+export const onRequest = async ({ request }) => {
+  return new Response(await request.text())
+}
+```
+
+Anyways in the above code the cloning of the request should be up to the user (if they want to read the request
+body more than once they should clone the request themselves), so we should remove the `.clone()` in a major
+release and let users know that no automatic cloning is going to be performed under the hood for them.

--- a/fixtures/pages-functions-request-clone/functions/multi-handler/_middleware.ts
+++ b/fixtures/pages-functions-request-clone/functions/multi-handler/_middleware.ts
@@ -1,0 +1,9 @@
+export async function onRequest(context) {
+	try {
+		const reqText = await context.request.text();
+		console.log(`[_MIDDLEWARE] Received: "${reqText}"`);
+		return await context.next();
+	} catch (err) {
+		return new Response(`${err.message}\n${err.stack}`, { status: 500 });
+	}
+}

--- a/fixtures/pages-functions-request-clone/functions/multi-handler/index.ts
+++ b/fixtures/pages-functions-request-clone/functions/multi-handler/index.ts
@@ -1,0 +1,4 @@
+export async function onRequestPost({ request }: { request: Request }) {
+	const reqText = await request.text();
+	return new Response(`[POST] Received: "${reqText}"`);
+}

--- a/fixtures/pages-functions-request-clone/functions/single-handler/index.ts
+++ b/fixtures/pages-functions-request-clone/functions/single-handler/index.ts
@@ -1,0 +1,4 @@
+export async function onRequestPost({ request }: { request: Request }) {
+	const reqText = await request.text();
+	return new Response(`[POST] Received: "${reqText}"`);
+}

--- a/fixtures/pages-functions-request-clone/package.json
+++ b/fixtures/pages-functions-request-clone/package.json
@@ -1,11 +1,12 @@
 {
-	"name": "pages-functions-app",
+	"name": "pages-functions-request-clone",
 	"version": "0.0.0",
 	"private": true,
 	"sideEffects": false,
+	"main": "dist/worker.js",
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "wrangler pages dev public --port 8789",
+		"dev": "wrangler pages dev public --binding=NAME=VALUE --binding=OTHER_NAME=THING=WITH=EQUALS --r2=BUCKET --port 8789",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"

--- a/fixtures/pages-functions-request-clone/tests/pages-functions-request-clone.test.ts
+++ b/fixtures/pages-functions-request-clone/tests/pages-functions-request-clone.test.ts
@@ -1,0 +1,61 @@
+import { resolve } from "node:path";
+import { setTimeout } from "node:timers/promises";
+import { fetch } from "undici";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
+
+describe("Pages Functions - Request Clone", () => {
+	let ip: string,
+		port: number,
+		stop: (() => Promise<unknown>) | undefined,
+		getOutput: () => string;
+
+	beforeAll(async () => {
+		({ ip, port, stop, getOutput } = await runWranglerPagesDev(
+			resolve(__dirname, ".."),
+			"public",
+			[]
+		));
+	});
+
+	afterAll(async () => {
+		await stop?.();
+	});
+
+	it("single-handler POST requests work as expected and don't cause runtime errors/warnings", async ({
+		expect,
+	}) => {
+		const response = await fetch(`http://${ip}:${port}/single-handler`, {
+			method: "POST",
+			body: "this is a test",
+		});
+		const text = await response.text();
+		expect(text).toMatchInlineSnapshot(
+			'"[POST] Received: \\"this is a test\\""'
+		);
+		await setTimeout(1000);
+		const output = getOutput();
+		expect(output).not.toContain(
+			"Your worker created multiple branches of a single stream"
+		);
+	});
+
+	it("multi-handler POST requests work as expected but cause runtime errors/warnings", async ({
+		expect,
+	}) => {
+		const response = await fetch(`http://${ip}:${port}/multi-handler`, {
+			method: "POST",
+			body: "this is a test",
+		});
+		const text = await response.text();
+		expect(text).toMatchInlineSnapshot(
+			'"[POST] Received: \\"this is a test\\""'
+		);
+		await setTimeout(1000);
+		const output = getOutput();
+		expect(output).toContain(`[_MIDDLEWARE] Received: "this is a test"`);
+		expect(output).toContain(
+			"Your worker created multiple branches of a single stream"
+		);
+	});
+});

--- a/fixtures/pages-functions-request-clone/tests/tsconfig.json
+++ b/fixtures/pages-functions-request-clone/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"types": ["node"],
+		"esModuleInterop": true
+	},
+	"include": ["**/*.ts", "../../../node-types.d.ts"]
+}

--- a/fixtures/pages-functions-request-clone/tsconfig.json
+++ b/fixtures/pages-functions-request-clone/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"include": ["index.d.ts", "functions"],
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "CommonJS",
+		"lib": ["ES2020"],
+		"types": ["@cloudflare/workers-types"],
+		"moduleResolution": "node",
+		"noEmit": true,
+		"skipLibCheck": true
+	}
+}

--- a/fixtures/pages-functions-request-clone/vitest.config.ts
+++ b/fixtures/pages-functions-request-clone/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/packages/wrangler/templates/pages-template-plugin.ts
+++ b/packages/wrangler/templates/pages-template-plugin.ts
@@ -1,4 +1,5 @@
 import { match } from "path-to-regexp";
+import type { MatchResult } from "path-to-regexp";
 
 //note: this explicitly does not include the * character, as pages requires this
 const escapeRegex = /[.+?^${}()|[\]\\]/g;
@@ -65,55 +66,35 @@ type RouteHandler = {
 // inject `routes` via ESBuild
 declare const routes: RouteHandler[];
 
-function* executeRequest(request: Request, relativePathname: string) {
-	// First, iterate through the routes (backwards) and execute "middlewares" on partial route matches
-	for (const route of [...routes].reverse()) {
-		if (route.method && route.method !== request.method) {
-			continue;
-		}
+type HandlersWrapper = {
+	handlers: PagesFunction<unknown, string, Record<string, unknown>>[];
+	matchResult: MatchResult<object>;
+	mountMatchResult: MatchResult<object>;
+};
 
-		// replaces with "\\$&", this prepends a backslash to the matched string, e.g. "[" becomes "\["
-		const routeMatcher = match(route.routePath.replace(escapeRegex, "\\$&"), {
-			end: false,
-		});
-		const mountMatcher = match(route.mountPath.replace(escapeRegex, "\\$&"), {
-			end: false,
-		});
-		const matchResult = routeMatcher(relativePathname);
-		const mountMatchResult = mountMatcher(relativePathname);
-		if (matchResult && mountMatchResult) {
-			for (const handler of route.middlewares.flat()) {
-				yield {
-					handler,
-					params: matchResult.params as Params,
-					path: mountMatchResult.path,
-				};
-			}
+function* executeRequest(
+	middlewares: HandlersWrapper[],
+	module: HandlersWrapper | undefined
+) {
+	for (const middleware of middlewares) {
+		const { handlers, matchResult, mountMatchResult } = middleware!;
+		for (const handler of handlers) {
+			yield {
+				handler,
+				params: matchResult.params as Params,
+				path: mountMatchResult.path,
+			};
 		}
 	}
 
-	// Then look for the first exact route match and execute its "modules"
-	for (const route of routes) {
-		if (route.method && route.method !== request.method) {
-			continue;
-		}
-
-		const routeMatcher = match(route.routePath.replace(escapeRegex, "\\$&"), {
-			end: true,
-		});
-		const mountMatcher = match(route.mountPath.replace(escapeRegex, "\\$&"), {
-			end: false,
-		});
-		const matchResult = routeMatcher(relativePathname);
-		const mountMatchResult = mountMatcher(relativePathname);
-		if (matchResult && mountMatchResult && route.modules.length) {
-			for (const handler of route.modules.flat()) {
-				yield {
-					handler,
-					params: matchResult.params as Params,
-					path: matchResult.path,
-				};
-			}
+	if (module) {
+		const { handlers, matchResult } = module;
+		for (const handler of handlers) {
+			yield {
+				handler,
+				params: matchResult.params as Params,
+				path: matchResult.path,
+			};
 			break;
 		}
 	}
@@ -131,7 +112,27 @@ export default function (pluginArgs: unknown) {
 			url.pathname.replace(workerContext.functionPath, "") || ""
 		}`.replace(/^\/\//, "/");
 
-		const handlerIterator = executeRequest(request, relativePathname);
+		const middlewares = collectHandlersWrappers(
+			request,
+			relativePathname,
+			"middlewares"
+		);
+
+		const numOfMiddlewareHandlers = middlewares
+			.map(({ handlers }) => handlers.length ?? 0)
+			.reduce((a, b) => a + b, 0);
+
+		const modules = collectHandlersWrappers(
+			request,
+			relativePathname,
+			"modules"
+		);
+		const module = modules[0];
+
+		const numberOfHandlers = numOfMiddlewareHandlers + (module ? 1 : 0);
+
+		const handlerIterator = executeRequest(middlewares, modules[0]);
+
 		const pluginNext = async (input?: RequestInfo, init?: RequestInit) => {
 			if (input !== undefined) {
 				let url = input;
@@ -146,7 +147,17 @@ export default function (pluginArgs: unknown) {
 			if (result.done === false) {
 				const { handler, params, path } = result.value;
 				const context = {
-					request: new Request(request.clone()),
+					request: new Request(
+						// Note: We should never clone the request because this might cause requests to remain unused, waste
+						//       memory and generate runtime workerd errors/warnings, the potential cloning of the request
+						//       should be the user's responsibility.
+						//       We cannot however remove the `clone()` call here because when there are multiple handlers,
+						//       currently more than one of them can read the request body (without them ever cloning the request),
+						//       so in order not to have to introduce a breaking change we are calling `clone()` only when more than
+						//       one handler is present, otherwise it is safe to just use the original request object.
+						//       In the next major release we should remove the `clone()` call entirely.
+						numberOfHandlers > 1 ? request.clone() : request
+					),
 					functionPath: workerContext.functionPath + path,
 					next: pluginNext,
 					params,
@@ -188,3 +199,37 @@ const cloneResponse = (response: Response) =>
 		[101, 204, 205, 304].includes(response.status) ? null : response.body,
 		response
 	);
+
+function collectHandlersWrappers(
+	request: Request,
+	relativePathname: string,
+	kind: "middlewares" | "modules"
+): HandlersWrapper[] {
+	// If we're collecting middlewares, those need to be applied in the reverse order
+	const targetRoutes = kind === "middlewares" ? [...routes].reverse() : routes;
+
+	return targetRoutes
+		.map((route) => {
+			if (route.method && route.method !== request.method) {
+				return null;
+			}
+
+			// replaces with "\\$&", this prepends a backslash to the matched string, e.g. "[" becomes "\["
+			const routeMatcher = match(route.routePath.replace(escapeRegex, "\\$&"), {
+				end: kind === "middlewares" ? false : true,
+			});
+			const mountMatcher = match(route.mountPath.replace(escapeRegex, "\\$&"), {
+				end: false,
+			});
+			const matchResult = routeMatcher(relativePathname);
+			const mountMatchResult = mountMatcher(relativePathname);
+			if (matchResult && mountMatchResult) {
+				return {
+					handlers: route[kind],
+					matchResult,
+					mountMatchResult,
+				};
+			}
+		})
+		.filter(Boolean) as HandlersWrapper[];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,24 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/pages-functions-request-clone:
+    devDependencies:
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20221111.1
+        version: 4.20231025.0
+      pages-plugin-example:
+        specifier: workspace:*
+        version: link:../pages-plugin-example
+      undici:
+        specifier: ^5.28.2
+        version: 5.28.2
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/pages-functions-wasm-app:
     devDependencies:
       '@cloudflare/workers-tsconfig':


### PR DESCRIPTION
Partially fixes #3259 (the full fix can only be applied as a breaking change so it'll have to wait for a wrangler major release unfortunately)

Supersedes #4861 

___

Example for the changes: https://github.com/dario-piotrowicz/cf-pages-functions-request-clone-repro

___

TODO:
 - [ ] understand why this only occurred in POST requests
 - [ ] investigate alternative suggested in [comment](https://github.com/cloudflare/workers-sdk/pull/4916#issuecomment-1925948244)
 - [ ] add tests for plugins
