### PR TITLE
fix(wrangler): remove triggered_by annotation from createDeployment

### DIFF
--- a/.changeset/breezy-badgers-play.md
+++ b/.changeset/breezy-badgers-play.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Remove triggered_by annotation from experimental versions deploy command.

--- a/packages/wrangler/src/versions/api.ts
+++ b/packages/wrangler/src/versions/api.ts
@@ -115,7 +115,6 @@ export async function createDeployment(
 					([version_id, percentage]) => ({ version_id, percentage })
 				),
 				annotations: {
-					"workers/triggered_by": "deployment",
 					"workers/message": message,
 				},
 			}),


### PR DESCRIPTION
This got lost in translation:
https://github.com/cloudflare/workers-sdk/pull/5224#discussion_r1531287879

## What this PR solves / how to test

Fixes `npx wrangler versions deploy --experimental-gradual-rollouts` being rejected by the API, as `triggered_by` can't be set by the client.

## Author has addressed the following

- Tests
  - [x] Not necessary because: experimental feature
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included

- Public documentation
  - [x] Not necessary because: experimental feature, docs are WIP

