### PR TITLE
[C3] chore: update qwik template to use `getPlatformProxy`

### DIFF
--- a/.changeset/warm-weeks-stare.md
+++ b/.changeset/warm-weeks-stare.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+chore: update qwik template to use `getPlatformProxy`
+
+update the C3 Qwik template to use the `getPlatformProxy` utility instead of the deprecated `getBindingsProxy` one

--- a/packages/create-cloudflare/templates/qwik/c3.ts
+++ b/packages/create-cloudflare/templates/qwik/c3.ts
@@ -40,9 +40,9 @@ const addBindingsProxy = (ctx: C3Context) => {
 let env = {};
 
 if(process.env.NODE_ENV === 'development') {
-  const { getBindingsProxy } = await import('wrangler');
-  const { bindings } = await getBindingsProxy();
-  env = bindings;
+  const { getPlatformProxy } = await import('wrangler');
+  const platformProxy = await getPlatformProxy();
+  env = platformProxy.env;
 }
 `;
 


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR updates the C3 Qwik template to use the `getPlatformProxy` utility instead of the deprecated `getBindingsProxy` one

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: there are already e2e tests for quick
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): either https://github.com/cloudflare/cloudflare-docs/pull/12915
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
