### PR TITLE
implement `--experimental-versions` flag + aliases

### DIFF
--- a/.changeset/grumpy-apples-draw.md
+++ b/.changeset/grumpy-apples-draw.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: rename `--experimental-gradual-rollouts` to `--experimental-versions` flag
+
+The `--experimental-gradual-rollouts` flag has been made an alias and will still work.
+
+And additional shorthand alias `--x-versions` has also been added and will work too.

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -1,18 +1,6 @@
 import { setImmediate } from "node:timers/promises";
-import { normalizeOutput } from "../../../e2e/helpers/normalize";
-import { collectCLIOutput } from "../helpers/collect-cli-output";
-import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import { msw, mswGetVersion } from "../helpers/msw";
-import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
-
-// --help
-// implicit subhelp
-// --experimental-gradual-rollouts
-// --experimental-versions
-// --x-versions
 
 describe("versions --help", () => {
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -1,0 +1,173 @@
+import { setImmediate } from "node:timers/promises";
+import { normalizeOutput } from "../../../e2e/helpers/normalize";
+import { collectCLIOutput } from "../helpers/collect-cli-output";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { msw, mswGetVersion } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import writeWranglerToml from "../helpers/write-wrangler-toml";
+
+// --help
+// implicit subhelp
+// --experimental-gradual-rollouts
+// --experimental-versions
+// --x-versions
+
+describe("versions --help", () => {
+	const std = mockConsoleMethods();
+
+	test("shows generic help w/ --help flag but w/o --experimental-versions flag", async () => {
+		const result = runWrangler("versions --help");
+
+		await expect(result).resolves.toBeUndefined();
+
+		expect(std.out).toMatchInlineSnapshot(`
+		"wrangler
+
+		Commands:
+		  wrangler docs [command..]            📚 Open wrangler's docs in your browser
+		  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
+		  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/workers-sdk/tree/main/templates
+		  wrangler dev [script]                👂 Start a local server for developing your worker
+		  wrangler deploy [script]             🆙 Deploy your Worker to Cloudflare.  [aliases: publish]
+		  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
+		  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
+		  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
+		  wrangler secret:bulk [json]          🗄️  Bulk upload secrets for a Worker
+		  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
+		  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
+		  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
+		  wrangler pages                       ⚡️ Configure Cloudflare Pages
+		  wrangler queues                      🇶 Configure Workers Queues
+		  wrangler r2                          📦 Interact with an R2 store
+		  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
+		  wrangler d1                          🗄  Interact with a D1 database
+		  wrangler hyperdrive                  🚀 Configure Hyperdrive databases
+		  wrangler ai                          🤖 Interact with AI models
+		  wrangler vectorize                   🧮 Interact with Vectorize indexes
+		  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
+		  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
+		  wrangler login                       🔓 Login to Cloudflare
+		  wrangler logout                      🚪 Logout from Cloudflare
+		  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
+		  wrangler types [path]                📝 Generate types from bindings & module rules in config
+		  wrangler deployments                 🚢 List and view details for deployments
+		  wrangler rollback [deployment-id]    🔙 Rollback a deployment
+
+		Flags:
+		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+		  -c, --config                    Path to .toml configuration file  [string]
+		  -e, --env                       Environment to use for operations and .env files  [string]
+		  -h, --help                      Show help  [boolean]
+		  -v, --version                   Show version number  [boolean]"
+	`);
+	});
+
+	test("shows versions help w/ --help and --experimental-versions flag", async () => {
+		const result = runWrangler("versions --help --experimental-versions");
+
+		await expect(result).resolves.toBeUndefined();
+
+		expect(std.out).toMatchInlineSnapshot(`
+		"wrangler versions
+
+		Commands:
+		  wrangler versions view <version-id>         View the details of a specific version of your Worker [beta]
+		  wrangler versions list                      List the 10 most recent Versions of your Worker [beta]
+		  wrangler versions upload                    Uploads your Worker code and config as a new Version [beta]
+		  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [beta]
+
+		Flags:
+		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+		  -c, --config                    Path to .toml configuration file  [string]
+		  -e, --env                       Environment to use for operations and .env files  [string]
+		  -h, --help                      Show help  [boolean]
+		  -v, --version                   Show version number  [boolean]"
+	`);
+	});
+});
+
+describe("versions subhelp", () => {
+	const std = mockConsoleMethods();
+
+	test("fails without --experimental-versions flag", async () => {
+		const result = runWrangler("versions");
+
+		await expect(result).rejects.toMatchInlineSnapshot(
+			`[Error: Unknown argument: versions]`
+		);
+	});
+
+	test("shows implicit subhelp with --experimental-versions flag", async () => {
+		const result = runWrangler("versions --experimental-versions");
+
+		await expect(result).resolves.toBeUndefined();
+		await setImmediate(); // wait for subhelp
+
+		expect(std.out).toMatchInlineSnapshot(`
+		"wrangler versions
+
+		Commands:
+		  wrangler versions view <version-id>         View the details of a specific version of your Worker [beta]
+		  wrangler versions list                      List the 10 most recent Versions of your Worker [beta]
+		  wrangler versions upload                    Uploads your Worker code and config as a new Version [beta]
+		  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [beta]
+
+		Flags:
+		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+		  -c, --config                    Path to .toml configuration file  [string]
+		  -e, --env                       Environment to use for operations and .env files  [string]
+		  -h, --help                      Show help  [boolean]
+		  -v, --version                   Show version number  [boolean]"
+	`);
+	});
+
+	test("shows implicit subhelp with --x-versions flag", async () => {
+		const result = runWrangler("versions --x-versions");
+
+		await expect(result).resolves.toBeUndefined();
+		await setImmediate(); // wait for subhelp
+
+		expect(std.out).toMatchInlineSnapshot(`
+		"wrangler versions
+
+		Commands:
+		  wrangler versions view <version-id>         View the details of a specific version of your Worker [beta]
+		  wrangler versions list                      List the 10 most recent Versions of your Worker [beta]
+		  wrangler versions upload                    Uploads your Worker code and config as a new Version [beta]
+		  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [beta]
+
+		Flags:
+		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+		  -c, --config                    Path to .toml configuration file  [string]
+		  -e, --env                       Environment to use for operations and .env files  [string]
+		  -h, --help                      Show help  [boolean]
+		  -v, --version                   Show version number  [boolean]"
+	`);
+	});
+
+	test("shows implicit subhelp with --experimental-gradual-rollouts flag", async () => {
+		const result = runWrangler("versions --experimental-gradual-rollouts");
+
+		await expect(result).resolves.toBeUndefined();
+		await setImmediate(); // wait for subhelp
+
+		expect(std.out).toMatchInlineSnapshot(`
+		"wrangler versions
+
+		Commands:
+		  wrangler versions view <version-id>         View the details of a specific version of your Worker [beta]
+		  wrangler versions list                      List the 10 most recent Versions of your Worker [beta]
+		  wrangler versions upload                    Uploads your Worker code and config as a new Version [beta]
+		  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [beta]
+
+		Flags:
+		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+		  -c, --config                    Path to .toml configuration file  [string]
+		  -e, --env                       Environment to use for operations and .env files  [string]
+		  -h, --help                      Show help  [boolean]
+		  -v, --version                   Show version number  [boolean]"
+	`);
+	});
+});


### PR DESCRIPTION
## What this PR solves / how to test

Implement `--experimental-versions` flag
+ alias: `--x-versions` (shorthand for convenience)
+ alias: `--experimental-gradual-rollouts` (for backwards compat)

This change is heading in the direction of a more general approach of formalising experimental flags (and potentially allowing alternate enablement like env vars and/or wrangler.toml properties) and having a `--x-foo` shorthand for `--experimental-foo` flags, but this PR implements the convention just for `--experimental-versions` with the more general approach to come in a follow-up.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: experimental

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
