### PR TITLE
Use partitioned cookies

### DIFF
--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -204,7 +204,10 @@ app.get(`${previewDomain}/.update-preview-token`, (c) => {
 
 	if (
 		c.req.header("Sec-Fetch-Dest") !== "iframe" ||
-		!c.req.header("Referer")?.startsWith("https://workers.cloudflare.com")
+		!(
+			c.req.header("Referer")?.startsWith("https://workers.cloudflare.com") ||
+			c.req.header("Referer")?.startsWith("http://localhost")
+		)
 	) {
 		throw new PreviewRequestForbidden();
 	}
@@ -224,6 +227,7 @@ app.get(`${previewDomain}/.update-preview-token`, (c) => {
 		sameSite: "None",
 		httpOnly: true,
 		domain: url.hostname,
+		partitioned: true,
 	});
 
 	return c.redirect(url.searchParams.get("suffix") ?? "/", 307);

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -85,7 +85,7 @@ describe("Preview Worker", () => {
 			'"/hello?world"'
 		);
 		expect(resp.headers.get("set-cookie") ?? "").toMatchInlineSnapshot(
-			`"token=${defaultUserToken}; Domain=random-data.playground-testing.devprod.cloudflare.dev; Path=/; HttpOnly; Secure; SameSite=None"`
+			`"token=${defaultUserToken}; Domain=random-data.playground-testing.devprod.cloudflare.dev; Path=/; HttpOnly; Secure; SameSite=None; Partitioned"`
 		);
 	});
 	it("shouldn't be redirected with no token", async () => {

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -105,7 +105,7 @@ describe("Preview Worker", () => {
 		);
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"TokenUpdateFailed\\",\\"message\\":\\"Provide valid token\\",\\"data\\":{}}"'
+			`"{"error":"TokenUpdateFailed","message":"Provide valid token","data":{}}"`
 		);
 	});
 	it("shouldn't be redirected with invalid token", async () => {
@@ -125,7 +125,7 @@ describe("Preview Worker", () => {
 		);
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"TokenUpdateFailed\\",\\"message\\":\\"Provide valid token\\",\\"data\\":{}}"'
+			`"{"error":"TokenUpdateFailed","message":"Provide valid token","data":{}}"`
 		);
 	});
 
@@ -194,7 +194,7 @@ describe("Preview Worker", () => {
 		const resp = await fetch(PREVIEW_REMOTE);
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"PreviewRequestFailed\\",\\"message\\":\\"Valid token not found\\",\\"data\\":{}}"'
+			`"{"error":"PreviewRequestFailed","message":"Valid token not found","data":{}}"`
 		);
 	});
 	it("should reject invalid cookie header", async () => {
@@ -205,7 +205,7 @@ describe("Preview Worker", () => {
 		});
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"PreviewRequestFailed\\",\\"message\\":\\"Valid token not found\\",\\"data\\":{}}"'
+			`"{"error":"PreviewRequestFailed","message":"Valid token not found","data":{}}"`
 		);
 	});
 	it("should reject invalid token", async () => {
@@ -216,7 +216,7 @@ describe("Preview Worker", () => {
 		});
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"PreviewRequestFailed\\",\\"message\\":\\"Valid token not found\\",\\"data\\":{\\"tokenId\\":\\"TEST_TOKEN\\"}}"'
+			`"{"error":"PreviewRequestFailed","message":"Valid token not found","data":{"tokenId":"TEST_TOKEN"}}"`
 		);
 	});
 
@@ -244,7 +244,7 @@ describe("Preview Worker", () => {
 		});
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"RawHttpFailed\\",\\"message\\":\\"Provide valid token\\",\\"data\\":{}}"'
+			`"{"error":"RawHttpFailed","message":"Provide valid token","data":{}}"`
 		);
 	});
 	it("should reject invalid token for raw HTTP response", async () => {
@@ -258,7 +258,7 @@ describe("Preview Worker", () => {
 		});
 		expect(resp.status).toBe(400);
 		expect(await resp.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"RawHttpFailed\\",\\"message\\":\\"Provide valid token\\",\\"data\\":{}}"'
+			`"{"error":"RawHttpFailed","message":"Provide valid token","data":{}}"`
 		);
 	});
 });
@@ -312,7 +312,7 @@ describe("Upload Worker", () => {
 		});
 		expect(w.status).toBe(401);
 		expect(await w.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"UploadFailed\\",\\"message\\":\\"Valid token not provided\\",\\"data\\":{}}"'
