### PR TITLE
fix: move annotations under metadata in create-worker-upload-form

### DIFF
--- a/.changeset/tender-kiwis-love.md
+++ b/.changeset/tender-kiwis-love.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: `versions upload` annotations (`--message` and/or `--tag`) are now applied correctly to the uploaded Worker Version

--- a/packages/wrangler/src/__tests__/versions/versions.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.list.test.ts
@@ -45,24 +45,28 @@ describe("versions list", () => {
 			Source:      Upload
 			Tag:         -
 			Message:     -
+
 			Version ID:  30000000-0000-0000-0000-000000000000
 			Created:     2021-02-02T00:00:00.000Z
 			Author:      Kathryn-Janeway@federation.org
 			Source:      Rollback
 			Tag:         -
 			Message:     Rolled back for this version
+
 			Version ID:  20000000-0000-0000-0000-000000000000
 			Created:     2021-02-03T00:00:00.000Z
 			Author:      Kathryn-Janeway@federation.org
 			Source:      Wrangler 🤠
 			Tag:         -
 			Message:     -
+
 			Version ID:  10000000-0000-0000-0000-000000000000
 			Created:     2021-01-04T00:00:00.000Z
 			Author:      Jean-Luc-Picard@federation.org
 			Source:      Rollback
 			Tag:         -
 			Message:     -
+
 			"
 		`);
 
@@ -87,24 +91,28 @@ describe("versions list", () => {
 			Source:      Upload
 			Tag:         -
 			Message:     -
+
 			Version ID:  30000000-0000-0000-0000-000000000000
 			Created:     2021-02-02T00:00:00.000Z
 			Author:      Kathryn-Janeway@federation.org
 			Source:      Rollback
 			Tag:         -
 			Message:     Rolled back for this version
+
 			Version ID:  20000000-0000-0000-0000-000000000000
 			Created:     2021-02-03T00:00:00.000Z
 			Author:      Kathryn-Janeway@federation.org
 			Source:      Wrangler 🤠
 			Tag:         -
 			Message:     -
+
 			Version ID:  10000000-0000-0000-0000-000000000000
 			Created:     2021-01-04T00:00:00.000Z
 			Author:      Jean-Luc-Picard@federation.org
 			Source:      Rollback
 			Tag:         -
 			Message:     -
+
 			"
 		`);
 

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -95,7 +95,8 @@ export type WorkerMetadataBinding =
 			destination: string;
 	  };
 
