### PR TITLE
chore: ensure that dependabot updates package-lock.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,15 @@ updates:
       - "dependencies"
   # Check for workerd & workers-types updates for Miniflare
   - package-ecosystem: "npm"
-    directory: "/packages/miniflare"
+    # If you restrict the update to a directory that is not the root
+    # then it will not update the package-lock.json.
+    directory: "/"
+    groups:
+      # We want to keep workerd and workers-types updates in lock-step
+      workerd-and-workers-types:
+        patterns:
+          - "workerd"
+          - "@cloudflare/workers-types"
     schedule:
       interval: "daily"
     versioning-strategy: increase


### PR DESCRIPTION
Previously we limited the workerd updates to the miniflare package by setting the `directory` configuration. But it seems that this fails to update the package lockfile because that is higher up in the root of the repo.

Changing the `directory` back to `/` should cover the package lockfile, although it will also update all packages and fixtures that contain potential updates (notably for workers-types). But this is probably a good thing overall.

