### PR TITLE
chore: add missing `defineNavigatorUserAgent` dependency to useEsbuild hook

### DIFF
--- a/.changeset/orange-avocados-fail.md
+++ b/.changeset/orange-avocados-fail.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: add missing `defineNavigatorUserAgent` dependency to useEsbuild hook

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -262,6 +262,7 @@ export function useEsbuild({
 		experimentalLocal,
 		projectRoot,
 		onBundleStart,
+		defineNavigatorUserAgent,
 	]);
 	return bundle;
 }


### PR DESCRIPTION
In PRs we're getting this eslint warning:
![Screenshot 2024-02-12 at 11 54 50](https://github.com/cloudflare/workers-sdk/assets/61631103/9f624a0b-8835-42d9-a911-196e6a48358a)

(I think this was introduced in #4499)

This PR adds the missing `defineNavigatorUserAgent` dependency removing the warning