### PR TITLE
Add python support for remote dev

### DIFF
--- a/.changeset/kind-ducks-pay.md
+++ b/.changeset/kind-ducks-pay.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Python support for remote dev

--- a/.changeset/kind-ducks-pay.md
+++ b/.changeset/kind-ducks-pay.md
@@ -2,4 +2,4 @@
 "wrangler": minor
 ---
 
-Python support for remote dev
+feature: Python support for remote dev

--- a/packages/wrangler/src/deployment-bundle/source-url.ts
+++ b/packages/wrangler/src/deployment-bundle/source-url.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from "url";
 import type { CfModule } from "./worker";
 
 function withSourceURL(source: string, sourcePath: string, isPython = false) {
-	if(isPython) {
+	if (isPython) {
 		return `${source}\n# sourceURL=${pathToFileURL(sourcePath)}`;
 	}
 	return `${source}\n//# sourceURL=${pathToFileURL(sourcePath)}`;
@@ -20,7 +20,11 @@ export function withSourceURLs(
 	modules: CfModule[]
 ): { entrypointSource: string; modules: CfModule[] } {
 	let entrypointSource = fs.readFileSync(entrypointPath, "utf8");
-	entrypointSource = withSourceURL(entrypointSource, entrypointPath, entrypointPath.endsWith(".py"));
+	entrypointSource = withSourceURL(
+		entrypointSource,
+		entrypointPath,
+		entrypointPath.endsWith(".py")
+	);
 
 	modules = modules.map((module) => {
 		if (

--- a/packages/wrangler/src/deployment-bundle/source-url.ts
+++ b/packages/wrangler/src/deployment-bundle/source-url.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import { pathToFileURL } from "url";
 import type { CfModule } from "./worker";
 
-function withSourceURL(source: string, sourcePath: string) {
+function withSourceURL(source: string, sourcePath: string, isPython = false) {
+	if(isPython) {
+		return `${source}\n# sourceURL=${pathToFileURL(sourcePath)}`;
+	}
 	return `${source}\n//# sourceURL=${pathToFileURL(sourcePath)}`;
 }
 
@@ -17,7 +20,7 @@ export function withSourceURLs(
 	modules: CfModule[]
 ): { entrypointSource: string; modules: CfModule[] } {
 	let entrypointSource = fs.readFileSync(entrypointPath, "utf8");
-	entrypointSource = withSourceURL(entrypointSource, entrypointPath);
+	entrypointSource = withSourceURL(entrypointSource, entrypointPath, entrypointPath.endsWith(".py"));
 
 	modules = modules.map((module) => {
 		if (

--- a/packages/wrangler/src/deployment-bundle/source-url.ts
+++ b/packages/wrangler/src/deployment-bundle/source-url.ts
@@ -2,10 +2,7 @@ import fs from "node:fs";
 import { pathToFileURL } from "url";
 import type { CfModule } from "./worker";
 
-function withSourceURL(source: string, sourcePath: string, isPython = false) {
-	if (isPython) {
-		return `${source}\n# sourceURL=${pathToFileURL(sourcePath)}`;
-	}
+function withSourceURL(source: string, sourcePath: string) {
 	return `${source}\n//# sourceURL=${pathToFileURL(sourcePath)}`;
 }
 
@@ -20,11 +17,9 @@ export function withSourceURLs(
 	modules: CfModule[]
 ): { entrypointSource: string; modules: CfModule[] } {
 	let entrypointSource = fs.readFileSync(entrypointPath, "utf8");
-	entrypointSource = withSourceURL(
-		entrypointSource,
-		entrypointPath,
-		entrypointPath.endsWith(".py")
-	);
+	if (!entrypointPath.endsWith(".py")) {
+		entrypointSource = withSourceURL(entrypointSource, entrypointPath);
+	}
 
 	modules = modules.map((module) => {
 		if (

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -596,7 +596,7 @@ async function createRemoteWorkerInit(props: {
 		main: {
 			name: path.basename(props.bundle.path),
 			filePath: props.bundle.path,
-			type: getBundleType(props.format),
+			type: getBundleType(props.format, path.basename(props.bundle.path)),
 			content,
 		},
 		modules,


### PR DESCRIPTION
This PR makes sure that the bundle type is set correctly in remote dev mode when the main module is a Python module. It also ensures that the source URL annotation is written in Python style when the entry point is a Python module. 

**Author has addressed the following:**

- Tests
  - [ ] Included
  - [x] Not necessary because: one-line change on experimental feature
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: one-line change on experimental feature; we will also be writing docs for the feature in the near future. 

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
