### PR TITLE
Feature: `dispatch-namespace` option in `wrangler deploy`

### DIFF
--- a/.changeset/seven-spies-drive.md
+++ b/.changeset/seven-spies-drive.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feature: add --dispatch-namespace to wrangler deploy to support uploading Workers directly to a Workers for Platforms dispatch namespace.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -1190,6 +1190,19 @@ describe("normalizeAndValidateConfig()", () => {
 			            - Expected \\"name\\" to be of type string, alphanumeric and lowercase with dashes only but got \\"!@#$%^&*(()\\"."
 		        `);
 			});
+
+			it("should accept any Worker name if the dispatch-namespace flag is used", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						name: "example.com",
+						main: "index.js",
+					},
+					undefined,
+					{ env: undefined, "dispatch-namespace": "test-namespace" }
+				);
+				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasErrors()).toBe(false);
+			});
 		});
 
 		describe("[build]", () => {

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -9015,6 +9015,34 @@ export default{
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});
+
+	describe("--dispatch-namespace", () => {
+		it("should upload to dispatch namespace", async () => {
+			writeWranglerToml();
+			const scriptContent = `
+      export default {
+				fetch() {
+					return new Response("Hello, World!");
+				}
+			}
+    `;
+			fs.writeFileSync("index.js", scriptContent);
+			mockUploadWorkerRequest({
+				expectedMainModule: "index.js",
+				expectedDispatchNamespace: "test-dispatch-namespace",
+			});
+
+			await runWrangler(
+				"deploy --dispatch-namespace test-dispatch-namespace index.js"
+			);
+			expect(std.out).toMatchInlineSnapshot(`
+			"Total Upload: xx KiB / gzip: xx KiB
+			Uploaded test-name (TIMINGS)
+			  Dispatch Namespace: test-dispatch-namespace
+			Current Deployment ID: Galaxy-Class"
+		`);
+		});
+	});
 });
 
 /** Write mock assets to the file system so they can be uploaded. */

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -27,6 +27,7 @@ export function mockUploadWorkerRequest(
 		legacyEnv?: boolean;
 		keepVars?: boolean;
 		tag?: string;
+		expectedDispatchNamespace?: string;
 	} = {}
 ) {
 	const {
@@ -46,11 +47,19 @@ export function mockUploadWorkerRequest(
 		expectedCapnpSchema,
 		expectedLimits,
 		keepVars,
+		expectedDispatchNamespace,
 	} = options;
 	if (env && !legacyEnv) {
 		msw.use(
 			rest.put(
 				"*/accounts/:accountId/workers/services/:scriptName/environments/:envName",
+				handleUpload
+			)
+		);
+	} else if (expectedDispatchNamespace) {
+		msw.use(
+			rest.put(
+				"*/accounts/:accountId/workers/dispatch/namespaces/:dispatchNamespace/scripts/:scriptName",
 				handleUpload
 			)
 		);
@@ -79,6 +88,9 @@ export function mockUploadWorkerRequest(
 			"true"
 		);
 		expect(req.url.searchParams.get("excludeScript")).toEqual("true");
+		if (expectedDispatchNamespace) {
+			expect(req.params.dispatchNamespace).toEqual(expectedDispatchNamespace);
+		}
 
 		const formBody = await (
 			req as MockedRequest as RestRequestWithFormData

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -136,10 +136,6 @@ export function normalizeAndValidateConfig(
 		diagnostics,
 		configPath,
 		rawConfig,
-		undefined,
-		undefined,
-		undefined,
-		undefined,
 		isDispatchNamespace
 	);
 
@@ -158,11 +154,11 @@ export function normalizeAndValidateConfig(
 				envDiagnostics,
 				configPath,
 				rawEnv,
+				isDispatchNamespace,
 				envName,
 				topLevelEnv,
 				isLegacyEnv,
-				rawConfig,
-				isDispatchNamespace
+				rawConfig
 			);
 			diagnostics.addChild(envDiagnostics);
 		} else {
@@ -173,11 +169,11 @@ export function normalizeAndValidateConfig(
 				envDiagnostics,
 				configPath,
 				{},
+				isDispatchNamespace,
 				envName,
 				topLevelEnv,
 				isLegacyEnv,
-				rawConfig,
-				isDispatchNamespace
+				rawConfig
 			);
 			const envNames = rawConfig.env
 				? `The available configured environment names are: ${JSON.stringify(
@@ -1006,7 +1002,8 @@ const validateTailConsumers: ValidatorFn = (diagnostics, field, value) => {
 function normalizeAndValidateEnvironment(
 	diagnostics: Diagnostics,
 	configPath: string | undefined,
-	topLevelEnv: RawEnvironment
+	topLevelEnv: RawEnvironment,
+	isDispatchNamespace: boolean
 ): Environment;
 /**
  * Validate the named environment configuration and return the normalized values.
@@ -1015,6 +1012,7 @@ function normalizeAndValidateEnvironment(
 	diagnostics: Diagnostics,
 	configPath: string | undefined,
 	rawEnv: RawEnvironment,
+	isDispatchNamespace: boolean,
 	envName: string,
 	topLevelEnv: Environment,
 	isLegacyEnv: boolean,
@@ -1027,21 +1025,21 @@ function normalizeAndValidateEnvironment(
 	diagnostics: Diagnostics,
 	configPath: string | undefined,
 	rawEnv: RawEnvironment,
+	isDispatchNamespace: boolean,
 	envName?: string,
 	topLevelEnv?: Environment,
 	isLegacyEnv?: boolean,
-	rawConfig?: RawConfig,
-	isDispatchNamespace?: boolean
+	rawConfig?: RawConfig
 ): Environment;
 function normalizeAndValidateEnvironment(
 	diagnostics: Diagnostics,
 	configPath: string | undefined,
 	rawEnv: RawEnvironment,
+	isDispatchNamespace: boolean,
 	envName = "top level",
 	topLevelEnv?: Environment | undefined,
 	isLegacyEnv?: boolean,
-	rawConfig?: RawConfig | undefined,
-	isDispatchNamespace?: boolean | undefined
+	rawConfig?: RawConfig | undefined
 ): Environment {
 	deprecated(
 		diagnostics,

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -128,10 +128,19 @@ export function normalizeAndValidateConfig(
 		);
 	}
 
+	const isDispatchNamespace =
+		typeof args["dispatch-namespace"] === "string" &&
+		args["dispatch-namespace"].trim() !== "";
+
 	const topLevelEnv = normalizeAndValidateEnvironment(
 		diagnostics,
 		configPath,
-		rawConfig
+		rawConfig,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		isDispatchNamespace
 	);
 
 	//TODO: find a better way to define the type of Args that can be passed to the normalizeAndValidateConfig()
@@ -152,7 +161,8 @@ export function normalizeAndValidateConfig(
 				envName,
 				topLevelEnv,
 				isLegacyEnv,
-				rawConfig
+				rawConfig,
+				isDispatchNamespace
 			);
 			diagnostics.addChild(envDiagnostics);
 		} else {
@@ -166,7 +176,8 @@ export function normalizeAndValidateConfig(
 				envName,
 				topLevelEnv,
 				isLegacyEnv,
-				rawConfig
+				rawConfig,
+				isDispatchNamespace
 			);
 			const envNames = rawConfig.env
 				? `The available configured environment names are: ${JSON.stringify(
@@ -1009,6 +1020,19 @@ function normalizeAndValidateEnvironment(
 	isLegacyEnv: boolean,
 	rawConfig: RawConfig
 ): Environment;
+/**
+ * Validate the named environment configuration and return the normalized values.
+ */
+function normalizeAndValidateEnvironment(
+	diagnostics: Diagnostics,
+	configPath: string | undefined,
+	rawEnv: RawEnvironment,
+	envName?: string,
+	topLevelEnv?: Environment,
+	isLegacyEnv?: boolean,
+	rawConfig?: RawConfig,
+	isDispatchNamespace?: boolean
+): Environment;
 function normalizeAndValidateEnvironment(
 	diagnostics: Diagnostics,
 	configPath: string | undefined,
@@ -1016,7 +1040,8 @@ function normalizeAndValidateEnvironment(
 	envName = "top level",
 	topLevelEnv?: Environment | undefined,
 	isLegacyEnv?: boolean,
-	rawConfig?: RawConfig | undefined
+	rawConfig?: RawConfig | undefined,
+	isDispatchNamespace?: boolean | undefined
 ): Environment {
 	deprecated(
 		diagnostics,
@@ -1130,7 +1155,7 @@ function normalizeAndValidateEnvironment(
 			topLevelEnv,
 			rawEnv,
 			"name",
-			isValidName,
+			isDispatchNamespace ? isString : isValidName,
 			appendEnvName(envName),
 			undefined
 		),

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -234,6 +234,11 @@ export function deployOptions(yargs: CommonYargsArgv) {
 					"Expire old assets in given seconds rather than immediate deletion.",
 				type: "number",
 			})
+			.option("dispatch-namespace", {
+				describe:
+					"Name of a dispatch namespace to deploy the Worker to (Workers for Platforms)",
+				type: "string",
+			})
 	);
 }
 
@@ -337,5 +342,6 @@ export async function deployHandler(
 		logpush: args.logpush,
 		oldAssetTtl: args.oldAssetTtl,
 		projectRoot,
+		dispatchNamespace: args.dispatchNamespace,
 	});
 }


### PR DESCRIPTION
**What this PR solves / how to test:**
Ability to deploy workers to dispatch namespaces (Workers for Platforms product).

Usage: `wrangler deploy --dispatch-namespace <namespace>`

This is an improvement to PR #2746 because:
- Correct terminology of 'dispatch namespace' used instead of 'platform namespace'.
- Excludes tasks related to routes. custom domains. cron/schedules, and queue consumers when `dispatch-namespace` option used (these features aren't supported in Workers for Platforms)
- Allows for any name to be used for the script when `dispatch-namespace` option used, because Workers for Platforms doesn't check script names

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/13442
  - [ ] Not necessary because: 