### PR TITLE
fix: ensure worker reloads when importing `node:*` modules

### DIFF
--- a/.changeset/cuddly-apples-divide.md
+++ b/.changeset/cuddly-apples-divide.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: ensure `wrangler dev` can reload without crashing when importing `node:*` modules
+
+The previous Wrangler release introduced a regression that caused reloads to fail when importing `node:*` modules. This change fixes that, and ensures these modules can always be resolved.

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -162,6 +162,7 @@ describe("basic dev tests", () => {
 					name = "${workerName}"
 					main = "src/index.ts"
 					compatibility_date = "2023-01-01"
+					compatibility_flags = ["nodejs_compat"]
 
 					[vars]
 					KEY = "value"
@@ -195,9 +196,12 @@ describe("basic dev tests", () => {
 
 			await worker.seed({
 				"src/index.ts": dedent`
+						import { Buffer } from "node:buffer";
 						export default {
 							fetch(request, env) {
-								return new Response("Updated Worker! " + env.KEY)
+								const base64Message = Buffer.from("Updated Worker!").toString("base64");
+								const message = Buffer.from(base64Message, "base64").toString();
+								return new Response(message + " " + env.KEY)
 							}
 						}`,
 			});
@@ -216,6 +220,7 @@ describe("basic dev tests", () => {
 						name = "${workerName}"
 						main = "src/index.ts"
 						compatibility_date = "2023-01-01"
+						compatibility_flags = ["nodejs_compat"]
 
 						[vars]
 						KEY = "updated"

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -72,7 +72,7 @@ describe("isNavigatorDefined", () => {
 			assert(false, "Unreachable");
 		} catch (e) {
 			expect(e).toMatchInlineSnapshot(
-				`[AssertionError: Can't both enable and disable a flag]`
+				`[Error: Can't both enable and disable a flag]`
 			);
 		}
 	});

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -12,10 +12,10 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 	name: "nodejs_compat imports plugin",
 	setup(pluginBuild) {
 		// Infinite loop detection
-		const seen = new Set();
+		const seen = new Set<string>();
 
 		// Prevent multiple warnings per package
-		const warnedPackaged = new Map();
+		const warnedPackaged = new Map<string, string[]>();
 
 		pluginBuild.onStart(() => {
 			seen.clear();
@@ -41,14 +41,12 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 					// esbuild couldn't resolve the package
 					// We should warn the user, but not fail the build
 
-					if (!warnedPackaged.has(path)) {
-						warnedPackaged.set(path, [opts.importer]);
-					} else {
-						warnedPackaged.set(path, [
-							...warnedPackaged.get(path),
-							opts.importer,
-						]);
+					let pathWarnedPackaged = warnedPackaged.get(path);
+					if (pathWarnedPackaged === undefined) {
+						warnedPackaged.set(path, (pathWarnedPackaged = []));
 					}
+					pathWarnedPackaged.push(opts.importer);
+
 					return { external: true };
 				}
 				// This is a normal package—don't treat it specially

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -3,12 +3,6 @@ import chalk from "chalk";
 import { logger } from "../../logger";
 import type { Plugin } from "esbuild";
 
-// Infinite loop detection
-const seen = new Set();
-
-// Prevent multiple warnings per package
-const warnedPackaged = new Map();
-
 /**
  * An esbuild plugin that will mark any `node:...` imports as external.
  */
@@ -17,8 +11,16 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 ) => ({
 	name: "nodejs_compat imports plugin",
 	setup(pluginBuild) {
-		seen.clear();
-		warnedPackaged.clear();
+		// Infinite loop detection
+		const seen = new Set();
+
+		// Prevent multiple warnings per package
+		const warnedPackaged = new Map();
+
+		pluginBuild.onStart(() => {
+			seen.clear();
+			warnedPackaged.clear();
+		});
 		pluginBuild.onResolve(
 			{ filter: /node:.*/ },
 			async ({ path, kind, resolveDir, ...opts }) => {

--- a/packages/wrangler/src/navigator-user-agent.ts
+++ b/packages/wrangler/src/navigator-user-agent.ts
@@ -1,16 +1,16 @@
-import assert from "node:assert";
+import { UserError } from "./errors";
 
 export function isNavigatorDefined(
 	compatibility_date: string | undefined,
 	compatibility_flags: string[] = []
 ) {
-	assert(
-		!(
-			compatibility_flags.includes("global_navigator") &&
-			compatibility_flags.includes("no_global_navigator")
-		),
-		"Can't both enable and disable a flag"
-	);
+	if (
+		compatibility_flags.includes("global_navigator") &&
+		compatibility_flags.includes("no_global_navigator")
+	) {
+		throw new UserError("Can't both enable and disable a flag");
+	}
+
 	if (compatibility_flags.includes("global_navigator")) {
 		return true;
 	}


### PR DESCRIPTION
Fixes #4959.

**What this PR solves / how to test:**

#4499 introduced a bug which prevented reloads when importing `node:*` modules. The internal per-build `seen` cache was not cleared between builds, resulting in this branch being hit...

https://github.com/cloudflare/workers-sdk/blob/1c4f1635165d98abc0558dcf148fe1d3ce9a2ca1/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts#L28-L30

...and the resolution failing. This change wraps that in an `onStart()`, so it's called at the start of each build, and also moves the caches inside the plugin, so multiple instances of the plugin can be created.

To test this, follow the reproduction instructions in #4959, no errors should be reported.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a regression

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
