### PR TITLE
docs: add `README` to `vitest-pool-workers`

### DIFF
--- a/packages/vitest-pool-workers/README.md
+++ b/packages/vitest-pool-workers/README.md
@@ -1,0 +1,12 @@
+# `@cloudflare/vitest-pool-workers`
+
+The Workers Vitest integration allows you to run your Vitest tests inside the Workers runtime.
+Refer to the [documentation](https://developers.cloudflare.com/workers/testing/vitest-integration/) and [examples](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples/) for more information.
+
+- ✅ Supports both **unit tests** and **integration tests**
+- 📚 Provides direct access to Workers runtime APIs and bindings
+- 📦 Implements isolated per-test storage
+- 🔥 Runs tests fully-locally using [Miniflare](https://miniflare.dev/)
+- ⚡️ Leverages Vitest's hot-module reloading for near instant reruns
+- ↩️ Provides a declarative interface for mocking outbound requests
+- 🧩 Supports projects with multiple Workers

--- a/packages/vitest-pool-workers/README.md
+++ b/packages/vitest-pool-workers/README.md
@@ -1,6 +1,6 @@
 # `@cloudflare/vitest-pool-workers`
 
-The Workers Vitest integration allows you to run your Vitest tests inside the Workers runtime.
+The Workers Vitest integration allows you to write Vitest tests that run inside the Workers runtime.
 Refer to the [documentation](https://developers.cloudflare.com/workers/testing/vitest-integration/) and [examples](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples/) for more information.
 
 - ✅ Supports both **unit tests** and **integration tests**


### PR DESCRIPTION
## What this PR solves / how to test

This PR adds the missing `README.md` to `vitest-pool-workers`. 👍 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: adding a markdown file
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: release should be triggered by `miniflare` dependency update
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: already linking to docs

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
