### PR TITLE
C3: Update remaining dev and deployment scripts

### DIFF
--- a/.changeset/friendly-jobs-serve.md
+++ b/.changeset/friendly-jobs-serve.md
@@ -2,4 +2,4 @@
 "create-cloudflare": patch
 ---
 
-Aligns all `webFramework` templates to use `dev` and `deploy` instead of `pages:dev` and `pages:deploy` in package scripts.
+Aligns most `webFramework` templates to use `dev` and `deploy` instead of `pages:dev` and `pages:deploy` in package scripts.

--- a/.changeset/friendly-jobs-serve.md
+++ b/.changeset/friendly-jobs-serve.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Aligns all `webFramework` templates to use `dev` and `deploy` instead of `pages:dev` and `pages:deploy` in package scripts.

--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -54,7 +54,10 @@ type FrameworkTestConfig = RunnerConfig & {
 		route: string;
 		expectedText: string;
 	};
+	flags?: string[];
 };
+
+const { name: pm, npx } = detectPackageManager();
 
 // These are ordered based on speed and reliability for ease of debugging
 const frameworkTests: Record<string, FrameworkTestConfig> = {
@@ -75,6 +78,15 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 			route: "/test",
 			expectedText: "C3_TEST",
 		},
+		flags: [
+			"--skip-houston",
+			"--no-install",
+			"--no-git",
+			"--template",
+			"blog",
+			"--typescript",
+			"strict",
+		],
 	},
 	docusaurus: {
 		unsupportedPms: ["bun"],
@@ -85,6 +97,7 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 			route: "/",
 			expectedText: "Dinosaurs are cool",
 		},
+		flags: [`--package-manager`, pm],
 	},
 	angular: {
 		testCommitMessage: true,
@@ -93,6 +106,7 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 			route: "/",
 			expectedText: "Congratulations! Your app is running.",
 		},
+		flags: ["--style", "sass"],
 	},
 	gatsby: {
 		unsupportedPms: ["bun", "pnpm"],
@@ -166,6 +180,7 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 			route: "/test",
 			expectedText: "C3_TEST",
 		},
+		flags: ["--typescript", "--no-install", "--no-git-init"],
 	},
 	next: {
 		promptHandlers: [
@@ -180,6 +195,16 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 			route: "/",
 			expectedText: "Create Next App",
 		},
+		flags: [
+			"--typescript",
+			"--no-install",
+			"--eslint",
+			"--tailwind",
+			"--src-dir",
+			"--app",
+			"--import-alias",
+			"@/*",
+		],
 	},
 	nuxt: {
 		testCommitMessage: true,
@@ -269,6 +294,7 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 			route: "/",
 			expectedText: "Vite App",
 		},
+		flags: ["--ts"],
 	},
 };
 
@@ -315,7 +341,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 				const projectName = getName(framework);
 				const frameworkConfig = frameworkMap[framework as FrameworkName];
 
