### PR TITLE
ci: remove fixture from changeset releases

### DIFF
--- a/fixtures/additional-modules/package.json
+++ b/fixtures/additional-modules/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "additional-modules",
-	"version": "0.0.1",
 	"private": true,
 	"scripts": {
 		"build": "wrangler deploy --dry-run --outdir=dist",

--- a/fixtures/ai-app/package.json
+++ b/fixtures/ai-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "ai-app",
-	"version": "1.0.1",
 	"private": true,
 	"description": "",
 	"license": "ISC",

--- a/fixtures/d1-worker-app/package.json
+++ b/fixtures/d1-worker-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "d1-worker-app",
-	"version": "1.0.0",
 	"private": true,
 	"description": "",
 	"license": "ISC",

--- a/fixtures/dev-env/package.json
+++ b/fixtures/dev-env/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "dev-env",
-	"version": "1.0.1",
 	"private": true,
 	"description": "",
 	"license": "ISC",

--- a/fixtures/durable-objects-app/package.json
+++ b/fixtures/durable-objects-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "do-worker-app",
-	"version": "1.0.0",
 	"private": true,
 	"description": "",
 	"license": "ISC",

--- a/fixtures/import-wasm-example/package.json
+++ b/fixtures/import-wasm-example/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "import-wasm-example",
-	"version": "1.0.1",
 	"private": true,
 	"description": "",
 	"author": "",

--- a/fixtures/import-wasm-static/package.json
+++ b/fixtures/import-wasm-static/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "import-wasm-static",
-	"version": "0.0.1",
 	"private": true,
 	"sideEffects": false,
 	"exports": {

--- a/fixtures/interactive-dev-tests/package.json
+++ b/fixtures/interactive-dev-tests/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "interactive-dev-tests",
-	"version": "0.0.1",
 	"private": true,
 	"scripts": {
 		"test": "vitest run",

--- a/fixtures/isomorphic-random-example/package.json
+++ b/fixtures/isomorphic-random-example/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "isomorphic-random-example",
-	"version": "0.0.1",
 	"private": true,
 	"description": "Isomorphic secure-random library, demonstrating `exports` use with Workers",
 	"exports": {

--- a/fixtures/legacy-site-app/package.json
+++ b/fixtures/legacy-site-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "legacy-site-app",
-	"version": "0.0.0",
 	"private": true,
 	"description": "",
 	"keywords": [],

--- a/fixtures/legacy-site-app/workers-site/package.json
+++ b/fixtures/legacy-site-app/workers-site/package.json
@@ -1,5 +1,4 @@
 {
-	"version": "1.0.0",
 	"private": true,
 	"description": "A template for kick starting a Cloudflare Workers project",
 	"license": "MIT",

--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "local-mode-tests",
-	"version": "1.0.1",
 	"private": true,
 	"description": "",
 	"keywords": [],

--- a/fixtures/no-bundle-import/package.json
+++ b/fixtures/no-bundle-import/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "no-bundle-import",
-	"version": "0.0.1",
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",

--- a/fixtures/node-app-pages/package.json
+++ b/fixtures/node-app-pages/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "node-app-pages",
-	"version": "0.0.0",
 	"private": true,
 	"sideEffects": false,
 	"main": "dist/worker.js",

--- a/fixtures/pages-d1-shim/package.json
+++ b/fixtures/pages-d1-shim/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-d1-shim",
-	"version": "0.0.1",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/fixtures/pages-dev-proxy-with-script/package.json
+++ b/fixtures/pages-dev-proxy-with-script/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-dev-proxy-with-script",
-	"version": "0.0.0",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-functions-app",
-	"version": "0.0.0",
 	"private": true,
 	"sideEffects": false,
 	"main": "dist/worker.js",

--- a/fixtures/pages-functions-wasm-app/package.json
+++ b/fixtures/pages-functions-wasm-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-functions-wasm-app",
-	"version": "0.0.1",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/fixtures/pages-functions-with-routes-app/package.json
+++ b/fixtures/pages-functions-with-routes-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-functions-with-routes-app",
-	"version": "0.0.1",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/fixtures/pages-plugin-example/package.json
+++ b/fixtures/pages-plugin-example/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-plugin-example",
-	"version": "0.0.0",
 	"private": true,
 	"main": "dist/index.js",
 	"types": "index.d.ts",

--- a/fixtures/pages-plugin-mounted-on-root-app/package.json
+++ b/fixtures/pages-plugin-mounted-on-root-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-plugin-mounted-on-root-app",
-	"version": "0.0.0",
 	"private": true,
 	"sideEffects": false,
 	"main": "dist/worker.js",

--- a/fixtures/pages-proxy-app/package.json
+++ b/fixtures/pages-proxy-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-proxy-app",
-	"version": "0.1.2",
 	"private": true,
 	"sideEffects": false,
 	"main": "server/index.js",

--- a/fixtures/pages-simple-assets/package.json
+++ b/fixtures/pages-simple-assets/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-simple-assets",
-	"version": "0.0.0",
 	"private": true,
 	"sideEffects": false,
 	"main": "dist/worker.js",

--- a/fixtures/pages-workerjs-and-functions-app/package.json
+++ b/fixtures/pages-workerjs-and-functions-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-workerjs-and-functions-app",
-	"version": "0.0.1",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/fixtures/pages-workerjs-app/package.json
+++ b/fixtures/pages-workerjs-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-workerjs-app",
-	"version": "0.0.0",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/fixtures/pages-workerjs-directory/package.json
+++ b/fixtures/pages-workerjs-directory/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-workerjs-directory",
-	"version": "0.0.1",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/fixtures/pages-workerjs-wasm-app/package.json
+++ b/fixtures/pages-workerjs-wasm-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-workerjs-wasm-app",
-	"version": "0.0.1",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/fixtures/pages-workerjs-with-routes-app/package.json
+++ b/fixtures/pages-workerjs-with-routes-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-workerjs-with-routes-app",
-	"version": "0.0.1",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/fixtures/pages-ws-app/package.json
+++ b/fixtures/pages-ws-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "pages-ws-app",
-	"version": "0.1.2",
 	"private": true,
 	"sideEffects": false,
 	"main": "server/index.js",

--- a/fixtures/routing-app/package.json
+++ b/fixtures/routing-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "routing-app",
-	"version": "0.0.0",
 	"private": true,
 	"description": "routing-app for testing",
 	"scripts": {

--- a/fixtures/rules-app/package.json
+++ b/fixtures/rules-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "rules-app",
-	"version": "1.0.0",
 	"private": true,
 	"description": "",
 	"keywords": [],

--- a/fixtures/shared/package.json
+++ b/fixtures/shared/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "fixtures-shared",
-	"version": "0.0.0",
 	"private": true,
 	"description": "Shared fixtures for testing",
 	"devDependencies": {

--- a/fixtures/sites-app/package.json
+++ b/fixtures/sites-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "sites-app",
-	"version": "0.0.0",
 	"private": true,
 	"description": "",
 	"keywords": [],

--- a/fixtures/wasm-app/package.json
+++ b/fixtures/wasm-app/package.json
@@ -1,5 +1,4 @@
 {
 	"name": "wasm-app",
-	"version": "1.0.0",
 	"private": true
 }

--- a/fixtures/worker-app/package.json
+++ b/fixtures/worker-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "worker-app",
-	"version": "1.0.1",
 	"private": true,
 	"description": "",
 	"license": "ISC",

--- a/fixtures/worker-ts/package.json
+++ b/fixtures/worker-ts/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "worker-ts",
-	"version": "0.0.1",
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",

--- a/fixtures/workers-chat-demo/package.json
+++ b/fixtures/workers-chat-demo/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "workers-chat-demo",
-	"version": "1.0.0",
 	"private": true,
 	"description": "An edge chat service that runs on Cloudflare Workers using Durable Objects"
 }

--- a/fixtures/wrangler-dev-api-app/package.json
+++ b/fixtures/wrangler-dev-api-app/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "wrangler-dev-api-app",
-	"version": "1.0.0",
 	"private": true,
 	"description": "",
 	"license": "ISC",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 	"author": "wrangler@cloudflare.com",
 	"scripts": {
 		"build": "dotenv -- turbo build",
-		"check": "node ensure-turbo-build-output.mjs && dotenv -- turbo check:lint check:type check:format type:tests",
+		"check": "pnpm check:fixtures && node ensure-turbo-build-output.mjs && dotenv -- turbo check:lint check:type check:format type:tests",
+		"check:fixtures": "node -r esbuild-register tools/deployments/ensure-fixtures-are-not-deployable.ts",
 		"check:format": "prettier . --check --ignore-unknown",
 		"check:lint": "dotenv -- turbo check:lint",
 		"check:type": "dotenv -- turbo check:type type:tests",

--- a/tools/deployments/__tests__/deploy-non-npm-packages.test.ts
+++ b/tools/deployments/__tests__/deploy-non-npm-packages.test.ts
@@ -118,7 +118,7 @@ describe("deployPackage", () => {
 	}) => {
 		deployPackage("foo");
 		expect(execSync).toHaveBeenCalledWith(
-			"pnpm -F foo deploy",
+			"pnpm -F foo run deploy",
 			expect.any(Object)
 		);
 	});

--- a/tools/deployments/deploy-non-npm-packages.ts
+++ b/tools/deployments/deploy-non-npm-packages.ts
@@ -105,7 +105,7 @@ export function findDeployablePackageNames(): Set<string> {
  */
 export function deployPackage(pkgName: string) {
 	try {
-		execSync(`pnpm -F ${pkgName} deploy`, {
+		execSync(`pnpm -F ${pkgName} run deploy`, {
 			env: process.env,
 			stdio: "inherit",
 		});

--- a/tools/deployments/ensure-fixtures-are-not-deployable.ts
+++ b/tools/deployments/ensure-fixtures-are-not-deployable.ts
@@ -6,8 +6,8 @@ if (require.main === module) {
 	const errors = ensureFixturesAreNotDeployable();
 	if (errors.length > 0) {
 		console.error("::error::Fixture checks:" + errors.map((e) => `\n- ${e}`));
-		console.log("::endgroup::");
 	}
+	console.log("::endgroup::");
 	process.exit(errors.length > 0 ? 1 : 0);
 }
 

--- a/tools/deployments/ensure-fixtures-are-not-deployable.ts
+++ b/tools/deployments/ensure-fixtures-are-not-deployable.ts
@@ -1,0 +1,57 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+if (require.main === module) {
+	console.log("::group::Checking fixtures");
+	const errors = ensureFixturesAreNotDeployable();
+	if (errors.length > 0) {
+		console.error("::error::Fixture checks:" + errors.map((e) => `\n- ${e}`));
+		console.log("::endgroup::");
+	}
+	process.exit(errors.length > 0 ? 1 : 0);
+}
+
+/**
+ * Ensures that we don't accidentally create git tags and releases for fixtures
+ * by someone inadvertently adding a version to their package.json or making them non-private.
+ *
+ * Check the package.json for each fixture and ensure that they are all private and have no `version` property.
+ */
+export function ensureFixturesAreNotDeployable(): string[] {
+	const fixturesDirectory = resolve(__dirname, "../../fixtures");
+	const allFixtureDirectories = readdirSync(fixturesDirectory);
+	const errors: string[] = [];
+	for (const dir of allFixtureDirectories) {
+		try {
+			console.log(`- ${dir}`);
+			const packageJSONPath = resolve(fixturesDirectory, dir, "package.json");
+			if (!existsSync(packageJSONPath)) {
+				continue;
+			}
+			const fixturePackage = JSON.parse(
+				readFileSync(packageJSONPath, "utf-8")
+			) as PackageJSON;
+			if (fixturePackage.private !== true) {
+				errors.push(
+					`Fixture "${dir}" is not private. Add \`"private": true\` to its package.json`
+				);
+			}
+			if (fixturePackage.version) {
+				errors.push(
+					`Fixture "${dir}" has the disallowed "version" property. Please remove this.`
+				);
+			}
+		} catch {
+			errors.push(
+				`Unable to load or parse fixture "${dir}" package. Please check it has a valid package.json.`
+			);
+		}
+	}
+	return errors;
+}
+
+export type PackageJSON = {
+	name: string;
+	private?: boolean;
+	version?: string;
+};


### PR DESCRIPTION
When we last did a release (by merging the Version Packages PR) all the fixtures got git tagged and had Github releases created. Although this did not actually deploy them anyway, it caused confusion and noise on the Discord server, where releases are automatically publicised.

This change should disable changesets altogether for the fixtures by removing the `version` property from their package.json files.

I have tested this out on a practice repository: https://github.com/petebacondarwin/worker-pr-test