### PR TITLE
improve(r2): Update Sippy endpoint request payloads to match new schema

### DIFF
--- a/.changeset/five-cooks-share.md
+++ b/.changeset/five-cooks-share.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Update API calls for Sippy's endpoints

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -344,7 +344,7 @@ describe("r2", () => {
 						)
 					);
 					await runWrangler(
-						"r2 bucket sippy enable testBucket --r2-key-id=some-key --r2-secret-access-key=some-secret --provider=AWS --key-id=aws-key --secret-access-key=aws-secret --bucket=awsBucket"
+						"r2 bucket sippy enable testBucket --r2-access-key-id=some-key --r2-secret-access-key=some-secret --provider=AWS --access-key-id=aws-key --secret-access-key=aws-secret --region=awsRegion --bucket=awsBucket"
 					);
 					expect(std.out).toMatchInlineSnapshot(
 						`"✨ Successfully enabled Sippy on the 'testBucket' bucket."`
@@ -376,7 +376,7 @@ describe("r2", () => {
 						)
 					);
 					await runWrangler(
-						"r2 bucket sippy enable testBucket --r2-key-id=some-key --r2-secret-access-key=some-secret --provider=GCS --client-email=gcs-client-email --private-key=gcs-private-key --bucket=gcsBucket"
+						"r2 bucket sippy enable testBucket --r2-access-key-id=some-key --r2-secret-access-key=some-secret --provider=GCS --client-email=gcs-client-email --private-key=gcs-private-key --bucket=gcsBucket"
 					);
 					expect(std.out).toMatchInlineSnapshot(
 						`"✨ Successfully enabled Sippy on the 'testBucket' bucket."`
@@ -410,12 +410,12 @@ describe("r2", () => {
 				      --provider  [choices: \\"AWS\\", \\"GCS\\"]
 				      --bucket                    The name of the upstream bucket  [string]
 				      --region                    (AWS provider only) The region of the upstream bucket  [string]
-				      --key-id                    (AWS provider only) The secret access key id for the upstream bucket  [string]
+				      --access-key-id             (AWS provider only) The secret access key id for the upstream bucket  [string]
 				      --secret-access-key         (AWS provider only) The secret access key for the upstream bucket  [string]
 				      --service-account-key-file  (GCS provider only) The path to your Google Cloud service account key JSON file  [string]
 				      --client-email              (GCS provider only) The client email for your Google Cloud service account key  [string]
 				      --private-key               (GCS provider only) The private key for your Google Cloud service account key  [string]
-				      --r2-key-id                 The secret access key id for this R2 bucket  [string]
+				      --r2-access-key-id          The secret access key id for this R2 bucket  [string]
 				      --r2-secret-access-key      The secret access key for this R2 bucket  [string]"
 			`);
 					expect(std.err).toMatchInlineSnapshot(`

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -326,12 +326,18 @@ describe("r2", () => {
 							"*/accounts/some-account-id/r2/buckets/testBucket/sippy",
 							async (request, response, context) => {
 								expect(await request.json()).toEqual({
-									access_key: "aws-secret",
-									bucket: "awsBucket",
-									key_id: "aws-key",
-									provider: "AWS",
-									r2_access_key: "some-secret",
-									r2_key_id: "some-key",
+									source: {
+										provider: "aws",
+										region: "awsRegion",
+										bucket: "awsBucket",
+										accessKeyId: "aws-key",
+										secretAccessKey: "aws-secret",
+									},
+									destination: {
+										provider: "r2",
+										accessKeyId: "some-key",
+										secretAccessKey: "some-secret",
+									},
 								});
 								return response.once(context.json(createFetchResult({})));
 							}
@@ -353,12 +359,17 @@ describe("r2", () => {
 							"*/accounts/some-account-id/r2/buckets/testBucket/sippy",
 							async (request, response, context) => {
 								expect(await request.json()).toEqual({
-									private_key: "gcs-private-key",
-									bucket: "gcsBucket",
-									client_email: "gcs-client-email",
-									provider: "GCS",
-									r2_access_key: "some-secret",
-									r2_key_id: "some-key",
+									source: {
+										provider: "gcs",
+										bucket: "gcsBucket",
+										clientEmail: "gcs-client-email",
+										privateKey: "gcs-private-key",
+									},
+									destination: {
+										provider: "r2",
+										accessKeyId: "some-key",
+										secretAccessKey: "some-secret",
+									},
 								});
 								return response.once(context.json(createFetchResult({})));
 							}
@@ -522,7 +533,7 @@ describe("r2", () => {
 				);
 				await runWrangler("r2 bucket sippy get testBucket");
 				expect(std.out).toMatchInlineSnapshot(
-					`"Sippy upstream bucket: https://storage.googleapis.com/storage/v1/b/testBucket."`
+					`"Sippy configuration: https://storage.googleapis.com/storage/v1/b/testBucket"`
 				);
 			});
 		});

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -224,6 +224,18 @@ export async function usingLocalBucket<T>(
 	}
 }
 
+type SippyConfig = {
+	source:
+		| { provider: "aws"; region: string; bucket: string }
+		| { provider: "gcs"; bucket: string };
+	destination: {
+		provider: "r2";
+		account: string;
+		bucket: string;
+		accessKeyId: string;
+	};
+};
+
 /**
  * Retreive the sippy upstream bucket for the bucket with the given name
  */
@@ -231,7 +243,7 @@ export async function getR2Sippy(
 	accountId: string,
 	bucketName: string,
 	jurisdiction?: string
-): Promise<string> {
+): Promise<SippyConfig> {
 	const headers: HeadersInit = {};
 	if (jurisdiction !== undefined) {
 		headers["cf-r2-jurisdiction"] = jurisdiction;
@@ -260,26 +272,27 @@ export async function deleteR2Sippy(
 	);
 }
 
-export type R2Credentials = {
-	bucket: string;
-	r2_key_id: string;
-	r2_access_key: string;
+export type SippyPutParams = {
+	source:
+		| {
+				provider: "aws";
+				region: string;
+				bucket: string;
+				accessKeyId: string;
+				secretAccessKey: string;
+		  }
+		| {
+				provider: "gcs";
+				bucket: string;
+				clientEmail: string;
+				privateKey: string;
+		  };
+	destination: {
+		provider: "r2";
+		accessKeyId: string;
+		secretAccessKey: string;
+	};
 };
-
-export type SippyPutConfig = R2Credentials &
-	(
-		| {
-				provider: "AWS";
-				zone: string | undefined;
-				key_id: string;
-				access_key: string;
-		  }
-		| {
-				provider: "GCS";
-				client_email: string;
-				private_key: string;
-		  }
-	);
 
 /**
  * Enable sippy on the bucket with the given name
@@ -287,15 +300,17 @@ export type SippyPutConfig = R2Credentials &
 export async function putR2Sippy(
 	accountId: string,
 	bucketName: string,
-	config: SippyPutConfig,
+	params: SippyPutParams,
 	jurisdiction?: string
 ): Promise<void> {
-	const headers: HeadersInit = {};
+	const headers: HeadersInit = {
+		"Content-Type": "application/json",
+	};
 	if (jurisdiction !== undefined) {
 		headers["cf-r2-jurisdiction"] = jurisdiction;
 	}
 	return await fetchResult(
 		`/accounts/${accountId}/r2/buckets/${bucketName}/sippy`,
-		{ method: "PUT", body: JSON.stringify(config), headers }
+		{ method: "PUT", body: JSON.stringify(params), headers }
 	);
 }

--- a/packages/wrangler/src/r2/sippy.ts
+++ b/packages/wrangler/src/r2/sippy.ts
@@ -38,7 +38,7 @@ export function EnableOptions(yargs: CommonYargsArgv) {
 			description: "(AWS provider only) The region of the upstream bucket",
 			string: true,
 		})
-		.option("key-id", {
+		.option("access-key-id", {
 			description:
 				"(AWS provider only) The secret access key id for the upstream bucket",
 			string: true,
@@ -63,7 +63,7 @@ export function EnableOptions(yargs: CommonYargsArgv) {
 				"(GCS provider only) The private key for your Google Cloud service account key",
 			string: true,
 		})
-		.option("r2-key-id", {
+		.option("r2-access-key-id", {
 			description: "The secret access key id for this R2 bucket",
 			string: true,
 		})
@@ -101,10 +101,10 @@ export async function EnableHandler(
 			args.region ??= await prompt(
 				"Enter the AWS region where your S3 bucket is located (example: us-west-2):"
 			);
-			args.keyId ??= await prompt(
+			args.accessKeyId ??= await prompt(
 				"Enter your AWS Access Key ID (requires read and list access):"
 			);
-			if (!args.keyId) {
+			if (!args.accessKeyId) {
 				throw new UserError("Must specify an AWS Access Key ID.");
 			}
 			args.secretAccessKey ??= await prompt(
@@ -129,10 +129,10 @@ export async function EnableHandler(
 			}
 		}
 
-		args.r2KeyId ??= await prompt(
+		args.r2AccessKeyId ??= await prompt(
 			"Enter your R2 Access Key ID (requires read and write access):"
 		);
-		if (!args.r2KeyId) {
+		if (!args.r2AccessKeyId) {
 			throw new UserError("Must specify an R2 Access Key ID.");
 		}
 		args.r2SecretAccessKey ??= await prompt("Enter your R2 Secret Access Key:");


### PR DESCRIPTION
**What this PR solves / how to test:**
Before Sippy hits beta, we'd like to change the shape of the request payloads. This updates Wrangler's API calls to Sippy's endpoints to use these new payloads.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: existing tests should continue to pass
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): https://github.com/cloudflare/cloudflare-docs/pull/12823
  - [ ] Not necessary because:
