### PR TITLE
Remove second wrangler banner from namespace rename

### DIFF
--- a/.changeset/young-chefs-change.md
+++ b/.changeset/young-chefs-change.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix(wrangler): Remove second banner from `wrangler dispatch-namespace rename`

--- a/.changeset/young-chefs-change.md
+++ b/.changeset/young-chefs-change.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-fix(wrangler): Remove second banner from `wrangler dispatch-namespace rename`
+fix: remove second Wrangler banner from `wrangler dispatch-namespace rename`

--- a/packages/wrangler/src/__tests__/worker-namespace.test.ts
+++ b/packages/wrangler/src/__tests__/worker-namespace.test.ts
@@ -1,4 +1,5 @@
 import { rest } from "msw";
+import { printWranglerBanner } from "../update-check";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import {
@@ -335,6 +336,7 @@ describe("dispatch-namespace", () => {
 			expect(std.out).toMatchInlineSnapshot(
 				`"Renamed dispatch namespace \\"my-namespace\\" to \\"new-namespace\\""`
 			);
+			expect((printWranglerBanner as jest.Mock).mock.calls.length).toEqual(1);
 		});
 	});
 });

--- a/packages/wrangler/src/dispatch-namespace.ts
+++ b/packages/wrangler/src/dispatch-namespace.ts
@@ -8,12 +8,12 @@ import type { CommonYargsArgv, CommonYargsOptions } from "./yargs-types";
 import type { CommandModule } from "yargs";
 
 type Namespace = {
-	namespace_id: string;
-	namespace_name: string;
-	created_on: string;
-	created_by: string;
-	modified_on: string;
-	modified_by: string;
+  namespace_id: string;
+  namespace_name: string;
+  created_on: string;
+  created_by: string;
+  modified_on: string;
+  modified_by: string;
 };
 
 // Supporting Workers For Platforms
