### PR TITLE
perf(worker-rust): Add `dev` env for faster local build times

### DIFF
--- a/templates/experimental/worker-rust/Cargo.toml
+++ b/templates/experimental/worker-rust/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 worker = "0.0.17"
 
 [profile.release]
+opt-level = "s" # optimize for size in release builds
 lto = true
 strip = true
 codegen-units = 1

--- a/templates/experimental/worker-rust/package.json
+++ b/templates/experimental/worker-rust/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev"
+		"dev": "wrangler dev --env dev"
 	},
 	"devDependencies": {
 		"wrangler": "^3.1.2"

--- a/templates/experimental/worker-rust/package.json
+++ b/templates/experimental/worker-rust/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev --local"
+		"dev": "wrangler dev"
 	},
 	"devDependencies": {
 		"wrangler": "^3.1.2"

--- a/templates/experimental/worker-rust/wrangler.toml
+++ b/templates/experimental/worker-rust/wrangler.toml
@@ -4,3 +4,6 @@ compatibility_date = "2023-06-28"
 
 [build]
 command = "cargo install -q worker-build && worker-build --release"
+
+[env.dev]
+build = { command = "cargo install -q worker-build && worker-build --dev" }


### PR DESCRIPTION
**What this PR solves / how to test:**

Add a `dev`-environment to `wrangler.toml` which builds with `worker-build --dev` instead of `worker-build --release`.
This makes build times for local development much faster.

Add `opt-level = "s"` to `Cargo.toml` so release builds are optimized for size.

Remove the deprecated `--local` parameter from the `wrangler` invocation.

**Author has addressed the following:**

Not sure which of these I should do (and how).

- Tests
  - [ ] Included
  - [x] Not necessary because: basic configuration change in a template
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: we don't have changesets for templates??
- Associated docs
  - [ ] Issue(s)/PR(s): **do we need to update some docs??**
  - [ ] Not necessary because:
