### PR TITLE
Remove tab size/width editor settings

### DIFF
--- a/.changeset/nice-kiwis-explain.md
+++ b/.changeset/nice-kiwis-explain.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: remove tab_width from all template .editorconfig files

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,4 +4,4 @@ root = true
 [*]
 end_of_line = lf
 indent_style = tab
-tab_width = 2
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,7 +59,6 @@
 	"eslint.runtime": "node",
 	"files.trimTrailingWhitespace": true,
 	"typescript.tsdk": "node_modules/typescript/lib",
-	"editor.tabSize": 2,
 	"files.associations": {
 		"api-extractor.json": "jsonc",
 		"CODEOWNERS": "plaintext",

--- a/packages/create-cloudflare/.editorconfig
+++ b/packages/create-cloudflare/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/common/js/.editorconfig
+++ b/packages/create-cloudflare/templates/common/js/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/common/ts/.editorconfig
+++ b/packages/create-cloudflare/templates/common/ts/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/hello-world-durable-object/js/.editorconfig
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/js/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/hello-world-durable-object/ts/.editorconfig
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/ts/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/hello-world/js/.editorconfig
+++ b/packages/create-cloudflare/templates/hello-world/js/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/hello-world/ts/.editorconfig
+++ b/packages/create-cloudflare/templates/hello-world/ts/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/pre-existing/js/.editorconfig
+++ b/packages/create-cloudflare/templates/pre-existing/js/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/queues/js/.editorconfig
+++ b/packages/create-cloudflare/templates/queues/js/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/queues/ts/.editorconfig
+++ b/packages/create-cloudflare/templates/queues/ts/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/scheduled/js/.editorconfig
+++ b/packages/create-cloudflare/templates/scheduled/js/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/packages/create-cloudflare/templates/scheduled/ts/.editorconfig
+++ b/packages/create-cloudflare/templates/scheduled/ts/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/experimental/worker-cobol/.editorconfig
+++ b/templates/experimental/worker-cobol/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/experimental/worker-emscripten/.editorconfig
+++ b/templates/experimental/worker-emscripten/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/pages-example-forum-app/.editorconfig
+++ b/templates/pages-example-forum-app/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/pages-functions-cors/.editorconfig
+++ b/templates/pages-functions-cors/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/pages-image-sharing/.editorconfig
+++ b/templates/pages-image-sharing/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/pages-plugin-static-forms/.editorconfig
+++ b/templates/pages-plugin-static-forms/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-aws/.editorconfig
+++ b/templates/worker-aws/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-d1-api/.editorconfig
+++ b/templates/worker-d1-api/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-d1/.editorconfig
+++ b/templates/worker-d1/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-durable-objects/.editorconfig
+++ b/templates/worker-durable-objects/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-example-request-scheduler/.editorconfig
+++ b/templates/worker-example-request-scheduler/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-example-wordle/.editorconfig
+++ b/templates/worker-example-wordle/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-mysql/.editorconfig
+++ b/templates/worker-mysql/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-postgres/.editorconfig
+++ b/templates/worker-postgres/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-r2/.editorconfig
+++ b/templates/worker-r2/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-router/.editorconfig
+++ b/templates/worker-router/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-sites-react/.editorconfig
+++ b/templates/worker-sites-react/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-sites/.editorconfig
+++ b/templates/worker-sites/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-speedtest/.editorconfig
+++ b/templates/worker-speedtest/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-typescript/.editorconfig
+++ b/templates/worker-typescript/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-websocket-durable-objects/.editorconfig
+++ b/templates/worker-websocket-durable-objects/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-websocket/.editorconfig
+++ b/templates/worker-websocket/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker-worktop/.editorconfig
+++ b/templates/worker-worktop/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/templates/worker/.editorconfig
+++ b/templates/worker/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
## What this PR solves / how to test

Tab size should be a setting devs set for themselves. I see no reason for the project to impose a tab size on the dev.

For example, I would like it to be 4 :)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: chore
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because: chore
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: chore

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
