### PR TITLE
ci: ensure that workers.new is deployed to the correct account

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -76,3 +76,5 @@ jobs:
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          WORKERS_NEW_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.WORKERS_NEW_CLOUDFLARE_ACCOUNT_ID }}
+          WORKERS_NEW_CLOUDFLARE_API_TOKEN: ${{ secrets.WORKERS_NEW_CLOUDFLARE_API_TOKEN }}

--- a/packages/workers.new/package.json
+++ b/packages/workers.new/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"check:lint": "eslint .",
-		"deploy": "wrangler deploy",
+		"deploy": "CLOUDFLARE_ACCOUNT_ID=$WORKERS_NEW_CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN=$WORKERS_NEW_CLOUDFLARE_API_TOKEN wrangler deploy",
 		"dev": "wrangler dev",
 		"test": "vitest run",
 		"test:ci": "vitest run"


### PR DESCRIPTION
## What this PR solves / how to test

The workers.new Worker is not deployed to the same account as the other Workers in this monorepo.
Therefore it needs its own account id and api token.
These have been added to Github as secrets:
- WORKERS_NEW_CLOUDFLARE_ACCOUNT_ID
- WORKERS_NEW_CLOUDFLARE_API_TOKEN

This PR changes the deploy script of workers.new to use these secrets in the `wrangler deploy` command.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: CI configuration
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no changes to public packages
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: no user facing change
