### PR TITLE
ci: disable file parallelism for fixture tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"fix": "pnpm run prettify && dotenv -- turbo check:lint -- --fix",
 		"prettify": "prettier . --write --ignore-unknown",
 		"test": "dotenv -- turbo test",
-		"test:ci": "vitest run && dotenv -- turbo test:ci --filter=wrangler --filter=miniflare --filter=kv-asset-handler --filter=@cloudflare/vitest-pool-workers",
+		"test:ci": "vitest run --no-file-parallelism && dotenv -- turbo test:ci --filter=wrangler --filter=miniflare --filter=kv-asset-handler --filter=@cloudflare/vitest-pool-workers",
 		"test:watch": "turbo test:watch",
 		"type:tests": "dotenv -- turbo type:tests",
 		"gen:package": "turbo gen package"
@@ -53,7 +53,7 @@
 		"node": ">=16.17.0"
 	},
 	"volta": {
-		"node": "16.13.0"
+		"node": "16.17.0"
 	},
 	"pnpm": {
 		"peerDependencyRules": {


### PR DESCRIPTION
## What this PR solves / how to test

Some of the `get-{bindings,platform}-proxy` tests have been flaking in CI recently. I think this is because they're trying to connect to the dev registry, but the dev registry was started by an earlier test that just finished. This leads to socket errors like `other side closed`. The proper solution to this problem is to start a dev registry for each test (file). We could do this by assigning a different dev registry port for each test (file/project). In the meantime, this change disables parallelism for the fixture tests, ensuring if a dev registry is started, it is definitely shut down before another test begins.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: changing CI configuration
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: changing CI configuration
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: changing CI configuration

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
