### PR TITLE
[miniflare] chore: add missing `miniflare` changeset for `workerd` bump

### DIFF
--- a/.changeset/big-actors-cheat.md
+++ b/.changeset/big-actors-cheat.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+chore: bump `workerd` to [`1.20240208.0`](https://github.com/cloudflare/workerd/releases/tag/v1.20240208.0)


### PR DESCRIPTION
**What this PR solves / how to test:**

The [`Version Packages`](https://github.com/cloudflare/workers-sdk/pull/5061) PR is currently a little broken. We think this is because the `miniflare` packages has changes without a corresponding changeset. This PR adds the missing changeset, which we should've included anyways.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: adding a changeset
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: adding a changeset

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
