### PR TITLE
[C3] fix: make sure that all C3 projects include in their `.gitignore` the wrangler files

### DIFF
--- a/.changeset/stale-needles-unite.md
+++ b/.changeset/stale-needles-unite.md
@@ -1,0 +1,9 @@
+---
+"create-cloudflare": patch
+---
+
+fix: make sure that all C3 projects include in their `.gitignore` the wrangler files
+
+previously only the worker templates included in their `.gitignore` the wrangler files
+(those being `.dev.vars` and `.wrangler`), make sure to instead include such files in
+the `.gitignore` files of all the templates including the full stack ones

--- a/.changeset/stale-needles-unite.md
+++ b/.changeset/stale-needles-unite.md
@@ -4,6 +4,4 @@
 
 fix: make sure that all C3 projects include in their `.gitignore` the wrangler files
 
-Previously only the worker templates included in their `.gitignore` the wrangler files
-(those being `.dev.vars` and `.wrangler`). Make sure to instead include such files in
-the `.gitignore` files of all the templates including the full stack ones.
+Previously only the worker templates included in their `.gitignore` the wrangler files (those being `.dev.vars` and `.wrangler`). Make sure to instead include such files in the `.gitignore` files of all the templates including the full stack ones.

--- a/.changeset/stale-needles-unite.md
+++ b/.changeset/stale-needles-unite.md
@@ -4,6 +4,6 @@
 
 fix: make sure that all C3 projects include in their `.gitignore` the wrangler files
 
-previously only the worker templates included in their `.gitignore` the wrangler files
-(those being `.dev.vars` and `.wrangler`), make sure to instead include such files in
-the `.gitignore` files of all the templates including the full stack ones
+Previously only the worker templates included in their `.gitignore` the wrangler files
+(those being `.dev.vars` and `.wrangler`). Make sure to instead include such files in
+the `.gitignore` files of all the templates including the full stack ones.

