### PR TITLE
fix: d1 migrations create to use the highest migration number plus one

### DIFF
--- a/.changeset/thick-yaks-cry.md
+++ b/.changeset/thick-yaks-cry.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: change d1 migrations create to use the highest migration number rather than the first non-existing migration number to allow for gaps in the migration files.

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -131,7 +131,7 @@ export function getNextMigrationNumber(migrationsPath: string): number {
 	const migrationNumbers = getMigrationNames(migrationsPath).map((migration) =>
 		parseInt(migration.split("_")[0])
 	);
-	const highestMigrationNumber = Math.max(...migrationNumbers);
+	const highestMigrationNumber = Math.max(...migrationNumbers, 0);
 
 	return highestMigrationNumber + 1;
 }

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -124,16 +124,12 @@ function getMigrationNames(migrationsPath: string): Array<string> {
 	return migrations;
 }
 
+/**
+ * Returns the highest current migration number plus one, ignoring any missing numbers.
+ */
 export function getNextMigrationNumber(migrationsPath: string): number {
-	let highestMigrationNumber = -1;
-
-	for (const migration in getMigrationNames(migrationsPath)) {
-		const migrationNumber = parseInt(migration.split("_")[0]);
-
-		if (migrationNumber > highestMigrationNumber) {
-			highestMigrationNumber = migrationNumber;
-		}
-	}
+	const migrationNumbers = getMigrationNames(migrationsPath).map((migration) => parseInt(migration.split("_")[0]));
+	const highestMigrationNumber = Math.max(...migrationNumbers);
 
 	return highestMigrationNumber + 1;
 }

--- a/packages/wrangler/src/d1/migrations/helpers.ts
+++ b/packages/wrangler/src/d1/migrations/helpers.ts
@@ -128,7 +128,9 @@ function getMigrationNames(migrationsPath: string): Array<string> {
  * Returns the highest current migration number plus one, ignoring any missing numbers.
  */
 export function getNextMigrationNumber(migrationsPath: string): number {
-	const migrationNumbers = getMigrationNames(migrationsPath).map((migration) => parseInt(migration.split("_")[0]));
+	const migrationNumbers = getMigrationNames(migrationsPath).map((migration) =>
+		parseInt(migration.split("_")[0])
+	);
 	const highestMigrationNumber = Math.max(...migrationNumbers);
 
 	return highestMigrationNumber + 1;


### PR DESCRIPTION
## What this PR solves / how to test
Previously, if you wanted to remove a migration (e.g. number 5 out of 10), you had to:
- Comment everything in the migration file and add `SELECT ...` just to have a query in it; or
- Delete it and lower the number of all preceding migrations.

Previously:
```cmd
// 0001_my-cool-migration.sql
// 0003_my-cool-migration.sql

wrangler d1 migrations create my-cool-database my-cool-migration // 0003_my-cool-migration.sql
```

After:
```cmd
// 0001_my-cool-migration.sql
// 0003_my-cool-migration.sql

wrangler d1 migrations create my-cool-database my-cool-migration // 0004_my-cool-migration.sql
```

## Author has addressed the following
This PR changes the logic of `getNextMigrationNumber` to actually get the _highest_ migration number plus one, rather than the first missing migration number plus one, which can be an existing migration number. 

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [X] Not necessary because: no existing test cases for the migration helpers
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [X] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [X] Not necessary because: nothing is explicitly stated about the next migration number in the docs

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
