### PR TITLE
feat: cli flag to disable interactive dev session

### DIFF
--- a/.changeset/tender-buckets-confess.md
+++ b/.changeset/tender-buckets-confess.md
@@ -4,5 +4,5 @@
 
 feat: expose `--show-interactive-dev-session` flag
 
-This flag disables the interactive mode of the dev session, a feature that already exists internally but was not exposed to the user.
+This flag controls the interactive mode of the dev session, a feature that already exists internally but was not exposed to the user.
 This is useful for CI/CD environments where the interactive mode is not desired, or running in tools like `turbo` and `nx`.

--- a/.changeset/tender-buckets-confess.md
+++ b/.changeset/tender-buckets-confess.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+feat: expose `--show-interactive-dev-session` flag
+
+This flag disables the interactive mode of the dev session, a feature that already exists internally but was not exposed to the user.
+This is useful for CI/CD environments where the interactive mode is not desired, or running in tools like `turbo` and `nx`.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1258,7 +1258,8 @@ describe("wrangler dev", () => {
 			      --persist-to                                 Specify directory to use for local persistence (defaults to .wrangler/state)  [string]
 			      --live-reload                                Auto reload HTML pages when change is detected in local mode  [boolean]
 			      --test-scheduled                             Test scheduled events by visiting /__scheduled in browser  [boolean] [default: false]
-			      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]",
+			      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]
+			      --show-interactive-dev-session               Show interactive dev session  [boolean] [default: true]",
 			  "warn": "",
 			}
 		`);
@@ -1476,6 +1477,30 @@ describe("wrangler dev", () => {
 			",
 			}
 		`);
+		});
+	});
+
+	describe("--show-interactive-dev-session", () => {
+		it("should show interactive dev session by default", async () => {
+			fs.writeFileSync("index.js", `export default { }`);
+			await runWrangler("dev index.js");
+			expect(
+				(Dev as jest.Mock).mock.calls[0][0].showInteractiveDevSession
+			).toBeTruthy();
+		});
+		it("should show interactive dev session with --show-interactive-dev-session", async () => {
+			fs.writeFileSync("index.js", `export default { }`);
+			await runWrangler("dev index.js --show-interactive-dev-session");
+			expect(
+				(Dev as jest.Mock).mock.calls[0][0].showInteractiveDevSession
+			).toBeTruthy();
+		});
+		it("should not show interactive dev session with --show-interactive-dev-session=false", async () => {
+			fs.writeFileSync("index.js", `export default { }`);
+			await runWrangler("dev index.js --show-interactive-dev-session=false");
+			expect(
+				(Dev as jest.Mock).mock.calls[0][0].showInteractiveDevSession
+			).toBeFalsy();
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1259,7 +1259,7 @@ describe("wrangler dev", () => {
 			      --live-reload                                Auto reload HTML pages when change is detected in local mode  [boolean]
 			      --test-scheduled                             Test scheduled events by visiting /__scheduled in browser  [boolean] [default: false]
 			      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]
-			      --show-interactive-dev-session               Show interactive dev session  [boolean]",
+			      --show-interactive-dev-session               Show interactive dev session  (defaults to true if the terminal supports interactivity)  [boolean]",
 			  "warn": "",
 			}
 		`);

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1259,7 +1259,7 @@ describe("wrangler dev", () => {
 			      --live-reload                                Auto reload HTML pages when change is detected in local mode  [boolean]
 			      --test-scheduled                             Test scheduled events by visiting /__scheduled in browser  [boolean] [default: false]
 			      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]
-			      --show-interactive-dev-session               Show interactive dev session  [boolean] [default: true]",
+			      --show-interactive-dev-session               Show interactive dev session  [boolean]",
 			  "warn": "",
 			}
 		`);
@@ -1481,13 +1481,6 @@ describe("wrangler dev", () => {
 	});
 
 	describe("--show-interactive-dev-session", () => {
-		it("should show interactive dev session by default", async () => {
-			fs.writeFileSync("index.js", `export default { }`);
-			await runWrangler("dev index.js");
-			expect(
-				(Dev as jest.Mock).mock.calls[0][0].showInteractiveDevSession
-			).toBeTruthy();
-		});
 		it("should show interactive dev session with --show-interactive-dev-session", async () => {
 			fs.writeFileSync("index.js", `export default { }`);
 			await runWrangler("dev index.js --show-interactive-dev-session");

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -278,7 +278,7 @@ export function devOptions(yargs: CommonYargsArgv) {
 				default: "log" as LoggerLevel,
 			})
 			.option("show-interactive-dev-session", {
-				describe: "Show interactive dev session",
+				describe: "Show interactive dev session (defaults to true)",
 				type: "boolean",
 			})
 	);

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -278,7 +278,8 @@ export function devOptions(yargs: CommonYargsArgv) {
 				default: "log" as LoggerLevel,
 			})
 			.option("show-interactive-dev-session", {
-				describe: "Show interactive dev session (defaults to true)",
+				describe:
+					"Show interactive dev session  (defaults to true if the terminal supports interactivity)",
 				type: "boolean",
 			})
 	);

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -277,6 +277,11 @@ export function devOptions(yargs: CommonYargsArgv) {
 				// Yargs requires this to type log-level properly
 				default: "log" as LoggerLevel,
 			})
+			.option("show-interactive-dev-session", {
+				describe: "Show interactive dev session",
+				type: "boolean",
+				default: true,
+			})
 	);
 }
 
