### PR TITLE
chore(wrangler): Add `pages dev` tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.node }}
       cancel-in-progress: true
-    timeout-minutes: 15
+    timeout-minutes: 20
     if: github.repository_owner == 'cloudflare' && (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains(github.event.*.labels.*.name, 'e2e' )))
     name: "E2E Test"
     strategy:

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -5,36 +5,87 @@ import getPort from "get-port";
 import shellac from "shellac";
 import { fetch } from "undici";
 import { beforeEach, describe, expect, it } from "vitest";
+import { normalizeOutput } from "./helpers/normalize";
 import { retry } from "./helpers/retry";
 import { dedent, makeRoot, seed } from "./helpers/setup";
 import { WRANGLER } from "./helpers/wrangler-command";
 
+type MaybePromise<T = void> = T | Promise<T>;
+
+interface SessionData {
+	port: number;
+	stdout: string;
+	stderr: string;
+}
+
+const waitUntilOutputContains = async (
+	session: SessionData,
+	substring: string,
+	intervalMs = 100
+) => {
+	await retry(
+		(stdout) => !stdout.includes(substring),
+		async () => {
+			await setTimeout(intervalMs);
+			return session.stdout + "\n\n\n" + session.stderr;
+		}
+	);
+};
+
 async function runDevSession(
 	workerPath: string,
 	flags: string,
-	session: (port: number) => Promise<void>
+	session: (sessionData: SessionData) => MaybePromise
 ) {
 	let pid;
 	try {
-		const port = await getPort();
+		const portFlagMatch = flags.match(/--port (\d+)/);
+		let port = 0;
+		if (portFlagMatch) {
+			port = parseInt(portFlagMatch[1]);
+		}
+		if (port === 0) {
+			port = await getPort();
+			flags += ` --port ${port}`;
+		}
+
 		// Must use the `in` statement in the shellac script rather than `.in()` modifier on the `shellac` object
 		// otherwise the working directory does not get picked up.
+		let promiseResolve: (() => void) | undefined;
+		const promise = new Promise<void>((resolve) => (promiseResolve = resolve));
 		const bg = await shellac.env(process.env).bg`
+		await ${() => promise}
+
 		in ${workerPath} {
 			exits {
-				$ ${WRANGLER} pages dev ${flags} --port ${port}
+				$ ${WRANGLER} pages dev ${flags}
 			}
 		}
 			`;
+
 		pid = bg.pid;
-		await session(port);
+
+		// sessionData is a mutable object where stdout/stderr update
+		const sessionData: SessionData = {
+			port,
+			stdout: "",
+			stderr: "",
+		};
+
+		bg.process.stdout.on("data", (chunk) => (sessionData.stdout += chunk));
+		bg.process.stderr.on("data", (chunk) => (sessionData.stderr += chunk));
+		// Only start `wrangler pages dev` once we've registered output listeners so we don't miss messages
+		promiseResolve?.();
+
+		await session(sessionData);
+
 		return bg.promise;
 	} finally {
 		if (pid) process.kill(pid);
 	}
 }
 
