### PR TITLE
Improve `getPlatformProxy`'s (no-op) caches

### DIFF
--- a/.changeset/cuddly-icons-itch.md
+++ b/.changeset/cuddly-icons-itch.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+fix: make sure `getPlatformProxy` produces a production-like `caches` object
+
+make sure that the `caches` object returned to `getPlatformProxy` behaves
+in the same manner as the one present in production (where calling unsupported
+methods throws a helpful error message)
+
+note: make sure that the unsupported methods are however not included in the
+`CacheStorage` type definition

--- a/.changeset/rich-needles-dress.md
+++ b/.changeset/rich-needles-dress.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+fix: relax the `getPlatformProxy`'s' cache request/response types
+
+prior to these changes the caches obtained from `getPlatformProxy`
+would use `unknown`s as their types, this proved too restrictive
+and incompatible with the equivalent `@cloudflare/workers-types`
+types, we decided to use `any`s instead to allow for more flexibility
+whilst also making the type compatible with workers-types

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.caches.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.caches.test.ts
@@ -17,6 +17,44 @@ describe("getPlatformProxy - caches", () => {
 			}
 		})
 	);
+
+	it("should match the production runtime caches object", async () => {
+		const { caches: platformProxyCaches, dispose } = await getPlatformProxy();
+		const caches = platformProxyCaches as any;
+		try {
+			expect(Object.keys(caches)).toEqual(["default"]);
+
+			expect(() => {
+				caches.has("my-cache");
+			}).toThrowError(
+				"Failed to execute 'has' on 'CacheStorage': the method is not implemented."
+			);
+
+			expect(() => {
+				caches.delete("my-cache");
+			}).toThrowError(
+				"Failed to execute 'delete' on 'CacheStorage': the method is not implemented."
+			);
+
+			expect(() => {
+				caches.keys();
+			}).toThrowError(
+				"Failed to execute 'keys' on 'CacheStorage': the method is not implemented."
+			);
+
+			expect(() => {
+				caches.match(new URL("https://localhost"));
+			}).toThrowError(
+				"Failed to execute 'match' on 'CacheStorage': the method is not implemented."
+			);
+
+			expect(() => {
+				caches.nonExistentMethod();
+			}).toThrowError("caches.nonExistentMethod is not a function");
+		} finally {
+			await dispose();
+		}
+	});
 });
 
 async function testNoOpCache(

--- a/packages/wrangler/src/api/integrations/platform/caches.ts
+++ b/packages/wrangler/src/api/integrations/platform/caches.ts
@@ -24,6 +24,24 @@
  * No-op implementation of CacheStorage
  */
 export class CacheStorage {
+	constructor() {
+		const unsupportedMethods = ["has", "delete", "keys", "match"];
+		unsupportedMethods.forEach((method) => {
+			Object.defineProperty(this, method, {
+				enumerable: false,
+				value: () => {
+					throw new Error(
+						`Failed to execute '${method}' on 'CacheStorage': the method is not implemented.`
+					);
+				},
+			});
+		});
+		Object.defineProperty(this, "default", {
+			enumerable: true,
+			value: this.default,
+		});
+	}
+
 	async open(cacheName: string): Promise<Cache> {
 		return new Cache();
 	}

--- a/packages/wrangler/src/api/integrations/platform/caches.ts
+++ b/packages/wrangler/src/api/integrations/platform/caches.ts
@@ -51,8 +51,14 @@ export class CacheStorage {
 	}
 }
 
-type CacheRequest = unknown;
-type CacheResponse = unknown;
+/* eslint-disable @typescript-eslint/no-explicit-any --
+   In order to make the API convenient to use in and Node.js programs we try not to
+   restrict the types that's why we're using `any`s as the request/response types
+   (making this API flexible and compatible with the cache types in `@cloudflare/workers-types`)
+*/
+type CacheRequest = any;
+type CacheResponse = any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 /**
  * No-op implementation of Cache


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR does two things:
 - Updates the `caches` object returned from `getPlatformProxy` so that they are more aligned to the actual workerd versions

 - Updates the request/response types used by the cache objects to be `any`s, this is to solve a shortcoming we recently noticed in which we saw that by using `unknown`s we make the `CacheStorage` type from `getPlatformProxy` incompatible with the type of the same name from `@cloudflare/workers-types` (forcing users to use ugly castings in order to make this more usable)
   ![example](https://github.com/cloudflare/workers-sdk/assets/61631103/fa63d64e-7937-4948-bd6f-7e7081c9e475)


**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because:
      - the added methods are not to be documented (since they are a quality of life improvement but not something that we need to document/clarify to users) 
      - the `getPlatformProxy` result types aren't currently documented (https://developers.cloudflare.com/workers/wrangler/api/#return-type-1) 

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
