### PR TITLE
[D1] default `wrangler d1 execute` to local mode first.

### DIFF
--- a/.changeset/hungry-cougars-tie.md
+++ b/.changeset/hungry-cougars-tie.md
@@ -2,8 +2,8 @@
 "wrangler": minor
 ---
 
-feat: default `wrangler d1 execute` to local mode first, to match `wrangler dev`
+feat: default `wrangler d1 execute` and `wrangler d1 migrations` commands to local mode first, to match `wrangler dev`
 
-This PR defaults `wrangler d1 execute` to use the local development environment provided by wrangler to match the default behaviour in `wrangler dev`.
+This PR defaults `wrangler d1 execute` and `wrangler d1 migrations` commands to use the local development environment provided by wrangler to match the default behaviour in `wrangler dev`.
 
-BREAKING CHANGE: `wrangler d1 execute` now defaults `--local` to `true`. When running `wrangler d1 execute` against a remote D1 database, you will need to provide the `--remote` flag.
+BREAKING CHANGE: `wrangler d1 execute` and `wrangler d1 migrations` commands now default `--local` to `true`. When running `wrangler d1 execute` against a remote D1 database, you will need to provide the `--remote` flag.

--- a/.changeset/hungry-cougars-tie.md
+++ b/.changeset/hungry-cougars-tie.md
@@ -2,8 +2,8 @@
 "wrangler": minor
 ---
 
-feat: default `wrangler d1 execute` and `wrangler d1 migrations` commands to local mode first, to match `wrangler dev`
+refactor: default `wrangler d1 execute` and `wrangler d1 migrations` commands to local mode first, to match `wrangler dev`
 
 This PR defaults `wrangler d1 execute` and `wrangler d1 migrations` commands to use the local development environment provided by wrangler to match the default behaviour in `wrangler dev`.
 
-BREAKING CHANGE: `wrangler d1 execute` and `wrangler d1 migrations` commands now default `--local` to `true`. When running `wrangler d1 execute` against a remote D1 database, you will need to provide the `--remote` flag.
+BREAKING CHANGE (for a beta feature): `wrangler d1 execute` and `wrangler d1 migrations` commands now default `--local` to `true`. When running `wrangler d1 execute` against a remote D1 database, you will need to provide the `--remote` flag.

--- a/.changeset/hungry-cougars-tie.md
+++ b/.changeset/hungry-cougars-tie.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+feat: default `wrangler d1 execute` to local mode first, to match `wrangler dev`
+
+This PR defaults `wrangler d1 execute` to use the local development environment provided by wrangler to match the default behaviour in `wrangler dev`.
+
+BREAKING CHANGE: `wrangler d1 execute` now defaults `--local` to `true`. When running `wrangler d1 execute` against a remote D1 database, you will need to provide the `--remote` flag.

--- a/.changeset/sour-mugs-rule.md
+++ b/.changeset/sour-mugs-rule.md
@@ -1,9 +1,0 @@
----
-"wrangler": minor
----
-
-feat: default `wrangler d1 migrations apply` to local mode first, to match `wrangler dev`
-
-This PR defaults `wrangler d1 migrations apply` to use the local development environment provided by wrangler to match the default behaviour in `wrangler dev`.
-
-BREAKING CHANGE: `wrangler d1 migrations apply` now defaults `--local` to `true`. When running `wrangler d1 migrations apply` against a remote D1 database, you will need to provide the `--remote` flag.

--- a/.changeset/sour-mugs-rule.md
+++ b/.changeset/sour-mugs-rule.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+feat: default `wrangler d1 migrations apply` to local mode first, to match `wrangler dev`
+
+This PR defaults `wrangler d1 migrations apply` to use the local development environment provided by wrangler to match the default behaviour in `wrangler dev`.
+
+BREAKING CHANGE: `wrangler d1 migrations apply` now defaults `--local` to `true`. When running `wrangler d1 migrations apply` against a remote D1 database, you will need to provide the `--remote` flag.

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -37,7 +37,7 @@ describe("execute", () => {
 		);
 	});
 
