### PR TITLE
Deprecate `version` command

### DIFF
--- a/.changeset/twelve-penguins-guess.md
+++ b/.changeset/twelve-penguins-guess.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+chore: deprecate `wrangler version` command
+
+`wrangler version` is an undocumented alias for `wrangler --version`. It is being deprecated in favour of the more conventional flag syntax to avoid confusion with a new (upcoming) `wrangler versions` command.

--- a/packages/wrangler/src/__tests__/version.test.ts
+++ b/packages/wrangler/src/__tests__/version.test.ts
@@ -18,7 +18,7 @@ describe("version", () => {
 	// `);
 	// });
 
-	it("should output current version if !isTTY calling -v", async () => {
+	it("should output current version if !isTTY calling with `-v` flag", async () => {
 		setIsTTY(false);
 
 		await runWrangler("-v");
@@ -26,10 +26,22 @@ describe("version", () => {
 	});
 
 	// This run separately as command handling is different
-	it("should output current version if !isTTY calling --version", async () => {
+	it("should output current version if !isTTY calling with `--version` flag", async () => {
 		setIsTTY(false);
 
 		await runWrangler("--version");
 		expect(std.out).toMatch(version);
+	});
+
+	it("should output current version if !isTTY calling (deprecated) `version` command", async () => {
+		setIsTTY(false);
+
+		await runWrangler("version");
+		expect(std.out).toMatch(version);
+		expect(std.warn).toMatchInlineSnapshot(`
+		"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`wrangler version\` is deprecated and will be removed in a future major version. Please use \`wrangler --version\` instead.[0m
+
+		"
+	`);
 	});
 });

--- a/packages/wrangler/src/__tests__/version.test.ts
+++ b/packages/wrangler/src/__tests__/version.test.ts
@@ -23,6 +23,7 @@ describe("version", () => {
 
 		await runWrangler("-v");
 		expect(std.out).toMatch(version);
+		expect(std.warn).toBe("");
 	});
 
 	// This run separately as command handling is different
@@ -31,6 +32,7 @@ describe("version", () => {
 
 		await runWrangler("--version");
 		expect(std.out).toMatch(version);
+		expect(std.warn).toBe("");
 	});
 
 	it("should output current version if !isTTY calling (deprecated) `version` command", async () => {

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -703,7 +703,7 @@ export function createCLIParser(argv: string[]) {
 	// This set to false to allow overwrite of default behaviour
 	wrangler.version(false);
 
-	// version
+	// version (DEPRECATED)
 	wrangler.command(
 		"version",
 		false,
@@ -714,6 +714,10 @@ export function createCLIParser(argv: string[]) {
 			} else {
 				logger.log(wranglerVersion);
 			}
+
+			logger.warn(
+				"`wrangler version` is deprecated and will be removed in a future major version. Please use `wrangler --version` instead."
+			);
 		}
 	);
 


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR deprecated the `wrangler version` command. It does the same thing as `wrangler --version` which can be used instead. Deprecating because it could cause confusion with the upcoming `wrangler versions ...` commands.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: this command was never documented.

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
