### PR TITLE
[vitest-pool-workers] fix: add link to migration guide in environment error and add missing `package.json` metadata

### DIFF
--- a/.changeset/fair-queens-cheat.md
+++ b/.changeset/fair-queens-cheat.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: link [migration guide](https://developers.cloudflare.com/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2/) when `environment: "miniflare"` is specified in Vitest configuration

--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -28,6 +28,7 @@ body:
         - Wrangler core
         - Miniflare
         - KV Asset Handler
+        - Workers Vitest Integration
         - Other
     validations:
       required: true

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -1,6 +1,30 @@
 {
 	"name": "@cloudflare/vitest-pool-workers",
 	"version": "0.1.2",
+	"description": "Workers Vitest integration for writing Vitest unit and integration tests that run inside the Workers runtime",
+	"keywords": [
+		"cloudflare",
+		"workers",
+		"worker",
+		"vitest",
+		"jest",
+		"pool",
+		"environment",
+		"miniflare",
+		"unit",
+		"integration",
+		"test"
+	],
+	"homepage": "https://github.com/cloudflare/workers-sdk/tree/main/packages/vitest-pool-workers#readme",
+	"bugs": {
+		"url": "https://github.com/cloudflare/workers-sdk/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cloudflare/workers-sdk.git",
+		"directory": "packages/vitest-pool-workers"
+	},
+	"license": "MIT",
 	"main": "dist/pool/index.mjs",
 	"types": "test/cloudflare-test.d.ts",
 	"exports": {

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -207,18 +207,17 @@ export async function parseProjectOptions(
 	if (environment !== undefined && environment !== "node") {
 		const quotedEnvironment = JSON.stringify(environment);
 
-		let migrationGuide = "";
+		let migrationGuide = ".";
 		if (environment === "miniflare") {
-			// TODO(soon): include a link to the migration guide once it's written
 			migrationGuide =
-				", and refer to the migration guide if upgrading from `vitest-environment-miniflare`";
+				", and refer to the migration guide if upgrading from `vitest-environment-miniflare`:\nhttps://developers.cloudflare.com/workers/testing/vitest-integration/get-started/migrate-from-miniflare-2/";
 		}
 
 		const relativePath = getRelativeProjectPath(project);
 		const message = [
 			`Unexpected custom \`environment\` ${quotedEnvironment} in project ${relativePath}.`,
 			"The Workers pool always runs your tests inside of an environment providing Workers runtime APIs.",
-			`Please remove the \`environment\` configuration${migrationGuide}.`,
+			`Please remove the \`environment\` configuration${migrationGuide}`,
 			"Use `poolMatchGlobs`/`environmentMatchGlobs` to run a subset of your tests in a different pool/environment.",
 		].join("\n");
 		throw new TypeError(message);


### PR DESCRIPTION
## What this PR solves / how to test

This PR adds a link to the migration guide when `environment: "miniflare"` is specified in Vitest config, and adds some missing metadata to `package.json`.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: changing error messaging
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: linking to existing documentation 😃 

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
