### PR TITLE
update non-versioned script settings in `versions deploy`

### DIFF
--- a/.changeset/funny-trees-cross.md
+++ b/.changeset/funny-trees-cross.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: save non-versioned script-settings (logpush, tail_consumers) on `wrangler versions deploy`. This command still requires `--experimental-versions`.

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/versions.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/versions.ts
@@ -211,3 +211,23 @@ export const mswPostNewDeployment = rest.post(
 		);
 	}
 );
+
+export const mswPatchNonVersionedScriptSettings = rest.patch(
+	"*/accounts/:accountId/workers/scripts/:workerName/script-settings",
+	(request, response, context) => {
+		return response(context.json(createFetchResult(request.json())));
+	}
+);
+export const mswGetNonVersionedScriptSettings = rest.patch(
+	"*/accounts/:accountId/workers/scripts/:workerName/script-settings",
+	(request, response, context) => {
+		return response(
+			context.json(
+				createFetchResult({
+					logpush: false,
+					tail_consumers: [],
+				})
+			)
+		);
+	}
+);

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/versions.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/versions.ts
@@ -214,8 +214,8 @@ export const mswPostNewDeployment = rest.post(
 
 export const mswPatchNonVersionedScriptSettings = rest.patch(
 	"*/accounts/:accountId/workers/scripts/:workerName/script-settings",
-	(request, response, context) => {
-		return response(context.json(createFetchResult(request.json())));
+	async (request, response, context) => {
+		return response(context.json(createFetchResult(await request.json())));
 	}
 );
 export const mswGetNonVersionedScriptSettings = rest.patch(

--- a/packages/wrangler/src/__tests__/helpers/msw/index.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/index.ts
@@ -12,9 +12,11 @@ import { mswSuccessR2handlers } from "./handlers/r2";
 import { default as mswSucessScriptHandlers } from "./handlers/script";
 import { mswSuccessUserHandlers } from "./handlers/user";
 import {
+	mswGetNonVersionedScriptSettings,
 	mswGetVersion,
 	mswListNewDeployments,
 	mswListVersions,
+	mswPatchNonVersionedScriptSettings,
 	mswPostNewDeployment,
 } from "./handlers/versions";
 import { default as mswZoneHandlers } from "./handlers/zones";
@@ -61,4 +63,6 @@ export {
 	mswGetVersion,
 	mswListNewDeployments,
 	mswListVersions,
+	mswGetNonVersionedScriptSettings,
+	mswPatchNonVersionedScriptSettings,
 };

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -97,9 +97,14 @@ describe("versions deploy", () => {
 			├ Add a deployment message (skipped)
 			│
 			│
+			│ No non-versioned settings to sync. Skipping...
 			│
 			╰  SUCCESS  Deployed named-worker version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);
+
+			expect(normalizeOutput(std.out)).toContain(
+				"No non-versioned settings to sync. Skipping..."
+			);
 		});
 
 		test("fails without --name arg", async () => {
@@ -186,6 +191,7 @@ describe("versions deploy", () => {
 			├ Add a deployment message (skipped)
 			│
 			│
+			│ No non-versioned settings to sync. Skipping...
 			│
 			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);
@@ -229,6 +235,7 @@ describe("versions deploy", () => {
 			├ Add a deployment message (skipped)
 			│
 			│
+			│ No non-versioned settings to sync. Skipping...
 			│
 			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);
@@ -280,6 +287,7 @@ describe("versions deploy", () => {
 			├ Add a deployment message (skipped)
 			│
 			│
+			│ No non-versioned settings to sync. Skipping...
 			│
 			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 50% and version 00000000-0000-0000-0000-000000000000 at 50% (TIMINGS)"
 		`);
@@ -323,6 +331,7 @@ describe("versions deploy", () => {
 			├ Add a deployment message (skipped)
 			│
 			│
+			│ No non-versioned settings to sync. Skipping...
 			│
 			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);
@@ -374,6 +383,7 @@ describe("versions deploy", () => {
 			├ Add a deployment message (skipped)
 			│
 			│
+			│ No non-versioned settings to sync. Skipping...
 			│
 			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 30% and version 00000000-0000-0000-0000-000000000000 at 70% (TIMINGS)"
 		`);
@@ -425,6 +435,7 @@ describe("versions deploy", () => {
 			├ Add a deployment message (skipped)
 			│
 			│
+			│ No non-versioned settings to sync. Skipping...
 			│
 			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 40% and version 00000000-0000-0000-0000-000000000000 at 60% (TIMINGS)"
 		`);
@@ -532,6 +543,7 @@ describe("versions deploy", () => {
 			├ Add a deployment message (skipped)
 			│
 			│
+			│ No non-versioned settings to sync. Skipping...
 			│
 			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 33.333%, version 00000000-0000-0000-0000-000000000000 at 33.334%, and version 00000000-0000-0000-0000-000000000000 at 33.333% (TIMINGS)"
 		`);
@@ -579,6 +591,118 @@ describe("versions deploy", () => {
 			│ Deployment message My versioned deployment message
 			│
 			│
+			│ No non-versioned settings to sync. Skipping...
+			│
+			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+		`);
+		});
+
+		test("with logpush in wrangler.toml", async () => {
+			writeWranglerToml({
+				logpush: true,
+			});
+
+			const result = runWrangler(
+				"versions deploy 10000000-0000-0000-0000-000000000000 --yes --experimental-gradual-rollouts"
+			);
+
+			await expect(result).resolves.toBeUndefined();
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"╭ Deploy Worker Versions by splitting traffic between multiple versions
+			│
+			│
+			├ Your current deployment has 2 version(s):
+			│
+			│ (10%) 00000000-0000-0000-0000-000000000000
+			│       Created:  TIMESTAMP
+			│           Tag:  -
+			│       Message:  -
+			│
+			│ (90%) 00000000-0000-0000-0000-000000000000
+			│       Created:  TIMESTAMP
+			│           Tag:  -
+			│       Message:  -
+			│
+			│
+			├ Which version(s) do you want to deploy?
+			├ 1 Worker Version(s) selected
+			│
+			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+			│              Created:  TIMESTAMP
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├ What percentage of traffic should Worker Version 1 receive?
+			├ 100% of traffic
+			├
+			├ Add a deployment message (skipped)
+			│
+			│
+			│
+			│ Synced non-versioned settings:
+			│            logpush:  true
+			│     tail_consumers:  <skipped>
+			│
+			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+		`);
+
+			expect(normalizeOutput(std.out)).toContain("logpush:  true");
+		});
+
+		test("with logpush and tail_consumers in wrangler.toml", async () => {
+			writeWranglerToml({
+				logpush: false,
+				tail_consumers: [
+					{ service: "worker-1" },
+					{ service: "worker-2", environment: "preview" },
+					{ service: "worker-3", environment: "staging" },
+				],
+			});
+
+			const result = runWrangler(
+				"versions deploy 10000000-0000-0000-0000-000000000000 --yes --experimental-gradual-rollouts"
+			);
+
+			await expect(result).resolves.toBeUndefined();
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			"╭ Deploy Worker Versions by splitting traffic between multiple versions
+			│
+			│
+			├ Your current deployment has 2 version(s):
+			│
+			│ (10%) 00000000-0000-0000-0000-000000000000
+			│       Created:  TIMESTAMP
+			│           Tag:  -
+			│       Message:  -
+			│
+			│ (90%) 00000000-0000-0000-0000-000000000000
+			│       Created:  TIMESTAMP
+			│           Tag:  -
+			│       Message:  -
+			│
+			│
+			├ Which version(s) do you want to deploy?
+			├ 1 Worker Version(s) selected
+			│
+			├     Worker Version 1:  00000000-0000-0000-0000-000000000000
+			│              Created:  TIMESTAMP
+			│                  Tag:  -
+			│              Message:  -
+			│
+			├ What percentage of traffic should Worker Version 1 receive?
+			├ 100% of traffic
+			├
+			├ Add a deployment message (skipped)
+			│
+			│
+			│
+			│ Synced non-versioned settings:
+			│            logpush:  false
+			│     tail_consumers:  worker-1
+			│                      worker-2 (preview)
+			│                      worker-3 (staging)
 			│
 			╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -14,6 +14,7 @@ import {
 	mswGetVersion,
 	mswListNewDeployments,
 	mswListVersions,
+	mswPatchNonVersionedScriptSettings,
 	mswPostNewDeployment,
 } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
@@ -52,7 +53,8 @@ describe("versions deploy", () => {
 			mswListNewDeployments,
 			mswListVersions,
 			mswGetVersion,
-			mswPostNewDeployment
+			mswPostNewDeployment,
+			mswPatchNonVersionedScriptSettings
 		);
 	});
 

--- a/packages/wrangler/src/utils/render-labelled-values.ts
+++ b/packages/wrangler/src/utils/render-labelled-values.ts
@@ -55,7 +55,7 @@ export default function formatLabelledValues(
 								spacerCount -
 								labelLengthsWithoutANSI[i] -
 								labelAlignment.length
-						: valuesAlignment + spacerCount
+						: valuesAlignment + spacerCount + indentationCount
 				);
 
 				return prefixSpacing + line;

--- a/packages/wrangler/src/versions/api.ts
+++ b/packages/wrangler/src/versions/api.ts
@@ -137,7 +137,7 @@ export async function patchNonVersionedScriptSettings(
 	workerName: string,
 	settings: Partial<NonVersionedScriptSettings>
 ) {
-	const res = await fetchResult(
+	const res = await fetchResult<typeof settings>(
 		`/accounts/${accountId}/workers/scripts/${workerName}/script-settings`,
 		{
 			method: "PATCH",

--- a/packages/wrangler/src/versions/api.ts
+++ b/packages/wrangler/src/versions/api.ts
@@ -1,4 +1,5 @@
 import { fetchResult } from "../cfetch";
+import type { TailConsumer } from "../config/environment";
 import type {
 	ApiDeployment,
 	ApiVersion,
@@ -122,6 +123,42 @@ export async function createDeployment(
 	);
 
 	// TODO: handle specific errors
+
+	return res;
+}
+
+type NonVersionedScriptSettings = {
+	logpush: boolean;
+	tail_consumers: TailConsumer[];
+};
+
+export async function patchNonVersionedScriptSettings(
+	accountId: string,
+	workerName: string,
+	settings: Partial<NonVersionedScriptSettings>
+) {
+	const res = await fetchResult(
+		`/accounts/${accountId}/workers/scripts/${workerName}/script-settings`,
+		{
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(settings),
+		}
+	);
+
+	// TODO: handle specific errors
+
+	return res;
+}
+
+export async function fetchNonVersionedScriptSettings(
+	accountId: string,
+	workerName: string
+): Promise<NonVersionedScriptSettings> {
+	const res = await fetchResult<NonVersionedScriptSettings>(
+		`/accounts/${accountId}/workers/scripts/${workerName}/script-settings`,
+		{ method: "GET" }
+	);
 
 	return res;
 }

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -18,6 +18,7 @@ import {
 	fetchLatestDeploymentVersions,
 	fetchLatestUploadedVersions,
 	fetchVersions,
+	patchNonVersionedScriptSettings,
 } from "./api";
 import type {
 	CommonYargsArgv,
@@ -171,6 +172,11 @@ export async function versionsDeployHandler(args: VersionsDeployArgs) {
 				confirmedVersionTraffic,
 				message
 			);
+
+			await patchNonVersionedScriptSettings(accountId, workerName, {
+				logpush: config.logpush,
+				tail_consumers: config.tail_consumers,
+			});
 		},
 	});
 

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -13,6 +13,7 @@ import { UserError } from "../errors";
 import * as metrics from "../metrics";
 import { printWranglerBanner } from "../update-check";
 import { requireAuth } from "../user";
+import formatLabelledValues from "../utils/render-labelled-values";
 import {
 	createDeployment,
 	fetchLatestDeploymentVersions,
@@ -20,6 +21,7 @@ import {
 	fetchVersions,
 	patchNonVersionedScriptSettings,
 } from "./api";
+import type { Config } from "../config";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -172,13 +174,10 @@ export async function versionsDeployHandler(args: VersionsDeployArgs) {
 				confirmedVersionTraffic,
 				message
 			);
-
-			await patchNonVersionedScriptSettings(accountId, workerName, {
-				logpush: config.logpush,
-				tail_consumers: config.tail_consumers,
-			});
 		},
 	});
+
+	await maybePatchSettings(accountId, workerName, config);
 
 	const elapsedMilliseconds = Date.now() - start;
 	const elapsedSeconds = elapsedMilliseconds / 1000;
@@ -437,6 +436,57 @@ async function promptPercentages(
 	}
 
 	return confirmedVersionTraffic;
+}
+
+async function maybePatchSettings(
+	accountId: string,
+	workerName: string,
+	config: Pick<Config, "logpush" | "tail_consumers">
+) {
+	const maybeUndefinedSettings = {
+		logpush: config.logpush,
+		tail_consumers: config.tail_consumers,
+	};
+	const definedSettings = Object.fromEntries(
+		Object.entries(maybeUndefinedSettings).filter(
+			([, value]) => value !== undefined
+		)
+	);
+
+	const hasZeroSettingsToSync = Object.keys(definedSettings).length === 0;
+	if (hasZeroSettingsToSync) {
+		cli.log("No non-versioned settings to sync. Skipping...");
+		return;
+	}
+
+	const patchedSettings = await spinnerWhile({
+		startMessage: `Syncing non-versioned settings`,
+		async promise() {
+			return await patchNonVersionedScriptSettings(
+				accountId,
+				workerName,
+				definedSettings
+			);
+		},
+	});
+
+	const formattedSettings = formatLabelledValues(
+		{
+			logpush: String(patchedSettings.logpush ?? "<skipped>"),
+			tail_consumers:
+				patchedSettings.tail_consumers
+					?.map((tc) =>
+						tc.environment ? `${tc.service} (${tc.environment})` : tc.service
+					)
+					.join("\n") ?? "<skipped>",
+		},
+		{
+			labelJustification: "right",
+			indentationCount: 4,
+		}
+	);
+
+	cli.log("Synced non-versioned settings:\n" + formattedSettings);
 }
 
 // ***********


### PR DESCRIPTION
## What this PR solves / how to test

CR: https://jira.cfdata.org/browse/CR-850334

Adds a PATCH call after a `wrangler versions deploy` to save settings which could not be included in `wrangler versions upload` but are specified in wrangler.toml and expected by users to be saved upon regular `wrangler deploy`.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/13429
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
