### PR TITLE
Handle multiple set cookie headers

### DIFF
--- a/.changeset/tall-wombats-reply.md
+++ b/.changeset/tall-wombats-reply.md
@@ -1,0 +1,6 @@
+---
+"edge-preview-authenticated-proxy": patch
+"playground-preview-worker": patch
+---
+
+fix: Handle multiple set cookie headers

--- a/packages/edge-preview-authenticated-proxy/src/index.ts
+++ b/packages/edge-preview-authenticated-proxy/src/index.ts
@@ -220,23 +220,31 @@ async function handleRawHttp(request: Request, url: URL) {
 		})
 	);
 
+	const responseHeaders = new Headers(workerResponse.headers);
+
+	const rawHeaders = new Headers({
+		"Access-Control-Allow-Origin": request.headers.get("Origin") ?? "",
+		"Access-Control-Allow-Methods": "*",
+		"Access-Control-Allow-Credentials": "true",
+		"cf-ew-status": workerResponse.status.toString(),
+		"Access-Control-Expose-Headers": "*",
+		Vary: "Origin",
+	});
+
 	// The client needs the raw headers from the worker
 	// Prefix them with `cf-ew-raw-`, so that response headers from _this_ worker don't interfere
-	const rawHeaders: Record<string, string> = {};
-	for (const header of workerResponse.headers.entries()) {
-		rawHeaders[`cf-ew-raw-${header[0]}`] = header[1];
+	const setCookieHeader = responseHeaders.getSetCookie();
+	for (const setCookie of setCookieHeader) {
+		rawHeaders.append("cf-ew-raw-set-cookie", setCookie);
 	}
+	responseHeaders.delete("Set-Cookie");
+	for (const header of responseHeaders.entries()) {
+		rawHeaders.set(`cf-ew-raw-${header[0]}`, header[1]);
+	}
+
 	return new Response(workerResponse.body, {
 		...workerResponse,
-		headers: {
-			...rawHeaders,
-			"Access-Control-Allow-Origin": request.headers.get("Origin") ?? "",
-			"Access-Control-Allow-Methods": "*",
-			"Access-Control-Allow-Credentials": "true",
-			"cf-ew-status": workerResponse.status.toString(),
-			"Access-Control-Expose-Headers": "*",
-			Vary: "Origin",
-		},
+		headers: rawHeaders,
 	});
 }
 

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -296,6 +296,8 @@ compatibility_date = "2023-01-01"
 
 describe("Raw HTTP preview", () => {
 	let worker: UnstableDevWorker;
+	let remote: UnstableDevWorker;
+	let tmpDir: string;
 
 	beforeAll(async () => {
 		worker = await unstable_dev(path.join(__dirname, "../src/index.ts"), {
@@ -304,6 +306,66 @@ describe("Raw HTTP preview", () => {
 			experimental: {
 				disableExperimentalWarning: true,
 			},
+		});
+
+		tmpDir = await fs.realpath(
+			await fs.mkdtemp(path.join(os.tmpdir(), "preview-tests"))
+		);
+
+		await fs.writeFile(
+			path.join(tmpDir, "remote.js"),
+			/*javascript*/ `
+				export default {
+					fetch(request) {
+						const url = new URL(request.url)
+						if(url.pathname === "/exchange") {
+							return Response.json({
+								token: "TEST_TOKEN",
+								prewarm: "TEST_PREWARM"
+							})
+						}
+						if(url.pathname === "/redirect") {
+							return Response.redirect("https://example.com", 302)
+						}
+						if(url.pathname === "/method") {
+							return new Response(request.method)
+						}
+						if(url.pathname === "/status") {
+							return new Response(407)
+						}
+						if(url.pathname === "/header") {
+							return new Response(request.headers.get("X-Custom-Header"))
+						}
+						if(url.pathname === "/cookies") {
+							const headers = new Headers();
+
+							headers.append("Set-Cookie", "foo=1");
+							headers.append("Set-Cookie", "bar=2");
+
+							return new Response(undefined, {
+								headers,
+							});
+						}
+						return Response.json({
+							url: request.url,
+							headers: [...request.headers.entries()]
+						})
+					}
+				}
+			`.trim()
+		);
+
+		await fs.writeFile(
+			path.join(tmpDir, "wrangler.toml"),
+			/*toml*/ `
+name = "remote-worker"
+compatibility_date = "2023-01-01"
+			`.trim()
+		);
+
+		remote = await unstable_dev(path.join(tmpDir, "remote.js"), {
+			config: path.join(tmpDir, "wrangler.toml"),
+			experimental: { disableExperimentalWarning: true },
 		});
 	});
 
@@ -339,5 +401,25 @@ describe("Raw HTTP preview", () => {
 		);
 
 		expect(resp.headers.get("Access-Control-Allow-Methods")).toBe("*");
+	});
+
+	it("should preserve multiple cookies", async () => {
+		const token = randomBytes(4096).toString("hex");
+		const resp = await worker.fetch(
+			`https://0000.rawhttp.devprod.cloudflare.dev/cookies`,
+			{
+				method: "GET",
+				headers: {
+					"Access-Control-Request-Method": "GET",
+					origin: "https://cloudflare.dev",
+					"X-CF-Token": token,
+					"X-CF-Remote": `http://127.0.0.1:${remote.port}`,
+				},
+			}
+		);
+
+		expect(resp.headers.get("cf-ew-raw-set-cookie")).toMatchInlineSnapshot(
+			`"foo=1, bar=2"`
+		);
 	});
 });


### PR DESCRIPTION
Fixes #5073

**What this PR solves / how to test:**

This ensures that multiple `Set-Cookie` headers in the raw HTTP tab within the Playground and Quick Edit are shown. 

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because: These packages don't currently use changesets
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: Bugfix