-export interface WorkerMetadata {
+// for PUT /accounts/:accountId/workers/scripts/:scriptName
+export type WorkerMetadataPut = {
 	/** The name of the entry point module. Only exists when the worker is in the ES module format */
 	main_module?: string;
 	/** The name of the entry point module. Only exists when the worker is in the service-worker format */
@@ -111,10 +112,16 @@ export interface WorkerMetadata {
 	placement?: CfPlacement;
 	tail_consumers?: CfTailConsumer[];
 	limits?: CfUserLimits;
-	annotations?: Record<string, string>;
 	// Allow unsafe.metadata to add arbitrary properties at runtime
 	[key: string]: unknown;
-}
+};
+
+// for POST /accounts/:accountId/workers/:workerName/versions
+export type WorkerMetadataVersionsPost = WorkerMetadataPut & {
+	annotations?: Record<string, string>;
+};
+
+export type WorkerMetadata = WorkerMetadataPut | WorkerMetadataVersionsPost;
 
 /**
  * Creates a `FormData` upload from a `CfWorkerInit`.
@@ -133,6 +140,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		placement,
 		tail_consumers,
 		limits,
+		annotations,
 	} = worker;
 
 	let { modules } = worker;

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -111,6 +111,7 @@ export interface WorkerMetadata {
 	placement?: CfPlacement;
 	tail_consumers?: CfTailConsumer[];
 	limits?: CfUserLimits;
+	annotations?: Record<string, string>;
 	// Allow unsafe.metadata to add arbitrary properties at runtime
 	[key: string]: unknown;
 }
@@ -470,6 +471,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		...(placement && { placement }),
 		...(tail_consumers && { tail_consumers }),
 		...(limits && { limits }),
+		...(annotations && { annotations }),
 	};
 
 	if (bindings.unsafe?.metadata !== undefined) {

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -306,6 +306,7 @@ export interface CfWorkerInit {
 	placement: CfPlacement | undefined;
 	tail_consumers: CfTailConsumer[] | undefined;
 	limits: CfUserLimits | undefined;
+	annotations?: Record<string, string | undefined>;
 }
 
 export interface CfWorkerContext {

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -143,12 +143,6 @@ export function versionsUploadOptions(yargs: CommonYargsArgv) {
 				describe: "Don't actually deploy",
 				type: "boolean",
 			})
-			.option("keep-vars", {
-				describe:
-					"Stop wrangler from deleting vars that are not present in the wrangler.toml\nBy default Wrangler will remove all vars and replace them with those found in the wrangler.toml configuration.\nIf your development approach is to modify vars after deployment via the dashboard you may wish to set this flag.",
-				default: false,
-				type: "boolean",
-			})
 			// args only for `versions upload`, not `deploy`
 			.option("tag", {
 				describe: "A tag for this Worker Gradual Rollouts Version",
@@ -219,7 +213,7 @@ export async function versionsUploadHandler(
 		outDir: args.outdir,
 		dryRun: args.dryRun,
 		noBundle: !(args.bundle ?? !config.no_bundle),
-		keepVars: args.keepVars,
+		keepVars: false,
 		projectRoot,
 
 		tag: args.tag,

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -66,6 +66,7 @@ export async function versionsListHandler(args: VersionsListArgs) {
 		});
 
 		logRaw(formattedVersion);
+		logRaw(``);
 	}
 }
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -387,7 +387,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			annotations: {
 				"workers/message": props.message,
 				"workers/tag": props.tag,
-				"workers/triggered_by": "wrangler",
 			},
 		};
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -115,14 +115,14 @@ export default async function versionsUpload(props: Props): Promise<void> {
 
 			if (default_environment.script.last_deployed_from === "dash") {
 				logger.warn(
-					`You are about to publish a Workers Service that was last published via the Cloudflare Dashboard.\nEdits that have been made via the dashboard will be overridden by your local code and config.`
+					`You are about to upload a Worker Version that was last published via the Cloudflare Dashboard.\nEdits that have been made via the dashboard will be overridden by your local code and config.`
 				);
 				if (!(await confirm("Would you like to continue?"))) {
 					return;
 				}
 			} else if (default_environment.script.last_deployed_from === "api") {
 				logger.warn(
-					`You are about to publish a Workers Service that was last updated via the script API.\nEdits that have been made via the script API will be overridden by your local code and config.`
+					`You are about to upload a Workers Version that was last updated via the API.\nEdits that have been made via the API will be overridden by your local code and config.`
 				);
 				if (!(await confirm("Would you like to continue?"))) {
 					return;
@@ -144,7 +144,7 @@ export default async function versionsUpload(props: Props): Promise<void> {
 			""
 		).padStart(2, "0")}-${(new Date().getDate() + "").padStart(2, "0")}`;
 
-		throw new UserError(`A compatibility_date is required when publishing. Add the following to your wrangler.toml file:.
+		throw new UserError(`A compatibility_date is required when uploading a Worker Version. Add the following to your wrangler.toml file:.
     \`\`\`
     compatibility_date = "${compatibilityDateStr}"
     \`\`\`
@@ -154,7 +154,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	const jsxFactory = props.jsxFactory || config.jsx_factory;
 	const jsxFragment = props.jsxFragment || config.jsx_fragment;
-	const keepVars = props.keepVars || config.keep_vars;
 
 	const minify = props.minify ?? config.minify;
 
@@ -190,7 +189,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	const scriptName = props.name;
 	if (!scriptName) {
 		throw new UserError(
-			'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+			'You need to provide a name when uploading a Worker Version. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
 		);
 	}
 
@@ -379,7 +378,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			compatibility_date: props.compatibilityDate ?? config.compatibility_date,
 			compatibility_flags: compatibilityFlags,
 			usage_model: config.usage_model,
-			keepVars,
+			keepVars: false,
 			logpush: undefined,
 			placement,
 			tail_consumers: config.tail_consumers,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -384,6 +384,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			placement,
 			tail_consumers: config.tail_consumers,
 			limits: config.limits,
+			annotations: {
+				"workers/message": props.message,
+				"workers/tag": props.tag,
+				"workers/triggered_by": "wrangler",
+			},
 		};
 
 		// As this is not deterministic for testing, we detect if in a jest environment and run asynchronously
@@ -421,15 +426,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			// We can also now tell whether available_on_subdomain is set
 			try {
 				const body = createWorkerUploadForm(worker);
-
-				body.set(
-					"annotations",
-					JSON.stringify({
-						"workers/message": props.message,
-						"workers/tag": props.tag,
-						"workers/triggered_by": "wrangler",
-					})
-				);
 
 				const result = await fetchResult<{
 					available_on_subdomain: boolean;


### PR DESCRIPTION


## What this PR solves / how to test

This fixes annotations in versions upload to match where the api expects to find them

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no existing tests – will add in follow-up
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: experimental

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
