### PR TITLE
remove create-cloudflare noisy test logs (by mocking `spinner`)

### DIFF
--- a/packages/create-cloudflare/src/__tests__/common.test.ts
+++ b/packages/create-cloudflare/src/__tests__/common.test.ts
@@ -1,3 +1,4 @@
+import { spinner } from "@cloudflare/cli/interactive";
 import * as command from "helpers/command";
 import { SemVer } from "semver";
 import { getGlobalDispatcher, MockAgent, setGlobalDispatcher } from "undici";
@@ -12,10 +13,20 @@ import {
 import { isUpdateAvailable } from "../helpers/cli";
 
 vi.mock("process");
+vi.mock("@cloudflare/cli/interactive");
 
 function promisify<T>(value: T) {
 	return new Promise<T>((res) => res(value));
 }
+
+beforeEach(() => {
+	// we mock `spinner` to remove noisy logs from the test runs
+	vi.mocked(spinner).mockImplementation(() => ({
+		start() {},
+		update() {},
+		stop() {},
+	}));
+});
 
 describe("isGitConfigured", () => {
 	test("fully configured", async () => {

--- a/packages/create-cloudflare/src/__tests__/templates.test.ts
+++ b/packages/create-cloudflare/src/__tests__/templates.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, statSync } from "fs";
+import { spinner } from "@cloudflare/cli/interactive";
 import {
 	appendFile,
 	directoryExists,
@@ -12,6 +13,16 @@ import type { C3Context } from "types";
 
 vi.mock("fs");
 vi.mock("helpers/files");
+vi.mock("@cloudflare/cli/interactive");
+
+beforeEach(() => {
+	// we mock `spinner` to remove noisy logs from the test runs
+	vi.mocked(spinner).mockImplementation(() => ({
+		start() {},
+		update() {},
+		stop() {},
+	}));
+});
 
 describe("addWranglerToGitIgnore", () => {
 	const writeFileResults: {

--- a/packages/create-cloudflare/src/__tests__/workers.test.ts
+++ b/packages/create-cloudflare/src/__tests__/workers.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, readdirSync } from "fs";
+import { spinner } from "@cloudflare/cli/interactive";
 import { getWorkerdCompatibilityDate } from "helpers/command";
 import { readFile, writeFile } from "helpers/files";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -14,6 +15,16 @@ import type { C3Context } from "types";
 vi.mock("helpers/files");
 vi.mock("helpers/command");
 vi.mock("fs");
+vi.mock("@cloudflare/cli/interactive");
+
+beforeEach(() => {
+	// we mock `spinner` to remove noisy logs from the test runs
+	vi.mocked(spinner).mockImplementation(() => ({
+		start() {},
+		update() {},
+		stop() {},
+	}));
+});
 
 const mockWorkersTypesDirListing = [
 	"2021-11-03",


### PR DESCRIPTION
## What this PR solves / how to test

Removes noisy logs from create-cloudflare tests such as these: https://github.com/cloudflare/workers-sdk/actions/runs/8164300583/job/22332302711?pr=5173#step:8:33

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included (this is updating tests)
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: not needed for tests update
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: not needed for tests update

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
