### PR TITLE
[C3]: align wrangler.toml template file for Next.js with those of the other frameworks

### DIFF
--- a/.changeset/quiet-timers-stare.md
+++ b/.changeset/quiet-timers-stare.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+chore/fix: in the Next.js scaffold example, reuse existing `MY_KV_NAMESPACE` commented out binding instead of adding a new `MY_KV` one

--- a/packages/create-cloudflare/templates/next/README.md
+++ b/packages/create-cloudflare/templates/next/README.md
@@ -65,4 +65,4 @@ In order to enable the example:
 
 After doing this you can run the `dev` or `preview` script and visit the `/api/hello` route to see the example in action.
 
-Finally, if you also want to see the example work in the deployed application make sure to add a `MY_KV` binding to your Pages application in its [dashboard kv bindings settings section](https://dash.cloudflare.com/?to=/:account/pages/view/:pages-project/settings/functions#kv_namespace_bindings_section). After having configured it make sure to re-deploy your application.
+Finally, if you also want to see the example work in the deployed application make sure to add a `MY_KV_NAMESPACE` binding to your Pages application in its [dashboard kv bindings settings section](https://dash.cloudflare.com/?to=/:account/pages/view/:pages-project/settings/functions#kv_namespace_bindings_section). After having configured it make sure to re-deploy your application.

--- a/packages/create-cloudflare/templates/next/app/js/app/api/hello/route.js
+++ b/packages/create-cloudflare/templates/next/app/js/app/api/hello/route.js
@@ -12,7 +12,7 @@ export async function GET(request) {
   // )
   //
   // KV Example:
-  // const myKv = getRequestContext().env.MY_KV
+  // const myKv = getRequestContext().env.MY_KV_NAMESPACE
   // await myKv.put('suffix', ' from a KV store!')
   // const suffix = await myKv.get('suffix')
   // responseText += suffix

--- a/packages/create-cloudflare/templates/next/app/ts/app/api/hello/route.ts
+++ b/packages/create-cloudflare/templates/next/app/ts/app/api/hello/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
   // )
   //
   // KV Example:
-  // const myKv = getRequestContext().env.MY_KV
+  // const myKv = getRequestContext().env.MY_KV_NAMESPACE
   // await myKv.put('suffix', ' from a KV store!')
   // const suffix = await myKv.get('suffix')
   // responseText += suffix

--- a/packages/create-cloudflare/templates/next/c3.ts
+++ b/packages/create-cloudflare/templates/next/c3.ts
@@ -37,7 +37,7 @@ const generate = async (ctx: C3Context) => {
 	//       and consistent with that of all the other frameworks
 	//       (instead of making it a special case which needs extra care)
 	newToml.replace(
-		/#\s+\[\[kv_namespaces\]\]\n#\s+binding\s+=\s+"MY_KV_NAMESPACE"\n#\s+id\s+=\s+"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"/,
+		/#\s+\[\[kv_namespaces\]\]\n#\s+binding\s+=\s+"MY_KV_NAMESPACE"\n#\s+id\s+=\s+"[a-zA-Z0-9]+?"/,
 		($1) => `# KV Example:\n${$1}`
 	);
 

--- a/packages/create-cloudflare/templates/next/c3.ts
+++ b/packages/create-cloudflare/templates/next/c3.ts
@@ -16,7 +16,6 @@ import {
 } from "helpers/files";
 import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
-import MagicString from "magic-string";
 import { getTemplatePath } from "../../src/templates";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Args, C3Context } from "types";
@@ -30,18 +29,14 @@ const generate = async (ctx: C3Context) => {
 
 	const wranglerToml = readFile(join(getTemplatePath(ctx), "wrangler.toml"));
 
-	const newToml = new MagicString(wranglerToml);
-
 	// Note: here we add `# KV Example:` to the toml file for the KV example, we don't actually
 	//       include the comment in the template wrangler.toml file just so to keep it identical
 	//       and consistent with that of all the other frameworks
 	//       (instead of making it a special case which needs extra care)
-	newToml.replace(
+	const newTomlContent = wranglerToml.replace(
 		/#\s+\[\[kv_namespaces\]\]\n#\s+binding\s+=\s+"MY_KV_NAMESPACE"\n#\s+id\s+=\s+"[a-zA-Z0-9]+?"/,
 		($1) => `# KV Example:\n${$1}`
 	);
-
-	const newTomlContent = newToml.toString();
 
 	if (!/# KV Example/.test(newTomlContent)) {
 		// This should never happen to users, it is a check mostly so that

--- a/packages/create-cloudflare/templates/next/pages/js/pages/api/hello.js
+++ b/packages/create-cloudflare/templates/next/pages/js/pages/api/hello.js
@@ -14,7 +14,7 @@ export default async function handler(req) {
   // )
   //
   // KV Example:
-  // const myKv = getRequestContext().env.MY_KV
+  // const myKv = getRequestContext().env.MY_KV_NAMESPACE
   // await myKv.put('suffix', ' from a KV store!')
   // const suffix = await myKv.get('suffix')
   // responseText += suffix

--- a/packages/create-cloudflare/templates/next/pages/ts/pages/api/hello.ts
+++ b/packages/create-cloudflare/templates/next/pages/ts/pages/api/hello.ts
@@ -15,7 +15,7 @@ export default async function handler(req: NextRequest) {
   // )
   //
   // KV Example:
-  // const myKv = getRequestContext().env.MY_KV;
+  // const myKv = getRequestContext().env.MY_KV_NAMESPACE
   // await myKv.put('suffix', ' from a KV store!')
   // const suffix = await myKv.get('suffix')
   // responseText += suffix

--- a/packages/create-cloudflare/templates/next/wrangler.toml
+++ b/packages/create-cloudflare/templates/next/wrangler.toml
@@ -52,7 +52,3 @@ compatibility_flags = ["nodejs_compat"]
 # binding = "MY_SERVICE"
 # service = "my-service"
 
-# KV Example:
-# [[kv_namespaces]]
-# binding = "MY_KV"
-# id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"


### PR DESCRIPTION
## What this PR solves / how to test

the wrangler.toml file for Next.js has an extra `MY_KV` binding that is used for the scaffold example we provide to the user

this can be a bit inconvenient as this is the only toml among all the framework that has such extra binding, this requires us to take extra care of the toml when making modifications while all the other toml template files instead are all the same

fix this by alinging the toml file with that all the other frameworks and adding to it whatever is necessary for the scaffold KV example programmatically

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: this flow is already all tested
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: the binding name is included in the template README and not something we document elsewhere

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
