### PR TITLE
Implement `versions deploy` command

### DIFF
--- a/.changeset/popular-melons-explain.md
+++ b/.changeset/popular-melons-explain.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+feature: Implement `wrangler versions deploy` command.
+
+For now, invocations should use the `--experimental-gradual-rollouts` flag.
+
+Without args, a user will be guided through prompts. If args are specified, they are used as the default values for the prompts. If the `--yes` flag is specified, the defaults are automatically accepted for a non-interactive flow.

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -133,10 +133,14 @@ export const crash: (msg?: string, extra?: string) => never = (msg, extra) => {
 	exit(1);
 };
 
-export const error = (msg?: string, extra?: string) => {
+export const error = (
+	msg?: string,
+	extra?: string,
+	corner = shapes.corners.bl
+) => {
 	if (msg) {
 		process.stderr.write(
-			`${gray(shapes.corners.bl)} ${status.error} ${dim(msg)}\n${
+			`${gray(corner)} ${status.error} ${dim(msg)}\n${
 				extra ? space() + extra + "\n" : ""
 			}`
 		);

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -10,6 +10,7 @@ import {
 	hidden,
 	white,
 } from "./colors";
+import { stderr, stdout } from "./streams";
 
 export const shapes = {
 	diamond: "◇",
@@ -51,7 +52,7 @@ export const space = (n = 1) => {
 // Primitive for printing to stdout. Use this instead of
 // console.log or printing to stdout directly
 export const logRaw = (msg: string) => {
-	process.stdout.write(`${msg}\n`);
+	stdout.write(`${msg}\n`);
 };
 
 // A simple stylized log for use within a prompt
@@ -139,7 +140,7 @@ export const error = (
 	corner = shapes.corners.bl
 ) => {
 	if (msg) {
-		process.stderr.write(
+		stderr.write(
 			`${gray(corner)} ${status.error} ${dim(msg)}\n${
 				extra ? space() + extra + "\n" : ""
 			}`

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -567,6 +567,30 @@ export const spinner = (
 	};
 };
 
+type FactoryOrValue<T> = T | (() => T);
+const unwrapFactory = <T>(input: FactoryOrValue<T>): T => {
+	const output = typeof input === "function" ? (input as () => T)() : input;
+	return output;
+};
+export const spinnerWhile = async <T>(opts: {
+	promise: FactoryOrValue<Promise<T>>;
+	startMessage: FactoryOrValue<string>;
+	endMessage?: FactoryOrValue<string>;
+	spinner?: ReturnType<typeof spinner>;
+}): Promise<T> => {
+	const s = opts.spinner ?? spinner();
+
+	s.start(unwrapFactory(opts.startMessage));
+
+	try {
+		const result = await unwrapFactory(opts.promise);
+
+		return result;
+	} finally {
+		s.stop(unwrapFactory(opts.endMessage));
+	}
+};
+
 export const isInteractive = () => {
 	return process.stdin.isTTY;
 };

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -8,11 +8,12 @@ import {
 import { createLogUpdate } from "log-update";
 import { blue, bold, brandColor, dim, gray, white } from "./colors";
 import SelectRefreshablePrompt from "./select-list";
+import { stdout } from "./streams";
 import { cancel, crash, logRaw, newline, shapes, space, status } from "./index";
 import type { OptionWithDetails } from "./select-list";
 import type { Prompt } from "@clack/core";
 
-const logUpdate = createLogUpdate(process.stdout);
+const logUpdate = createLogUpdate(stdout);
 
 export type Arg = string | boolean | string[] | undefined | number;
 export const grayBar = gray(shapes.bar);
@@ -392,7 +393,7 @@ const getSelectListRenderers = (config: ListPromptConfig) => {
 	const { question, helpText: _helpText } = config;
 	let options = config.options;
 	const helpText = _helpText ?? "";
-	const { rows } = process.stdout;
+	const { rows } = stdout;
 	const defaultRenderer: Renderer = ({ cursor, value }, prompt: Prompt) => {
 		if (prompt instanceof SelectRefreshablePrompt) {
 			options = prompt.options;

--- a/packages/cli/streams.ts
+++ b/packages/cli/streams.ts
@@ -1,0 +1,9 @@
+/**
+ * This file simply re-exports the process's writeable streams
+ * The intention is to provide a boundary to mock in tests
+ * Anywhere in this package that writes to stdout/stderr,
+ * should use this module to get references to them.
+ */
+
+export const stdout = process.stdout;
+export const stderr = process.stderr;

--- a/packages/wrangler/e2e/helpers/normalize.ts
+++ b/packages/wrangler/e2e/helpers/normalize.ts
@@ -22,6 +22,7 @@ export function normalizeOutput(
 		stripEmptyNewlines,
 		normalizeDebugLogFilepath,
 		squashLocalNetworkBindings,
+		removeZeroWidthSpaces,
 	];
 	for (const f of functions) {
 		stdout = f(stdout);
@@ -166,4 +167,8 @@ function removeStandardPricingWarning(stdout: string): string {
 		/🚧 New Workers Standard pricing is now available\. Please visit the dashboard to view details and opt-in to new pricing: https:\/\/dash\.cloudflare\.com\/[^/]+\/workers\/standard\/opt-in\./,
 		""
 	);
+}
+
+function removeZeroWidthSpaces(stdout: string) {
+	return stdout.replaceAll(/\u200a|\u200b/g, " ");
 }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -93,7 +93,7 @@
 			]
 		},
 		"transformIgnorePatterns": [
-			"node_modules/.pnpm/(?!find-up|locate-path|p-locate|p-limit|p-timeout|p-queue|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color|pretty-bytes)"
+			"node_modules/.pnpm/(?!find-up|locate-path|p-locate|p-limit|p-timeout|p-queue|yocto-queue|path-exists|execa|strip-final-newline|npm-run-path|path-key|onetime|mimic-fn|human-signals|is-stream|get-port|supports-color|pretty-bytes|strip-ansi|ansi-regex)"
 		],
 		"snapshotFormat": {
 			"escapeString": true,

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/versions.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/versions.ts
@@ -1,0 +1,213 @@
+import { rest } from "msw";
+import { createFetchResult } from "../index";
+
+export const mswListNewDeployments = rest.get(
+	"*/accounts/:accountId/workers/scripts/:workerName/deployments",
+	(request, response, context) => {
+		const workerName = String(request.params["workerName"]);
+		return response(
+			context.json(
+				createFetchResult({
+					deployments: [
+						{
+							id: `Galaxy-Class-${workerName}`,
+							source: "api",
+							strategy: "percentage",
+							author_email: "Jean-Luc-Picard@federation.org",
+							created_on: "2021-01-04T00:00:00.000000Z",
+							annotations: {
+								"workers/triggered_by": "rollback",
+								"workers/rollback_from": "MOCK-DEPLOYMENT-ID-2222",
+							},
+							versions: [
+								{
+									version_id: "10000000-0000-0000-0000-000000000000",
+									percentage: 10,
+								},
+								{
+									version_id: "20000000-0000-0000-0000-000000000000",
+									percentage: 90,
+								},
+							],
+						},
+						{
+							id: `Galaxy-Class-${workerName}`,
+							source: "wrangler",
+							strategy: "percentage",
+							author_email: "Jean-Luc-Picard@federation.org",
+							created_on: "2021-01-01T00:00:00.000000Z",
+							annotations: {
+								"workers/triggered_by": "upload",
+							},
+							versions: [
+								{
+									version_id: "10000000-0000-0000-0000-000000000000",
+									percentage: 20,
+								},
+								{
+									version_id: "20000000-0000-0000-0000-000000000000",
+									percentage: 80,
+								},
+							],
+						},
+						{
+							id: `Intrepid-Class-${workerName}`,
+							source: "wrangler",
+							strategy: "percentage",
+							author_email: "Kathryn-Janeway@federation.org",
+							created_on: "2021-02-02T00:00:00.000000Z",
+							annotations: {
+								"workers/triggered_by": "rollback",
+								"workers/rollback_from": "MOCK-DEPLOYMENT-ID-1111",
+								"workers/message": "Rolled back for this version",
+							},
+							versions: [
+								{
+									version_id: "10000000-0000-0000-0000-000000000000",
+									percentage: 30,
+								},
+								{
+									version_id: "20000000-0000-0000-0000-000000000000",
+									percentage: 70,
+								},
+							],
+						},
+						{
+							id: `3mEgaU1T-Intrepid-someThing-${workerName}`,
+							source: "wrangler",
+							strategy: "percentage",
+							author_email: "Kathryn-Janeway@federation.org",
+							created_on: "2021-02-03T00:00:00.000000Z",
+							versions: [
+								{
+									version_id: "10000000-0000-0000-0000-000000000000",
+									percentage: 40,
+								},
+								{
+									version_id: "20000000-0000-0000-0000-000000000000",
+									percentage: 60,
+								},
+							],
+						},
+					],
+				})
+			)
+		);
+	}
+);
+
+const latestVersion = (workerName: string) => ({
+	id: `10000000-0000-0000-0000-000000000000`,
+	number: "1701-E",
+	annotations: {
+		"workers/triggered_by": "rollback",
+		"workers/rollback_from": "MOCK-DEPLOYMENT-ID-2222",
+	},
+	metadata: {
+		author_id: "Picard-Gamma-6-0-7-3",
+		author_email: "Jean-Luc-Picard@federation.org",
+		source: "wrangler",
+		created_on: "2021-01-04T00:00:00.000000Z",
+		modified_on: "2021-01-04T00:00:00.000000Z",
+	},
+	resources: {
+		script: workerName,
+		bindings: [],
+	},
+});
+export const mswListVersions = rest.get(
+	"*/accounts/:accountId/workers/scripts/:workerName/versions",
+	(request, response, context) => {
+		const workerName = String(request.params["workerName"]);
+		return response(
+			context.json(
+				createFetchResult({
+					latest: latestVersion(workerName),
+					items: [
+						{
+							id: `40000000-0000-0000-0000-000000000000`,
+							number: "1701-E",
+							annotations: {
+								"workers/triggered_by": "upload",
+							},
+							metadata: {
+								author_id: "Picard-Gamma-6-0-7-3",
+								author_email: "Jean-Luc-Picard@federation.org",
+								source: "wrangler",
+								created_on: "2021-01-01T00:00:00.000000Z",
+								modified_on: "2021-01-01T00:00:00.000000Z",
+							},
+						},
+						{
+							id: `30000000-0000-0000-0000-000000000000`,
+							number: "NCC-74656",
+							annotations: {
+								"workers/triggered_by": "rollback",
+								"workers/rollback_from": "MOCK-DEPLOYMENT-ID-1111",
+								"workers/message": "Rolled back for this version",
+							},
+							metadata: {
+								author_id: "Kathryn-Jane-Gamma-6-0-7-3",
+								author_email: "Kathryn-Janeway@federation.org",
+								source: "wrangler",
+								created_on: "2021-02-02T00:00:00.000000Z",
+								modified_on: "2021-02-02T00:00:00.000000Z",
+							},
+						},
+						{
+							id: `20000000-0000-0000-0000-000000000000`,
+							number: "NCC-74656",
+							metadata: {
+								author_id: "Kathryn-Jane-Gamma-6-0-7-3",
+								author_email: "Kathryn-Janeway@federation.org",
+								source: "wrangler",
+								created_on: "2021-02-03T00:00:00.000000Z",
+								modified_on: "2021-02-03T00:00:00.000000Z",
+							},
+						},
+						latestVersion(workerName),
+					],
+				})
+			)
+		);
+	}
+);
+
+export const mswGetVersion = rest.get(
+	"*/accounts/:accountId/workers/scripts/:workerName/versions/:versionId",
+	(request, response, context) => {
+		const versionId = String(request.params["versionId"]);
+
+		if (versionId === "ffffffff-ffff-ffff-ffff-ffffffffffff") {
+			return response(context.json(createFetchResult({}, false)));
+		}
+
+		return response(
+			context.json(
+				createFetchResult({
+					id: versionId,
+					number: "1701-E",
+					annotations: {
+						"workers/triggered_by": "upload",
+					},
+					metadata: {
+						author_id: "Picard-Gamma-6-0-7-3",
+						author_email: "Jean-Luc-Picard@federation.org",
+						source: "wrangler",
+						created_on: "2021-01-01T00:00:00.000000Z",
+						modified_on: "2021-01-01T00:00:00.000000Z",
+					},
+				})
+			)
+		);
+	}
+);
+
+export const mswPostNewDeployment = rest.post(
+	"*/accounts/:accountId/workers/scripts/:workerName/deployments",
+	(request, response, context) => {
+		return response(
+			context.json(createFetchResult({ id: "mock-new-deployment-id" }))
+		);
+	}
+);

--- a/packages/wrangler/src/__tests__/helpers/msw/index.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/index.ts
@@ -11,6 +11,12 @@ import { mswSuccessOauthHandlers } from "./handlers/oauth";
 import { mswSuccessR2handlers } from "./handlers/r2";
 import { default as mswSucessScriptHandlers } from "./handlers/script";
 import { mswSuccessUserHandlers } from "./handlers/user";
+import {
+	mswGetVersion,
+	mswListNewDeployments,
+	mswListVersions,
+	mswPostNewDeployment,
+} from "./handlers/versions";
 import { default as mswZoneHandlers } from "./handlers/zones";
 
 export const msw = setupServer();
@@ -51,4 +57,8 @@ export {
 	mswAccessHandlers,
 	mswSuccessDeploymentScriptMetadata,
 	mswSuccessDeploymentScriptAPI,
+	mswPostNewDeployment,
+	mswGetVersion,
+	mswListNewDeployments,
+	mswListVersions,
 };

--- a/packages/wrangler/src/__tests__/jest.setup.ts
+++ b/packages/wrangler/src/__tests__/jest.setup.ts
@@ -274,3 +274,15 @@ jest.mock(
 	},
 	{ virtual: true }
 );
+
+jest.mock("@cloudflare/cli/streams", () => {
+	const { PassThrough } = jest.requireActual("node:stream");
+	const stdout = new PassThrough();
+	const stderr = new PassThrough();
+
+	return {
+		__esModule: true,
+		stdout,
+		stderr,
+	};
+});

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -1,0 +1,107 @@
+import yargs from "yargs";
+import {
+	parseVersionSpecs,
+	versionsDeployOptions,
+} from "../../versions/deploy";
+import type { VersionsDeployArgs } from "../../versions/deploy";
+
+describe("versions deploy", () => {});
+
+describe("units", () => {
+	describe("parseVersionSpecs", () => {
+		// @ts-expect-error passing a fresh yargs() as param but it expects one preconfigured with global options
+		const options = versionsDeployOptions(yargs());
+
+		test("no args", () => {
+			const input = "";
+
+			const args = options.parse(input) as VersionsDeployArgs;
+			const result = parseVersionSpecs(args);
+
+			expect(result).toMatchObject(new Map());
+		});
+
+		test("1 positional arg", () => {
+			const input = "10000000-0000-0000-0000-000000000000@10%";
+
+			const args = options.parse(input) as VersionsDeployArgs;
+			const result = parseVersionSpecs(args);
+
+			expect(Object.fromEntries(result)).toMatchObject({
+				"10000000-0000-0000-0000-000000000000": 10,
+			});
+		});
+		test("2 positional args", () => {
+			const input =
+				"10000000-0000-0000-0000-000000000000@10% 20000000-0000-0000-0000-000000000000@90%";
+
+			const args = options.parse(input) as VersionsDeployArgs;
+			const result = parseVersionSpecs(args);
+
+			expect(Object.fromEntries(result)).toMatchObject({
+				"10000000-0000-0000-0000-000000000000": 10,
+				"20000000-0000-0000-0000-000000000000": 90,
+			});
+		});
+
+		test("1 pair of named args", () => {
+			const input =
+				"--version-id 10000000-0000-0000-0000-000000000000 --percentage 10";
+
+			const args = options.parse(input) as VersionsDeployArgs;
+			const result = parseVersionSpecs(args);
+
+			expect(Object.fromEntries(result)).toMatchObject({
+				"10000000-0000-0000-0000-000000000000": 10,
+			});
+		});
+		test("2 pairs of named args", () => {
+			const input =
+				"--version-id 10000000-0000-0000-0000-000000000000 --percentage 10 --version-id 20000000-0000-0000-0000-000000000000 --percentage 90";
+
+			const args = options.parse(input) as VersionsDeployArgs;
+			const result = parseVersionSpecs(args);
+
+			expect(Object.fromEntries(result)).toMatchObject({
+				"10000000-0000-0000-0000-000000000000": 10,
+				"20000000-0000-0000-0000-000000000000": 90,
+			});
+		});
+		test("unordered named args", () => {
+			const input =
+				"--version-id 10000000-0000-0000-0000-000000000000 --version-id 20000000-0000-0000-0000-000000000000 --percentage 10 --percentage 90";
+
+			const args = options.parse(input) as VersionsDeployArgs;
+			const result = parseVersionSpecs(args);
+
+			expect(Object.fromEntries(result)).toMatchObject({
+				"10000000-0000-0000-0000-000000000000": 10,
+				"20000000-0000-0000-0000-000000000000": 90,
+			});
+		});
+		test("unpaired named args", () => {
+			const input =
+				"--version-id 10000000-0000-0000-0000-000000000000 --percentage 10 --version-id 20000000-0000-0000-0000-000000000000";
+
+			const args = options.parse(input) as VersionsDeployArgs;
+			const result = parseVersionSpecs(args);
+
+			expect(Object.fromEntries(result)).toMatchObject({
+				"10000000-0000-0000-0000-000000000000": 10,
+				"20000000-0000-0000-0000-000000000000": null,
+			});
+		});
+		test("unpaired, unordered named args", () => {
+			const input =
+				"--version-id 10000000-0000-0000-0000-000000000000 --version-id 20000000-0000-0000-0000-000000000000 --percentage 10";
+
+			const args = options.parse(input) as VersionsDeployArgs;
+			const result = parseVersionSpecs(args);
+
+			expect(Object.fromEntries(result)).toMatchObject({
+				"10000000-0000-0000-0000-000000000000": 10,
+				"20000000-0000-0000-0000-000000000000": null,
+			});
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -2,6 +2,8 @@ import yargs from "yargs";
 import {
 	assignAndDistributePercentages,
 	parseVersionSpecs,
+	summariseVersionTraffic,
+	validateTrafficSubtotal,
 	versionsDeployOptions,
 } from "../../versions/deploy";
 import type { VersionsDeployArgs } from "../../versions/deploy";
@@ -124,6 +126,118 @@ describe("units", () => {
 			);
 
 			expect(Object.fromEntries(result)).toMatchObject(expected);
+		});
+	});
+
+	describe("summariseVersionTraffic", () => {
+		test("none unspecified", () => {
+			const result = summariseVersionTraffic(
+				new Map(
+					Object.entries({
+						v1: 10,
+						v2: 90,
+					})
+				),
+				["v1", "v2"]
+			);
+
+			expect(result).toMatchObject({
+				subtotal: 100,
+				unspecifiedCount: 0,
+			});
+		});
+
+		test("subtotal above 100", () => {
+			const result = summariseVersionTraffic(
+				new Map(
+					Object.entries({
+						v1: 30,
+						v2: 90,
+					})
+				),
+				["v1", "v2"]
+			);
+
+			expect(result).toMatchObject({
+				subtotal: 120,
+				unspecifiedCount: 0,
+			});
+		});
+
+		test("subtotal below 100", () => {
+			const result = summariseVersionTraffic(
+				new Map(
+					Object.entries({
+						v1: 10,
+						v2: 50,
+					})
+				),
+				["v1", "v2"]
+			);
+
+			expect(result).toMatchObject({
+				subtotal: 60,
+				unspecifiedCount: 0,
+			});
+		});
+
+		test("counts unspecified", () => {
+			const result = summariseVersionTraffic(
+				new Map(
+					Object.entries({
+						v1: 10,
+						v2: 50,
+					})
+				),
+				["v1", "v2", "v3", "v4"]
+			);
+
+			expect(result).toMatchObject({
+				subtotal: 60,
+				unspecifiedCount: 2,
+			});
+		});
+	});
+
+	describe("validateTrafficSubtotal", () => {
+		test("errors if subtotal above max", () => {
+			expect(() =>
+				validateTrafficSubtotal(101, { min: 0, max: 100 })
+			).toThrowErrorMatchingInlineSnapshot(
+				`"Sum of specified percentages (101%) must be at most 100%"`
+			);
+		});
+		test("errors if subtotal below min", () => {
+			expect(() =>
+				validateTrafficSubtotal(-1, { min: 0, max: 100 })
+			).toThrowErrorMatchingInlineSnapshot(
+				`"Sum of specified percentages (-1%) must be at least 0%"`
+			);
+		});
+		test("different error message if min === max", () => {
+			expect(() =>
+				validateTrafficSubtotal(101, { min: 100, max: 100 })
+			).toThrowErrorMatchingInlineSnapshot(
+				`"Sum of specified percentages (101%) must be 100%"`
+			);
+		});
+		test("no error if subtotal above max but not above max + EPSILON", () => {
+			expect(() => validateTrafficSubtotal(100.001)).not.toThrow();
+
+			expect(() =>
+				validateTrafficSubtotal(100.01)
+			).toThrowErrorMatchingInlineSnapshot(
+				`"Sum of specified percentages (100.01%) must be 100%"`
+			);
+		});
+		test("no error if subtotal below min but not below min - EPSILON", () => {
+			expect(() => validateTrafficSubtotal(99.999)).not.toThrow();
+
+			expect(() =>
+				validateTrafficSubtotal(99.99)
+			).toThrowErrorMatchingInlineSnapshot(
+				`"Sum of specified percentages (99.99%) must be 100%"`
+			);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -12,11 +12,16 @@ describe("versions deploy", () => {});
 
 describe("units", () => {
 	describe("parseVersionSpecs", () => {
-		// @ts-expect-error passing a fresh yargs() as param but it expects one preconfigured with global options
-		const options = versionsDeployOptions(yargs());
+		const options = yargs().command(
+			"versions deploy [version-specs..]",
+			"",
+			// @ts-expect-error creating the command using a fresh yargs() but it expects one preconfigured with global options
+			versionsDeployOptions,
+			() => {}
+		);
 
 		test("no args", () => {
-			const input = "";
+			const input = "versions deploy";
 
 			const args = options.parse(input) as VersionsDeployArgs;
 			const result = parseVersionSpecs(args);
@@ -25,7 +30,7 @@ describe("units", () => {
 		});
 
 		test("1 positional arg", () => {
-			const input = "10000000-0000-0000-0000-000000000000@10%";
+			const input = "versions deploy 10000000-0000-0000-0000-000000000000@10%";
 
 			const args = options.parse(input) as VersionsDeployArgs;
 			const result = parseVersionSpecs(args);
@@ -49,7 +54,7 @@ describe("units", () => {
 
 		test("1 pair of named args", () => {
 			const input =
-				"--version-id 10000000-0000-0000-0000-000000000000 --percentage 10";
+				"versions deploy --version-id 10000000-0000-0000-0000-000000000000 --percentage 10";
 
 			const args = options.parse(input) as VersionsDeployArgs;
 			const result = parseVersionSpecs(args);
@@ -60,7 +65,7 @@ describe("units", () => {
 		});
 		test("2 pairs of named args", () => {
 			const input =
-				"--version-id 10000000-0000-0000-0000-000000000000 --percentage 10 --version-id 20000000-0000-0000-0000-000000000000 --percentage 90";
+				"versions deploy --version-id 10000000-0000-0000-0000-000000000000 --percentage 10 --version-id 20000000-0000-0000-0000-000000000000 --percentage 90";
 
 			const args = options.parse(input) as VersionsDeployArgs;
 			const result = parseVersionSpecs(args);
@@ -72,7 +77,7 @@ describe("units", () => {
 		});
 		test("unordered named args", () => {
 			const input =
-				"--version-id 10000000-0000-0000-0000-000000000000 --version-id 20000000-0000-0000-0000-000000000000 --percentage 10 --percentage 90";
+				"versions deploy --version-id 10000000-0000-0000-0000-000000000000 --version-id 20000000-0000-0000-0000-000000000000 --percentage 10 --percentage 90";
 
 			const args = options.parse(input) as VersionsDeployArgs;
 			const result = parseVersionSpecs(args);
@@ -84,7 +89,7 @@ describe("units", () => {
 		});
 		test("unpaired named args", () => {
 			const input =
-				"--version-id 10000000-0000-0000-0000-000000000000 --percentage 10 --version-id 20000000-0000-0000-0000-000000000000";
+				"versions deploy --version-id 10000000-0000-0000-0000-000000000000 --percentage 10 --version-id 20000000-0000-0000-0000-000000000000";
 
 			const args = options.parse(input) as VersionsDeployArgs;
 			const result = parseVersionSpecs(args);
@@ -96,7 +101,7 @@ describe("units", () => {
 		});
 		test("unpaired, unordered named args", () => {
 			const input =
-				"--version-id 10000000-0000-0000-0000-000000000000 --version-id 20000000-0000-0000-0000-000000000000 --percentage 10";
+				"versions deploy --version-id 10000000-0000-0000-0000-000000000000 --version-id 20000000-0000-0000-0000-000000000000 --percentage 10";
 
 			const args = options.parse(input) as VersionsDeployArgs;
 			const result = parseVersionSpecs(args);

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -70,12 +70,12 @@ describe("versions deploy", () => {
 			│
 			├ Your current deployment has 2 version(s):
 			│
-			│ (40%) 00000000-0000-0000-0000-000000000000
+			│ (10%) 00000000-0000-0000-0000-000000000000
 			│       Created:  1/1/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -
 			│
-			│ (60%) 00000000-0000-0000-0000-000000000000
+			│ (90%) 00000000-0000-0000-0000-000000000000
 			│       Created:  1/1/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -
@@ -129,12 +129,12 @@ describe("versions deploy", () => {
 			│
 			├ Your current deployment has 2 version(s):
 			│
-			│ (40%) 00000000-0000-0000-0000-000000000000
+			│ (10%) 00000000-0000-0000-0000-000000000000
 			│       Created:  1/4/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -
 			│
-			│ (60%) 00000000-0000-0000-0000-000000000000
+			│ (90%) 00000000-0000-0000-0000-000000000000
 			│       Created:  2/3/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -
@@ -154,39 +154,39 @@ describe("versions deploy", () => {
 			await expect(result).resolves.toBeUndefined();
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-					"╭ Deploy Worker Versions by splitting traffic between multiple versions
-					│
-					│
-					├ Your current deployment has 2 version(s):
-					│
-					│ (40%) 00000000-0000-0000-0000-000000000000
-					│       Created:  1/4/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│ (60%) 00000000-0000-0000-0000-000000000000
-					│       Created:  2/3/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│
-					├ Which version(s) do you want to deploy?
-					├ 1 Worker Version(s) selected
-					│
-					├     Worker Version 1:  00000000-0000-0000-0000-000000000000
-					│              Created:  1/4/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├ What percentage of traffic should Worker Version 1 receive?
-					├ 100% of traffic
-					├
-					├ Add a deployment message (skipped)
-					│
-					│
-					│
-					╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
-			`);
+			"╭ Deploy Worker Versions by splitting traffic between multiple versions
+			│
+			│
+			├ Your current deployment has 2 version(s):
+			│
+			│ (10%) 00000000-0000-0000-0000-000000000000
+			│       Created:  1/4/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│ (90%) 00000000-0000-0000-0000-000000000000
+			│       Created:  2/3/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│
+			├ Which version(s) do you want to deploy?
+			├ 1 Worker Version(s) selected
+			│
+			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+			│              Created:  1/4/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├ What percentage of traffic should Worker Version 1 receive?
+			├ 100% of traffic
+			├
+			├ Add a deployment message (skipped)
+			│
+			│
+			│
+			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+		`);
 		});
 
 		test("1 version @ (explicit) 100%", async () => {
@@ -197,39 +197,39 @@ describe("versions deploy", () => {
 			await expect(result).resolves.toBeUndefined();
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-					"╭ Deploy Worker Versions by splitting traffic between multiple versions
-					│
-					│
-					├ Your current deployment has 2 version(s):
-					│
-					│ (40%) 00000000-0000-0000-0000-000000000000
-					│       Created:  1/4/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│ (60%) 00000000-0000-0000-0000-000000000000
-					│       Created:  2/3/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│
-					├ Which version(s) do you want to deploy?
-					├ 1 Worker Version(s) selected
-					│
-					├     Worker Version 1:  00000000-0000-0000-0000-000000000000
-					│              Created:  1/4/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├ What percentage of traffic should Worker Version 1 receive?
-					├ 100% of traffic
-					├
-					├ Add a deployment message (skipped)
-					│
-					│
-					│
-					╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
-			`);
+			"╭ Deploy Worker Versions by splitting traffic between multiple versions
+			│
+			│
+			├ Your current deployment has 2 version(s):
+			│
+			│ (10%) 00000000-0000-0000-0000-000000000000
+			│       Created:  1/4/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│ (90%) 00000000-0000-0000-0000-000000000000
+			│       Created:  2/3/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│
+			├ Which version(s) do you want to deploy?
+			├ 1 Worker Version(s) selected
+			│
+			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+			│              Created:  1/4/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├ What percentage of traffic should Worker Version 1 receive?
+			├ 100% of traffic
+			├
+			├ Add a deployment message (skipped)
+			│
+			│
+			│
+			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+		`);
 		});
 
 		test("2 versions @ (implicit) 50% each", async () => {
@@ -240,47 +240,47 @@ describe("versions deploy", () => {
 			await expect(result).resolves.toBeUndefined();
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-					"╭ Deploy Worker Versions by splitting traffic between multiple versions
-					│
-					│
-					├ Your current deployment has 2 version(s):
-					│
-					│ (40%) 00000000-0000-0000-0000-000000000000
-					│       Created:  1/4/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│ (60%) 00000000-0000-0000-0000-000000000000
-					│       Created:  2/3/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│
-					├ Which version(s) do you want to deploy?
-					├ 2 Worker Version(s) selected
-					│
-					├     Worker Version 1:  00000000-0000-0000-0000-000000000000
-					│              Created:  1/4/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├     Worker Version 2:  00000000-0000-0000-0000-000000000000
-					│              Created:  2/3/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├ What percentage of traffic should Worker Version 1 receive?
-					├ 50% of traffic
-					├
-					├ What percentage of traffic should Worker Version 2 receive?
-					├ 50% of traffic
-					├
-					├ Add a deployment message (skipped)
-					│
-					│
-					│
-					╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 50% and version 00000000-0000-0000-0000-000000000000 at 50% (TIMINGS)"
-			`);
+			"╭ Deploy Worker Versions by splitting traffic between multiple versions
+			│
+			│
+			├ Your current deployment has 2 version(s):
+			│
+			│ (10%) 00000000-0000-0000-0000-000000000000
+			│       Created:  1/4/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│ (90%) 00000000-0000-0000-0000-000000000000
+			│       Created:  2/3/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│
+			├ Which version(s) do you want to deploy?
+			├ 2 Worker Version(s) selected
+			│
+			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+			│              Created:  1/4/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├     Worker Version 2:  00000000-0000-0000-0000-000000000000
+			│              Created:  2/3/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├ What percentage of traffic should Worker Version 1 receive?
+			├ 50% of traffic
+			├
+			├ What percentage of traffic should Worker Version 2 receive?
+			├ 50% of traffic
+			├
+			├ Add a deployment message (skipped)
+			│
+			│
+			│
+			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 50% and version 00000000-0000-0000-0000-000000000000 at 50% (TIMINGS)"
+		`);
 		});
 
 		test("1 version @ (explicit) 100%", async () => {
@@ -291,39 +291,39 @@ describe("versions deploy", () => {
 			await expect(result).resolves.toBeUndefined();
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-					"╭ Deploy Worker Versions by splitting traffic between multiple versions
-					│
-					│
-					├ Your current deployment has 2 version(s):
-					│
-					│ (40%) 00000000-0000-0000-0000-000000000000
-					│       Created:  1/4/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│ (60%) 00000000-0000-0000-0000-000000000000
-					│       Created:  2/3/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│
-					├ Which version(s) do you want to deploy?
-					├ 1 Worker Version(s) selected
-					│
-					├     Worker Version 1:  00000000-0000-0000-0000-000000000000
-					│              Created:  1/4/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├ What percentage of traffic should Worker Version 1 receive?
-					├ 100% of traffic
-					├
-					├ Add a deployment message (skipped)
-					│
-					│
-					│
-					╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
-			`);
+			"╭ Deploy Worker Versions by splitting traffic between multiple versions
+			│
+			│
+			├ Your current deployment has 2 version(s):
+			│
+			│ (10%) 00000000-0000-0000-0000-000000000000
+			│       Created:  1/4/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│ (90%) 00000000-0000-0000-0000-000000000000
+			│       Created:  2/3/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│
+			├ Which version(s) do you want to deploy?
+			├ 1 Worker Version(s) selected
+			│
+			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+			│              Created:  1/4/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├ What percentage of traffic should Worker Version 1 receive?
+			├ 100% of traffic
+			├
+			├ Add a deployment message (skipped)
+			│
+			│
+			│
+			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+		`);
 		});
 
 		test("2 versions @ (explicit) 30% + (implicit) 70%", async () => {
@@ -334,47 +334,47 @@ describe("versions deploy", () => {
 			await expect(result).resolves.toBeUndefined();
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-					"╭ Deploy Worker Versions by splitting traffic between multiple versions
-					│
-					│
-					├ Your current deployment has 2 version(s):
-					│
-					│ (40%) 00000000-0000-0000-0000-000000000000
-					│       Created:  1/4/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│ (60%) 00000000-0000-0000-0000-000000000000
-					│       Created:  2/3/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│
-					├ Which version(s) do you want to deploy?
-					├ 2 Worker Version(s) selected
-					│
-					├     Worker Version 1:  00000000-0000-0000-0000-000000000000
-					│              Created:  1/4/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├     Worker Version 2:  00000000-0000-0000-0000-000000000000
-					│              Created:  2/3/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├ What percentage of traffic should Worker Version 1 receive?
-					├ 30% of traffic
-					├
-					├ What percentage of traffic should Worker Version 2 receive?
-					├ 70% of traffic
-					├
-					├ Add a deployment message (skipped)
-					│
-					│
-					│
-					╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 30% and version 00000000-0000-0000-0000-000000000000 at 70% (TIMINGS)"
-			`);
+			"╭ Deploy Worker Versions by splitting traffic between multiple versions
+			│
+			│
+			├ Your current deployment has 2 version(s):
+			│
+			│ (10%) 00000000-0000-0000-0000-000000000000
+			│       Created:  1/4/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│ (90%) 00000000-0000-0000-0000-000000000000
+			│       Created:  2/3/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│
+			├ Which version(s) do you want to deploy?
+			├ 2 Worker Version(s) selected
+			│
+			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+			│              Created:  1/4/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├     Worker Version 2:  00000000-0000-0000-0000-000000000000
+			│              Created:  2/3/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├ What percentage of traffic should Worker Version 1 receive?
+			├ 30% of traffic
+			├
+			├ What percentage of traffic should Worker Version 2 receive?
+			├ 70% of traffic
+			├
+			├ Add a deployment message (skipped)
+			│
+			│
+			│
+			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 30% and version 00000000-0000-0000-0000-000000000000 at 70% (TIMINGS)"
+		`);
 		});
 
 		test("2 versions @ (explicit) 40% + (explicit) 60%", async () => {
@@ -385,47 +385,47 @@ describe("versions deploy", () => {
 			await expect(result).resolves.toBeUndefined();
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-					"╭ Deploy Worker Versions by splitting traffic between multiple versions
-					│
-					│
-					├ Your current deployment has 2 version(s):
-					│
-					│ (40%) 00000000-0000-0000-0000-000000000000
-					│       Created:  1/4/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│ (60%) 00000000-0000-0000-0000-000000000000
-					│       Created:  2/3/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│
-					├ Which version(s) do you want to deploy?
-					├ 2 Worker Version(s) selected
-					│
-					├     Worker Version 1:  00000000-0000-0000-0000-000000000000
-					│              Created:  1/4/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├     Worker Version 2:  00000000-0000-0000-0000-000000000000
-					│              Created:  2/3/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├ What percentage of traffic should Worker Version 1 receive?
-					├ 40% of traffic
-					├
-					├ What percentage of traffic should Worker Version 2 receive?
-					├ 60% of traffic
-					├
-					├ Add a deployment message (skipped)
-					│
-					│
-					│
-					╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 40% and version 00000000-0000-0000-0000-000000000000 at 60% (TIMINGS)"
-			`);
+			"╭ Deploy Worker Versions by splitting traffic between multiple versions
+			│
+			│
+			├ Your current deployment has 2 version(s):
+			│
+			│ (10%) 00000000-0000-0000-0000-000000000000
+			│       Created:  1/4/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│ (90%) 00000000-0000-0000-0000-000000000000
+			│       Created:  2/3/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│
+			├ Which version(s) do you want to deploy?
+			├ 2 Worker Version(s) selected
+			│
+			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+			│              Created:  1/4/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├     Worker Version 2:  00000000-0000-0000-0000-000000000000
+			│              Created:  2/3/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├ What percentage of traffic should Worker Version 1 receive?
+			├ 40% of traffic
+			├
+			├ What percentage of traffic should Worker Version 2 receive?
+			├ 60% of traffic
+			├
+			├ Add a deployment message (skipped)
+			│
+			│
+			│
+			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 40% and version 00000000-0000-0000-0000-000000000000 at 60% (TIMINGS)"
+		`);
 		});
 
 		describe("max versions restrictions (temp)", () => {
@@ -444,12 +444,12 @@ describe("versions deploy", () => {
 			│
 			├ Your current deployment has 2 version(s):
 			│
-			│ (40%) 00000000-0000-0000-0000-000000000000
+			│ (10%) 00000000-0000-0000-0000-000000000000
 			│       Created:  1/4/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -
 			│
-			│ (60%) 00000000-0000-0000-0000-000000000000
+			│ (90%) 00000000-0000-0000-0000-000000000000
 			│       Created:  2/3/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -
@@ -489,12 +489,12 @@ describe("versions deploy", () => {
 			│
 			├ Your current deployment has 2 version(s):
 			│
-			│ (40%) 00000000-0000-0000-0000-000000000000
+			│ (10%) 00000000-0000-0000-0000-000000000000
 			│       Created:  1/4/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -
 			│
-			│ (60%) 00000000-0000-0000-0000-000000000000
+			│ (90%) 00000000-0000-0000-0000-000000000000
 			│       Created:  2/3/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -
@@ -546,40 +546,40 @@ describe("versions deploy", () => {
 			await expect(result).resolves.toBeUndefined();
 
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-					"╭ Deploy Worker Versions by splitting traffic between multiple versions
-					│
-					│
-					├ Your current deployment has 2 version(s):
-					│
-					│ (40%) 00000000-0000-0000-0000-000000000000
-					│       Created:  1/4/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│ (60%) 00000000-0000-0000-0000-000000000000
-					│       Created:  2/3/2021, TIMESTAMP AM
-					│           Tag:  -
-					│       Message:  -
-					│
-					│
-					├ Which version(s) do you want to deploy?
-					├ 1 Worker Version(s) selected
-					│
-					├     Worker Version 1:  00000000-0000-0000-0000-000000000000
-					│              Created:  1/4/2021, TIMESTAMP AM
-					│                  Tag:  -
-					│              Message:  -
-					│
-					├ What percentage of traffic should Worker Version 1 receive?
-					├ 100% of traffic
-					├
-					├ Add a deployment message
-					│ Deployment message My versioned deployment message
-					│
-					│
-					│
-					╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
-			`);
+			"╭ Deploy Worker Versions by splitting traffic between multiple versions
+			│
+			│
+			├ Your current deployment has 2 version(s):
+			│
+			│ (10%) 00000000-0000-0000-0000-000000000000
+			│       Created:  1/4/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│ (90%) 00000000-0000-0000-0000-000000000000
+			│       Created:  2/3/2021, TIMESTAMP AM
+			│           Tag:  -
+			│       Message:  -
+			│
+			│
+			├ Which version(s) do you want to deploy?
+			├ 1 Worker Version(s) selected
+			│
+			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+			│              Created:  1/4/2021, TIMESTAMP AM
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├ What percentage of traffic should Worker Version 1 receive?
+			├ 100% of traffic
+			├
+			├ Add a deployment message
+			│ Deployment message My versioned deployment message
+			│
+			│
+			│
+			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+		`);
 		});
 
 		test("fails for non-existent versionId", async () => {
@@ -598,12 +598,12 @@ describe("versions deploy", () => {
 			│
 			├ Your current deployment has 2 version(s):
 			│
-			│ (40%) 00000000-0000-0000-0000-000000000000
+			│ (10%) 00000000-0000-0000-0000-000000000000
 			│       Created:  1/4/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -
 			│
-			│ (60%) 00000000-0000-0000-0000-000000000000
+			│ (90%) 00000000-0000-0000-0000-000000000000
 			│       Created:  2/3/2021, TIMESTAMP AM
 			│           Tag:  -
 			│       Message:  -

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -720,7 +720,7 @@ export function createCLIParser(argv: string[]) {
 				)
 				.command(
 					"deploy [version-specs..]",
-					"Safely roll out new versions of your Worker by splitting traffic between multiple versions",
+					"Safely roll out new versions of your Worker by splitting traffic between multiple versions [beta]",
 					versionsDeployOptions,
 					versionsDeployHandler
 				);

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -67,6 +67,10 @@ import {
 } from "./user";
 import { vectorize } from "./vectorize/index";
 import { versionsUploadHandler, versionsUploadOptions } from "./versions";
+import {
+	versionsDeployHandler,
+	versionsDeployOptions,
+} from "./versions/deploy";
 import { whoami } from "./whoami";
 import { asJson } from "./yargs-types";
 import type { Config } from "./config";
@@ -197,7 +201,7 @@ export function createCLIParser(argv: string[]) {
 		// the `wrangler` variable
 		.version(false)
 		.option("v", {
-			describe: "Show version number",
+			describe: "Show Wrangler version number",
 			alias: "version",
 			type: "boolean",
 		})
@@ -707,12 +711,19 @@ export function createCLIParser(argv: string[]) {
 	);
 	if (experimentalGradualRollouts) {
 		wrangler.command("versions", false, (versionYargs) => {
-			return versionYargs.command(
-				"upload",
-				"Upload a Worker for Gradual Rollouts [beta]",
-				versionsUploadOptions,
-				versionsUploadHandler
-			);
+			return versionYargs
+				.command(
+					"upload",
+					"Uploads your Worker code and config as a new version [beta]",
+					versionsUploadOptions,
+					versionsUploadHandler
+				)
+				.command(
+					"deploy",
+					"Safely roll out new versions of your Worker by splitting traffic between multiple versions",
+					versionsDeployOptions,
+					versionsDeployHandler
+				);
 		});
 	}
 

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -719,7 +719,7 @@ export function createCLIParser(argv: string[]) {
 					versionsUploadHandler
 				)
 				.command(
-					"deploy",
+					"deploy [version-specs..]",
 					"Safely roll out new versions of your Worker by splitting traffic between multiple versions",
 					versionsDeployOptions,
 					versionsDeployHandler

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -201,7 +201,7 @@ export function createCLIParser(argv: string[]) {
 		// the `wrangler` variable
 		.version(false)
 		.option("v", {
-			describe: "Show Wrangler version number",
+			describe: "Show version number",
 			alias: "version",
 			type: "boolean",
 		})

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -65,7 +65,8 @@ export type EventNames =
 	| "view docs"
 	| "view deployments"
 	| "rollback deployments"
-	| "upload worker version";
+	| "upload worker version"
+	| "deploy worker version(s)";
 
 /**
  * Send a metrics event, with no extra properties, to Cloudflare, if usage tracking is enabled.

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -66,7 +66,7 @@ export type EventNames =
 	| "view deployments"
 	| "rollback deployments"
 	| "upload worker version"
-	| "deploy worker version(s)";
+	| "deploy worker versions";
 
 /**
  * Send a metrics event, with no extra properties, to Cloudflare, if usage tracking is enabled.

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -1,0 +1,649 @@
+import assert from "assert";
+import path from "path";
+import * as cli from "@cloudflare/cli";
+import { brandColor, gray, white } from "@cloudflare/cli/colors";
+import {
+	grayBar,
+	inputPrompt,
+	leftT,
+	spinner,
+} from "@cloudflare/cli/interactive";
+import { fetchResult } from "../cfetch";
+import { findWranglerToml, readConfig } from "../config";
+import { UserError } from "../errors";
+import { printWranglerBanner } from "../update-check";
+import { requireAuth } from "../user";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+const EPSILON = 0.001; // used to avoid floating-point errors. Comparions to a value +/- EPSILON will mean "roughly equals the value".
+const BLANK_INPUT = "-"; // To be used where optional user-input is displayed and the value is nullish
+const ZERO_WIDTH_SPACE = "​"; // Some log lines get trimmed and so, to indent, the line is prefixed with a zero-width space
+const VERSION_CACHE = new Map<string, WorkerVersion>();
+
+type Args = StrictYargsOptionsToInterface<typeof versionsDeployOptions>;
+
+type OptionalPercentage = number | null; // null means automatically assign (evenly distribute remaining traffic)
+type Percentage = number;
+type UUID = string;
+type VersionId = UUID;
+type WorkerVersion = {
+	id: VersionId;
+	created: Date;
+	tag?: string;
+	message?: string;
+};
+type ApiDeployment = {
+	id: string;
+	source: "api" | string;
+	strategy: "percentage" | string;
+	author_email: string;
+	annotations: Record<string, string>;
+	versions: Array<{ version_id: VersionId; percentage: Percentage }>;
+	created_on: string;
+};
+type ApiVersion = {
+	id: VersionId;
+	number: number;
+	metadata: {
+		created_on: string;
+		modified_on: string;
+		source: "api" | string;
+		author_id: string;
+		author_email: string;
+	};
+	annotations: Record<string, string> & {
+		"workers/triggered_by"?: "upload" | string;
+		"workers/message"?: string;
+		"workers/tag"?: string;
+	};
+	// resources: { script: [Object]; script_runtime: [Object]; bindings: [] };
+};
+
+export function versionsDeployOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.option("name", {
+			describe: "Name of the worker",
+			type: "string",
+			requiresArg: true,
+		})
+		.option("version-id", {
+			describe: "Worker Version ID(s) to deploy",
+			type: "array",
+			string: true,
+			requiresArg: true,
+		})
+		.option("percentage", {
+			describe:
+				"Percentage of traffic to split between Worker Version(s) (0-100)",
+			type: "array",
+			number: true,
+			requiresArg: true,
+		})
+		.positional("version-specs", {
+			describe:
+				"Shorthand notation to deploy Worker Version(s) [<version-id>@<percentage>...].",
+			type: "string",
+			array: true,
+		})
+		.option("message", {
+			describe: "Description of this deployment (optional)",
+			type: "string",
+			requiresArg: true,
+		})
+		.option("tag", {
+			describe: "Tag attribute of this deployment (optional)",
+			type: "string",
+			requiresArg: true,
+		})
+		.option("yes", {
+			alias: "y",
+			describe: "Automatically accept defaults to prompts.",
+			type: "boolean",
+			default: false,
+		})
+		.option("dry-run", {
+			describe: "Don't actually deploy",
+			type: "boolean",
+			default: false,
+		})
+		.option("max-versions", {
+			hidden: true, // experimental, not supported long-term
+			describe: "Maximum allowed versions to select",
+			type: "number",
+			default: 2,
+		});
+}
+
+export async function versionsDeployHandler(
+	args: StrictYargsOptionsToInterface<typeof versionsDeployOptions>
+) {
+	await printWranglerBanner();
+
+	const accountId = await getAccountId(args);
+	const workerName = args.name ?? "worker-app";
+	const optionalVersionTraffic = parseVersionSpecs(args);
+
+	cli.startSection(
+		"Deploy Worker Versions",
+		"by splitting traffic between multiple versions",
+		true
+	);
+
+	await printLatestDeployment(accountId, workerName);
+
+	// prompt to confirm or change the versionIds from the args
+	const confirmedVersionsToDeploy = await promptVersionsToDeploy(
+		accountId,
+		workerName,
+		[...optionalVersionTraffic.keys()]
+	);
+
+	// validate we have at least 1 version
+	if (confirmedVersionsToDeploy.length === 0) {
+		throw new UserError("You must select at least 1 version to deploy.");
+	}
+
+	// validate we have at most experimentalMaxVersions (default: 2)
+	if (confirmedVersionsToDeploy.length > args.maxVersions) {
+		throw new UserError(
+			`You must select at most ${args.maxVersions} versions to deploy.`
+		);
+	}
+
+	// prompt to confirm or change the percentages for each confirmed version to deploy
+	const confirmedVersionTraffic = await promptPercentages(
+		confirmedVersionsToDeploy,
+		optionalVersionTraffic,
+		args.yes
+	);
+
+	// prompt for deployment message
+	const message = await inputPrompt<string | undefined>({
+		type: "text",
+		label: "Deployment message",
+		defaultValue: args.message,
+		question: "Add a deployment message",
+		helpText: "(optional)",
+	});
+
+	// // prompt for deployment tag
+	// const tag = await inputPrompt<string | undefined>({
+	// 	type: "text",
+	// 	label: "Deployment tag",
+	// 	defaultValue: args.tag,
+	// 	question: "Add a deployment tag",
+	// 	helpText: "(optional)",
+	// });
+
+	// if (args.dryRun) {
+	// 	cli.cancel("--dry-run: exiting");
+	// 	return;
+	// }
+
+	const start = Date.now();
+
+	await createDeployment(
+		accountId,
+		workerName,
+		confirmedVersionTraffic,
+		message
+		// , tag
+	);
+
+	const elapsedMilliseconds = Date.now() - start;
+	const elapsedSeconds = elapsedMilliseconds / 1000;
+	const elapsedString = `${elapsedSeconds.toFixed(2)} sec`;
+	const trafficSummaryString = Array.from(confirmedVersionTraffic)
+		.map(([versionId, percentage]) => `version ${versionId} at ${percentage}%`)
+		.join(" and ");
+
+	cli.success(
+		`Deployed ${workerName} ${trafficSummaryString} (${elapsedString})`
+	);
+}
+
+async function getAccountId(
+	args: Pick<Args, "config" | "name" | "dryRun" | "experimentalJsonConfig">
+) {
+	const configPath =
+		args.config || (args.name && findWranglerToml(path.dirname(args.name)));
+	const config = readConfig(configPath, args);
+	const accountId = await requireAuth(config);
+
+	return accountId;
+}
+
+async function printLatestDeployment(accountId: string, workerName: string) {
+	const s = spinner();
+	s.start("Fetching latest deployment");
+	const [versions, traffic] = await fetchLatestDeploymentVersions(
+		accountId,
+		workerName
+	);
+	s.stop();
+
+	cli.logRaw(
+		`${leftT} Your current deployment has ${versions.length} version(s):`
+	);
+
+	for (const version of versions) {
+		const trafficString = brandColor(`(${traffic.get(version.id)}%)`);
+		const versionIdString = white(version.id);
+
+		cli.log(
+			gray(`
+${trafficString} ${versionIdString}
+      Created:  ${version.created.toLocaleString()}
+          Tag:  ${version.tag ?? BLANK_INPUT}
+      Message:  ${version.message ?? BLANK_INPUT}`)
+		);
+	}
+
+	cli.newline();
+
+	VERSION_CACHE; // store in
+}
+
+async function promptVersionsToDeploy(
+	accountId: string,
+	workerName: string,
+	defaultSelectedVersionIds: VersionId[]
+): Promise<VersionId[]> {
+	const s = spinner();
+	s.start("Fetching deployable versions");
+	await fetchLatestUploadedVersions(accountId, workerName);
+	await fetchVersions(accountId, workerName, ...defaultSelectedVersionIds);
+	s.stop();
+
+	const selectableVersions = Array.from(VERSION_CACHE.values()).sort(
+		(a, b) => b.created.getTime() - a.created.getTime()
+	);
+
+	const question = "Which version(s) do you want to deploy?";
+
+	const result = await inputPrompt<string[]>({
+		type: "multiselect",
+		question,
+		options: selectableVersions.map((version) => ({
+			value: version.id,
+			label: version.id,
+			sublabel: gray(`
+${ZERO_WIDTH_SPACE}       Created:  ${version.created.toLocaleString()}
+${ZERO_WIDTH_SPACE}           Tag:  ${version.tag ?? BLANK_INPUT}
+${ZERO_WIDTH_SPACE}       Message:  ${version.message ?? BLANK_INPUT}
+            `),
+		})),
+		label: "",
+		helpText: "Use SPACE to select/unselect version(s) and ENTER to submit.",
+		defaultValue: defaultSelectedVersionIds,
+		validate(versionIds) {
+			if (versionIds === undefined) {
+				return `You must select at least 1 version to deploy.`;
+			}
+		},
+		renderers: {
+			submit({ value: versionIds }) {
+				assert(Array.isArray(versionIds));
+
+				const label = brandColor(
+					`${versionIds.length} Worker Version(s) selected`
+				);
+
+				const versions = versionIds?.map((versionId, i) => {
+					const version = VERSION_CACHE.get(versionId);
+
+					// shouldn't be possible, but better a UserError than an assertion error
+					if (version === undefined) throw new UserError("Invalid Version ID");
+
+					return `${grayBar}
+${leftT} ${white(`    Worker Version ${i + 1}: `, version.id)}
+${grayBar} ${gray("             Created: ", version.created.toLocaleString())}
+${grayBar} ${gray("                 Tag: ", version.tag ?? BLANK_INPUT)}
+${grayBar} ${gray("             Message: ", version.message ?? BLANK_INPUT)}`;
+				});
+
+				return [
+					`${leftT} ${question}`,
+					`${leftT} ${label}`,
+					...versions,
+					grayBar,
+				];
+			},
+		},
+	});
+
+	return result;
+}
+
+async function promptPercentages(
+	versionIds: VersionId[],
+	optionalVersionTraffic: Map<VersionId, OptionalPercentage>,
+	yesFlag: boolean,
+	confirmedVersionTraffic = new Map<string, number>()
+) {
+	let n = 0;
+	for (const versionId of versionIds) {
+		n++;
+
+		const defaultVersionTraffic = assignAndDistributePercentages(
+			versionIds,
+			new Map([...optionalVersionTraffic, ...confirmedVersionTraffic])
+		);
+
+		const defaultValue = defaultVersionTraffic
+			.get(versionId)
+			?.toFixed(3)
+			.replace(/\.?0+$/, ""); // strip unecessary 0s after the decimal (e.g. 20.000 -> 20, 20.500 -> 20.5)
+
+		const question = `What percentage of traffic should Worker Version ${n} receive?`;
+
+		const answer = await inputPrompt({
+			type: "text",
+			question,
+			helpText: "(0-100)",
+			label: `Traffic`,
+			defaultValue,
+			initialValue: confirmedVersionTraffic.get(versionId)?.toString(),
+			format: (val) => `${val}%`,
+			validate: (val) => {
+				const input = val !== "" ? val : defaultValue;
+				const percentage = parseFloat(input?.toString() ?? "");
+
+				if (isNaN(percentage) || percentage < 0 || percentage > 100)
+					return "Please enter a number between 0 and 100.";
+			},
+			renderers: {
+				submit({ value }) {
+					const percentage = parseFloat(value?.toString() ?? "");
+
+					return [
+						leftT + cli.space() + white(question),
+						leftT +
+							cli.space() +
+							brandColor(`${percentage}%`) +
+							gray(" of traffic"),
+						leftT,
+					];
+				},
+			},
+		});
+
+		const percentage = parseFloat(answer);
+
+		confirmedVersionTraffic.set(versionId, percentage);
+	}
+
+	const { subtotal } = summariseVersionTraffic(
+		confirmedVersionTraffic,
+		versionIds
+	);
+	try {
+		validateTrafficSubtotal(subtotal);
+	} catch (err) {
+		if (err instanceof UserError) {
+			cli.error(err.message, undefined, leftT);
+
+			return promptPercentages(
+				versionIds,
+				optionalVersionTraffic,
+				yesFlag,
+				confirmedVersionTraffic
+			);
+		}
+
+		throw err;
+	}
+
+	return confirmedVersionTraffic;
+}
+
+// ***********
+//    API
+// ***********
+
+async function fetchVersion(
+	accountId: string,
+	workerName: string,
+	versionId: VersionId
+) {
+	const cachedVersion = VERSION_CACHE.get(versionId);
+	if (cachedVersion) return cachedVersion;
+
+	const apiVersion = await fetchResult<ApiVersion>(
+		`/accounts/${accountId}/workers/scripts/${workerName}/versions/${versionId}`
+	);
+
+	const version = castAndCacheWorkerVersion(apiVersion);
+
+	return version;
+}
+async function fetchVersions(
+	accountId: string,
+	workerName: string,
+	...versionIds: VersionId[]
+) {
+	return Promise.all(
+		versionIds.map((versionId) =>
+			fetchVersion(accountId, workerName, versionId)
+		)
+	);
+}
+async function fetchLatestDeploymentVersions(
+	accountId: string,
+	workerName: string
+): Promise<[WorkerVersion[], Map<VersionId, Percentage>]> {
+	const { deployments } = await fetchResult<{ deployments: ApiDeployment[] }>(
+		`/accounts/${accountId}/workers/scripts/${workerName}/deployments`
+	);
+
+	const latestDeployment = deployments.at(0); // TODO: is the latest deployment .at(0) or .at(-1)?
+	if (!latestDeployment) return [[], new Map()];
+
+	const versionTraffic = new Map(
+		latestDeployment.versions.map(({ version_id: versionId, percentage }) => [
+			versionId,
+			percentage,
+		])
+	);
+	const versions = await fetchVersions(
+		accountId,
+		workerName,
+		...versionTraffic.keys()
+	);
+
+	return [versions, versionTraffic];
+}
+async function fetchLatestUploadedVersions(
+	accountId: string,
+	workerName: string
+): Promise<WorkerVersion[]> {
+	const { items } = await fetchResult<{ items: ApiVersion[] }>(
+		`/accounts/${accountId}/workers/scripts/${workerName}/versions`
+	);
+
+	const versions = items.map(castAndCacheWorkerVersion);
+
+	return versions;
+}
+function castAndCacheWorkerVersion(apiVersion: ApiVersion) {
+	const version: WorkerVersion = {
+		id: apiVersion.id,
+		created: new Date(apiVersion.metadata.created_on),
+		message: apiVersion.annotations["workers/message"],
+		tag: apiVersion.annotations["workers/tag"],
+	};
+
+	console.log(apiVersion, "\n\n\n");
+	VERSION_CACHE.set(version.id, version);
+
+	return version;
+}
+async function createDeployment(
+	accountId: string,
+	workerName: string,
+	versionTraffic: Map<VersionId, Percentage>,
+	message: string | undefined
+	//, tag: string | undefined
+) {
+	const res = await fetchResult(
+		`/accounts/${accountId}/workers/scripts/${workerName}/deployments`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				strategy: "percentage",
+				versions: Array.from(versionTraffic).map(
+					([version_id, percentage]) => ({ version_id, percentage })
+				),
+				annotations: {
+					"workers/triggered_by": "deployment",
+					"workers/message": message,
+					// "workers/tag": tag,
+				},
+			}),
+		}
+	);
+
+	// TODO: handle specific errors
+
+	return res;
+}
+
+// ***********
+//    UNITS
+// ***********
+
+export function parseVersionSpecs(
+	args: Pick<
+		StrictYargsOptionsToInterface<typeof versionsDeployOptions>,
+		"versionSpecs" | "versionId" | "percentage"
+	>
+): Map<VersionId, OptionalPercentage> {
+	const versionIds: string[] = [];
+	const percentages: OptionalPercentage[] = [];
+
+	for (const spec of args.versionSpecs ?? []) {
+		const [versionId, percentageString] = spec.split("@");
+
+		const percentage =
+			percentageString === "" ? null : parseFloat(percentageString);
+
+		if (percentage !== null) {
+			if (isNaN(percentage)) {
+				throw new UserError(
+					`Could not parse percentage value from version-spec positional arg "${spec}"`
+				);
+			}
+
+			if (percentage < 0 || percentage > 100) {
+				throw new UserError(
+					`Percentage value (${percentage}%) parsed from version-spec positional arg "${spec}" must be between 0 and 100.`
+				);
+			}
+		}
+
+		versionIds.push(versionId);
+		percentages.push(percentage);
+	}
+
+	// after parsing positonal args, merge in the explicit args
+	// the 2 kinds of args shouldn't be used together but, if they are, positional args are given precedence
+
+	const UUID_REGEX =
+		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+	for (const versionId of args.versionId ?? []) {
+		if (!UUID_REGEX.test(versionId)) {
+			throw new UserError(`Version ID must be a valid UUID (${versionId}).`);
+		}
+
+		versionIds.push(versionId);
+	}
+
+	for (const percentage of args.percentage ?? []) {
+		if (percentage < 0 || percentage > 100) {
+			throw new UserError(
+				`Percentage value (${percentage}%) must be between 0 and 100.`
+			);
+		}
+
+		percentages.push(percentage);
+	}
+
+	const optionalVersionTraffic = new Map<VersionId, OptionalPercentage>(
+		versionIds.map((_, i) => [versionIds[i], percentages[i] ?? null])
+	);
+
+	return optionalVersionTraffic;
+}
+
+function assignAndDistributePercentages(
+	versionIds: VersionId[],
+	optionalVersionTraffic: Map<VersionId, OptionalPercentage>
+): Map<VersionId, Percentage> {
+	const { subtotal, unspecifiedCount } = summariseVersionTraffic(
+		optionalVersionTraffic,
+		versionIds
+	);
+
+	const unspecifiedPercentageReplacement =
+		unspecifiedCount === 0 || subtotal > 100
+			? 0
+			: (100 - subtotal) / unspecifiedCount;
+
+	const versionTraffic = new Map<VersionId, Percentage>(
+		versionIds.map((versionId) => [
+			versionId,
+			optionalVersionTraffic.get(versionId) ?? unspecifiedPercentageReplacement,
+		])
+	);
+
+	return versionTraffic;
+}
+
+function summariseVersionTraffic(
+	optionalVersionTraffic: Map<VersionId, OptionalPercentage>,
+	versionIds: VersionId[] = Array.from(optionalVersionTraffic.keys())
+) {
+	const versionsWithoutPercentage = versionIds.filter(
+		(versionId) => optionalVersionTraffic.get(versionId) == null
+	);
+	const percentages = versionIds.map<OptionalPercentage>(
+		(versionId) => optionalVersionTraffic.get(versionId) ?? null
+	);
+	const percentagesSubtotal = percentages.reduce<number>(
+		(sum, x) => sum + (x ?? 0),
+		0
+	);
+
+	return {
+		subtotal: percentagesSubtotal,
+		unspecifiedCount: versionsWithoutPercentage.length,
+	};
+}
+
+function validateTrafficSubtotal(
+	subtotal: number,
+	{ max = 100, min = 100, epsilon = EPSILON } = {}
+) {
+	const isAbove = subtotal > max + epsilon;
+	const isBelow = subtotal < min - epsilon;
+
+	if (max === min && (isAbove || isBelow)) {
+		throw new UserError(
+			`Sum of specified percentages (${subtotal}%) must be ${max}%`
+		);
+	}
+	if (isAbove) {
+		throw new UserError(
+			`Sum of specified percentages (${subtotal}%) must be at most ${max}%`
+		);
+	}
+	if (isBelow) {
+		throw new UserError(
+			`Sum of specified percentages (${subtotal}%) must be at least ${min}%`
+		);
+	}
+}

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -21,7 +21,7 @@ import type {
 const EPSILON = 0.001; // used to avoid floating-point errors. Comparions to a value +/- EPSILON will mean "roughly equals the value".
 const BLANK_INPUT = "-"; // To be used where optional user-input is displayed and the value is nullish
 const ZERO_WIDTH_SPACE = "​"; // Some log lines get trimmed and so, to indent, the line is prefixed with a zero-width space
-const VERSION_CACHE = new Map<string, WorkerVersion>();
+const VERSION_CACHE = new Map<VersionId, WorkerVersion>();
 
 type Args = StrictYargsOptionsToInterface<typeof versionsDeployOptions>;
 
@@ -41,8 +41,11 @@ type ApiDeployment = {
 	strategy: "percentage" | string;
 	author_email: string;
 	annotations: Record<string, string>;
-	versions: Array<{ version_id: VersionId; percentage: Percentage }>;
 	created_on: string;
+	versions: Array<{
+		version_id: VersionId;
+		percentage: Percentage;
+	}>;
 };
 type ApiVersion = {
 	id: VersionId;
@@ -322,8 +325,8 @@ async function promptPercentages(
 	versionIds: VersionId[],
 	optionalVersionTraffic: Map<VersionId, OptionalPercentage>,
 	yesFlag: boolean,
-	confirmedVersionTraffic = new Map<string, number>()
-) {
+	confirmedVersionTraffic = new Map<VersionId, Percentage>()
+): Promise<Map<VersionId, Percentage>> {
 	let n = 0;
 	for (const versionId of versionIds) {
 		n++;

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -20,7 +20,7 @@ import type {
 
 const EPSILON = 0.001; // used to avoid floating-point errors. Comparions to a value +/- EPSILON will mean "roughly equals the value".
 const BLANK_INPUT = "-"; // To be used where optional user-input is displayed and the value is nullish
-const ZERO_WIDTH_SPACE = "​"; // Some log lines get trimmed and so, to indent, the line is prefixed with a zero-width space
+const ZERO_WIDTH_SPACE = "\u200B"; // Some log lines get trimmed and so, to indent, the line is prefixed with a zero-width space
 const VERSION_CACHE = new Map<VersionId, WorkerVersion>();
 
 type Args = StrictYargsOptionsToInterface<typeof versionsDeployOptions>;

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -123,7 +123,7 @@ export async function versionsDeployHandler(args: VersionsDeployArgs) {
 
 	const config = getConfig(args);
 	await metrics.sendMetricsEvent(
-		"deploy worker version(s)",
+		"deploy worker versions",
 		{},
 		{
 			sendMetrics: config.send_metrics,

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -632,7 +632,7 @@ export function summariseVersionTraffic(
 	};
 }
 
-function validateTrafficSubtotal(
+export function validateTrafficSubtotal(
 	subtotal: number,
 	{ max = 100, min = 100, epsilon = EPSILON } = {}
 ) {

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -96,11 +96,6 @@ export function versionsDeployOptions(yargs: CommonYargsArgv) {
 			type: "string",
 			requiresArg: true,
 		})
-		.option("tag", {
-			describe: "Tag attribute of this deployment (optional)",
-			type: "string",
-			requiresArg: true,
-		})
 		.option("yes", {
 			alias: "y",
 			describe: "Automatically accept defaults to prompts.",
@@ -172,19 +167,10 @@ export async function versionsDeployHandler(
 		helpText: "(optional)",
 	});
 
-	// // prompt for deployment tag
-	// const tag = await inputPrompt<string | undefined>({
-	// 	type: "text",
-	// 	label: "Deployment tag",
-	// 	defaultValue: args.tag,
-	// 	question: "Add a deployment tag",
-	// 	helpText: "(optional)",
-	// });
-
-	// if (args.dryRun) {
-	// 	cli.cancel("--dry-run: exiting");
-	// 	return;
-	// }
+	if (args.dryRun) {
+		cli.cancel("--dry-run: exiting");
+		return;
+	}
 
 	const start = Date.now();
 
@@ -193,7 +179,6 @@ export async function versionsDeployHandler(
 		workerName,
 		confirmedVersionTraffic,
 		message
-		// , tag
 	);
 
 	const elapsedMilliseconds = Date.now() - start;
@@ -489,7 +474,6 @@ async function createDeployment(
 	workerName: string,
 	versionTraffic: Map<VersionId, Percentage>,
 	message: string | undefined
-	//, tag: string | undefined
 ) {
 	const res = await fetchResult(
 		`/accounts/${accountId}/workers/scripts/${workerName}/deployments`,
@@ -504,7 +488,6 @@ async function createDeployment(
 				annotations: {
 					"workers/triggered_by": "deployment",
 					"workers/message": message,
-					// "workers/tag": tag,
 				},
 			}),
 		}

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -587,7 +587,7 @@ export function parseVersionSpecs(
 	return optionalVersionTraffic;
 }
 
-function assignAndDistributePercentages(
+export function assignAndDistributePercentages(
 	versionIds: VersionId[],
 	optionalVersionTraffic: Map<VersionId, OptionalPercentage>
 ): Map<VersionId, Percentage> {
@@ -611,7 +611,7 @@ function assignAndDistributePercentages(
 	return versionTraffic;
 }
 
-function summariseVersionTraffic(
+export function summariseVersionTraffic(
 	optionalVersionTraffic: Map<VersionId, OptionalPercentage>,
 	versionIds: VersionId[] = Array.from(optionalVersionTraffic.keys())
 ) {

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -485,7 +485,7 @@ async function fetchLatestDeploymentVersions(
 		`/accounts/${accountId}/workers/scripts/${workerName}/deployments`
 	);
 
-	const latestDeployment = deployments.at(-1);
+	const latestDeployment = deployments.at(0);
 	if (!latestDeployment) return [[], new Map()];
 
 	const versionTraffic = new Map(

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -43,7 +43,7 @@ type ApiDeployment = {
 	source: "api" | string;
 	strategy: "percentage" | string;
 	author_email: string;
-	annotations: Record<string, string>;
+	annotations?: Record<string, string>;
 	created_on: string;
 	versions: Array<{
 		version_id: VersionId;
@@ -60,7 +60,7 @@ type ApiVersion = {
 		author_id: string;
 		author_email: string;
 	};
-	annotations: Record<string, string> & {
+	annotations?: Record<string, string> & {
 		"workers/triggered_by"?: "upload" | string;
 		"workers/message"?: string;
 		"workers/tag"?: string;
@@ -459,7 +459,7 @@ async function fetchLatestDeploymentVersions(
 		`/accounts/${accountId}/workers/scripts/${workerName}/deployments`
 	);
 
-	const latestDeployment = deployments.at(0); // TODO: is the latest deployment .at(0) or .at(-1)?
+	const latestDeployment = deployments.at(-1);
 	if (!latestDeployment) return [[], new Map()];
 
 	const versionTraffic = new Map(
@@ -492,11 +492,10 @@ function castAndCacheWorkerVersion(apiVersion: ApiVersion) {
 	const version: WorkerVersion = {
 		id: apiVersion.id,
 		created: new Date(apiVersion.metadata.created_on),
-		message: apiVersion.annotations["workers/message"],
-		tag: apiVersion.annotations["workers/tag"],
+		message: apiVersion.annotations?.["workers/message"],
+		tag: apiVersion.annotations?.["workers/tag"],
 	};
 
-	console.log(apiVersion, "\n\n\n");
 	VERSION_CACHE.set(version.id, version);
 
 	return version;

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -194,9 +194,11 @@ export async function versionsDeployHandler(
 	const elapsedMilliseconds = Date.now() - start;
 	const elapsedSeconds = elapsedMilliseconds / 1000;
 	const elapsedString = `${elapsedSeconds.toFixed(2)} sec`;
-	const trafficSummaryString = Array.from(confirmedVersionTraffic)
-		.map(([versionId, percentage]) => `version ${versionId} at ${percentage}%`)
-		.join(" and ");
+
+	const trafficSummaryList = Array.from(confirmedVersionTraffic).map(
+		([versionId, percentage]) => `version ${versionId} at ${percentage}%`
+	);
+	const trafficSummaryString = new Intl.ListFormat().format(trafficSummaryList);
 
 	cli.success(
 		`Deployed ${workerName} ${trafficSummaryString} (${elapsedString})`


### PR DESCRIPTION
**What this PR solves / how to test:**

This PR implements the `versions deploy` command as a sibling command to the, already merged, `versions upload` command. Both are still behind the `--experimental-gradual-rollouts` flag.

Note: in the commands below, it is assumed you have followed the install instructions of the prerelease build (from the bot comment in this PR). You can, instead, replace "wrangler" with the prerelease URL from the bot comment.

The most common usage will be without args where the prompts will walk you through selecting Versions and percentages for each and adding a deployment message. A sane default is provided for each percentage, evenly distributing the remaining percentage across the remaining versions.
```sh
$ npx wrangler versions deploy    --experimental-gradual-rollouts
```

You can also specify positional args in the form of `<version-id>` or `<version-id>@<percentage>` which will set the default selected Versions and the default associated percentage for each. The prompts are still presented but with prefilled defaults that the user can press ENTER to confirm.
```sh
# 1 version preselected by default
$ npx wrangler versions deploy 095f00a7-23a7-43b7-a227-e4c97cab5f22    --experimental-gradual-rollouts

