### PR TITLE
WAFFLE-538 Add Miniflare support/tests for Ratelimits emulation

### DIFF
--- a/packages/miniflare/src/plugins/index.ts
+++ b/packages/miniflare/src/plugins/index.ts
@@ -8,6 +8,7 @@ import { HYPERDRIVE_PLUGIN, HYPERDRIVE_PLUGIN_NAME } from "./hyperdrive";
 import { KV_PLUGIN, KV_PLUGIN_NAME } from "./kv";
 import { QUEUES_PLUGIN, QUEUES_PLUGIN_NAME } from "./queues";
 import { R2_PLUGIN, R2_PLUGIN_NAME } from "./r2";
+import { RATELIMIT_PLUGIN, RATELIMIT_PLUGIN_NAME } from "./ratelimit";
 
 export const PLUGINS = {
 	[CORE_PLUGIN_NAME]: CORE_PLUGIN,
@@ -18,6 +19,7 @@ export const PLUGINS = {
 	[QUEUES_PLUGIN_NAME]: QUEUES_PLUGIN,
 	[R2_PLUGIN_NAME]: R2_PLUGIN,
 	[HYPERDRIVE_PLUGIN_NAME]: HYPERDRIVE_PLUGIN,
+	[RATELIMIT_PLUGIN_NAME]: RATELIMIT_PLUGIN,
 };
 export type Plugins = typeof PLUGINS;
 
@@ -63,7 +65,8 @@ export type WorkerOptions = z.input<typeof CORE_PLUGIN.options> &
 	z.input<typeof KV_PLUGIN.options> &
 	z.input<typeof QUEUES_PLUGIN.options> &
 	z.input<typeof R2_PLUGIN.options> &
-	z.input<typeof HYPERDRIVE_PLUGIN.options>;
+	z.input<typeof HYPERDRIVE_PLUGIN.options> &
+	z.input<typeof RATELIMIT_PLUGIN.options>;
 export type SharedOptions = z.input<typeof CORE_PLUGIN.sharedOptions> &
 	z.input<typeof CACHE_PLUGIN.sharedOptions> &
 	z.input<typeof D1_PLUGIN.sharedOptions> &
@@ -110,3 +113,4 @@ export * from "./kv";
 export * from "./queues";
 export * from "./r2";
 export * from "./hyperdrive";
+export * from "./ratelimit";

--- a/packages/miniflare/src/plugins/ratelimit/index.ts
+++ b/packages/miniflare/src/plugins/ratelimit/index.ts
@@ -1,0 +1,82 @@
+import SCRIPT_RATELIMIT_OBJECT from "worker:ratelimit/ratelimit";
+import { z } from "zod";
+import {
+	Worker_Binding,
+} from "../../runtime";
+import {
+	Plugin,
+	kProxyNodeBinding,
+} from "../shared";
+
+export enum PeriodType {
+	TENSECONDS = 10,
+	MINUTE = 60
+}
+
+export const RatelimitConfigSchema = z.object({
+	simple: z.object({
+		limit: z.number().gt(0),
+		
+		// may relax this to be any number in the future
+		period: z.nativeEnum(PeriodType).optional(),
+	})
+});
+export const RatelimitOptionsSchema = z.object({
+	ratelimits: z.record(RatelimitConfigSchema).optional(),
+});
+
+export const RATELIMIT_PLUGIN_NAME = "ratelimit";
+const SERVICE_RATELIMIT_PREFIX = `${RATELIMIT_PLUGIN_NAME}`;
+const SERVICE_RATELIMIT_MODULE = `cloudflare-internal:${SERVICE_RATELIMIT_PREFIX}:module`;
+
+function buildJsonBindings(bindings: Record<string, any>): Worker_Binding[] {
+	return Object.entries(bindings).map(([name, value]) => ({
+		name,
+		json: JSON.stringify(value),
+	}));
+}
+
+export const RATELIMIT_PLUGIN: Plugin<typeof RatelimitOptionsSchema> = {
+	options: RatelimitOptionsSchema,
+	getBindings(options: z.infer<typeof RatelimitOptionsSchema>) {
+		if (!options.ratelimits) {
+			return [];
+		}
+		const bindings = Object.entries(options.ratelimits).map<Worker_Binding>(([name, config]) => ({
+			name,
+			wrapped: {
+				moduleName: SERVICE_RATELIMIT_MODULE,
+				innerBindings: buildJsonBindings({
+					namespaceId: name,
+					limit: config.simple.limit,
+					period: config.simple.period,
+				})
+			},
+		}));
+		return bindings;
+	},
+	getNodeBindings(options: z.infer<typeof RatelimitOptionsSchema>) {
+		if (!options.ratelimits) {
+			return {};
+		}
+		return Object.fromEntries(Object.keys(options.ratelimits).map((name) => [name, kProxyNodeBinding]));
+	},
+	async getServices({
+		options,
+	}) {
+		if (!options.ratelimits) {
+			return [];
+		}
+		
+		return {
+			services: [],
+			extensions: [{
+				modules: [{
+					name: SERVICE_RATELIMIT_MODULE,
+					esModule: SCRIPT_RATELIMIT_OBJECT(),
+					internal: true,
+				}],
+			}],
+		}
+	},
+};

--- a/packages/miniflare/src/workers/ratelimit/ratelimit.worker.ts
+++ b/packages/miniflare/src/workers/ratelimit/ratelimit.worker.ts
@@ -1,0 +1,87 @@
+// Emulated Ratelimit Binding
+
+// ENV configuration
+interface RatelimitConfig {
+  namespaceId: number
+  limit: number
+  period: number
+}
+
+// options for Ratelimit
+//   (should be kept in sync with https://bitbucket.cfdata.org/projects/EW/repos/edgeworker/browse/src/edgeworker/internal-api/ratelimit.capnp)
+interface RatelimitOptions {
+  key?: string
+  limit?: number
+  period?: number
+}
+const RatelimitOptionKeys = ['key', 'limit', 'period']
+const RatelimitPeriodValues = [ 10, 60 ]
+
+// result from Ratelimit call
+//   (should be kept in sync with https://bitbucket.cfdata.org/projects/EW/repos/edgeworker/browse/src/edgeworker/internal-api/ratelimit.capnp)
+interface RatelimitResult {
+  success: boolean
+}
+
+function validate(test: boolean, message: string) {
+    if (!test) {
+        console.log(message)
+        throw new Error(message)
+    }
+}
+
+class Ratelimit {
+  namespaceId: number
+  limitVal: number
+  period: number
+  buckets: Map<string, number>
+  epoch: number
+
+  constructor(config: RatelimitConfig) {
+    this.namespaceId = config.namespaceId
+    this.limitVal = config.limit
+    this.period = config.period
+
+    this.buckets = new Map<string,number>()
+    this.epoch = 0
+  }
+
+  // method that counts and checks against the limit in in-memory buckets
+  async limit(options: unknown): Promise<RatelimitResult> {
+    // validate options input
+    validate(typeof(options)=='object', 'invalid rate limit options')
+    const invalidProps = Object.keys(options || {}).filter((key) => !RatelimitOptionKeys.includes(key))
+    validate(invalidProps.length==0, `Bad rate limit options: [${invalidProps.join(',')}]`)
+    // eslint-disable-next-line prefer-const
+    let { key, limit, period } = options as RatelimitOptions;
+    validate(!key || typeof(key) == 'string', `invalid key: ${key}`)
+    validate(!limit || typeof(limit) == 'number', `limit must be a number: ${limit}`)
+    validate(!period || typeof(period) == 'number', `period must be a number: ${period}`)
+    validate(!period || RatelimitPeriodValues.includes(period), `unsupported period: ${period}`)
+
+    key = key || ""
+    period = period || this.period
+    limit = limit || this.limitVal
+    const epoch = Math.floor(Date.now()/(period*1000))
+    if (epoch != this.epoch) {
+      // clear counters
+      this.epoch = epoch
+      this.buckets.clear()
+    }
+    const val = this.buckets.get(key) || 0
+    if (val>=limit) {
+      return {
+        success: false
+      }
+    }
+    this.buckets.set(key, val+1)
+    return {
+      success: true
+    }
+  }
+}
+
+// create a new Ratelimit
+export default function(env: RatelimitConfig) {
+  return new Ratelimit(env)
+}

--- a/packages/miniflare/src/workers/ratelimit/ratelimit.worker.ts
+++ b/packages/miniflare/src/workers/ratelimit/ratelimit.worker.ts
@@ -2,86 +2,100 @@
 
 // ENV configuration
 interface RatelimitConfig {
-  namespaceId: number
-  limit: number
-  period: number
+	namespaceId: number;
+	limit: number;
+	period: number;
 }
 
 // options for Ratelimit
 //   (should be kept in sync with https://bitbucket.cfdata.org/projects/EW/repos/edgeworker/browse/src/edgeworker/internal-api/ratelimit.capnp)
 interface RatelimitOptions {
-  key?: string
-  limit?: number
-  period?: number
+	key?: string;
+	limit?: number;
+	period?: number;
 }
-const RatelimitOptionKeys = ['key', 'limit', 'period']
-const RatelimitPeriodValues = [ 10, 60 ]
+const RatelimitOptionKeys = ["key", "limit", "period"];
+const RatelimitPeriodValues = [10, 60];
 
 // result from Ratelimit call
 //   (should be kept in sync with https://bitbucket.cfdata.org/projects/EW/repos/edgeworker/browse/src/edgeworker/internal-api/ratelimit.capnp)
 interface RatelimitResult {
-  success: boolean
+	success: boolean;
 }
 
 function validate(test: boolean, message: string) {
-    if (!test) {
-        console.log(message)
-        throw new Error(message)
-    }
+	if (!test) {
+		console.log(message);
+		throw new Error(message);
+	}
 }
 
 class Ratelimit {
-  namespaceId: number
-  limitVal: number
-  period: number
-  buckets: Map<string, number>
-  epoch: number
+	namespaceId: number;
+	limitVal: number;
+	period: number;
+	buckets: Map<string, number>;
+	epoch: number;
 
-  constructor(config: RatelimitConfig) {
-    this.namespaceId = config.namespaceId
-    this.limitVal = config.limit
-    this.period = config.period
+	constructor(config: RatelimitConfig) {
+		this.namespaceId = config.namespaceId;
+		this.limitVal = config.limit;
+		this.period = config.period;
 
-    this.buckets = new Map<string,number>()
-    this.epoch = 0
-  }
+		this.buckets = new Map<string, number>();
+		this.epoch = 0;
+	}
 
-  // method that counts and checks against the limit in in-memory buckets
-  async limit(options: unknown): Promise<RatelimitResult> {
-    // validate options input
-    validate(typeof(options)=='object', 'invalid rate limit options')
-    const invalidProps = Object.keys(options || {}).filter((key) => !RatelimitOptionKeys.includes(key))
-    validate(invalidProps.length==0, `Bad rate limit options: [${invalidProps.join(',')}]`)
-    // eslint-disable-next-line prefer-const
-    let { key, limit, period } = options as RatelimitOptions;
-    validate(!key || typeof(key) == 'string', `invalid key: ${key}`)
-    validate(!limit || typeof(limit) == 'number', `limit must be a number: ${limit}`)
-    validate(!period || typeof(period) == 'number', `period must be a number: ${period}`)
-    validate(!period || RatelimitPeriodValues.includes(period), `unsupported period: ${period}`)
+	// method that counts and checks against the limit in in-memory buckets
+	async limit(options: unknown): Promise<RatelimitResult> {
+		// validate options input
+		validate(typeof options == "object", "invalid rate limit options");
+		const invalidProps = Object.keys(options || {}).filter(
+			(key) => !RatelimitOptionKeys.includes(key)
+		);
+		validate(
+			invalidProps.length == 0,
+			`Bad rate limit options: [${invalidProps.join(",")}]`
+		);
+		// eslint-disable-next-line prefer-const
+		let { key, limit, period } = options as RatelimitOptions;
+		validate(!key || typeof key == "string", `invalid key: ${key}`);
+		validate(
+			!limit || typeof limit == "number",
+			`limit must be a number: ${limit}`
+		);
+		validate(
+			!period || typeof period == "number",
+			`period must be a number: ${period}`
+		);
+		validate(
+			!period || RatelimitPeriodValues.includes(period),
+			`unsupported period: ${period}`
+		);
 
-    key = key || ""
-    period = period || this.period
-    limit = limit || this.limitVal
-    const epoch = Math.floor(Date.now()/(period*1000))
-    if (epoch != this.epoch) {
-      // clear counters
-      this.epoch = epoch
-      this.buckets.clear()
-    }
-    const val = this.buckets.get(key) || 0
-    if (val>=limit) {
-      return {
-        success: false
-      }
-    }
-    this.buckets.set(key, val+1)
-    return {
-      success: true
-    }
-  }
+		key = key || "";
+		period = period || this.period;
+		limit = limit || this.limitVal;
+		const epoch = Math.floor(Date.now() / (period * 1000));
+		if (epoch != this.epoch) {
+			// clear counters
+			this.epoch = epoch;
+			this.buckets.clear();
+		}
+		const val = this.buckets.get(key) || 0;
+		if (val >= limit) {
+			return {
+				success: false,
+			};
+		}
+		this.buckets.set(key, val + 1);
+		return {
+			success: true,
+		};
+	}
 }
 
 // create a new Ratelimit
-export default function(env: RatelimitConfig) {
-  return new Ratelimit(env)
+export default function (env: RatelimitConfig) {
+	return new Ratelimit(env);
 }

--- a/packages/miniflare/test/plugins/ratelimit/index.spec.ts
+++ b/packages/miniflare/test/plugins/ratelimit/index.spec.ts
@@ -1,22 +1,19 @@
 import test from "ava";
-import {
-	Miniflare,
-} from "miniflare";
-import { z } from "zod";
+import { Miniflare } from "miniflare";
 
 test("ratelimit", async (t) => {
 	const mf = new Miniflare({
 		verbose: true,
-		
+
 		ratelimits: {
 			TESTRATE: {
 				simple: {
 					limit: 2,
 					period: 60,
-				}
-			}
+				},
+			},
 		},
-		
+
 		modules: true,
 		script: `
 		export default {
@@ -33,14 +30,14 @@ test("ratelimit", async (t) => {
 		`,
 	});
 	t.teardown(() => mf.dispose());
-	
+
 	let res = await mf.dispatchFetch("http://localhost");
 	t.is(res.status, 200);
 	t.is(await res.text(), "success");
 	res = await mf.dispatchFetch("http://localhost");
 	t.is(res.status, 200);
 	t.is(await res.text(), "success");
-	
+
 	res = await mf.dispatchFetch("http://localhost");
 	t.is(res.status, 429);
 	t.is(await res.text(), "rate limited");
@@ -49,57 +46,63 @@ test("ratelimit", async (t) => {
 test("ratelimit validation", async (t) => {
 	const mf = new Miniflare({
 		verbose: true,
-		
+
 		ratelimits: {
 			TESTRATE: {
 				simple: {
 					limit: 2,
 					period: 60,
-				}
-			}
+				},
+			},
 		},
-		
+
 		modules: true,
 		script: `
 		export default {
 			async fetch(request, env, ctx) {
-                const options = await request.json()
-                try {
-                    const { success } = await env.TESTRATE.limit(options);
-                } catch (e) {
-                    return new Response(e, {status: 200})
-                }
+				const options = await request.json()
+				try {
+					const { success } = await env.TESTRATE.limit(options);
+				} catch (e) {
+					return new Response(e, {status: 200})
+				}
 				return new Response("should have resulted in error", { status: 500 });
 			},
 		}
 		`,
 	});
 	t.teardown(() => mf.dispose());
-	
-    const TESTS = [{
-        options: 'invalid',
-        error: 'Error: invalid rate limit options',
-    },{
-        options: {invalid:'foo'},
-        error: 'Error: Bad rate limit options: [invalid]',
-    },{
-        options: {limit:'bad'},
-        error: 'Error: limit must be a number: bad',
-    },{
-        options: {period:'bad'},
-        error: 'Error: period must be a number: bad',
-    },{
-        options: {period:1},
-        error: 'Error: unsupported period: 1',
-    }]
-    
-    for (const {options, error} of TESTS) {
-        const body = JSON.stringify(options);
-        const res = await mf.dispatchFetch("http://localhost", {
-            method: 'POST',
-            body,
-        })
-        t.is(res.status, 200, `Bad status for [${body}]`);
-        t.is(await res.text(), error, `Mismatched error for [${body}]`);
-    }
+
+	const TESTS = [
+		{
+			options: "invalid",
+			error: "Error: invalid rate limit options",
+		},
+		{
+			options: { invalid: "foo" },
+			error: "Error: Bad rate limit options: [invalid]",
+		},
+		{
+			options: { limit: "bad" },
+			error: "Error: limit must be a number: bad",
+		},
+		{
+			options: { period: "bad" },
+			error: "Error: period must be a number: bad",
+		},
+		{
+			options: { period: 1 },
+			error: "Error: unsupported period: 1",
+		},
+	];
+
+	for (const { options, error } of TESTS) {
+		const body = JSON.stringify(options);
+		const res = await mf.dispatchFetch("http://localhost", {
+			method: "POST",
+			body,
+		});
+		t.is(res.status, 200, `Bad status for [${body}]`);
+		t.is(await res.text(), error, `Mismatched error for [${body}]`);
+	}
 });

--- a/packages/miniflare/test/plugins/ratelimit/index.spec.ts
+++ b/packages/miniflare/test/plugins/ratelimit/index.spec.ts
@@ -1,0 +1,105 @@
+import test from "ava";
+import {
+	Miniflare,
+} from "miniflare";
+import { z } from "zod";
+
+test("ratelimit", async (t) => {
+	const mf = new Miniflare({
+		verbose: true,
+		
+		ratelimits: {
+			TESTRATE: {
+				simple: {
+					limit: 2,
+					period: 60,
+				}
+			}
+		},
+		
+		modules: true,
+		script: `
+		export default {
+			async fetch(request, env, ctx) {
+				const { success } = await env.TESTRATE.limit({
+					key: "test",
+				});
+				if (!success) {
+					return new Response("rate limited", { status: 429 });
+				}
+				return new Response("success", { status: 200 });
+			},
+		}
+		`,
+	});
+	t.teardown(() => mf.dispose());
+	
+	let res = await mf.dispatchFetch("http://localhost");
+	t.is(res.status, 200);
+	t.is(await res.text(), "success");
+	res = await mf.dispatchFetch("http://localhost");
+	t.is(res.status, 200);
+	t.is(await res.text(), "success");
+	
+	res = await mf.dispatchFetch("http://localhost");
+	t.is(res.status, 429);
+	t.is(await res.text(), "rate limited");
+});
+
+test("ratelimit validation", async (t) => {
+	const mf = new Miniflare({
+		verbose: true,
+		
+		ratelimits: {
+			TESTRATE: {
+				simple: {
+					limit: 2,
+					period: 60,
+				}
+			}
+		},
+		
+		modules: true,
+		script: `
+		export default {
+			async fetch(request, env, ctx) {
+                const options = await request.json()
+                try {
+                    const { success } = await env.TESTRATE.limit(options);
+                } catch (e) {
+                    return new Response(e, {status: 200})
+                }
+				return new Response("should have resulted in error", { status: 500 });
+			},
+		}
+		`,
+	});
+	t.teardown(() => mf.dispose());
+	
+    const TESTS = [{
+        options: 'invalid',
+        error: 'Error: invalid rate limit options',
+    },{
+        options: {invalid:'foo'},
+        error: 'Error: Bad rate limit options: [invalid]',
+    },{
+        options: {limit:'bad'},
+        error: 'Error: limit must be a number: bad',
+    },{
+        options: {period:'bad'},
+        error: 'Error: period must be a number: bad',
+    },{
+        options: {period:1},
+        error: 'Error: unsupported period: 1',
+    }]
+    
+    for (const {options, error} of TESTS) {
+        const body = JSON.stringify(options);
+        const res = await mf.dispatchFetch("http://localhost", {
+            method: 'POST',
+            body,
+        })
+        t.is(res.status, 200, `Bad status for [${body}]`);
+        t.is(await res.text(), error, `Mismatched error for [${body}]`);
+    }
+});

--- a/packages/miniflare/test/plugins/ratelimit/index.spec.ts
+++ b/packages/miniflare/test/plugins/ratelimit/index.spec.ts
@@ -80,7 +80,7 @@ test("ratelimit validation", async (t) => {
 		},
 		{
 			options: { invalid: "foo" },
-			error: "Error: Bad rate limit options: [invalid]",
+			error: "Error: bad rate limit options: [invalid]",
 		},
 		{
 			options: { limit: "bad" },


### PR DESCRIPTION
Fixes # WAFFLE-538.

Add emulated Ratelimit bindings to Miniflare to allow internal development.


- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [ ] Not necessary because:
- Associated docs
  - [x] Issue(s)/PR(s): WAFFLE-538 (not for public consumption yet)
  - [ ] Not necessary because:

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