+			`"{"error":"UploadFailed","message":"Valid token not provided","data":{}}"`
 		);
 	});
 	it("should reject invalid token", async () => {
@@ -326,7 +326,7 @@ describe("Upload Worker", () => {
 		});
 		expect(w.status).toBe(401);
 		expect(await w.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"UploadFailed\\",\\"message\\":\\"Valid token not provided\\",\\"data\\":{}}"'
+			`"{"error":"UploadFailed","message":"Valid token not provided","data":{}}"`
 		);
 	});
 	it("should reject invalid form data", async () => {
@@ -340,7 +340,7 @@ describe("Upload Worker", () => {
 		});
 		expect(w.status).toBe(400);
 		expect(await w.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected valid form data\\",\\"data\\":{\\"error\\":\\"TypeError: Unrecognized Content-Type header value. FormData can only parse the following MIME types: multipart/form-data, application/x-www-form-urlencoded\\"}}"'
+			`"{"error":"BadUpload","message":"Expected valid form data","data":{"error":"TypeError: Unrecognized Content-Type header value. FormData can only parse the following MIME types: multipart/form-data, application/x-www-form-urlencoded"}}"`
 		);
 	});
 	it("should reject missing metadata", async () => {
@@ -362,7 +362,7 @@ export default {
 		});
 		expect(w.status).toBe(400);
 		expect(await w.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected metadata file to be defined\\",\\"data\\":{}}"'
+			`"{"error":"BadUpload","message":"Expected metadata file to be defined","data":{}}"`
 		);
 	});
 	it("should reject invalid metadata json", async () => {
@@ -381,7 +381,7 @@ Content-Type: application/json
 		});
 		expect(w.status).toBe(400);
 		expect(await w.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected metadata file to be valid\\",\\"data\\":{}}"'
+			`"{"error":"BadUpload","message":"Expected metadata file to be valid","data":{}}"`
 		);
 	});
 	it("should reject invalid metadata", async () => {
@@ -400,7 +400,7 @@ Content-Type: application/json
 		});
 		expect(w.status).toBe(400);
 		expect(await w.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"BadUpload\\",\\"message\\":\\"Expected metadata file to be valid\\",\\"data\\":{}}"'
+			`"{"error":"BadUpload","message":"Expected metadata file to be valid","data":{}}"`
 		);
 	});
 	it("should reject service worker", async () => {
@@ -424,7 +424,7 @@ Content-Type: application/json
 		});
 		expect(w.status).toBe(400);
 		expect(await w.text()).toMatchInlineSnapshot(
-			'"{\\"error\\":\\"ServiceWorkerNotSupported\\",\\"message\\":\\"Service Workers are not supported in the Workers Playground\\",\\"data\\":{}}"'
+			`"{"error":"ServiceWorkerNotSupported","message":"Service Workers are not supported in the Workers Playground","data":{}}"`
 		);
 	});
 });

--- a/packages/workers-playground/.env.development
+++ b/packages/workers-playground/.env.development
@@ -1,0 +1,2 @@
+VITE_PLAYGROUND_ROOT=playground-testing.devprod.cloudflare.dev
+VITE_PLAYGROUND_PREVIEW=playground-testing.devprod.cloudflare.dev

