### PR TITLE
Add private host option for private networks support in hyperdrive

### DIFF
--- a/.changeset/bright-planets-unite.md
+++ b/.changeset/bright-planets-unite.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feature: Add support for private networking in Hyperdrive configs

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -484,7 +484,7 @@ describe("hyperdrive dev tests", () => {
 					[[hyperdrive]]
 					binding = "HYPERDRIVE"
 					id = "hyperdrive_id"
-					localConnectionString = "postgresql://user%3Aname:%21pass@127.0.0.1:${port}/some_db"
+					localConnectionString = "postgresql://user:%21pass@127.0.0.1:${port}/some_db"
 			`,
 			"src/index.ts": dedent`
 					export default {
@@ -516,7 +516,7 @@ describe("hyperdrive dev tests", () => {
 			);
 			const url = new URL(text);
 			expect(url.pathname).toBe("/some_db");
-			expect(url.username).toBe("user:name");
+			expect(url.username).toBe("user");
 			expect(url.password).toBe("!pass");
 			expect(url.host).not.toBe("localhost");
 		});

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -119,7 +119,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 12345,
 		    \\"database\\": \\"database\\",
-		    \\"user\\": \\"test\\"
+		    \\"user\\": \\"test\\",
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -143,7 +144,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"database\\",
-		    \\"user\\": \\"test\\"
+		    \\"user\\": \\"test\\",
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -167,7 +169,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 12345,
 		    \\"database\\": \\"database\\",
-		    \\"user\\": \\"test\\"
+		    \\"user\\": \\"test\\",
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false,
@@ -193,7 +196,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"private.example.com\\",
 		    \\"port\\": 12345,
 		    \\"database\\": \\"database\\",
-		    \\"user\\": \\"test\\"
+		    \\"user\\": \\"test\\",
+		    \\"private_host\\": true
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -217,7 +221,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"user:name\\"
+		    \\"user\\": \\"user:name\\",
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -241,7 +246,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
+		    \\"user\\": \\"test\\",
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -265,7 +271,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"/\\"weird/\\" dbname\\",
-		    \\"user\\": \\"test\\"
+		    \\"user\\": \\"test\\",
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -334,7 +341,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 1234,
 		    \\"database\\": \\"mydb\\",
-		    \\"user\\": \\"newuser\\"
+		    \\"user\\": \\"newuser\\",
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -358,7 +366,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"private.example.com\\",
 		    \\"port\\": 1234,
 		    \\"database\\": \\"mydb\\",
-		    \\"user\\": \\"newuser\\"
+		    \\"user\\": \\"newuser\\",
+		    \\"private_host\\": true
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -500,7 +509,7 @@ function mockHyperdriveRequest() {
 									database: reqBody.origin.database,
 									scheme: reqBody.origin.protocol,
 									user: reqBody.origin.user,
-									privateHost: reqBody.origin.privateHost,
+									private_host: reqBody.origin.private_host,
 								},
 								caching: reqBody.caching,
 							},
@@ -527,7 +536,7 @@ function mockHyperdriveRequest() {
 												port: reqBody.origin.port,
 												database: reqBody.origin.database,
 												user: reqBody.origin.user,
-												privateHost: reqBody.origin.privateHost,
+												private_host: reqBody.origin.private_host,
 										  }
 										: defaultConfig.origin,
 								caching: reqBody.caching ?? defaultConfig.caching,
@@ -558,7 +567,7 @@ function mockHyperdriveRequest() {
 									port: 3211,
 									database: "mydb",
 									user: "dbuser",
-									privateHost: false,
+									private_host: false,
 								},
 								caching: {
 									disabled: false,

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -119,8 +119,7 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 12345,
 		    \\"database\\": \\"database\\",
-		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": false
+		    \\"user\\": \\"test\\"
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -144,8 +143,7 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"database\\",
-		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": false
+		    \\"user\\": \\"test\\"
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -169,8 +167,7 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 12345,
 		    \\"database\\": \\"database\\",
-		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": false
+		    \\"user\\": \\"test\\"
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false,
@@ -196,8 +193,7 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"private.example.com\\",
 		    \\"port\\": 12345,
 		    \\"database\\": \\"database\\",
-		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": true
+		    \\"user\\": \\"test\\"
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -221,8 +217,7 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"user:name\\",
-		    \\"privateHost\\": false
+		    \\"user\\": \\"user:name\\"
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -246,8 +241,7 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": false
+		    \\"user\\": \\"test\\"
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -271,8 +265,7 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"/\\"weird/\\" dbname\\",
-		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": false
+		    \\"user\\": \\"test\\"
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -308,7 +301,7 @@ describe("hyperdrive commands", () => {
 		    \\"port\\": 5432,
 		    \\"database\\": \\"database\\",
 		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": false
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -341,8 +334,7 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 1234,
 		    \\"database\\": \\"mydb\\",
-		    \\"user\\": \\"newuser\\",
-		    \\"privateHost\\": false
+		    \\"user\\": \\"newuser\\"
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -366,8 +358,7 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"private.example.com\\",
 		    \\"port\\": 1234,
 		    \\"database\\": \\"mydb\\",
-		    \\"user\\": \\"newuser\\",
-		    \\"privateHost\\": true
+		    \\"user\\": \\"newuser\\"
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -407,7 +398,7 @@ describe("hyperdrive commands", () => {
 		    \\"port\\": 5432,
 		    \\"database\\": \\"database\\",
 		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": false
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false,
@@ -434,7 +425,7 @@ describe("hyperdrive commands", () => {
 		    \\"port\\": 5432,
 		    \\"database\\": \\"database\\",
 		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": false
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": true
@@ -459,7 +450,7 @@ describe("hyperdrive commands", () => {
 		    \\"port\\": 5432,
 		    \\"database\\": \\"database\\",
 		    \\"user\\": \\"test\\",
-		    \\"privateHost\\": false
+		    \\"private_host\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -477,7 +468,7 @@ const defaultConfig: HyperdriveConfig = {
 		port: 5432,
 		database: "database",
 		user: "test",
-		privateHost: false,
+		private_host: false,
 	},
 	caching: {
 		disabled: false,

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -107,7 +107,7 @@ describe("hyperdrive commands", () => {
 	it("should handle creating a hyperdrive config", async () => {
 		mockHyperdriveRequest();
 		await runWrangler(
-			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com:12345/neondb'"
+			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com:12345/database'"
 		);
 		expect(std.out).toMatchInlineSnapshot(`
 		"🚧 Creating 'test123'
@@ -118,8 +118,9 @@ describe("hyperdrive commands", () => {
 		  \\"origin\\": {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 12345,
-		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
+		    \\"database\\": \\"database\\",
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -131,7 +132,7 @@ describe("hyperdrive commands", () => {
 	it("should handle creating a hyperdrive config for postgres without a port specified", async () => {
 		mockHyperdriveRequest();
 		await runWrangler(
-			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com/neondb'"
+			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com/database'"
 		);
 		expect(std.out).toMatchInlineSnapshot(`
 		"🚧 Creating 'test123'
@@ -142,8 +143,9 @@ describe("hyperdrive commands", () => {
 		  \\"origin\\": {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
-		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
+		    \\"database\\": \\"database\\",
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -155,7 +157,7 @@ describe("hyperdrive commands", () => {
 	it("should handle creating a hyperdrive config with caching options", async () => {
 		mockHyperdriveRequest();
 		await runWrangler(
-			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com:12345/neondb' --max-age=30 --swr=15"
+			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com:12345/database' --max-age=30 --swr=15"
 		);
 		expect(std.out).toMatchInlineSnapshot(`
 		"🚧 Creating 'test123'
@@ -166,13 +168,39 @@ describe("hyperdrive commands", () => {
 		  \\"origin\\": {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 12345,
-		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
+		    \\"database\\": \\"database\\",
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false,
 		    \\"maxAge\\": 30,
 		    \\"staleWhileRevalidate\\": 15
+		  }
+		}"
+	`);
+	});
+
+	it("should handle creating a hyperdrive with a private host", async () => {
+		mockHyperdriveRequest();
+		await runWrangler(
+			"hyperdrive create test123 --connection-string='postgresql://test:password@private.example.com:12345/database' --private-host=true"
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+		"🚧 Creating 'test123'
+		✅ Created new Hyperdrive config
+		 {
+		  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
+		  \\"name\\": \\"test123\\",
+		  \\"origin\\": {
+		    \\"host\\": \\"private.example.com\\",
+		    \\"port\\": 12345,
+		    \\"database\\": \\"database\\",
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": true
+		  },
+		  \\"caching\\": {
+		    \\"disabled\\": false
 		  }
 		}"
 	`);
@@ -193,7 +221,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"user:name\\"
+		    \\"user\\": \\"user:name\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -217,7 +246,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -241,7 +271,8 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
 		    \\"database\\": \\"/\\"weird/\\" dbname\\",
-		    \\"user\\": \\"test\\"
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -258,7 +289,7 @@ describe("hyperdrive commands", () => {
 		┌──────────────────────────────────────┬─────────┬────────┬────────────────┬──────┬──────────┬────────────────────┐
 		│ id                                   │ name    │ user   │ host           │ port │ database │ caching            │
 		├──────────────────────────────────────┼─────────┼────────┼────────────────┼──────┼──────────┼────────────────────┤
-		│ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx │ test123 │ test   │ example.com    │ 5432 │ neondb   │ {\\"disabled\\":false} │
+		│ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx │ test123 │ test   │ example.com    │ 5432 │ database │ {\\"disabled\\":false} │
 		├──────────────────────────────────────┼─────────┼────────┼────────────────┼──────┼──────────┼────────────────────┤
 		│ yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy │ new-db  │ dbuser │ www.google.com │ 3211 │ mydb     │ {\\"disabled\\":false} │
 		└──────────────────────────────────────┴─────────┴────────┴────────────────┴──────┴──────────┴────────────────────┘"
@@ -275,8 +306,9 @@ describe("hyperdrive commands", () => {
 		  \\"origin\\": {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
-		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
+		    \\"database\\": \\"database\\",
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -309,7 +341,33 @@ describe("hyperdrive commands", () => {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 1234,
 		    \\"database\\": \\"mydb\\",
-		    \\"user\\": \\"newuser\\"
+		    \\"user\\": \\"newuser\\",
+		    \\"privateHost\\": false
+		  },
+		  \\"caching\\": {
+		    \\"disabled\\": false
+		  }
+		}"
+	`);
+	});
+
+	it("should handle updating a hyperdrive config's origin with private host", async () => {
+		mockHyperdriveRequest();
+		await runWrangler(
+			`hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --origin-host=private.example.com --origin-port=1234 --database=mydb --origin-user=newuser --origin-password='passw0rd!' --private-host=true`
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+		"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+		✅ Updated xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx Hyperdrive config
+		 {
+		  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
+		  \\"name\\": \\"test123\\",
+		  \\"origin\\": {
+		    \\"host\\": \\"private.example.com\\",
+		    \\"port\\": 1234,
+		    \\"database\\": \\"mydb\\",
+		    \\"user\\": \\"newuser\\",
+		    \\"privateHost\\": true
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -347,8 +405,9 @@ describe("hyperdrive commands", () => {
 		  \\"origin\\": {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
-		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
+		    \\"database\\": \\"database\\",
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false,
@@ -373,8 +432,9 @@ describe("hyperdrive commands", () => {
 		  \\"origin\\": {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
-		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
+		    \\"database\\": \\"database\\",
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": true
@@ -397,8 +457,9 @@ describe("hyperdrive commands", () => {
 		  \\"origin\\": {
 		    \\"host\\": \\"example.com\\",
 		    \\"port\\": 5432,
-		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
+		    \\"database\\": \\"database\\",
+		    \\"user\\": \\"test\\",
+		    \\"privateHost\\": false
 		  },
 		  \\"caching\\": {
 		    \\"disabled\\": false
@@ -414,8 +475,9 @@ const defaultConfig: HyperdriveConfig = {
 	origin: {
 		host: "example.com",
 		port: 5432,
-		database: "neondb",
+		database: "database",
 		user: "test",
+		privateHost: false,
 	},
 	caching: {
 		disabled: false,
@@ -447,6 +509,7 @@ function mockHyperdriveRequest() {
 									database: reqBody.origin.database,
 									scheme: reqBody.origin.protocol,
 									user: reqBody.origin.user,
+									privateHost: reqBody.origin.privateHost,
 								},
 								caching: reqBody.caching,
 							},
@@ -473,6 +536,7 @@ function mockHyperdriveRequest() {
 												port: reqBody.origin.port,
 												database: reqBody.origin.database,
 												user: reqBody.origin.user,
+												privateHost: reqBody.origin.privateHost,
 										  }
 										: defaultConfig.origin,
 								caching: reqBody.caching ?? defaultConfig.caching,
@@ -503,6 +567,7 @@ function mockHyperdriveRequest() {
 									port: 3211,
 									database: "mydb",
 									user: "dbuser",
+									privateHost: false,
 								},
 								caching: {
 									disabled: false,

--- a/packages/wrangler/src/hyperdrive/client.ts
+++ b/packages/wrangler/src/hyperdrive/client.ts
@@ -18,7 +18,7 @@ export type PublicOrigin = Origin & {
 	scheme?: string;
 	database?: string;
 	user?: string;
-	privateHost?: boolean;
+	private_host?: boolean;
 };
 
 export type OriginWithPassword = PublicOrigin & {

--- a/packages/wrangler/src/hyperdrive/client.ts
+++ b/packages/wrangler/src/hyperdrive/client.ts
@@ -18,6 +18,7 @@ export type PublicOrigin = Origin & {
 	scheme?: string;
 	database?: string;
 	user?: string;
+	privateHost?: boolean;
 };
 
 export type OriginWithPassword = PublicOrigin & {

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -40,6 +40,7 @@ export function options(yargs: CommonYargsArgv) {
 				type: "boolean",
 				describe:
 					"Whether the provided host is part of your Cloudflare Zero Trust private network",
+				default: false,
 			},
 		})
 		.epilogue(hyperdriveBetaWarning);

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -97,7 +97,7 @@ export async function handler(
 				database: decodeURIComponent(url.pathname.replace("/", "")),
 				user: decodeURIComponent(url.username),
 				password: decodeURIComponent(url.password),
-				privateHost: args.privateHost ?? false,
+				private_host: args.privateHost ?? false,
 			},
 			caching: {
 				disabled: args.cachingDisabled,

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -36,6 +36,11 @@ export function options(yargs: CommonYargsArgv) {
 				describe:
 					"Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled",
 			},
+			"private-host": {
+				type: "boolean",
+				describe:
+					"Whether the provided host is part of your Cloudflare Zero Trust private network",
+			},
 		})
 		.epilogue(hyperdriveBetaWarning);
 }
@@ -91,6 +96,7 @@ export async function handler(
 				database: decodeURIComponent(url.pathname.replace("/", "")),
 				user: decodeURIComponent(url.username),
 				password: decodeURIComponent(url.password),
+				privateHost: args.privateHost ?? false,
 			},
 			caching: {
 				disabled: args.cachingDisabled,

--- a/packages/wrangler/src/hyperdrive/update.ts
+++ b/packages/wrangler/src/hyperdrive/update.ts
@@ -60,7 +60,8 @@ export function options(yargs: CommonYargsArgv) {
 			},
 			"private-host": {
 				type: "boolean",
-				describe: "Disables the caching of SQL responses",
+				describe:
+					"Whether the provided host is part of your Cloudflare Zero Trust private network",
 				default: false,
 			},
 		})

--- a/packages/wrangler/src/hyperdrive/update.ts
+++ b/packages/wrangler/src/hyperdrive/update.ts
@@ -122,7 +122,7 @@ export async function handler(
 			database: args.database,
 			user: args.originUser,
 			password: args.originPassword,
-			privateHost: args.privateHost,
+			private_host: args.privateHost,
 		};
 	}
 

--- a/packages/wrangler/src/hyperdrive/update.ts
+++ b/packages/wrangler/src/hyperdrive/update.ts
@@ -58,6 +58,11 @@ export function options(yargs: CommonYargsArgv) {
 				describe:
 					"Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled",
 			},
+			"private-host": {
+				type: "boolean",
+				describe: "Disables the caching of SQL responses",
+				default: false,
+			},
 		})
 		.epilogue(hyperdriveBetaWarning);
 }
@@ -116,6 +121,7 @@ export async function handler(
 			database: args.database,
 			user: args.originUser,
 			password: args.originPassword,
+			privateHost: args.privateHost,
 		};
 	}
 


### PR DESCRIPTION
## What this PR solves / how to test
Support for configuring hyperdrives for databases that are inside a customer's private network
LDW CR-851053

## Author has addressed the following
- Tests
  -  [ ] TODO (before merge)
  -  [x] Included
  -  [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  -  [ ] TODO (before merge)
  -  [x] Included
  -  [ ] Not necessary because:
- Public documentation
  -  [ ] TODO (before merge)
  -  [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/13654
  -  [ ] Not necessary because: Does not change the Hyperdrive command or its options.