### PR TITLE
fix(wrangler): Improvements to `--init-from-dash`

### DIFF
--- a/.changeset/eighty-peas-clean.md
+++ b/.changeset/eighty-peas-clean.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Improvements to `--init-from-dash`
+
+Adds user-specified CPU limit to `wrangler.toml` if one exists. Excludes `usage_model` from `wrangler.toml` in all cases, since this field is deprecated and no longer used.


### PR DESCRIPTION
- Include [user limits](https://developers.cloudflare.com/workers/wrangler/configuration/#limits) in wrangler.toml
- Hide usage model from wrangler.toml in all cases

## What this PR solves / how to test

Fixes WP-868. The `usage_model` config field is always ignored by wrangler and should not be set.

## Author has addressed the following

- Tests
  - [x] Included
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
- Public documentation
  - [x] Not necessary because: These are bugfixes.

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
