### PR TITLE
Remove support for LifecycleDeletion action

### DIFF
--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -591,7 +591,7 @@ describe("r2", () => {
 					).resolves.toBe(undefined);
 					expect(std.out).toMatchInlineSnapshot(`
 				"Sending this configuration to \\"my-bucket\\":
-				{\\"rules\\":[{\\"prefix\\":\\"\\",\\"suffix\\":\\"\\",\\"actions\\":[\\"PutObject\\",\\"CompleteMultipartUpload\\",\\"CopyObject\\",\\"DeleteObject\\",\\"LifecycleDeletion\\"]}]}
+				{\\"rules\\":[{\\"prefix\\":\\"\\",\\"suffix\\":\\"\\",\\"actions\\":[\\"PutObject\\",\\"CompleteMultipartUpload\\",\\"CopyObject\\",\\"DeleteObject\\"]}]}
 				Configuration created successfully!"
 			`);
 				});

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -326,7 +326,6 @@ export const R2EventableOperations = [
 	"CompleteMultipartUpload",
 	"AbortMultipartUpload",
 	"CopyObject",
-	"LifecycleDeletion",
 ] as const;
 export type R2EventableOperation = typeof R2EventableOperations[number];
 
@@ -335,7 +334,7 @@ export const actionsForEventCategories: Record<
 	R2EventableOperation[]
 > = {
 	object_create: ["PutObject", "CompleteMultipartUpload", "CopyObject"],
-	object_delete: ["DeleteObject", "LifecycleDeletion"],
+	object_delete: ["DeleteObject"],
 };
 
 export type R2EventType = keyof typeof actionsForEventCategories;


### PR DESCRIPTION
Support for emitting notifications based around this type of action will be supported eventually, but not until throughput improvements to supporting infrastructure are completed.

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [X] Not necessary because: Very minor change to existing, tested functionality
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [X] Not necessary because: Covered by the changeset in #5294. That change and this are expected to go out in the same release.
- Public documentation
  - [X] Not necessary because: Comprehensive docs for R2 Event Notifications are forthcoming, but this feature is in pre-release state.


