### PR TITLE
make the entrypoint optional for the `types` command

### DIFF
--- a/.changeset/breezy-worms-pull.md
+++ b/.changeset/breezy-worms-pull.md
@@ -1,0 +1,15 @@
+---
+"wrangler": patch
+---
+
+fix: make the entrypoint optional for the `types` command
+
+Currently running `wrangler types` against a `wrangler.toml` file without a defined entrypoint (`main` value)
+causes the command to error with the following message:
+
+```
+✘ [ERROR] Missing entry-point: The entry-point should be specified via the command line (e.g. `wrangler types path/to/script`) or the `main` config field.
+```
+
+However developers could want to generate types without the entrypoint being defined (for example when using `getBindingsProxy`), so these changes
+make the entrypoint no longer mandatory for the `types` command, defaulting on assuming the use of the modules syntax if no entrypoint is specified.

--- a/.changeset/breezy-worms-pull.md
+++ b/.changeset/breezy-worms-pull.md
@@ -12,4 +12,4 @@ causes the command to error with the following message:
 ```
 
 However developers could want to generate types without the entrypoint being defined (for example when using `getBindingsProxy`), so these changes
-make the entrypoint no longer mandatory for the `types` command, defaulting on assuming the use of the modules syntax if no entrypoint is specified.
+make the entrypoint optional for the `types` command, assuming modules syntax if none is specified.

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -235,4 +235,24 @@ describe("generateTypes()", () => {
 		"
 	`);
 	});
+
+	it("should accept a toml file without an entrypoint and fallback to the standard modules declarations", async () => {
+		fs.writeFileSync(
+			"./wrangler.toml",
+			TOML.stringify({
+				vars: bindingsConfigMock.vars,
+			} as unknown as TOML.JsonMap),
+			"utf-8"
+		);
+
+		await runWrangler("types");
+		expect(std.out).toMatchInlineSnapshot(`
+		"interface Env {
+			SOMETHING: \\"asdasdfasdf\\";
+			ANOTHER: \\"thing\\";
+			OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+		}
+		"
+	`);
+	});
 });

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -12,11 +12,13 @@ export async function generateTypes(
 	configToDTS: Partial<Config>,
 	config: Config
 ) {
-	let entrypointFormat: CfScriptFormat = "modules";
-	try {
-		const entry = await getEntry({}, config, "types");
-		entrypointFormat = entry.format;
-	} catch {}
+	const configContainsEntryPoint =
+		config.main !== undefined || !!config.site?.["entry-point"];
+
+	const entrypointFormat: CfScriptFormat = configContainsEntryPoint
+		? (await getEntry({}, config, "types")).format
+		: "modules";
+
 	const envTypeStructure: string[] = [];
 
 	if (configToDTS.kv_namespaces) {

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -4,6 +4,7 @@ import { getEntry } from "./deployment-bundle/entry";
 import { UserError } from "./errors";
 import { logger } from "./logger";
 import type { Config } from "./config";
+import type { CfScriptFormat } from "./deployment-bundle/worker";
 
 // Currently includes bindings & rules for declaring modules
 
@@ -11,7 +12,11 @@ export async function generateTypes(
 	configToDTS: Partial<Config>,
 	config: Config
 ) {
-	const entry = await getEntry({}, config, "types");
+	let entrypointFormat: CfScriptFormat = "modules";
+	try {
+		const entry = await getEntry({}, config, "types");
+		entrypointFormat = entry.format;
+	} catch {}
 	const envTypeStructure: string[] = [];
 
 	if (configToDTS.kv_namespaces) {
@@ -136,7 +141,7 @@ export async function generateTypes(
 	writeDTSFile({
 		envTypeStructure,
 		modulesTypeStructure,
-		formatType: entry.format,
+		formatType: entrypointFormat,
 	});
 }
 


### PR DESCRIPTION
**What this PR solves / how to test:**
Run `wrangler types` against a `wrangler.toml` file not including a `main` field.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: the `types` command doesn't seem to have tests associated with it (I can look into adding them here or in a followup PR if we want)
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [ ] Not necessary because:
  - [x] I can add the info here: https://developers.cloudflare.com/workers/wrangler/commands/#types if desired

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
