### PR TITLE
[wrangler] Watch the entire module root + watch requirements.txt

### DIFF
--- a/.changeset/green-jokes-decide.md
+++ b/.changeset/green-jokes-decide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Watch the entire module root for changes in `--no-bundle` mode, rather than just the entrypoint file.

--- a/.changeset/thin-penguins-drum.md
+++ b/.changeset/thin-penguins-drum.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Reload Python workers when the `requirements.txt` file changes

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -1,12 +1,13 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import shellac from "shellac";
+import dedent from "ts-dedent";
 import { fetch } from "undici";
 import { beforeAll, describe, expect, it } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { normalizeOutput } from "./helpers/normalize";
 import { retry } from "./helpers/retry";
-import { dedent, makeRoot, seed } from "./helpers/setup";
+import { makeRoot, seed } from "./helpers/setup";
 import { WRANGLER } from "./helpers/wrangler-command";
 
 function matchWorkersDev(stdout: string): string {

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -91,7 +91,7 @@ async function runDevSession(
 
 		in ${workerPath} {
 			exits {
-        $$ ${WRANGLER} dev ${flags}
+        $ ${WRANGLER} dev ${flags}
 			}
 		}
 			`;

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -5,11 +5,12 @@ import * as nodeNet from "node:net";
 import path from "node:path";
 import { setTimeout } from "node:timers/promises";
 import shellac from "shellac";
+import dedent from "ts-dedent";
 import { Agent, fetch, setGlobalDispatcher } from "undici";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { normalizeOutput } from "./helpers/normalize";
 import { retry } from "./helpers/retry";
-import { dedent, makeRoot, seed } from "./helpers/setup";
+import { makeRoot, seed } from "./helpers/setup";
 import { WRANGLER } from "./helpers/wrangler-command";
 
 // Use `Agent` with lower timeouts so `fetch()`s inside `retry()`s don't block for a long time
@@ -90,7 +91,7 @@ async function runDevSession(
 
 		in ${workerPath} {
 			exits {
-        $ ${WRANGLER} dev ${flags}
+        $$ ${WRANGLER} dev ${flags}
 			}
 		}
 			`;
@@ -323,7 +324,7 @@ describe("basic dev python tests", () => {
 			});
 
 			const { text: text2 } = await retry(
-				(s) => s.status !== 200 || s.text === "py hello world",
+				(s) => s.status !== 200 || s.text === "py hello world 6",
 				async () => {
 					const r = await fetch(`http://127.0.0.1:${session.port}`);
 					return { text: await r.text(), status: r.status };

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -286,11 +286,11 @@ describe("basic dev python tests", () => {
 					compatibility_date = "2023-01-01"
 					compatibility_flags = ["python_workers"]
 			`,
-			"arith.py": dedent`
+			"arithmetic.py": dedent`
 					def mul(a,b):
 						return a*b`,
 			"index.py": dedent`
-					from arith import mul
+					from arithmetic import mul
 
 					from js import Response
 					def on_fetch(request):
@@ -345,7 +345,7 @@ describe("basic dev python tests", () => {
 			expect(text).toMatchInlineSnapshot('"py hello world 6"');
 
 			await worker.seed({
-				"arith.py": dedent`
+				"arithmetic.py": dedent`
 					def mul(a,b):
 						return a+b`,
 			});

--- a/packages/wrangler/e2e/helpers/setup.ts
+++ b/packages/wrangler/e2e/helpers/setup.ts
@@ -1,47 +1,9 @@
-import assert from "node:assert";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
 export async function makeRoot() {
 	return await mkdtemp(path.join(os.tmpdir(), "wrangler-smoke-"));
-}
-
-// Tagged template literal for removing indentation from a block of text.
-// If the first line is empty, it will be ignored.
-export function dedent(strings: TemplateStringsArray, ...values: unknown[]) {
-	// Convert template literal arguments back to a regular string
-	const raw = String.raw({ raw: strings }, ...values);
-	// Split the string by lines
-	let lines = raw.split("\n");
-	assert(lines.length > 0);
-
-	// If the last line is just whitespace, remove it
-	if (lines[lines.length - 1].trim() === "") {
-		lines = lines.slice(0, lines.length - 1);
-	}
-
-	// Find the minimum-length indent, excluding the first line
-	let minIndent = "";
-	// (Could use `minIndent.length` for this, but then would need to start with
-	// infinitely long string)
-	let minIndentLength = Infinity;
-	for (const line of lines.slice(1)) {
-		const indent = line.match(/^[ \t]*/)?.[0];
-		if (indent != null && indent.length < minIndentLength) {
-			minIndent = indent;
-			minIndentLength = indent.length;
-		}
-	}
-
-	// If the first line is just whitespace, remove it
-	if (lines.length > 0 && lines[0].trim() === "") lines = lines.slice(1);
-
-	// Remove indent from all lines, and return them all joined together
-	lines = lines.map((line) =>
-		line.startsWith(minIndent) ? line.substring(minIndent.length) : line
-	);
-	return lines.join("\n");
 }
 
 // Seeds the `root` directory on the file system with some data. Use in

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -3,11 +3,12 @@ import path from "node:path";
 import { setTimeout } from "node:timers/promises";
 import getPort from "get-port";
 import shellac from "shellac";
+import dedent from "ts-dedent";
 import { fetch } from "undici";
 import { beforeEach, describe, expect, it } from "vitest";
 import { normalizeOutput } from "./helpers/normalize";
 import { retry } from "./helpers/retry";
-import { dedent, makeRoot, seed } from "./helpers/setup";
+import { makeRoot, seed } from "./helpers/setup";
 import { WRANGLER } from "./helpers/wrangler-command";
 
 type MaybePromise<T = void> = T | Promise<T>;

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -1,10 +1,11 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import shellac from "shellac";
+import dedent from "ts-dedent";
 import { beforeAll, chai, describe, expect, it } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { normalizeOutput } from "./helpers/normalize";
-import { dedent, makeRoot, seed } from "./helpers/setup";
+import { makeRoot, seed } from "./helpers/setup";
 import { WRANGLER } from "./helpers/wrangler-command";
 
 chai.config.truncateThreshold = 1e6;

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -199,11 +199,23 @@ export function useEsbuild({
 			// Capture the `stop()` method to use as the `useEffect()` destructor.
 			stopWatching = bundleResult?.stop;
 
-			// if "noBundle" is true, then we need to manually watch the entry point and
-			// trigger "builds" when it changes
+			// if "noBundle" is true, then we need to manually watch all modules and
+			// trigger "builds" when any change
 			if (noBundle) {
-				const watcher = watch(entry.file, {
+				const watching = [path.resolve(entry.moduleRoot)];
+				// Should we try and watch a Python reqyurements.txt file?
+				const pythonRequirements =
+					getBundleType(entry.format, entry.file) === "python"
+						? path.resolve(entry.directory, "requirements.txt")
+						: undefined;
+
+				if (pythonRequirements) {
+					watching.push(pythonRequirements);
+				}
+
+				const watcher = watch(watching, {
 					persistent: true,
+					ignored: [".git", "node_modules"],
 				}).on("change", async (_event) => {
 					await updateBundle();
 				});

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -204,13 +204,13 @@ export function useEsbuild({
 			if (noBundle) {
 				const watching = [path.resolve(entry.moduleRoot)];
 				// Check whether we need to watch a Python requirements.txt file.
-				const pythonRequirements =
+				const watchPythonRequirements =
 					getBundleType(entry.format, entry.file) === "python"
 						? path.resolve(entry.directory, "requirements.txt")
 						: undefined;
 
-				if (pythonRequirements) {
-					watching.push(pythonRequirements);
+				if (watchPythonRequirements) {
+					watching.push(watchPythonRequirements);
 				}
 
 				const watcher = watch(watching, {

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -203,7 +203,7 @@ export function useEsbuild({
 			// trigger "builds" when any change
 			if (noBundle) {
 				const watching = [path.resolve(entry.moduleRoot)];
-				// Should we try and watch a Python reqyurements.txt file?
+				// Check whether we need to watch a Python requirements.txt file.
 				const pythonRequirements =
 					getBundleType(entry.format, entry.file) === "python"
 						? path.resolve(entry.directory, "requirements.txt")


### PR DESCRIPTION
## What this PR solves / how to test

In `--no-bundle` mode watch the entire module root for changes, rather than just the entrypoint file. Additionally, watch the `requirements.txt` file for Python workers.

Fixes [EW-8223](https://jira.cfdata.org/browse/EW-8223)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bugfix to how this behaviour should work

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
