### PR TITLE
feat(wrangler-d1): Teach wrangler d1 insights about more timePeriods

### DIFF
--- a/.changeset/large-seals-kiss.md
+++ b/.changeset/large-seals-kiss.md
@@ -2,4 +2,6 @@
 "wrangler": patch
 ---
 
-Teach wrangler d1 insights about more timePeriods
+fix: add more timePeriods to `wrangler d1 insights`
+
+This PR updates `wrangler d1 insights` to accept arbitrary timePeriod values up to 31 days.

--- a/.changeset/large-seals-kiss.md
+++ b/.changeset/large-seals-kiss.md
@@ -1,0 +1,5 @@
+---
+"wrangler": major
+---
+
+Teach wrangler d1 insights about more timePeriods

--- a/.changeset/large-seals-kiss.md
+++ b/.changeset/large-seals-kiss.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": major
+"wrangler": patch
 ---
 
 Teach wrangler d1 insights about more timePeriods

--- a/packages/wrangler/src/__tests__/d1/insights.test.ts
+++ b/packages/wrangler/src/__tests__/d1/insights.test.ts
@@ -1,0 +1,42 @@
+import { vi } from "vitest";
+import { getDurationDates } from "../../d1/insights";
+
+describe("getDurationDates()", () => {
+	beforeAll(() => {
+		vi.useFakeTimers();
+		//lock time to 2023-08-01 UTC
+		vi.setSystemTime(new Date(2023, 7, 1));
+	});
+
+	afterAll(() => {
+		vi.useRealTimers();
+	});
+
+	it("should throw an error if duration is greater than 31 days (in days)", () => {
+		expect(() => getDurationDates("32d")).toThrowError(
+			"Duration cannot be greater than 31 days"
+		);
+	});
+	it("should throw an error if duration is greater than 31 days (in minutes)", () => {
+		expect(() => getDurationDates("44641m")).toThrowError(
+			"Duration cannot be greater than 44640 minutes (31 days)"
+		);
+	});
+
+	it("should throw an error if duration is greater than 31 days (in hours)", () => {
+		expect(() => getDurationDates("745h")).toThrowError(
+			"Duration cannot be greater than 744 hours (31 days)"
+		);
+	});
+
+	it("should throw an error if duration unit is invalid", () => {
+		expect(() => getDurationDates("1y")).toThrowError("Invalid duration unit");
+	});
+
+	it("should return the correct start and end dates", () => {
+		const [startDate, endDate] = getDurationDates("5d");
+
+		expect(+new Date(startDate)).toBe(+new Date(2023, 6, 27));
+		expect(+new Date(endDate)).toBe(+new Date(2023, 7, 1));
+	});
+});

--- a/packages/wrangler/src/d1/insights.ts
+++ b/packages/wrangler/src/d1/insights.ts
@@ -55,7 +55,7 @@ const cliOptionToGraphQLOption = {
 	count: "count",
 };
 
-function getDurationDates(durationString: string) {
+export function getDurationDates(durationString: string) {
 	const endDate = new Date();
 
 	const durationValue = parseInt(durationString.slice(0, -1));

--- a/packages/wrangler/src/d1/insights.ts
+++ b/packages/wrangler/src/d1/insights.ts
@@ -18,7 +18,6 @@ export function Options(d1ListYargs: CommonYargsArgv) {
 			demandOption: true,
 		})
 		.option("timePeriod", {
-			choices: ["1d", "7d", "31d"] as const,
 			describe: "Fetch data from now to the provided time period",
 			default: "1d" as const,
 		})
@@ -56,6 +55,35 @@ const cliOptionToGraphQLOption = {
 	count: "count",
 };
 
+function getDurationDates(durationString: string) {
+	const endDate = new Date();
+
+	const durationValue = parseInt(durationString.slice(0, -1));
+	const durationUnit = durationString.slice(-1);
+
+	let startDate;
+	switch (durationUnit) {
+		case "d":
+			if (durationValue > 31) {
+				throw new Error("Duration cannot be greater than 31 days");
+			}
+			startDate = new Date(
+				endDate.getTime() - durationValue * 24 * 60 * 60 * 1000
+			);
+			break;
+		case "m":
+			startDate = new Date(endDate.getTime() - durationValue * 60 * 1000);
+			break;
+		case "h":
+			startDate = new Date(endDate.getTime() - durationValue * 60 * 60 * 1000);
+			break;
+		default:
+			throw new Error("Invalid duration unit");
+	}
+
+	return [startDate.toISOString(), endDate.toISOString()];
+}
+
 type HandlerOptions = StrictYargsOptionsToInterface<typeof Options>;
 export const Handler = withConfig<HandlerOptions>(
 	async ({
@@ -80,11 +108,7 @@ export const Handler = withConfig<HandlerOptions>(
 		const output: Record<string, string | number>[] = [];
 
 		if (result.version !== "alpha") {
-			const convertedTimePeriod = Number(timePeriod.replace("d", ""));
-			const endDate = new Date();
-			const startDate = new Date(
-				new Date(endDate).setDate(endDate.getDate() - convertedTimePeriod)
-			);
+			const [startDate, endDate] = getDurationDates(timePeriod);
 			const parsedSortBy = cliOptionToGraphQLOption[sortBy];
 			const orderByClause =
 				parsedSortBy === "count"
@@ -122,8 +146,8 @@ export const Handler = withConfig<HandlerOptions>(
 							filter: {
 								AND: [
 									{
-										datetimeHour_geq: startDate.toISOString(),
-										datetimeHour_leq: endDate.toISOString(),
+										datetimeHour_geq: startDate,
+										datetimeHour_leq: endDate,
 										databaseId: db.uuid,
 									},
 								],

--- a/packages/wrangler/src/d1/insights.ts
+++ b/packages/wrangler/src/d1/insights.ts
@@ -72,9 +72,19 @@ function getDurationDates(durationString: string) {
 			);
 			break;
 		case "m":
+			if (durationValue > 31 * 24 * 60) {
+				throw new Error(
+					`Duration cannot be greater than ${31 * 24 * 60} minutes (31 days)`
+				);
+			}
 			startDate = new Date(endDate.getTime() - durationValue * 60 * 1000);
 			break;
 		case "h":
+			if (durationValue > 31 * 24) {
+				throw new Error(
+					`Duration cannot be greater than ${31 * 24} hours (31 days)`
+				);
+			}
 			startDate = new Date(endDate.getTime() - durationValue * 60 * 60 * 1000);
 			break;
 		default:


### PR DESCRIPTION
## What this PR solves / how to test

This PR teaches `wrangler d1 insights` about more timePeriods. The input can now be of the form`\d+[dmh]`

Fixes #5048 

## Author has addressed the following

- Tests
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because:
