### PR TITLE
fix: fixup E2E test snapshots now that user errors don't prompt GitHub

### DIFF
--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -79,8 +79,7 @@ describe("r2", () => {
 			}
     `;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"Downloading "testr2" from "wrangler-smoke-test-bucket".
-			If you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose"
+			"Downloading "testr2" from "wrangler-smoke-test-bucket"."
 		`);
 		expect(normalize(stderr)).toMatchInlineSnapshot(`
 			"X [ERROR] The specified key does not exist.
@@ -108,8 +107,7 @@ describe("r2", () => {
 			}
 		`;
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"Creating object "testr2" in bucket "wrangler-smoke-test-bucket".
-			If you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose"
+			"Creating object "testr2" in bucket "wrangler-smoke-test-bucket"."
 		`);
 		expect(normalize(stderr)).toMatchInlineSnapshot(`
 			"X [ERROR] The specified bucket does not exist.


### PR DESCRIPTION
**What this PR solves / how to test:**

Follow up to #5030, we missed a couple of snapshots in the E2E tests. 🙃 

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: fixing tests
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: fixing tests

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
