### PR TITLE
Catch erroneous use of `deployments view [deployment-id] --experimental-versions` command

### DIFF
--- a/.changeset/tough-suns-punch.md
+++ b/.changeset/tough-suns-punch.md
@@ -4,4 +4,4 @@
 
 chore: add `wrangler deployments view [deployment-id] --experimental-versions` command
 
-This command will display a deprecation message and point the user to run either `wrangler deployments status --experimental-versions` or `wrangler versions view <version-id> --experimental-versions` instead.
+This command will display an error message which points the user to run either `wrangler deployments status --experimental-versions` or `wrangler versions view <version-id> --experimental-versions` instead.

--- a/.changeset/tough-suns-punch.md
+++ b/.changeset/tough-suns-punch.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+chore: add `wrangler deployments view [deployment-id] --experimental-versions` command
+
+This command will display a deprecation message and point the user to run either `wrangler deployments status --experimental-versions` or `wrangler versions view <version-id> --experimental-versions` instead.

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
@@ -1,18 +1,22 @@
+import { UserError } from "../../../errors";
 import { runWrangler } from "../../helpers/run-wrangler";
 
 describe("deployments view", () => {
-	test("depracted error when run with no args", async () => {
+	test("error when run with no args", async () => {
 		const result = runWrangler("deployments view  --x-versions");
 
 		await expect(result).rejects.toMatchInlineSnapshot(
-			`[Error: \`wrangler deployments view\` is deprecated and will be removed in a future major version. Please use \`wrangler deployments status --x-versions\` instead.]`
+			`[Error: \`wrangler deployments view\` has been renamed \`wrangler deployments status --x-versions\`. Please use that command instead.]`
 		);
+		await expect(result).rejects.toBeInstanceOf(UserError);
 	});
-	test("depracted error when run with positional arg", async () => {
+
+	test("error when run with positional arg", async () => {
 		const result = runWrangler("deployments view dummy-id  --x-versions");
 
 		await expect(result).rejects.toMatchInlineSnapshot(
-			`[Error: \`wrangler deployments view <deployment-id>\` is deprecated and will be removed in a future major version. Deployment ID is now referred to as Version ID. Please use \`wrangler versions view [version-id] --x-versions\` instead.]`
+			`[Error: \`wrangler deployments view <deployment-id>\` has been renamed \`wrangler versions view [version-id] --x-versions\`. Please use that command instead.]`
 		);
+		await expect(result).rejects.toBeInstanceOf(UserError);
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
@@ -1,0 +1,18 @@
+import { runWrangler } from "../../helpers/run-wrangler";
+
+describe("deployments view", () => {
+	test("depracted error when run with no args", async () => {
+		const result = runWrangler("deployments view  --x-versions");
+
+		await expect(result).rejects.toMatchInlineSnapshot(
+			`[Error: \`wrangler deployments view\` is deprecated and will be removed in a future major version. Please use \`wrangler deployments status --x-versions\` instead.]`
+		);
+	});
+	test("depracted error when run with positional arg", async () => {
+		const result = runWrangler("deployments view dummy-id  --x-versions");
+
+		await expect(result).rejects.toMatchInlineSnapshot(
+			`[Error: \`wrangler deployments view <deployment-id>\` is deprecated and will be removed in a future major version. Deployment ID is now referred to as Version ID. Please use \`wrangler versions view [version-id] --x-versions\` instead.]`
+		);
+	});
+});

--- a/packages/wrangler/src/versions/deployments/index.ts
+++ b/packages/wrangler/src/versions/deployments/index.ts
@@ -6,6 +6,10 @@ import {
 	versionsDeploymentsStatusHandler,
 	versionsDeploymentsStatusOptions,
 } from "./status";
+import {
+	versionsDeploymentsViewHandler,
+	versionsDeploymentsViewOptions,
+} from "./view";
 import type { CommonYargsArgv } from "../../yargs-types";
 
 export default function registerVersionsDeploymentsSubcommands(
@@ -23,5 +27,11 @@ export default function registerVersionsDeploymentsSubcommands(
 			"See the current state of your production [beta]",
 			versionsDeploymentsStatusOptions,
 			versionsDeploymentsStatusHandler
+		)
+		.command(
+			"view [deployment-id]",
+			false,
+			versionsDeploymentsViewOptions,
+			versionsDeploymentsViewHandler
 		);
 }

--- a/packages/wrangler/src/versions/deployments/view.ts
+++ b/packages/wrangler/src/versions/deployments/view.ts
@@ -31,11 +31,11 @@ export async function versionsDeploymentsViewHandler(
 
 	if (args.deploymentId === undefined) {
 		throw new UserError(
-			"`wrangler deployments view` is deprecated and will be removed in a future major version. Please use `wrangler deployments status --x-versions` instead."
+			"`wrangler deployments view` has been renamed `wrangler deployments status --x-versions`. Please use that command instead."
 		);
 	} else {
 		throw new UserError(
-			"`wrangler deployments view <deployment-id>` is deprecated and will be removed in a future major version. Deployment ID is now referred to as Version ID. Please use `wrangler versions view [version-id] --x-versions` instead."
+			"`wrangler deployments view <deployment-id>` has been renamed `wrangler versions view [version-id] --x-versions`. Please use that command instead."
 		);
 	}
 }

--- a/packages/wrangler/src/versions/deployments/view.ts
+++ b/packages/wrangler/src/versions/deployments/view.ts
@@ -1,0 +1,41 @@
+import { UserError } from "../../errors";
+import { printWranglerBanner } from "../../update-check";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../../yargs-types";
+
+export type VersionsDeploymentsViewArgs = StrictYargsOptionsToInterface<
+	typeof versionsDeploymentsViewOptions
+>;
+
+export function versionsDeploymentsViewOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.option("name", {
+			describe: "Name of the worker",
+			type: "string",
+			requiresArg: true,
+		})
+		.positional("deployment-id", {
+			describe:
+				"Deprecated. Deployment ID is now referred to as Version ID. Please use `wrangler versions view [version-id]` instead.",
+			type: "string",
+			requiresArg: true,
+		});
+}
+
+export async function versionsDeploymentsViewHandler(
+	args: VersionsDeploymentsViewArgs
+) {
+	await printWranglerBanner();
+
+	if (args.deploymentId === undefined) {
+		throw new UserError(
+			"`wrangler deployments view` is deprecated and will be removed in a future major version. Please use `wrangler deployments status --x-versions` instead."
+		);
+	} else {
+		throw new UserError(
+			"`wrangler deployments view <deployment-id>` is deprecated and will be removed in a future major version. Deployment ID is now referred to as Version ID. Please use `wrangler versions view [version-id] --x-versions` instead."
+		);
+	}
+}


### PR DESCRIPTION
## What this PR solves / how to test

Adds a `view` command to the new `deployments` subcommands opted-in via the `--experimental-versions` flag which shows a deprecation message and points the user to either run `wrangler deployments status --experimental-versions` or `wrangler versions view <version-id> --experimental-versions` instead.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
