### PR TITLE
[create-cloudflare] fix:  `tsconfig` settings for "Hello world" template

### DIFF
--- a/.changeset/sixty-ants-do.md
+++ b/.changeset/sixty-ants-do.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+test: add vitest-pool-workers package and example tests to `hello-world` templates

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -8,6 +8,8 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.0.0",
+		"vitest": "1.3.0",
+		"@cloudflare/vitest-pool-workers": "^0.1.0"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
+++ b/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
@@ -1,0 +1,20 @@
+import { env, createExecutionContext, waitOnExecutionContext, SELF } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import worker from "../src";
+
+describe("Hello World worker", () => {
+  it("responds with Hello World! (unit style)", async () => {
+    const request = new Request("http://example.com");
+    // Create an empty context to pass to `worker.fetch()`.
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    // Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
+    await waitOnExecutionContext(ctx);
+    expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+  });
+
+  it("responds with Hello World! (integration style)", async () => {
+   const response = await SELF.fetch(request, env, ctx);
+   expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+ });
+});

--- a/packages/create-cloudflare/templates/hello-world/js/vitest.config.js
+++ b/packages/create-cloudflare/templates/hello-world/js/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.toml" },
+      },
+    },
+  },
+});

--- a/packages/create-cloudflare/templates/hello-world/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world/js/wrangler.toml
@@ -1,6 +1,7 @@
 name = "<TBD>"
 main = "src/index.js"
 compatibility_date = "<TBD>"
+compatibility_flags = ["nodejs_compat"]
 
 # Variable bindings. These are arbitrary, plaintext strings (similar to environment variables)
 # Note: Use secrets to store sensitive data.

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -5,10 +5,13 @@
 	"scripts": {
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",
-		"start": "wrangler dev"
+		"start": "wrangler dev",
+		"test": "vitest"
 	},
 	"devDependencies": {
 		"typescript": "^5.0.4",
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.0.0",
+		"vitest": "1.3.0",
+		"@cloudflare/vitest-pool-workers": "^0.1.0"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/ts/test/index.spec.ts
+++ b/packages/create-cloudflare/templates/hello-world/ts/test/index.spec.ts
@@ -1,0 +1,25 @@
+// test/index.spec.ts
+import { env, createExecutionContext, waitOnExecutionContext, SELF } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import worker from "../src/index";
+
+// For now, you'll need to do something like this to get a correctly-typed
+// `Request` to pass to `worker.fetch()`.
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+describe("Hello World worker", () => {
+  it("responds with Hello World! (unit style)", async () => {
+    const request = new IncomingRequest("http://example.com");
+    // Create an empty context to pass to `worker.fetch()`.
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    // Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
+    await waitOnExecutionContext(ctx);
+    expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+  });
+
+  it("responds with Hello World! (integration style)", async () => {
+   const response = await SELF.fetch("https://example.com");
+   expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+ });
+});

--- a/packages/create-cloudflare/templates/hello-world/ts/test/tsconfig.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": [
+      "@cloudflare/workers-types/experimental",
+      "@cloudflare/vitest-pool-workers"
+    ]
+  },
+  "include": ["./**/*.ts", "../src/env.d.ts"],
+  "exclude": []
+}

--- a/packages/create-cloudflare/templates/hello-world/ts/tsconfig.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/tsconfig.json
@@ -26,7 +26,7 @@
 		/* Modules */
 		"module": "es2022" /* Specify what module code is generated. */,
 		// "rootDir": "./",                                  /* Specify the root folder within your source files. */
-		"moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+		"moduleResolution": "Bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
 		// "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
 		// "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
 		// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -97,5 +97,6 @@
 		/* Completeness */
 		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
 		"skipLibCheck": true /* Skip type checking all .d.ts files. */
-	}
+	},
+	"exclude": ["test"]
 }

--- a/packages/create-cloudflare/templates/hello-world/ts/vitest.config.ts
+++ b/packages/create-cloudflare/templates/hello-world/ts/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.toml" },
+      },
+    },
+  },
+});

--- a/packages/create-cloudflare/templates/hello-world/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world/ts/wrangler.toml
@@ -1,6 +1,7 @@
 name = "<TBD>"
 main = "src/index.ts"
 compatibility_date = "<TBD>"
+compatibility_flags = ["nodejs_compat"]
 
 # Variable bindings. These are arbitrary, plaintext strings (similar to environment variables)
 # Note: Use secrets to store sensitive data.


### PR DESCRIPTION
This commit sets the tsconfig  `moduleResolution` config key to `bundler` inside the create-cloudflare "Hello world" template to resolve the /config sub-export of @cloudflare/vitest-config-workers

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: only tsconfig change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: changeset already exists
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: only tsconfig change

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
