### PR TITLE
Remove noise from C3 args tests (by mocking `console.error`)

### DIFF
--- a/packages/create-cloudflare/src/helpers/__tests__/args.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/args.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { parseArgs } from "../args";
+import type { MockInstance } from "vitest";
 
 vi.mock("yargs/helpers", () => ({ hideBin: (x: string[]) => x }));
 
 describe("Cli", () => {
+	let consoleErrorMock: MockInstance;
+
+	beforeEach(() => {
+		// mock `console.error` for all tests in order to avoid noise
+		consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
 	describe("parseArgs", () => {
 		test("no arguments provide", async () => {
 			const result = await parseArgs([]);
@@ -20,9 +28,6 @@ describe("Cli", () => {
 			const processExitMock = vi
 				.spyOn(process, "exit")
 				.mockImplementation(() => null as never);
-			const consoleErrorMock = vi
-				.spyOn(console, "error")
-				.mockImplementation(() => {});
 
 			await parseArgs(["my-project", "123"]);
 


### PR DESCRIPTION
## What this PR solves / how to test

This PR is removing some noise I've noticed has been introduced in the C3 unit tests recently: https://github.com/cloudflare/workers-sdk/actions/runs/8335183298/job/22810182117#step:8:49

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: this PR is only touching tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: this PR is only touching tests

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
