### PR TITLE
miniflare: fix node 21.7.0 compatibility

### DIFF
--- a/.changeset/clean-nails-talk.md
+++ b/.changeset/clean-nails-talk.md
@@ -2,4 +2,4 @@
 "miniflare": patch
 ---
 
-fix node 21.7.0 compatiblity
+fix: ensure `miniflare` works with Node 21.7.0+

--- a/.changeset/clean-nails-talk.md
+++ b/.changeset/clean-nails-talk.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix node 21.7.0 compatiblity

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -625,8 +625,7 @@ function safeReadableStreamFrom(iterable: AsyncIterable<Uint8Array>) {
 			async cancel() {
 				await iterator.return?.();
 			},
-		},
-		0
+		}
 	);
 }
 


### PR DESCRIPTION
The `ReadableStream` constructor was being called with an invalid, numerical second argument. Node 21.7.0 now runs stricter checks on that parameter, which was causing construction to fail.

We eliminate the second argument.


## What this PR solves / how to test


Fixes  #5190 

## Author has addressed the following

- Tests
  - [x] TODO (before merge): There should be a change to the tests to ensure node 21.7.0 gets tested. That's all.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
- Public documentation
  - [x] Not necessary because: Not relevant changes
