### PR TITLE
Add warning for explicit usage model after bundled/unbound deprecation

### DIFF
--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -26,6 +26,17 @@ async function standardPricingWarning(
 	accountId: string | undefined,
 	config: Config
 ) {
+	if (Date.now() >= Date.UTC(2024, 2, 1, 14)) {
+		if (config.usage_model !== undefined) {
+			logger.warn(
+				"The `usage_model` defined in wrangler.toml is deprecated and no longer used. Visit our developer docs for details: https://developers.cloudflare.com/workers/wrangler/configuration/#usage-model"
+			);
+		}
+
+		// TODO: After March 1st 2024 remove the code below
+		return;
+	}
+
 	try {
 		const { standard, reason } = await fetchResult<{
 			standard: boolean;

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -19,6 +19,17 @@ async function standardPricingWarning(
 	accountId: string | undefined,
 	config: Config
 ) {
+	if (Date.now() >= Date.UTC(2024, 2, 1, 14)) {
+		if (config.usage_model !== undefined) {
+			logger.warn(
+				"The `usage_model` defined in wrangler.toml is deprecated and no longer used. Visit our developer docs for details: https://developers.cloudflare.com/workers/wrangler/configuration/#usage-model"
+			);
+		}
+
+		// TODO: After March 1st 2024 remove the code below
+		return;
+	}
+
 	try {
 		const { standard, reason } = await fetchResult<{
 			standard: boolean;


### PR DESCRIPTION
Fixes WP-785

Adds a warning when deploying a Worker with an explicit usage model defined in your `wrangler.toml` as after March 1st all customers will only be able to configure usage model within the dashboard as part of the deprecation of bundled and unbound.

Testing can be done by building Wrangler, setting your system time to be after March 1st, and ensuring you see the warning when deploying a Worker.

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: Small change not necessary for patch notes
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: No relevant public-facing documentation