### PR TITLE
Support `wrangler pages functions build-env`

### DIFF
--- a/.changeset/hungry-teachers-poke.md
+++ b/.changeset/hungry-teachers-poke.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Support the hidden command `wrangler pages functions build-env`

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -364,7 +364,7 @@ export const defaultWranglerConfig: Config = {
 	},
 	usage_model: undefined,
 	rules: [],
-	build: {},
+	build: { command: undefined, watch_dir: "./src", cwd: undefined },
 	no_bundle: undefined,
 	minify: undefined,
 	node_compat: undefined,

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -84,7 +84,7 @@ export function readConfig<CommandArgs>(
 	// If we detected a Pages project, run config file validation against
 	// Pages specific validation rules
 	if (isPagesConfig) {
-		logger.info(
+		logger.debug(
 			`Configuration file belonging to ⚡️ Pages ⚡️ project detected.`
 		);
 

--- a/packages/wrangler/src/config/validation-pages.ts
+++ b/packages/wrangler/src/config/validation-pages.ts
@@ -32,6 +32,8 @@ const supportedPagesConfigFields = [
 	"analytics_engine_datasets",
 	"ai",
 	"dev",
+	// normalizeAndValidateConfig() sets this value
+	"configPath",
 ] as const;
 
 export function validatePagesConfig(

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -1,0 +1,31 @@
+import { readConfig } from "../config";
+import { FatalError } from "../errors";
+import { logger } from "../logger";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+export type PagesBuildEnvArgs = StrictYargsOptionsToInterface<typeof Options>;
+
+export function Options(yargs: CommonYargsArgv) {
+	return yargs;
+}
+
+export const Handler = async (args: PagesBuildEnvArgs) => {
+	const config = readConfig(undefined, {
+		...args,
+		// eslint-disable-next-line turbo/no-undeclared-env-vars
+		env: process.env.PAGES_ENVIRONMENT,
+	});
+	if (!config.pages_build_output_dir) {
+		throw new FatalError("No Pages config file found");
+	}
+
+	// Ensure JSON variables are not included
+	const textVars = Object.fromEntries(
+		Object.entries(config.vars).filter(([_, v]) => typeof v === "string")
+	);
+
+	logger.log(JSON.stringify(textVars));
+};

--- a/packages/wrangler/src/pages/index.ts
+++ b/packages/wrangler/src/pages/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-shadow */
 
 import * as Build from "./build";
+import * as BuildEnv from "./build-env";
 import * as Deploy from "./deploy";
 import * as DeploymentTails from "./deployment-tails";
 import * as Deployments from "./deployments";
@@ -41,6 +42,12 @@ export function pages(yargs: CommonYargsArgv) {
 						"Compile a folder of Cloudflare Pages Functions into a single Worker",
 						Build.Options,
 						Build.Handler
+					)
+					.command(
+						"build-env",
+						"Render a list of environment variables from the config file",
+						BuildEnv.Options,
+						BuildEnv.Handler
 					)
 					.command(
 						"optimize-routes [routesPath] [outputRoutesPath]",


### PR DESCRIPTION
## What this PR solves / how to test

This adds a hidden `wrangler pages functions build-env` command, which prints the environment variables for the current environment to the terminal. This is for use by internal tooling, and shouldn't be used directly by end users.

Fixes [DEVX-1179](https://jira.cfdata.org/browse/DEVX-1179)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: This is a hidden command

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
