### PR TITLE
[D1] fix `wrangler d1 migration apply` to for queries not ending in a semi-colon

### DIFF
--- a/.changeset/gorgeous-taxis-argue.md
+++ b/.changeset/gorgeous-taxis-argue.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: fix migration apply to allow migrations that dont end in a semicolon

--- a/.changeset/gorgeous-taxis-argue.md
+++ b/.changeset/gorgeous-taxis-argue.md
@@ -2,4 +2,10 @@
 "wrangler": patch
 ---
 
-fix: fix migration apply to allow migrations that dont end in a semicolon
+fix: fix `wrangler d1 migrations apply` to allow migrations that dont end in a semicolon
+
+Prior to this PR, migrations such as: `SELECT 1` would fail with a nonsensical error about INSERTS: `✘ [ERROR] near "INSERT": syntax error at offset 199 [code: 7500]`
+
+What was happening was that wrangler was injecting a statement at the end of the migration, to update the migrations table saying the query successfully executed.
+
+To avoid this, this PR moves the statement to the start of the migration.

--- a/.changeset/gorgeous-taxis-argue.md
+++ b/.changeset/gorgeous-taxis-argue.md
@@ -2,7 +2,7 @@
 "wrangler": patch
 ---
 
-fix: fix `wrangler d1 migrations apply` to allow migrations that dont end in a semicolon
+fix: fix `wrangler d1 migrations apply` to allow migrations that don't end in a semicolon
 
 Prior to this PR, migrations such as: `SELECT 1` would fail with a nonsensical error about INSERTS: `✘ [ERROR] near "INSERT": syntax error at offset 199 [code: 7500]`
 

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -146,15 +146,10 @@ Your database may not be available to serve requests during the migration, conti
 		}
 
 		for (const migration of unappliedMigrations) {
-			let query = fs.readFileSync(
-				`${migrationsPath}/${migration.name}`,
-				"utf8"
-			);
-			query += `
-								INSERT INTO ${migrationsTableName} (name)
-								values ('${migration.name}');
+			let query = `
+								INSERT INTO ${migrationsTableName} (name) VALUES ('${migration.name}');
 						`;
-
+			query += fs.readFileSync(`${migrationsPath}/${migration.name}`, "utf8");
 			let success = true;
 			let errorNotes: Array<string> = [];
 			try {


### PR DESCRIPTION
Prior to this PR, migrations such as:
```
SELECT 1
```

would fail with a nonsensical error about INSERTS: `✘ [ERROR] near "INSERT": syntax error at offset 199 [code: 7500]`

What was happening was that wrangler was injecting a statement at the end of the migration, to update the migrations table saying the query successfully executed.

To avoid this, this PR moves the statement to the start of the migration.