### PR TITLE
fix: wait for actual port before opening browser with `--port=0`

### DIFF
--- a/.changeset/khaki-wasps-glow.md
+++ b/.changeset/khaki-wasps-glow.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: wait for actual port before opening browser with `--port=0`
+
+Previously, running `wrangler dev --remote --port=0` and then immediately pressing `b` would open `localhost:0` in your default browser. This change queues up opening the browser until Wrangler knows the port the dev server was started on.

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -200,10 +200,14 @@ let port: number;
 
 // When starting on `port: 0`, we won't know the port to use until `workerd` has started. If the user tries to open the
 // browser before we know this, they'll open `localhost:0` which is incorrect.
+let portUsable = false;
 let portUsablePromiseResolve: () => void;
 const portUsablePromise = new Promise<void>(
 	(resolve) => (portUsablePromiseResolve = resolve)
 );
+// If the user has pressed `b`, but the port isn't ready yet, prevent any further presses of `b` opening a browser,
+// until the port is ready.
+let blockBrowserOpen = false;
 
 function InteractiveDevSession(props: DevProps) {
 	const toggles = useHotkeys({
@@ -224,6 +228,7 @@ function InteractiveDevSession(props: DevProps) {
 	useTunnel(toggles.tunnel);
 
 	const onReady = (newIp: string, newPort: number, proxyData: ProxyData) => {
+		portUsable = true;
 		portUsablePromiseResolve();
 		ip = newIp;
 		port = newPort;
@@ -658,7 +663,13 @@ function useHotkeys(props: {
 					break;
 				// open browser
 				case "b": {
-					if (port === 0) await portUsablePromise;
+					if (port === 0) {
+						if (!portUsable) logger.info("Waiting for port...");
+						if (blockBrowserOpen) return;
+						blockBrowserOpen = true;
+						await portUsablePromise;
+						blockBrowserOpen = false;
+					}
 					if (ip === "0.0.0.0" || ip === "*") {
 						await openInBrowser(`${localProtocol}://127.0.0.1:${port}`);
 						return;


### PR DESCRIPTION
Fixes part of #3907.

**What this PR solves / how to test:**

When running `wrangler dev --port=0`, Wrangler doesn't know the port the dev server started up on until the `onReady` callback is called. In `--remote` mode, this can take a while meaning there's a significant period of time where pressing <kbd>b</kbd> opens `localhost:0`. This change ensures we wait until the first `onReady` call before opening the browser with the correct port.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: should ideally have some, but the hotkeys are only testable when stdin is a TTY, meaning we'd need to write these in `interactive-dev-tests`. But the behaviour is only observable when using `--remote` mode which requires Cloudflare account credentials. We could write a unit test for this, but again this is tricky because `useHotkeys()` relies on the `useInput()` hook from Ink, which we'd need to mock. This behaviour also relies on module-level variables. 😬 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing a regression

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
