### PR TITLE
[C3] Rename 'webFramework' --type argument to 'web-framework'

### DIFF
--- a/.changeset/hungry-candles-knock.md
+++ b/.changeset/hungry-candles-knock.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+feat: Rename 'webFramework' --type argument to 'web-framework' and show deprecation warning when used.

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -60,7 +60,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 			const argv = [
 				"foo",
 				"--type",
-				"webFramework",
+				"web-framework",
 				"--no-deploy",
 				"--version",
 			];

--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -440,7 +440,7 @@ const runCli = async (
 	const args = [
 		projectPath,
 		"--type",
-		"webFramework",
+		"web-framework",
 		"--framework",
 		framework,
 		NO_DEPLOY ? "--no-deploy" : "--deploy",


### PR DESCRIPTION
## What this PR solves / how to test

All other templates use kebab-case so this sticks out like a sore thumb. `--type webFramework` is still allowed for now, but shows a warning when used.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/13566
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
