### PR TITLE
chore: apply prettier formatting to create-cloudflare tests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -49,6 +49,7 @@ packages/miniflare
 packages/create-cloudflare/templates/**/*.*
 !packages/create-cloudflare/templates/**/c3.ts
 !packages/create-cloudflare/templates/**/test/**/*.ts
+!packages/create-cloudflare/templates/**/test/**/*.js
 
 
 # Some of the `@cloudflare/vitest-pool-workers` examples use `satisfies` as it

--- a/.prettierignore
+++ b/.prettierignore
@@ -45,9 +45,11 @@ packages/miniflare
 
 # In the C3 templates, in particular framework templates, we want to be able to
 # use any format that the framework authors prefer/use in their own templates,
-# so let's ignore all the c3 template files, exlcuding the c3.ts ones
+# so let's ignore all the c3 template files, exlcuding the c3.ts ones, and tests
 packages/create-cloudflare/templates/**/*.*
 !packages/create-cloudflare/templates/**/c3.ts
+!packages/create-cloudflare/templates/**/test/**/*.ts
+
 
 # Some of the `@cloudflare/vitest-pool-workers` examples use `satisfies` as it
 # makes typing unit tests much easier. Our current version of Prettier doesn't

--- a/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
+++ b/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
@@ -1,20 +1,20 @@
-import { env, createExecutionContext, waitOnExecutionContext, SELF } from "cloudflare:test";
-import { describe, it, expect } from "vitest";
-import worker from "../src";
+import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import worker from '../src';
 
-describe("Hello World worker", () => {
-  it("responds with Hello World! (unit style)", async () => {
-    const request = new Request("http://example.com");
-    // Create an empty context to pass to `worker.fetch()`.
-    const ctx = createExecutionContext();
-    const response = await worker.fetch(request, env, ctx);
-    // Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-    await waitOnExecutionContext(ctx);
-    expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-  });
+describe('Hello World worker', () => {
+	it('responds with Hello World! (unit style)', async () => {
+		const request = new Request('http://example.com');
+		// Create an empty context to pass to `worker.fetch()`.
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
+		await waitOnExecutionContext(ctx);
+		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+	});
 
-  it("responds with Hello World! (integration style)", async () => {
-   const response = await SELF.fetch("http://example.com");
-   expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
- });
+	it('responds with Hello World! (integration style)', async () => {
+		const response = await SELF.fetch(request, env, ctx);
+		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+	});
 });

--- a/packages/create-cloudflare/templates/hello-world/ts/test/index.spec.ts
+++ b/packages/create-cloudflare/templates/hello-world/ts/test/index.spec.ts
@@ -1,25 +1,25 @@
 // test/index.spec.ts
-import { env, createExecutionContext, waitOnExecutionContext, SELF } from "cloudflare:test";
-import { describe, it, expect } from "vitest";
-import worker from "../src/index";
+import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import worker from '../src/index';
 
 // For now, you'll need to do something like this to get a correctly-typed
 // `Request` to pass to `worker.fetch()`.
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
-describe("Hello World worker", () => {
-  it("responds with Hello World! (unit style)", async () => {
-    const request = new IncomingRequest("http://example.com");
-    // Create an empty context to pass to `worker.fetch()`.
-    const ctx = createExecutionContext();
-    const response = await worker.fetch(request, env, ctx);
-    // Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-    await waitOnExecutionContext(ctx);
-    expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-  });
+describe('Hello World worker', () => {
+	it('responds with Hello World! (unit style)', async () => {
+		const request = new IncomingRequest('http://example.com');
+		// Create an empty context to pass to `worker.fetch()`.
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
+		await waitOnExecutionContext(ctx);
+		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+	});
 
-  it("responds with Hello World! (integration style)", async () => {
-    const response = await SELF.fetch("https://example.com");
-    expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
- });
+	it('responds with Hello World! (integration style)', async () => {
+		const response = await SELF.fetch('https://example.com');
+		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+	});
 });


### PR DESCRIPTION
## What this PR solves / how to test

Applies prettier formatting to vitest examples in c3, to match the formatting for the worker.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: No functional changes
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: No functional changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: No functional changes

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