# 2 versions preselected by default (the default percentage for each will be 50%)
$ npx wrangler versions deploy 095f00a7-23a7-43b7-a227-e4c97cab5f22  1a88955c-2fbd-4a72-9d9b-3ba1e59842f2    -experimental-gradual-rollouts

# 2 versions preselected by default – one with explicit 10% traffic, the other with implicit 90%
$ npx wrangler versions deploy 095f00a7-23a7-43b7-a227-e4c97cab5f22@10%   1a88955c-2fbd-4a72-9d9b-3ba1e59842f2    --experimental-gradual-rollouts
# ^ the 2nd version will have 90% by default (evenly distributed after the first version was assigned 10%)

# 2 versions preselected by default – both with explicit traffic 10% and 90%
$ npx wrangler versions deploy 095f00a7-23a7-43b7-a227-e4c97cab5f22@10%   1a88955c-2fbd-4a72-9d9b-3ba1e59842f2@90%    --experimental-gradual-rollouts
```

You can also specify named args `--version-id` and `--percentage` repeatedly. All `--version-id` args are read in order into an array. All `--percentage` args are read in order into an array. The indexes of each array are then used to correlate. By specifying less `--percentage` args than `--version-id` args, the percentages for the excess versions are deemed unspecified, like with positional args without `@<percentage>`, and will have the remaining percentage distributed evenly as with positional/prompted percentages.

```sh
$ npx wrangler versions deploy    --experimental-gradual-rollouts \
    --version-id 095f00a7-23a7-43b7-a227-e4c97cab5f22 \
    --percentage 10% \
    --version-id 1a88955c-2fbd-4a72-9d9b-3ba1e59842f2 \
    --percentage 90% 
