### PR TITLE
[miniflare] fix: ensure magic proxy works when starting on non-local `host`s, and IPv6 addresses can be used as `host`s

### DIFF
--- a/.changeset/silent-geese-leave.md
+++ b/.changeset/silent-geese-leave.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: ensure internals can access `workerd` when starting on non-local `host`
+
+Previously, if Miniflare was configured to start on a `host` that wasn't `127.0.0.1`, `::1`, `*`, `::`, or `0.0.0.0`, calls to `Miniflare` API methods relying on the magic proxy (e.g. `getKVNamespace()`, `getWorker()`, etc.) would fail. This change ensures `workerd` is always accessible to Miniflare's internals. This also fixes `wrangler dev` when using local network address such as `192.168.0.10` with the `--ip` flag.

--- a/.changeset/tender-nails-tickle.md
+++ b/.changeset/tender-nails-tickle.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: ensure IPv6 addresses can be used as `host`s
+
+Previously, if Miniflare was configured to start on an IPv6 `host`, it could crash. This change ensures IPv6 addresses are handled correctly. This also fixes `wrangler dev` when using IPv6 addresses such as `::1` with the `--ip` flag.

--- a/packages/miniflare/src/http/server.ts
+++ b/packages/miniflare/src/http/server.ts
@@ -1,24 +1,19 @@
 import fs from "fs/promises";
 import { z } from "zod";
-import {
-	CORE_PLUGIN,
-	HEADER_CF_BLOB,
-	SERVICE_ENTRY,
-	SOCKET_ENTRY,
-} from "../plugins";
-import { HttpOptions, Socket, Socket_Https } from "../runtime";
+import { CORE_PLUGIN, HEADER_CF_BLOB } from "../plugins";
+import { HttpOptions, Socket_Https } from "../runtime";
 import { Awaitable } from "../workers";
 import { CERT, KEY } from "./cert";
 
