### PR TITLE
[wrangler] chore: bump `workerd` to `1.20240314.0`

### DIFF
--- a/.changeset/poor-tools-impress.md
+++ b/.changeset/poor-tools-impress.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+chore: bump `workerd` to [`1.20240314.0`](https://github.com/cloudflare/workerd/releases/tag/v1.20240314.0)

--- a/fixtures/dev-env/tests/index.test.ts
+++ b/fixtures/dev-env/tests/index.test.ts
@@ -349,7 +349,7 @@ describe("startDevWorker: ProxyController", () => {
 		});
 
 		res = await run.worker.fetch("http://dummy");
-		await expect(res.text()).resolves.toBe("Error: Boom!");
+		await expect(res.text()).resolves.toMatch(/^Error: Boom!/);
 
 		await new Promise((r) => setTimeout(r, 100)); // allow some time for the error to be logged (TODO: replace with retry/waitUntil helper)
 		expect(consoleErrorSpy).toBeCalledWith(
@@ -372,7 +372,7 @@ describe("startDevWorker: ProxyController", () => {
 		});
 
 		res = await run.worker.fetch("http://dummy");
-		await expect(res.text()).resolves.toBe("Error: Boom 2!");
+		await expect(res.text()).resolves.toMatch(/^Error: Boom 2!/);
 
 		await new Promise((r) => setTimeout(r, 100)); // allow some time for the error to be logged (TODO: replace with retry/waitUntil helper)
 		expect(consoleErrorSpy).toBeCalledWith(

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240208.0",
+		"@cloudflare/workers-types": "^4.20240314.0",
 		"@types/node": "20.8.3",
 		"jose": "^5.2.2",
 		"miniflare": "workspace:*",

--- a/fixtures/vitest-pool-workers-examples/queues/test/queue-consumer-integration-self.test.ts
+++ b/fixtures/vitest-pool-workers-examples/queues/test/queue-consumer-integration-self.test.ts
@@ -24,9 +24,9 @@ it("consumes queue messages", async () => {
 	];
 	const result = await SELF.queue("queue", messages);
 	expect(result.outcome).toBe("ok");
-	expect(result.retryAll).toBe(false); // `true` if `batch.retryAll()` called
+	expect(result.retryBatch.retry).toBe(false); // `true` if `batch.retryAll()` called
 	expect(result.ackAll).toBe(false); // `true` if `batch.ackAll()` called
-	expect(result.explicitRetries).toStrictEqual([]);
+	expect(result.retryMessages).toStrictEqual([]);
 	expect(result.explicitAcks).toStrictEqual([messages[0].id, messages[1].id]);
 
 	expect(await env.QUEUE_RESULTS.get("/1")).toBe("ONE");

--- a/fixtures/vitest-pool-workers-examples/queues/test/queue-consumer-unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/queues/test/queue-consumer-unit.test.ts
@@ -29,9 +29,9 @@ it("consumes queue messages", async () => {
 	// `getQueueResult()` implicitly calls `waitOnExecutionContext()`
 	const result = await getQueueResult(batch, ctx);
 	expect(result.outcome).toBe("ok");
-	expect(result.retryAll).toBe(false); // `true` if `batch.retryAll()` called
+	expect(result.retryBatch.retry).toBe(false); // `true` if `batch.retryAll()` called
 	expect(result.ackAll).toBe(false); // `true` if `batch.ackAll()` called
-	expect(result.explicitRetries).toStrictEqual([]);
+	expect(result.retryMessages).toStrictEqual([]);
 	expect(result.explicitAcks).toStrictEqual([messages[0].id, messages[1].id]);
 
 	expect(await env.QUEUE_RESULTS.get("/1")).toBe("ONE");

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -49,7 +49,7 @@
 		"glob-to-regexp": "^0.4.1",
 		"stoppable": "^1.1.0",
 		"undici": "^5.28.2",
-		"workerd": "1.20240304.0",
+		"workerd": "1.20240314.0",
 		"ws": "^8.11.0",
 		"youch": "^3.2.2",
 		"zod": "^3.20.6"
@@ -57,7 +57,7 @@
 	"devDependencies": {
 		"@ava/typescript": "^4.0.0",
 		"@cloudflare/kv-asset-handler": "workspace:*",
-		"@cloudflare/workers-types": "^4.20231002.0",
+		"@cloudflare/workers-types": "^4.20240314.0",
 		"@microsoft/api-extractor": "^7.36.3",
 		"@types/debug": "^4.1.7",
 		"@types/estree": "^1.0.0",

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -914,7 +914,7 @@ test("Miniflare: python modules", async (t) => {
 				type: "PythonModule",
 				path: "index.py",
 				contents:
-					"from test_module import add; from js import Response;\ndef fetch(request):\n  return Response.new(add(2,2))",
+					"from test_module import add; from js import Response;\ndef on_fetch(request):\n  return Response.new(add(2,2))",
 			},
 			{
 				type: "PythonModule",
@@ -1180,10 +1180,12 @@ test("Miniflare: getWorker() allows dispatching events directly", async (t) => {
 	]);
 	t.deepEqual(queueResult, {
 		outcome: "ok",
-		retryAll: true,
 		ackAll: false,
-		explicitRetries: [],
+		retryBatch: {
+			retry: true,
+		},
 		explicitAcks: [],
+		retryMessages: [],
 	});
 	queueResult = await fetcher.queue("queue", [
 		{ id: "c", timestamp: new Date(3000), body: new Uint8Array([1, 2, 3]) },
@@ -1191,10 +1193,12 @@ test("Miniflare: getWorker() allows dispatching events directly", async (t) => {
 	]);
 	t.deepEqual(queueResult, {
 		outcome: "ok",
-		retryAll: false,
 		ackAll: false,
-		explicitRetries: [],
+		retryBatch: {
+			retry: false
+		},
 		explicitAcks: ["perfect"],
+		retryMessages: [],
 	});
 
 	res = await fetcher.fetch("http://localhost/queue");

--- a/packages/miniflare/test/plugins/d1/index.with-wrangler-shim.spec.ts
+++ b/packages/miniflare/test/plugins/d1/index.with-wrangler-shim.spec.ts
@@ -71,7 +71,7 @@ class TestD1PreparedStatement implements D1PreparedStatement {
 		return this.db[kSend]("/prepare/all", this);
 	}
 
-	raw<T = unknown>(): Promise<T[]> {
+	raw<T = unknown>(): Promise<[string[], ...T[]]> {
 		return this.db[kSend]("/prepare/raw", this);
 	}
 }

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -54,7 +54,7 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20231121.0",
+		"@cloudflare/workers-types": "^4.20240314.0",
 		"@types/node": "20.8.3",
 		"capnp-ts": "^0.7.0",
 		"capnpc-ts": "^0.7.0",

--- a/packages/vitest-pool-workers/src/worker/events.ts
+++ b/packages/vitest-pool-workers/src/worker/events.ts
@@ -341,17 +341,19 @@ export async function getQueueResult(
 	}
 	await waitOnExecutionContext(ctx);
 
-	const explicitRetries: string[] = [];
+	const retryMessages: QueueRetryMessage[] = [];
 	const explicitAcks: string[] = [];
 	for (const message of batch.messages) {
-		if (message[kRetry]) explicitRetries.push(message.id);
+		if (message[kRetry]) retryMessages.push({ msgId: message.id });
 		if (message[kAck]) explicitAcks.push(message.id);
 	}
 	return {
 		outcome: "ok",
-		retryAll: batch[kRetryAll],
+		retryBatch: {
+			retry: batch[kRetryAll],
+		},
 		ackAll: batch[kAckAll],
-		explicitRetries,
+		retryMessages,
 		explicitAcks,
 	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,8 +614,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest-pool-workers
       '@cloudflare/workers-types':
-        specifier: ^4.20240208.0
-        version: 4.20240208.0
+        specifier: ^4.20240314.0
+        version: 4.20240314.0
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
@@ -973,8 +973,8 @@ importers:
         specifier: ^5.28.2
         version: 5.28.3
       workerd:
-        specifier: 1.20240304.0
-        version: 1.20240304.0
+        specifier: 1.20240314.0
+        version: 1.20240314.0
       ws:
         specifier: ^8.11.0
         version: 8.14.2
@@ -992,8 +992,8 @@ importers:
         specifier: workspace:*
         version: link:../kv-asset-handler
       '@cloudflare/workers-types':
-        specifier: ^4.20231002.0
-        version: 4.20231025.0
+        specifier: ^4.20240314.0
+        version: 4.20240314.0
       '@microsoft/api-extractor':
         specifier: ^7.36.3
         version: 7.38.2(@types/node@18.16.10)
@@ -1270,8 +1270,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20231121.0
-        version: 4.20240208.0
+        specifier: ^4.20240314.0
+        version: 4.20240314.0
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
@@ -4100,8 +4100,8 @@ packages:
       marked: 0.3.19
     dev: false
 
-  /@cloudflare/workerd-darwin-64@1.20240304.0:
-    resolution: {integrity: sha512-rfHlvsWzkqEEQNvm14AOE/BYHYzB9wxQHCaZZEgwOuTl5KpDcs9La0N0LaDTR78ESumIWOcifVmko2VTrZb7TQ==}
+  /@cloudflare/workerd-darwin-64@1.20240314.0:
+    resolution: {integrity: sha512-19xW64AmkjGnp9ZSwa5RPMTBJ0eqadY/oLs3RcdC8J+R8vT766U2bgxyuf3VATlOf+T7t28aGYzW/QcBRls9eg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -4109,8 +4109,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-darwin-arm64@1.20240304.0:
-    resolution: {integrity: sha512-IXGOxHsPdRYfAzcY6IroI1PDvx3hhXf18qFCloHp8Iw5bzLgq/PTjcp10Z/2xedZ2hVlfpHy1eEptsTmi9YeNw==}
+  /@cloudflare/workerd-darwin-arm64@1.20240314.0:
+    resolution: {integrity: sha512-gq78D30GlNSg55YRzCzNHPuLp87L7xmYCYa5hIuIE7xpqhqGN6FV/mRtp2TQ5VoDXiuq1F+VdEZDwQFvrNAvtg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4118,8 +4118,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-64@1.20240304.0:
-    resolution: {integrity: sha512-G1BEzbw9TFIeMvc425F145IetC7fuH4KOkGhseLq9y/mt5PfDWkghwmXSK+q0BiMwm0XAobtzVlHcEr2u4WlRQ==}
+  /@cloudflare/workerd-linux-64@1.20240314.0:
+    resolution: {integrity: sha512-1PYddg+lGGOUkXNt3LEHB0GvIBWjilTNwmbacGyyVRm+zaWGKqt2bS3bW/TY6cHJ1lxFe/fDMrQOgnSBB7jGIw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -4127,8 +4127,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-arm64@1.20240304.0:
-    resolution: {integrity: sha512-LLk/d/y77TRu6QOG3CJUI2cD3Ff2lSg0ts6G83bsm9ZK+WKObWFFSPBy9l81m3EnlKFh7RZCzxN4J10kuDaO8w==}
+  /@cloudflare/workerd-linux-arm64@1.20240314.0:
+    resolution: {integrity: sha512-GIyyO+TKYQ7TsM/DgpoHP2uQrJuPEc/cpRaXYeOzHerGAdQRej6iS2+LAnTJgLTXgOC4DE622mKBL3tnZvuKVQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -4136,8 +4136,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-windows-64@1.20240304.0:
-    resolution: {integrity: sha512-I/j6nVpM+WDPg+bYUAiKLkwQsjrXFjpOGHvwYmcM44hnDjgODzk7AbVssEIXnhEO3oupBeuKvffr0lvX0Ngmpw==}
+  /@cloudflare/workerd-windows-64@1.20240314.0:
+    resolution: {integrity: sha512-NWZeVXEXJfPuLAXfMTiFusJNOMnsHkBae0C4hlqzwIzYiQ0PYnQ+BEWFS5eWy5dZihhFrsW3VRYqnTbgESIkzw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -4162,6 +4162,10 @@ packages:
 
   /@cloudflare/workers-types@4.20240208.0:
     resolution: {integrity: sha512-MVGTTjZpJu4kJONvai5SdJzWIhOJbuweVZ3goI7FNyG+JdoQH41OoB+nMhLsX626vPLZVWGPIWsiSo/WZHzgQw==}
+    dev: true
+
+  /@cloudflare/workers-types@4.20240314.0:
+    resolution: {integrity: sha512-eg2dK/tYSiFvQu3sexjB32WEGi3GEmY6pLRF4nrV9Rwi2F2965o6f6604jQY8whhrmNdEoWErSjhuuUld6xgKQ==}
     dev: true
 
   /@cnakazawa/watch@1.0.4:
@@ -20787,17 +20791,17 @@ packages:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
 
-  /workerd@1.20240304.0:
-    resolution: {integrity: sha512-/tYxdypPh9NKQje9r7bgBB73vAQfCQZbEPjNlxE/ml7jNKMHnRZv/D+By4xO0IPAifa37D0sJFokvYOahz1Lqw==}
+  /workerd@1.20240314.0:
+    resolution: {integrity: sha512-5vXqDe6vJTMpfPVW8Vtcy2zcVIBnOIMv0D+Z0gVPMPq++KwEyQWzCIVLpIyc28EUc5bW3gEO49E8BN1PQebgfw==}
     engines: {node: '>=16'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20240304.0
-      '@cloudflare/workerd-darwin-arm64': 1.20240304.0
-      '@cloudflare/workerd-linux-64': 1.20240304.0
-      '@cloudflare/workerd-linux-arm64': 1.20240304.0
-      '@cloudflare/workerd-windows-64': 1.20240304.0
+      '@cloudflare/workerd-darwin-64': 1.20240314.0
+      '@cloudflare/workerd-darwin-arm64': 1.20240314.0
+      '@cloudflare/workerd-linux-64': 1.20240314.0
+      '@cloudflare/workerd-linux-arm64': 1.20240314.0
+      '@cloudflare/workerd-windows-64': 1.20240314.0
     dev: false
 
   /wrap-ansi@6.2.0:


### PR DESCRIPTION
This PR bumps the `workerd` version to `1.20240314.0`, and fixes some failing tests as a result of this bump. The changes are based off of https://github.com/cloudflare/workers-sdk/pull/5230.

The PR should address the following items:

- [x]  Update the dev-env fixture snapshots
- [x] Update Miniflare snapshots, tests, and code for Queues changes (please refer to https://github.com/cloudflare/workerd/commit/3cc6fd9367fd5c2c79bf0ffabb1820b97c40bc1a)

In the process it also turned out a `workers-types` version bump was necessary in the `vitest-pool-workers` related work, which in turn required updating the code to support the Queue changes


## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: version bump

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
