### PR TITLE
More strict handling of requirement specifiers in requirements.txt.

### DIFF
--- a/.changeset/swift-peaches-battle.md
+++ b/.changeset/swift-peaches-battle.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Including version identifiers in Python requirements.txt will now throw an error

--- a/.changeset/swift-peaches-battle.md
+++ b/.changeset/swift-peaches-battle.md
@@ -2,4 +2,4 @@
 "wrangler": minor
 ---
 
-Including version identifiers in Python requirements.txt will now throw an error
+fix: Including version identifiers in Python requirements.txt will now throw an error

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -74,9 +74,9 @@ export async function findAdditionalModules(
 			for (const requirement of pythonRequirements.split("\n")) {
 				if (requirement === "") continue;
 				if (!isValidPythonPackageName(requirement)) {
-					throw new UserError(`Invalid Python package name "${
-						requirement
-					}" found in requirements.txt. Note that requirements.txt should contain package names only, not version specifiers.`);
+					throw new UserError(
+						`Invalid Python package name "${requirement}" found in requirements.txt. Note that requirements.txt should contain package names only, not version specifiers.`
+					);
 				}
 
 				modules.push({
@@ -86,8 +86,10 @@ export async function findAdditionalModules(
 					filePath: undefined,
 				});
 			}
-			// We don't care if a requirements.txt isn't found
 		} catch (e) {
+			if (e instanceof UserError) throw e;
+
+			// We don't care if a requirements.txt isn't found
 			logger.debug(
 				"Python entrypoint detected, but no requirements.txt file found."
 			);

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -30,6 +30,16 @@ async function* getFiles(
 }
 
 /**
+ * Checks if a given string is a valid Python package identifier.
+ * See https://packaging.python.org/en/latest/specifications/name-normalization/
+ * @param name The package name to validate
+ */
+function isValidPythonPackageName(name: string): boolean {
+	const regex = /^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$/i;
+	return regex.test(name);
+}
+
+/**
  * Search the filesystem under the `moduleRoot` of the `entry` for potential additional modules
  * that match the given `rules`.
  */
@@ -61,17 +71,20 @@ export async function findAdditionalModules(
 				"utf-8"
 			);
 
-			// This is incredibly naive. However, it supports common syntax for requirements.txt
 			for (const requirement of pythonRequirements.split("\n")) {
-				const packageName = requirement.match(/^[^\d\W]\w*/);
-				if (typeof packageName?.[0] === "string") {
-					modules.push({
-						type: "python-requirement",
-						name: packageName?.[0],
-						content: "",
-						filePath: undefined,
-					});
+				if (requirement === "") continue;
+				if (!isValidPythonPackageName(requirement)) {
+					throw new UserError(`Invalid Python package name "${
+						requirement
+					}" found in requirements.txt. Note that requirements.txt should contain package names only, not version specifiers.`);
 				}
+
+				modules.push({
+					type: "python-requirement",
+					name: requirement,
+					content: "",
+					filePath: undefined,
+				});
 			}
 			// We don't care if a requirements.txt isn't found
 		} catch (e) {

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -65,34 +65,33 @@ export async function findAdditionalModules(
 		getBundleType(entry.format, entry.file) === "python";
 
 	if (isPythonEntrypoint) {
+		let pythonRequirements = "";
 		try {
-			const pythonRequirements = await readFile(
+			pythonRequirements = await readFile(
 				path.resolve(entry.directory, "requirements.txt"),
 				"utf-8"
 			);
-
-			for (const requirement of pythonRequirements.split("\n")) {
-				if (requirement === "") continue;
-				if (!isValidPythonPackageName(requirement)) {
-					throw new UserError(
-						`Invalid Python package name "${requirement}" found in requirements.txt. Note that requirements.txt should contain package names only, not version specifiers.`
-					);
-				}
-
-				modules.push({
-					type: "python-requirement",
-					name: requirement,
-					content: "",
-					filePath: undefined,
-				});
-			}
 		} catch (e) {
-			if (e instanceof UserError) throw e;
-
 			// We don't care if a requirements.txt isn't found
 			logger.debug(
 				"Python entrypoint detected, but no requirements.txt file found."
 			);
+		}
+
+		for (const requirement of pythonRequirements.split("\n")) {
+			if (requirement === "") continue;
+			if (!isValidPythonPackageName(requirement)) {
+				throw new UserError(
+					`Invalid Python package name "${requirement}" found in requirements.txt. Note that requirements.txt should contain package names only, not version specifiers.`
+				);
+			}
+
+			modules.push({
+				type: "python-requirement",
+				name: requirement,
+				content: "",
+				filePath: undefined,
+			});
 		}
 	}
 	if (modules.length > 0) {


### PR DESCRIPTION
After some discussion, the runtime team has decided that we should prevent users from specifying version identifiers altogether within requirements.txt, rather than silently dropping them. This would prevent users from being deluded into thinking that they could specify versions of Python packages in Python workers, then being confused because their code mysteriously breaks. 

Fixes EW-8189.

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: We're moving fast on this experimental functionality and I will be testing the change manually with the prerelease build. The original code also didn't include tests. 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: documented inline

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
