### PR TITLE
Add `wrangler.toml` support in `pages deploy`

### DIFF
--- a/.changeset/chilly-queens-compare.md
+++ b/.changeset/chilly-queens-compare.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: Add `wrangler.toml` support in `wrangler pages deploy`
+
+As we are adding `wrangler.toml` support for Pages, we want to ensure that `wrangler pages deploy` works with a configuration file.

--- a/fixtures/pages-functions-with-config-file-app/wrangler.toml
+++ b/fixtures/pages-functions-with-config-file-app/wrangler.toml
@@ -1,7 +1,6 @@
 pages_build_output_dir = "./public"
-name = "pages-with-config-file-app"
+name = "pages-functions-with-config-file-app"
 compatibility_date = "2024-01-01"
-#compatibility_flags = []
 
 [vars]
 VAR1 = "holiday"

--- a/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
@@ -7,7 +7,7 @@ import { runInTempDir } from "./../helpers/run-in-tmp";
 import { runWrangler } from "./../helpers/run-wrangler";
 import type { Deployment } from "./../../pages/types";
 
-describe("deployment list", () => {
+describe("pages deployment list", () => {
 	runInTempDir();
 	mockAccountId();
 	mockApiToken();

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -12,7 +12,7 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { replaceRandomWithConstantData } from "../helpers/string-dynamic-values-matcher";
 
-describe("functions build", () => {
+describe("pages functions build", () => {
 	const std = mockConsoleMethods();
 
 	runInTempDir();

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -4,7 +4,7 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import writeWranglerToml from "../helpers/write-wrangler-toml";
 
-describe("pages-build-env", () => {
+describe("pages build env", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
 	const originalEnv = process.env;

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -270,7 +270,7 @@ function mockSupportingDashRequests(
 		)
 	);
 }
-describe("pages-download-config", () => {
+describe("pages download config", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
 

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -6,7 +6,7 @@ import { msw } from "./../helpers/msw";
 import { runInTempDir } from "./../helpers/run-in-tmp";
 import { runWrangler } from "./../helpers/run-wrangler";
 
-describe("project create", () => {
+describe("pages project create", () => {
 	const std = mockConsoleMethods();
 
 	runInTempDir();

--- a/packages/wrangler/src/__tests__/pages/project-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-delete.test.ts
@@ -8,7 +8,7 @@ import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 
-describe("project delete", () => {
+describe("pages project delete", () => {
 	const std = mockConsoleMethods();
 
 	runInTempDir();

--- a/packages/wrangler/src/__tests__/pages/project-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-list.test.ts
@@ -7,7 +7,7 @@ import { runInTempDir } from "./../helpers/run-in-tmp";
 import { runWrangler } from "./../helpers/run-wrangler";
 import type { Project } from "./../../pages/types";
 
-describe("project list", () => {
+describe("pages project list", () => {
 	runInTempDir();
 	mockConsoleMethods();
 	mockAccountId();

--- a/packages/wrangler/src/__tests__/pages/project-upload.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-upload.test.ts
@@ -12,7 +12,7 @@ import { runWrangler } from "../helpers/run-wrangler";
 import type { UploadPayloadFile } from "../../pages/types";
 import type { RestRequest } from "msw";
 
-describe("project upload", () => {
+describe("pages project upload", () => {
 	const ENV_COPY = process.env;
 	const std = mockConsoleMethods();
 

--- a/packages/wrangler/src/__tests__/pages/project-validate.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-validate.test.ts
@@ -11,7 +11,7 @@ jest.mock("../../pages/constants", () => ({
 	MAX_ASSET_COUNT: 10,
 }));
 
-describe("project validate", () => {
+describe("pages project validate", () => {
 	const std = mockConsoleMethods();
 
 	runInTempDir();

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -169,9 +169,10 @@ export async function deploy({
 	}
 
 	const nodejsCompat =
-		config?.compatibility_flags?.includes("nodejs_compat") ??
-		deploymentConfig.compatibility_flags?.includes("nodejs_compat") ??
-		false;
+		config !== undefined
+			? config.compatibility_flags?.includes("nodejs_compat") ?? false
+			: deploymentConfig.compatibility_flags?.includes("nodejs_compat") ??
+			  false;
 	const defineNavigatorUserAgent = isNavigatorDefined(
 		config?.compatibility_date ?? deploymentConfig.compatibility_date,
 		config?.compatibility_flags ?? deploymentConfig.compatibility_flags

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -111,7 +111,8 @@ export function readConfig<CommandArgs>(
 		);
 
 		const envNames = rawConfig.env ? Object.keys(rawConfig.env) : [];
-		const pagesDiagnostics = validatePagesConfig(config, envNames);
+		const projectName = rawConfig?.name;
+		const pagesDiagnostics = validatePagesConfig(config, envNames, projectName);
 
 		if (pagesDiagnostics.hasWarnings()) {
 			logger.warn(pagesDiagnostics.renderWarnings());

--- a/packages/wrangler/src/config/validation-pages.ts
+++ b/packages/wrangler/src/config/validation-pages.ts
@@ -90,7 +90,7 @@ function validateProjectName(
 
 /**
  * Validate that no named-environments other than "preview" and "production"
- * were specififed in the configuration file for Pages
+ * were specified in the configuration file for Pages
  */
 function validatePagesEnvironmentNames(
 	envNames: string[],

--- a/packages/wrangler/src/config/validation-pages.ts
+++ b/packages/wrangler/src/config/validation-pages.ts
@@ -39,11 +39,12 @@ const supportedPagesConfigFields = [
 
 export function validatePagesConfig(
 	config: Config,
-	envNames: string[]
+	envNames: string[],
+	projectName?: string
 ): Diagnostics {
 	// exhaustive check
 	if (!config.pages_build_output_dir) {
-		throw new FatalError(`Attempting to validate Pages configuration file, but no "pages_build_output_dir" configuration key was found.
+		throw new FatalError(`Attempting to validate Pages configuration file, but "pages_build_output_dir" field was not found.
 		"pages_build_output_dir" is required for Pages projects.`);
 	}
 
@@ -52,6 +53,7 @@ export function validatePagesConfig(
 	);
 
 	validateMainField(config, diagnostics);
+	validateProjectName(projectName, diagnostics);
 	validatePagesEnvironmentNames(envNames, diagnostics);
 	validateUnsupportedFields(config, diagnostics);
 
@@ -59,7 +61,7 @@ export function validatePagesConfig(
 }
 
 /**
- * Validate that configuration file doesn't declare "main", if
+ * Validate that configuration file doesn't specify "main", if
  * "pages_build_output_dir" is present
  */
 function validateMainField(config: Config, diagnostics: Diagnostics) {
@@ -72,8 +74,23 @@ function validateMainField(config: Config, diagnostics: Diagnostics) {
 }
 
 /**
+ * Validate that "name" field is specified at the top-level
+ */
+function validateProjectName(
+	name: string | undefined,
+	diagnostics: Diagnostics
+) {
+	if (name === undefined || name.trim() === "") {
+		diagnostics.errors.push(
+			`Missing top-level field "name" in configuration file.\n` +
+				`Pages requires the name of your project to be configured at the top-level of your \`wrangler.toml\` file. This is because, in Pages, environments target the same project.`
+		);
+	}
+}
+
+/**
  * Validate that no named-environments other than "preview" and "production"
- * were declared in the configuration file for Pages
+ * were specififed in the configuration file for Pages
  */
 function validatePagesEnvironmentNames(
 	envNames: string[],

--- a/packages/wrangler/src/pages/deploy.tsx
+++ b/packages/wrangler/src/pages/deploy.tsx
@@ -100,8 +100,8 @@ export const Handler = async (args: PagesDeployArgs) => {
 		/*
 		 * this reads the config file with `env` set to `undefined`, which will
 		 * return the top-level config. This contains all the information we
-		 * need from now. We will perform a second config file read later
-		 * in `/api/pages/deploy`, that will get the environment specififc config
+		 * need for now. We will perform a second config file read later
+		 * in `/api/pages/deploy`, that will get the environment specific config
 		 */
 		config = readConfig(configPath, { ...args, env: undefined }, true);
 	} catch (err) {
@@ -113,8 +113,6 @@ export const Handler = async (args: PagesDeployArgs) => {
 			throw err;
 		}
 	}
-
-	// const isPagesConfig = isPagesWranglerToml(configPath);
 
 	/*
 	 * If we found a `wrangler.toml` config file that doesn't specify
@@ -163,10 +161,7 @@ export const Handler = async (args: PagesDeployArgs) => {
 	}
 
 	const isInteractive = process.stdin.isTTY;
-	if (
-		(!projectName || (projectName !== undefined && !isExistingProject)) &&
-		isInteractive
-	) {
+	if ((!projectName || !isExistingProject) && isInteractive) {
 		let existingOrNew: "existing" | "new" = "new";
 
 		/*

--- a/packages/wrangler/src/pages/deploy.tsx
+++ b/packages/wrangler/src/pages/deploy.tsx
@@ -4,6 +4,7 @@ import SelectInput from "ink-select-input";
 import React from "react";
 import { deploy } from "../api/pages/deploy";
 import { fetchResult } from "../cfetch";
+import { findWranglerToml, isPagesWranglerToml, readConfig } from "../config";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { prompt } from "../dialogs";
 import { FatalError } from "../errors";
@@ -13,6 +14,7 @@ import { requireAuth } from "../user";
 import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
 import { listProjects } from "./projects";
 import { promptSelectProject } from "./prompt-select-project";
+import type { Config } from "../config";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -20,7 +22,7 @@ import type {
 import type { PagesConfigCache } from "./types";
 import type { Project } from "@cloudflare/types";
 
-type PublishArgs = StrictYargsOptionsToInterface<typeof Options>;
+type PagesDeployArgs = StrictYargsOptionsToInterface<typeof Options>;
 
 export function Options(yargs: CommonYargsArgv) {
 	return yargs
@@ -73,76 +75,137 @@ export function Options(yargs: CommonYargsArgv) {
 		});
 }
 
-export const Handler = async ({
-	_,
-	directory,
-	projectName,
-	branch,
-	commitHash,
-	commitMessage,
-	commitDirty,
-	skipCaching,
-	bundle,
-	noBundle,
-	config: wranglerConfig,
-}: PublishArgs) => {
+export const Handler = async (args: PagesDeployArgs) => {
+	let { branch, commitHash, commitMessage, commitDirty } = args;
+
 	// Check for deprecated `wrangler pages publish` command
-	if (_[1] === "publish") {
+	if (args._[1] === "publish") {
 		logger.warn(
 			"`wrangler pages publish` is deprecated and will be removed in the next major version.\nPlease use `wrangler pages deploy` instead, which accepts exactly the same arguments."
 		);
 	}
 
-	if (wranglerConfig) {
-		throw new FatalError("Pages does not support wrangler.toml", 1);
+	if (args.config) {
+		throw new FatalError(
+			"Pages does not support custom paths for the `wrangler.toml` configuration file",
+			1
+		);
 	}
 
+	let config: Config | undefined;
+	const configPath = findWranglerToml(process.cwd(), false);
+	const isPagesConfig = isPagesWranglerToml(configPath);
+
+	/*
+	 * If we found a `wrangler.toml` config file that doesn't specify
+	 * `pages_build_output_dir`, we'll ignore the file, but inform users
+	 * that we did find one, just not valid for Pages.
+	 */
+	if (configPath && isPagesConfig === false) {
+		logger.warn(
+			`Pages now has wrangler.toml support.\n` +
+				`We detected a configuration file at ${configPath} but it is missing the "pages_build_output_dir" field, required by Pages.\n` +
+				`If you would like to use this configuration file to deploy your project, please use "pages_build_output_dir" to specify the directory of static files to upload.\n` +
+				`Ignoring configuration file for now, and proceeding with project deploy.`
+		);
+	}
+
+	if (isPagesConfig) {
+		/*
+		 * this reads the config file with `env` set to `undefined`, which will
+		 * return the top-level config. This contains all the information we
+		 * need from now. We will perform a second config file read later
+		 * in `/api/pages/deploy`, that will get the environment specififc config
+		 */
+		config = readConfig(configPath, { ...args, env: undefined });
+	}
+
+	const directory = args.directory ?? config?.pages_build_output_dir;
 	if (!directory) {
-		throw new FatalError("Must specify a directory.", 1);
+		throw new FatalError(
+			"Must specify a directory of assets to deploy. Please specify the [<directory>] argument in the `pages deploy` command, or configure `pages_build_output_dir` in your `wrangler.toml` configuration file.",
+			1
+		);
 	}
 
-	const config = getConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME);
-	const accountId = await requireAuth(config);
+	const configCache = getConfigCache<PagesConfigCache>(
+		PAGES_CONFIG_CACHE_FILENAME
+	);
+	const accountId = await requireAuth(configCache);
 
-	projectName ??= config.project_name;
+	let projectName =
+		args.projectName ?? config?.name ?? configCache.project_name;
+	let isExistingProject = true;
+
+	if (projectName) {
+		try {
+			await fetchResult<Project>(
+				`/accounts/${accountId}/pages/projects/${projectName}`
+			);
+		} catch (err) {
+			// code `8000007` corresponds to project not found
+			if ((err as { code: number }).code !== 8000007) {
+				throw err;
+			} else {
+				isExistingProject = false;
+			}
+		}
+	}
 
 	const isInteractive = process.stdin.isTTY;
-	if (!projectName && isInteractive) {
-		const projects = (await listProjects({ accountId })).filter(
-			(project) => !project.source
-		);
-
+	if (
+		(!projectName || (projectName !== undefined && !isExistingProject)) &&
+		isInteractive
+	) {
 		let existingOrNew: "existing" | "new" = "new";
 
-		if (projects.length > 0) {
-			existingOrNew = await new Promise<"new" | "existing">((resolve) => {
-				const { unmount } = render(
-					<>
-						<Text>
-							No project selected. Would you like to create one or use an
-							existing project?
-						</Text>
-						<SelectInput
-							items={[
-								{
-									key: "new",
-									label: "Create a new project",
-									value: "new",
-								},
-								{
-									key: "existing",
-									label: "Use an existing project",
-									value: "existing",
-								},
-							]}
-							onSelect={async (selected) => {
-								resolve(selected.value as "new" | "existing");
-								unmount();
-							}}
-						/>
-					</>
-				);
-			});
+		/*
+		 * if no project name was specified, we should give users the option
+		 * of creating a new project, or selecting an existing one, if any are
+		 * associated with their `accountId`
+		 */
+		if (!projectName) {
+			// get projects that are not connected to an SCM source (GitHub/GitLab)
+			// aka direct-upload projects
+			const duProjects = (await listProjects({ accountId })).filter(
+				(project) => !project.source
+			);
+
+			if (duProjects.length > 0) {
+				const message =
+					"No project specified. Would you like to create one or use an existing project?";
+				const items: NewOrExistingItem[] = [
+					{
+						key: "new",
+						label: "Create a new project",
+						value: "new",
+					},
+					{
+						key: "existing",
+						label: "Use an existing project",
+						value: "existing",
+					},
+				];
+
+				existingOrNew = await promptSelectExistingOrNewProject(message, items);
+			}
+		}
+
+		/*
+		 * if project name was specified, but no project with that name is
+		 * associated with their `accountId`, we should offer users the option
+		 * to create that project for them
+		 */
+		if (projectName !== undefined && !isExistingProject) {
+			const message = `The project you specified does not exist: "${projectName}". Would you like to create it?"`;
+			const items: NewOrExistingItem[] = [
+				{
+					key: "new",
+					label: "Create a new project",
+					value: "new",
+				},
+			];
+			existingOrNew = await promptSelectExistingOrNewProject(message, items);
 		}
 
 		switch (existingOrNew) {
@@ -151,10 +214,12 @@ export const Handler = async ({
 				break;
 			}
 			case "new": {
-				projectName = await prompt("Enter the name of your new project:");
-
 				if (!projectName) {
-					throw new FatalError("Must specify a project name.", 1);
+					projectName = await prompt("Enter the name of your new project:");
+
+					if (!projectName) {
+						throw new FatalError("Must specify a project name.", 1);
+					}
 				}
 
 				let isGitDir = true;
@@ -252,13 +317,14 @@ export const Handler = async ({
 		accountId,
 		projectName,
 		branch,
-		skipCaching,
 		commitMessage,
 		commitHash,
 		commitDirty,
+		skipCaching: args.skipCaching,
 		// TODO: Here lies a known bug. If you specify both `--bundle` and `--no-bundle`, this behavior is undefined and you will get unexpected results.
 		// There is no sane way to get the true value out of yargs, so here we are.
-		bundle: bundle ?? !noBundle,
+		bundle: args.bundle ?? !args.noBundle,
+		args,
 	});
 
 	saveToConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME, {
@@ -271,3 +337,29 @@ export const Handler = async ({
 	);
 	await metrics.sendMetricsEvent("create pages deployment");
 };
+
+type NewOrExistingItem = {
+	key: string;
+	label: string;
+	value: "new" | "existing";
+};
+
+function promptSelectExistingOrNewProject(
+	message: string,
+	items: NewOrExistingItem[]
+): Promise<"new" | "existing"> {
+	return new Promise<"new" | "existing">((resolve) => {
+		const { unmount } = render(
+			<>
+				<Text>{message}</Text>
+				<SelectInput
+					items={items}
+					onSelect={async (selected) => {
+						resolve(selected.value as "new" | "existing");
+						unmount();
+					}}
+				/>
+			</>
+		);
+	});
+}

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -267,6 +267,8 @@ export const Handler = async (args: PagesDevArguments) => {
 		);
 	}
 
+	// for `dev` we always use the top-level config, which means we need
+	// to read the config file with `env` set to `undefined`
 	const config = readConfig(undefined, args);
 	const resolvedDirectory = args.directory ?? config.pages_build_output_dir;
 	const [_pages, _dev, ...remaining] = args._;

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -269,7 +269,7 @@ export const Handler = async (args: PagesDevArguments) => {
 
 	// for `dev` we always use the top-level config, which means we need
 	// to read the config file with `env` set to `undefined`
-	const config = readConfig(undefined, args);
+	const config = readConfig(undefined, { ...args, env: undefined });
 	const resolvedDirectory = args.directory ?? config.pages_build_output_dir;
 	const [_pages, _dev, ...remaining] = args._;
 	const command = remaining;


### PR DESCRIPTION
## What this PR solves / how to test

This PR adds `wrangler.toml` support in `pages deploy`

♫♫♫
```
Starlight, star bright
First star I see tonight
Starlight, star bright
Make everything alright
```
♫♫♫

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: not necessary at this stage of the work

## Test Plan 🚀

Apart from unit/integration/fixtures tests, this PR was manually tested based on the following test plan:

<details>
<summary>

- [x]  `pages deploy [<directory>]` should still work correctly, for Pages projects without a config file

</summary>

```
npx wrangler pages deploy public
```
<img width="752" alt="Screenshot 2024-03-28 at 11 00 36" src="https://github.com/cloudflare/workers-sdk/assets/4638332/b07c73be-1d40-4fed-aaef-dc8e9f62b985">

<img width="569" alt="Screenshot 2024-03-28 at 11 02 07" src="https://github.com/cloudflare/workers-sdk/assets/4638332/7957b80c-9321-4fad-b9f0-5b9ea0a94cc3">
</details>

<details>
<summary>

- [x] `pages deploy` should pick up configuration from `wrangler.toml`, if file exists and `pages_build_output_dir` is specified

</summary>

```
# wrangler.toml

pages_build_output_dir = "./public"
name = "pages-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "celebrate"
```

```js
// /functions/celebrate.ts

return new Response(
  `[/celebrate]:\n` +
   `🎵 🎵 🎵\n` +
   `You can turn this world around\n` +
   `And bring back all of those happy days\n` +
   `Put your troubles down\n` +
   `It's time to ${context.env.VAR2}\n` +
   `🎵 🎵 🎵`
);
```
```
npx wrangler pages deploy
```
<img width="871" alt="Screenshot 2024-03-31 at 20 15 41" src="https://github.com/cloudflare/workers-sdk/assets/4638332/cbb30b57-59ce-4a70-bea5-d8ace279e9a0">

<img width="625" alt="Screenshot 2024-03-31 at 20 17 49" src="https://github.com/cloudflare/workers-sdk/assets/4638332/37f8774f-238e-44d9-a1d4-c346264caf72">

</details>

<details>
<summary>

- [x] `pages deploy [<directory>]` should warn and ignore the `wrangler.toml` file, if it exists but `pages_build_output_dir` is not specified


</summary>

```
# wrangler.toml

name = "pages-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "celebrate"
```

```js
// /functions/celebrate.ts

return new Response(
  `[/celebrate]:\n` +
   `🎵 🎵 🎵\n` +
   `You can turn this world around\n` +
   `And bring back all of those happy days\n` +
   `Put your troubles down\n` +
   `It's time to ${context.env.VAR2}\n` +
   `🎵 🎵 🎵`
);
```
```
npx wrangler pages deploy
```
<img width="870" alt="Screenshot 2024-03-31 at 23 46 18" src="https://github.com/cloudflare/workers-sdk/assets/4638332/91802ead-b6ec-444d-b54c-ae39aa6baf1a">
<img width="621" alt="Screenshot 2024-03-31 at 23 46 43" src="https://github.com/cloudflare/workers-sdk/assets/4638332/5a4d7527-1080-47a1-ac41-a3387b4b6856">


</details>

<details>
<summary>

- [x] `pages deploy` with valid `wrangler.toml` should deploy to new projects

</summary>

```
# wrangler.toml

pages_build_output_dir = "./public"
name = "pages-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "celebrate"
```

```js
// /functions/celebrate.ts

return new Response(
  `[/celebrate]:\n` +
   `🎵 🎵 🎵\n` +
   `You can turn this world around\n` +
   `And bring back all of those happy days\n` +
   `Put your troubles down\n` +
   `It's time to ${context.env.VAR2}\n` +
   `🎵 🎵 🎵`
);
```
```
npx wrangler pages deploy
```
<img width="891" alt="Screenshot 2024-03-31 at 20 15 31" src="https://github.com/cloudflare/workers-sdk/assets/4638332/5f9446a0-5290-480b-98e0-ac434ec3c833">
<img width="871" alt="Screenshot 2024-03-31 at 20 15 41" src="https://github.com/cloudflare/workers-sdk/assets/4638332/719e1b3b-14bb-4982-9bfa-e1c2ff5812c5">
<img width="625" alt="Screenshot 2024-03-31 at 20 17 49" src="https://github.com/cloudflare/workers-sdk/assets/4638332/a0dcac84-eaf5-463c-a6e3-1ecfd9563ae6">

</details>

<details>
<summary>

- [x] `pages deploy` with valid `wrangler.toml` should deploy to existing projects

</summary>

```
# wrangler.toml

pages_build_output_dir = "./public"
name = "pages-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "celebrate"
```

```js
// /functions/celebrate.ts

return new Response(
  `[/celebrate]:\n` +
   `🎵 🎵 🎵\n` +
   `You can turn this world around\n` +
   `And bring back all of those happy days\n` +
   `Put your troubles down\n` +
   `It's time to ${context.env.VAR2}\n` +
   `🎵 🎵 🎵`
);
```
```
npx wrangler pages deploy
```
<img width="883" alt="Screenshot 2024-03-31 at 21 55 17" src="https://github.com/cloudflare/workers-sdk/assets/4638332/fec669d5-2eeb-4f45-9c46-54026033b51a">
<img width="633" alt="Screenshot 2024-03-31 at 21 57 31" src="https://github.com/cloudflare/workers-sdk/assets/4638332/1b40b079-6ada-49a9-b08d-d87247a9b554">


</details>

<details>
<summary>

- [x] `pages deploy` should fail if no `[<directory>]` argument was passed and configuration file does not specify `pages_build_output_dir`

</summary>

```
# wrangler.toml

name = "pages-functions-with-config-file-app"
compatibility_date = "2024-01-01"
```
```
npx wrangler pages deploy
```
<img width="964" alt="Screenshot 2024-03-31 at 23 54 33" src="https://github.com/cloudflare/workers-sdk/assets/4638332/9127e313-cc21-4863-887c-bd84520dd0b9">


</details>

<details>
<summary>

- [x] `pages deploy` should fail if configuration file is not valid

</summary>

```
# wrangler.toml

pages_build_output_dir = "./public"
name = "pages-functions-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "celebrate"

[kv_namespaces]
namespace_origin = "invalid"

[env.staging]
[env.staging.vars]
VAR1 = "test"
```
```
npx wrangler pages deploy
```
<img width="759" alt="Screenshot 2024-03-31 at 23 58 59" src="https://github.com/cloudflare/workers-sdk/assets/4638332/2acdbe30-637b-4f85-95a6-9048cd6fb8b8">
<img width="808" alt="Screenshot 2024-03-31 at 23 58 02" src="https://github.com/cloudflare/workers-sdk/assets/4638332/04b8a6ca-6b98-4006-8dcc-81e525fe77d7">

</details>

<details>
<summary>

- [x] `pages deploy` should always deploy to the Pages project specified by the top-level `name` configuration field, regardless of the corresponding env-level configuration

</summary>

```
# wrangler.toml

pages_build_output_dir = "./public"
name = "pages-functions-with-config-file-app"
compatibility_date = "2024-01-01"

[env.production]
name = "pages-functions-with-config-file-app-production"
```
```
npx wrangler pages deploy
```
<img width="882" alt="Screenshot 2024-04-01 at 17 28 37" src="https://github.com/cloudflare/workers-sdk/assets/4638332/ffbce894-d87e-487e-9649-d24358f74629">

<img width="622" alt="Screenshot 2024-04-01 at 17 28 52" src="https://github.com/cloudflare/workers-sdk/assets/4638332/dd7dfafd-676c-4531-9ee6-f40fc21ddb56">

</details>

<details>
<summary>

- [x] `pages deploy` should fail if top-level `name` configuration field is not specified, irrespective of the targeted environment, and whether that environment's configuration specififes the `name` field

</summary>

```
# wrangler.toml

pages_build_output_dir = "./public"
compatibility_date = "2024-01-01"

[env.production]
name = "pages-functions-with-config-file-app"
```
```
npx wrangler pages deploy --branch=main
```
<img width="740" alt="Screenshot 2024-04-01 at 17 35 51" src="https://github.com/cloudflare/workers-sdk/assets/4638332/aec7d939-3ad5-405b-adc1-05e67a1310cb">

</details>

<details>
<summary>

- [x] `pages deploy --branch=<name_of_production_branch>` should apply `production` specific configuration when deploying  to the `production` environment, if `[env.production]` is specified in `wrangler.toml`

</summary>

```
#wrangler.toml

pages_build_output_dir = "./public"
name = "pages-functions-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "celebrate"

[env.preview]
[env.preview.vars]
VAR1 = "🌤️ holiday 🌤️"
VAR2 = "🤸🏻 celebrate 🤸🏻"

[env.production]
[env.production.vars]
VAR1 = "🏖️ holiday 🏖️"
VAR2 = "🥳 celebrate 🥳"
```
```
npx wrangler pages deploy --branch=main
```
<img width="879" alt="Screenshot 2024-04-01 at 00 26 42" src="https://github.com/cloudflare/workers-sdk/assets/4638332/e375d669-e24d-4731-b168-b08c736aa3d2">
<img width="617" alt="Screenshot 2024-04-01 at 00 27 00" src="https://github.com/cloudflare/workers-sdk/assets/4638332/80e94bcd-6a31-4b92-a0f2-77b1f0918d61">
<img width="1252" alt="Screenshot 2024-04-01 at 00 31 42" src="https://github.com/cloudflare/workers-sdk/assets/4638332/c2cbd2aa-31d4-4181-8485-3357ba25e926">


</details>

<details>
<summary>

- [x] `pages deploy --branch=<name_of_production_branch>` should fallback to top-level configuration when deploying to the `production` environment,  if `[env.production]` is not specified in `wrangler.toml`

</summary>

```
# wrangler.toml

pages_build_output_dir = "./public"
name = "pages-functions-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "🪩 celebrate 🪩"
```
```
npx wrangler pages deploy --branch=staging
```
<img width="875" alt="Screenshot 2024-04-01 at 00 43 08" src="https://github.com/cloudflare/workers-sdk/assets/4638332/9248adce-e19c-4b05-bdac-4e429ffbfd3b">

<img width="642" alt="Screenshot 2024-04-01 at 00 43 24" src="https://github.com/cloudflare/workers-sdk/assets/4638332/d542f9dd-54ab-40b3-a268-c2ceacab30b6">
<img width="1247" alt="Screenshot 2024-04-01 at 00 43 33" src="https://github.com/cloudflare/workers-sdk/assets/4638332/69aeb6ce-e360-49e1-bec8-6db69139320e">

</details>

<details>
<summary>

- [x] `pages deploy --branch=<name_of_non_prod_branch>` should apply `preview` specific configuration when deploying  to the `preview` environment, if `[env.preview]` is specified in `wrangler.toml`

</summary>

```
# wrangler.toml

pages_build_output_dir = "./public"
name = "pages-functions-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "celebrate"

[env.preview]
[env.preview.vars]
VAR1 = "🌤️ holiday 🌤️"
VAR2 = "🤸🏻 celebrate 🤸🏻"

[env.production]
[env.production.vars]
VAR1 = "🏖️ holiday 🏖️"
VAR2 = "🥳 celebrate 🥳"
```
```
npx wrangler pages deploy --branch=staging
```
<img width="877" alt="Screenshot 2024-04-01 at 00 36 24" src="https://github.com/cloudflare/workers-sdk/assets/4638332/45ed1b3a-cdf0-4fb8-8bd1-2f59d1380f7c">
<img width="633" alt="Screenshot 2024-04-01 at 00 34 06" src="https://github.com/cloudflare/workers-sdk/assets/4638332/8638f791-cddd-4786-a4e4-2cb985880cb5">
<img width="1254" alt="Screenshot 2024-04-01 at 00 31 50" src="https://github.com/cloudflare/workers-sdk/assets/4638332/015def15-e40e-48aa-8440-ed58f933c18b">

</details>

<details>
<summary>

- [x] `pages deploy --branch=<name_of_non_prod_branch>` should fallback to top-level configuration when deploying to the `preview` environment,  if `[env.preview]` is not specified in `wrangler.toml`

</summary>

```
# wrangler.toml

pages_build_output_dir = "./public"
name = "pages-functions-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "🪩 celebrate 🪩"
```
```
npx wrangler pages deploy --branch=staging
```
<img width="870" alt="Screenshot 2024-04-01 at 00 40 23" src="https://github.com/cloudflare/workers-sdk/assets/4638332/e949c2f1-62bf-41e2-82a5-d4bd8baf485c">
<img width="630" alt="Screenshot 2024-04-01 at 00 40 43" src="https://github.com/cloudflare/workers-sdk/assets/4638332/56a47fc3-8005-48b0-8524-c3166276d512">
<img width="1250" alt="Screenshot 2024-04-01 at 00 40 55" src="https://github.com/cloudflare/workers-sdk/assets/4638332/ab480bd7-a6bf-476b-adc1-02d98944889e">

</details>

<details>
<summary>

- [ ] `pages deploy` should apply inheritable environment config specified in wrangler.toml, specific to the environment targeted by the deployment

</summary>
</details>

<details>
<summary>

- [ ] `pages deploy` should apply non-inheritable environment config specified in wrangler.toml, specific to the environment targeted by the deployment

</summary>
</details>

<details>
<summary>

- [x] `pages deploy` should override `wrangler.toml` config with cmd line args

</summary>

```
# wrangler.toml

pages_build_output_dir = "./dist"
name = "pages-functions-app"
compatibility_date = "2024-01-01"
```
```
npx wrangler pages deploy public --project-name=pages-functions-with-config-file-app
```
<img width="871" alt="Screenshot 2024-04-01 at 17 56 12" src="https://github.com/cloudflare/workers-sdk/assets/4638332/ec980fa6-1c8a-4989-aaf8-d75690444e95">
<img width="648" alt="Screenshot 2024-04-01 at 17 56 33" src="https://github.com/cloudflare/workers-sdk/assets/4638332/b6e3a834-cf11-4217-bfc4-4ce602759ec1">


</details>

<details>
<summary>

- [x] `pages deploy` should allow existing Pages projects to opt in using a config file

</summary>

- deploy new project without `wrangler.toml`

```
npx wrangler pages deploy public --project-name=pages-functions-with-config-file-app
```
<img width="898" alt="Screenshot 2024-04-01 at 17 49 04" src="https://github.com/cloudflare/workers-sdk/assets/4638332/f81423b3-5b1b-4f9e-9460-9e1434c135dd">
<img width="621" alt="Screenshot 2024-04-01 at 17 48 47" src="https://github.com/cloudflare/workers-sdk/assets/4638332/196ec491-6802-4153-a9f9-dbb568b1e4f3">

- add `wrangler.toml` file and re-deploy
```
# wrangler.toml

pages_build_output_dir = "./public"
name = "pages-functions-with-config-file-app"
compatibility_date = "2024-01-01"

[vars]
VAR1 = "holiday"
VAR2 = "celebrate"
```
```
npx wrangler pages deploy
```
<img width="878" alt="Screenshot 2024-04-01 at 17 52 19" src="https://github.com/cloudflare/workers-sdk/assets/4638332/18c1f420-dc41-4622-8523-c115ba536dcf">
<img width="641" alt="Screenshot 2024-04-01 at 17 52 34" src="https://github.com/cloudflare/workers-sdk/assets/4638332/2a361f30-e5d8-4362-9ca0-47f91d517488">

</details>

<details>
<summary>

- [ ] `pages deploy` should allow existing Pages projects to opt out of using a config file

</summary>
</details>

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
