### PR TITLE
Fixed `vitest` peer dependency min/max version

### DIFF
--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -72,7 +72,7 @@
 	"peerDependencies": {
 		"@vitest/runner": "1.3.0",
 		"@vitest/snapshot": "1.3.0",
-		"vitest": "1.3.0"
+		"vitest": ">=1.3.0"
 	},
 	"workers-sdk": {
 		"prerelease": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1254,7 +1254,7 @@ importers:
         specifier: workspace:*
         version: link:../miniflare
       vitest:
-        specifier: 1.3.0
+        specifier: '>=1.3.0'
         version: 1.3.0(@types/node@20.8.3)
       wrangler:
         specifier: workspace:*


### PR DESCRIPTION
## What this PR solves / how to test

- Allows for support for Vitest version >1.3.0, including `1.3.1` & `1.4.0`
	- Version `1.4.0` was released [earlier today](https://github.com/vitest-dev/vitest/releases/tag/v1.4.0) & without this an error gets thrown that only version `1.3.0` is supported.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
	  - Updated a peer dependency to set a minimum & maximum version
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
