### PR TITLE
widen multi-env `vars` types in `wrangler types` and add `--strict-vars` option to the command

### DIFF
--- a/.changeset/proud-forks-build.md
+++ b/.changeset/proud-forks-build.md
@@ -1,0 +1,39 @@
+---
+"wrangler": patch
+---
+
+fix: widen multi-env `vars` types in `wrangler types`
+
+Currently types for variable generate string literal, those are appropriate when
+a single environment has been specified in the config file but if multiple environments
+are specified this however wrongly restricts the typing, the changes here fix such
+incorrect behavior.
+
+For example, given a `wrangler.toml` containing the following:
+
+```
+[vars]
+MY_VAR = "dev value"
+
+[env.production]
+[env.production.vars]
+MY_VAR = "prod value"
+```
+
+running `wrangler types` would generate:
+
+```ts
+interface Env {
+	MY_VAR: "dev value";
+}
+```
+
+making typescript incorrectly assume that `MY_VAR` is always going to be `"dev value"`
+
+after these changes, the generated interface would instead be:
+
+```ts
+interface Env {
+	MY_VAR: "dev value" | "prod value";
+}
+```

--- a/.changeset/proud-forks-build.md
+++ b/.changeset/proud-forks-build.md
@@ -4,10 +4,8 @@
 
 fix: widen multi-env `vars` types in `wrangler types`
 
-Currently types for variable generate string literal, those are appropriate when
-a single environment has been specified in the config file but if multiple environments
-are specified this however wrongly restricts the typing, the changes here fix such
-incorrect behavior.
+Currently, the type generated for `vars` is a string literal consisting of the value of the variable in the top level environment. If multiple environments
+are specified this wrongly restricts the type, since the variable could contain any of the values from each of the environments.
 
 For example, given a `wrangler.toml` containing the following:
 

--- a/.changeset/proud-forks-build.md
+++ b/.changeset/proud-forks-build.md
@@ -13,7 +13,6 @@ For example, given a `wrangler.toml` containing the following:
 [vars]
 MY_VAR = "dev value"
 
-[env.production]
 [env.production.vars]
 MY_VAR = "prod value"
 ```

--- a/.changeset/unlucky-timers-sort.md
+++ b/.changeset/unlucky-timers-sort.md
@@ -1,0 +1,46 @@
+---
+"wrangler": minor
+---
+
+add `loose-vars` option to `wrangler types`
+
+add a new `--loose-vars` option to `wrangler types` that developers can use to get more
+loose types for their variables instead of literal and union types
+
+these more loose types can be useful when developers change often their `vars` values,
+even more so when multiple environments are involved
+
+## Example
+
+With a toml containing:
+
+```toml
+[vars]
+MY_VARIABLE = "production_value"
+MY_NUMBERS = [1, 2, 3]
+
+[env.staging.vars]
+MY_VARIABLE = "staging_value"
+MY_NUMBERS = [7, 8, 9]
+```
+
+the `wrangler types` command would generate the following interface:
+
+```
+interface Env {
+        MY_VARIABLE: "production_value" | "staging_value";
+        MY_NUMBERS: [1,2,3] | [7,8,9];
+}
+```
+
+while `wrangler types --loose-vars` would instead generate:
+
+```
+interface Env {
+        MY_VARIABLE: string;
+        MY_NUMBERS: number[];
+}
+```
+
+(allowing the developer to easily change their toml variables without the
+risk of braking typescript types)

--- a/.changeset/unlucky-timers-sort.md
+++ b/.changeset/unlucky-timers-sort.md
@@ -2,12 +2,12 @@
 "wrangler": minor
 ---
 
-add `loose-vars` option to `wrangler types`
+add `strict-vars` option to `wrangler types`
 
-add a new `--loose-vars` option to `wrangler types` that developers can use to get more
-loose types for their variables instead of literal and union types
+add a new `--strict-vars` option to `wrangler types` that developers can use to enable/disable
+more strict/literal types for their variables
 
-these more loose types can be useful when developers change often their `vars` values,
+opting out of strict variables can be useful when developers change often their `vars` values,
 even more so when multiple environments are involved
 
 ## Example
@@ -33,7 +33,7 @@ interface Env {
 }
 ```
 
-while `wrangler types --loose-vars` would instead generate:
+while `wrangler types --strict-vars=false` would instead generate:
 
 ```
 interface Env {

--- a/.changeset/unlucky-timers-sort.md
+++ b/.changeset/unlucky-timers-sort.md
@@ -43,4 +43,4 @@ interface Env {
 ```
 
 (allowing the developer to easily change their toml variables without the
-risk of braking typescript types)
+risk of breaking typescript types)

