### PR TITLE
chore: add `turbo.json` to `kv-asset-handler`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
 	"author": "wrangler@cloudflare.com",
 	"scripts": {
 		"build": "dotenv -- turbo build",
-		"check": "dotenv -- turbo check:lint check:type check:format type:tests",
+		"check": "node ensure-turbo-build-output.mjs && dotenv -- turbo check:lint check:type check:format type:tests",
 		"check:format": "prettier . --check --ignore-unknown",
-		"check:lint": "node ensure-turbo-build-output.mjs && dotenv -- turbo check:lint",
+		"check:lint": "dotenv -- turbo check:lint",
 		"check:type": "dotenv -- turbo check:type type:tests",
 		"dev": "dotenv -- turbo dev",
 		"fix": "pnpm run prettify && dotenv -- turbo check:lint -- --fix",

--- a/packages/kv-asset-handler/turbo.json
+++ b/packages/kv-asset-handler/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://turbo.build/schema.json",
+	"extends": ["//"],
+	"pipeline": {
+		"build": {
+			"outputs": ["dist/**"]
+		}
+	}
+}


### PR DESCRIPTION
**What this PR solves / how to test:**

The `@cloudflare/kv-asset-handler` package was missing a `turbo.json`. This file is required to ensure Turborepo caches the correct stuff, and correctly invalidates caches when needed. We have a linting script to prevent missing `turbo.json` files, but it looks like it wasn't running. I think this is because our `Checks` job runs `pnpm run check`, which calls `turbo check:lint`, but this then doesn't run the root `check:lint` script. I've moved this lint to the `check` script. 👍 

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: changing internal build configuration
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: changing internal build configuration
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: changing internal build configuration

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