--- a/packages/create-cloudflare/src/__tests__/templates.test.ts
+++ b/packages/create-cloudflare/src/__tests__/templates.test.ts
@@ -1,0 +1,240 @@
+import { existsSync, statSync } from "fs";
+import { appendFile, readFile, writeFile } from "helpers/files";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { addWranglerToGitIgnore } from "../templates";
+import type { PathLike } from "fs";
+import type { C3Context } from "types";
+
+vi.mock("fs");
+vi.mock("helpers/files");
+
+describe("addWranglerToGitIgnore", () => {
+	const writeFileResults: {
+		file: string | undefined;
+		content: string | undefined;
+	} = { file: undefined, content: undefined };
+	const appendFileResults: {
+		file: string | undefined;
+		content: string | undefined;
+	} = { file: undefined, content: undefined };
+
+	beforeAll(() => {
+		vi.mocked(writeFile).mockImplementation((file: string, content: string) => {
+			writeFileResults.file = file;
+			writeFileResults.content = content;
+		});
+		vi.mocked(appendFile).mockImplementation(
+			(file: string, content: string) => {
+				appendFileResults.file = file;
+				appendFileResults.content = content;
+			}
+		);
+	});
+
+	beforeEach(() => {
+		vi.mocked(statSync).mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			(path: string) => ({
+				isDirectory() {
+					return path.endsWith(".git");
+				},
+			})
+		);
+		vi.mocked(existsSync).mockReset();
+		vi.mocked(readFile).mockReset();
+		appendFileResults.file = undefined;
+		appendFileResults.content = undefined;
+		writeFileResults.file = undefined;
+		writeFileResults.content = undefined;
+	});
+
+	test("should append the wrangler section to a standard gitignore file", () => {
+		mockGitIgnore(
+			"my-project/.gitignore",
+			`
+      node_modules
+      .vscode`
+		);
+		addWranglerToGitIgnore({
+			project: { path: "my-project" },
+		} as unknown as C3Context);
+
+		expect(appendFileResults.file).toMatchInlineSnapshot(
+			`"my-project/.gitignore"`
+		);
+		expect(appendFileResults.content).toMatchInlineSnapshot(`
+			"
+
+			# wrangler files
+			.wrangler
+			.dev.vars
+			"
+		`);
+	});
+
+	test("should not touch the gitignore file if it already contains all wrangler files", () => {
+		mockGitIgnore(
+			"my-project/.gitignore",
+			`
+      node_modules
+      .dev.vars
+      .vscode
+      .wrangler
+    `
+		);
+		addWranglerToGitIgnore({
+			project: { path: "my-project" },
+		} as unknown as C3Context);
+
+		expect(appendFileResults.file).toBeUndefined();
+		expect(appendFileResults.content).toBeUndefined();
+	});
+
+	test("should not touch the gitignore file if contains all wrangler files (and can cope with comments)", () => {
+		mockGitIgnore(
+			"my-project/.gitignore",
+			`
+      node_modules
+      .wrangler # This is for wrangler
+      .dev.vars # this is for wrangler and getPlatformProxy
+      .vscode
+    `
+		);
+		addWranglerToGitIgnore({
+			project: { path: "my-project" },
+		} as unknown as C3Context);
+
+		expect(appendFileResults.file).toBeUndefined();
+		expect(appendFileResults.content).toBeUndefined();
+	});
+
+	test("should append to the gitignore file the missing wrangler files when some is already present (without including the section heading)", () => {
+		mockGitIgnore(
+			"my-project/.gitignore",
+			`
+      node_modules
+      .dev.vars
+      .vscode`
+		);
+		addWranglerToGitIgnore({
+			project: { path: "my-project" },
+		} as unknown as C3Context);
+
+		expect(appendFileResults.file).toMatchInlineSnapshot(
+			`"my-project/.gitignore"`
+		);
+		expect(appendFileResults.content).toMatchInlineSnapshot(`
+			"
+
+			.wrangler
+			"
+		`);
+	});
+
+	test("when it appends to the gitignore file it includes an empty line only if there wasn't one already", () => {
+		mockGitIgnore(
+			"my-project/.gitignore",
+			`
+      node_modules
+      .dev.vars
+      .vscode
+
+    `
+		);
+		addWranglerToGitIgnore({
+			project: { path: "my-project" },
+		} as unknown as C3Context);
+
+		expect(appendFileResults.file).toMatchInlineSnapshot(
+			`"my-project/.gitignore"`
+		);
+		expect(appendFileResults.content).toMatchInlineSnapshot(`
+			"
+			.wrangler
+			"
+		`);
+	});
+
+	test("should create the gitignore file if it didn't exist already", () => {
+		// let's mock a gitignore file to be read by readFile
+		mockGitIgnore("my-project/.gitignore", "");
+		// but let's pretend that it doesn't exist
+		vi.mocked(existsSync).mockImplementation(() => false);
+
+		addWranglerToGitIgnore({
+			project: { path: "my-project" },
+		} as unknown as C3Context);
+
+		// writeFile wrote the (empty) gitignore file
+		expect(writeFileResults.file).toMatchInlineSnapshot(
+			`"my-project/.gitignore"`
+		);
+		expect(writeFileResults.content).toMatchInlineSnapshot(`""`);
+
+		// and the correct lines were then added to it
+		expect(appendFileResults.file).toMatchInlineSnapshot(
+			`"my-project/.gitignore"`
+		);
+		expect(appendFileResults.content).toMatchInlineSnapshot(`
+			"
+
+			# wrangler files
+			.wrangler
+			.dev.vars
+			"
+		`);
+	});
+
+	test("should not create the gitignore file the project doesn't use git", () => {
+		// let's mock a gitignore file to be read by readFile
+		mockGitIgnore("my-project/.gitignore", "");
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		vi.mocked(statSync).mockImplementation(() => ({
+			isDirectory() {
+				return false;
+			},
+		}));
+		vi.mocked(existsSync).mockImplementation(() => false);
+
+		addWranglerToGitIgnore({
+			project: { path: "my-project" },
+		} as unknown as C3Context);
+
+		expect(writeFileResults.file).toBeUndefined();
+		expect(writeFileResults.content).toBeUndefined();
+	});
+
+	test("should not add the .wrangler entry if a .wrangler/ is already included)", () => {
+		mockGitIgnore(
+			"my-project/.gitignore",
+			`
+      node_modules
+      .wrangler/ # This is for wrangler
+      .vscode
+    `
+		);
+		addWranglerToGitIgnore({
+			project: { path: "my-project" },
+		} as unknown as C3Context);
+
+		expect(appendFileResults.file).toMatchInlineSnapshot(
+			`"my-project/.gitignore"`
+		);
+		expect(appendFileResults.content).toMatchInlineSnapshot(`
+			"
+			.dev.vars
+			"
+		`);
+	});
+
+	function mockGitIgnore(path: string, content: string) {
+		vi.mocked(existsSync).mockImplementation(
+			(filePath: PathLike) => filePath === path
+		);
+		vi.mocked(readFile).mockImplementation((filePath: string) =>
+			filePath === path ? content.replace(/\n\s*/g, "\n") : ""
+		);
+	}
+});

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -27,6 +27,7 @@ import {
 } from "./common";
 import { createProject } from "./pages";
 import {
+	addWranglerToGitIgnore,
 	copyTemplateFiles,
 	selectTemplate,
 	updatePackageName,
@@ -146,6 +147,8 @@ const configure = async (ctx: C3Context) => {
 	if (template.configure) {
 		await template.configure({ ...ctx });
 	}
+
+	addWranglerToGitIgnore(ctx);
 
 	await updatePackageScripts(ctx);
 

--- a/packages/create-cloudflare/src/helpers/files.ts
+++ b/packages/create-cloudflare/src/helpers/files.ts
@@ -1,4 +1,4 @@
-import fs, { existsSync } from "fs";
+import fs, { existsSync, statSync } from "fs";
 import { join } from "path";
 import { crash } from "@cloudflare/cli";
 import TOML from "@iarna/toml";
@@ -33,6 +33,18 @@ export const readFile = (path: string) => {
 	try {
 		return fs.readFileSync(path, "utf-8");
 	} catch (error) {
+		return crash(error as string);
+	}
+};
+
+export const directoryExists = (path: string): boolean => {
+	try {
+		const { isDirectory } = statSync(path);
+		return isDirectory();
+	} catch (error) {
+		if ((error as { code: string }).code === "ENOENT") {
+			return false;
+		}
 		return crash(error as string);
 	}
 };

--- a/packages/create-cloudflare/src/helpers/files.ts
+++ b/packages/create-cloudflare/src/helpers/files.ts
@@ -39,8 +39,8 @@ export const readFile = (path: string) => {
 
 export const directoryExists = (path: string): boolean => {
 	try {
-		const { isDirectory } = statSync(path);
-		return isDirectory();
+		const stat = statSync(path);
+		return stat.isDirectory();
 	} catch (error) {
 		if ((error as { code: string }).code === "ENOENT") {
 			return false;

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -485,8 +485,8 @@ export const addWranglerToGitIgnore = (ctx: C3Context) => {
 	const gitDirExists = directoryExists(`${ctx.project.path}/.git`);
 
 	if (!gitIgnorePreExisted && !gitDirExists) {
-		// if there is no .gitIgnore file and neither a .git directory
-		// bail as the project is likely not targeting/using git
+		// if there is no .gitignore file and neither a .git directory
+		// then bail as the project is likely not targeting/using git
 		return;
 	}
 

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -480,18 +480,17 @@ export const getCopyFilesDestinationDir = (
 
 export const addWranglerToGitIgnore = (ctx: C3Context) => {
 	const gitIgnorePath = `${ctx.project.path}/.gitignore`;
-	const gitIgnoreExists = existsSync(gitIgnorePath);
+	const gitIgnorePreExisted = existsSync(gitIgnorePath);
 
 	const gitDirExists = directoryExists(`${ctx.project.path}/.git`);
 
-	if (!gitIgnoreExists && !gitDirExists) {
+	if (!gitIgnorePreExisted && !gitDirExists) {
 		// if there is no .gitIgnore file and neither a .git directory
 		// bail as the project is likely not targeting/using git
 		return;
 	}
 
-	const fileExisted = gitIgnoreExists;
-	if (!fileExisted) {
+	if (!gitIgnorePreExisted) {
 		writeFile(gitIgnorePath, "");
 	}
 
@@ -528,7 +527,7 @@ export const addWranglerToGitIgnore = (ctx: C3Context) => {
 	appendFile(gitIgnorePath, linesToAppend.join("\n"));
 
 	s.stop(
-		`${brandColor(fileExisted ? "updated" : "created")} ${dim(
+		`${brandColor(gitIgnorePreExisted ? "updated" : "created")} ${dim(
 			".gitignore file"
 		)}`
 	);

--- a/packages/wrangler/templates/gitignore
+++ b/packages/wrangler/templates/gitignore
@@ -165,8 +165,3 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.\*
-
-# wrangler project
-
-.dev.vars
-.wrangler/


### PR DESCRIPTION
**What this PR solves / how to test:**

previously only the worker templates included in their `.gitignore` the wrangler files
(those being `.dev.vars` and `.wrangler`), make sure to instead include such files in
the `.gitignore` files of all the templates including the full stack ones

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: quality of life improvement not needing documentation

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