-				const { argv, promptHandlers, verifyDeploy } =
+				const { promptHandlers, verifyDeploy, flags } =
 					frameworkTests[framework];
 
 				if (!verifyDeploy) {
@@ -332,7 +358,7 @@ describe.concurrent(`E2E: Web frameworks`, () => {
 						projectPath,
 						logStream,
 						{
-							argv: [...(argv ?? [])],
+							argv: [...(flags ? ["--", ...flags] : [])],
 							promptHandlers,
 						}
 					);
@@ -463,7 +489,6 @@ const verifyDevScript = async (
 	// Run the devserver on a random port to avoid colliding with other tests
 	const TEST_PORT = Math.ceil(Math.random() * 1000) + 20000;
 
-	const { name: pm } = detectPackageManager();
 	const proc = spawnWithLogging(
 		[
 			pm,
@@ -518,8 +543,6 @@ const verifyBuildScript = async (
 	}
 
 	const { outputDir, script, route, expectedText } = verifyBuild;
-
-	const { name: pm, npx } = detectPackageManager();
 
 	// Run the `build-cf-types` script to generate types for bindings in fixture
 	const buildTypesProc = spawnWithLogging(

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -201,11 +201,6 @@ export const runFrameworkGenerator = async (ctx: C3Context, args: string[]) => {
 	// newline
 	logRaw("");
 
-	if (process.env.VITEST) {
-		const flags = ctx.template.testFlags ?? [];
-		cmd.push(...flags);
-	}
-
 	await runCommand(cmd, { env });
 };
 

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -85,8 +85,6 @@ export type TemplateConfig = {
 		ctx: C3Context
 	) => Promise<Record<string, string | object>>;
 
-	/** An array of flags that will be added to the call to the framework cli during tests.*/
-	testFlags?: string[];
 	/** An array of compatibility flags to be specified when deploying to pages or workers.*/
 	compatibilityFlags?: string[];
 

--- a/packages/create-cloudflare/templates/angular/c3.ts
+++ b/packages/create-cloudflare/templates/angular/c3.ts
@@ -85,11 +85,11 @@ const config: TemplateConfig = {
 	configure,
 	transformPackageJson: async () => ({
 		scripts: {
-			start: `${npm} run pages:build && wrangler pages dev dist/cloudflare ${await compatDateFlag()} --experimental-local`,
+			start: `${npm} run build && wrangler pages dev dist/cloudflare ${await compatDateFlag()} --experimental-local`,
+			build: `ng build && ${npm} run process`,
 			process:
 				"node ./tools/copy-files.mjs && node ./tools/alter-polyfills.mjs",
-			"pages:build": `ng build && ${npm} run process`,
-			deploy: `${npm} run pages:build && wrangler pages deploy dist/cloudflare`,
+			deploy: `${npm} run build && wrangler pages deploy dist/cloudflare`,
 		},
 	}),
 	deployScript: "deploy",

--- a/packages/create-cloudflare/templates/angular/c3.ts
+++ b/packages/create-cloudflare/templates/angular/c3.ts
@@ -94,6 +94,5 @@ const config: TemplateConfig = {
 			deploy: `${npm} run build && wrangler pages deploy dist/cloudflare`,
 		},
 	}),
-	testFlags: ["--style", "sass"],
 };
 export default config;

--- a/packages/create-cloudflare/templates/angular/c3.ts
+++ b/packages/create-cloudflare/templates/angular/c3.ts
@@ -81,6 +81,8 @@ const config: TemplateConfig = {
 	copyFiles: {
 		path: "./templates",
 	},
+	devScript: "start",
+	deployScript: "deploy",
 	generate,
 	configure,
 	transformPackageJson: async () => ({
@@ -92,8 +94,6 @@ const config: TemplateConfig = {
 			deploy: `${npm} run build && wrangler pages deploy dist/cloudflare`,
 		},
 	}),
-	deployScript: "deploy",
-	devScript: "start",
 	testFlags: ["--style", "sass"],
 };
 export default config;

--- a/packages/create-cloudflare/templates/astro/c3.ts
+++ b/packages/create-cloudflare/templates/astro/c3.ts
@@ -107,14 +107,5 @@ const config: TemplateConfig = {
 			...(usesTypescript(ctx) && { "build-cf-types": `wrangler types` }),
 		},
 	}),
-	testFlags: [
-		"--skip-houston",
-		"--no-install",
-		"--no-git",
-		"--template",
-		"blog",
-		"--typescript",
-		"strict",
-	],
 };
 export default config;

--- a/packages/create-cloudflare/templates/docusaurus/c3.ts
+++ b/packages/create-cloudflare/templates/docusaurus/c3.ts
@@ -22,6 +22,5 @@ const config: TemplateConfig = {
 	}),
 	devScript: "start",
 	deployScript: "deploy",
-	testFlags: [`--package-manager`, npm],
 };
 export default config;

