### PR TITLE
Only return successful cached responses

### DIFF
--- a/.changeset/new-kiwis-press.md
+++ b/.changeset/new-kiwis-press.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/prerelease-registry": patch
+---
+
+fix: Only return successful cached responses

--- a/packages/prerelease-registry/functions/utils/getArtifactForWorkflowRun.ts
+++ b/packages/prerelease-registry/functions/utils/getArtifactForWorkflowRun.ts
@@ -26,7 +26,7 @@ export const getArtifactForWorkflowRun = async ({
 	const cache = caches.default;
 
 	const cachedResponse = await cache.match(cacheKey);
-	if (cachedResponse) return cachedResponse;
+	if (cachedResponse && cachedResponse.status === 200) return cachedResponse;
 
 	try {
 		const artifactsResponse = await gitHubFetch(


### PR DESCRIPTION
## What this PR solves / how to test

Somehow the prerelease registry is sometimes returning empty 404 responses from the Workers Cache. This change fixes that by only returning cached responses with a 200 status code.

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: This _appears_ to be some sort of intermittent bug in Workers cache, and is not reliably reproducible enough to be testable.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: internal package

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
