### PR TITLE
[C3] fix: improve error message when no accounts found during deployment

### DIFF
--- a/.changeset/large-pumpkins-try.md
+++ b/.changeset/large-pumpkins-try.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+fix: display helpful error message when no accounts found during deployment
+
+Previously, C3 would display `TypeError: Cannot read properties of undefined (reading 'value')` if you were logged in as a user without access to any accounts. This change ensures a more appropriate error message is displayed in this case.

--- a/packages/create-cloudflare/src/wrangler/accounts.ts
+++ b/packages/create-cloudflare/src/wrangler/accounts.ts
@@ -11,7 +11,12 @@ export const chooseAccount = async (ctx: C3Context) => {
 
 	let accountId: string;
 
-	if (Object.keys(accounts).length == 1) {
+	const numAccounts = Object.keys(accounts).length;
+	if (numAccounts === 0) {
+		throw new Error(
+			"Unable to find any accounts to deploy to! Please ensure you're logged in as a user that can deploy Workers."
+		);
+	} else if (numAccounts === 1) {
 		const accountName = Object.keys(accounts)[0];
 		accountId = accounts[accountName];
 		s.stop(`${brandColor("account")} ${dim(accountName)}`);


### PR DESCRIPTION
## What this PR solves / how to test

Ref: CUSTESC-39344

Previously, C3 would display `TypeError: Cannot read properties of undefined (reading 'value')` if you were logged in as a user without access to any accounts. This change ensures a more appropriate error message is displayed in this case.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: it doesn't look like these code paths are tested at the moment. Happy to add some though if they are?
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: improving error messaging

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
