### PR TITLE
C3: Adapt Astro c3 flow to their v10 Cloudflare adapter

### DIFF
--- a/.changeset/large-rice-bow.md
+++ b/.changeset/large-rice-bow.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+update Astro c3 logic for their new v10 Cloudflare adapter

--- a/packages/create-cloudflare/templates/astro/c3.ts
+++ b/packages/create-cloudflare/templates/astro/c3.ts
@@ -46,9 +46,9 @@ const updateAstroConfig = () => {
 			n.node.arguments = [
 				b.objectExpression([
 					b.objectProperty(
-						b.identifier("runtime"),
+						b.identifier("platformProxy"),
 						b.objectExpression([
-							b.objectProperty(b.identifier("mode"), b.stringLiteral("local")),
+							b.objectProperty(b.identifier("enable"), b.booleanLiteral(true)),
 						])
 					),
 				]),

--- a/packages/create-cloudflare/templates/astro/c3.ts
+++ b/packages/create-cloudflare/templates/astro/c3.ts
@@ -48,7 +48,7 @@ const updateAstroConfig = () => {
 					b.objectProperty(
 						b.identifier("platformProxy"),
 						b.objectExpression([
-							b.objectProperty(b.identifier("enable"), b.booleanLiteral(true)),
+							b.objectProperty(b.identifier("enabled"), b.booleanLiteral(true)),
 						])
 					),
 				]),

--- a/packages/create-cloudflare/templates/astro/snippets/runtimeDeclaration.ts
+++ b/packages/create-cloudflare/templates/astro/snippets/runtimeDeclaration.ts
@@ -1,4 +1,5 @@
-type Runtime = import("@astrojs/cloudflare").DirectoryRuntime<Env>;
+type Runtime = import("@astrojs/cloudflare").AdvancedRuntime<Env>;
+
 declare namespace App {
 	interface Locals extends Runtime {}
 }

--- a/packages/create-cloudflare/templates/astro/snippets/runtimeDeclaration.ts
+++ b/packages/create-cloudflare/templates/astro/snippets/runtimeDeclaration.ts
@@ -1,4 +1,4 @@
-type Runtime = import("@astrojs/cloudflare").AdvancedRuntime<Env>;
+type Runtime = import("@astrojs/cloudflare").Runtime<Env>;
 
 declare namespace App {
 	interface Locals extends Runtime {}


### PR DESCRIPTION
## What this PR solves / how to test

This PR updates c3 to handle the upcoming Astro v10 cloudflare adapter (https://github.com/withastro/adapters/pull/159)

To test the changes in this PR:
 - create a new Astro app using C3 (opting in to typescript to also test the types update)
    ```
    npx https://prerelease-registry.devprod.cloudflare.dev/workers-sdk/runs/8452603565/npm-package-create-cloudflare-5410 --no-auto-update
    ```
 - update the `@astrojs/cloudflare` version to `astrojs/cloudflare@experimental--cf-10`:
   ```
   npm i -D @astrojs/cloudflare@experimental--cf-10
   ```
 - make sure that everything works as expected

> [!NOTE]
> The C3 e2es are currently supposed to fail as the v10 Astro Cloudflare adapter hasn't been released yet, this PR should be merged after the v10 release (and by that time the e2es should pass)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included (this flow is tested by the C3 e2es already)
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: this just makes sure things will work the same when Astro releases their v10 Cloudflare adapter

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
