### PR TITLE
Versions rollback

### DIFF
--- a/.changeset/big-hounds-breathe.md
+++ b/.changeset/big-hounds-breathe.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feature: Implement versioned rollbacks via `wrangler rollback [version-id] --experimental-versions`.
+
+Please note, the `experimental-versions` flag is required to use the new behaviour. The original `wrangler rollback` command is unchanged if run without this flag.

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -611,7 +611,7 @@ export const spinner = (
 				}
 				clearLoop();
 			} else {
-				if (msg) {
+				if (msg !== undefined) {
 					logUpdate(`\n${grayBar} ${msg}`);
 				}
 				newline();

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -16,6 +16,9 @@ function matchWhoamiEmail(stdout: string): string {
 function matchVersionId(stdout: string): string {
 	return stdout.match(/Version ID:\s+([a-f\d-]+)/)?.[1] as string;
 }
+function matchDeploymentId(stdout: string): string {
+	return stdout.match(/Deployment ID:\s+([a-f\d-]+)/)?.[1] as string;
+}
 function countOccurences(stdout: string, substring: string) {
 	return stdout.split(substring).length - 1;
 }
@@ -27,6 +30,7 @@ describe("versions deploy", () => {
 	let runInRoot: typeof shellac;
 	let runInWorker: typeof shellac;
 	let normalize: (str: string) => string;
+	let versionId0: string;
 	let versionId1: string;
 	let versionId2: string;
 
@@ -55,11 +59,13 @@ describe("versions deploy", () => {
 			"To publish your Worker to the Internet, run `npm run deploy`"
 		);
 
-		// TEMP: wrangler deploy needed for the first time to *create* the worker (will create 1 extra version + deployment in snapshots below)
-		await runInWorker`$ ${WRANGLER} deploy`;
+		// TEMP: regular deploy needed for the first time to *create* the worker (will create 1 extra version + deployment in snapshots below)
+		const deploy = await runInWorker`$ ${WRANGLER} deploy`;
+
+		versionId0 = matchDeploymentId(deploy.stdout);
 	});
 
-	it("upload worker version (with message and tag)", async () => {
+	it("upload 1st worker version", async () => {
 		const upload =
 			await runInWorker`$ ${WRANGLER} versions upload --message "Upload via e2e test" --tag "e2e-upload"  --x-versions`;
 
@@ -94,7 +100,7 @@ describe("versions deploy", () => {
 		expect(list.stdout).toMatch(/Tag:\s+e2e-upload/);
 	});
 
-	it("deploy worker version", async () => {
+	it("deploy 1st worker version", async () => {
 		const deploy =
 			await runInWorker`$ ${WRANGLER} versions deploy ${versionId1}@100% --message "Deploy via e2e test" --yes  --x-versions`;
 
@@ -160,7 +166,7 @@ describe("versions deploy", () => {
 		expect(list.stdout).toContain(versionId1);
 	});
 
-	it("modify & upload worker version", async () => {
+	it("modify & upload 2nd worker version", async () => {
 		await seed(workerPath, {
 			"src/index.ts": dedent`
 				export default {
@@ -180,12 +186,11 @@ describe("versions deploy", () => {
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Uploaded tmp-e2e-wrangler (TIMINGS)"
 		`);
-	});
 
-	it("list 2 versions", async () => {
-		const list = await runInWorker`$ ${WRANGLER} versions list  --x-versions`;
+		const versionsList =
+			await runInWorker`$ ${WRANGLER} versions list  --x-versions`;
 
-		expect(normalize(list.stdout)).toMatchInlineSnapshot(`
+		expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
 			"Version ID:  00000000-0000-0000-0000-000000000000
 			Created:     TIMESTAMP
 			Author:      person@example.com
@@ -206,13 +211,16 @@ describe("versions deploy", () => {
 			Message:     -"
 		`);
 
-		expect(list.stdout).toMatch(/Message:\s+Upload AGAIN via e2e test/);
-		expect(list.stdout).toMatch(/Tag:\s+e2e-upload-AGAIN/);
+		expect(versionsList.stdout).toMatch(/Message:\s+Upload AGAIN via e2e test/);
+		expect(versionsList.stdout).toMatch(/Tag:\s+e2e-upload-AGAIN/);
 	});
 
-	it("deploy worker version", async () => {
+	it("deploy 2nd worker version", async () => {
 		const deploy =
 			await runInWorker`$ ${WRANGLER} versions deploy ${versionId2}@100% --message "Deploy AGAIN via e2e test" --yes  --x-versions`;
+
+		const deploymentsList =
+			await runInWorker`$ ${WRANGLER} deployments list  --x-versions`;
 
 		expect(normalize(deploy.stdout)).toMatchInlineSnapshot(`
 			"╭ Deploy Worker Versions by splitting traffic between multiple versions
@@ -247,13 +255,9 @@ describe("versions deploy", () => {
 			│
 			╰  SUCCESS  Deployed tmp-e2e-wrangler version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);
-	});
 
-	it("list 2 deployments", async () => {
-		const list =
-			await runInWorker`$ ${WRANGLER} deployments list  --x-versions`;
-
-		expect(normalize(list.stdout)).toMatchInlineSnapshot(`
+		// list 2 deployments (+ old deployment)
+		expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`
 			"Created:     TIMESTAMP
 			Author:      person@example.com
 			Source:      Unknown (deployment)
@@ -279,15 +283,22 @@ describe("versions deploy", () => {
 			                     Tag:  -
 			                 Message:  -"
 		`);
-		expect(list.stderr).toMatchInlineSnapshot('""');
+		expect(deploymentsList.stderr).toMatchInlineSnapshot('""');
 
-		expect(list.stdout).toContain(versionId1);
-		expect(list.stdout).toContain(versionId2);
+		expect(countOccurences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
+		expect(countOccurences(deploymentsList.stdout, versionId1)).toBe(1); // once for versions deploy, only
+		expect(countOccurences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
 	});
 
-	it("rollback to first worker version", async () => {
+	it("rollback to implicit worker version (1st version)", async () => {
 		const rollback =
 			await runInWorker`$ ${WRANGLER} rollback --message "Rollback via e2e test" --yes  --x-versions`;
+
+		const versionsList =
+			await runInWorker`$ ${WRANGLER} versions list  --x-versions`;
+
+		const deploymentsList =
+			await runInWorker`$ ${WRANGLER} deployments list  --x-versions`;
 
 		expect(normalize(rollback.stdout)).toMatchInlineSnapshot(`
 			"├ Fetching latest deployment
@@ -326,12 +337,9 @@ describe("versions deploy", () => {
 		expect(rollback.stdout).toContain(
 			`Worker Version ${versionId1} has been deployed to 100% of traffic`
 		);
-	});
 
-	it("list same versions as before rollback (no new versions)", async () => {
-		const list = await runInWorker`$ ${WRANGLER} versions list  --x-versions`;
-
-		expect(normalize(list.stdout)).toMatchInlineSnapshot(`
+		// list same versions as before (no new versions created)
+		expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
 			"Version ID:  00000000-0000-0000-0000-000000000000
 			Created:     TIMESTAMP
 			Author:      person@example.com
@@ -351,13 +359,9 @@ describe("versions deploy", () => {
 			Tag:         -
 			Message:     -"
 		`);
-	});
 
-	it("list deployments with new rollback deployment of first version (1 new deployment)", async () => {
-		const list =
-			await runInWorker`$ ${WRANGLER} deployments list  --x-versions`;
-
-		expect(normalize(list.stdout)).toMatchInlineSnapshot(`
+		// list deployments with new rollback deployment of 1st version (1 new deployment created)
+		expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`
 			"Created:     TIMESTAMP
 			Author:      person@example.com
 			Source:      Unknown (deployment)
@@ -392,8 +396,125 @@ describe("versions deploy", () => {
 			                 Message:  -"
 		`);
 
-		expect(countOccurences(list.stdout, versionId1)).toBe(2); // once for deploy, once for rollback
-		expect(countOccurences(list.stdout, versionId2)).toBe(1); // once for deploy, only
+		expect(countOccurences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
+		expect(countOccurences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
+		expect(countOccurences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
+	});
+
+	it("rollback to specific worker version (0th version)", async () => {
+		const rollback =
+			await runInWorker`$ ${WRANGLER} rollback ${versionId0} --message "Rollback to old version" --yes  --x-versions`;
+
+		const versionsList =
+			await runInWorker`$ ${WRANGLER} versions list  --x-versions`;
+
+		const deploymentsList =
+			await runInWorker`$ ${WRANGLER} deployments list  --x-versions`;
+
+		expect(normalize(rollback.stdout)).toMatchInlineSnapshot(`
+			"├ Fetching latest deployment
+			│
+			├ Your current deployment has 1 version(s):
+			│
+			│ (100%) 00000000-0000-0000-0000-000000000000
+			│       Created:  TIMESTAMP
+			│           Tag:  e2e-upload
+			│       Message:  Upload via e2e test
+			│
+			├ Please provide a message for this rollback (120 characters max, optional)?
+			│ Message Rollback to old version
+			│
+			│
+			╰  WARNING  You are about to rollback to Worker Version 00000000-0000-0000-0000-000000000000:
+			│
+			│ (100%) 00000000-0000-0000-0000-000000000000
+			│       Created:  TIMESTAMP
+			│           Tag:  -
+			│       Message:  -
+			│
+			├ Are you sure you want to deploy this Worker Version to 100% of traffic?
+			│ yes Rollback
+			│
+			├ Performing rollback
+			│
+			│
+			│
+			╰  SUCCESS  Worker Version 00000000-0000-0000-0000-000000000000 has been deployed to 100% of traffic."
+		`);
+
+		expect(rollback.stdout).toContain(
+			`Worker Version ${versionId0} has been deployed to 100% of traffic`
+		);
+
+		// list same versions as before (no new versions created)
+		expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
+			"Version ID:  00000000-0000-0000-0000-000000000000
+			Created:     TIMESTAMP
+			Author:      person@example.com
+			Source:      Unknown (version_upload)
+			Tag:         e2e-upload-AGAIN
+			Message:     Upload AGAIN via e2e test
+			Version ID:  00000000-0000-0000-0000-000000000000
+			Created:     TIMESTAMP
+			Author:      person@example.com
+			Source:      Unknown (version_upload)
+			Tag:         e2e-upload
+			Message:     Upload via e2e test
+			Version ID:  00000000-0000-0000-0000-000000000000
+			Created:     TIMESTAMP
+			Author:      person@example.com
+			Source:      Upload
+			Tag:         -
+			Message:     -"
+		`);
+
+		// list deployments with new rollback deployment of 0th version (1 new deployment created)
+		expect(normalize(deploymentsList.stdout)).toMatchInlineSnapshot(`
+			"Created:     TIMESTAMP
+			Author:      person@example.com
+			Source:      Unknown (deployment)
+			Message:     Rollback to old version
+			Version(s):  (100%) 00000000-0000-0000-0000-000000000000
+			                 Created:  TIMESTAMP
+			                     Tag:  -
+			                 Message:  -
+			Created:     TIMESTAMP
+			Author:      person@example.com
+			Source:      Unknown (deployment)
+			Message:     Rollback via e2e test
+			Version(s):  (100%) 00000000-0000-0000-0000-000000000000
+			                 Created:  TIMESTAMP
+			                     Tag:  e2e-upload
+			                 Message:  Upload via e2e test
+			Created:     TIMESTAMP
+			Author:      person@example.com
+			Source:      Unknown (deployment)
+			Message:     Deploy AGAIN via e2e test
+			Version(s):  (100%) 00000000-0000-0000-0000-000000000000
+			                 Created:  TIMESTAMP
+			                     Tag:  e2e-upload-AGAIN
+			                 Message:  Upload AGAIN via e2e test
+			Created:     TIMESTAMP
+			Author:      person@example.com
+			Source:      Unknown (deployment)
+			Message:     Deploy via e2e test
+			Version(s):  (100%) 00000000-0000-0000-0000-000000000000
+			                 Created:  TIMESTAMP
+			                     Tag:  e2e-upload
+			                 Message:  Upload via e2e test
+			Created:     TIMESTAMP
+			Author:      person@example.com
+			Source:      Upload
+			Message:     Automatic deployment on upload.
+			Version(s):  (100%) 00000000-0000-0000-0000-000000000000
+			                 Created:  TIMESTAMP
+			                     Tag:  -
+			                 Message:  -"
+		`);
+
+		expect(countOccurences(deploymentsList.stdout, versionId0)).toBe(2); // once for regular deploy, once for rollback
+		expect(countOccurences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
+		expect(countOccurences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
 	});
 
 	it("delete worker", async () => {

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -23,7 +23,7 @@ import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
-import type { Percentage, VersionCache, VersionId } from "./types";
+import type { ApiVersion, Percentage, VersionCache, VersionId } from "./types";
 
 const EPSILON = 0.001; // used to avoid floating-point errors. Comparions to a value +/- EPSILON will mean "roughly equals the value".
 const BLANK_INPUT = "-"; // To be used where optional user-input is displayed and the value is nullish
@@ -198,7 +198,7 @@ function getConfig(
 	return config;
 }
 
-async function printLatestDeployment(
+export async function printLatestDeployment(
 	accountId: string,
 	workerName: string,
 	versionCache: VersionCache
@@ -214,6 +214,13 @@ async function printLatestDeployment(
 		`${leftT} Your current deployment has ${versions.length} version(s):`
 	);
 
+	printVersions(versions, traffic);
+}
+
+export function printVersions(
+	versions: ApiVersion[],
+	traffic: Map<VersionId, Percentage>
+) {
 	for (const version of versions) {
 		const trafficString = brandColor(`(${traffic.get(version.id)}%)`);
 		const versionIdString = white(version.id);

--- a/packages/wrangler/src/versions/deployments/list.ts
+++ b/packages/wrangler/src/versions/deployments/list.ts
@@ -1,15 +1,13 @@
 import assert from "assert";
-import path from "path";
 import { logRaw } from "@cloudflare/cli";
 import { brandColor, gray } from "@cloudflare/cli/colors";
-import { findWranglerToml, readConfig } from "../../config";
 import { UserError } from "../../errors";
 import * as metrics from "../../metrics";
 import { printWranglerBanner } from "../../update-check";
 import { requireAuth } from "../../user";
 import formatLabelledValues from "../../utils/render-labelled-values";
 import { fetchLatestDeployments, fetchVersions } from "../api";
-import { getVersionSource } from "../list";
+import { getConfig, getVersionSource } from "../list";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -94,19 +92,6 @@ export async function versionsDeploymentsListHandler(
 	});
 
 	logRaw(formattedDeployments.join("\n\n"));
-}
-
-function getConfig(
-	args: Pick<
-		VersionsDeloymentsListArgs,
-		"config" | "name" | "experimentalJsonConfig"
-	>
-) {
-	const configPath =
-		args.config || (args.name && findWranglerToml(path.dirname(args.name)));
-	const config = readConfig(configPath, args);
-
-	return config;
 }
 
 export function getDeploymentSource(deployment: ApiDeployment) {

--- a/packages/wrangler/src/versions/deployments/status.ts
+++ b/packages/wrangler/src/versions/deployments/status.ts
@@ -1,14 +1,13 @@
 import assert from "assert";
-import path from "path";
 import { logRaw } from "@cloudflare/cli";
 import { brandColor, gray } from "@cloudflare/cli/colors";
-import { findWranglerToml, readConfig } from "../../config";
 import { UserError } from "../../errors";
 import * as metrics from "../../metrics";
 import { printWranglerBanner } from "../../update-check";
 import { requireAuth } from "../../user";
 import formatLabelledValues from "../../utils/render-labelled-values";
 import { fetchLatestDeployment, fetchVersions } from "../api";
+import { getConfig } from "../list";
 import { getDeploymentSource } from "./list";
 import type {
 	CommonYargsArgv,
@@ -95,17 +94,4 @@ export async function versionsDeploymentsStatusHandler(
 	});
 
 	logRaw(formattedDeployment);
-}
-
-function getConfig(
-	args: Pick<
-		VersionsDeploymentsStatusArgs,
-		"config" | "name" | "experimentalJsonConfig"
-	>
-) {
-	const configPath =
-		args.config || (args.name && findWranglerToml(path.dirname(args.name)));
-	const config = readConfig(configPath, args);
-
-	return config;
 }

--- a/packages/wrangler/src/versions/rollback/index.ts
+++ b/packages/wrangler/src/versions/rollback/index.ts
@@ -1,0 +1,147 @@
+import * as cli from "@cloudflare/cli";
+import { inputPrompt, spinnerWhile } from "@cloudflare/cli/interactive";
+import { UserError } from "../../errors";
+import { requireAuth } from "../../user";
+import { createDeployment, fetchLatestDeployments, fetchVersion } from "../api";
+import { printLatestDeployment, printVersions } from "../deploy";
+import { getConfig } from "../list";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+	SubHelp,
+} from "../../yargs-types";
+import type { VersionId } from "../types";
+
+export type VersionsRollbackArgs = StrictYargsOptionsToInterface<
+	typeof versionsRollbackOptions
+>;
+
+export default function registerVersionsRollbackCommand(
+	yargs: CommonYargsArgv,
+	epilogue: string,
+	subHelp: SubHelp
+) {
+	return yargs
+		.command(
+			"rollback [version-id]",
+			"🔙 Rollback to a Worker Version",
+			versionsRollbackOptions,
+			versionsRollbackHandler
+		)
+		.command(subHelp)
+		.epilogue(epilogue);
+}
+
+export function versionsRollbackOptions(rollbackYargs: CommonYargsArgv) {
+	return rollbackYargs
+		.positional("version-id", {
+			describe: "The ID of the Worker Version to rollback to",
+			type: "string",
+			demandOption: false,
+		})
+		.option("name", {
+			describe: "The name of your worker",
+			type: "string",
+		})
+		.option("message", {
+			alias: "m",
+			describe: "The reason for this rollback (optional)",
+			type: "string",
+			default: undefined,
+		})
+		.option("yes", {
+			alias: "y",
+			describe: "Automatically accept defaults to prompts",
+			type: "boolean",
+			default: false,
+		});
+}
+
+export async function versionsRollbackHandler(args: VersionsRollbackArgs) {
+	const config = getConfig(args);
+	const accountId = await requireAuth(config);
+	const workerName = args.name ?? config.name;
+
+	if (workerName === undefined) {
+		throw new UserError(
+			'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+		);
+	}
+
+	await printLatestDeployment(accountId, workerName, new Map());
+
+	const versionId =
+		args.versionId ??
+		(await spinnerWhile({
+			promise: fetchDefaultRollbackVersionId(accountId, workerName),
+			startMessage: "Finding latest stable Worker Version to rollback to",
+			endMessage: "",
+		}));
+
+	const message = await inputPrompt({
+		type: "text",
+		label: "Message",
+		question:
+			"Please provide a message for this rollback (120 characters max, optional)?",
+		defaultValue: args.message ?? "Rollback",
+		acceptDefault: args.yes,
+	});
+
+	const version = await fetchVersion(accountId, workerName, versionId);
+	cli.warn(`You are about to rollback to Worker Version ${versionId}:`);
+	const rollbackTraffic = new Map([[versionId, 100]]);
+	printVersions([version], rollbackTraffic);
+
+	const confirm = await inputPrompt({
+		type: "confirm",
+		label: "Rollback",
+		question:
+			"Are you sure you want to deploy this Worker Version to 100% of traffic?",
+		defaultValue: args.yes, // defaultValue: false.    if --yes, defaultValue: true
+		acceptDefault: args.yes,
+	});
+
+	if (!confirm) {
+		cli.log("Aborting rollback...");
+		return;
+	}
+
+	await spinnerWhile({
+		async promise() {
+			await createDeployment(accountId, workerName, rollbackTraffic, message);
+		},
+		startMessage: `Performing rollback`,
+		endMessage: "",
+	});
+
+	cli.success(
+		`Worker Version ${versionId} has been deployed to 100% of traffic.`
+	);
+}
+
+async function fetchDefaultRollbackVersionId(
+	accountId: string,
+	workerName: string
+): Promise<VersionId> {
+	const deployments = await fetchLatestDeployments(accountId, workerName);
+
+	// sort by latest first
+	deployments.sort((a, b) => b.created_on.localeCompare(a.created_on));
+
+	// we don't want to rollback to the current deployment so remove the latest (current) deployment
+	deployments.shift();
+
+	for (const deployment of deployments) {
+		// we define a stable version as one deployed to 100%
+		const stableVersion = deployment.versions.find(
+			({ percentage }) => percentage === 100
+		);
+
+		if (stableVersion) return stableVersion.version_id;
+	}
+
+	// if we get here, we did not find a stable version
+	throw new Error(
+		"Could not find stable Worker Version to rollback to. Please try again with an explicit Version ID."
+	);
+}

--- a/packages/wrangler/src/yargs-types.ts
+++ b/packages/wrangler/src/yargs-types.ts
@@ -1,5 +1,5 @@
 import type { OnlyCamelCase } from "./config/config";
-import type { ArgumentsCamelCase, Argv } from "yargs";
+import type { ArgumentsCamelCase, Argv, CommandModule } from "yargs";
 
 /**
  * Yargs options included in every wrangler command.
@@ -65,3 +65,5 @@ export function asJson(yargs: CommonYargsArgv): CommonYargsArgvJSON {
 		default: false,
 	});
 }
+
+export type SubHelp = CommandModule<CommonYargsOptions, CommonYargsOptions>;


### PR DESCRIPTION
## What this PR solves / how to test

CR: https://jira.cfdata.org/browse/CR-850334

This PR implements versioned rollbacks via `wrangler rollback [version-id] --experimental-versions`.

Please note, the `experimental-versions` flag is required to use the new behaviour and the original `wrangler rollback` command is unchanged if run without this flag. 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/13429
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