--- a/packages/create-cloudflare/templates/docusaurus/c3.ts
+++ b/packages/create-cloudflare/templates/docusaurus/c3.ts
@@ -1,5 +1,4 @@
 import { runFrameworkGenerator } from "helpers/command";
-import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
@@ -18,10 +17,11 @@ const config: TemplateConfig = {
 	generate,
 	transformPackageJson: async () => ({
 		scripts: {
-			"pages:dev": `wrangler pages dev ${await compatDateFlag()} --proxy 3000 -- ${npm} run start`,
-			"pages:deploy": `${npm} run build && wrangler pages deploy ./build`,
+			deploy: `${npm} run build && wrangler pages deploy ./build`,
 		},
 	}),
+	devScript: "start",
+	deployScript: "deploy",
 	testFlags: [`--package-manager`, npm],
 };
 export default config;

--- a/packages/create-cloudflare/templates/gatsby/c3.ts
+++ b/packages/create-cloudflare/templates/gatsby/c3.ts
@@ -1,6 +1,5 @@
 import { inputPrompt } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "helpers/command";
-import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
@@ -38,9 +37,12 @@ const config: TemplateConfig = {
 	generate,
 	transformPackageJson: async () => ({
 		scripts: {
-			"pages:dev": `wrangler pages dev ${await compatDateFlag()} --proxy 8000 -- ${npm} run develop`,
-			"pages:deploy": `${npm} run build && wrangler pages deploy ./public`,
+			deploy: `${npm} run build && wrangler pages deploy ./public`,
+			preview: `${npm} run build && wrangler pages dev ./public`,
 		},
 	}),
+	devScript: "develop",
+	deployScript: "deploy",
+	previewScript: "preview",
 };
 export default config;

--- a/packages/create-cloudflare/templates/next/c3.ts
+++ b/packages/create-cloudflare/templates/next/c3.ts
@@ -158,9 +158,6 @@ export default {
 	id: "next",
 	platform: "pages",
 	displayName: "Next",
-	devScript: "dev",
-	previewScript: "preview",
-	deployScript: "deploy",
 	generate,
 	configure,
 	copyFiles: {
@@ -212,6 +209,9 @@ export default {
 			},
 		};
 	},