--- a/packages/workers-playground/README.md
+++ b/packages/workers-playground/README.md
@@ -2,13 +2,15 @@
 
 This package contains the client side assets used in the Workers Playground available in the Cloudflare Dashboard at [https://workers.cloudflare.com/playground].
 
-## Developing
+## Developing locally
 
-In the root of the monorepo:
+> This is intended for internal Cloudflare developers. Currently, it's not possible to contribute to this package as an external contributor
 
-1. Run `pnpm -F workers-playground dev`
+- Ensure the rest of the team are aware you're working on the Workers Playground, as there's only one instance of the testing `playground-preview-worker`.
 
-This will run the Vite dev server, which will watch the source files and reload the browser on changes.
+- Run `pnpm run dev` in the root of this package. That will start the local Vite server for the playground frontend, with API calls hitting the testing `playground-preview-worker`.
+
+- To test changes to the playground preview worker, run `pnpm run deploy:testing` in `packages/playground-preview-worker` to deploy it to the test environment.
 
 ## Building
 

--- a/packages/workers-playground/src/QuickEditor/HTTPTab/HTTPTab.tsx
+++ b/packages/workers-playground/src/QuickEditor/HTTPTab/HTTPTab.tsx
@@ -152,23 +152,21 @@ export function HTTPTab() {
 					Send
 				</Button>
 			</Form>
-			<SplitPane
-				split="horizontal"
-				defaultSize="30%"
-				paneStyle={{
-					display: "flex",
-				}}
-				style={{
-					position: "relative",
-					minHeight: "initial",
-				}}
-				minSize={50}
-				maxSize={-50}
-			>
-				<Div overflow="auto" display="flex" flexDirection="column" width="100%">
+			<Div display="flex" flexDirection="column" height="calc(100% - 52px)">
+				<Div
+					overflow="auto"
+					display="flex"
+					flexDirection="column"
+					width="100%"
+					borderBottom="1px solid"
+					borderBottomColor="rgb(182, 182, 182)"
+					flexShrink={0}
+				>
 					<Div p={2} display="flex" gap={2} flexDirection="column">
 						<Div display="flex" alignItems="baseline">
-							<StyledLabel htmlFor="request_headers">Headers </StyledLabel>
+							<StyledLabel htmlFor="request_headers" alignSelf="center" mb={0}>
+								Headers{" "}
+							</StyledLabel>
 							<Button
 								onClick={() => setHeaders((headers) => [...headers, ["", ""]])}
 								ml="auto"
@@ -181,7 +179,7 @@ export function HTTPTab() {
 						{headers.length ? (
 							<RequestHeaders headers={headers} onChange={setHeaders} />
 						) : (
-							<Toast type="info">No headers specified</Toast>
+							hasBody && <Toast type="info">No headers specified</Toast>
 						)}
 					</Div>
 					{hasBody && (
@@ -219,7 +217,7 @@ export function HTTPTab() {
 						</Toast>
 					)}
 				</Output>
-			</SplitPane>
+			</Div>
 		</Div>
 	);
 }

--- a/packages/workers-playground/src/QuickEditor/ToolsPane.tsx
+++ b/packages/workers-playground/src/QuickEditor/ToolsPane.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@cloudflare/component-icon";
 import { A, Div } from "@cloudflare/elements";
 import { isDarkMode, theme } from "@cloudflare/style-const";
 import { createComponent } from "@cloudflare/style-container";
+import { useState } from "react";
 import DevtoolsIframe from "./DevtoolsIframe";
 import { HTTPTab } from "./HTTPTab/HTTPTab";
 import PreviewTab from "./PreviewTab/PreviewTab";
@@ -18,6 +19,11 @@ const Main = createComponent(() => ({
 }));
 
 export default function ToolsPane() {
+	const [isSafari] = useState(
+		() =>
+			/Safari\/\d+/.test(navigator.userAgent) &&
+			!/Chrome\/\d+/.test(navigator.userAgent)
+	);
 	return (
 		<SplitPane split="horizontal" defaultSize="70%" minSize={50} maxSize={-50}>
 			<Div width="100%">
@@ -25,10 +31,12 @@ export default function ToolsPane() {
 					<Tabs defaultIndex={0} forceRenderTabPanel={true}>
 						<TabBar>
 							<TabList className="worker-editor-tablist">
-								<Tab>
-									<Icon type="eye" mr={2} />
-									Preview
-								</Tab>
+								{!isSafari && (
+									<Tab>
+										<Icon type="eye" mr={2} />
+										Preview
+									</Tab>
+								)}
 								<Tab>
 									<Icon type="two-way" mr={2} />
 									HTTP
@@ -74,9 +82,11 @@ export default function ToolsPane() {
 							</Div>
 						</TabBar>
 
-						<TabPanel>
-							<PreviewTab />
-						</TabPanel>
+						{!isSafari && (
+							<TabPanel>
+								<PreviewTab />
+							</TabPanel>
+						)}
 						<TabPanel>
 							<HTTPTab />
 						</TabPanel>

--- a/packages/workers-playground/vite.config.ts
+++ b/packages/workers-playground/vite.config.ts
@@ -1,20 +1,23 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import pluginRewriteAll from "vite-plugin-rewrite-all";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-	plugins: [pluginRewriteAll(), react()],
-	server: {
-		proxy: {
-			"/playground/api": {
-				target: "https://playground.devprod.cloudflare.dev",
-				changeOrigin: true,
-				rewrite: (path) => path.replace(/^\/playground/, ""),
+export default defineConfig(({ mode }) => {
+	const playgroundHost = loadEnv(mode, process.cwd())["VITE_PLAYGROUND_ROOT"];
+	return {
+		plugins: [pluginRewriteAll(), react()],
+		server: {
+			proxy: {
+				"/playground/api": {
+					target: `https://${playgroundHost}`,
+					changeOrigin: true,
+					rewrite: (path) => path.replace(/^\/playground/, ""),
+				},
 			},
 		},
-	},
 
-	appType: "spa",
-	base: "/playground",
+		appType: "spa",
+		base: "/playground",
+	};
 });


### PR DESCRIPTION
Partially fixes [DEVX-1156](https://jira.cfdata.org/browse/DEVX-1156). There will be a followup PR to address the same issue in `edge-preview-authenticated-proxy`

**What this PR solves / how to test:**

This PR ensures that the Workers Playground uses partitioned cookies for it's preview system, to address the [upcoming deprecation of third party cookies in Chrome](https://developers.google.com/privacy-sandbox/3pcd/chips).

This PR can be tested by following the steps in `packages/workers-playground/README.md` to build a local copy of the playground, and then running it in a version of chrome with the cookie phaseout flag enabled (`chrome://flags#test-third-party-cookie-phaseout`)

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: This relies on manual testing in a version of chrome with the flag enabled
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: The package doesn't follow changesets
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: This isn't a change to documented behaviour
