### PR TITLE
Use 'cloudflare' template for Remix in C3 rather than 'vite-cloudflare'

### DIFF
--- a/.changeset/two-vans-kick.md
+++ b/.changeset/two-vans-kick.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: Use `cloudflare` template for Remix in C3 rather than `vite-cloudflare`

--- a/packages/create-cloudflare/templates/remix/c3.ts
+++ b/packages/create-cloudflare/templates/remix/c3.ts
@@ -13,7 +13,7 @@ const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,
 		"--template",
-		"https://github.com/remix-run/remix/tree/main/templates/vite-cloudflare",
+		"https://github.com/remix-run/remix/tree/main/templates/cloudflare",
 	]);
 
 	logRaw(""); // newline


### PR DESCRIPTION
## What this PR solves / how to test

C3 is broken with Remix right now.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: upstream
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bug fix

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