# is equivalent to
$ npx wrangler versions deploy    --experimental-gradual-rollouts \
    --version-id 095f00a7-23a7-43b7-a227-e4c97cab5f22 \
    --version-id 1a88955c-2fbd-4a72-9d9b-3ba1e59842f2 \
    --percentage 10% \
    --percentage 90% 
```

A mixture of positional and named args will work and should be relatively predictable, with positional args taking precedence.

By using the `--yes` flag, the prompt defaults will be automatically accepted. This will allow the following: 
```sh
# deploy 2 versions with (implicit) 50% split – with positional args
$ npx wrangler versions deploy 095f00a7-23a7-43b7-a227-e4c97cab5f22  1a88955c-2fbd-4a72-9d9b-3ba1e59842f2  --yes    --experimental-gradual-rollouts

# deploy 2 versions with (explicit) 10% and (implicit) 90% split – with positional args
$ npx wrangler versions deploy 095f00a7-23a7-43b7-a227-e4c97cab5f22@10%   1a88955c-2fbd-4a72-9d9b-3ba1e59842f2  --yes    --experimental-gradual-rollouts

# deploy 2 versions with (explicit) 10% and (explicit) 90% split – with positional args
$ npx wrangler versions deploy 095f00a7-23a7-43b7-a227-e4c97cab5f22@10%   1a88955c-2fbd-4a72-9d9b-3ba1e59842f2@90%  --yes    --experimental-gradual-rollouts

# deploy 2 versions with (explicit) 10% and (implicit) 90% split – with named args
$ npx wrangler versions deploy  --yes    --experimental-gradual-rollouts \
    --version-id 095f00a7-23a7-43b7-a227-e4c97cab5f22 \
    --percentage 10% \
    --version-id 1a88955c-2fbd-4a72-9d9b-3ba1e59842f2

# deploy 2 versions with (explicit) 10% and (explicit) 90% split – with named args
$ npx wrangler versions deploy  --yes    --experimental-gradual-rollouts \
    --version-id 095f00a7-23a7-43b7-a227-e4c97cab5f22 \
    --percentage 10% \
    --version-id 1a88955c-2fbd-4a72-9d9b-3ba1e59842f2 \
    --percentage 90% 
```

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
  - [ ] TODO before merging
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
  - [ ] TODO before merging
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: internal command for now, documentation coming before open beta.

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
