### PR TITLE
v2 backport: Ignore OPTIONS requests in Oauth server

### DIFF
--- a/.changeset/rude-mice-study.md
+++ b/.changeset/rude-mice-study.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Ignore OPTIONS requests in Wrangler's oauth server

--- a/.changeset/rude-mice-study.md
+++ b/.changeset/rude-mice-study.md
@@ -3,3 +3,7 @@
 ---
 
 fix: Ignore OPTIONS requests in Wrangler's oauth server
+
+In Chrome v123, the auth requests from the browser back to wrangler now first include a CORS OPTIONS preflight request before the expected GET request. Wrangler was able to successfully complete the login with the first (OPTIONS) request, and therefore upon the second (GET) request, errored because the token exchange had already occured and could not be repeated.
+
+Wrangler now stops processing the OPTIONS request before completing the token exchange and only proceeds on the expected GET request.

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -953,6 +953,7 @@ export async function login(
 
 			assert(req.url, "This request doesn't have a URL"); // This should never happen
 			const { pathname, query } = url.parse(req.url, true);
+			if (req.method !== "GET") return res.end("OK");
 			switch (pathname) {
 				case "/oauth/callback": {
 					let hasAuthCode = false;


### PR DESCRIPTION
## What this PR solves / how to test

This PR backports the fix (for `wrangler login` to work with Chrome v123) to wrangler v2. This patch has already been applied to wrangler v3 in #5324.

Fixes #5328

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