-describe("pages dev tests", () => {
+describe("pages dev", () => {
 	let workerName: string;
 	let workerPath: string;
 
@@ -53,8 +104,170 @@ describe("pages dev tests", () => {
 		});
 	});
 
-	it("can modify worker during dev session (_worker)", async () => {
-		await runDevSession(workerPath, ".", async (port) => {
+	it("should warn if no [--compatibility_date] command line arg was specified", async () => {
+		await runDevSession(workerPath, ".", async (session) => {
+			await seed(workerPath, {
+				"_worker.js": dedent`
+						export default {
+							fetch(request, env) {
+								return new Response("Testing [--compatibility_date]")
+							}
+						}`,
+			});
+			const { text, stderr } = await retry(
+				(s) => s.status !== 200,
+				async () => {
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
+					return {
+						text: await r.text(),
+						status: r.status,
+						stderr: session.stderr,
+					};
+				}
+			);
+
+			const currentDate = new Date().toISOString().substring(0, 10);
+			expect(text).toMatchInlineSnapshot('"Testing [--compatibility_date]"');
+			expect(normalizeOutput(stderr).replaceAll(currentDate, "<current-date>"))
+				.toMatchInlineSnapshot(`
+				"▲ [WARNING] No compatibility_date was specified. Using today's date: <current-date>.
+				  Pass it in your terminal:
+				  \`\`\`
+				  --compatibility-date=<current-date>
+				  \`\`\`
+				  See https://developers.cloudflare.com/workers/platform/compatibility-dates/ for more information."
+			`);
+		});
+	});
+
+	it("should warn that [--experimental-local] is no longer required, if specified", async () => {
+		await runDevSession(
+			workerPath,
+			". --experimental-local",
+			async (session) => {
+				await seed(workerPath, {
+					"_worker.js": dedent`
+						export default {
+							fetch(request, env) {
+								return new Response("Testing [--experimental-local]")
+							}
+						}`,
+				});
+				const { text, stderr } = await retry(
+					(s) => s.status !== 200,
+					async () => {
+						const r = await fetch(`http://127.0.0.1:${session.port}`);
+						return {
+							text: await r.text(),
+							status: r.status,
+							stderr: session.stderr,
+						};
+					}
+				);
+
+				const currentDate = new Date().toISOString().substring(0, 10);
+				expect(text).toMatchInlineSnapshot('"Testing [--experimental-local]"');
+				expect(
+					normalizeOutput(stderr).replaceAll(currentDate, "<current-date>")
+				).toMatchInlineSnapshot(`
+				"▲ [WARNING] --experimental-local is no longer required and will be removed in a future version.
+				  \`wrangler pages dev\` now uses the local Cloudflare Workers runtime by default.
+				▲ [WARNING] No compatibility_date was specified. Using today's date: <current-date>.
+				  Pass it in your terminal:
+				  \`\`\`
+				  --compatibility-date=<current-date>
+				  \`\`\`
+				  See https://developers.cloudflare.com/workers/platform/compatibility-dates/ for more information."
+			`);
+			}
+		);
+	});
+
+	it("should show [--service] related warnings if specified as arg in the command line", async () => {
+		await runDevSession(
+			workerPath,
+			". --service STAGING_SERVICE=test-worker@staging",
+			async (session) => {
+				await waitUntilOutputContains(session, "WARNING");
+
+				const normalizedOutput = normalizeOutput(session.stderr);
+				expect(normalizedOutput).toContain(
+					`[WARNING] Support for service binding environments is experimental.`
+				);
+				expect(normalizedOutput).toContain(
+					`[WARNING] ⎔ Support for service bindings in local mode is experimental and may change.`
+				);
+			}
+		);
+	});
+
+	it("should warn if bindings specified as args in the command line are invalid", async () => {
+		await runDevSession(
+			workerPath,
+			". --service test --kv = --do test --d1 = --r2 =",
+			async (session) => {
+				await waitUntilOutputContains(session, "WARNING");
+
+				const normalizedOutput = normalizeOutput(session.stderr);
+				expect(normalizedOutput).toContain(
+					`[WARNING] Could not parse Service binding: test`
+				);
+				expect(normalizedOutput).toContain(
+					`[WARNING] Could not parse KV binding: =`
+				);
+				expect(normalizedOutput).toContain(
+					`[WARNING] Could not parse Durable Object binding: test`
+				);
+				expect(normalizedOutput).toContain(
+					`[WARNING] Could not parse R2 binding: =`
+				);
+				expect(normalizedOutput).toContain(
+					`[WARNING] Could not parse D1 binding: =`
+				);
+			}
+		);
+	});
+
+	it("should use bindings specified as args in the command line", async () => {
+		await runDevSession(
+			workerPath,
+			". --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 TEST_R2",
+			async (session) => {
+				await seed(workerPath, {
+					"_worker.js": dedent`
+							export default {
+								fetch(request, env) {
+									return new Response("Hello world")
+								}
+							}`,
+				});
+
+				await waitUntilOutputContains(
+					session,
+					"Your worker has access to the following bindings:"
+				);
+
+				expect(normalizeOutput(session.stdout).replace(/\s/g, "")).toContain(
+					`
+					Your worker has access to the following bindings:
+					- Durable Objects:
+					  - TEST_DO: TestDurableObject (defined in a)
+					- KV Namespaces:
+					  - TEST_KV: TEST_KV
+					- D1 Databases:
+					  - TEST_D1: local-TEST_D1 (TEST_D1)
+					- R2 Buckets:
+					  - TEST_R2: TEST_R2
+					- Services:
+					  - TEST_SERVICE: test-worker
+				`.replace(/\s/g, "")
+				);
+			}
+		);
+	});
+
+	it("should modify worker during dev session (_worker)", async () => {
+		await runDevSession(workerPath, ".", async (session) => {
 			await seed(workerPath, {
 				"_worker.js": dedent`
 						export default {
@@ -66,7 +279,7 @@ describe("pages dev tests", () => {
 			const { text } = await retry(
 				(s) => s.status !== 200,
 				async () => {
-					const r = await fetch(`http://127.0.0.1:${port}`);
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
 					return { text: await r.text(), status: r.status };
 				}
 			);
@@ -84,7 +297,7 @@ describe("pages dev tests", () => {
 			const { text: text2 } = await retry(
 				(s) => s.status !== 200 || s.text === "Hello World!",
 				async () => {
-					const r = await fetch(`http://127.0.0.1:${port}`);
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
 					return { text: await r.text(), status: r.status };
 				}
 			);
@@ -92,8 +305,8 @@ describe("pages dev tests", () => {
 		});
 	});
 
-	it("can modify worker during dev session (function)", async () => {
-		await runDevSession(workerPath, ".", async (port) => {
+	it("should modify worker during dev session (Functions)", async () => {
+		await runDevSession(workerPath, ".", async (session) => {
 			await seed(workerPath, {
 				"functions/_middleware.js": dedent`
 						export async function onRequest() {
@@ -103,7 +316,7 @@ describe("pages dev tests", () => {
 			const { text } = await retry(
 				(s) => s.status !== 200,
 				async () => {
-					const r = await fetch(`http://127.0.0.1:${port}`);
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
 					return { text: await r.text(), status: r.status };
 				}
 			);
@@ -119,7 +332,7 @@ describe("pages dev tests", () => {
 			const { text: text2 } = await retry(
 				(s) => s.status !== 200 || s.text === "Hello World!",
 				async () => {
-					const r = await fetch(`http://127.0.0.1:${port}`);
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
 					return { text: await r.text(), status: r.status };
 				}
 			);
@@ -127,8 +340,8 @@ describe("pages dev tests", () => {
 		});
 	});
 
-	it("can recover from syntax error during dev session (_worker)", async () => {
-		const out = await runDevSession(workerPath, ".", async (port) => {
+	it("should recover from syntax error during dev session (_worker)", async () => {
+		const out = await runDevSession(workerPath, ".", async (session) => {
 			await seed(workerPath, {
 				"_worker.js": dedent`
 						export default {
@@ -140,7 +353,7 @@ describe("pages dev tests", () => {
 			const { text } = await retry(
 				(s) => s.status !== 200,
 				async () => {
-					const r = await fetch(`http://127.0.0.1:${port}`);
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
 					return { text: await r.text(), status: r.status };
 				}
 			);
@@ -171,7 +384,7 @@ describe("pages dev tests", () => {
 			const { text: text2 } = await retry(
 				(s) => s.status !== 200 || s.text === "Hello World!",
 				async () => {
-					const r = await fetch(`http://127.0.0.1:${port}`);
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
 					return { text: await r.text(), status: r.status };
 				}
 			);
@@ -179,8 +392,9 @@ describe("pages dev tests", () => {
 		});
 		expect(out.stderr).toContain("Failed to bundle");
 	});
-	it("can recover from syntax error during dev session (function)", async () => {
-		const out = await runDevSession(workerPath, ".", async (port) => {
+
+	it("should recover from syntax error during dev session (Functions)", async () => {
+		const out = await runDevSession(workerPath, ".", async (session) => {
 			await seed(workerPath, {
 				"functions/_middleware.js": dedent`
 						export async function onRequest() {
@@ -190,7 +404,7 @@ describe("pages dev tests", () => {
 			const { text } = await retry(
 				(s) => s.status !== 200,
 				async () => {
-					const r = await fetch(`http://127.0.0.1:${port}`);
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
 					return { text: await r.text(), status: r.status };
 				}
 			);
@@ -217,7 +431,7 @@ describe("pages dev tests", () => {
 			const { text: text2 } = await retry(
 				(s) => s.status !== 200 || s.text === "Hello World!",
 				async () => {
-					const r = await fetch(`http://127.0.0.1:${port}`);
+					const r = await fetch(`http://127.0.0.1:${session.port}`);
 					return { text: await r.text(), status: r.status };
 				}
 			);
@@ -226,5 +440,138 @@ describe("pages dev tests", () => {
 		expect(out.stderr).toContain(
 			"Unexpected error building Functions directory"
 		);
+	});
+
+	it("should support modifying _routes.json during dev session", async () => {
+		await runDevSession(workerPath, ".", async (session) => {
+			await seed(workerPath, {
+				"_worker.js": dedent`
+						export default {
+							async fetch(request, env) {
+								const url = new URL(request.url);
+								if (url.pathname === "/foo") {
+									return new Response("foo");
+								}
+								if (url.pathname === "/bar") {
+									return new Response("bar");
+								}
+								return new Response("Hello _routes.json")
+							}
+						}`,
+				"_routes.json": dedent`
+					{
+						"version": 1,
+						"include": ["/foo", "/bar"],
+						"exclude": []
+					}
+				`,
+				"index.html": dedent`
+					hello world
+				`,
+			});
+
+			const { text: foo } = await retry(
+				(s) => s.status !== 200,
+				async () => {
+					const r = await fetch(`http://127.0.0.1:${session.port}/foo`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(foo).toMatchInlineSnapshot('"foo"');
+
+			const { text: bar } = await retry(
+				(s) => s.status !== 200 || s.text === "foo",
+				async () => {
+					const r = await fetch(`http://127.0.0.1:${session.port}/bar`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(bar).toMatchInlineSnapshot('"bar"');
+
+			await seed(workerPath, {
+				"_routes.json": dedent`
+					{
+						"version": 1,
+						"include": ["/foo"],
+						"exclude": ["/bar"]
+					}
+				`,
+			});
+
+			// Give a bit of time for the change to propagate.
+			await setTimeout(5000);
+
+			const { text: foo2 } = await retry(
+				(s) => s.status !== 200 || s.text === "bar",
+				async () => {
+					const r = await fetch(`http://127.0.0.1:${session.port}/foo`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(foo2).toMatchInlineSnapshot('"foo"');
+
+			const { text: bar2 } = await retry(
+				(s) => s.status !== 200 || s.text === "foo",
+				async () => {
+					const r = await fetch(`http://127.0.0.1:${session.port}/bar`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(bar2).toMatchInlineSnapshot('"hello world"');
+		});
+	});
+
+	it("should validate _routes.json during dev session, and fallback to default value", async () => {
+		await runDevSession(workerPath, ".", async (session) => {
+			await seed(workerPath, {
+				"functions/foo.ts": dedent`
+					export async function onRequest() {
+						return new Response("FOO");
+					}`,
+				"_routes.json": dedent`
+					{
+						"version": 1,
+						"include": ["/foo"],
+						"exclude": []
+					}
+				`,
+			});
+
+			const { text: foo } = await retry(
+				(s) => s.status !== 200,
+				async () => {
+					const r = await fetch(`http://127.0.0.1:${session.port}/foo`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(foo).toMatchInlineSnapshot('"FOO"');
+
+			// invalid _routes.json because include rule does not start with `/`
+			await seed(workerPath, {
+				"_routes.json": dedent`
+					{
+						"version": 1,
+						"include": ["foo"],
+						"exclude": []
+					}
+				`,
+			});
+
+			const { stderr } = await retry(
+				(s) => !s.stderr.includes("ERROR"),
+				() => {
+					return { stderr: session.stderr };
+				}
+			);
+
+			const normalizedStderr = normalizeOutput(stderr);
+			expect(normalizedStderr).toContain(
+				"[ERROR] FatalError: Invalid _routes.json file found"
+			);
+			expect(normalizedStderr).toContain("All rules must start with '/'.");
+			expect(normalizedStderr).toContain(
+				"[WARNING] Falling back to the following _routes.json default"
+			);
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -1,0 +1,34 @@
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+
+/**
+ * Given that `runWrangler()` mocks out the underlying implementation
+ * (see "jest.setup.ts") there's only so much worth testing here.
+ */
+describe("pages dev", () => {
+	runInTempDir();
+
+	it("should error if neither [<directory>] nor [--<command>] command line args were specififed", async () => {
+		await expect(
+			runWrangler("pages dev")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Must specify a directory of static assets to serve or a command to run or a proxy port."`
+		);
+	});
+
+	it("should error if both [<directory>] and [--<command>] command line args were specififed", async () => {
+		await expect(
+			runWrangler("pages dev public -- yarn dev")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Specify either a directory OR a proxy command, not both."`
+		);
+	});
+
+	it("should error if the [--config] command line arg was specififed", async () => {
+		await expect(
+			runWrangler("pages dev public --config=/path/to/wrangler.toml")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Pages does not support wrangler.toml"`
+		);
+	});
+});


### PR DESCRIPTION
## What this PR solves / how to test

This PR adds some sanity-check unit and e2e tests for `wrangler pages dev`.

<img width="780" alt="Screenshot 2024-03-22 at 13 33 27" src="https://github.com/cloudflare/workers-sdk/assets/4638332/40b60328-6f24-4f40-83e5-3dddcf63af65">

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: not user facing. Only adding tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: not user facing. Only adding tests

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
