### PR TITLE
[C3] fix: update the remix template url used (as the old one is no longer valid)

### DIFF
--- a/.changeset/pretty-hotels-brake.md
+++ b/.changeset/pretty-hotels-brake.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: update the remix template url used (as the old one is no longer valid)

--- a/packages/create-cloudflare/templates/remix/c3.ts
+++ b/packages/create-cloudflare/templates/remix/c3.ts
@@ -13,7 +13,7 @@ const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,
 		"--template",
-		"https://github.com/remix-run/remix/tree/main/templates/vite-cloudflare",
+		"https://github.com/remix-run/remix/tree/main/templates/cloudflare",
 	]);
 
 	logRaw(""); // newline


### PR DESCRIPTION
## What this PR solves / how to test

Remix has renamed their `vite-cloudflare` template to `cloudflare` (https://github.com/remix-run/remix/pull/9077)
as a result this broke C3's Remix flow, this PR is amending that

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: the C3 Remix flow is already tested 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: no behavioural changes, just fixing the broken C3 Remix flow

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
