### PR TITLE
[wrangler] fix: switch default logging level of `unstable_dev()` to `warn`

### DIFF
--- a/.changeset/fluffy-yaks-matter.md
+++ b/.changeset/fluffy-yaks-matter.md
@@ -1,0 +1,13 @@
+---
+"wrangler": patch
+---
+
+fix: switch default logging level of `unstable_dev()` to `warn`
+
+When running `unstable_dev()` in its default "test mode", the logging level was set to `none`. This meant any Worker startup errors or helpful warnings wouldn't be shown. This change switches the default to `warn`. To restore the previous behaviour, include `logLevel: "none"` in your options object:
+
+```js
+const worker = await unstable_dev("path/to/script.js", {
+	logLevel: "none",
+});
+```

--- a/fixtures/local-mode-tests/src/nodejs-compat.ts
+++ b/fixtures/local-mode-tests/src/nodejs-compat.ts
@@ -1,0 +1,7 @@
+import { Buffer } from "node:buffer";
+
+export default <ExportedHandler>{
+	async fetch() {
+		return new Response(Buffer.from("test").toString("base64"));
+	},
+};

--- a/fixtures/local-mode-tests/tests/logging.test.ts
+++ b/fixtures/local-mode-tests/tests/logging.test.ts
@@ -1,0 +1,38 @@
+import path from "node:path";
+import util from "node:util";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { unstable_dev } from "wrangler";
+
+let output = "";
+function spyOnConsoleMethod(name: keyof typeof console) {
+	vi.spyOn(console, name).mockImplementation((...args: unknown[]) => {
+		output += util.format(...args) + "\n";
+	});
+}
+beforeEach(() => {
+	spyOnConsoleMethod("debug");
+	spyOnConsoleMethod("log");
+	spyOnConsoleMethod("info");
+	spyOnConsoleMethod("error");
+	spyOnConsoleMethod("warn");
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	output = "";
+});
+
+it("logs startup errors", async () => {
+	try {
+		const worker = await unstable_dev(
+			path.resolve(__dirname, "..", "src", "nodejs-compat.ts"),
+			{
+				config: path.resolve(__dirname, "..", "wrangler.logging.toml"),
+				// Intentionally omitting `compatibilityFlags: ["nodejs_compat"]`
+				experimental: { disableExperimentalWarning: true },
+			}
+		);
+		await worker.stop();
+		expect.fail("Expected unstable_dev() to fail");
+	} catch {}
+	expect(output).toContain('No such module "node:buffer"');
+});

--- a/fixtures/local-mode-tests/wrangler.logging.toml
+++ b/fixtures/local-mode-tests/wrangler.logging.toml
@@ -1,0 +1,2 @@
+name = "local-mode-tests"
+compatibility_date = "2024-01-01"

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -144,7 +144,7 @@ export async function unstable_dev(
 		readyResolve = resolve;
 	});
 
-	const defaultLogLevel = testMode ? "none" : "log";
+	const defaultLogLevel = testMode ? "warn" : "log";
 	const local = options?.local ?? true;
 
 	const devOptions: StartDevOptions = {


### PR DESCRIPTION
Fixes #3362.

**What this PR solves / how to test:**

When running `unstable_dev()` in its default "test mode", the logging level was set to `none`. This meant any Worker startup errors or helpful warnings wouldn't be shown. This change switches the default to `warn`. For example, this means if you fail to include `nodejs_compat` and try to import `node:buffer`, you'll now see the following output, as opposed to an unclear failure:

![image](https://github.com/cloudflare/workers-sdk/assets/15955327/775cd946-92ac-4ff4-85a2-f7f9cfd90d4d)

**Author has addressed the following:**

- Tests
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
  - [ ] Not necessary because:
- Associated docs
  - [ ] Issue(s)/PR(s):
  - [x] Not necessary because: we don't currently document the default logging level, and I think users would expect any errors/warnings to be surfaced.

**Note for PR author:**

We want to celebrate and highlight awesome PR review! If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
