### PR TITLE
explicitly 'keep' secret_text and secret_key bindings

### DIFF
--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8947,7 +8947,7 @@ export default{
 			writeWranglerToml();
 			writeWorkerSource();
 			mockSubDomainRequest();
-			mockUploadWorkerRequest({ keepVars: true });
+			mockUploadWorkerRequest({ keepVars: true, keepSecrets: true });
 			mockOAuthServerCallback();
 			mockGetMemberships([]);
 
@@ -8999,7 +8999,7 @@ export default{
 			});
 			writeWorkerSource();
 			mockSubDomainRequest();
-			mockUploadWorkerRequest({ keepVars: true });
+			mockUploadWorkerRequest({ keepVars: true, keepSecrets: true });
 			mockOAuthServerCallback();
 			mockGetMemberships([]);
 

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -26,6 +26,7 @@ export function mockUploadWorkerRequest(
 		env?: string;
 		legacyEnv?: boolean;
 		keepVars?: boolean;
+		keepSecrets?: boolean;
 		tag?: string;
 		expectedDispatchNamespace?: string;
 	} = {}
@@ -47,6 +48,7 @@ export function mockUploadWorkerRequest(
 		expectedCapnpSchema,
 		expectedLimits,
 		keepVars,
+		keepSecrets,
 		expectedDispatchNamespace,
 	} = options;
 	if (env && !legacyEnv) {
@@ -108,12 +110,9 @@ export function mockUploadWorkerRequest(
 		}
 
 		if (keepVars) {
-			expect(metadata.keep_bindings).toEqual([
-				"plain_text",
-				"json",
-				"secret_text",
-				"secret_key",
-			]);
+			expect(metadata.keep_bindings).toContain(["plain_text", "json"]);
+		} else if (keepSecrets) {
+			expect(metadata.keep_bindings).toContain(["secret_text", "secret_key"]);
 		} else {
 			expect(metadata.keep_bindings).toBeFalsy();
 		}

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -108,7 +108,12 @@ export function mockUploadWorkerRequest(
 		}
 
 		if (keepVars) {
-			expect(metadata.keep_bindings).toEqual(["plain_text", "json"]);
+			expect(metadata.keep_bindings).toEqual([
+				"plain_text",
+				"json",
+				"secret_text",
+				"secret_key",
+			]);
 		} else {
 			expect(metadata.keep_bindings).toBeFalsy();
 		}

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -110,9 +110,13 @@ export function mockUploadWorkerRequest(
 		}
 
 		if (keepVars) {
-			expect(metadata.keep_bindings).toContain(["plain_text", "json"]);
+			expect(metadata.keep_bindings).toEqual(
+				expect.arrayContaining(["plain_text", "json"])
+			);
 		} else if (keepSecrets) {
-			expect(metadata.keep_bindings).toContain(["secret_text", "secret_key"]);
+			expect(metadata.keep_bindings).toEqual(
+				expect.arrayContaining(["secret_text", "secret_key"])
+			);
 		} else {
 			expect(metadata.keep_bindings).toBeFalsy();
 		}

--- a/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
+++ b/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
@@ -75,6 +75,7 @@ function createWorkerBundleFormData(workerBundle: BundleResult): FormData {
 		compatibility_flags: undefined,
 		usage_model: undefined,
 		keepVars: undefined,
+		keepSecrets: undefined,
 		logpush: undefined,
 		placement: undefined,
 		tail_consumers: undefined,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -650,6 +650,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			compatibility_flags: compatibilityFlags,
 			usage_model: config.usage_model,
 			keepVars,
+			keepSecrets: keepVars, // keepVars implies keepSecrets
 			logpush: props.logpush !== undefined ? props.logpush : config.logpush,
 			placement,
 			tail_consumers: config.tail_consumers,

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -302,6 +302,7 @@ export interface CfWorkerInit {
 	compatibility_flags: string[] | undefined;
 	usage_model: "bundled" | "unbound" | undefined;
 	keepVars: boolean | undefined;
+	keepSecrets: boolean | undefined;
 	logpush: boolean | undefined;
 	placement: CfPlacement | undefined;
 	tail_consumers: CfTailConsumer[] | undefined;

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -630,6 +630,7 @@ async function createRemoteWorkerInit(props: {
 		compatibility_flags: props.compatibilityFlags,
 		usage_model: props.usageModel,
 		keepVars: true,
+		keepSecrets: true,
 		logpush: false,
 		placement: undefined, // no placement in dev
 		tail_consumers: undefined, // no tail consumers in dev - TODO revisit?

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -102,6 +102,7 @@ async function createDraftWorker({
 				compatibility_flags: undefined,
 				usage_model: undefined,
 				keepVars: false, // this doesn't matter since it's a new script anyway
+				keepSecrets: false, // this doesn't matter since it's a new script anyway
 				logpush: false,
 				placement: undefined,
 				tail_consumers: undefined,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -378,7 +378,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			compatibility_date: props.compatibilityDate ?? config.compatibility_date,
 			compatibility_flags: compatibilityFlags,
 			usage_model: config.usage_model,
-			keepVars: false,
+			keepVars: false, // the wrangler.toml should be the source-of-truth for vars
+			keepSecrets: true, // until wrangler.toml specifies secret bindings, we need to inherit from the previous Worker Version
 			logpush: undefined,
 			placement,
 			tail_consumers: config.tail_consumers,


### PR DESCRIPTION
## What this PR solves / how to test

This PR changes deployments to explicitly 'keep' (inherit from previous Version) secret_text and secret_key bindings. These were implicitly inherited bindings before but we want to explicitly inherit them now because we no longer implicitly inherit plain_text bindings in version uploads so we need to explicitly only inherit the secret bindings. This also opens the possibility of maybe eventually specifying secret bindings (without values, of course) in wrangler.toml in the future.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no user-facing change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: no user-facing change

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
