### PR TITLE
[miniflare] fix: allow relative modules `scriptPath` outside of CWD

### DIFF
--- a/.changeset/gentle-mayflies-shout.md
+++ b/.changeset/gentle-mayflies-shout.md
@@ -1,0 +1,17 @@
+---
+"miniflare": patch
+---
+
+fix: allow relative `scriptPath`/`modulesRoot`s to break out of current working directory
+
+Previously, Miniflare would resolve relative `scriptPath`s against `moduleRoot` multiple times resulting in incorrect paths and module names. This would lead to `can't use ".." to break out of starting directory` `workerd` errors. This change ensures Miniflare uses `scriptPath` as is, and only resolves it relative to `modulesRoot` when computing module names. Note this bug didn't affect service workers. This allows you to reference a modules `scriptPath` outside the working directory with something like:
+
+```js
+const mf = new Miniflare({
+	modules: true,
+	modulesRoot: "..",
+	scriptPath: "../worker.mjs",
+});
+```
+
+Fixes #4721

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -721,8 +721,9 @@ function getWorkerScript(
 	workerIndex: number,
 	additionalModuleNames: string[]
 ): { serviceWorkerScript: string } | { modules: Worker_Module[] } {
-	const modulesRoot =
-		("modulesRoot" in options ? options.modulesRoot : undefined) ?? "";
+	const modulesRoot = path.resolve(
+		("modulesRoot" in options ? options.modulesRoot : undefined) ?? ""
+	);
 	if (Array.isArray(options.modules)) {
 		// If `modules` is a manually defined modules array, use that
 		return {

--- a/packages/miniflare/src/plugins/core/modules.ts
+++ b/packages/miniflare/src/plugins/core/modules.ts
@@ -174,8 +174,6 @@ export class ModuleLocator {
 	}
 
 	visitEntrypoint(code: string, modulePath: string) {
-		modulePath = path.resolve(this.modulesRoot, modulePath);
-
 		// If we've already visited this path, return
 		if (this.#visitedPaths.has(modulePath)) return;
 		this.#visitedPaths.add(modulePath);

--- a/packages/miniflare/test/test-shared/storage.ts
+++ b/packages/miniflare/test/test-shared/storage.ts
@@ -32,6 +32,18 @@ export async function useTmp(t: ExecutionContext): Promise<string> {
 	return filePath;
 }
 
+// Must be called from a `.serial()` test
+export function useCwd(t: ExecutionContext, cwd: string) {
+	const originalCwd = process.cwd();
+	const originalPWD = process.env.PWD;
+	process.chdir(cwd);
+	process.env.PWD = cwd;
+	t.teardown(() => {
+		process.chdir(originalCwd);
+		process.env.PWD = originalPWD;
+	});
+}
+
 type ValidReadableStreamBYOBRequest = Omit<
 	ReadableStreamBYOBRequest,
 	"view"


### PR DESCRIPTION
Fixes #4721.

**What this PR solves / how to test:**

Previously, Miniflare would resolve relative `scriptPath`s against `moduleRoot` multiple times resulting in incorrect paths and module names. This would lead to `can't use ".." to break out of starting directory` `workerd` errors. This change ensures Miniflare uses `scriptPath` as is, and only resolves it relative to `modulesRoot` when computing module names. Note this bug didn't affect service workers. This allows you to reference a modules `scriptPath` outside the working directory with something like:

```js
const mf = new Miniflare({
	modules: true,
	modulesRoot: "..",
	scriptPath: "../worker.mjs",
});
```

Notably, this wasn't a problem if `modulesRoot` and `scriptPath` were absolute paths.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a bug

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