+	devScript: "dev",
+	previewScript: "preview",
+	deployScript: "deploy",
 	testFlags: [
 		"--typescript",
 		"--no-install",

--- a/packages/create-cloudflare/templates/next/c3.ts
+++ b/packages/create-cloudflare/templates/next/c3.ts
@@ -212,15 +212,5 @@ export default {
 	devScript: "dev",
 	previewScript: "preview",
 	deployScript: "deploy",
-	testFlags: [
-		"--typescript",
-		"--no-install",
-		"--eslint",
-		"--tailwind",
-		"--src-dir",
-		"--app",
-		"--import-alias",
-		"@/*",
-	],
 	compatibilityFlags: ["nodejs_compat"],
 } as TemplateConfig;

--- a/packages/create-cloudflare/templates/nuxt/c3.ts
+++ b/packages/create-cloudflare/templates/nuxt/c3.ts
@@ -117,8 +117,6 @@ const config: TemplateConfig = {
 	copyFiles: {
 		path: "./templates",
 	},
-	devScript: "dev",
-	deployScript: "deploy",
 	generate,
 	configure,
 	transformPackageJson: async () => ({
@@ -128,5 +126,8 @@ const config: TemplateConfig = {
 			"build-cf-types": `wrangler types`,
 		},
 	}),
+	devScript: "dev",
+	deployScript: "deploy",
+	previewScript: "preview",
 };
 export default config;

--- a/packages/create-cloudflare/templates/qwik/c3.ts
+++ b/packages/create-cloudflare/templates/qwik/c3.ts
@@ -130,8 +130,6 @@ const config: TemplateConfig = {
 	copyFiles: {
 		path: "./templates",
 	},
-	devScript: "dev",
-	deployScript: "deploy",
 	generate,
 	configure,
 	transformPackageJson: async () => ({
@@ -141,5 +139,8 @@ const config: TemplateConfig = {
 			"build-cf-types": `wrangler types`,
 		},
 	}),
+	devScript: "dev",
+	deployScript: "deploy",
+	previewScript: "preview",
 };
 export default config;

--- a/packages/create-cloudflare/templates/react/c3.ts
+++ b/packages/create-cloudflare/templates/react/c3.ts
@@ -1,6 +1,5 @@
 import { logRaw } from "@cloudflare/cli";
 import { runFrameworkGenerator } from "helpers/command";
-import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
@@ -21,9 +20,12 @@ const config: TemplateConfig = {
 	generate,
 	transformPackageJson: async () => ({
 		scripts: {
-			"pages:dev": `wrangler pages dev ${await compatDateFlag()} --port 3000 -- ${npm} start`,
-			"pages:deploy": `${npm} run build && wrangler pages deploy ./build`,
+			deploy: `${npm} run build && wrangler pages deploy ./build`,
+			preview: `${npm} run build && wrangler pages dev ./build`,
 		},
 	}),
+	devScript: "dev",
+	deployScript: "deploy",
+	previewScript: "preview",
 };
 export default config;

--- a/packages/create-cloudflare/templates/remix/c3.ts
+++ b/packages/create-cloudflare/templates/remix/c3.ts
@@ -62,6 +62,5 @@ const config: TemplateConfig = {
 	devScript: "dev",
 	deployScript: "deploy",
 	previewScript: "preview",
-	testFlags: ["--typescript", "--no-install", "--no-git-init"],
 };
 export default config;

--- a/packages/create-cloudflare/templates/solid/c3.ts
+++ b/packages/create-cloudflare/templates/solid/c3.ts
@@ -73,9 +73,9 @@ const config: TemplateConfig = {
 			deploy: `${npm} run build && wrangler pages deploy ./dist`,
 		},
 	}),
+	compatibilityFlags: ["nodejs_compat"],
 	devScript: "dev",
 	deployScript: "deploy",
 	previewScript: "preview",
-	compatibilityFlags: ["nodejs_compat"],
 };
 export default config;

--- a/packages/create-cloudflare/templates/vue/c3.ts
+++ b/packages/create-cloudflare/templates/vue/c3.ts
@@ -24,6 +24,5 @@ const config: TemplateConfig = {
 	devScript: "dev",
 	deployScript: "deploy",
 	previewScript: "preview",
-	testFlags: ["--ts"],
 };
 export default config;

--- a/packages/create-cloudflare/templates/vue/c3.ts
+++ b/packages/create-cloudflare/templates/vue/c3.ts
@@ -1,5 +1,4 @@
 import { runFrameworkGenerator } from "helpers/command";
-import { compatDateFlag } from "helpers/files";
 import { detectPackageManager } from "helpers/packages";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
@@ -18,10 +17,13 @@ const config: TemplateConfig = {
 	generate,
 	transformPackageJson: async () => ({
 		scripts: {
-			"pages:dev": `wrangler pages dev ${await compatDateFlag()} --proxy 5173 -- ${npm} run dev`,
-			"pages:deploy": `${npm} run build && wrangler pages deploy ./dist`,
+			deploy: `${npm} run build && wrangler pages deploy ./dist`,
+			preview: `${npm} run build && wrangler pages dev ./dist`,
 		},
 	}),
+	devScript: "dev",
+	deployScript: "deploy",
+	previewScript: "preview",
 	testFlags: ["--ts"],
 };
 export default config;


### PR DESCRIPTION
## What this PR solves / how to test

This updates the remaining `webFramework` templates to use `dev` and `deploy` instead of `pages:dev` and `pages:deploy` in their package scripts.

It also moves the `testFlags` config option for frameworks from their template definitions into the frameworks e2e test config.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [ x ] Not necessary because: Existing coverage sufficient
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [ x ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
