### PR TITLE
[wrangler] fix: allow `port` option to be specified with `unstable_dev()`

### DIFF
--- a/.changeset/quick-apricots-punch.md
+++ b/.changeset/quick-apricots-punch.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: allow `port` option to be specified with `unstable_dev()`
+
+Previously, specifying a non-zero `port` when using `unstable_dev()` would try to start two servers on that `port`. This change ensures we only start the user-facing server on the specified `port`, allow `unstable_dev()` to startup correctly.

--- a/fixtures/local-mode-tests/tests/specified-port.test.ts
+++ b/fixtures/local-mode-tests/tests/specified-port.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert";
+import nodeNet from "node:net";
+import path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { unstable_dev } from "wrangler";
+import type { UnstableDevWorker } from "wrangler";
+
+function getPort() {
+	return new Promise<number>((resolve, reject) => {
+		const server = nodeNet.createServer((socket) => socket.destroy());
+		server.listen(0, () => {
+			const address = server.address();
+			assert(typeof address === "object" && address !== null);
+			server.close((err) => {
+				if (err) reject(err);
+				else resolve(address.port);
+			});
+		});
+	});
+}
+
+describe("specific port", () => {
+	let worker: UnstableDevWorker;
+
+	beforeAll(async () => {
+		worker = await unstable_dev(
+			path.resolve(__dirname, "..", "src", "module.ts"),
+			{
+				config: path.resolve(__dirname, "..", "wrangler.module.toml"),
+				port: await getPort(),
+				experimental: {
+					disableExperimentalWarning: true,
+					disableDevRegistry: true,
+				},
+			}
+		);
+	});
+
+	afterAll(async () => {
+		await worker?.stop();
+	});
+
+	it("fetches worker", async () => {
+		const resp = await worker.fetch("/");
+		expect(resp.status).toBe(200);
+	});
+});

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -162,8 +162,8 @@ export async function startDevServer(
 			compatibilityFlags: props.compatibilityFlags,
 			bindings: props.bindings,
 			assetPaths: props.assetPaths,
-			initialPort: props.initialPort,
-			initialIp: props.initialIp,
+			initialPort: undefined, // hard-code for userworker, DevEnv-ProxyWorker now uses this prop value
+			initialIp: "127.0.0.1", // hard-code for userworker, DevEnv-ProxyWorker now uses this prop value
 			rules: props.rules,
 			inspectorPort: props.inspectorPort,
 			runtimeInspectorPort: props.runtimeInspectorPort,


### PR DESCRIPTION
Fixes #4813.

**What this PR solves / how to test:**

https://github.com/cloudflare/workers-sdk/pull/4497 introduced a proxy server in front of the user's worker. The proxy worker was configured to start up on the user-specified port (if any), with the user worker starting on a random port:

https://github.com/cloudflare/workers-sdk/blob/0699506d9cab929779d19ec2af9b53ccb70c0e7b/packages/wrangler/src/dev/dev.tsx#L438-L439

Unfortunately, this change wasn't copied over to the "test mode" `unstable_dev()` implementation, meaning `unstable_dev()` tried to start the user worker on the same port as the proxy worker if a non-zero `port` was specified. This PR brings that change over.

To test this, run the `local-mode-tests`, a new `specified-port.test.ts` file has been added. 🙂 

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a regression

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
