### PR TITLE
test: include additional context in startup error test

### DIFF
--- a/fixtures/local-mode-tests/tests/logging.test.ts
+++ b/fixtures/local-mode-tests/tests/logging.test.ts
@@ -22,6 +22,7 @@ afterEach(() => {
 });
 
 it("logs startup errors", async () => {
+	let caughtError: unknown;
 	try {
 		const worker = await unstable_dev(
 			path.resolve(__dirname, "..", "src", "nodejs-compat.ts"),
@@ -33,6 +34,12 @@ it("logs startup errors", async () => {
 		);
 		await worker.stop();
 		expect.fail("Expected unstable_dev() to fail");
-	} catch {}
-	expect(output).toContain('No such module "node:buffer"');
+	} catch (e) {
+		caughtError = e;
+	}
+	const context = util.inspect(
+		{ caughtError, output },
+		{ maxStringLength: null }
+	);
+	expect(output, context).toContain('No such module "node:buffer"');
 });


### PR DESCRIPTION
## What this PR solves / how to test

This test is flaking in CI, but we're not sure why. This change adds some additional context to the assertion error, so we can debug the issue.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: additional debugging for existing test
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no user facing changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: no user facing changes

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
