### PR TITLE
[do not merge] Don't strip version numbers from requirements.txt

### DIFF
--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -63,15 +63,12 @@ export async function findAdditionalModules(
 
 			// This is incredibly naive. However, it supports common syntax for requirements.txt
 			for (const requirement of pythonRequirements.split("\n")) {
-				const packageName = requirement.match(/^[^\d\W]\w*/);
-				if (typeof packageName?.[0] === "string") {
-					modules.push({
-						type: "python-requirement",
-						name: packageName?.[0],
-						content: "",
-						filePath: undefined,
-					});
-				}
+				modules.push({
+					type: "python-requirement",
+					name: requirement,
+					content: "",
+					filePath: undefined,
+				});
 			}
 			// We don't care if a requirements.txt isn't found
 		} catch (e) {


### PR DESCRIPTION
Currently we strip version numbers from requirements.txt when translating to a worker config (and that's probably what we want). However, for now we need to specify the version number to make some packages work within pyodide and workerd.