### PR TITLE
Implement `versions list` + `versions view` commands

### DIFF
--- a/.changeset/spotty-vans-bow.md
+++ b/.changeset/spotty-vans-bow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feature: Implement `wrangler versions list` and `wrangler versions view` commands behind the `--experimental-gradual-rollouts` flag.

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -21,7 +21,7 @@ import { runWrangler } from "../helpers/run-wrangler";
 import writeWranglerToml from "../helpers/write-wrangler-toml";
 import type { VersionsDeployArgs } from "../../versions/deploy";
 
-function mockProcessOutput() {
+function collectStreamOutput() {
 	const std = { out: "", err: "" };
 	const onStdOutData = (chunk: Buffer) => (std.out += chunk.toString());
 	const onStdErrData = (chunk: Buffer) => (std.err += chunk.toString());
@@ -45,7 +45,7 @@ describe("versions deploy", () => {
 	mockAccountId();
 	mockApiToken();
 	runInTempDir();
-	const std = mockProcessOutput();
+	const std = collectStreamOutput();
 
 	beforeEach(() => {
 		msw.use(

--- a/packages/wrangler/src/__tests__/versions/versions.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.list.test.ts
@@ -1,3 +1,4 @@
+import { normalizeOutput } from "../../../e2e/helpers/normalize";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw, mswListVersions } from "../helpers/msw";
@@ -27,11 +28,9 @@ describe("versions list", () => {
 
 			expect(std.out).toMatchInlineSnapshot(`""`);
 
-			expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou need to provide a name when deploying a worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = \\"<name>\\"\`[0m
-
-			"
-		`);
+			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(
+				`"X [ERROR] You need to provide a name when deploying a worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = \\"<name>\\"\`"`
+			);
 		});
 
 		test("prints versions to stdout", async () => {

--- a/packages/wrangler/src/__tests__/versions/versions.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.list.test.ts
@@ -44,28 +44,28 @@ describe("versions list", () => {
 			"Version ID:  40000000-0000-0000-0000-000000000000
 			Created:     1/1/2021, 12:00:00 AM
 			Author:      Jean-Luc-Picard@federation.org
-			Source:      wrangler
+			Source:      Upload
 			Tag:         -
 			Message:     -
 
 			Version ID:  30000000-0000-0000-0000-000000000000
 			Created:     2/2/2021, 12:00:00 AM
 			Author:      Kathryn-Janeway@federation.org
-			Source:      wrangler
+			Source:      Rollback
 			Tag:         -
 			Message:     Rolled back for this version
 
 			Version ID:  20000000-0000-0000-0000-000000000000
 			Created:     2/3/2021, 12:00:00 AM
 			Author:      Kathryn-Janeway@federation.org
-			Source:      wrangler
+			Source:      Wrangler 🤠
 			Tag:         -
 			Message:     -
 
 			Version ID:  10000000-0000-0000-0000-000000000000
 			Created:     1/4/2021, 12:00:00 AM
 			Author:      Jean-Luc-Picard@federation.org
-			Source:      wrangler
+			Source:      Rollback
 			Tag:         -
 			Message:     -
 			"
@@ -89,28 +89,28 @@ describe("versions list", () => {
 			"Version ID:  40000000-0000-0000-0000-000000000000
 			Created:     1/1/2021, 12:00:00 AM
 			Author:      Jean-Luc-Picard@federation.org
-			Source:      wrangler
+			Source:      Upload
 			Tag:         -
 			Message:     -
 
 			Version ID:  30000000-0000-0000-0000-000000000000
 			Created:     2/2/2021, 12:00:00 AM
 			Author:      Kathryn-Janeway@federation.org
-			Source:      wrangler
+			Source:      Rollback
 			Tag:         -
 			Message:     Rolled back for this version
 
 			Version ID:  20000000-0000-0000-0000-000000000000
 			Created:     2/3/2021, 12:00:00 AM
 			Author:      Kathryn-Janeway@federation.org
-			Source:      wrangler
+			Source:      Wrangler 🤠
 			Tag:         -
 			Message:     -
 
 			Version ID:  10000000-0000-0000-0000-000000000000
 			Created:     1/4/2021, 12:00:00 AM
 			Author:      Jean-Luc-Picard@federation.org
-			Source:      wrangler
+			Source:      Rollback
 			Tag:         -
 			Message:     -
 			"

--- a/packages/wrangler/src/__tests__/versions/versions.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.list.test.ts
@@ -1,0 +1,123 @@
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { msw, mswListVersions } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import writeWranglerToml from "../helpers/write-wrangler-toml";
+
+describe("versions list", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+	const std = mockConsoleMethods();
+
+	beforeEach(() => {
+		msw.use(mswListVersions);
+	});
+
+	describe("without wrangler.toml", () => {
+		test("fails with no args", async () => {
+			const result = runWrangler(
+				"versions list  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: You need to provide a name when deploying a worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = "<name>"\`]`
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`""`);
+
+			expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou need to provide a name when deploying a worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = \\"<name>\\"\`[0m
+
+			"
+		`);
+		});
+
+		test("prints versions to stdout", async () => {
+			const result = runWrangler(
+				"versions list --name test-name  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).resolves.toBeUndefined();
+
+			expect(std.out).toMatchInlineSnapshot(`
+			"Version ID:  40000000-0000-0000-0000-000000000000
+			Created:     1/1/2021, 12:00:00 AM
+			Author:      Jean-Luc-Picard@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     -
+
+			Version ID:  30000000-0000-0000-0000-000000000000
+			Created:     2/2/2021, 12:00:00 AM
+			Author:      Kathryn-Janeway@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     Rolled back for this version
+
+			Version ID:  20000000-0000-0000-0000-000000000000
+			Created:     2/3/2021, 12:00:00 AM
+			Author:      Kathryn-Janeway@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     -
+
+			Version ID:  10000000-0000-0000-0000-000000000000
+			Created:     1/4/2021, 12:00:00 AM
+			Author:      Jean-Luc-Picard@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     -
+			"
+		`);
+
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+	});
+
+	describe("with wrangler.toml", () => {
+		beforeEach(writeWranglerToml);
+
+		test("prints versions to stdout", async () => {
+			const result = runWrangler(
+				"versions list  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).resolves.toBeUndefined();
+
+			expect(std.out).toMatchInlineSnapshot(`
+			"Version ID:  40000000-0000-0000-0000-000000000000
+			Created:     1/1/2021, 12:00:00 AM
+			Author:      Jean-Luc-Picard@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     -
+
+			Version ID:  30000000-0000-0000-0000-000000000000
+			Created:     2/2/2021, 12:00:00 AM
+			Author:      Kathryn-Janeway@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     Rolled back for this version
+
+			Version ID:  20000000-0000-0000-0000-000000000000
+			Created:     2/3/2021, 12:00:00 AM
+			Author:      Kathryn-Janeway@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     -
+
+			Version ID:  10000000-0000-0000-0000-000000000000
+			Created:     1/4/2021, 12:00:00 AM
+			Author:      Jean-Luc-Picard@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     -
+			"
+		`);
+
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/versions/versions.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.view.test.ts
@@ -26,17 +26,22 @@ describe("versions view", () => {
 				`[Error: Not enough non-option arguments: got 0, need at least 1]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-			"wrangler versions view <version-id>
+			expect(std.out).toMatchInlineSnapshot(`
+			"
+			wrangler versions view <version-id>
+
 			View the details of a specific version of your Worker [beta]
+
 			Positionals:
 			  version-id  The Worker Version ID to view  [string] [required]
+
 			Flags:
 			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
 			  -c, --config                    Path to .toml configuration file  [string]
 			  -e, --env                       Environment to use for operations and .env files  [string]
 			  -h, --help                      Show help  [boolean]
 			  -v, --version                   Show version number  [boolean]
+
 			Options:
 			      --name  Name of the worker  [string]"
 		`);
@@ -55,17 +60,22 @@ describe("versions view", () => {
 				`[Error: Not enough non-option arguments: got 0, need at least 1]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-			"wrangler versions view <version-id>
+			expect(std.out).toMatchInlineSnapshot(`
+			"
+			wrangler versions view <version-id>
+
 			View the details of a specific version of your Worker [beta]
+
 			Positionals:
 			  version-id  The Worker Version ID to view  [string] [required]
+
 			Flags:
 			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
 			  -c, --config                    Path to .toml configuration file  [string]
 			  -e, --env                       Environment to use for operations and .env files  [string]
 			  -h, --help                      Show help  [boolean]
 			  -v, --version                   Show version number  [boolean]
+
 			Options:
 			      --name  Name of the worker  [string]"
 		`);
@@ -84,7 +94,7 @@ describe("versions view", () => {
 				`[Error: You need to provide a name when deploying a worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = "<name>"\`]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`""`);
+			expect(std.out).toMatchInlineSnapshot(`""`);
 
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(
 				`"X [ERROR] You need to provide a name when deploying a worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = \\"<name>\\"\`"`
@@ -98,13 +108,14 @@ describe("versions view", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-			"Version ID:  00000000-0000-0000-0000-000000000000
-			Created:     1/1/2021, TIMESTAMP AM
+			expect(std.out).toMatchInlineSnapshot(`
+			"Version ID:  10000000-0000-0000-0000-000000000000
+			Created:     1/1/2021, 12:00:00 AM
 			Author:      Jean-Luc-Picard@federation.org
 			Source:      wrangler
 			Tag:         -
-			Message:     -"
+			Message:     -
+			"
 		`);
 
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
@@ -123,17 +134,22 @@ describe("versions view", () => {
 				`[Error: Not enough non-option arguments: got 0, need at least 1]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-			"wrangler versions view <version-id>
+			expect(std.out).toMatchInlineSnapshot(`
+			"
+			wrangler versions view <version-id>
+
 			View the details of a specific version of your Worker [beta]
+
 			Positionals:
 			  version-id  The Worker Version ID to view  [string] [required]
+
 			Flags:
 			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
 			  -c, --config                    Path to .toml configuration file  [string]
 			  -e, --env                       Environment to use for operations and .env files  [string]
 			  -h, --help                      Show help  [boolean]
 			  -v, --version                   Show version number  [boolean]
+
 			Options:
 			      --name  Name of the worker  [string]"
 		`);
@@ -150,13 +166,14 @@ describe("versions view", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-			"Version ID:  00000000-0000-0000-0000-000000000000
-			Created:     1/1/2021, TIMESTAMP AM
+			expect(std.out).toMatchInlineSnapshot(`
+			"Version ID:  10000000-0000-0000-0000-000000000000
+			Created:     1/1/2021, 12:00:00 AM
 			Author:      Jean-Luc-Picard@federation.org
 			Source:      wrangler
 			Tag:         -
-			Message:     -"
+			Message:     -
+			"
 		`);
 
 			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/versions/versions.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.view.test.ts
@@ -112,7 +112,7 @@ describe("versions view", () => {
 			"Version ID:  10000000-0000-0000-0000-000000000000
 			Created:     1/1/2021, 12:00:00 AM
 			Author:      Jean-Luc-Picard@federation.org
-			Source:      wrangler
+			Source:      Upload
 			Tag:         -
 			Message:     -
 			"
@@ -170,7 +170,7 @@ describe("versions view", () => {
 			"Version ID:  10000000-0000-0000-0000-000000000000
 			Created:     1/1/2021, 12:00:00 AM
 			Author:      Jean-Luc-Picard@federation.org
-			Source:      wrangler
+			Source:      Upload
 			Tag:         -
 			Message:     -
 			"

--- a/packages/wrangler/src/__tests__/versions/versions.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.view.test.ts
@@ -1,0 +1,183 @@
+import { normalizeOutput } from "../../../e2e/helpers/normalize";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { msw, mswGetVersion } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import writeWranglerToml from "../helpers/write-wrangler-toml";
+
+describe("versions view", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+	const std = mockConsoleMethods();
+
+	beforeEach(() => {
+		msw.use(mswGetVersion);
+	});
+
+	describe("without wrangler.toml", () => {
+		test("fails with no args", async () => {
+			const result = runWrangler(
+				"versions view  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: Not enough non-option arguments: got 0, need at least 1]`
+			);
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"wrangler versions view <version-id>
+			View the details of a specific version of your Worker [beta]
+			Positionals:
+			  version-id  The Worker Version ID to view  [string] [required]
+			Flags:
+			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+			  -c, --config                    Path to .toml configuration file  [string]
+			  -e, --env                       Environment to use for operations and .env files  [string]
+			  -h, --help                      Show help  [boolean]
+			  -v, --version                   Show version number  [boolean]
+			Options:
+			      --name  Name of the worker  [string]"
+		`);
+
+			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(
+				`"X [ERROR] Not enough non-option arguments: got 0, need at least 1"`
+			);
+		});
+
+		test("fails with --name arg only", async () => {
+			const result = runWrangler(
+				"versions view --name test-name  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: Not enough non-option arguments: got 0, need at least 1]`
+			);
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"wrangler versions view <version-id>
+			View the details of a specific version of your Worker [beta]
+			Positionals:
+			  version-id  The Worker Version ID to view  [string] [required]
+			Flags:
+			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+			  -c, --config                    Path to .toml configuration file  [string]
+			  -e, --env                       Environment to use for operations and .env files  [string]
+			  -h, --help                      Show help  [boolean]
+			  -v, --version                   Show version number  [boolean]
+			Options:
+			      --name  Name of the worker  [string]"
+		`);
+
+			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(
+				`"X [ERROR] Not enough non-option arguments: got 0, need at least 1"`
+			);
+		});
+
+		test("fails with positional version-id arg only", async () => {
+			const result = runWrangler(
+				"versions view 10000000-0000-0000-0000-000000000000  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: You need to provide a name when deploying a worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = "<name>"\`]`
+			);
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`""`);
+
+			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(
+				`"X [ERROR] You need to provide a name when deploying a worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = \\"<name>\\"\`"`
+			);
+		});
+
+		test("succeeds with positional version-id arg and --name arg", async () => {
+			const result = runWrangler(
+				"versions view 10000000-0000-0000-0000-000000000000 --name test-name  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).resolves.toBeUndefined();
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"Version ID:  00000000-0000-0000-0000-000000000000
+			Created:     1/1/2021, TIMESTAMP AM
+			Author:      Jean-Luc-Picard@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     -"
+		`);
+
+			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
+		});
+	});
+
+	describe("with wrangler.toml", () => {
+		beforeEach(writeWranglerToml);
+
+		test("fails with no args", async () => {
+			const result = runWrangler(
+				"versions view  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: Not enough non-option arguments: got 0, need at least 1]`
+			);
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"wrangler versions view <version-id>
+			View the details of a specific version of your Worker [beta]
+			Positionals:
+			  version-id  The Worker Version ID to view  [string] [required]
+			Flags:
+			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+			  -c, --config                    Path to .toml configuration file  [string]
+			  -e, --env                       Environment to use for operations and .env files  [string]
+			  -h, --help                      Show help  [boolean]
+			  -v, --version                   Show version number  [boolean]
+			Options:
+			      --name  Name of the worker  [string]"
+		`);
+
+			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(
+				`"X [ERROR] Not enough non-option arguments: got 0, need at least 1"`
+			);
+		});
+
+		test("succeeds with positional version-id arg only", async () => {
+			const result = runWrangler(
+				"versions view 10000000-0000-0000-0000-000000000000  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).resolves.toBeUndefined();
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"Version ID:  00000000-0000-0000-0000-000000000000
+			Created:     1/1/2021, TIMESTAMP AM
+			Author:      Jean-Luc-Picard@federation.org
+			Source:      wrangler
+			Tag:         -
+			Message:     -"
+		`);
+
+			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
+		});
+
+		test("fails with non-existent version-id", async () => {
+			const result = runWrangler(
+				"versions view ffffffff-ffff-ffff-ffff-ffffffffffff  --experimental-gradual-rollouts"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name/versions/ffffffff-ffff-ffff-ffff-ffffffffffff) failed.]`
+			);
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"X [ERROR] A request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name/versions/00000000-0000-0000-0000-000000000000) failed.
+			  If you think this is a bug, please open an issue at:
+			  https://github.com/cloudflare/workers-sdk/issues/new/choose"
+		`);
+
+			expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
+		});
+	});
+});

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -66,11 +66,7 @@ import {
 	validateScopeKeys,
 } from "./user";
 import { vectorize } from "./vectorize/index";
-import { versionsUploadHandler, versionsUploadOptions } from "./versions";
-import {
-	versionsDeployHandler,
-	versionsDeployOptions,
-} from "./versions/deploy";
+import registerVersionsSubcommands from "./versions";
 import { whoami } from "./whoami";
 import { asJson } from "./yargs-types";
 import type { Config } from "./config";
@@ -710,21 +706,7 @@ export function createCLIParser(argv: string[]) {
 		"--experimental-gradual-rollouts"
 	);
 	if (experimentalGradualRollouts) {
-		wrangler.command("versions", false, (versionYargs) => {
-			return versionYargs
-				.command(
-					"upload",
-					"Uploads your Worker code and config as a new version [beta]",
-					versionsUploadOptions,
-					versionsUploadHandler
-				)
-				.command(
-					"deploy [version-specs..]",
-					"Safely roll out new versions of your Worker by splitting traffic between multiple versions [beta]",
-					versionsDeployOptions,
-					versionsDeployHandler
-				);
-		});
+		wrangler.command("versions", false, registerVersionsSubcommands);
 	}
 
 	wrangler.exitProcess(false);

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -67,6 +67,7 @@ export type EventNames =
 	| "rollback deployments"
 	| "upload worker version"
 	| "deploy worker versions"
+	| "view worker version"
 	| "list worker versions";
 
 /**

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -66,7 +66,8 @@ export type EventNames =
 	| "view deployments"
 	| "rollback deployments"
 	| "upload worker version"
-	| "deploy worker versions";
+	| "deploy worker versions"
+	| "list worker versions";
 
 /**
  * Send a metrics event, with no extra properties, to Cloudflare, if usage tracking is enabled.

--- a/packages/wrangler/src/utils/render-labelled-values.ts
+++ b/packages/wrangler/src/utils/render-labelled-values.ts
@@ -1,0 +1,22 @@
+import { logger } from "../logger";
+
+export default function renderLabelledValues(
+	view: Record<string, string>,
+	{ print = logger.log as (line: string) => unknown, spacerCount = 2 } = {}
+) {
+	const alignment =
+		Math.max(...Object.keys(view).map((key) => key.length)) + spacerCount;
+	for (const [label, value] of Object.entries(view)) {
+		const paddedLabel = label.padEnd(alignment);
+		const alignedValue = value
+			?.split("\n")
+			.map((line, lineNo) =>
+				lineNo === 0 ? line : " ".repeat(alignment) + line
+			)
+			.join("\n");
+
+		print(paddedLabel + alignedValue);
+	}
+
+	print("");
+}

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -12,6 +12,7 @@ import * as metrics from "../metrics";
 import { requireAuth } from "../user";
 import { collectKeyValues } from "../utils/collectKeyValues";
 import { versionsDeployHandler, versionsDeployOptions } from "./deploy";
+import { versionsListHandler, versionsListOptions } from "./list";
 import versionsUpload from "./upload";
 import type { Config } from "../config";
 import type {
@@ -230,14 +231,20 @@ export default function registerVersionsSubcommands(
 ) {
 	versionYargs
 		.command(
+			"list",
+			"List the 10 most recent Versions of your Worker [beta]",
+			versionsListOptions,
+			versionsListHandler
+		)
+		.command(
 			"upload",
-			"Uploads your Worker code and config as a new version [beta]",
+			"Uploads your Worker code and config as a new Version [beta]",
 			versionsUploadOptions,
 			versionsUploadHandler
 		)
 		.command(
 			"deploy [version-specs..]",
-			"Safely roll out new versions of your Worker by splitting traffic between multiple versions [beta]",
+			"Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [beta]",
 			versionsDeployOptions,
 			versionsDeployHandler
 		);

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -11,6 +11,7 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
 import { collectKeyValues } from "../utils/collectKeyValues";
+import { versionsDeployHandler, versionsDeployOptions } from "./deploy";
 import versionsUpload from "./upload";
 import type { Config } from "../config";
 import type {
@@ -222,4 +223,22 @@ export async function versionsUploadHandler(
 		tag: args.tag,
 		message: args.message,
 	});
+}
+
+export default function registerVersionsSubcommands(
+	versionYargs: CommonYargsArgv
+) {
+	versionYargs
+		.command(
+			"upload",
+			"Uploads your Worker code and config as a new version [beta]",
+			versionsUploadOptions,
+			versionsUploadHandler
+		)
+		.command(
+			"deploy [version-specs..]",
+			"Safely roll out new versions of your Worker by splitting traffic between multiple versions [beta]",
+			versionsDeployOptions,
+			versionsDeployHandler
+		);
 }

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -14,6 +14,7 @@ import { collectKeyValues } from "../utils/collectKeyValues";
 import { versionsDeployHandler, versionsDeployOptions } from "./deploy";
 import { versionsListHandler, versionsListOptions } from "./list";
 import versionsUpload from "./upload";
+import { versionsViewHandler, versionsViewOptions } from "./view";
 import type { Config } from "../config";
 import type {
 	CommonYargsArgv,
@@ -230,6 +231,12 @@ export default function registerVersionsSubcommands(
 	versionYargs: CommonYargsArgv
 ) {
 	versionYargs
+		.command(
+			"view <version-id>",
+			"View the details of a specific version of your Worker [beta]",
+			versionsViewOptions,
+			versionsViewHandler
+		)
 		.command(
 			"list",
 			"List the 10 most recent Versions of your Worker [beta]",

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import * as cli from "@cloudflare/cli";
 import { fetchResult } from "../cfetch";
 import { findWranglerToml, readConfig } from "../config";
 import { UserError } from "../errors";

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -29,7 +29,7 @@ type ApiVersion = {
 		author_id: string;
 		author_email: string;
 	};
-	annotations?: Record<string, string> & {
+	annotations?: {
 		"workers/triggered_by"?: "upload" | string;
 		"workers/message"?: string;
 		"workers/tag"?: string;
@@ -75,14 +75,14 @@ export async function versionsListHandler(args: VersionsListArgs) {
 			"Version ID:": version.id,
 			"Created:": new Date(version.metadata["created_on"]).toLocaleString(),
 			"Author:": version.metadata.author_email,
-			"Source:": version.metadata.source,
+			"Source:": getSource(version),
 			"Tag:": version.annotations?.["workers/tag"] ?? BLANK_INPUT,
 			"Message:": version.annotations?.["workers/message"] ?? BLANK_INPUT,
 		});
 	}
 }
 
-function getConfig(
+export function getConfig(
 	args: Pick<VersionsListArgs, "config" | "name" | "experimentalJsonConfig">
 ) {
 	const configPath =
@@ -90,4 +90,45 @@ function getConfig(
 	const config = readConfig(configPath, args);
 
 	return config;
+}
+
+export function getSource(version: {
+	metadata: Pick<ApiVersion["metadata"], "source">;
+	annotations?: Pick<
+		NonNullable<ApiVersion["annotations"]>,
+		"workers/triggered_by"
+	>;
+}) {
+	return version.annotations?.["workers/triggered_by"] === undefined
+		? formatSource(version.metadata.source)
+		: formatTrigger(version.annotations["workers/triggered_by"]);
+}
+
+export function formatSource(source: string): string {
+	switch (source) {
+		case "api":
+			return "API 📡";
+		case "dash":
+			return "Dashboard 🖥️";
+		case "wrangler":
+			return "Wrangler 🤠";
+		case "terraform":
+			return "Terraform 🏗️";
+		default:
+			return "Other";
+	}
+}
+export function formatTrigger(trigger: string): string {
+	switch (trigger) {
+		case "upload":
+			return "Upload";
+		case "secret":
+			return "Secret Change";
+		case "rollback":
+			return "Rollback";
+		case "promotion":
+			return "Promotion";
+		default:
+			return "Unknown";
+	}
 }

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -1,0 +1,108 @@
+import path from "path";
+import * as cli from "@cloudflare/cli";
+import { fetchResult } from "../cfetch";
+import { findWranglerToml, readConfig } from "../config";
+import { UserError } from "../errors";
+import * as metrics from "../metrics";
+import { printWranglerBanner } from "../update-check";
+import { requireAuth } from "../user";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+const BLANK_INPUT = "-"; // To be used where optional user-input is displayed and the value is nullish
+
+export type VersionsListArgs = StrictYargsOptionsToInterface<
+	typeof versionsListOptions
+>;
+
+type UUID = string;
+type VersionId = UUID;
+type ApiVersion = {
+	id: VersionId;
+	number: number;
+	metadata: {
+		created_on: string;
+		modified_on: string;
+		source: "api" | string;
+		author_id: string;
+		author_email: string;
+	};
+	annotations?: Record<string, string> & {
+		"workers/triggered_by"?: "upload" | string;
+		"workers/message"?: string;
+		"workers/tag"?: string;
+	};
+	// other properties not typed as not used
+};
+
+export function versionsListOptions(yargs: CommonYargsArgv) {
+	return yargs.option("name", {
+		describe: "Name of the worker",
+		type: "string",
+		requiresArg: true,
+	});
+}
+
+export async function versionsListHandler(args: VersionsListArgs) {
+	await printWranglerBanner();
+
+	const config = getConfig(args);
+	await metrics.sendMetricsEvent(
+		"list worker versions",
+		{},
+		{
+			sendMetrics: config.send_metrics,
+		}
+	);
+
+	const accountId = await requireAuth(config);
+	const workerName = args.name ?? config.name;
+
+	if (workerName === undefined) {
+		throw new UserError(
+			'You need to provide a name when deploying a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+		);
+	}
+
+	const { items: versions } = await fetchResult<{ items: ApiVersion[] }>(
+		`/accounts/${accountId}/workers/scripts/${workerName}/versions`
+	);
+
+	for (const version of versions) {
+		const view = {
+			"Version ID": version.id,
+			Created: new Date(version.metadata["created_on"]).toLocaleString(),
+			Author: version.metadata.author_email,
+			Source: version.metadata.source,
+			Tag: version.annotations?.["workers/tag"] ?? BLANK_INPUT,
+			Message: version.annotations?.["workers/message"] ?? BLANK_INPUT,
+		};
+
+		const alignment = 17;
+		for (const [label, value] of Object.entries(view)) {
+			const paddedLabel = `${label}:`.padEnd(alignment);
+			const alignedValue = value
+				?.split("\n")
+				.map((line, lineNo) =>
+					lineNo === 0 ? line : " ".repeat(alignment) + line
+				)
+				.join("\n");
+
+			cli.logRaw(paddedLabel + alignedValue);
+		}
+
+		cli.logRaw(``);
+	}
+}
+
+function getConfig(
+	args: Pick<VersionsListArgs, "config" | "name" | "experimentalJsonConfig">
+) {
+	const configPath =
+		args.config || (args.name && findWranglerToml(path.dirname(args.name)));
+	const config = readConfig(configPath, args);
+
+	return config;
+}

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -6,6 +6,7 @@ import { UserError } from "../errors";
 import * as metrics from "../metrics";
 import { printWranglerBanner } from "../update-check";
 import { requireAuth } from "../user";
+import renderLabelledValues from "../utils/render-labelled-values";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -71,29 +72,14 @@ export async function versionsListHandler(args: VersionsListArgs) {
 	);
 
 	for (const version of versions) {
-		const view = {
-			"Version ID": version.id,
-			Created: new Date(version.metadata["created_on"]).toLocaleString(),
-			Author: version.metadata.author_email,
-			Source: version.metadata.source,
-			Tag: version.annotations?.["workers/tag"] ?? BLANK_INPUT,
-			Message: version.annotations?.["workers/message"] ?? BLANK_INPUT,
-		};
-
-		const alignment = 17;
-		for (const [label, value] of Object.entries(view)) {
-			const paddedLabel = `${label}:`.padEnd(alignment);
-			const alignedValue = value
-				?.split("\n")
-				.map((line, lineNo) =>
-					lineNo === 0 ? line : " ".repeat(alignment) + line
-				)
-				.join("\n");
-
-			cli.logRaw(paddedLabel + alignedValue);
-		}
-
-		cli.logRaw(``);
+		renderLabelledValues({
+			"Version ID:": version.id,
+			"Created:": new Date(version.metadata["created_on"]).toLocaleString(),
+			"Author:": version.metadata.author_email,
+			"Source:": version.metadata.source,
+			"Tag:": version.annotations?.["workers/tag"] ?? BLANK_INPUT,
+			"Message:": version.annotations?.["workers/message"] ?? BLANK_INPUT,
+		});
 	}
 }
 

--- a/packages/wrangler/src/versions/view.ts
+++ b/packages/wrangler/src/versions/view.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import * as cli from "@cloudflare/cli";
 import { fetchResult } from "../cfetch";
 import { findWranglerToml, readConfig } from "../config";
 import { UserError } from "../errors";

--- a/packages/wrangler/src/versions/view.ts
+++ b/packages/wrangler/src/versions/view.ts
@@ -44,6 +44,7 @@ export function versionsViewOptions(yargs: CommonYargsArgv) {
 			describe: "The Worker Version ID to view",
 			type: "string",
 			requiresArg: true,
+			demandOption: true,
 		})
 		.option("name", {
 			describe: "Name of the worker",

--- a/packages/wrangler/src/versions/view.ts
+++ b/packages/wrangler/src/versions/view.ts
@@ -1,0 +1,98 @@
+import path from "path";
+import * as cli from "@cloudflare/cli";
+import { fetchResult } from "../cfetch";
+import { findWranglerToml, readConfig } from "../config";
+import { UserError } from "../errors";
+import * as metrics from "../metrics";
+import { printWranglerBanner } from "../update-check";
+import { requireAuth } from "../user";
+import renderLabelledValues from "../utils/render-labelled-values";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+const BLANK_INPUT = "-"; // To be used where optional user-input is displayed and the value is nullish
+
+export type VersionsViewArgs = StrictYargsOptionsToInterface<
+	typeof versionsViewOptions
+>;
+
+type UUID = string;
+type VersionId = UUID;
+type ApiVersion = {
+	id: VersionId;
+	number: number;
+	metadata: {
+		created_on: string;
+		modified_on: string;
+		source: "api" | string;
+		author_id: string;
+		author_email: string;
+	};
+	annotations?: Record<string, string> & {
+		"workers/triggered_by"?: "upload" | string;
+		"workers/message"?: string;
+		"workers/tag"?: string;
+	};
+	// other properties not typed as not used
+};
+
+export function versionsViewOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("version-id", {
+			describe: "The Worker Version ID to view",
+			type: "string",
+			requiresArg: true,
+		})
+		.option("name", {
+			describe: "Name of the worker",
+			type: "string",
+			requiresArg: true,
+		});
+}
+
+export async function versionsViewHandler(args: VersionsViewArgs) {
+	await printWranglerBanner();
+
+	const config = getConfig(args);
+	await metrics.sendMetricsEvent(
+		"view worker version",
+		{},
+		{
+			sendMetrics: config.send_metrics,
+		}
+	);
+
+	const accountId = await requireAuth(config);
+	const workerName = args.name ?? config.name;
+
+	if (workerName === undefined) {
+		throw new UserError(
+			'You need to provide a name when deploying a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+		);
+	}
+
+	const version = await fetchResult<ApiVersion>(
+		`/accounts/${accountId}/workers/scripts/${workerName}/versions/${args.versionId}`
+	);
+
+	renderLabelledValues({
+		"Version ID:": version.id,
+		"Created:": new Date(version.metadata["created_on"]).toLocaleString(),
+		"Author:": version.metadata.author_email,
+		"Source:": version.metadata.source,
+		"Tag:": version.annotations?.["workers/tag"] ?? BLANK_INPUT,
+		"Message:": version.annotations?.["workers/message"] ?? BLANK_INPUT,
+	});
+}
+
+function getConfig(
+	args: Pick<VersionsViewArgs, "config" | "name" | "experimentalJsonConfig">
+) {
+	const configPath =
+		args.config || (args.name && findWranglerToml(path.dirname(args.name)));
+	const config = readConfig(configPath, args);
+
+	return config;
+}

--- a/packages/wrangler/src/versions/view.ts
+++ b/packages/wrangler/src/versions/view.ts
@@ -1,11 +1,10 @@
-import path from "path";
 import { fetchResult } from "../cfetch";
-import { findWranglerToml, readConfig } from "../config";
 import { UserError } from "../errors";
 import * as metrics from "../metrics";
 import { printWranglerBanner } from "../update-check";
 import { requireAuth } from "../user";
 import renderLabelledValues from "../utils/render-labelled-values";
+import { getConfig, getSource } from "./list";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -81,18 +80,8 @@ export async function versionsViewHandler(args: VersionsViewArgs) {
 		"Version ID:": version.id,
 		"Created:": new Date(version.metadata["created_on"]).toLocaleString(),
 		"Author:": version.metadata.author_email,
-		"Source:": version.metadata.source,
+		"Source:": getSource(version),
 		"Tag:": version.annotations?.["workers/tag"] ?? BLANK_INPUT,
 		"Message:": version.annotations?.["workers/message"] ?? BLANK_INPUT,
 	});
-}
-
-function getConfig(
-	args: Pick<VersionsViewArgs, "config" | "name" | "experimentalJsonConfig">
-) {
-	const configPath =
-		args.config || (args.name && findWranglerToml(path.dirname(args.name)));
-	const config = readConfig(configPath, args);
-
-	return config;
 }


### PR DESCRIPTION
## What this PR solves / how to test

This PR implements the `versions list` and `versions view <version-id>` commands. They are very similar so a single PR seemed fine.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: currently internal and experimental

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