-	it("should reject the use of --preview with --local", async () => {
+	it("should reject the use of --local", async () => {
 		setIsTTY(false);
 		writeWranglerToml({
 			d1_databases: [
@@ -46,8 +46,10 @@ describe("execute", () => {
 		});
 
 		await expect(
-			runWrangler(`d1 execute db --command "select;" --local --preview`)
-		).rejects.toThrowError(`Error: can't use --preview with --local`);
+			runWrangler(`d1 execute db --command "select;" --local`)
+		).rejects.toThrowError(
+			"`wrangler d1 execute` now defaults to local mode. Remove --local from your command to continue"
+		);
 	});
 
 	it("should reject the use of --remote with --local", async () => {
@@ -60,10 +62,12 @@ describe("execute", () => {
 
 		await expect(
 			runWrangler(`d1 execute db --command "select;" --local --remote`)
-		).rejects.toThrowError(`Error: can't use --remote with --local`);
+		).rejects.toThrowError(
+			"`wrangler d1 execute` now defaults to local mode. Remove --local from your command to continue."
+		);
 	});
 
-	it("should reject the use of --preview with --local with --json", async () => {
+	it("should reject the use of --local with --json", async () => {
 		setIsTTY(false);
 		writeWranglerToml({
 			d1_databases: [
@@ -72,35 +76,9 @@ describe("execute", () => {
 		});
 
 		await expect(
-			runWrangler(`d1 execute db --command "select;" --local --preview --json`)
-		).rejects.toThrowError(`Error: can't use --preview with --local`);
-	});
-
-	it("should expect --local when using --persist-to", async () => {
-		setIsTTY(false);
-		writeWranglerToml({
-			d1_databases: [
-				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
-			],
-		});
-		await runWrangler("d1 migrations create db test");
-
-		await expect(
-			runWrangler("d1 migrations apply --local db --preview")
-		).rejects.toThrowError(`Error: can't use --preview with --local`);
-	});
-
-	it("should reject --remote when using --persist-to", async () => {
-		setIsTTY(false);
-		writeWranglerToml({
-			d1_databases: [
-				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
-			],
-		});
-		await runWrangler("d1 migrations create db test");
-
-		await expect(
-			runWrangler("d1 migrations apply db --remote --persist-to asdf")
-		).rejects.toThrowError(`persist-to -> local`);
+			runWrangler(`d1 execute db --command "select;" --local --json`)
+		).rejects.toThrowError(
+			"`wrangler d1 execute` now defaults to local mode. Remove --local from your command to continue."
+		);
 	});
 });

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -37,21 +37,6 @@ describe("execute", () => {
 		);
 	});
 
-	it("should reject the use of --local", async () => {
-		setIsTTY(false);
-		writeWranglerToml({
-			d1_databases: [
-				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
-			],
-		});
-
-		await expect(
-			runWrangler(`d1 execute db --command "select;" --local`)
-		).rejects.toThrowError(
-			"`wrangler d1 execute` now defaults to local mode. Remove --local from your command to continue"
-		);
-	});
-
 	it("should reject the use of --remote with --local", async () => {
 		setIsTTY(false);
 		writeWranglerToml({
@@ -63,11 +48,11 @@ describe("execute", () => {
 		await expect(
 			runWrangler(`d1 execute db --command "select;" --local --remote`)
 		).rejects.toThrowError(
-			"`wrangler d1 execute` now defaults to local mode. Remove --local from your command to continue."
+			"Error: can't use --local and --remote at the same time"
 		);
 	});
 
-	it("should reject the use of --local with --json", async () => {
+	it("should reject the use of --preview with --local", async () => {
 		setIsTTY(false);
 		writeWranglerToml({
 			d1_databases: [
@@ -76,9 +61,30 @@ describe("execute", () => {
 		});
 
 		await expect(
-			runWrangler(`d1 execute db --command "select;" --local --json`)
+			runWrangler(`d1 execute db --command "select;" --local --preview`)
+		).rejects.toThrowError(`Error: can't use --preview without --remote`);
+	});
+
+	it("should reject the use of --preview with --local with --json", async () => {
+		setIsTTY(false);
+		writeWranglerToml({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+
+		await expect(
+			runWrangler(`d1 execute db --command "select;" --local --preview --json`)
 		).rejects.toThrowError(
-			"`wrangler d1 execute` now defaults to local mode. Remove --local from your command to continue."
+			JSON.stringify(
+				{
+					error: {
+						text: "Error: can't use --preview without --remote",
+					},
+				},
+				null,
+				2
+			)
 		);
 	});
 });

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -47,7 +47,7 @@ describe("migrate", () => {
 			});
 			// If we get to the point where we are checking for migrations then we have not been asked to log in.
 			await expect(
-				runWrangler("d1 migrations apply --local DATABASE")
+				runWrangler("d1 migrations apply DATABASE")
 			).rejects.toThrowError(
 				`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
 			);
@@ -117,7 +117,9 @@ Ok to create /tmp/my-migrations-go-here?`,
 Your database may not be available to serve requests during the migration, continue?`,
 				result: true,
 			});
-			await expect(runWrangler("d1 migrations apply db")).rejects.toThrowError(
+			await expect(
+				runWrangler("d1 migrations apply db --remote")
+			).rejects.toThrowError(
 				`More than one account available but unable to select one in non-interactive mode.`
 			);
 		});
@@ -195,7 +197,9 @@ Your database may not be available to serve requests during the migration, conti
 				result: true,
 			});
 			//if we get to this point, wrangler knows the account_id
-			await expect(runWrangler("d1 migrations apply db")).rejects.toThrowError(
+			await expect(
+				runWrangler("d1 migrations apply db --remote")
+			).rejects.toThrowError(
 				`request to https://api.cloudflare.com/client/v4/accounts/nx01/d1/database/xxxx/backup failed`
 			);
 		});

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -57,9 +57,9 @@ describe("migrate", () => {
 			setIsTTY(false);
 			writeWranglerToml();
 			await expect(
-				runWrangler("d1 migrations apply DATABASE")
+				runWrangler("d1 migrations apply DATABASE --remote")
 			).rejects.toThrowError(
-				"Can't find a DB with name/binding 'DATABASE' in local config. Check info in wrangler.toml..."
+				"Couldn't find a D1 DB with the name or binding 'DATABASE' in wrangler.toml."
 			);
 		});
 
@@ -68,24 +68,10 @@ describe("migrate", () => {
 			writeWranglerToml();
 			// If we get to the point where we are checking for migrations then we have not checked wrangler.toml.
 			await expect(
-				runWrangler("d1 migrations apply --local DATABASE")
+				runWrangler("d1 migrations apply DATABASE")
 			).rejects.toThrowError(
 				`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
 			);
-		});
-
-		it("should reject the use of --preview with --local", async () => {
-			setIsTTY(false);
-			writeWranglerToml({
-				d1_databases: [
-					{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
-				],
-			});
-			await runWrangler("d1 migrations create db test");
-
-			await expect(
-				runWrangler("d1 migrations apply --local db --preview")
-			).rejects.toThrowError(`Error: can't use --preview with --local`);
 		});
 
 		it("multiple accounts: should throw when trying to apply migrations without an account_id in config", async () => {
@@ -253,9 +239,9 @@ Your database may not be available to serve requests during the migration, conti
 			setIsTTY(false);
 			writeWranglerToml();
 			await expect(
-				runWrangler("d1 migrations list DATABASE")
+				runWrangler("d1 migrations list DATABASE --remote")
 			).rejects.toThrowError(
-				"Can't find a DB with name/binding 'DATABASE' in local config. Check info in wrangler.toml..."
+				"Couldn't find a D1 DB with the name or binding 'DATABASE' in wrangler.toml."
 			);
 		});
 
@@ -263,7 +249,7 @@ Your database may not be available to serve requests during the migration, conti
 			setIsTTY(false);
 
 			await expect(
-				runWrangler("d1 migrations list DATABASE")
+				runWrangler("d1 migrations list DATABASE --remote")
 			).rejects.toThrowError(
 				"In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work"
 			);
@@ -274,7 +260,7 @@ Your database may not be available to serve requests during the migration, conti
 			writeWranglerToml();
 			// If we get to the point where we are checking for migrations then we have not checked wrangler.toml.
 			await expect(
-				runWrangler("d1 migrations list --local DATABASE")
+				runWrangler("d1 migrations list DATABASE")
 			).rejects.toThrowError(
 				`No migrations present at ${cwd().replaceAll("\\", "/")}/migrations.`
 			);

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -74,6 +74,20 @@ describe("migrate", () => {
 			);
 		});
 
+		it("should reject the use of --preview with --local", async () => {
+			setIsTTY(false);
+			writeWranglerToml({
+				d1_databases: [
+					{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+				],
+			});
+			await runWrangler("d1 migrations create db test");
+
+			await expect(
+				runWrangler("d1 migrations apply --local db --preview")
+			).rejects.toThrowError(`Error: can't use --preview without --remote`);
+		});
+
 		it("multiple accounts: should throw when trying to apply migrations without an account_id in config", async () => {
 			setIsTTY(false);
 

--- a/packages/wrangler/src/__tests__/d1/utils.test.ts
+++ b/packages/wrangler/src/__tests__/d1/utils.test.ts
@@ -1,0 +1,176 @@
+import { rest } from "msw";
+import { type Config } from "../../config";
+import {
+	getDatabaseByNameOrBinding,
+	getDatabaseInfoFromConfig,
+} from "../../d1/utils";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockGetMemberships } from "../helpers/mock-oauth-flow";
+import { msw } from "../helpers/msw";
+
+describe("getDatabaseInfoFromConfig", () => {
+	it("should handle no database", () => {
+		const config = {
+			d1_databases: [],
+		} as unknown as Config;
+		expect(getDatabaseInfoFromConfig(config, "db")).toBeNull();
+	});
+
+	it("should handle no matching database", () => {
+		const config = {
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		} as unknown as Config;
+		expect(getDatabaseInfoFromConfig(config, "db2")).toBeNull();
+	});
+
+	it("should handle matching database", () => {
+		const config = {
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		} as unknown as Config;
+		expect(getDatabaseInfoFromConfig(config, "db")).toEqual({
+			uuid: "xxxx",
+			previewDatabaseUuid: undefined,
+			binding: "DATABASE",
+			name: "db",
+			migrationsTableName: "d1_migrations",
+			migrationsFolderPath: "./migrations",
+			internal_env: undefined,
+		});
+	});
+
+	it("should handle matching a database with a custom migrations folder", () => {
+		const config = {
+			d1_databases: [
+				{
+					binding: "DATABASE",
+					database_name: "db",
+					database_id: "xxxx",
+					migrations_dir: "./custom_migrations",
+				},
+			],
+		} as unknown as Config;
+		expect(getDatabaseInfoFromConfig(config, "db")).toEqual({
+			uuid: "xxxx",
+			previewDatabaseUuid: undefined,
+			binding: "DATABASE",
+			name: "db",
+			migrationsTableName: "d1_migrations",
+			migrationsFolderPath: "./custom_migrations",
+			internal_env: undefined,
+		});
+	});
+
+	it("should handle matching a database with custom migrations table", () => {
+		const config = {
+			d1_databases: [
+				{
+					binding: "DATABASE",
+					database_name: "db",
+					database_id: "xxxx",
+					migrations_table: "custom_migrations",
+				},
+			],
+		} as unknown as Config;
+		expect(getDatabaseInfoFromConfig(config, "db")).toEqual({
+			uuid: "xxxx",
+			previewDatabaseUuid: undefined,
+			binding: "DATABASE",
+			name: "db",
+			migrationsTableName: "custom_migrations",
+			migrationsFolderPath: "./migrations",
+			internal_env: undefined,
+		});
+	});
+
+	it("should handle matching a database when there are multiple databases", () => {
+		const config = {
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+				{ binding: "DATABASE2", database_name: "db2", database_id: "yyyy" },
+			],
+		} as unknown as Config;
+		expect(getDatabaseInfoFromConfig(config, "db2")).toEqual({
+			uuid: "yyyy",
+			previewDatabaseUuid: undefined,
+			binding: "DATABASE2",
+			name: "db2",
+			migrationsTableName: "d1_migrations",
+			migrationsFolderPath: "./migrations",
+			internal_env: undefined,
+		});
+	});
+});
+
+describe("getDatabaseByNameOrBinding", () => {
+	mockAccountId({ accountId: null });
+	mockApiToken();
+
+	it("should handle no database", async () => {
+		mockGetMemberships([
+			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+		]);
+		msw.use(
+			rest.get("*/accounts/:accountId/d1/database", async (req, res, ctx) => {
+				return res(
+					ctx.status(200),
+					ctx.json({
+						result: [
+							{
+								file_size: 7421952,
+								name: "benchmark3-v1",
+								num_tables: 2,
+								uuid: "7b0c1d24-ec57-4179-8663-9b82dafe9277",
+								version: "alpha",
+							},
+						],
+						success: true,
+						errors: [],
+						messages: [],
+					})
+				);
+			})
+		);
+		const config = {
+			d1_databases: [],
+		} as unknown as Config;
+		await expect(
+			getDatabaseByNameOrBinding(config, "123", "db")
+		).rejects.toThrowError("Couldn't find DB with name 'db'");
+	});
+
+	it("should handle a matching database", async () => {
+		mockGetMemberships([
+			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+		]);
+		const mockDb = {
+			file_size: 7421952,
+			name: "db",
+			num_tables: 2,
+			uuid: "7b0c1d24-ec57-4179-8663-9b82dafe9277",
+			version: "alpha",
+		};
+		msw.use(
+			rest.get("*/accounts/:accountId/d1/database", async (req, res, ctx) => {
+				return res(
+					ctx.status(200),
+					ctx.json({
+						result: [mockDb],
+						success: true,
+						errors: [],
+						messages: [],
+					})
+				);
+			})
+		);
+		const config = {
+			d1_databases: [],
+		} as unknown as Config;
+		await expect(
+			getDatabaseByNameOrBinding(config, "123", "db")
+		).resolves.toStrictEqual(mockDb);
+	});
+});

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -215,7 +215,7 @@ export async function executeSql({
 	if (preview && local)
 		throw new UserError(`Error: can't use --preview with --local`);
 	if (remote && local)
-		throw new UserError(`Error: can't use --preview with --local`);
+		throw new UserError(`Error: can't use --remote with --local`);
 	if (persistTo && !local)
 		throw new UserError(`Error: can't use --persist-to without --local`);
 	if (persistTo && remote)

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -49,6 +49,13 @@ export function Options(yargs: CommonYargsArgv) {
 			describe:
 				"Execute commands/files against a local DB for use with wrangler dev",
 			type: "boolean",
+			deprecated: true,
+		})
+		.option("remote", {
+			describe:
+				"Execute commands/files against a remote DB for use with wrangler dev",
+			type: "boolean",
+			default: false,
 		})
 		.option("file", {
 			describe: "A .sql file to ingest",
@@ -85,6 +92,7 @@ type HandlerOptions = StrictYargsOptionsToInterface<typeof Options>;
 export const Handler = async (args: HandlerOptions): Promise<void> => {
 	const {
 		local,
+		remote,
 		database,
 		yes,
 		persistTo,
@@ -109,6 +117,7 @@ export const Handler = async (args: HandlerOptions): Promise<void> => {
 	try {
 		const response: QueryResult[] | null = await executeSql({
 			local,
+			remote,
 			config,
 			name: database,
 			shouldPrompt: isInteractive && !yes,
@@ -168,6 +177,7 @@ export const Handler = async (args: HandlerOptions): Promise<void> => {
 
 export async function executeSql({
 	local,
+	remote,
 	config,
 	name,
 	shouldPrompt,
@@ -179,6 +189,7 @@ export async function executeSql({
 	batchSize,
 }: {
 	local: boolean | undefined;
+	remote: boolean | undefined;
 	config: ConfigFields<DevConfig> & Environment;
 	name: string;
 	shouldPrompt: boolean | undefined;
@@ -194,12 +205,21 @@ export async function executeSql({
 		// set loggerLevel to error to avoid logs appearing in JSON output
 		logger.loggerLevel = "error";
 	}
+	if (local) {
+		logger.log(
+			"You no longer need to provide --local with `wrangler d1 execute`, local will be used by default."
+		);
+	}
 	const sql = file ? readFileSync(file) : command;
 	if (!sql) throw new UserError(`Error: must provide --command or --file.`);
 	if (preview && local)
 		throw new UserError(`Error: can't use --preview with --local`);
+	if (remote && local)
+		throw new UserError(`Error: can't use --preview with --local`);
 	if (persistTo && !local)
 		throw new UserError(`Error: can't use --persist-to without --local`);
+	if (persistTo && remote)
+		throw new UserError(`Error: can't use --persist-to with --remote`);
 	logger.log(`🌀 Mapping SQL input into an array of statements`);
 	const queries = splitSqlQuery(sql);
 
@@ -211,21 +231,22 @@ export async function executeSql({
 			);
 		}
 	}
-	const result = local
-		? await executeLocally({
-				config,
-				name,
-				queries,
-				persistTo,
-		  })
-		: await executeRemotely({
+	const result = remote
+		? await executeRemotely({
 				config,
 				name,
 				shouldPrompt,
 				batches: batchSplit(queries, batchSize),
 				json,
 				preview,
+		  })
+		: await executeLocally({
+				config,
+				name,
+				queries,
+				persistTo,
 		  });
+
 	if (json) logger.loggerLevel = existingLogLevel;
 	return result;
 }

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -48,6 +48,7 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 		config,
 		database,
 		local,
+		remote,
 		persistTo,
 		preview,
 		batchSize,
@@ -160,6 +161,7 @@ Your database may not be available to serve requests during the migration, conti
 			try {
 				const response = await executeSql({
 					local,
+					remote,
 					config,
 					name: database,
 					shouldPrompt: isInteractive() && !CI.isCI(),

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -77,6 +77,7 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 		await initMigrationsTable({
 			migrationsTableName,
 			local,
+			remote,
 			config,
 			name: database,
 			persistTo,
@@ -88,6 +89,7 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 				migrationsTableName,
 				migrationsPath,
 				local,
+				remote,
 				config,
 				name: database,
 				persistTo,

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -55,9 +55,14 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 	}): Promise<void> => {
 		await printWranglerBanner();
 		const databaseInfo = getDatabaseInfoFromConfig(config, database);
-		if (!databaseInfo && !local) {
+		if (local) {
 			throw new UserError(
-				`Can't find a DB with name/binding '${database}' in local config. Check info in wrangler.toml...`
+				"`wrangler d1 execute` now defaults to local mode. Remove --local from your command to continue."
+			);
+		}
+		if (!databaseInfo && remote) {
+			throw new UserError(
+				`Couldn't find a D1 DB with the name or binding '${database}' in wrangler.toml.`
 			);
 		}
 
@@ -76,7 +81,6 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 			databaseInfo?.migrationsTableName ?? DEFAULT_MIGRATION_TABLE;
 		await initMigrationsTable({
 			migrationsTableName,
-			local,
 			remote,
 			config,
 			name: database,
@@ -88,7 +92,6 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 			await getUnappliedMigrations({
 				migrationsTableName,
 				migrationsPath,
-				local,
 				remote,
 				config,
 				name: database,
@@ -162,7 +165,6 @@ Your database may not be available to serve requests during the migration, conti
 			let errorNotes: Array<string> = [];
 			try {
 				const response = await executeSql({
-					local,
 					remote,
 					config,
 					name: database,

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -55,11 +55,7 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 	}): Promise<void> => {
 		await printWranglerBanner();
 		const databaseInfo = getDatabaseInfoFromConfig(config, database);
-		if (local) {
-			throw new UserError(
-				"`wrangler d1 execute` now defaults to local mode. Remove --local from your command to continue."
-			);
-		}
+
 		if (!databaseInfo && remote) {
 			throw new UserError(
 				`Couldn't find a D1 DB with the name or binding '${database}' in wrangler.toml.`
@@ -81,6 +77,7 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 			databaseInfo?.migrationsTableName ?? DEFAULT_MIGRATION_TABLE;
 		await initMigrationsTable({
 			migrationsTableName,
+			local,
 			remote,
 			config,
 			name: database,
@@ -92,6 +89,7 @@ export const ApplyHandler = withConfig<ApplyHandlerOptions>(
 			await getUnappliedMigrations({
 				migrationsTableName,
 				migrationsPath,
+				local,
 				remote,
 				config,
 				name: database,
@@ -165,6 +163,7 @@ Your database may not be available to serve requests during the migration, conti
 			let errorNotes: Array<string> = [];
 			try {
 				const response = await executeSql({
+					local,
 					remote,
 					config,
 					name: database,

--- a/packages/wrangler/src/d1/migrations/create.tsx
+++ b/packages/wrangler/src/d1/migrations/create.tsx
@@ -32,7 +32,7 @@ export const CreateHandler = withConfig<CreateHandlerOptions>(
 		const databaseInfo = getDatabaseInfoFromConfig(config, database);
 		if (!databaseInfo) {
 			throw new UserError(
-				`Can't find a DB with name/binding '${database}' in local config. Check info in wrangler.toml...`
+				`Couldn't find a D1 DB with the name or binding '${database}' in wrangler.toml.`
 			);
 		}
 

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -43,6 +43,7 @@ export async function getUnappliedMigrations({
 	migrationsTableName,
 	migrationsPath,
 	local,
+	remote,
 	config,
 	name,
 	persistTo,
@@ -51,6 +52,7 @@ export async function getUnappliedMigrations({
 	migrationsTableName: string;
 	migrationsPath: string;
 	local: boolean | undefined;
+	remote: boolean | undefined;
 	config: ConfigFields<DevConfig> & Environment;
 	name: string;
 	persistTo: string | undefined;
@@ -60,6 +62,7 @@ export async function getUnappliedMigrations({
 		await listAppliedMigrations(
 			migrationsTableName,
 			local,
+			remote,
 			config,
 			name,
 			persistTo,
@@ -84,6 +87,7 @@ export async function getUnappliedMigrations({
 const listAppliedMigrations = async (
 	migrationsTableName: string,
 	local: boolean | undefined,
+	remote: boolean | undefined,
 	config: ConfigFields<DevConfig> & Environment,
 	name: string,
 	persistTo: string | undefined,
@@ -91,6 +95,7 @@ const listAppliedMigrations = async (
 ): Promise<Migration[]> => {
 	const response: QueryResult[] | null = await executeSql({
 		local,
+		remote,
 		config,
 		name,
 		shouldPrompt: isInteractive() && !CI.isCI(),
@@ -141,6 +146,7 @@ export function getNextMigrationNumber(migrationsPath: string): number {
 export const initMigrationsTable = async ({
 	migrationsTableName,
 	local,
+	remote,
 	config,
 	name,
 	persistTo,
@@ -148,6 +154,7 @@ export const initMigrationsTable = async ({
 }: {
 	migrationsTableName: string;
 	local: boolean | undefined;
+	remote: boolean | undefined;
 	config: ConfigFields<DevConfig> & Environment;
 	name: string;
 	persistTo: string | undefined;
@@ -155,6 +162,7 @@ export const initMigrationsTable = async ({
 }) => {
 	return executeSql({
 		local,
+		remote,
 		config,
 		name,
 		shouldPrompt: isInteractive() && !CI.isCI(),

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -42,6 +42,7 @@ export async function getMigrationsPath({
 export async function getUnappliedMigrations({
 	migrationsTableName,
 	migrationsPath,
+	local,
 	remote,
 	config,
 	name,
@@ -50,6 +51,7 @@ export async function getUnappliedMigrations({
 }: {
 	migrationsTableName: string;
 	migrationsPath: string;
+	local: boolean | undefined;
 	remote: boolean | undefined;
 	config: ConfigFields<DevConfig> & Environment;
 	name: string;
@@ -57,14 +59,15 @@ export async function getUnappliedMigrations({
 	preview: boolean | undefined;
 }): Promise<Array<string>> {
 	const appliedMigrations = (
-		await listAppliedMigrations(
+		await listAppliedMigrations({
 			migrationsTableName,
+			local,
 			remote,
 			config,
 			name,
 			persistTo,
-			preview
-		)
+			preview,
+		})
 	).map((migration) => {
 		return migration.name;
 	});
@@ -81,15 +84,27 @@ export async function getUnappliedMigrations({
 	return unappliedMigrations;
 }
 
-const listAppliedMigrations = async (
-	migrationsTableName: string,
-	remote: boolean | undefined,
-	config: ConfigFields<DevConfig> & Environment,
-	name: string,
-	persistTo: string | undefined,
-	preview: boolean | undefined
-): Promise<Migration[]> => {
+type ListAppliedMigrationsProps = {
+	migrationsTableName: string;
+	local: boolean | undefined;
+	remote: boolean | undefined;
+	config: ConfigFields<DevConfig> & Environment;
+	name: string;
+	persistTo: string | undefined;
+	preview: boolean | undefined;
+};
+
+const listAppliedMigrations = async ({
+	migrationsTableName,
+	local,
+	remote,
+	config,
+	name,
+	persistTo,
+	preview,
+}: ListAppliedMigrationsProps): Promise<Migration[]> => {
 	const response: QueryResult[] | null = await executeSql({
+		local,
 		remote,
 		config,
 		name,
@@ -140,6 +155,7 @@ export function getNextMigrationNumber(migrationsPath: string): number {
 
 export const initMigrationsTable = async ({
 	migrationsTableName,
+	local,
 	remote,
 	config,
 	name,
@@ -147,6 +163,7 @@ export const initMigrationsTable = async ({
 	preview,
 }: {
 	migrationsTableName: string;
+	local: boolean | undefined;
 	remote: boolean | undefined;
 	config: ConfigFields<DevConfig> & Environment;
 	name: string;
@@ -154,6 +171,7 @@ export const initMigrationsTable = async ({
 	preview: boolean | undefined;
 }) => {
 	return executeSql({
+		local,
 		remote,
 		config,
 		name,

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -42,7 +42,6 @@ export async function getMigrationsPath({
 export async function getUnappliedMigrations({
 	migrationsTableName,
 	migrationsPath,
-	local,
 	remote,
 	config,
 	name,
@@ -51,7 +50,6 @@ export async function getUnappliedMigrations({
 }: {
 	migrationsTableName: string;
 	migrationsPath: string;
-	local: boolean | undefined;
 	remote: boolean | undefined;
 	config: ConfigFields<DevConfig> & Environment;
 	name: string;
@@ -61,7 +59,6 @@ export async function getUnappliedMigrations({
 	const appliedMigrations = (
 		await listAppliedMigrations(
 			migrationsTableName,
-			local,
 			remote,
 			config,
 			name,
@@ -86,7 +83,6 @@ export async function getUnappliedMigrations({
 
 const listAppliedMigrations = async (
 	migrationsTableName: string,
-	local: boolean | undefined,
 	remote: boolean | undefined,
 	config: ConfigFields<DevConfig> & Environment,
 	name: string,
@@ -94,7 +90,6 @@ const listAppliedMigrations = async (
 	preview: boolean | undefined
 ): Promise<Migration[]> => {
 	const response: QueryResult[] | null = await executeSql({
-		local,
 		remote,
 		config,
 		name,
@@ -145,7 +140,6 @@ export function getNextMigrationNumber(migrationsPath: string): number {
 
 export const initMigrationsTable = async ({
 	migrationsTableName,
-	local,
 	remote,
 	config,
 	name,
@@ -153,7 +147,6 @@ export const initMigrationsTable = async ({
 	preview,
 }: {
 	migrationsTableName: string;
-	local: boolean | undefined;
 	remote: boolean | undefined;
 	config: ConfigFields<DevConfig> & Environment;
 	name: string;
@@ -161,7 +154,6 @@ export const initMigrationsTable = async ({
 	preview: boolean | undefined;
 }) => {
 	return executeSql({
-		local,
 		remote,
 		config,
 		name,

--- a/packages/wrangler/src/d1/migrations/list.tsx
+++ b/packages/wrangler/src/d1/migrations/list.tsx
@@ -28,7 +28,14 @@ export function ListOptions(yargs: CommonYargsArgv) {
 type ListHandlerOptions = StrictYargsOptionsToInterface<typeof ListOptions>;
 
 export const ListHandler = withConfig<ListHandlerOptions>(
-	async ({ config, database, local, persistTo, preview }): Promise<void> => {
+	async ({
+		config,
+		database,
+		local,
+		remote,
+		persistTo,
+		preview,
+	}): Promise<void> => {
 		await printWranglerBanner();
 		if (!local) {
 			await requireAuth({});
@@ -58,6 +65,7 @@ export const ListHandler = withConfig<ListHandlerOptions>(
 		await initMigrationsTable({
 			migrationsTableName,
 			local,
+			remote,
 			config,
 			name: database,
 			persistTo,
@@ -69,6 +77,7 @@ export const ListHandler = withConfig<ListHandlerOptions>(
 				migrationsTableName,
 				migrationsPath,
 				local,
+				remote,
 				config,
 				name: database,
 				persistTo,

--- a/packages/wrangler/src/d1/migrations/list.tsx
+++ b/packages/wrangler/src/d1/migrations/list.tsx
@@ -28,7 +28,14 @@ export function ListOptions(yargs: CommonYargsArgv) {
 type ListHandlerOptions = StrictYargsOptionsToInterface<typeof ListOptions>;
 
 export const ListHandler = withConfig<ListHandlerOptions>(
-	async ({ config, database, remote, persistTo, preview }): Promise<void> => {
+	async ({
+		config,
+		database,
+		local,
+		remote,
+		persistTo,
+		preview,
+	}): Promise<void> => {
 		await printWranglerBanner();
 		if (remote) {
 			await requireAuth({});
@@ -57,6 +64,7 @@ export const ListHandler = withConfig<ListHandlerOptions>(
 
 		await initMigrationsTable({
 			migrationsTableName,
+			local,
 			remote,
 			config,
 			name: database,
@@ -68,6 +76,7 @@ export const ListHandler = withConfig<ListHandlerOptions>(
 			await getUnappliedMigrations({
 				migrationsTableName,
 				migrationsPath,
+				local,
 				remote,
 				config,
 				name: database,

--- a/packages/wrangler/src/d1/migrations/list.tsx
+++ b/packages/wrangler/src/d1/migrations/list.tsx
@@ -28,23 +28,16 @@ export function ListOptions(yargs: CommonYargsArgv) {
 type ListHandlerOptions = StrictYargsOptionsToInterface<typeof ListOptions>;
 
 export const ListHandler = withConfig<ListHandlerOptions>(
-	async ({
-		config,
-		database,
-		local,
-		remote,
-		persistTo,
-		preview,
-	}): Promise<void> => {
+	async ({ config, database, remote, persistTo, preview }): Promise<void> => {
 		await printWranglerBanner();
-		if (!local) {
+		if (remote) {
 			await requireAuth({});
 		}
 
 		const databaseInfo = getDatabaseInfoFromConfig(config, database);
-		if (!databaseInfo && !local) {
+		if (!databaseInfo && remote) {
 			throw new UserError(
-				`Can't find a DB with name/binding '${database}' in local config. Check info in wrangler.toml...`
+				`Couldn't find a D1 DB with the name or binding '${database}' in wrangler.toml.`
 			);
 		}
 
@@ -64,7 +57,6 @@ export const ListHandler = withConfig<ListHandlerOptions>(
 
 		await initMigrationsTable({
 			migrationsTableName,
-			local,
 			remote,
 			config,
 			name: database,
@@ -76,7 +68,6 @@ export const ListHandler = withConfig<ListHandlerOptions>(
 			await getUnappliedMigrations({
 				migrationsTableName,
 				migrationsPath,
-				local,
 				remote,
 				config,
 				name: database,

--- a/packages/wrangler/src/d1/migrations/options.ts
+++ b/packages/wrangler/src/d1/migrations/options.ts
@@ -5,8 +5,15 @@ export function MigrationOptions(yargs: CommonYargsArgv) {
 	return Database(yargs)
 		.option("local", {
 			describe:
-				"Execute commands/files against a local DB for use with wrangler dev --local",
+				"Execute commands/files against a local DB for use with wrangler dev",
 			type: "boolean",
+			deprecated: true,
+		})
+		.option("remote", {
+			describe:
+				"Execute commands/files against a remote DB for use with wrangler dev --remote",
+			type: "boolean",
+			default: false,
 		})
 		.option("preview", {
 			describe: "Execute commands/files against a preview D1 DB",

--- a/packages/wrangler/src/d1/migrations/options.ts
+++ b/packages/wrangler/src/d1/migrations/options.ts
@@ -7,13 +7,11 @@ export function MigrationOptions(yargs: CommonYargsArgv) {
 			describe:
 				"Execute commands/files against a local DB for use with wrangler dev",
 			type: "boolean",
-			deprecated: true,
 		})
 		.option("remote", {
 			describe:
 				"Execute commands/files against a remote DB for use with wrangler dev --remote",
 			type: "boolean",
-			default: false,
 		})
 		.option("preview", {
 			describe: "Execute commands/files against a preview D1 DB",
@@ -26,6 +24,5 @@ export function MigrationOptions(yargs: CommonYargsArgv) {
 			type: "string",
 			requiresArg: true,
 		})
-		.implies("preview", "remote")
 		.implies("persist-to", "local");
 }

--- a/packages/wrangler/src/d1/migrations/options.ts
+++ b/packages/wrangler/src/d1/migrations/options.ts
@@ -26,5 +26,6 @@ export function MigrationOptions(yargs: CommonYargsArgv) {
 			type: "string",
 			requiresArg: true,
 		})
+		.implies("preview", "remote")
 		.implies("persist-to", "local");
 }


### PR DESCRIPTION
This PR defaults both `wrangler d1 execute` and `wrangler d1 migrations apply` to use the local development environment provided by wrangler to match the default behaviour in `wrangler dev`.

BREAKING CHANGE: `wrangler d1 execute` and `wrangler d1 migrations apply` now default `--local` to `true`. When running `wrangler d1 execute` or `wrangler d1 migrations apply` against a remote D1 database, you will need to provide the `--remote` flag.

---

## Why?

`wrangler dev` used to default to remote preview Workers, and `wrangler d1 execute`/`wrangler d1 migrations apply` followed this practice. With wrangler v3, `wrangler dev` was updated without updating `wrangler d1 execute`/`wrangler d1 migrations apply`. This PR fixes this, and ensures `wrangler dev` and `wrangler d1 execute`/`wrangler d1 migrations apply` match again.

Closes STOR-2892 internally.

---

## Preview

You can try this out via `npx wrangler@d1`. For example:

```
npx wrangler@d1 d1 execute <DBNAME> --command ="..."
```

## What this looks like:

### Local
```
npx wrangler@d1 d1 execute northwind-test --command="SELECT 1;"         
 ⛅️ wrangler 0.0.0-e4c703ba
---------------------------
🌀 Mapping SQL input into an array of statements
🌀 Executing on local database northwind-test (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) from .wrangler/state/v3/d1:
🌀 To execute on your remote database, add a --remote flag to your wrangler command.
┌───┐
│ 1 │
├───┤
│ 1 │
└───┘
```

### Remote
```
 npx wrangler@d1 d1 execute northwind-test --command="SELECT 1;" --remote
 ⛅️ wrangler 0.0.0-e4c703ba
---------------------------
🌀 Mapping SQL input into an array of statements
🌀 Parsing 1 statements
🌀 Executing on remote database northwind-test (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx):
🌀 To execute on your local development database, remove the --remote flag from your wrangler command.
🚣 Executed 1 commands in 0.1596ms
┌───┐
│ 1 │
├───┤
│ 1 │
└───┘
```