### PR TITLE
[playground-preview-worker] fix: don't report invalid upload input

### DIFF
--- a/packages/playground-preview-worker/.eslintrc.js
+++ b/packages/playground-preview-worker/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+	root: true,
+	extends: ["@cloudflare/eslint-config-worker"],
+};

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -6,6 +6,7 @@
 		"build-middleware": "pnpm run build-middleware:common && pnpm run build-middleware:loader",
 		"build-middleware:common": "pnpm dlx esbuild ../wrangler/templates/middleware/common.ts --outfile=src/middleware/common.module.template",
 		"build-middleware:loader": "pnpm dlx esbuild ../wrangler/templates/middleware/loader-modules.ts --outfile=src/middleware/loader.module.template",
+		"check:lint": "eslint .",
 		"deploy": "wrangler -j deploy",
 		"deploy:testing": "wrangler -j deploy -e testing",
 		"start": "wrangler -j dev",
@@ -16,6 +17,7 @@
 		"zod": "^3.22.3"
 	},
 	"devDependencies": {
+		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-types": "^4.20230321.0",
 		"@types/cookie": "^0.5.1",
 		"cookie": "^0.5.0",

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -12,7 +12,7 @@
 		"test:e2e": "vitest run"
 	},
 	"dependencies": {
-		"hono": "^3.3.2",
+		"hono": "^3.12.11",
 		"zod": "^3.22.3"
 	},
 	"devDependencies": {

--- a/packages/playground-preview-worker/src/errors.ts
+++ b/packages/playground-preview-worker/src/errors.ts
@@ -115,7 +115,10 @@ export class PreviewRequestForbidden extends HttpError {
 
 export class BadUpload extends HttpError {
 	name = "BadUpload";
-	constructor(message = "Invalid upload") {
+	constructor(message = "Invalid upload", private readonly error?: string) {
 		super(message, 400, false);
+	}
+	get data() {
+		return { error: this.error };
 	}
 }

--- a/packages/playground-preview-worker/src/errors.ts
+++ b/packages/playground-preview-worker/src/errors.ts
@@ -1,0 +1,121 @@
+import type { ZodIssue } from "zod";
+
+export class HttpError extends Error {
+	constructor(
+		message: string,
+		readonly status: number,
+		// Only report errors to sentry when they represent actionable errors
+		readonly reportable: boolean
+	) {
+		super(message);
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+	toResponse() {
+		return Response.json(
+			{
+				error: this.name,
+				message: this.message,
+				data: this.data,
+			},
+			{
+				status: this.status,
+				headers: {
+					"Access-Control-Allow-Origin": "*",
+					"Access-Control-Allow-Methods": "GET,PUT,POST",
+				},
+			}
+		);
+	}
+
+	get data(): Record<string, unknown> {
+		return {};
+	}
+}
+
+export class WorkerTimeout extends HttpError {
+	name = "WorkerTimeout";
+	constructor() {
+		super("Worker timed out", 400, false);
+	}
+
+	toResponse(): Response {
+		return new Response("Worker timed out");
+	}
+}
+
+export class ServiceWorkerNotSupported extends HttpError {
+	name = "ServiceWorkerNotSupported";
+	constructor() {
+		super(
+			"Service Workers are not supported in the Workers Playground",
+			400,
+			false
+		);
+	}
+}
+export class ZodSchemaError extends HttpError {
+	name = "ZodSchemaError";
+	constructor(private issues: ZodIssue[]) {
+		super("Something went wrong", 500, true);
+	}
+
+	get data(): { issues: string } {
+		return { issues: JSON.stringify(this.issues) };
+	}
+}
+
+export class PreviewError extends HttpError {
+	name = "PreviewError";
+	constructor(private error: string) {
+		super(error, 400, false);
+	}
+
+	get data(): { error: string } {
+		return { error: this.error };
+	}
+}
+
+export class TokenUpdateFailed extends HttpError {
+	name = "TokenUpdateFailed";
+	constructor() {
+		super("Provide valid token", 400, false);
+	}
+}
+
+export class RawHttpFailed extends HttpError {
+	name = "RawHttpFailed";
+	constructor() {
+		super("Provide valid token", 400, false);
+	}
+}
+
+export class PreviewRequestFailed extends HttpError {
+	name = "PreviewRequestFailed";
+	constructor(private tokenId: string | undefined, reportable: boolean) {
+		super("Valid token not found", 400, reportable);
+	}
+	get data(): { tokenId: string | undefined } {
+		return { tokenId: this.tokenId };
+	}
+}
+
+export class UploadFailed extends HttpError {
+	name = "UploadFailed";
+	constructor() {
+		super("Valid token not provided", 401, false);
+	}
+}
+
+export class PreviewRequestForbidden extends HttpError {
+	name = "PreviewRequestForbidden";
+	constructor() {
+		super("Preview request forbidden", 403, false);
+	}
+}
+
+export class BadUpload extends HttpError {
+	name = "BadUpload";
+	constructor(message = "Invalid upload") {
+		super(message, 400, false);
+	}
+}

--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -1,10 +1,10 @@
 import { Hono } from "hono";
 import { getCookie, setCookie } from "hono/cookie";
 import prom from "promjs";
-import { Toucan } from "toucan-js";
-import { ZodIssue } from "zod";
 import { handleException, setupSentry } from "./sentry";
 import type { RegistryType } from "promjs";
+import type { Toucan } from "toucan-js";
+import type { ZodIssue } from "zod";
 
 const app = new Hono<{
 	Bindings: Env;
@@ -261,7 +261,7 @@ app.get(`${rootDomain}/`, async (c) => {
 });
 
 app.post(`${rootDomain}/api/worker`, async (c) => {
-	let userId = getCookie(c, "user");
+	const userId = getCookie(c, "user");
 	if (!userId) {
 		throw new UploadFailed();
 	}
@@ -282,7 +282,7 @@ app.post(`${rootDomain}/api/worker`, async (c) => {
 
 app.get(`${rootDomain}/api/inspector`, async (c) => {
 	const url = new URL(c.req.url);
-	let userId = url.searchParams.get("user");
+	const userId = url.searchParams.get("user");
 	if (!userId) {
 		throw new PreviewRequestFailed("", false);
 	}

--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -1,10 +1,17 @@
 import { Hono } from "hono";
 import { getCookie, setCookie } from "hono/cookie";
 import prom from "promjs";
+import {
+	HttpError,
+	PreviewRequestFailed,
+	PreviewRequestForbidden,
+	RawHttpFailed,
+	TokenUpdateFailed,
+	UploadFailed,
+} from "./errors";
 import { handleException, setupSentry } from "./sentry";
 import type { RegistryType } from "promjs";
 import type { Toucan } from "toucan-js";
-import type { ZodIssue } from "zod";
 
 const app = new Hono<{
 	Bindings: Env;
@@ -20,125 +27,6 @@ const app = new Hono<{
 
 const rootDomain = ROOT;
 const previewDomain = PREVIEW;
-export class HttpError extends Error {
-	constructor(
-		message: string,
-		readonly status: number,
-		// Only report errors to sentry when they represent actionable errors
-		readonly reportable: boolean
-	) {
-		super(message);
-		Object.setPrototypeOf(this, new.target.prototype);
-	}
-	toResponse() {
-		return Response.json(
-			{
-				error: this.name,
-				message: this.message,
-				data: this.data,
-			},
-			{
-				status: this.status,
-				headers: {
-					"Access-Control-Allow-Origin": "*",
-					"Access-Control-Allow-Methods": "GET,PUT,POST",
-				},
-			}
-		);
-	}
-
-	get data(): Record<string, unknown> {
-		return {};
-	}
-}
-
-export class WorkerTimeout extends HttpError {
-	name = "WorkerTimeout";
-	constructor() {
-		super("Worker timed out", 400, false);
-	}
-
-	toResponse(): Response {
-		return new Response("Worker timed out");
-	}
-}
-
-export class ServiceWorkerNotSupported extends HttpError {
-	name = "ServiceWorkerNotSupported";
-	constructor() {
-		super(
-			"Service Workers are not supported in the Workers Playground",
-			400,
-			false
-		);
-	}
-}
-export class ZodSchemaError extends HttpError {
-	name = "ZodSchemaError";
-	constructor(private issues: ZodIssue[]) {
-		super("Something went wrong", 500, true);
-	}
-
-	get data(): { issues: string } {
-		return { issues: JSON.stringify(this.issues) };
-	}
-}
-
-export class PreviewError extends HttpError {
-	name = "PreviewError";
-	constructor(private error: string) {
-		super(error, 400, false);
-	}
-
-	get data(): { error: string } {
-		return { error: this.error };
-	}
-}
-
-class TokenUpdateFailed extends HttpError {
-	name = "TokenUpdateFailed";
-	constructor() {
-		super("Provide valid token", 400, false);
-	}
-}
-
-class RawHttpFailed extends HttpError {
-	name = "RawHttpFailed";
-	constructor() {
-		super("Provide valid token", 400, false);
-	}
-}
-
-class PreviewRequestFailed extends HttpError {
-	name = "PreviewRequestFailed";
-	constructor(private tokenId: string | undefined, reportable: boolean) {
-		super("Valid token not found", 400, reportable);
-	}
-	get data(): { tokenId: string | undefined } {
-		return { tokenId: this.tokenId };
-	}
-}
-
-class UploadFailed extends HttpError {
-	name = "UploadFailed";
-	constructor() {
-		super("Valid token not provided", 401, false);
-	}
-}
-
-class PreviewRequestForbidden extends HttpError {
-	name = "PreviewRequestForbidden";
-	constructor() {
-		super("Preview request forbidden", 403, false);
-	}
-}
-
-export class BadUpload extends HttpError {
-	name = "BadUpload";
-	constructor(message = "Invalid upload") {
-		super(message, 400, false);
-	}
-}
 
 /**
  * Given a preview token, this endpoint allows for raw http calls to be inspected

--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -133,6 +133,13 @@ class PreviewRequestForbidden extends HttpError {
 	}
 }
 
+export class BadUpload extends HttpError {
+	name = "BadUpload";
+	constructor(message = "Invalid upload") {
+		super(message, 400, false);
+	}
+}
+
 /**
  * Given a preview token, this endpoint allows for raw http calls to be inspected
  *

--- a/packages/playground-preview-worker/src/realish.ts
+++ b/packages/playground-preview-worker/src/realish.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { PreviewError } from ".";
+import { PreviewError } from "./errors";
 
 const APIResponse = <T extends z.ZodTypeAny>(resultSchema: T) =>
 	z.union([

--- a/packages/playground-preview-worker/src/sentry.ts
+++ b/packages/playground-preview-worker/src/sentry.ts
@@ -1,5 +1,5 @@
 import { Toucan } from "toucan-js";
-import { z, ZodError } from "zod";
+import { ZodError } from "zod";
 import { HttpError, ZodSchemaError } from ".";
 
 export function handleException(e: unknown, sentry: Toucan): Response {

--- a/packages/playground-preview-worker/src/sentry.ts
+++ b/packages/playground-preview-worker/src/sentry.ts
@@ -1,6 +1,6 @@
 import { Toucan } from "toucan-js";
 import { ZodError } from "zod";
-import { HttpError, ZodSchemaError } from ".";
+import { HttpError, ZodSchemaError } from "./errors";
 
 export function handleException(e: unknown, sentry: Toucan): Response {
 	console.error(e);

--- a/packages/playground-preview-worker/src/user.do.ts
+++ b/packages/playground-preview-worker/src/user.do.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert";
 import { Buffer } from "node:buffer";
 import z from "zod";
+import { BadUpload, ServiceWorkerNotSupported, WorkerTimeout } from "./errors";
 import { constructMiddleware } from "./inject-middleware";
 import { doUpload, setupTokens } from "./realish";
 import { handleException, setupSentry } from "./sentry";
-import { BadUpload, ServiceWorkerNotSupported, WorkerTimeout } from ".";
 import type { RealishPreviewConfig, UploadResult } from "./realish";
 
 const encoder = new TextEncoder();

--- a/packages/playground-preview-worker/src/user.do.ts
+++ b/packages/playground-preview-worker/src/user.do.ts
@@ -163,7 +163,7 @@ export class UserSession {
 		try {
 			worker = await request.formData();
 		} catch (e) {
-			throw new BadUpload(`Expected valid form data`);
+			throw new BadUpload(`Expected valid form data`, String(e));
 		}
 
 		const m = worker.get("metadata");

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -85,7 +85,7 @@ describe("Preview Worker", () => {
 			'"/hello?world"'
 		);
 		expect(resp.headers.get("set-cookie") ?? "").toMatchInlineSnapshot(
-			`"token=${defaultUserToken}; Domain=random-data.playground-testing.devprod.cloudflare.dev; HttpOnly; Secure; SameSite=None"`
+			`"token=${defaultUserToken}; Domain=random-data.playground-testing.devprod.cloudflare.dev; Path=/; HttpOnly; Secure; SameSite=None"`
 		);
 	});
 	it("shouldn't be redirected with no token", async () => {
@@ -196,6 +196,15 @@ describe("Preview Worker", () => {
 		expect(await resp.text()).toMatchInlineSnapshot(
 			'"{\\"error\\":\\"PreviewRequestFailed\\",\\"message\\":\\"Valid token not found\\",\\"data\\":{}}"'
 		);
+	});
+	it("should reject invalid cookie header", async () => {
+		const resp = await fetch(PREVIEW_REMOTE, {
+			headers: {
+				cookie: "token",
+			},
+		});
+		expect(resp.status).toBe(400);
+		expect(await resp.text()).toMatchInlineSnapshot('"{\\"error\\":\\"PreviewRequestFailed\\",\\"message\\":\\"Valid token not found\\",\\"data\\":{}}"');
 	});
 	it("should reject invalid token", async () => {
 		const resp = await fetch(PREVIEW_REMOTE, {

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -340,7 +340,7 @@ describe("Upload Worker", () => {
 		});
 		expect(w.status).toBe(400);
 		expect(await w.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected valid form data\\",\\"data\\":{}}"'
+			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected valid form data\\",\\"data\\":{\\"error\\":\\"TypeError: Unrecognized Content-Type header value. FormData can only parse the following MIME types: multipart/form-data, application/x-www-form-urlencoded\\"}}"'
 		);
 	});
 	it("should reject missing metadata", async () => {
@@ -348,7 +348,7 @@ describe("Upload Worker", () => {
 			method: "POST",
 			headers: {
 				cookie: `user=${defaultUserToken}`,
-				"Content-Type": "text/plain",
+				"Content-Type": TEST_WORKER_CONTENT_TYPE,
 			},
 			body: `--${TEST_WORKER_BOUNDARY}
 Content-Disposition: form-data; name="index.js"; filename="index.js"
@@ -362,7 +362,7 @@ export default {
 		});
 		expect(w.status).toBe(400);
 		expect(await w.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected valid form data\\",\\"data\\":{}}"'
+			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected metadata file to be defined\\",\\"data\\":{}}"'
 		);
 	});
 	it("should reject invalid metadata json", async () => {

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -5,9 +5,9 @@ const REMOTE = "https://playground-testing.devprod.cloudflare.dev";
 const PREVIEW_REMOTE =
 	"https://random-data.playground-testing.devprod.cloudflare.dev";
 
-const TEST_WORKER_CONTENT_TYPE =
-	"multipart/form-data; boundary=----WebKitFormBoundaryqJEYLXuUiiZQHgvf";
-const TEST_WORKER = `------WebKitFormBoundaryqJEYLXuUiiZQHgvf
+const TEST_WORKER_BOUNDARY = "----WebKitFormBoundaryqJEYLXuUiiZQHgvf";
+const TEST_WORKER_CONTENT_TYPE = `multipart/form-data; boundary=${TEST_WORKER_BOUNDARY}`;
+const TEST_WORKER = `--${TEST_WORKER_BOUNDARY}
 Content-Disposition: form-data; name="index.js"; filename="index.js"
 Content-Type: application/javascript+module
 
@@ -39,12 +39,12 @@ export default {
 	}
 }
 
-------WebKitFormBoundaryqJEYLXuUiiZQHgvf
+--${TEST_WORKER_BOUNDARY}
 Content-Disposition: form-data; name="metadata"; filename="blob"
 Content-Type: application/json
 
 {"compatibility_date":"2023-05-04","main_module":"index.js"}
-------WebKitFormBoundaryqJEYLXuUiiZQHgvf--`;
+--${TEST_WORKER_BOUNDARY}--`;
 
 async function fetchUserToken() {
 	return fetch(REMOTE).then(
@@ -316,6 +316,104 @@ describe("Upload Worker", () => {
 		expect(w.status).toBe(401);
 		expect(await w.text()).toMatchInlineSnapshot(
 			'"{\\"error\\":\\"UploadFailed\\",\\"message\\":\\"Valid token not provided\\",\\"data\\":{}}"'
+		);
+	});
+	it("should reject invalid form data", async () => {
+		const w = await fetch(`${REMOTE}/api/worker`, {
+			method: "POST",
+			headers: {
+				cookie: `user=${defaultUserToken}`,
+				"Content-Type": "text/plain",
+			},
+			body: "not a form",
+		});
+		expect(w.status).toBe(400);
+		expect(await w.text()).toMatchInlineSnapshot(
+			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected valid form data\\",\\"data\\":{}}"'
+		);
+	});
+	it("should reject missing metadata", async () => {
+		const w = await fetch(`${REMOTE}/api/worker`, {
+			method: "POST",
+			headers: {
+				cookie: `user=${defaultUserToken}`,
+				"Content-Type": "text/plain",
+			},
+			body: `--${TEST_WORKER_BOUNDARY}
+Content-Disposition: form-data; name="index.js"; filename="index.js"
+Content-Type: application/javascript+module
+
+export default {
+	fetch(request) { return new Response("body"); }
+}
+
+--${TEST_WORKER_BOUNDARY}--`,
+		});
+		expect(w.status).toBe(400);
+		expect(await w.text()).toMatchInlineSnapshot(
+			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected valid form data\\",\\"data\\":{}}"'
+		);
+	});
+	it("should reject invalid metadata json", async () => {
+		const w = await fetch(`${REMOTE}/api/worker`, {
+			method: "POST",
+			headers: {
+				cookie: `user=${defaultUserToken}`,
+				"Content-Type": TEST_WORKER_CONTENT_TYPE,
+			},
+			body: `--${TEST_WORKER_BOUNDARY}
+Content-Disposition: form-data; name="metadata"; filename="blob"
+Content-Type: application/json
+
+{"compatibility_date":"2023-05-04",
+--${TEST_WORKER_BOUNDARY}--`,
+		});
+		expect(w.status).toBe(400);
+		expect(await w.text()).toMatchInlineSnapshot(
+			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected metadata file to be valid\\",\\"data\\":{}}"'
+		);
+	});
+	it("should reject invalid metadata", async () => {
+		const w = await fetch(`${REMOTE}/api/worker`, {
+			method: "POST",
+			headers: {
+				cookie: `user=${defaultUserToken}`,
+				"Content-Type": TEST_WORKER_CONTENT_TYPE,
+			},
+			body: `--${TEST_WORKER_BOUNDARY}
+Content-Disposition: form-data; name="metadata"; filename="blob"
+Content-Type: application/json
+
+{"compatibility_date":42,"main_module":"index.js"}
+--${TEST_WORKER_BOUNDARY}--`,
+		});
+		expect(w.status).toBe(400);
+		expect(await w.text()).toMatchInlineSnapshot(
+			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected metadata file to be valid\\",\\"data\\":{}}"'
+		);
+	});
+	it("should reject service worker", async () => {
+		const w = await fetch(`${REMOTE}/api/worker`, {
+			method: "POST",
+			headers: {
+				cookie: `user=${defaultUserToken}`,
+				"Content-Type": TEST_WORKER_CONTENT_TYPE,
+			},
+			body: `--${TEST_WORKER_BOUNDARY}
+Content-Disposition: form-data; name="index.js"; filename="index.js"
+Content-Type: application/javascript
+
+addEventListener("fetch", (event) => event.respondWith(new Response("body")));
+--${TEST_WORKER_BOUNDARY}
+Content-Disposition: form-data; name="metadata"; filename="blob"
+Content-Type: application/json
+
+{"compatibility_date":"2023-05-04","body_part":"index.js"}
+--${TEST_WORKER_BOUNDARY}--`,
+		});
+		expect(w.status).toBe(400);
+		expect(await w.text()).toMatchInlineSnapshot(
+			'"{\\"error\\":\\"ServiceWorkerNotSupported\\",\\"message\\":\\"Service Workers are not supported in the Workers Playground\\",\\"data\\":{}}"'
 		);
 	});
 });

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -204,7 +204,9 @@ describe("Preview Worker", () => {
 			},
 		});
 		expect(resp.status).toBe(400);
-		expect(await resp.text()).toMatchInlineSnapshot('"{\\"error\\":\\"PreviewRequestFailed\\",\\"message\\":\\"Valid token not found\\",\\"data\\":{}}"');
+		expect(await resp.text()).toMatchInlineSnapshot(
+			'"{\\"error\\":\\"PreviewRequestFailed\\",\\"message\\":\\"Valid token not found\\",\\"data\\":{}}"'
+		);
 	});
 	it("should reject invalid token", async () => {
 		const resp = await fetch(PREVIEW_REMOTE, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1040,6 +1040,9 @@ importers:
         specifier: ^3.22.3
         version: 3.22.3
     devDependencies:
+      '@cloudflare/eslint-config-worker':
+        specifier: workspace:*
+        version: link:../eslint-config-worker
       '@cloudflare/workers-types':
         specifier: ^4.20230321.0
         version: 4.20230821.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1034,8 +1034,8 @@ importers:
   packages/playground-preview-worker:
     dependencies:
       hono:
-        specifier: ^3.3.2
-        version: 3.5.6
+        specifier: ^3.12.11
+        version: 3.12.11
       zod:
         specifier: ^3.22.3
         version: 3.22.3
@@ -12490,6 +12490,11 @@ packages:
   /hex2dec@1.1.2:
     resolution: {integrity: sha512-Yu+q/XWr2fFQ11tHxPq4p4EiNkb2y+lAacJNhAdRXVfRIcDH6gi7htWFnnlIzvqHMHoWeIsfXlNAjZInpAOJDA==}
     dev: true
+
+  /hono@3.12.11:
+    resolution: {integrity: sha512-LSpxVgIMR3UzyFiXZaPvqBUGqyOKG0LMZqgMn2RXz9f+YAdkHSfFQQX0dtU72fPm5GnEMh5AYXs0ek5NYgMOmA==}
+    engines: {node: '>=16.0.0'}
+    dev: false
 
   /hono@3.5.6:
     resolution: {integrity: sha512-ycTOpIZJ6yLbjzoE+ojsesC7G7ZXfGSoCIDyvqmzlHc5Mk4Aj48Ed9R5g7gw3v7rOkS81pjcYIvWef/karq1iA==}


### PR DESCRIPTION
**What this PR solves / how to test:**

Similar to #4904, the PR validates returns 4xx errors for invalid user input, as opposed to 500's reported to Sentry. In particular, this should prevent the `Parsing a Body as FormData requires a Content-Type header.` errors we've been seeing. There's nothing we can do about these errors as they're caused by the client. This PR also bumps the `hono` version to address the `Cannot read properties of undefined (reading 'split')` errors.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: internal worker
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: internal worker

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
