### PR TITLE
chore: remove checks from PR template TODOS

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,15 +5,15 @@ Fixes #[insert GH or internal issue number(s)].
 ## Author has addressed the following
 
 - Tests
-  - [x] TODO (before merge)
+  - [ ] TODO (before merge)
   - [ ] Included
   - [ ] Not necessary because:
 - Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
-  - [x] TODO (before merge)
+  - [ ] TODO (before merge)
   - [ ] Included
   - [ ] Not necessary because:
 - Public documentation
-  - [x] TODO (before merge)
+  - [ ] TODO (before merge)
   - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
   - [ ] Not necessary because:
 


### PR DESCRIPTION
To make it clear that the developer has opted for TODO we don't now autocheck these boxes.

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
