### PR TITLE
[quick-edit] Partitioned cookies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,5 +68,8 @@
 	},
 	"[html]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	}
 }

--- a/fixtures/worker-app/package.json
+++ b/fixtures/worker-app/package.json
@@ -13,11 +13,12 @@
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
-		"wrangler": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:^",
-		"undici": "^5.28.3"
+		"undici": "^5.28.3",
+		"wrangler": "workspace:*"
 	},
 	"dependencies": {
+		"cookie": "^0.6.0",
 		"isomorphic-random-example": "workspace:^"
 	}
 }

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -36,12 +36,6 @@ export default {
 							secure: true,
 						}),
 					],
-					[
-						"Set-Cookie",
-						cookie.serialize("hello2", "world2", {
-							domain: `${hostname}:1`,
-						}),
-					],
 				],
 			});
 

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -1,3 +1,4 @@
+import cookie from "cookie";
 import { randomBytes } from "isomorphic-random-example";
 import { now } from "./dep";
 import { logErrors } from "./log";
@@ -15,10 +16,35 @@ export default {
 	async fetch(request) {
 		console.log("request log");
 
-		const { pathname, origin } = new URL(request.url);
+		const { pathname, origin, hostname, host } = new URL(request.url);
 		if (pathname === "/random") return new Response(hexEncode(randomBytes(8)));
 		if (pathname === "/error") throw new Error("Oops!");
 		if (pathname === "/redirect") return Response.redirect(`${origin}/foo`);
+		if (pathname === "/cookie")
+			return new Response("", {
+				headers: [
+					[
+						"Set-Cookie",
+						cookie.serialize("hello", "world", {
+							domain: hostname,
+						}),
+					],
+					[
+						"Set-Cookie",
+						cookie.serialize("hello2", "world2", {
+							domain: host,
+							secure: true,
+						}),
+					],
+					[
+						"Set-Cookie",
+						cookie.serialize("hello2", "world2", {
+							domain: `${hostname}:1`,
+						}),
+					],
+				],
+			});
+
 		if (request.headers.get("X-Test-URL") !== null) {
 			return new Response(request.url);
 		}

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -146,9 +146,8 @@ describe("'wrangler dev' correctly renders pages", () => {
 		const response = await fetch(`http://${ip}:${port}/cookie`);
 		expect(response.headers.getSetCookie()).toMatchInlineSnapshot(`
 			[
-			  "hello=world; Domain=prod.example.org",
-			  "hello2=world2; Domain=prod.example.org; Secure",
-			  "hello2=world2; Domain=prod.example.org:1",
+			  "hello=world; Domain=localhost",
+			  "hello2=world2; Domain=localhost; Secure",
 			]
 		`);
 	});

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -139,4 +139,17 @@ describe("'wrangler dev' correctly renders pages", () => {
 			`http://${ip}:${port}/foo`
 		);
 	});
+
+	it("rewrites set-cookie headers to the hostname, not host", async ({
+		expect,
+	}) => {
+		const response = await fetch(`http://${ip}:${port}/cookie`);
+		expect(response.headers.getSetCookie()).toMatchInlineSnapshot(`
+			[
+			  "hello=world; Domain=prod.example.org",
+			  "hello2=world2; Domain=prod.example.org; Secure",
+			  "hello2=world2; Domain=prod.example.org:1",
+			]
+		`);
+	});
 });

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -144,11 +144,12 @@ describe("'wrangler dev' correctly renders pages", () => {
 		expect,
 	}) => {
 		const response = await fetch(`http://${ip}:${port}/cookie`);
-		expect(response.headers.getSetCookie()).toMatchInlineSnapshot(`
+
+		expect(response.headers.getSetCookie()).toStrictEqual(
 			[
-			  "hello=world; Domain=localhost",
-			  "hello2=world2; Domain=localhost; Secure",
+				`hello=world; Domain=${ip}`,
+				`hello2=world2; Domain=${ip}; Secure`,
 			]
-		`);
+		);
 	});
 });

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -145,11 +145,9 @@ describe("'wrangler dev' correctly renders pages", () => {
 	}) => {
 		const response = await fetch(`http://${ip}:${port}/cookie`);
 
-		expect(response.headers.getSetCookie()).toStrictEqual(
-			[
-				`hello=world; Domain=${ip}`,
-				`hello2=world2; Domain=${ip}; Secure`,
-			]
-		);
+		expect(response.headers.getSetCookie()).toStrictEqual([
+			`hello=world; Domain=${ip}`,
+			`hello2=world2; Domain=${ip}; Secure`,
+		]);
 	});
 });

--- a/packages/edge-preview-authenticated-proxy/package.json
+++ b/packages/edge-preview-authenticated-proxy/package.json
@@ -13,10 +13,10 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "*",
 		"@cloudflare/workers-types": "^4.20230321.0",
-		"cookie": "^0.5.0",
+		"@types/cookie": "^0.6.0",
+		"cookie": "^0.6.0",
 		"promjs": "^0.4.2",
 		"toucan-js": "^3.1.0",
-		"wrangler": "workspace:*",
-		"@types/cookie": "^0.5.1"
+		"wrangler": "workspace:*"
 	}
 }

--- a/packages/edge-preview-authenticated-proxy/src/index.ts
+++ b/packages/edge-preview-authenticated-proxy/src/index.ts
@@ -297,6 +297,7 @@ async function updatePreviewToken(url: URL, env: Env, ctx: ExecutionContext) {
 				sameSite: "none",
 				httpOnly: true,
 				domain: url.hostname,
+				partitioned: true,
 			}),
 		},
 	});

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -142,7 +142,7 @@ compatibility_date = "2023-01-01"
 		expect(
 			removeUUID(resp.headers.get("set-cookie") ?? "")
 		).toMatchInlineSnapshot(
-			'"token=00000000-0000-0000-0000-000000000000; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; SameSite=None"'
+			'"token=00000000-0000-0000-0000-000000000000; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; Partitioned; SameSite=None"'
 		);
 		tokenId = (resp.headers.get("set-cookie") ?? "")
 			.split(";")[0]