@@ -23,189 +23,187 @@ type Namespace = {
  * Create a dynamic dispatch namespace.
  */
 async function createWorkerNamespace(accountId: string, name: string) {
-	const namespace = await fetchResult<Namespace>(
-		`/accounts/${accountId}/workers/dispatch/namespaces`,
-		{
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({ name }),
-		}
-	);
-	logger.log(
-		`Created dispatch namespace "${name}" with ID "${namespace.namespace_id}"`
-	);
+  const namespace = await fetchResult<Namespace>(
+    `/accounts/${accountId}/workers/dispatch/namespaces`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name }),
+    }
+  );
+  logger.log(
+    `Created dispatch namespace "${name}" with ID "${namespace.namespace_id}"`
+  );
 }
 
 /**
  * Delete a dynamic dispatch namespace.
  */
 async function deleteWorkerNamespace(accountId: string, name: string) {
-	await fetchResult(
-		`/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
-		{ method: "DELETE" }
-	);
-	logger.log(`Deleted dispatch namespace "${name}"`);
+  await fetchResult(
+    `/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
+    { method: "DELETE" }
+  );
+  logger.log(`Deleted dispatch namespace "${name}"`);
 }
 
 /**
  * List all created dynamic dispatch namespaces for an account
  */
 async function listWorkerNamespaces(accountId: string) {
-	logger.log(
-		await fetchResult<Namespace>(
-			`/accounts/${accountId}/workers/dispatch/namespaces`,
-			{
-				headers: {
-					"Content-Type": "application/json",
-				},
-			}
-		)
-	);
+  logger.log(
+    await fetchResult<Namespace>(
+      `/accounts/${accountId}/workers/dispatch/namespaces`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    )
+  );
 }
 
 /**
  * Get info for a specific dynamic dispatch namespace
  */
 async function getWorkerNamespaceInfo(accountId: string, name: string) {
-	logger.log(
-		await fetchResult<Namespace>(
-			`/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
-			{
-				headers: {
-					"Content-Type": "application/json",
-				},
-			}
-		)
-	);
+  logger.log(
+    await fetchResult<Namespace>(
+      `/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    )
+  );
 }
 
 /**
  * Rename a dynamic dispatch namespace
  */
 async function renameWorkerNamespace(
-	accountId: string,
-	oldName: string,
-	newName: string
+  accountId: string,
+  oldName: string,
+  newName: string
 ) {
-	void printWranglerBanner();
-
-	await fetchResult(
-		`/accounts/${accountId}/workers/dispatch/namespaces/${oldName}`,
-		{
-			method: "PUT",
-			headers: {
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({ name: newName }),
-		}
-	);
-	logger.log(`Renamed dispatch namespace "${oldName}" to "${newName}"`);
+  await fetchResult(
+    `/accounts/${accountId}/workers/dispatch/namespaces/${oldName}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: newName }),
+    }
+  );
+  logger.log(`Renamed dispatch namespace "${oldName}" to "${newName}"`);
 }
 
 export function workerNamespaceCommands(
-	workerNamespaceYargs: CommonYargsArgv,
-	subHelp: CommandModule<CommonYargsOptions, CommonYargsOptions>
+  workerNamespaceYargs: CommonYargsArgv,
+  subHelp: CommandModule<CommonYargsOptions, CommonYargsOptions>
 ) {
-	return workerNamespaceYargs
-		.command(subHelp)
-		.command(
-			"list",
-			"List all dispatch namespaces",
-			(args) => args,
-			async (args) => {
-				const config = readConfig(args.config, args);
-				const accountId = await requireAuth(config);
-				await listWorkerNamespaces(accountId);
-				await metrics.sendMetricsEvent("list dispatch namespaces", {
-					sendMetrics: config.send_metrics,
-				});
-			}
-		)
-		.command(
-			"get <name>",
-			"Get information about a dispatch namespace",
-			(yargs) => {
-				return yargs.positional("name", {
-					describe: "Name of the dispatch namespace",
-					type: "string",
-					demandOption: true,
-				});
-			},
-			async (args) => {
-				const config = readConfig(args.config, args);
-				const accountId = await requireAuth(config);
-				await getWorkerNamespaceInfo(accountId, args.name);
-				await metrics.sendMetricsEvent("view dispatch namespace", {
-					sendMetrics: config.send_metrics,
-				});
-			}
-		)
-		.command(
-			"create <name>",
-			"Create a dispatch namespace",
-			(yargs) => {
-				return yargs.positional("name", {
-					describe: "Name of the dispatch namespace",
-					type: "string",
-					demandOption: true,
-				});
-			},
-			async (args) => {
-				await printWranglerBanner();
-				const config = readConfig(args.config, args);
-				const accountId = await requireAuth(config);
-				await createWorkerNamespace(accountId, args.name);
-				await metrics.sendMetricsEvent("create dispatch namespace", {
-					sendMetrics: config.send_metrics,
-				});
-			}
-		)
-		.command(
-			"delete <name>",
-			"Delete a dispatch namespace",
-			(yargs) => {
-				return yargs.positional("name", {
-					describe: "Name of the dispatch namespace",
-					type: "string",
-					demandOption: true,
-				});
-			},
-			async (args) => {
-				await printWranglerBanner();
-				const config = readConfig(args.config, args);
-				const accountId = await requireAuth(config);
-				await deleteWorkerNamespace(accountId, args.name);
-				await metrics.sendMetricsEvent("delete dispatch namespace", {
-					sendMetrics: config.send_metrics,
-				});
-			}
-		)
-		.command(
-			"rename <old-name> <new-name>",
-			"Rename a dispatch namespace",
-			(yargs) => {
-				return yargs
-					.positional("old-name", {
-						describe: "Name of the dispatch namespace",
-						type: "string",
-						demandOption: true,
-					})
-					.positional("new-name", {
-						describe: "New name of the dispatch namespace",
-						type: "string",
-						demandOption: true,
-					});
-			},
-			async (args) => {
-				await printWranglerBanner();
-				const config = readConfig(args.config, args);
-				const accountId = await requireAuth(config);
-				await renameWorkerNamespace(accountId, args.oldName, args.newName);
-				await metrics.sendMetricsEvent("rename dispatch namespace", {
-					sendMetrics: config.send_metrics,
-				});
-			}
-		);
+  return workerNamespaceYargs
+    .command(subHelp)
+    .command(
+      "list",
+      "List all dispatch namespaces",
+      (args) => args,
+      async (args) => {
+        const config = readConfig(args.config, args);
+        const accountId = await requireAuth(config);
+        await listWorkerNamespaces(accountId);
+        await metrics.sendMetricsEvent("list dispatch namespaces", {
+          sendMetrics: config.send_metrics,
+        });
+      }
+    )
+    .command(
+      "get <name>",
+      "Get information about a dispatch namespace",
+      (yargs) => {
+        return yargs.positional("name", {
+          describe: "Name of the dispatch namespace",
+          type: "string",
+          demandOption: true,
+        });
+      },
+      async (args) => {
+        const config = readConfig(args.config, args);
+        const accountId = await requireAuth(config);
+        await getWorkerNamespaceInfo(accountId, args.name);
+        await metrics.sendMetricsEvent("view dispatch namespace", {
+          sendMetrics: config.send_metrics,
+        });
+      }
+    )
+    .command(
+      "create <name>",
+      "Create a dispatch namespace",
+      (yargs) => {
+        return yargs.positional("name", {
+          describe: "Name of the dispatch namespace",
+          type: "string",
+          demandOption: true,
+        });
+      },
+      async (args) => {
+        await printWranglerBanner();
+        const config = readConfig(args.config, args);
+        const accountId = await requireAuth(config);
+        await createWorkerNamespace(accountId, args.name);
+        await metrics.sendMetricsEvent("create dispatch namespace", {
+          sendMetrics: config.send_metrics,
+        });
+      }
+    )
+    .command(
+      "delete <name>",
+      "Delete a dispatch namespace",
+      (yargs) => {
+        return yargs.positional("name", {
+          describe: "Name of the dispatch namespace",
+          type: "string",
+          demandOption: true,
+        });
+      },
+      async (args) => {
+        await printWranglerBanner();
+        const config = readConfig(args.config, args);
+        const accountId = await requireAuth(config);
+        await deleteWorkerNamespace(accountId, args.name);
+        await metrics.sendMetricsEvent("delete dispatch namespace", {
+          sendMetrics: config.send_metrics,
+        });
+      }
+    )
+    .command(
+      "rename <old-name> <new-name>",
+      "Rename a dispatch namespace",
+      (yargs) => {
+        return yargs
+          .positional("old-name", {
+            describe: "Name of the dispatch namespace",
+            type: "string",
+            demandOption: true,
+          })
+          .positional("new-name", {
+            describe: "New name of the dispatch namespace",
+            type: "string",
+            demandOption: true,
+          });
+      },
+      async (args) => {
+        await printWranglerBanner();
+        const config = readConfig(args.config, args);
+        const accountId = await requireAuth(config);
+        await renameWorkerNamespace(accountId, args.oldName, args.newName);
+        await metrics.sendMetricsEvent("rename dispatch namespace", {
+          sendMetrics: config.send_metrics,
+        });
+      }
+    );
 }

--- a/packages/wrangler/src/dispatch-namespace.ts
+++ b/packages/wrangler/src/dispatch-namespace.ts
@@ -8,12 +8,12 @@ import type { CommonYargsArgv, CommonYargsOptions } from "./yargs-types";
 import type { CommandModule } from "yargs";
 
 type Namespace = {
-  namespace_id: string;
-  namespace_name: string;
-  created_on: string;
-  created_by: string;
-  modified_on: string;
-  modified_by: string;
+	namespace_id: string;
+	namespace_name: string;
+	created_on: string;
+	created_by: string;
+	modified_on: string;
+	modified_by: string;
 };
 
 // Supporting Workers For Platforms
@@ -23,187 +23,187 @@ type Namespace = {
  * Create a dynamic dispatch namespace.
  */
 async function createWorkerNamespace(accountId: string, name: string) {
-  const namespace = await fetchResult<Namespace>(
-    `/accounts/${accountId}/workers/dispatch/namespaces`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ name }),
-    }
-  );
-  logger.log(
-    `Created dispatch namespace "${name}" with ID "${namespace.namespace_id}"`
-  );
+	const namespace = await fetchResult<Namespace>(
+		`/accounts/${accountId}/workers/dispatch/namespaces`,
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ name }),
+		}
+	);
+	logger.log(
+		`Created dispatch namespace "${name}" with ID "${namespace.namespace_id}"`
+	);
 }
 
 /**
  * Delete a dynamic dispatch namespace.
  */
 async function deleteWorkerNamespace(accountId: string, name: string) {
-  await fetchResult(
-    `/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
-    { method: "DELETE" }
-  );
-  logger.log(`Deleted dispatch namespace "${name}"`);
+	await fetchResult(
+		`/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
+		{ method: "DELETE" }
+	);
+	logger.log(`Deleted dispatch namespace "${name}"`);
 }
 
 /**
  * List all created dynamic dispatch namespaces for an account
  */
 async function listWorkerNamespaces(accountId: string) {
-  logger.log(
-    await fetchResult<Namespace>(
-      `/accounts/${accountId}/workers/dispatch/namespaces`,
-      {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }
-    )
-  );
+	logger.log(
+		await fetchResult<Namespace>(
+			`/accounts/${accountId}/workers/dispatch/namespaces`,
+			{
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		)
+	);
 }
 
 /**
  * Get info for a specific dynamic dispatch namespace
  */
 async function getWorkerNamespaceInfo(accountId: string, name: string) {
-  logger.log(
-    await fetchResult<Namespace>(
-      `/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
-      {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }
-    )
-  );
+	logger.log(
+		await fetchResult<Namespace>(
+			`/accounts/${accountId}/workers/dispatch/namespaces/${name}`,
+			{
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		)
+	);
 }
 
 /**
  * Rename a dynamic dispatch namespace
  */
 async function renameWorkerNamespace(
-  accountId: string,
-  oldName: string,
-  newName: string
+	accountId: string,
+	oldName: string,
+	newName: string
 ) {
-  await fetchResult(
-    `/accounts/${accountId}/workers/dispatch/namespaces/${oldName}`,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ name: newName }),
-    }
-  );
-  logger.log(`Renamed dispatch namespace "${oldName}" to "${newName}"`);
+	await fetchResult(
+		`/accounts/${accountId}/workers/dispatch/namespaces/${oldName}`,
+		{
+			method: "PUT",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ name: newName }),
+		}
+	);
+	logger.log(`Renamed dispatch namespace "${oldName}" to "${newName}"`);
 }
 
 export function workerNamespaceCommands(
-  workerNamespaceYargs: CommonYargsArgv,
-  subHelp: CommandModule<CommonYargsOptions, CommonYargsOptions>
+	workerNamespaceYargs: CommonYargsArgv,
+	subHelp: CommandModule<CommonYargsOptions, CommonYargsOptions>
 ) {
-  return workerNamespaceYargs
-    .command(subHelp)
-    .command(
-      "list",
-      "List all dispatch namespaces",
-      (args) => args,
-      async (args) => {
-        const config = readConfig(args.config, args);
-        const accountId = await requireAuth(config);
-        await listWorkerNamespaces(accountId);
-        await metrics.sendMetricsEvent("list dispatch namespaces", {
-          sendMetrics: config.send_metrics,
-        });
-      }
-    )
-    .command(
-      "get <name>",
-      "Get information about a dispatch namespace",
-      (yargs) => {
-        return yargs.positional("name", {
-          describe: "Name of the dispatch namespace",
-          type: "string",
-          demandOption: true,
-        });
-      },
-      async (args) => {
-        const config = readConfig(args.config, args);
-        const accountId = await requireAuth(config);
-        await getWorkerNamespaceInfo(accountId, args.name);
-        await metrics.sendMetricsEvent("view dispatch namespace", {
-          sendMetrics: config.send_metrics,
-        });
-      }
-    )
-    .command(
-      "create <name>",
-      "Create a dispatch namespace",
-      (yargs) => {
-        return yargs.positional("name", {
-          describe: "Name of the dispatch namespace",
-          type: "string",
-          demandOption: true,
-        });
-      },
-      async (args) => {
-        await printWranglerBanner();
-        const config = readConfig(args.config, args);
-        const accountId = await requireAuth(config);
-        await createWorkerNamespace(accountId, args.name);
-        await metrics.sendMetricsEvent("create dispatch namespace", {
-          sendMetrics: config.send_metrics,
-        });
-      }
-    )
-    .command(
-      "delete <name>",
-      "Delete a dispatch namespace",
-      (yargs) => {
-        return yargs.positional("name", {
-          describe: "Name of the dispatch namespace",
-          type: "string",
-          demandOption: true,
-        });
-      },
-      async (args) => {
-        await printWranglerBanner();
-        const config = readConfig(args.config, args);
-        const accountId = await requireAuth(config);
-        await deleteWorkerNamespace(accountId, args.name);
-        await metrics.sendMetricsEvent("delete dispatch namespace", {
-          sendMetrics: config.send_metrics,
-        });
-      }
-    )
-    .command(
-      "rename <old-name> <new-name>",
-      "Rename a dispatch namespace",
-      (yargs) => {
-        return yargs
-          .positional("old-name", {
-            describe: "Name of the dispatch namespace",
-            type: "string",
-            demandOption: true,
-          })
-          .positional("new-name", {
-            describe: "New name of the dispatch namespace",
-            type: "string",
-            demandOption: true,
-          });
-      },
-      async (args) => {
-        await printWranglerBanner();
-        const config = readConfig(args.config, args);
-        const accountId = await requireAuth(config);
-        await renameWorkerNamespace(accountId, args.oldName, args.newName);
-        await metrics.sendMetricsEvent("rename dispatch namespace", {
-          sendMetrics: config.send_metrics,
-        });
-      }
-    );
+	return workerNamespaceYargs
+		.command(subHelp)
+		.command(
+			"list",
+			"List all dispatch namespaces",
+			(args) => args,
+			async (args) => {
+				const config = readConfig(args.config, args);
+				const accountId = await requireAuth(config);
+				await listWorkerNamespaces(accountId);
+				await metrics.sendMetricsEvent("list dispatch namespaces", {
+					sendMetrics: config.send_metrics,
+				});
+			}
+		)
+		.command(
+			"get <name>",
+			"Get information about a dispatch namespace",
+			(yargs) => {
+				return yargs.positional("name", {
+					describe: "Name of the dispatch namespace",
+					type: "string",
+					demandOption: true,
+				});
+			},
+			async (args) => {
+				const config = readConfig(args.config, args);
+				const accountId = await requireAuth(config);
+				await getWorkerNamespaceInfo(accountId, args.name);
+				await metrics.sendMetricsEvent("view dispatch namespace", {
+					sendMetrics: config.send_metrics,
+				});
+			}
+		)
+		.command(
+			"create <name>",
+			"Create a dispatch namespace",
+			(yargs) => {
+				return yargs.positional("name", {
+					describe: "Name of the dispatch namespace",
+					type: "string",
+					demandOption: true,
+				});
+			},
+			async (args) => {
+				await printWranglerBanner();
+				const config = readConfig(args.config, args);
+				const accountId = await requireAuth(config);
+				await createWorkerNamespace(accountId, args.name);
+				await metrics.sendMetricsEvent("create dispatch namespace", {
+					sendMetrics: config.send_metrics,
+				});
+			}
+		)
+		.command(
+			"delete <name>",
+			"Delete a dispatch namespace",
+			(yargs) => {
+				return yargs.positional("name", {
+					describe: "Name of the dispatch namespace",
+					type: "string",
+					demandOption: true,
+				});
+			},
+			async (args) => {
+				await printWranglerBanner();
+				const config = readConfig(args.config, args);
+				const accountId = await requireAuth(config);
+				await deleteWorkerNamespace(accountId, args.name);
+				await metrics.sendMetricsEvent("delete dispatch namespace", {
+					sendMetrics: config.send_metrics,
+				});
+			}
+		)
+		.command(
+			"rename <old-name> <new-name>",
+			"Rename a dispatch namespace",
+			(yargs) => {
+				return yargs
+					.positional("old-name", {
+						describe: "Name of the dispatch namespace",
+						type: "string",
+						demandOption: true,
+					})
+					.positional("new-name", {
+						describe: "New name of the dispatch namespace",
+						type: "string",
+						demandOption: true,
+					});
+			},
+			async (args) => {
+				await printWranglerBanner();
+				const config = readConfig(args.config, args);
+				const accountId = await requireAuth(config);
+				await renameWorkerNamespace(accountId, args.oldName, args.newName);
+				await metrics.sendMetricsEvent("rename dispatch namespace", {
+					sendMetrics: config.send_metrics,
+				});
+			}
+		);
 }


### PR DESCRIPTION
## What this PR solves / how to test

After noticing #5225 and definitely not renaming a dispatch namespace a few times to see if the team notices it, I found that the banner was being printed twice in that command.

While the linked PR removes the yargs handler, it leaves the function in place, so I thought I'd fix it to aid a potential reintroduction in the future by ensuring the consistency between these functions.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Banners are excluded from the snapshot the tests are checked against
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: small banner fix

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
