### PR TITLE
Allow marking externals in Pages Functions

### DIFF
--- a/.changeset/unlucky-kangaroos-brake.md
+++ b/.changeset/unlucky-kangaroos-brake.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: Allow marking external modules (with `--external`) to avoid bundling them when building Pages Functions
+
+It's useful for Pages Plugins which want to declare a peer dependency.

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -19,5 +19,8 @@
 	},
 	"engines": {
 		"node": ">=16.13"
+	},
+	"dependencies": {
+		"is-odd": "^3.0.1"
 	}
 }

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -124,6 +124,13 @@ describe("Pages Functions", () => {
 			expect(response.status).toBe(502);
 		});
 
+		it("should work with peer externals", async ({ expect }) => {
+			const response = await fetch(`http://${ip}:${port}/mounted-plugin/ext`);
+			const text = await response.text();
+			expect(text).toMatchInlineSnapshot(`"42 is even"`);
+			expect(response.status).toBe(200);
+		});
+
 		it("should mount a Plugin even if in a parameterized route", async ({
 			expect,
 		}) => {

--- a/fixtures/pages-plugin-example/functions/ext.ts
+++ b/fixtures/pages-plugin-example/functions/ext.ts
@@ -1,0 +1,5 @@
+import isOdd from "is-odd";
+
+export const onRequest: PagesFunction = () => {
+	return new Response(`42 is ${isOdd(42) ? "odd" : "even"}`);
+};

--- a/fixtures/pages-plugin-example/package.json
+++ b/fixtures/pages-plugin-example/package.json
@@ -10,10 +10,11 @@
 		"public/"
 	],
 	"scripts": {
-		"build": "wrangler pages functions build --plugin --outdir=dist",
+		"build": "wrangler pages functions build --plugin --outdir=dist --external=is-odd",
 		"check:type": "tsc"
 	},
 	"devDependencies": {
+		"is-odd": "^3.0.1",
 		"wrangler": "workspace:*"
 	}
 }

--- a/fixtures/pages-plugin-mounted-on-root-app/package.json
+++ b/fixtures/pages-plugin-mounted-on-root-app/package.json
@@ -19,5 +19,8 @@
 	},
 	"engines": {
 		"node": ">=16.13"
+	},
+	"dependencies": {
+		"is-odd": "^3.0.1"
 	}
 }

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -85,6 +85,7 @@ export type BundleOptions = {
 	local: boolean;
 	projectRoot: string | undefined;
 	defineNavigatorUserAgent: boolean;
+	external?: string[];
 };
 
 /**
@@ -122,6 +123,7 @@ export async function bundleWorker(
 		local,
 		projectRoot,
 		defineNavigatorUserAgent,
+		external,
 	}: BundleOptions
 ): Promise<BundleResult> {
 	// We create a temporary directory for any one-off files we
@@ -284,7 +286,9 @@ export async function bundleWorker(
 			  }
 			: {}),
 		inject,
-		external: bundle ? ["__STATIC_CONTENT_MANIFEST"] : undefined,
+		external: bundle
+			? ["__STATIC_CONTENT_MANIFEST", ...(external ? external : [])]
+			: undefined,
 		format: entry.format === "modules" ? "esm" : "iife",
 		target: COMMON_ESBUILD_OPTIONS.target,
 		sourcemap: sourcemap ?? true,

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -123,6 +123,11 @@ export function Options(yargs: CommonYargsArgv) {
 				deprecated: true,
 				hidden: true,
 			},
+			external: {
+				describe: "A list of module imports to exclude from bundling",
+				type: "string",
+				array: true,
+			},
 		});
 }
 
@@ -146,6 +151,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 			nodejsCompat,
 			legacyNodeCompat,
 			defineNavigatorUserAgent,
+			external,
 		} = validatedArgs;
 
 		try {
@@ -172,6 +178,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 				routesOutputPath,
 				local: false,
 				defineNavigatorUserAgent,
+				external,
 			});
 		} catch (e) {
 			if (e instanceof FunctionsNoRoutesError) {
@@ -213,6 +220,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 			legacyNodeCompat,
 			workerScriptPath,
 			defineNavigatorUserAgent,
+			external,
 		} = validatedArgs;
 
 		/**
@@ -243,6 +251,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 					watch,
 					nodejsCompat,
 					defineNavigatorUserAgent,
+					externalModules: external,
 				});
 			}
 		} else {
@@ -268,6 +277,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 					routesOutputPath,
 					local: false,
 					defineNavigatorUserAgent,
+					external,
 				});
 			} catch (e) {
 				if (e instanceof FunctionsNoRoutesError) {

--- a/packages/wrangler/src/pages/buildFunctions.ts
+++ b/packages/wrangler/src/pages/buildFunctions.ts
@@ -39,6 +39,7 @@ export async function buildFunctions({
 		`./functionsRoutes-${Math.random()}.mjs`
 	),
 	defineNavigatorUserAgent,
+	external,
 }: Partial<
 	Pick<
 		PagesBuildArgs,
@@ -51,6 +52,7 @@ export async function buildFunctions({
 		| "watch"
 		| "plugin"
 		| "buildOutputDirectory"
+		| "external"
 	>
 > & {
 	functionsDirectory: string;
@@ -120,6 +122,7 @@ export async function buildFunctions({
 			functionsDirectory: absoluteFunctionsDirectory,
 			local,
 			defineNavigatorUserAgent,
+			external,
 		});
 	} else {
 		bundle = await buildWorkerFromFunctions({
@@ -137,6 +140,7 @@ export async function buildFunctions({
 			legacyNodeCompat,
 			nodejsCompat,
 			defineNavigatorUserAgent,
+			external,
 		});
 	}
 

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -24,6 +24,7 @@ export function buildPluginFromFunctions({
 	functionsDirectory,
 	local,
 	defineNavigatorUserAgent,
+	external,
 }: Options) {
 	const entry: Entry = {
 		file: resolve(getBasePath(), "templates/pages-template-plugin.ts"),
@@ -51,6 +52,7 @@ export function buildPluginFromFunctions({
 		nodejsCompat: true,
 		define: {},
 		doBindings: [], // Pages functions don't support internal Durable Objects
+		external,
 		plugins: [
 			buildNotifierPlugin(onEnd),
 			{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,10 @@ importers:
         version: link:../../packages/wrangler
 
   fixtures/pages-functions-app:
+    dependencies:
+      is-odd:
+        specifier: ^3.0.1
+        version: 3.0.1
     devDependencies:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
@@ -413,11 +417,18 @@ importers:
 
   fixtures/pages-plugin-example:
     devDependencies:
+      is-odd:
+        specifier: ^3.0.1
+        version: 3.0.1
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
   fixtures/pages-plugin-mounted-on-root-app:
+    dependencies:
+      is-odd:
+        specifier: ^3.0.1
+        version: 3.0.1
     devDependencies:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
@@ -14127,9 +14138,19 @@ packages:
       kind-of: 3.2.2
     dev: true
 
+  /is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  /is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+    dependencies:
+      is-number: 6.0.0
 
   /is-path-cwd@2.2.0:
     resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}


### PR DESCRIPTION
## What this PR solves / how to test

This allows Pages Plugins authors to mark dependencies as external when bundling their plugin. This is useful if you want to declare a module as a peer dependency.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/13397
  - [ ] Not necessary because

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
