### PR TITLE
Ensure custom build failures are marked as user errors

### DIFF
--- a/.changeset/red-frogs-glow.md
+++ b/.changeset/red-frogs-glow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Report Custom Build failures as `UserError`s

--- a/packages/wrangler/src/__tests__/custom-build.test.ts
+++ b/packages/wrangler/src/__tests__/custom-build.test.ts
@@ -1,0 +1,13 @@
+import { runCustomBuild } from "../deployment-bundle/run-custom-build";
+import { UserError } from "../errors";
+import { runInTempDir } from "./helpers/run-in-tmp";
+
+describe("Custom Builds", () => {
+	runInTempDir();
+
+	it("runCustomBuild throws UserError when a command fails", async () => {
+		await expect(
+			runCustomBuild("/", "/", { command: `node -e "process.exit(1)"` })
+		).rejects.toBeInstanceOf(UserError);
+	});
+});

--- a/packages/wrangler/src/__tests__/custom-build.test.ts
+++ b/packages/wrangler/src/__tests__/custom-build.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { runCustomBuild } from "../deployment-bundle/run-custom-build";
 import { UserError } from "../errors";
 import { runInTempDir } from "./helpers/run-in-tmp";
@@ -6,8 +7,15 @@ describe("Custom Builds", () => {
 	runInTempDir();
 
 	it("runCustomBuild throws UserError when a command fails", async () => {
-		await expect(
-			runCustomBuild("/", "/", { command: `node -e "process.exit(1)"` })
-		).rejects.toBeInstanceOf(UserError);
+		try {
+			await runCustomBuild("/", "/", { command: `node -e "process.exit(1)"` });
+			assert(false, "Unreachable");
+		} catch (e) {
+			expect(e).toBeInstanceOf(UserError);
+			assert(e instanceof UserError);
+			expect(e.message).toMatchInlineSnapshot(
+				`"Running custom build \`node -e \\"process.exit(1)\\"\` failed. There are likely more logs from your build command above."`
+			);
+		}
 	});
 });

--- a/packages/wrangler/src/deployment-bundle/run-custom-build.ts
+++ b/packages/wrangler/src/deployment-bundle/run-custom-build.ts
@@ -17,16 +17,24 @@ export async function runCustomBuild(
 	build: Config["build"]
 ) {
 	if (build.command) {
-		// TODO: add a deprecation message here?
 		logger.log("Running custom build:", build.command);
-		await execaCommand(build.command, {
-			shell: true,
-			// we keep these two as "inherit" so that
-			// logs are still visible.
-			stdout: "inherit",
-			stderr: "inherit",
-			...(build.cwd && { cwd: build.cwd }),
-		});
+		try {
+			await execaCommand(build.command, {
+				shell: true,
+				// we keep these two as "inherit" so that
+				// logs are still visible.
+				stdout: "inherit",
+				stderr: "inherit",
+				...(build.cwd && { cwd: build.cwd }),
+			});
+		} catch (e) {
+			throw new UserError(
+				`Running custom build \`${build.command}\` failed. There are likely more logs from your build command above.`,
+				{
+					cause: e,
+				}
+			);
+		}
 
 		assertEntryPointExists(
 			expectedEntryAbsolute,


### PR DESCRIPTION
**What this PR solves / how to test:**

Ensure custom build failures are marked as `UserError`s, and don't offer to report them to Sentry.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because: 
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: Not a change in behaviour
