### PR TITLE
C3 - fix hono e2e tests

### DIFF
--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -115,6 +115,12 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 			route: "/",
 			expectedText: "Hello Hono!",
 		},
+		promptHandlers: [
+			{
+				matcher: /Do you want to install project dependencies\?/,
+				input: [keys.enter],
+			},
+		],
 	},
 	qwik: {
 		promptHandlers: [


### PR DESCRIPTION
## What this PR solves / how to test

The hono C3 e2e tests are currently broken (see [c3 hono e2es failing](https://github.com/cloudflare/workers-sdk/actions/runs/8138824477/job/22240512311?pr=5140)), this PR fixes this

> [!NOTE]
> The dependabot PR that bumped `create-hono` from 0.4.0 to 0.5.0 should have caught this
> but it didn't if you look at the run logs ([here](https://github.com/cloudflare/workers-sdk/actions/runs/8047695795?pr=5097)) you can see that the e2es were run using `create-hono@0.4.0` instead of `create-hono@0.5.0`
>  ![Screenshot 2024-03-04 at 12 40 00](https://github.com/cloudflare/workers-sdk/assets/61631103/8f044d96-59de-483b-bdff-52900e2a3c90)
>
> we need to investigate why that happened!

## Author has addressed the following

- Tests
  - [x] Included (the changes here update the C3 e2e tests)
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: no user facing change (just updating the c3 e2es)
- Public documentation
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because: no user facing change (just updating the c3 e2es)

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
