### PR TITLE
Fix Workers AI local mode fetcher not returning headers to client worker

### DIFF
--- a/.changeset/yellow-phones-buy.md
+++ b/.changeset/yellow-phones-buy.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Fix Workers-AI local mode fetcher not returning headers to client worker
+fix: ensure Workers-AI local mode fetcher returns headers to client worker

--- a/.changeset/yellow-phones-buy.md
+++ b/.changeset/yellow-phones-buy.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix Workers-AI local mode fetcher not returning headers to client worker

--- a/packages/wrangler/src/ai/fetcher.ts
+++ b/packages/wrangler/src/ai/fetcher.ts
@@ -1,4 +1,4 @@
-import {Headers, Response } from "miniflare";
+import { Headers, Response } from "miniflare";
 import { performApiFetch } from "../cfetch/internal";
 import { getAccountId } from "../user";
 import type { Request } from "miniflare";

--- a/packages/wrangler/src/ai/fetcher.ts
+++ b/packages/wrangler/src/ai/fetcher.ts
@@ -16,5 +16,12 @@ export async function AIFetcher(request: Request) {
 		duplex: "half",
 	});
 
-	return new Response(res.body, { status: res.status });
+	const respHeaders: Record<string, string> = {};
+	for (const [name, value] of res.headers) {
+		respHeaders[name] = value;
+	}
+	respHeaders.headers.delete("Host");
+	respHeaders.headers.delete("Content-Length");
+
+	return new Response(res.body, { status: res.status, headers: respHeaders });
 }

--- a/packages/wrangler/src/ai/fetcher.ts
+++ b/packages/wrangler/src/ai/fetcher.ts
@@ -1,4 +1,4 @@
-import { Response } from "miniflare";
+import {Headers, Response } from "miniflare";
 import { performApiFetch } from "../cfetch/internal";
 import { getAccountId } from "../user";
 import type { Request } from "miniflare";

--- a/packages/wrangler/src/ai/fetcher.ts
+++ b/packages/wrangler/src/ai/fetcher.ts
@@ -16,12 +16,9 @@ export async function AIFetcher(request: Request) {
 		duplex: "half",
 	});
 
-	const respHeaders: Record<string, string> = {};
-	for (const [name, value] of res.headers) {
-		respHeaders[name] = value;
-	}
-	respHeaders.headers.delete("Host");
-	respHeaders.headers.delete("Content-Length");
+	const respHeaders = new Headers(res.headers);
+	respHeaders.delete("Host");
+	respHeaders.delete("Content-Length");
 
 	return new Response(res.body, { status: res.status, headers: respHeaders });
 }


### PR DESCRIPTION
## What this PR solves / how to test

Fixes Workers AI local mode fetcher not returning headers to client worker

## Author has addressed the following

- Tests
  - [ ] Included
  - [x] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: this is a small fix

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