-export async function configureEntrySocket(
-	coreOpts: z.infer<typeof CORE_PLUGIN.sharedOptions>
-): Promise<Socket> {
-	const httpOptions = {
-		// Even though we inject a `cf` object in the entry worker, allow it to
-		// be customised via `dispatchFetch`
-		cfBlobHeader: HEADER_CF_BLOB,
-	};
+export const ENTRY_SOCKET_HTTP_OPTIONS: HttpOptions = {
+	// Even though we inject a `cf` object in the entry worker, allow it to
+	// be customised via `dispatchFetch`
+	cfBlobHeader: HEADER_CF_BLOB,
+};
 
+export async function getEntrySocketHttpOptions(
+	coreOpts: z.infer<typeof CORE_PLUGIN.sharedOptions>
+): Promise<{ http: HttpOptions } | { https: Socket_Https }> {
 	let privateKey: string | undefined = undefined;
 	let certificateChain: string | undefined = undefined;
 
@@ -36,12 +31,10 @@ export async function configureEntrySocket(
 		certificateChain = CERT;
 	}
 
-	let options: { http: HttpOptions } | { https: Socket_Https };
-
 	if (privateKey && certificateChain) {
-		options = {
+		return {
 			https: {
-				options: httpOptions,
+				options: ENTRY_SOCKET_HTTP_OPTIONS,
 				tlsOptions: {
 					keypair: {
 						privateKey: privateKey,
@@ -51,16 +44,8 @@ export async function configureEntrySocket(
 			},
 		};
 	} else {
-		options = {
-			http: httpOptions,
-		};
+		return { http: ENTRY_SOCKET_HTTP_OPTIONS };
 	}
-
-	return {
-		name: SOCKET_ENTRY,
-		service: { name: SERVICE_ENTRY },
-		...options,
-	};
 }
 
 function valueOrFile(

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1000,7 +1000,7 @@ export class Miniflare {
 			requestedPort = this.#socketPorts?.get(id);
 		}
 		// Otherwise, default to a new random port
-		return `${host}:${requestedPort ?? 0}`;
+		return `${getURLSafeHost(host)}:${requestedPort ?? 0}`;
 	}
 
 	async #assembleConfig(loopbackPort: number): Promise<Config> {

--- a/packages/miniflare/src/plugins/core/proxy/client.ts
+++ b/packages/miniflare/src/plugins/core/proxy/client.ts
@@ -67,6 +67,10 @@ const revivers: ReducersRevivers = {
 export const PROXY_SECRET = crypto.randomBytes(16);
 const PROXY_SECRET_HEX = PROXY_SECRET.toString("hex");
 
+function isClientError(status: number) {
+	return 400 <= status && status < 500;
+}
+
 // Exported public API of the proxy system
 export class ProxyClient {
 	#bridge: ProxyClientBridge;
@@ -300,6 +304,7 @@ class ProxyStubHandler<T extends object> implements ProxyHandler<T> {
 	}
 	async #parseAsyncResponse(resPromise: Promise<Response>): Promise<unknown> {
 		const res = await resPromise;
+		assert(!isClientError(res.status));
 
 		const typeHeader = res.headers.get(CoreHeaders.OP_RESULT_TYPE);
 		if (typeHeader === "Promise, ReadableStream") return res.body;
@@ -339,6 +344,7 @@ class ProxyStubHandler<T extends object> implements ProxyHandler<T> {
 		return this.#maybeThrow(res, result, this.#parseAsyncResponse);
 	}
 	#parseSyncResponse(syncRes: SynchronousResponse, caller: Function): unknown {
+		assert(!isClientError(syncRes.status));
 		assert(syncRes.body !== null);
 		// Unbuffered streams should only be sent as part of async responses
 		assert(syncRes.headers.get(CoreHeaders.OP_STRINGIFIED_SIZE) === null);

--- a/packages/miniflare/src/plugins/shared/constants.ts
+++ b/packages/miniflare/src/plugins/shared/constants.ts
@@ -7,6 +7,7 @@ import {
 import { CoreBindings, SharedBindings } from "../../workers";
 
 export const SOCKET_ENTRY = "entry";
+export const SOCKET_ENTRY_LOCAL = "entry:local";
 const SOCKET_DIRECT_PREFIX = "direct";
 
 export function getDirectSocketName(workerIndex: number) {

--- a/packages/miniflare/src/runtime/index.ts
+++ b/packages/miniflare/src/runtime/index.ts
@@ -29,7 +29,7 @@ export type SocketPorts = Map<SocketIdentifier, number /* port */>;
 
 export interface RuntimeOptions {
 	entryAddress: string;
-	loopbackPort: number;
+	loopbackAddress: string;
 	requiredSockets: SocketIdentifier[];
 	inspectorAddress?: string;
 	verbose?: boolean;
@@ -102,7 +102,7 @@ function getRuntimeArgs(options: RuntimeOptions) {
 		// (e.g. "streams_enable_constructors"), see https://github.com/cloudflare/workerd/pull/21
 		"--experimental",
 		`--socket-addr=${SOCKET_ENTRY}=${options.entryAddress}`,
-		`--external-addr=${SERVICE_LOOPBACK}=localhost:${options.loopbackPort}`,
+		`--external-addr=${SERVICE_LOOPBACK}=${options.loopbackAddress}`,
 		// Configure extra pipe for receiving control messages (e.g. when ready)
 		"--control-fd=3",
 		// Read config from stdin

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -218,6 +218,26 @@ const localInterface = (interfaces["en0"] ?? interfaces["eth0"])?.find(
 		t.is(await res.text(), "body");
 	}
 );
+test("Miniflare: can use IPv6 loopback as host", async (t) => {
+	const mf = new Miniflare({
+		host: "::1",
+		modules: true,
+		script: `export default { fetch(request, env) { return env.SERVICE.fetch(request); } }`,
+		serviceBindings: {
+			SERVICE() {
+				return new Response("body");
+			},
+		},
+	});
+	t.teardown(() => mf.dispose());
+
+	let res = await mf.dispatchFetch("https://example.com");
+	t.is(await res.text(), "body");
+
+	const worker = await mf.getWorker();
+	res = await worker.fetch("https://example.com");
+	t.is(await res.text(), "body");
+});
 
 test("Miniflare: routes to multiple workers with fallback", async (t) => {
 	const opts: MiniflareOptions = {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -7,6 +7,7 @@ import { existsSync } from "fs";
 import fs from "fs/promises";
 import http from "http";
 import { AddressInfo } from "net";
+import os from "os";
 import path from "path";
 import { Writable } from "stream";
 import { json, text } from "stream/consumers";
@@ -188,6 +189,35 @@ test("Miniflare: setOptions: can update host/port", async (t) => {
 	t.not(state1.url.port, state3.url.port);
 	t.is(state2.loopbackPort, state3.loopbackPort);
 });
+
+const interfaces = os.networkInterfaces();
+const localInterface = (interfaces["en0"] ?? interfaces["eth0"])?.find(
+	({ family }) => family === "IPv4"
+);
+(localInterface === undefined ? test.skip : test)(
+	"Miniflare: can use local network address as host",
+	async (t) => {
+		assert(localInterface !== undefined);
+		const mf = new Miniflare({
+			host: localInterface.address,
+			modules: true,
+			script: `export default { fetch(request, env) { return env.SERVICE.fetch(request); } }`,
+			serviceBindings: {
+				SERVICE() {
+					return new Response("body");
+				},
+			},
+		});
+		t.teardown(() => mf.dispose());
+
+		let res = await mf.dispatchFetch("https://example.com");
+		t.is(await res.text(), "body");
+
+		const worker = await mf.getWorker();
+		res = await worker.fetch("https://example.com");
+		t.is(await res.text(), "body");
+	}
+);
 
 test("Miniflare: routes to multiple workers with fallback", async (t) => {
 	const opts: MiniflareOptions = {


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #4993.

Previously, if Miniflare was configured to start on a `host` that wasn't `127.0.0.1`, `::1`, `*`, `::`, or `0.0.0.0`, calls to `Miniflare` API methods relying on the magic proxy (e.g. `getKVNamespace()`, `getWorker()`, etc.) would fail. This change ensures `workerd` is always accessible to Miniflare's internals, by configuring `workerd` with an additional local-only entry socket in this case. An unrelated issue meant if Miniflare was configured to start on an IPv6 `host`, it could crash. This change also ensures IPv6 addresses are handled correctly.

This means `wrangler dev` can now use local network and IPv6 address such as `192.168.0.10` and `::1` with the `--ip` flag.

To test this, run `wrangler dev --ip ::1` in `fixtures/worker-app`. Use `ifconfig` to find your local network IP, and try that out with the `--ip` flag too.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: fixing a regression

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
