### PR TITLE
[C3] chore: fix dependabot so that it used the correct package version

### DIFF
--- a/.github/workflows/c3-e2e-dependabot.yml
+++ b/.github/workflows/c3-e2e-dependabot.yml
@@ -10,11 +10,6 @@ on:
 env:
   node-version: 18.17.1
   bun-version: 1.0.3
-  # we need to fetch 3 commits because dependabot generates one, our changeset
-  # generation workflow generates another and we need the parent of both commits
-  # so that we can diff it (`git diff HEAD~n`) and see what package changed in
-  # the `package.json` file
-  COMMITS_TO_FETCH: 3
 
 jobs:
   get-dependabot-bumped-framework:
@@ -28,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: ${{ env.COMMITS_TO_FETCH }}
+          fetch-depth: 0
 
       - name: detect-bumped-framework
         id: detect
@@ -60,7 +55,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          fetch-depth: ${{ env.COMMITS_TO_FETCH }}
+          fetch-depth: 0
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/c3-e2e-dependabot.yml
+++ b/.github/workflows/c3-e2e-dependabot.yml
@@ -10,6 +10,11 @@ on:
 env:
   node-version: 18.17.1
   bun-version: 1.0.3
+  # we need to fetch 3 commits because dependabot generates one, our changeset
+  # generation workflow generates another and we need the parent of both commits
+  # so that we can diff it (`git diff HEAD~n`) and see what package changed in
+  # the `package.json` file
+  COMMITS_TO_FETCH: 3
 
 jobs:
   get-dependabot-bumped-framework:
@@ -23,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 3
+          fetch-depth: ${{ env.COMMITS_TO_FETCH }}
 
       - name: detect-bumped-framework
         id: detect
@@ -55,7 +60,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          fetch-depth: 3
+          fetch-depth: ${{ env.COMMITS_TO_FETCH }}
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/c3-e2e-dependabot.yml
+++ b/.github/workflows/c3-e2e-dependabot.yml
@@ -55,7 +55,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 3
+          ref: ${{ github.head_ref }}
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/c3-e2e-dependabot.yml
+++ b/.github/workflows/c3-e2e-dependabot.yml
@@ -3,7 +3,7 @@
 name: C3 E2E Tests (Dependabot)
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - .changeset/c3-frameworks-update-*.md
 
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 3
-          ref: ${{ github.head_ref }}
+
       - name: detect-bumped-framework
         id: detect
         uses: actions/github-script@v6
@@ -56,7 +56,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 3
-          ref: ${{ github.head_ref }}
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -8,11 +8,6 @@ on:
 env:
   node-version: 18.17.1
   bun-version: 1.0.3
-  # we need to fetch 3 commits because dependabot generates one, our changeset
-  # generation workflow generates another and we need the parent of both commits
-  # so that we can diff it (`git diff HEAD~n`) and see what package changed in
-  # the `package.json` file
-  COMMITS_TO_FETCH: 3
 
 jobs:
   e2e:
@@ -38,7 +33,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          fetch-depth: ${{ env.COMMITS_TO_FETCH }}
+          fetch-depth: 0
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 3
-          ref: ${{ github.head_ref }}
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 3
+          ref: ${{ github.head_ref }}
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -8,6 +8,12 @@ on:
 env:
   node-version: 18.17.1
   bun-version: 1.0.3
+  # we need to fetch 3 commits because dependabot generates one, our changeset
+  # generation workflow generates another and we need the parent of both commits
+  # so that we can diff it (`git diff HEAD~n`) and see what package changed in
+  # the `package.json` file
+  COMMITS_TO_FETCH: 3
+
 jobs:
   e2e:
     # Note: please keep this job in sync with the e2e-only-dependabot-bumped-framework one
@@ -32,7 +38,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          fetch-depth: 3
+          fetch-depth: ${{ env.COMMITS_TO_FETCH }}
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies


### PR DESCRIPTION
## What this PR solves / how to test

Currently our dependabot workflow is flawed and uses outdated version of framework
CLIs as you can see from this PR's description: https://github.com/cloudflare/workers-sdk/pull/5149

This is due to the wrong checkout performed in the `e2e-only-dependabot-bumped-framework` step which uses the version of the package.json file from `main` instead of getting the updated one.

This PR fixes such behavior.

## Author has addressed the following

- Tests
  - [ ] Included
  - [x] Not necessary because: this is only a gh actions change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Included
  - [x] Not necessary because: this is only a gh actions change
- Public documentation
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: this is only a gh actions change

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
