### PR TITLE
[D1] fix batch splitting to handle CASE as compound statement starts

### DIFF
--- a/.changeset/cyan-kiwis-return.md
+++ b/.changeset/cyan-kiwis-return.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: D1 batch splitting to handle CASE as compound statement starts

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -287,9 +287,28 @@ describe("splitSqlQuery()", () => {
 										FROM pragma_table_list(new."table")) THEN RAISE (
 																																		ABORT,
 																																		'Exception, table does not exist')
+				END ; END ;
+
+				CREATE TRIGGER test_after_insert_trigger AFTER
+				INSERT ON test BEGIN
+				SELECT CASE
+						WHEN NOT EXISTS
+									(SELECT 1
+										FROM pragma_table_list(new."table")) THEN RAISE (
+																																		ABORT,
+																																		'Exception, table does not exist')
 				END ; END ;`)
 		).toMatchInlineSnapshot(`
 		Array [
+		  "CREATE TRIGGER test_after_insert_trigger AFTER
+						INSERT ON test BEGIN
+						SELECT CASE
+								WHEN NOT EXISTS
+											(SELECT 1
+												FROM pragma_table_list(new.\\"table\\")) THEN RAISE (
+																																				ABORT,
+																																				'Exception, table does not exist')
+						END ; END",
 		  "CREATE TRIGGER test_after_insert_trigger AFTER
 						INSERT ON test BEGIN
 						SELECT CASE

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -241,7 +241,7 @@ describe("splitSqlQuery()", () => {
 	`);
 	});
 
-	it("should handle compound statements", () => {
+	it("should handle compound statements for BEGINs", () => {
 		expect(
 			splitSqlQuery(`
     CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
@@ -272,6 +272,33 @@ describe("splitSqlQuery()", () => {
 		                json_extract(new.properties, '$.name'),
 		                json_extract(new.properties, '$.preferredUsername'));
 		    END",
+		]
+	`);
+	});
+
+	it("should handle compound statements for CASEs", () => {
+		expect(
+			splitSqlQuery(`
+				CREATE TRIGGER test_after_insert_trigger AFTER
+				INSERT ON test BEGIN
+				SELECT CASE
+						WHEN NOT EXISTS
+									(SELECT 1
+										FROM pragma_table_list(new."table")) THEN RAISE (
+																																		ABORT,
+																																		'Exception, table does not exist')
+				END ; END ;`)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "CREATE TRIGGER test_after_insert_trigger AFTER
+						INSERT ON test BEGIN
+						SELECT CASE
+								WHEN NOT EXISTS
+											(SELECT 1
+												FROM pragma_table_list(new.\\"table\\")) THEN RAISE (
+																																				ABORT,
+																																				'Exception, table does not exist')
+						END ; END",
 		]
 	`);
 	});

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -153,7 +153,7 @@ function isDollarQuoteIdentifier(str: string) {
  * Returns true if the `str` ends with a compound statement `BEGIN` marker.
  */
 function isCompoundStatementStart(str: string) {
-	return /\sBEGIN|CASE\s$/.test(str);
+	return /\s(BEGIN|CASE)\s$/.test(str);
 }
 
 /**

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -153,7 +153,7 @@ function isDollarQuoteIdentifier(str: string) {
  * Returns true if the `str` ends with a compound statement `BEGIN` marker.
  */
 function isCompoundStatementStart(str: string) {
-	return /\sBEGIN\s$/.test(str);
+	return /\sBEGIN|CASE\s$/.test(str);
 }
 
 /**

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -150,7 +150,7 @@ function isDollarQuoteIdentifier(str: string) {
 }
 
 /**
- * Returns true if the `str` ends with a compound statement `BEGIN` marker.
+ * Returns true if the `str` ends with a compound statement `BEGIN` or `CASE` marker.
  */
 function isCompoundStatementStart(str: string) {
 	return /\s(BEGIN|CASE)\s$/.test(str);

--- a/packages/wrangler/test.sql
+++ b/packages/wrangler/test.sql
@@ -1,0 +1,1 @@
+CREATE TRIGGER test_after_insert_trigger  AFTER INSERT ON test BEGIN SELECT CASE WHEN NOT EXISTS( SELECT 1 FROM pragma_table_list(new."table") ) THEN RAISE (ABORT , 'Exception, table does not exist') END ; END ;

--- a/packages/wrangler/test.sql
+++ b/packages/wrangler/test.sql
@@ -1,1 +1,0 @@
-CREATE TRIGGER test_after_insert_trigger  AFTER INSERT ON test BEGIN SELECT CASE WHEN NOT EXISTS( SELECT 1 FROM pragma_table_list(new."table") ) THEN RAISE (ABORT , 'Exception, table does not exist') END ; END ;


### PR DESCRIPTION
Fixes #4326.

**What this PR solves / how to test:** Before, executing this query:
```sql
CREATE TRIGGER test_after_insert_trigger AFTER
INSERT ON test BEGIN
SELECT CASE
           WHEN NOT EXISTS
                  (SELECT 1
                   FROM pragma_table_list(new."table")) THEN RAISE (
                                                                    ABORT,
                                                                    'Exception, table does not exist')
       END ; END ;
```

Would falsely result in two statements, because `CASE` was not considered to be a compound statement. According to https://www.sqlite.org/lang_expr.html, it is, so I've just added it to the RegExp check for compound statement starts and that will solve it.

Before:
```
🌀 Mapping SQL input into an array of statements
🌀 Parsing 2 statements
🌀 Executing on remote database test (f9287979-a9b2-45b9-91a8-b948451a7330):
🌀 To execute on your local development database, pass the --local flag to 'wrangler d1 execute'

✘ [ERROR] A request to the Cloudflare API (/accounts/43a78553910250e441936e3db52a743a/d1/database/f9287979-a9b2-45b9-91a8-b948451a7330/query) failed.

  incomplete input [code: 7500]
```

After:
```
🌀 Mapping SQL input into an array of statements
🌀 Parsing 1 statements
🌀 Executing on remote database test (f9287979-a9b2-45b9-91a8-b948451a7330):
🌀 To execute on your local development database, pass the --local flag to 'wrangler d1 execute'
🚣 Executed 1 commands in 0.3064ms
```

**Author has addressed the following:**

- Tests
  - [X] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [X] Included
  - [ ] Not necessary because:
- Associated docs
  - [X] Issue(s)/PR(s): #4326
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