--- a/.changeset/unlucky-timers-sort.md
+++ b/.changeset/unlucky-timers-sort.md
@@ -2,7 +2,7 @@
 "wrangler": minor
 ---
 
-add `strict-vars` option to `wrangler types`
+add `--strict-vars` option to `wrangler types`
 
 add a new `--strict-vars` option to `wrangler types` that developers can use to enable/disable
 more strict/literal types for their variables

--- a/.changeset/unlucky-timers-sort.md
+++ b/.changeset/unlucky-timers-sort.md
@@ -4,8 +4,8 @@
 
 add `--strict-vars` option to `wrangler types`
 
-add a new `--strict-vars` option to `wrangler types` that developers can use to enable/disable
-more strict/literal types for their variables
+add a new `--strict-vars` option to `wrangler types` that developers can (by setting the
+flag to `false`) use to disable the default strict/literal types generation for their variables
 
 opting out of strict variables can be useful when developers change often their `vars` values,
 even more so when multiple environments are involved

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -602,7 +602,7 @@ describe("generateTypes()", () => {
 	`);
 	});
 
-	it("should respect the loose-vars option", async () => {
+	it("should allow opting out of strict-vars", async () => {
 		fs.writeFileSync(
 			"./wrangler.toml",
 			TOML.stringify({
@@ -616,7 +616,7 @@ describe("generateTypes()", () => {
 			"utf-8"
 		);
 
-		await runWrangler("types --loose-vars");
+		await runWrangler("types --strict-vars=false");
 
 		expect(std.out).toMatchInlineSnapshot(`
 		"Generating project types...
@@ -710,8 +710,8 @@ describe("generateTypes()", () => {
 		`);
 		});
 
-		it("should produce loose types for variables (with --loose-vars)", async () => {
-			await runWrangler("types --loose-vars=true");
+		it("should produce non-strict types for variables (with --strict-vars=false)", async () => {
+			await runWrangler("types --strict-vars=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
 			"Generating project types...

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -301,8 +301,7 @@ async function generateTypes(
 		for (const [varName, varInfo] of vars) {
 			const varValueTypes = new Set(
 				varInfo
-					.map(({ value }) => value)
-					.map((varValue) => {
+					.map(({ value: varValue }) => {
 						if (!strictVars) {
 							if (Array.isArray(varValue)) {
 								const typesInArray = [

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -635,7 +635,7 @@ function collectAllVars(
  * 		`['false', true]` returns `(string|boolean)[]`,
  *
  * @param array the target array
- * @returns the string representing the types of such array
+ * @returns a string representing the types of such array
  */
 function typeofArray(array: unknown[]): string {
 	const typesInArray = [...new Set(array.map((item) => typeof item))].sort();

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -39,11 +39,10 @@ export function typesOptions(yargs: CommonYargsArgv) {
 			describe: "The path of the generated runtime types file",
 			demandOption: false,
 		})
-		.option("loose-vars", {
+		.option("strict-vars", {
 			type: "boolean",
-			default: false,
-			describe:
-				'Generate "loose"/generic types instead of literal and union types for variables',
+			default: true,
+			describe: "Generate literal and union types for variables",
 		});
 }
 
@@ -154,7 +153,7 @@ export async function typesHandler(
 		config,
 		envInterface,
 		outputPath,
-		args.looseVars
+		args.strictVars
 	);
 }
 
@@ -253,7 +252,7 @@ async function generateTypes(
 	config: Config,
 	envInterface: string,
 	outputPath: string,
-	looseVars: boolean
+	strictVars: boolean
 ) {
 	const configContainsEntrypoint =
 		config.main !== undefined || !!config.site?.["entry-point"];
@@ -304,7 +303,7 @@ async function generateTypes(
 				varInfo
 					.map(({ value }) => value)
 					.map((varValue) => {
-						if (looseVars) {
+						if (!strictVars) {
 							if (Array.isArray(varValue)) {
 								const typesInArray = [
 									...new Set(varValue.map((item) => typeof item)),


### PR DESCRIPTION
Fixes #5082

This PR does two things:
 - one is widening the `vars` types that `wrangler types` generates when the same variables are defined in different environments (basically instead of incorrectly generate something like `MY_VAR: "dev value";` now we could correctly generate `MY_VAR: "dev value" | "prod value";` etc...)
 - two is adding a new option (currently called `--strict-vars`) that allows the generated types not to be literals/unions but to be loose/generic ones (e.g. instead of `MY_VAR: "dev value" | "prod value";` it allows the generation of `MY_VAR: string;`), this was added after various feedback and back and forth from the team (the concern being that literal values/unions can be annoying for people if they change their var values often)
 
For more details please check the changeset files in the PR 🙂

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: this is tested in unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18981
  - [ ] Documentation not necessary because:

