### PR TITLE
[edge-preview-authenticated-proxy] fix: don't report invalid user-specifiable URLs

### DIFF
--- a/packages/edge-preview-authenticated-proxy/src/index.ts
+++ b/packages/edge-preview-authenticated-proxy/src/index.ts
@@ -74,6 +74,19 @@ class PreviewRequestFailed extends HttpError {
 	}
 }
 
+class InvalidURL extends HttpError {
+	constructor(private readonly url: string) {
+		super("Invalid URL", 400, false);
+	}
+	get data() {
+		return { url: this.url };
+	}
+}
+
+function assertValidURL(maybeUrl: string) {
+	if (!URL.canParse(maybeUrl)) throw new InvalidURL(maybeUrl);
+}
+
 function switchRemote(url: URL, remote: string) {
 	const workerUrl = new URL(url);
 	const remoteUrl = new URL(remote);
@@ -252,6 +265,9 @@ async function updatePreviewToken(url: URL, env: Env, ctx: ExecutionContext) {
 		throw new TokenUpdateFailed();
 	}
 
+	assertValidURL(prewarmUrl);
+	assertValidURL(remote);
+
 	ctx.waitUntil(
 		fetch(prewarmUrl, {
 			method: "POST",
@@ -296,6 +312,7 @@ async function handleTokenExchange(url: URL) {
 	if (!exchangeUrl) {
 		throw new NoExchangeUrl();
 	}
+	assertValidURL(exchangeUrl);
 	const exchangeRes = await fetch(exchangeUrl);
 	if (exchangeRes.status !== 200) {
 		const exchange = new URL(exchangeUrl);

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -107,6 +107,16 @@ compatibility_date = "2023-01-01"
 		`
 		);
 	});
+	it("should reject invalid exchange_url", async () => {
+		const resp = await worker.fetch(
+			`https://preview.devprod.cloudflare.dev/exchange?exchange_url=not_an_exchange_url`,
+			{ method: "POST" }
+		);
+		expect(resp.status).toBe(400);
+		expect(await resp.text()).toMatchInlineSnapshot(
+			'"{\\"error\\":\\"Error\\",\\"message\\":\\"Invalid URL\\"}"'
+		);
+	});
 	it("should allow tokens > 4096 bytes", async () => {
 		// 4096 is the size limit for cookies
 		const token = randomBytes(4096).toString("hex");
@@ -178,6 +188,28 @@ compatibility_date = "2023-01-01"
 		tokenId = (resp.headers.get("set-cookie") ?? "")
 			.split(";")[0]
 			.split("=")[1];
+	});
+	it("should reject invalid prewarm url", async () => {
+		const resp = await worker.fetch(
+			`https://random-data.preview.devprod.cloudflare.dev/.update-preview-token?token=TEST_TOKEN&prewarm=not_a_prewarm_url&remote=${encodeURIComponent(
+				`http://127.0.0.1:${remote.port}`
+			)}&suffix=${encodeURIComponent("/hello?world")}`
+		);
+		expect(resp.status).toBe(400);
+		expect(await resp.text()).toMatchInlineSnapshot(
+			'"{\\"error\\":\\"Error\\",\\"message\\":\\"Invalid URL\\"}"'
+		);
+	});
+	it("should reject invalid remote url", async () => {
+		const resp = await worker.fetch(
+			`https://random-data.preview.devprod.cloudflare.dev/.update-preview-token?token=TEST_TOKEN&prewarm=${encodeURIComponent(
+				`http://127.0.0.1:${remote.port}/prewarm`
+			)}&remote=not_a_remote_url&suffix=${encodeURIComponent("/hello?world")}`
+		);
+		expect(resp.status).toBe(400);
+		expect(await resp.text()).toMatchInlineSnapshot(
+			'"{\\"error\\":\\"Error\\",\\"message\\":\\"Invalid URL\\"}"'
+		);
 	});
 
 	it("should convert cookie to header", async () => {


### PR DESCRIPTION
**What this PR solves / how to test:**

Similar to #4904 and #4937, this PR validates and returns 4xx errors for invalid user input, as opposed to 500's reported to Sentry. I _think_ these URLs are the only user controllable parameters that could result in uncaught errors in this worker. Things like invalid worker syntax/config are handled downstream.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: internal worker
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: internal worker

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
