### PR TITLE
fix: make `wrangler types` always generate a `d.ts` file for module worders

### DIFF
--- a/.changeset/weak-tools-judge.md
+++ b/.changeset/weak-tools-judge.md
@@ -1,0 +1,23 @@
+---
+"wrangler": patch
+---
+
+fix: make `wrangler types` always generate a `d.ts` file for module workers
+
+Currently if a config file doesn't define any binding nor module, running
+`wrangler types` against such file would not produce a `d.ts` file.
+
+Producing a `d.ts` file can however still be beneficial as it would define a correct
+env interface (even if empty) that can be expanded/referenced by user code (this can
+be particularly convenient for scaffolding tools that may want to always generate an
+env interface).
+
+Example:
+Before `wrangler types --env-interface MyEnv` run with an empty `wrangler.toml` file
+would not generate any file, after these change it would instead generate a file with
+the following content:
+
+```
+interface MyEnv {
+}
+```

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -306,8 +306,8 @@ function writeDTSFile({
 	let combinedTypeStrings = "";
 	if (formatType === "modules") {
 		combinedTypeStrings += `interface ${envInterface} {${envTypeStructure
-			.map((value, i) => `${i === 0 ? "\n" : ""}\t${value}`)
-			.join("\n")}\n}\n${modulesTypeStructure.join("\n")}`;
+			.map((value) => `\n\t${value}`)
+			.join("")}\n}\n${modulesTypeStructure.join("\n")}`;
 	} else {
 		combinedTypeStrings += `export {};\ndeclare global {\n${envTypeStructure
 			.map((value) => `\tconst ${value}`)

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -305,8 +305,8 @@ function writeDTSFile({
 
 	let combinedTypeStrings = "";
 	if (formatType === "modules") {
-		combinedTypeStrings += `interface ${envInterface} {\n${envTypeStructure
-			.map((value) => `\t${value}`)
+		combinedTypeStrings += `interface ${envInterface} {${envTypeStructure
+			.map((value, i) => `${i === 0 ? "\n" : ""}\t${value}`)
 			.join("\n")}\n}\n${modulesTypeStructure.join("\n")}`;
 	} else {
 		combinedTypeStrings += `export {};\ndeclare global {\n${envTypeStructure
@@ -316,7 +316,10 @@ function writeDTSFile({
 
 	const wranglerCommandUsed = ["wrangler", ...process.argv.slice(2)].join(" ");
 
-	if (envTypeStructure.length || modulesTypeStructure.length) {
+	const typesHaveBeenFound =
+		envTypeStructure.length || modulesTypeStructure.length;
+
+	if (formatType === "modules" || typesHaveBeenFound) {
 		fs.writeFileSync(
 			path,
 			[


### PR DESCRIPTION
**What this PR solves / how to test:**

Currently if a config file doesn't define any binding nor module, running
`wrangler types` against such file would not produce a `d.ts` file.

Producing a `d.ts` file can however still be beneficial as it would define a correct
env interface (even if empty) that can be expanded/referenced by user code (this can
be particularly convenient for scaffolding tools that may want to always generate an
env interface).

Example:
Before `wrangler types --env-interface MyEnv` run with an empty `wrangler.toml` file
would not generate any file, after these change it would instead generate a file with
the following content:

```
interface MyEnv {
}
```

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: this is a quality of life improvement that doesn't require documentation

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
