### PR TITLE
Update prefixes for e2e tests to cleanup all e2e workers

### DIFF
--- a/.github/workflows/c3-e2e-project-cleanup.yml
+++ b/.github/workflows/c3-e2e-project-cleanup.yml
@@ -2,6 +2,7 @@
 
 name: C3 E2E Project Cleanup
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 3 * * *" # Run at 3am each day
 env:

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -19,7 +19,7 @@ import { version } from "../package.json";
 import { quoteShellArgs } from "../src/common";
 import type { Suite, TestContext } from "vitest";
 
-export const C3_E2E_PREFIX = "c3-e2e-";
+export const C3_E2E_PREFIX = "tmp-c3-e2e-";
 
 export const keys = {
 	enter: "\x0d",

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -19,7 +19,7 @@ import { version } from "../package.json";
 import { quoteShellArgs } from "../src/common";
 import type { Suite, TestContext } from "vitest";
 
-export const C3_E2E_PREFIX = "tmp-c3-e2e-";
+export const C3_E2E_PREFIX = "tmp-e2e-c3";
 
 export const keys = {
 	enter: "\x0d",

--- a/packages/create-cloudflare/scripts/common.ts
+++ b/packages/create-cloudflare/scripts/common.ts
@@ -18,6 +18,8 @@ export type Worker = {
 	created_on: string;
 };
 
+const tmpPrefixes = ["tmp-stratus-e2e-", "tmp-wrangler-e2e-", "tmp-c3-e2e-"];
+
 const apiFetch = async (
 	path: string,
 	init = { method: "GET" },
@@ -78,7 +80,7 @@ export const listC3Projects = async () => {
 
 	return projects.filter(
 		(p) =>
-			p.name.startsWith("c3-e2e-") &&
+			tmpPrefixes.some((prefix) => p.name.startsWith(prefix)) &&
 			// Projects are more than an hour old
 			Date.now() - new Date(p.created_on).valueOf() > 1000 * 60 * 60
 	);
@@ -99,7 +101,7 @@ export const listC3Workers = async () => {
 		const res: Worker[] = await apiFetch(`/workers/scripts`, { method: "GET" });
 		return res.filter(
 			(p) =>
-				p.id.startsWith("c3-e2e-") &&
+				tmpPrefixes.some((prefix) => p.id.startsWith(prefix)) &&
 				// Workers are more than an hour old
 				Date.now() - new Date(p.created_on).valueOf() > 1000 * 60 * 60
 		);

--- a/packages/create-cloudflare/scripts/common.ts
+++ b/packages/create-cloudflare/scripts/common.ts
@@ -45,7 +45,7 @@ const apiFetch = async (
 	return json.result;
 };
 
-export const listC3Projects = async () => {
+export const listTmpE2EProjects = async () => {
 	const pageSize = 10;
 	let page = 1;
 
@@ -94,7 +94,7 @@ export const deleteProject = async (project: string) => {
 	}
 };
 
-export const listC3Workers = async () => {
+export const listTmpE2EWorkers = async () => {
 	try {
 		const res: Worker[] = await apiFetch(`/workers/scripts`, { method: "GET" });
 		return res.filter(

--- a/packages/create-cloudflare/scripts/common.ts
+++ b/packages/create-cloudflare/scripts/common.ts
@@ -18,8 +18,6 @@ export type Worker = {
 	created_on: string;
 };
 
-const tmpPrefixes = ["tmp-stratus-e2e-", "tmp-wrangler-e2e-", "tmp-c3-e2e-"];
-
 const apiFetch = async (
 	path: string,
 	init = { method: "GET" },
@@ -80,7 +78,7 @@ export const listC3Projects = async () => {
 
 	return projects.filter(
 		(p) =>
-			tmpPrefixes.some((prefix) => p.name.startsWith(prefix)) &&
+			p.name.startsWith("tmp-e2e-") &&
 			// Projects are more than an hour old
 			Date.now() - new Date(p.created_on).valueOf() > 1000 * 60 * 60
 	);
@@ -101,7 +99,7 @@ export const listC3Workers = async () => {
 		const res: Worker[] = await apiFetch(`/workers/scripts`, { method: "GET" });
 		return res.filter(
 			(p) =>
-				tmpPrefixes.some((prefix) => p.id.startsWith(prefix)) &&
+				p.id.startsWith("tmp-e2e-") &&
 				// Workers are more than an hour old
 				Date.now() - new Date(p.created_on).valueOf() > 1000 * 60 * 60
 		);

--- a/packages/create-cloudflare/scripts/e2eCleanup.ts
+++ b/packages/create-cloudflare/scripts/e2eCleanup.ts
@@ -1,8 +1,8 @@
 import {
 	deleteProject,
 	deleteWorker,
-	listC3Projects,
-	listC3Workers,
+	listTmpE2EProjects,
+	listTmpE2EWorkers,
 	Project,
 } from "./common";
 
@@ -17,7 +17,7 @@ if (!process.env.CLOUDFLARE_ACCOUNT_ID) {
 }
 
 const run = async () => {
-	const projectsToDelete = await listC3Projects();
+	const projectsToDelete = await listTmpE2EProjects();
 
 	for (const project of projectsToDelete) {
 		console.log("Deleting Pages project: " + project.name);
@@ -30,7 +30,7 @@ const run = async () => {
 		console.log(`Successfully deleted ${projectsToDelete.length} projects`);
 	}
 
-	const workersToDelete = await listC3Workers();
+	const workersToDelete = await listTmpE2EWorkers();
 
 	for (const worker of workersToDelete) {
 		console.log("Deleting worker: " + worker.id);

--- a/packages/wrangler/e2e/c3-integration.test.ts
+++ b/packages/wrangler/e2e/c3-integration.test.ts
@@ -12,7 +12,7 @@ import { WRANGLER } from "./helpers/wrangler-command";
 
 function matchWorkersDev(stdout: string): string {
 	return stdout.match(
-		/https:\/\/tmp-wrangler-e2e-.+?\.(.+?\.workers\.dev)/
+		/https:\/\/tmp-e2e-wrangler-.+?\.(.+?\.workers\.dev)/
 	)?.[1] as string;
 }
 
@@ -28,12 +28,12 @@ describe("c3 integration", () => {
 	beforeAll(async () => {
 		const root = await makeRoot();
 		runInRoot = shellac.in(root).env(process.env);
-		workerName = `tmp-wrangler-e2e-${crypto.randomBytes(4).toString("hex")}`;
+		workerName = `tmp-e2e-wrangler-${crypto.randomBytes(4).toString("hex")}`;
 		workerPath = path.join(root, workerName);
 		runInWorker = shellac.in(workerPath).env(process.env);
 		normalize = (str) =>
 			normalizeOutput(str, {
-				[workerName]: "tmp-wrangler-e2e",
+				[workerName]: "tmp-e2e-wrangler",
 				[CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
 			});
 
@@ -64,9 +64,9 @@ describe("c3 integration", () => {
 		const { stdout, stderr } = await runInWorker`$ ${WRANGLER} deploy`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
-			Uploaded tmp-wrangler-e2e (TIMINGS)
-			Published tmp-wrangler-e2e (TIMINGS)
-			  https://tmp-wrangler-e2e.SUBDOMAIN.workers.dev
+			Uploaded tmp-e2e-wrangler (TIMINGS)
+			Published tmp-e2e-wrangler (TIMINGS)
+			  https://tmp-e2e-wrangler.SUBDOMAIN.workers.dev
 			Current Deployment ID: 00000000-0000-0000-0000-000000000000"
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
@@ -84,9 +84,9 @@ describe("c3 integration", () => {
 	it("delete the worker", async () => {
 		const { stdout, stderr } = await runInWorker`$$ ${WRANGLER} delete`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"? Are you sure you want to delete tmp-wrangler-e2e? This action cannot be undone.
+			"? Are you sure you want to delete tmp-e2e-wrangler? This action cannot be undone.
 			🤖 Using fallback value in non-interactive context: yes
-			Successfully deleted tmp-wrangler-e2e"
+			Successfully deleted tmp-e2e-wrangler"
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
 		const { status } = await retry(

--- a/packages/wrangler/e2e/c3-integration.test.ts
+++ b/packages/wrangler/e2e/c3-integration.test.ts
@@ -12,7 +12,7 @@ import { WRANGLER } from "./helpers/wrangler-command";
 
 function matchWorkersDev(stdout: string): string {
 	return stdout.match(
-		/https:\/\/smoke-test-worker-.+?\.(.+?\.workers\.dev)/
+		/https:\/\/tmp-wrangler-e2e-.+?\.(.+?\.workers\.dev)/
 	)?.[1] as string;
 }
 
@@ -28,12 +28,12 @@ describe("c3 integration", () => {
 	beforeAll(async () => {
 		const root = await makeRoot();
 		runInRoot = shellac.in(root).env(process.env);
-		workerName = `smoke-test-worker-${crypto.randomBytes(4).toString("hex")}`;
+		workerName = `tmp-wrangler-e2e-${crypto.randomBytes(4).toString("hex")}`;
 		workerPath = path.join(root, workerName);
 		runInWorker = shellac.in(workerPath).env(process.env);
 		normalize = (str) =>
 			normalizeOutput(str, {
-				[workerName]: "smoke-test-worker",
+				[workerName]: "tmp-wrangler-e2e",
 				[CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
 			});
 
@@ -64,9 +64,9 @@ describe("c3 integration", () => {
 		const { stdout, stderr } = await runInWorker`$ ${WRANGLER} deploy`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
-			Uploaded smoke-test-worker (TIMINGS)
-			Published smoke-test-worker (TIMINGS)
-			  https://smoke-test-worker.SUBDOMAIN.workers.dev
+			Uploaded tmp-wrangler-e2e (TIMINGS)
+			Published tmp-wrangler-e2e (TIMINGS)
+			  https://tmp-wrangler-e2e.SUBDOMAIN.workers.dev
 			Current Deployment ID: 00000000-0000-0000-0000-000000000000"
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
@@ -84,9 +84,9 @@ describe("c3 integration", () => {
 	it("delete the worker", async () => {
 		const { stdout, stderr } = await runInWorker`$$ ${WRANGLER} delete`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"? Are you sure you want to delete smoke-test-worker? This action cannot be undone.
+			"? Are you sure you want to delete tmp-wrangler-e2e? This action cannot be undone.
 			🤖 Using fallback value in non-interactive context: yes
-			Successfully deleted smoke-test-worker"
+			Successfully deleted tmp-wrangler-e2e"
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
 		const { status } = await retry(

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -11,7 +11,7 @@ import { WRANGLER } from "./helpers/wrangler-command";
 
 function matchWorkersDev(stdout: string): string {
 	return stdout.match(
-		/https:\/\/tmp-wrangler-e2e-.+?\.(.+?\.workers\.dev)/
+		/https:\/\/tmp-e2e-wrangler-.+?\.(.+?\.workers\.dev)/
 	)?.[1] as string;
 }
 
@@ -30,7 +30,7 @@ describe("deployments", () => {
 
 	beforeAll(async () => {
 		root = await makeRoot();
-		workerName = `tmp-wrangler-e2e-${crypto.randomBytes(4).toString("hex")}`;
+		workerName = `tmp-e2e-wrangler-${crypto.randomBytes(4).toString("hex")}`;
 		workerPath = path.join(root, workerName);
 		runInRoot = shellac.in(root).env(process.env);
 		runInWorker = shellac.in(workerPath).env(process.env);
@@ -39,7 +39,7 @@ describe("deployments", () => {
 		);
 		normalize = (str) =>
 			normalizeOutput(str, {
-				[workerName]: "tmp-wrangler-e2e",
+				[workerName]: "tmp-e2e-wrangler",
 				[email]: "person@example.com",
 				[CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
 			});
@@ -57,9 +57,9 @@ describe("deployments", () => {
 		const { stdout } = await runInWorker`$ ${WRANGLER} deploy`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
-			Uploaded tmp-wrangler-e2e (TIMINGS)
-			Published tmp-wrangler-e2e (TIMINGS)
-			  https://tmp-wrangler-e2e.SUBDOMAIN.workers.dev
+			Uploaded tmp-e2e-wrangler (TIMINGS)
+			Published tmp-e2e-wrangler (TIMINGS)
+			  https://tmp-e2e-wrangler.SUBDOMAIN.workers.dev
 			Current Deployment ID: 00000000-0000-0000-0000-000000000000"
 		`);
 		workersDev = matchWorkersDev(stdout);
@@ -101,9 +101,9 @@ describe("deployments", () => {
 		const { stdout, stderr } = await runInWorker`$ ${WRANGLER} deploy`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
-			Uploaded tmp-wrangler-e2e (TIMINGS)
-			Published tmp-wrangler-e2e (TIMINGS)
-			  https://tmp-wrangler-e2e.SUBDOMAIN.workers.dev
+			Uploaded tmp-e2e-wrangler (TIMINGS)
+			Published tmp-e2e-wrangler (TIMINGS)
+			  https://tmp-e2e-wrangler.SUBDOMAIN.workers.dev
 			Current Deployment ID: 00000000-0000-0000-0000-000000000000"
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
@@ -175,9 +175,9 @@ describe("deployments", () => {
 	it("delete worker", async () => {
 		const { stdout, stderr } = await runInWorker`$ ${WRANGLER} delete`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"? Are you sure you want to delete tmp-wrangler-e2e? This action cannot be undone.
+			"? Are you sure you want to delete tmp-e2e-wrangler? This action cannot be undone.
 			🤖 Using fallback value in non-interactive context: yes
-			Successfully deleted tmp-wrangler-e2e"
+			Successfully deleted tmp-e2e-wrangler"
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
 		const status = await retry(

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -11,7 +11,7 @@ import { WRANGLER } from "./helpers/wrangler-command";
 
 function matchWorkersDev(stdout: string): string {
 	return stdout.match(
-		/https:\/\/smoke-test-worker-.+?\.(.+?\.workers\.dev)/
+		/https:\/\/tmp-wrangler-e2e-.+?\.(.+?\.workers\.dev)/
 	)?.[1] as string;
 }
 
@@ -30,7 +30,7 @@ describe("deployments", () => {
 
 	beforeAll(async () => {
 		root = await makeRoot();
-		workerName = `smoke-test-worker-${crypto.randomBytes(4).toString("hex")}`;
+		workerName = `tmp-wrangler-e2e-${crypto.randomBytes(4).toString("hex")}`;
 		workerPath = path.join(root, workerName);
 		runInRoot = shellac.in(root).env(process.env);
 		runInWorker = shellac.in(workerPath).env(process.env);
@@ -39,7 +39,7 @@ describe("deployments", () => {
 		);
 		normalize = (str) =>
 			normalizeOutput(str, {
-				[workerName]: "smoke-test-worker",
+				[workerName]: "tmp-wrangler-e2e",
 				[email]: "person@example.com",
 				[CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
 			});
@@ -57,9 +57,9 @@ describe("deployments", () => {
 		const { stdout } = await runInWorker`$ ${WRANGLER} deploy`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
-			Uploaded smoke-test-worker (TIMINGS)
-			Published smoke-test-worker (TIMINGS)
-			  https://smoke-test-worker.SUBDOMAIN.workers.dev
+			Uploaded tmp-wrangler-e2e (TIMINGS)
+			Published tmp-wrangler-e2e (TIMINGS)
+			  https://tmp-wrangler-e2e.SUBDOMAIN.workers.dev
 			Current Deployment ID: 00000000-0000-0000-0000-000000000000"
 		`);
 		workersDev = matchWorkersDev(stdout);
@@ -101,9 +101,9 @@ describe("deployments", () => {
 		const { stdout, stderr } = await runInWorker`$ ${WRANGLER} deploy`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
-			Uploaded smoke-test-worker (TIMINGS)
-			Published smoke-test-worker (TIMINGS)
-			  https://smoke-test-worker.SUBDOMAIN.workers.dev
+			Uploaded tmp-wrangler-e2e (TIMINGS)
+			Published tmp-wrangler-e2e (TIMINGS)
+			  https://tmp-wrangler-e2e.SUBDOMAIN.workers.dev
 			Current Deployment ID: 00000000-0000-0000-0000-000000000000"
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
@@ -175,9 +175,9 @@ describe("deployments", () => {
 	it("delete worker", async () => {
 		const { stdout, stderr } = await runInWorker`$ ${WRANGLER} delete`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"? Are you sure you want to delete smoke-test-worker? This action cannot be undone.
+			"? Are you sure you want to delete tmp-wrangler-e2e? This action cannot be undone.
 			🤖 Using fallback value in non-interactive context: yes
-			Successfully deleted smoke-test-worker"
+			Successfully deleted tmp-wrangler-e2e"
 		`);
 		expect(stderr).toMatchInlineSnapshot('""');
 		const status = await retry(

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -132,7 +132,7 @@ type DevWorker = {
 };
 async function makeWorker(): Promise<DevWorker> {
 	const root = await makeRoot();
-	const workerName = `tmp-wrangler-e2e-${crypto
+	const workerName = `tmp-e2e-wrangler-${crypto
 		.randomBytes(4)
 		.toString("hex")}`;
 	const workerPath = path.join(root, workerName);

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -132,7 +132,7 @@ type DevWorker = {
 };
 async function makeWorker(): Promise<DevWorker> {
 	const root = await makeRoot();
-	const workerName = `smoke-test-worker-${crypto
+	const workerName = `tmp-wrangler-e2e-${crypto
 		.randomBytes(4)
 		.toString("hex")}`;
 	const workerPath = path.join(root, workerName);

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -40,7 +40,7 @@ describe("pages dev tests", () => {
 
 	beforeEach(async () => {
 		const root = await makeRoot();
-		workerName = `tmp-wrangler-e2e-${crypto.randomBytes(4).toString("hex")}`;
+		workerName = `tmp-e2e-wrangler-${crypto.randomBytes(4).toString("hex")}`;
 		workerPath = path.join(root, workerName);
 		await seed(workerPath, {
 			"package.json": dedent`

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -40,7 +40,7 @@ describe("pages dev tests", () => {
 
 	beforeEach(async () => {
 		const root = await makeRoot();
-		workerName = `smoke-test-worker-${crypto.randomBytes(4).toString("hex")}`;
+		workerName = `tmp-wrangler-e2e-${crypto.randomBytes(4).toString("hex")}`;
 		workerPath = path.join(root, workerName);
 		await seed(workerPath, {
 			"package.json": dedent`


### PR DESCRIPTION
**What this PR solves / how to test:**

In a number of places, we run e2e tests against Cloudflare APIs that result in Workers and/or Pages projects being created. This included:
- C3 E2E tests
- Wrangler E2E tests
- Internal E2E tests

These tests all include cleanup as part of their logic (in an `afterEach` or similar), but sometimes fail to properly clean up the created projects (whether through tests crashing, CI timeouts, or random chance). Because of that, we have a CI job which cleans up created e2e projects after some period of time. Previously, it only cleanup up projects created by the C3 E2E tests—this PR ensures that the cleanup action cleans up projects created from the Wrangler, C3, or internal E2E tests. It also updates the Wrangler tests to include a clearer well-known prefix to support this. 

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: This is a modification to how our existing tests run
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: This isn't a user-facing change
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: This isn't a user-facing change
