### PR TITLE
chore(wrangler): Move misplaced tests to dedicated Pages test folder

### DIFF
--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
-import { mockConsoleMethods } from "./helpers/mock-console";
-import { runInTempDir } from "./helpers/run-in-tmp";
-import { runWrangler } from "./helpers/run-wrangler";
-import writeWranglerToml from "./helpers/write-wrangler-toml";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import writeWranglerToml from "../helpers/write-wrangler-toml";
 
 describe("pages-build-env", () => {
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -1,12 +1,12 @@
 import MockWebSocket from "jest-websocket-mock";
 import { rest } from "msw";
 import { Headers, Request } from "undici";
-import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
-import { mockConsoleMethods } from "./helpers/mock-console";
-import { useMockIsTTY } from "./helpers/mock-istty";
-import { msw } from "./helpers/msw";
-import { runInTempDir } from "./helpers/run-in-tmp";
-import { runWrangler } from "./helpers/run-wrangler";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { useMockIsTTY } from "../helpers/mock-istty";
+import { msw } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
 import type {
 	AlarmEvent,
 	EmailEvent,
@@ -16,7 +16,7 @@ import type {
 	TailEvent,
 	TailEventMessage,
 	TailInfo,
-} from "../tail/createTail";
+} from "../../tail/createTail";
 import type { RequestInit } from "undici";
 import type WebSocket from "ws";
 


### PR DESCRIPTION
## What this PR solves / how to test

All tests related to Pages commands should live under the Pages dedicated `src/__tests__/pages` folder. This PR moves a couple of "lost" Pages tests to that folder.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Not applicable. We're just moving some tests to a diff folder.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: not user facing. We're just moving some tests to a diff folder.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: Not applicable. We're just moving some tests to a diff folder.

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