@@ -152,7 +152,7 @@ compatibility_date = "2023-01-01"
 			{
 				method: "GET",
 				headers: {
-					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; SameSite=None`,
+					cookie: `token=${tokenId}`,
 				},
 			}
 		);
@@ -183,7 +183,7 @@ compatibility_date = "2023-01-01"
 		expect(
 			removeUUID(resp.headers.get("set-cookie") ?? "")
 		).toMatchInlineSnapshot(
-			'"token=00000000-0000-0000-0000-000000000000; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; SameSite=None"'
+			'"token=00000000-0000-0000-0000-000000000000; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; Partitioned; SameSite=None"'
 		);
 		tokenId = (resp.headers.get("set-cookie") ?? "")
 			.split(";")[0]
@@ -218,7 +218,7 @@ compatibility_date = "2023-01-01"
 			{
 				method: "GET",
 				headers: {
-					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; SameSite=None`,
+					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; Partitioned; SameSite=None`,
 				},
 			}
 		);
@@ -237,7 +237,7 @@ compatibility_date = "2023-01-01"
 			{
 				method: "GET",
 				headers: {
-					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; SameSite=None`,
+					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; Partitioned; SameSite=None`,
 				},
 				redirect: "manual",
 			}
@@ -255,7 +255,7 @@ compatibility_date = "2023-01-01"
 			{
 				method: "PUT",
 				headers: {
-					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; SameSite=None`,
+					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; Partitioned; SameSite=None`,
 				},
 				redirect: "manual",
 			}
@@ -270,7 +270,7 @@ compatibility_date = "2023-01-01"
 				method: "PUT",
 				headers: {
 					"X-Custom-Header": "custom",
-					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; SameSite=None`,
+					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; Partitioned; SameSite=None`,
 				},
 				redirect: "manual",
 			}
@@ -284,7 +284,7 @@ compatibility_date = "2023-01-01"
 			{
 				method: "PUT",
 				headers: {
-					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; SameSite=None`,
+					cookie: `token=${tokenId}; Domain=random-data.preview.devprod.cloudflare.dev; HttpOnly; Secure; Partitioned; SameSite=None`,
 				},
 				redirect: "manual",
 			}

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -305,10 +305,12 @@ function insertLiveReloadScript(
  */
 function rewriteUrlRelatedHeaders(headers: Headers, from: URL, to: URL) {
 	headers.forEach((value, key) => {
-		if (typeof value === "string" && value.includes(from.host)) {
+		if (typeof value === "string" && value.includes(from.hostname)) {
 			headers.set(
 				key,
-				value.replaceAll(from.origin, to.origin).replaceAll(from.host, to.host)
+				value
+					.replaceAll(from.origin, to.origin)
+					.replaceAll(from.hostname, to.hostname)
 			);
 		}
 	});

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -304,13 +304,22 @@ function insertLiveReloadScript(
  * so that this proxy is transparent to the Client Browser and User Worker.
  */
 function rewriteUrlRelatedHeaders(headers: Headers, from: URL, to: URL) {
+	const setCookie = headers.getAll("Set-Cookie");
+	headers.delete("Set-Cookie");
+	for (const cookie of setCookie) {
+		headers.append(
+			"Set-Cookie",
+			cookie.replace(
+				new RegExp(`Domain=${from.hostname}($|;|,)`),
+				`Domain=${to.hostname}$1`
+			)
+		);
+	}
 	headers.forEach((value, key) => {
-		if (typeof value === "string" && value.includes(from.hostname)) {
+		if (typeof value === "string" && value.includes(from.host)) {
 			headers.set(
 				key,
-				value
-					.replaceAll(from.origin, to.origin)
-					.replaceAll(from.hostname, to.hostname)
+				value.replaceAll(from.origin, to.origin).replaceAll(from.host, to.host)
 			);
 		}
 	});

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -33,7 +33,7 @@ export default {
 } as ExportedHandler<Env, unknown, ProxyWorkerIncomingRequestBody>;
 
 export class ProxyWorker implements DurableObject {
-	constructor(readonly state: DurableObjectState, readonly env: Env) {}
+	constructor(readonly state: DurableObjectState, readonly env: Env) { }
 
 	proxyData?: ProxyData;
 	requestQueue = new Map<Request, DeferredPromise<Response>>();
@@ -316,7 +316,11 @@ function rewriteUrlRelatedHeaders(headers: Headers, from: URL, to: URL) {
 		);
 	}
 	headers.forEach((value, key) => {
-		if (typeof value === "string" && value.includes(from.host)) {
+		if (
+			typeof value === "string" &&
+			value.includes(from.host) &&
+			key !== "set-cookie"
+		) {
 			headers.set(
 				key,
 				value.replaceAll(from.origin, to.origin).replaceAll(from.host, to.host)

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -306,6 +306,17 @@ function insertLiveReloadScript(
 function rewriteUrlRelatedHeaders(headers: Headers, from: URL, to: URL) {
 	const setCookie = headers.getAll("Set-Cookie");
 	headers.delete("Set-Cookie");
+	headers.forEach((value, key) => {
+		if (
+			typeof value === "string" &&
+			value.includes(from.host)
+		) {
+			headers.set(
+				key,
+				value.replaceAll(from.origin, to.origin).replaceAll(from.host, to.host)
+			);
+		}
+	});
 	for (const cookie of setCookie) {
 		headers.append(
 			"Set-Cookie",
@@ -315,16 +326,4 @@ function rewriteUrlRelatedHeaders(headers: Headers, from: URL, to: URL) {
 			)
 		);
 	}
-	headers.forEach((value, key) => {
-		if (
-			typeof value === "string" &&
-			value.includes(from.host) &&
-			key !== "set-cookie"
-		) {
-			headers.set(
-				key,
-				value.replaceAll(from.origin, to.origin).replaceAll(from.host, to.host)
-			);
-		}
-	});
 }

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -33,7 +33,7 @@ export default {
 } as ExportedHandler<Env, unknown, ProxyWorkerIncomingRequestBody>;
 
 export class ProxyWorker implements DurableObject {
-	constructor(readonly state: DurableObjectState, readonly env: Env) { }
+	constructor(readonly state: DurableObjectState, readonly env: Env) {}
 
 	proxyData?: ProxyData;
 	requestQueue = new Map<Request, DeferredPromise<Response>>();
@@ -307,10 +307,7 @@ function rewriteUrlRelatedHeaders(headers: Headers, from: URL, to: URL) {
 	const setCookie = headers.getAll("Set-Cookie");
 	headers.delete("Set-Cookie");
 	headers.forEach((value, key) => {
-		if (
-			typeof value === "string" &&
-			value.includes(from.host)
-		) {
+		if (typeof value === "string" && value.includes(from.host)) {
 			headers.set(
 				key,
 				value.replaceAll(from.origin, to.origin).replaceAll(from.host, to.host)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,9 @@ importers:
 
   fixtures/worker-app:
     dependencies:
+      cookie:
+        specifier: ^0.6.0
+        version: 0.6.0
       isomorphic-random-example:
         specifier: workspace:^
         version: link:../isomorphic-random-example
@@ -10216,7 +10219,6 @@ packages:
   /cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /copy-descriptor@0.1.1:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -838,7 +838,7 @@ importers:
         version: 8.49.0
       eslint-config-turbo:
         specifier: latest
-        version: 1.12.3(eslint@8.49.0)
+        version: 1.12.4(eslint@8.49.0)
       eslint-plugin-import:
         specifier: 2.26.x
         version: 2.26.0(@typescript-eslint/parser@6.7.2)(eslint@8.49.0)
@@ -11354,13 +11354,13 @@ packages:
       eslint: 8.49.0
     dev: true
 
-  /eslint-config-turbo@1.12.3(eslint@8.49.0):
-    resolution: {integrity: sha512-Q46MEOiNJpJWC3Et5/YEuIYYhbOieS04yZwQOinO2hpZw3folEXV+hbwVo8M+ap/q8gtpjIWiRMZ1A4QxmhEqQ==}
+  /eslint-config-turbo@1.12.4(eslint@8.49.0):
+    resolution: {integrity: sha512-5hqEaV6PNmAYLL4RTmq74OcCt8pgzOLnfDVPG/7PUXpQ0Mpz0gr926oCSFukywKKXjdum3VHD84S7Z9A/DqTAw==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:
       eslint: 8.49.0
-      eslint-plugin-turbo: 1.12.3(eslint@8.49.0)
+      eslint-plugin-turbo: 1.12.4(eslint@8.49.0)
     dev: false
 
   /eslint-import-resolver-node@0.3.7:
@@ -11787,8 +11787,8 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-turbo@1.12.3(eslint@8.49.0):
-    resolution: {integrity: sha512-7hEyxa+oP898EFNoxVenHlH8jtBwV1hbbIkdQWgqDcB0EmVNGVEZkYRo5Hm6BuMAjR433B+NISBJdj0bQo4/Lg==}
+  /eslint-plugin-turbo@1.12.4(eslint@8.49.0):
+    resolution: {integrity: sha512-3AGmXvH7E4i/XTWqBrcgu+G7YKZJV/8FrEn79kTd50ilNsv+U3nS2IlcCrQB6Xm2m9avGD9cadLzKDR1/UF2+g==}
     peerDependencies:
       eslint: '>6.6.0'
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -807,11 +807,11 @@ importers:
         specifier: ^4.20230321.0
         version: 4.20230821.0
       '@types/cookie':
-        specifier: ^0.5.1
-        version: 0.5.1
+        specifier: ^0.6.0
+        version: 0.6.0
       cookie:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       promjs:
         specifier: ^0.4.2
         version: 0.4.2
@@ -7048,6 +7048,10 @@ packages:
     resolution: {integrity: sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==}
     dev: true
 
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+    dev: true
+
   /@types/cross-spawn@6.0.2:
     resolution: {integrity: sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==}
     dependencies:
@@ -10208,6 +10212,11 @@ packages:
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
+
+  /cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+    dev: true
 
   /copy-descriptor@0.1.1:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}


### PR DESCRIPTION
Closes [DEVX-1156](https://jira.cfdata.org/browse/DEVX-1156). 

**What this PR solves / how to test:**

This PR ensures that the Workers Quick Edit uses partitioned cookies for it's preview system, to address the [upcoming deprecation of third party cookies in Chrome](https://developers.google.com/privacy-sandbox/3pcd/chips).

_Testing instructions TBD_

**Author has addressed the following:**

- Tests
  - [x] Included, but manual testing in Chrome TBD
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: The package doesn't follow changesets
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: This isn't a change to documented behaviour
