### PR TITLE
fix e2e test failures

### DIFF
--- a/packages/wrangler/e2e/helpers/normalize.ts
+++ b/packages/wrangler/e2e/helpers/normalize.ts
@@ -163,7 +163,7 @@ export function squashLocalNetworkBindings(stdout: string): string {
  */
 function removeStandardPricingWarning(stdout: string): string {
 	return stdout.replace(
-		/🚧 New Workers Standard pricing is now available. Please visit the dashboard to view details and opt-in to new pricing: https:\/\/dash.cloudflare.com\/[^/]+\/workers\/standard\/opt-in./,
+		/🚧 New Workers Standard pricing is now available\. Please visit the dashboard to view details and opt-in to new pricing: https:\/\/dash\.cloudflare\.com\/[^/]+\/workers\/standard\/opt-in\./,
 		""
 	);
 }

--- a/packages/wrangler/e2e/helpers/normalize.ts
+++ b/packages/wrangler/e2e/helpers/normalize.ts
@@ -31,7 +31,7 @@ export function normalizeOutput(
 			stdout = stdout.replaceAll(from, to);
 		}
 	}
-	return stdout;
+	return stdout.trim();
 }
 
 function stripEmptyNewlines(stdout: string): string {
@@ -163,7 +163,7 @@ export function squashLocalNetworkBindings(stdout: string): string {
  */
 function removeStandardPricingWarning(stdout: string): string {
 	return stdout.replace(
-		"🚧 New Workers Standard pricing is now available. Please visit the dashboard to view details and opt-in to new pricing: https://dash.cloudflare.com/CLOUDFLARE_ACCOUNT_ID/workers/standard/opt-in.",
+		/🚧 New Workers Standard pricing is now available. Please visit the dashboard to view details and opt-in to new pricing: https:\/\/dash.cloudflare.com\/[^/]+\/workers\/standard\/opt-in./,
 		""
 	);
 }

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -959,18 +959,15 @@ export function getBindings(
 				process.env[
 					`WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_${hyperdrive.binding}`
 				];
-			if (!connectionStringFromEnv || !hyperdrive.localConnectionString) {
+			if (!connectionStringFromEnv && !hyperdrive.localConnectionString) {
 				throw new UserError(
 					`When developing locally, you should use a local Postgres connection string to emulate Hyperdrive functionality. Please setup Postgres locally and set the value of the 'WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_${hyperdrive.binding}' variable or "${hyperdrive.binding}"'s "localConnectionString" to the Postgres connection string.`
 				);
 			}
 
 			// If there is a non-empty connection string specified in the environment,
-			// use that as our local connection stirng configuration.
-			if (
-				connectionStringFromEnv !== undefined &&
-				connectionStringFromEnv !== ""
-			) {
+			// use that as our local connection string configuration.
+			if (connectionStringFromEnv) {
 				logger.log(
 					`Found a non-empty WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING variable for binding. Hyperdrive will connect to this database during local development.`
 				);


### PR DESCRIPTION
* test: ensure that standard pricing warning is removed from normalized output in e2e tests
This normalization relied upon the ACCOUNT ID being a specific value, which is not always valid.

* fix: ensure that Hyperdrive in local dev can use the localConnectionString
Previously if there was no appropriate env var, then Wrangler would exit with an error.
This is checked by the Wrangler e2e tests, which were failing previously - so no need to add additional tests.
Broken in: https://github.com/cloudflare/workers-sdk/pull/4900


**Author has addressed the following:**

- Tests
  - [x] Included - it is fixing broken tests
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: it is a test change and the fix to Hyperdrive has not yet been released
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: no user facing change
