### PR TITLE
[KV] Remove `worker-` prefix from kv:namespace create when using wrangler in a pages project or without a `name` property

### DIFF
--- a/.changeset/tall-planets-pull.md
+++ b/.changeset/tall-planets-pull.md
@@ -1,0 +1,12 @@
+---
+"wrangler": major
+---
+
+feat: remove the default 'worker' prefix from the `kv:namespace create` command
+
+Previously, if there was no Worker defined by a local `wrangler.toml` or that Worker had no `name` property
+then any KV namespace that was created by Wrangler would use `worker_` as a prefix, rather than the Worker's
+name.
+
+This is a minor breaking change to the name given to a newly created KV namespace, which is unlikely to affect
+many, if any, developers.

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -113,10 +113,10 @@ describe("wrangler", () => {
 			});
 
 			it("should create a namespace", async () => {
-				mockCreateRequest("worker-UnitTestNamespace");
+				mockCreateRequest("UnitTestNamespace");
 				await runWrangler("kv:namespace create UnitTestNamespace");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "🌀 Creating namespace with title \\"worker-UnitTestNamespace\\"
+			          "🌀 Creating namespace with title \\"UnitTestNamespace\\"
 			          ✨ Success!
 			          Add the following to your configuration file in your kv_namespaces array:
 			          { binding = \\"UnitTestNamespace\\", id = \\"some-namespace-id\\" }"
@@ -124,10 +124,10 @@ describe("wrangler", () => {
 			});
 
 			it("should create a preview namespace if configured to do so", async () => {
-				mockCreateRequest("worker-UnitTestNamespace_preview");
+				mockCreateRequest("UnitTestNamespace_preview");
 				await runWrangler("kv:namespace create UnitTestNamespace --preview");
 				expect(std.out).toMatchInlineSnapshot(`
-			          "🌀 Creating namespace with title \\"worker-UnitTestNamespace_preview\\"
+			          "🌀 Creating namespace with title \\"UnitTestNamespace_preview\\"
 			          ✨ Success!
 			          Add the following to your configuration file in your kv_namespaces array:
 			          { binding = \\"UnitTestNamespace\\", preview_id = \\"some-namespace-id\\" }"
@@ -135,11 +135,11 @@ describe("wrangler", () => {
 			});
 
 			it("should create a namespace using configured worker name", async () => {
-				writeFileSync("./wrangler.toml", 'name = "other-worker"', "utf-8");
-				mockCreateRequest("other-worker-UnitTestNamespace");
+				writeFileSync("./wrangler.toml", 'name = "other"', "utf-8");
+				mockCreateRequest("other-UnitTestNamespace");
 				await runWrangler("kv:namespace create UnitTestNamespace");
 				expect(std.out).toMatchInlineSnapshot(`
-			            "🌀 Creating namespace with title \\"other-worker-UnitTestNamespace\\"
+			            "🌀 Creating namespace with title \\"other-UnitTestNamespace\\"
 			            ✨ Success!
 			            Add the following to your configuration file in your kv_namespaces array:
 			            { binding = \\"UnitTestNamespace\\", id = \\"some-namespace-id\\" }"
@@ -147,12 +147,12 @@ describe("wrangler", () => {
 			});
 
 			it("should create a namespace in an environment if configured to do so", async () => {
-				mockCreateRequest("worker-customEnv-UnitTestNamespace");
+				mockCreateRequest("customEnv-UnitTestNamespace");
 				await runWrangler(
 					"kv:namespace create UnitTestNamespace --env customEnv"
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-			          "🌀 Creating namespace with title \\"worker-customEnv-UnitTestNamespace\\"
+			          "🌀 Creating namespace with title \\"customEnv-UnitTestNamespace\\"
 			          ✨ Success!
 			          Add the following to your configuration file in your kv_namespaces array under [env.customEnv]:
 			          { binding = \\"UnitTestNamespace\\", id = \\"some-namespace-id\\" }"

--- a/packages/wrangler/src/kv/helpers.ts
+++ b/packages/wrangler/src/kv/helpers.ts
@@ -427,6 +427,17 @@ export function getKVNamespaceId(
 	return namespaceId;
 }
 
+/**
+ * KV namespace binding names must be valid JS identifiers.
+ */
+export function isValidKVNamespaceBinding(
+	binding: string | undefined
+): binding is string {
+	return (
+		typeof binding === "string" && /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(binding)
+	);
+}
+
 // TODO(soon): once we upgrade to TypeScript 5.2, this should actually use `using`:
 //  https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#using-declarations-and-explicit-resource-management
 export async function usingLocalNamespace<T>(

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -22,6 +22,7 @@ import {
 	getKVKeyValue,
 	getKVNamespaceId,
 	isKVKeyValue,
+	isValidKVNamespaceBinding,
 	listKVNamespaceKeys,
 	listKVNamespaces,
 	putKVBulkKeyValue,
@@ -60,10 +61,18 @@ export function kvNamespace(kvYargs: CommonYargsArgv) {
 					);
 				}
 
-				const name = config.name || "worker";
-				const environment = args.env ? `-${args.env}` : "";
+				if (!isValidKVNamespaceBinding(args.namespace)) {
+					throw new CommandLineArgsError(
+						`The namespace binding name "${args.namespace}" is invalid. It can only have alphanumeric and _ characters, and cannot begin with a number.`
+					);
+				}
+
+				const name = config.name || "";
+				const environment = args.env ? `${name && "-"}${args.env}` : "";
 				const preview = args.preview ? "_preview" : "";
-				const title = `${name}${environment}-${args.namespace}${preview}`;
+				const title = `${name}${environment}${(name || environment) && "-"}${
+					args.namespace
+				}${preview}`;
 
 				const accountId = await requireAuth(config);
 


### PR DESCRIPTION
Fixes #

**What this PR solves / how to test:**  Currently the kv:namespace create command differs from other `create` commands where it prefixes the input with `worker-` when using the command in e.g. a pages project without a `wrangler.toml` or with a `wrangler.toml` but without a `name` property. This is a regression to how the dashboard and other products works and can cause confusion for developers.

**Author has addressed the following:** This has been broken into two separate PRs to focus on two different topics, see #5050 for the original change.

- Tests
  - [X] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [X] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s): 
  - [x] Not necessary because: the docs do not mention the overly zealous validation of the title passed to the command.
