### PR TITLE
pass legacy-env through versions upload

### DIFF
--- a/.changeset/hungry-cooks-brake.md
+++ b/.changeset/hungry-cooks-brake.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add legacy_env support to experimental versions upload command.

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -3,7 +3,12 @@ import chalk from "chalk";
 import { fetchResult } from "../cfetch";
 import { findWranglerToml, readConfig } from "../config";
 import { getEntry } from "../deployment-bundle/entry";
-import { getRules, getScriptName, printWranglerBanner } from "../index";
+import {
+	getRules,
+	getScriptName,
+	isLegacyEnv,
+	printWranglerBanner,
+} from "../index";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
@@ -232,6 +237,7 @@ export async function versionsUploadHandler(
 		name: getScriptName(args, config),
 		rules: getRules(config),
 		entry,
+		legacyEnv: isLegacyEnv(config),
 		env: args.env,
 		compatibilityDate: args.latest
 			? new Date().toISOString().substring(0, 10)

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -44,6 +44,7 @@ type Props = {
 	entry: Entry;
 	rules: Config["rules"];
 	name: string | undefined;
+	legacyEnv: boolean | undefined;
 	env: string | undefined;
 	compatibilityDate: string | undefined;
 	compatibilityFlags: string[] | undefined;
@@ -324,7 +325,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			? await getMigrationsToUpload(scriptName, {
 					accountId,
 					config,
-					legacyEnv: false,
+					legacyEnv: props.legacyEnv,
 					env: props.env,
 			  })
 			: undefined;


### PR DESCRIPTION

**What this PR solves / how to test:**

**Author has addressed the following:**

- Tests

  - [x] Not necessary because: versions upload is experimental, doesn't have test suite yet. This brings it into conformance with standard deploy by not hardcoding is_legacy prop.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included



