### PR TITLE
un-quarantine the Next.js c3 e2e tests

### DIFF
--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -203,7 +203,6 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 			},
 		],
 		testCommitMessage: true,
-		quarantine: true,
 		verifyBuildCfTypes: {
 			outputFile: "env.d.ts",
 			envInterfaceName: "CloudflareEnv",


### PR DESCRIPTION
## What this PR solves / how to test

The [C2 E2E quarantined tests](https://github.com/cloudflare/workers-sdk/actions/workflows/c3-e2e-quarantine.yml) have been pretty stable as of late (with only very minor flakes), so we should be able to un-quarantine the Next.js one



## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included (this change is tests related)
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: this change is only for our internal tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: this change is only for our internal tests

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
