### PR TITLE
fix: ensure `tsc-all.mjs` can run on Windows

### DIFF
--- a/fixtures/vitest-pool-workers-examples/tsc-all.mjs
+++ b/fixtures/vitest-pool-workers-examples/tsc-all.mjs
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import childProcess from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -15,12 +16,17 @@ async function* walkTsConfigs(rootPath) {
 	}
 }
 
+assert(
+	process.env.PATH?.includes(path.join(__dirname, "node_modules/.bin")),
+	"Expected `tsc-all.mjs` to be run with `pnpm check:type`"
+);
+
 for await (const tsconfigPath of walkTsConfigs(__dirname)) {
 	console.log(`Checking ${path.relative(__dirname, tsconfigPath)}...`);
-	const result = childProcess.spawnSync(
-		"node_modules/.bin/tsc",
-		["-p", tsconfigPath],
-		{ stdio: "inherit", cwd: __dirname, shell: true }
-	);
+	const result = childProcess.spawnSync("tsc", ["-p", tsconfigPath], {
+		stdio: "inherit",
+		cwd: __dirname,
+		shell: true,
+	});
 	if (result.status !== 0) process.exitCode = 1;
 }


### PR DESCRIPTION
## What this PR solves / how to test

Should hopefully fix tests on `main`. `fixtures/vitest-pool-workers-examples/tsc-all.mjs` wasn't compatible with Windows, but checks run on Windows on `main`.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: fixing internal type checking script
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: fixing internal type checking script
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: fixing internal type checking script

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