@@ -345,6 +350,7 @@ export type AdditionalDevProps = {
 	moduleRoot?: string;
 	rules?: Rule[];
 	constellation?: Environment["constellation"];
+	showInteractiveDevSession?: boolean;
 };
 
 export type StartDevOptions = DevArguments &
@@ -356,7 +362,6 @@ export type StartDevOptions = DevArguments &
 		disableDevRegistry?: boolean;
 		enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
 		onReady?: (ip: string, port: number, proxyData: ProxyData) => void;
-		showInteractiveDevSession?: boolean;
 		updateCheck?: boolean;
 	};
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -280,7 +280,6 @@ export function devOptions(yargs: CommonYargsArgv) {
 			.option("show-interactive-dev-session", {
 				describe: "Show interactive dev session",
 				type: "boolean",
-				default: true,
 			})
 	);
 }

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -220,7 +220,6 @@ export function Options(yargs: CommonYargsArgv) {
 			"show-interactive-dev-session": {
 				describe: "Show interactive dev session",
 				type: "boolean",
-				default: true,
 			},
 		});
 }

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -218,7 +218,8 @@ export function Options(yargs: CommonYargsArgv) {
 				describe: "Specify logging level",
 			},
 			"show-interactive-dev-session": {
-				describe: "Show interactive dev session",
+				describe:
+					"Show interactive dev session (defaults to true if the terminal supports interactivity)",
 				type: "boolean",
 			},
 		});

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -217,6 +217,11 @@ export function Options(yargs: CommonYargsArgv) {
 				choices: ["debug", "info", "log", "warn", "error", "none"] as const,
 				describe: "Specify logging level",
 			},
+			"show-interactive-dev-session": {
+				describe: "Show interactive dev session",
+				type: "boolean",
+				default: true,
+			},
 		});
 }
 
@@ -248,6 +253,7 @@ export const Handler = async ({
 	config: config,
 	_: [_pages, _dev, ...remaining],
 	logLevel,
+	showInteractiveDevSession,
 }: StrictYargsOptionsToInterface<typeof Options>) => {
 	if (logLevel) {
 		logger.loggerLevel = logLevel;
@@ -751,7 +757,7 @@ export const Handler = async ({
 			},
 			liveReload,
 			forceLocal: true,
-			showInteractiveDevSession: undefined,
+			showInteractiveDevSession,
 			testMode: false,
 			watch: true,
 		},


### PR DESCRIPTION
Closes #5063 

For monorepos using tools like `turborepo` or `nx` it may be desirable to disable to interactive feature of the `wrangler dev` command.

The flag to disable this exists internally already in package.

This PR exposes this internal flag (that can be passed to `unstable_dev`) as a CLI arg, allowing the interactive session to be disabled.

I maintained consistency with the current variable naming.

- Tests
  - [x] Included (and fixture tests cover the defaults further)
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because: TODO
- Associated docs
  - [x] Issue(s)/PR(s): https://github.com/cloudflare/cloudflare-docs/pull/13188
  - [ ] Not necessary because: