### PR TITLE
Better messaging in remote mode

### DIFF
--- a/.changeset/tame-needles-give.md
+++ b/.changeset/tame-needles-give.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Ensures that switching to remote mode during a dev session (from local mode) will correctly use the right zone. Previously, zone detection happened before the dev session was mounted, and so dev sessions started with local mode would have no zone inferred, and would have failed to start, with an ugly error.

--- a/.changeset/tasty-jokes-provide.md
+++ b/.changeset/tasty-jokes-provide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Ensure that preview sessions created without a zone don't switch the host on which to start the preview from the one returned by the API.

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -734,7 +734,7 @@ describe("writes debug logs to hidden file", () => {
 	});
 });
 
-describe.only("zone selection", () => {
+describe("zone selection", () => {
 	let worker: DevWorker;
 
 	beforeEach(async () => {

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -840,8 +840,13 @@ describe("zone selection", () => {
 			`,
 		}));
 		await worker.runDevSession("--remote --ip 127.0.0.1", async (session) => {
-			await setTimeout(5000);
-			expect(session.stderr).toMatchInlineSnapshot(`
+			const { stderr } = await retry(
+				(s) => !s.stderr.includes("ERROR"),
+				() => {
+					return { stderr: session.stderr };
+				}
+			);
+			expect(stderr).toMatchInlineSnapshot(`
 				"[31m✘ [41;31m[[41;97mERROR[41;31m][0m [1mCould not access \`not-a-domain.testing.devprod.cloudflare.dev\`. Make sure the domain is set up to be proxied by Cloudflare.[0m
 
 				  For more details, refer to [4mhttps://developers.cloudflare.com/workers/configuration/routing/routes/#set-up-a-route[0m

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -846,13 +846,9 @@ describe("zone selection", () => {
 					return { stderr: session.stderr };
 				}
 			);
-			expect(stderr).toMatchInlineSnapshot(`
-				"[31m✘ [41;31m[[41;97mERROR[41;31m][0m [1mCould not access \`not-a-domain.testing.devprod.cloudflare.dev\`. Make sure the domain is set up to be proxied by Cloudflare.[0m
-
-				  For more details, refer to [4mhttps://developers.cloudflare.com/workers/configuration/routing/routes/#set-up-a-route[0m
-
-
-				"
+			expect(normalizeOutput(stderr)).toMatchInlineSnapshot(`
+				"X [ERROR] Could not access \`not-a-domain.testing.devprod.cloudflare.dev\`. Make sure the domain is set up to be proxied by Cloudflare.
+				  For more details, refer to https://developers.cloudflare.com/workers/configuration/routing/routes/#set-up-a-route"
 			`);
 		});
 	});

--- a/packages/wrangler/e2e/helpers/account-id.ts
+++ b/packages/wrangler/e2e/helpers/account-id.ts
@@ -1,1 +1,2 @@
-export const CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
+export const CLOUDFLARE_ACCOUNT_ID = process.env
+	.CLOUDFLARE_ACCOUNT_ID as string;

--- a/packages/wrangler/e2e/helpers/account-id.ts
+++ b/packages/wrangler/e2e/helpers/account-id.ts
@@ -1,8 +1,1 @@
-import assert from "node:assert";
-
-assert(
-	process.env.CLOUDFLARE_ACCOUNT_ID,
-	"Please provide a CLOUDFLARE_ACCOUNT_ID as an environment variable"
-);
-
 export const CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;

--- a/packages/wrangler/e2e/helpers/wrangler-command.ts
+++ b/packages/wrangler/e2e/helpers/wrangler-command.ts
@@ -1,1 +1,1 @@
-export const WRANGLER = process.env.WRANGLER;
+export const WRANGLER = process.env.WRANGLER as string;

--- a/packages/wrangler/e2e/helpers/wrangler-command.ts
+++ b/packages/wrangler/e2e/helpers/wrangler-command.ts
@@ -1,2 +1,1 @@
-export const WRANGLER =
-	process.env.WRANGLER ?? `pnpm --silent dlx wrangler@beta`;
+export const WRANGLER = process.env.WRANGLER;

--- a/packages/wrangler/e2e/validate-environment.ts
+++ b/packages/wrangler/e2e/validate-environment.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+
+assert(
+	process.env.WRANGLER,
+	'You must provide a way to run Wrangler (WRANGLER="pnpm --silent dlx wrangler@beta" will run the latest beta)'
+);
+
+assert(
+	process.env.CLOUDFLARE_ACCOUNT_ID,
+	"You must provide a CLOUDFLARE_ACCOUNT_ID as an environment variable"
+);
+
+assert(
+	process.env.CLOUDFLARE_API_TOKEN,
+	"You must provide a CLOUDFLARE_API_TOKEN as an environment variable"
+);
+
+assert(
+	process.env.CLOUDFLARE_ACCOUNT_ID === "8d783f274e1f82dc46744c297b015a2f",
+	"You must run Wrangler's e2e tests against DevProd Testing"
+);
+
+export const setup = () => {};

--- a/packages/wrangler/e2e/vitest.config.ts
+++ b/packages/wrangler/e2e/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		testTimeout: 240_000,
+		poolOptions: {
+			threads: {
+				singleThread: true,
+			},
+		},
+		retry: 2,
+		include: ["e2e/**/*.test.ts"],
+		globalSetup: path.resolve(__dirname, "./validate-environment.ts"),
+	},
+});

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -63,7 +63,7 @@
 		"test": "pnpm run assert-git-version && jest",
 		"test:ci": "pnpm run test --coverage",
 		"test:debug": "pnpm run test --silent=false --verbose=true",
-		"test:e2e": "vitest --test-timeout 240000 --poolOptions.threads.singleThread --dir ./e2e --retry 2 run",
+		"test:e2e": "vitest -c ./e2e/vitest.config.ts",
 		"test:watch": "pnpm run test --testTimeout=50000 --watch",
 		"type:tests": "tsc -p ./src/__tests__/tsconfig.json && tsc -p ./e2e/tsconfig.json"
 	},

--- a/packages/wrangler/src/__tests__/zones.test.ts
+++ b/packages/wrangler/src/__tests__/zones.test.ts
@@ -69,11 +69,11 @@ describe("Zones", () => {
 
 		test("string route (not a zone)", async () => {
 			mockGetZones("wrong.com", []);
-			await expect(
-				getZoneForRoute("wrong.com/*")
-			).rejects.toMatchInlineSnapshot(
-				`[Error: Could not find zone for wrong.com]`
-			);
+			await expect(getZoneForRoute("wrong.com/*")).rejects
+				.toMatchInlineSnapshot(`
+			[Error: Could not find zone for \`wrong.com\`. Make sure the domain is set up to be proxied by Cloudflare.
+			For more details, refer to https://developers.cloudflare.com/workers/configuration/routing/routes/#set-up-a-route]
+		`);
 		});
 		test("zone_id route", async () => {
 			// example-id and other-id intentionally different to show that the API is not called

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -404,7 +404,6 @@ export async function startDev(args: StartDevOptions) {
 			legacyNodeCompat,
 			nodejsCompat,
 			upstreamProtocol,
-			zoneId,
 			host,
 			routes,
 			getLocalPort,
@@ -439,7 +438,6 @@ export async function startDev(args: StartDevOptions) {
 					findAdditionalModules={configParam.find_additional_modules}
 					entry={entry}
 					env={args.env}
-					zone={zoneId}
 					host={host}
 					routes={routes}
 					processEntrypoint={processEntrypoint}
@@ -536,7 +534,6 @@ export async function startApiDev(args: StartDevOptions) {
 		legacyNodeCompat,
 		nodejsCompat,
 		upstreamProtocol,
-		zoneId,
 		host,
 		routes,
 		getLocalPort,
@@ -571,7 +568,6 @@ export async function startApiDev(args: StartDevOptions) {
 			findAdditionalModules: configParam.find_additional_modules,
 			entry: entry,
 			env: args.env,
-			zone: zoneId,
 			host: host,
 			routes: routes,
 			processEntrypoint,
@@ -715,7 +711,7 @@ async function validateDevServerSettings(
 		"dev"
 	);
 
-	const { zoneId, host, routes } = await getHostAndRoutes(args, config);
+	const { host, routes } = await getHostAndRoutes(args, config);
 	const initialIp = args.ip || config.dev.ip;
 	const initialIpListenCheck = initialIp === "*" ? "0.0.0.0" : initialIp;
 	const getLocalPort = memoizeGetPort(DEFAULT_LOCAL_PORT, initialIpListenCheck);
@@ -815,7 +811,6 @@ async function validateDevServerSettings(
 		getLocalPort,
 		getInspectorPort,
 		getRuntimeInspectorPort,
-		zoneId,
 		host,
 		routes,
 		cliDefines,

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -16,7 +16,7 @@ import * as metrics from "./metrics";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";
 import { getAccountFromCache, loginOrRefreshIfRequired } from "./user";
 import { collectKeyValues } from "./utils/collectKeyValues";
-import { getHostFromRoute } from "./zones";
+import { getHostFromRoute, getZoneIdForPreview } from "./zones";
 import {
 	DEFAULT_INSPECTOR_PORT,
 	DEFAULT_LOCAL_PORT,
@@ -457,7 +457,7 @@ export async function startDev(args: StartDevOptions) {
 					localProtocol={args.localProtocol || configParam.dev.local_protocol}
 					httpsKeyPath={args.httpsKeyPath}
 					httpsCertPath={args.httpsCertPath}
-					localUpstream={args.localUpstream ?? host}
+					localUpstream={args.localUpstream ?? host ?? getInferredHost(routes)}
 					localPersistencePath={localPersistencePath}
 					liveReload={args.liveReload || false}
 					accountId={
@@ -587,7 +587,7 @@ export async function startApiDev(args: StartDevOptions) {
 			localProtocol: args.localProtocol ?? configParam.dev.local_protocol,
 			httpsKeyPath: args.httpsKeyPath,
 			httpsCertPath: args.httpsCertPath,
-			localUpstream: args.localUpstream ?? host,
+			localUpstream: args.localUpstream ?? host ?? getInferredHost(routes),
 			localPersistencePath,
 			liveReload: args.liveReload ?? false,
 			accountId:
@@ -673,32 +673,34 @@ function maskVars(bindings: CfWorkerInit["bindings"], configParam: Config) {
 async function getHostAndRoutes(args: StartDevOptions, config: Config) {
 	// TODO: if worker_dev = false and no routes, then error (only for dev)
 	// Compute zone info from the `host` and `route` args and config;
-	let host = args.host || config.dev.host;
+	const host = args.host || config.dev.host;
 	const routes: Route[] | undefined =
 		args.routes || (config.route && [config.route]) || config.routes;
 
-	if (!host) {
-		if (routes) {
-			const firstRoute = routes[0];
-			host = getHostFromRoute(firstRoute);
+	return { host, routes };
+}
 
-			// TODO(consider): do we need really need to do this? I've added the condition to throw to match the previous implicit behaviour of `new URL()` throwing upon invalid URLs, but could we just continue here without an inferred host?
-			if (host === undefined) {
-				throw new UserError(
-					`Cannot infer host from first route: ${JSON.stringify(
-						firstRoute
-					)}.\nYou can explicitly set the \`dev.host\` configuration in your wrangler.toml file, for example:
+export function getInferredHost(routes: Route[] | undefined) {
+	if (routes) {
+		const firstRoute = routes[0];
+		const host = getHostFromRoute(firstRoute);
+
+		// TODO(consider): do we need really need to do this? I've added the condition to throw to match the previous implicit behaviour of `new URL()` throwing upon invalid URLs, but could we just continue here without an inferred host?
+		if (host === undefined) {
+			throw new UserError(
+				`Cannot infer host from first route: ${JSON.stringify(
+					firstRoute
+				)}.\nYou can explicitly set the \`dev.host\` configuration in your wrangler.toml file, for example:
 
 	\`\`\`
 	[dev]
 	host = "example.com"
 	\`\`\`
 `
-				);
-			}
+			);
 		}
+		return host;
 	}
-	return { host, routes };
 }
 
 async function validateDevServerSettings(
@@ -712,6 +714,14 @@ async function validateDevServerSettings(
 	);
 
 	const { host, routes } = await getHostAndRoutes(args, config);
+
+	// TODO: Remove this hack
+	// This function throws if the zone ID can't be found given the provided host and routes
+	// However, it's called as part of initialising a preview session, which is nested deep within
+	// React/Ink and useEffect()s, which swallow the error and turn it into a logw. Because it's a non-recoverable user error,
+	// we want it to exit the Wrangler process early to allow the user to fix it. Calling it here forces
+	// the error to be thrown where it will correctly exit the Wrangler process
+	if (args.remote) await getZoneIdForPreview(host, routes);
 	const initialIp = args.ip || config.dev.ip;
 	const initialIpListenCheck = initialIp === "*" ? "0.0.0.0" : initialIp;
 	const getLocalPort = memoizeGetPort(DEFAULT_LOCAL_PORT, initialIpListenCheck);

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -2,8 +2,9 @@ import { URL } from "node:url";
 import { fetch } from "undici";
 import { fetchResult } from "../cfetch";
 import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
+import { UserError } from "../errors";
 import { logger } from "../logger";
-import { parseJSON } from "../parse";
+import { ParseError, parseJSON } from "../parse";
 import { getAccessToken } from "../user/access";
 import type {
 	CfWorkerContext,
@@ -189,22 +190,35 @@ export async function createPreviewSession(
 	logger.debugWithSanitization("RESPONSE:", bodyText);
 
 	logger.debug("-- END EXCHANGE API RESPONSE");
+	try {
+		const { inspector_websocket, prewarm, token } = parseJSON<{
+			inspector_websocket: string;
+			token: string;
+			prewarm: string;
+		}>(bodyText);
+		const inspector = new URL(inspector_websocket);
+		inspector.searchParams.append("cf_workers_preview_token", token);
 
-	const { inspector_websocket, prewarm, token } = parseJSON<{
-		inspector_websocket: string;
-		token: string;
-		prewarm: string;
-	}>(bodyText);
-	const inspector = new URL(inspector_websocket);
-	inspector.searchParams.append("cf_workers_preview_token", token);
-
-	return {
-		id: randomId(),
-		value: token,
-		host: ctx.host ?? inspector.host,
-		inspectorUrl: switchHost(inspector.href, ctx.host, !!ctx.zone),
-		prewarmUrl: switchHost(prewarm, ctx.host, !!ctx.zone),
-	};
+		return {
+			id: randomId(),
+			value: token,
+			host: ctx.host ?? inspector.host,
+			inspectorUrl: switchHost(inspector.href, ctx.host, !!ctx.zone),
+			prewarmUrl: switchHost(prewarm, ctx.host, !!ctx.zone),
+		};
+	} catch (e) {
+		if (!(e instanceof ParseError)) {
+			throw e;
+		} else {
+			throw new UserError(
+				`Could not create remote preview session on ${
+					ctx.zone
+						? ` host \`${ctx.host}\` on zone \`${ctx.zone}\``
+						: `your account`
+				}.`
+			);
+		}
+	}
 }
 
 /**

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -165,7 +165,6 @@ export type DevProps = {
 	build: Config["build"];
 	env: string | undefined;
 	legacyEnv: boolean;
-	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
 	inspect: boolean;
@@ -496,7 +495,6 @@ function DevSession(props: DevSessionProps) {
 			usageModel={props.usageModel}
 			env={props.env}
 			legacyEnv={props.legacyEnv}
-			zone={props.zone}
 			host={props.host}
 			routes={props.routes}
 			onReady={announceAndOnReady}

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -59,7 +59,6 @@ interface RemoteProps {
 	usageModel: "bundled" | "unbound" | undefined;
 	env: string | undefined;
 	legacyEnv: boolean | undefined;
-	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
 	onReady?:
@@ -88,7 +87,6 @@ export function Remote(props: RemoteProps) {
 		usageModel: props.usageModel,
 		env: props.env,
 		legacyEnv: props.legacyEnv,
-		zone: props.zone,
 		host: props.host,
 		routes: props.routes,
 		onReady: props.onReady,
@@ -154,7 +152,6 @@ interface RemoteWorkerProps {
 	usageModel: "bundled" | "unbound" | undefined;
 	env: string | undefined;
 	legacyEnv: boolean | undefined;
-	zone: string | undefined;
 	host: string | undefined;
 	routes: Route[] | undefined;
 	onReady:
@@ -187,7 +184,6 @@ export function useWorker(
 				accountId: props.accountId,
 				env: props.env,
 				legacyEnv: props.legacyEnv,
-				zone: props.zone,
 				host: props.host,
 				routes: props.routes,
 				sendMetrics: props.sendMetrics,
@@ -230,7 +226,6 @@ export function useWorker(
 		props.host,
 		props.legacyEnv,
 		props.routes,
-		props.zone,
 		props.sendMetrics,
 		restartCounter,
 	]);
@@ -275,7 +270,6 @@ export function useWorker(
 				accountId: props.accountId,
 				env: props.env,
 				legacyEnv: props.legacyEnv,
-				zone: props.zone,
 				host: props.host,
 				routes: props.routes,
 				sendMetrics: props.sendMetrics,
@@ -376,7 +370,6 @@ export function useWorker(
 		props.modules,
 		props.env,
 		props.legacyEnv,
-		props.zone,
 		props.host,
 		props.routes,
 		session,
@@ -483,7 +476,6 @@ export async function getRemotePreviewToken(props: RemoteProps) {
 			accountId: props.accountId,
 			env: props.env,
 			legacyEnv: props.legacyEnv,
-			zone: props.zone,
 			host: props.host,
 			routes: props.routes,
 			sendMetrics: props.sendMetrics,

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -7,6 +7,7 @@ import { helpIfErrorIsSizeOrScriptStartup } from "../deploy/deploy";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
 import { getBundleType } from "../deployment-bundle/bundle-type";
 import { withSourceURLs } from "../deployment-bundle/source-url";
+import { getInferredHost } from "../dev";
 import { UserError } from "../errors";
 import { logger } from "../logger";
 import { syncAssets } from "../sites";
@@ -333,7 +334,7 @@ export function useWorker(
 					pathname: workerPreviewToken.inspectorUrl.pathname,
 				},
 				userWorkerInnerUrlOverrides: {
-					hostname: props.host,
+					hostname: props.host ?? getInferredHost(props.routes),
 					port: props.port.toString(),
 				},
 				headers: {
@@ -344,7 +345,11 @@ export function useWorker(
 				proxyLogsToController: true,
 			};
 
-			onReady?.(props.host || "localhost", props.port, proxyData);
+			onReady?.(
+				props.host ?? getInferredHost(props.routes) ?? "localhost",
+				props.port,
+				proxyData
+			);
 		}
 		start().catch((err) => {
 			// we want to log the error, but not end the process
@@ -634,7 +639,7 @@ async function createRemoteWorkerInit(props: {
 	return init;
 }
 
-async function getWorkerAccountAndContext(props: {
+export async function getWorkerAccountAndContext(props: {
 	accountId: string;
 	env?: string;
 	legacyEnv?: boolean;
@@ -654,7 +659,7 @@ async function getWorkerAccountAndContext(props: {
 		env: props.env,
 		legacyEnv: props.legacyEnv,
 		zone: zoneId,
-		host: props.host,
+		host: props.host ?? getInferredHost(props.routes),
 		routes: props.routes,
 		sendMetrics: props.sendMetrics,
 	};

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -212,6 +212,12 @@ export function useWorker(
 					"You can either enable local mode by pressing l, or register a workers.dev subdomain here:";
 				const onboardingLink = `https://dash.cloudflare.com/${props.accountId}/workers/onboarding`;
 				logger.error(`${errorMessage}\n${solutionMessage}\n${onboardingLink}`);
+			} else if (
+				(err.cause as { code: string; hostname: string })?.code === "ENOTFOUND"
+			) {
+				logger.error(
+					`Could not access \`${err.cause.hostname}\`. Make sure the domain is set up to be proxied by Cloudflare.\nFor more details, refer to https://developers.cloudflare.com/workers/configuration/routing/routes/#set-up-a-route`
+				);
 			} else if (err instanceof UserError) {
 				logger.error(err.message);
 			}

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -236,7 +236,6 @@ export async function startDevServer(
 			usageModel: props.usageModel,
 			env: props.env,
 			legacyEnv: props.legacyEnv,
-			zone: props.zone,
 			host: props.host,
 			routes: props.routes,
 			onReady: async (ip, port, proxyData) => {

--- a/packages/wrangler/src/dev/validate-dev-props.ts
+++ b/packages/wrangler/src/dev/validate-dev-props.ts
@@ -1,7 +1,7 @@
 import { UserError } from "../errors";
 import type { DevProps } from "./dev";
 
-export function validateDevProps(props: DevProps) {
+export function validateDevProps(props: Omit<DevProps, "host">) {
 	if (
 		!props.isWorkersSite &&
 		props.assetPaths &&

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -132,7 +132,9 @@ export async function getZoneIdFromHost(host: string): Promise<string> {
 		hostPieces.shift();
 	}
 
-	throw new UserError(`Could not find zone for ${host}`);
+	throw new UserError(
+		`Could not find zone for \`${host}\`. Make sure the domain is set up to be proxied by Cloudflare.\nFor more details, refer to https://developers.cloudflare.com/workers/configuration/routing/routes/#set-up-a-route`
+	);
 }
 
 /**

--- a/packages/wrangler/src/zones.ts
+++ b/packages/wrangler/src/zones.ts
@@ -93,7 +93,23 @@ export function getHostFromUrl(urlLike: string): string | undefined {
 		return undefined;
 	}
 }
-
+export async function getZoneIdForPreview(
+	host: string | undefined,
+	routes: Route[] | undefined
+) {
+	let zoneId: string | undefined;
+	if (host) {
+		zoneId = await getZoneIdFromHost(host);
+	}
+	if (!zoneId && routes) {
+		const firstRoute = routes[0];
+		const zone = await getZoneForRoute(firstRoute);
+		if (zone) {
+			zoneId = zone.id;
+		}
+	}
+	return zoneId;
+}
 /**
  * Given something that resembles a host, try to infer a zone id from it.
  *


### PR DESCRIPTION
Fixes #3755

**What this PR solves / how to test:**

This ensures that switching to remote mode during a dev session (from local mode) will correctly use the right zone. Previously, zone detection happened _before_ the dev session was mounted, and so dev sessions started with local mode would have no zone inferred, and would have failed to start, with an ugly error.

Additionally, it ensures that preview sessions created without a zone don't switch the host on which to start the preview from the one returned by the API.

It also improves messaging across the board for preview errors.

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: bugfixes

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
