### PR TITLE
Add waiting time

### DIFF
--- a/fixtures/local-mode-tests/tests/logging.test.ts
+++ b/fixtures/local-mode-tests/tests/logging.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { setTimeout } from "node:timers/promises";
 import util from "node:util";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { unstable_dev } from "wrangler";
@@ -37,6 +38,7 @@ it("logs startup errors", async () => {
 	} catch (e) {
 		caughtError = e;
 	}
+	await setTimeout(500);
 	const context = util.inspect(
 		{ caughtError, output },
 		{ maxStringLength: null }

--- a/fixtures/local-mode-tests/tests/logging.test.ts
+++ b/fixtures/local-mode-tests/tests/logging.test.ts
@@ -38,6 +38,7 @@ it("logs startup errors", async () => {
 	} catch (e) {
 		caughtError = e;
 	}
+	// wait a bit to give time for the `console` logging to complete
 	await setTimeout(500);
 	const context = util.inspect(
 		{ caughtError, output },


### PR DESCRIPTION
## What this PR solves / how to test

Stabilises `local-mode-tests` by ensuring `unstable_dev` has enough time to write to the terminal

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: bugfix to existing test
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: not user-facing
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because:not user-facing

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
