### PR TITLE
add helpful logging to --experimental-versions commands

### DIFF
--- a/.changeset/angry-brooms-destroy.md
+++ b/.changeset/angry-brooms-destroy.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: add helpful logging to --experimental-versions commands

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -67,16 +67,24 @@ export const newline = () => {
 	log("");
 };
 
+type FormatOptions = {
+	linePrefix?: string;
+	firstLinePrefix?: string;
+	newlineBefore?: boolean;
+	newlineAfter?: boolean;
+	formatLine?: (line: string) => string;
+	multiline?: boolean;
+};
 export const format = (
 	msg: string,
 	{
 		linePrefix = gray(shapes.bar),
-		firstLinePrefix = gray(shapes.bar),
+		firstLinePrefix = linePrefix,
 		newlineBefore = false,
 		newlineAfter = false,
 		formatLine = (line: string) => white(line),
 		multiline = true,
-	}
+	}: FormatOptions = {}
 ) => {
 	const lines = multiline ? msg.split("\n") : [msg];
 	const formattedLines = lines.map(

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -40,6 +40,7 @@ export const status = {
 	warning: bgYellow(` WARNING `),
 	info: bgBlue(` INFO `),
 	success: bgGreen(` SUCCESS `),
+	cancel: white.bgRed(` X `),
 };
 
 // Returns a string containing n non-trimmable spaces
@@ -66,18 +67,38 @@ export const newline = () => {
 	log("");
 };
 
+export const format = (
+	msg: string,
+	{
+		linePrefix = gray(shapes.bar),
+		firstLinePrefix = gray(shapes.bar),
+		newlineBefore = false,
+		newlineAfter = false,
+		formatLine = (line: string) => white(line),
+		multiline = true,
+	}
+) => {
+	const lines = multiline ? msg.split("\n") : [msg];
+	const formattedLines = lines.map(
+		(line, i) =>
+			(i === 0 ? firstLinePrefix : linePrefix) + space() + formatLine(line)
+	);
+
+	if (newlineBefore) formattedLines.unshift(linePrefix);
+	if (newlineAfter) formattedLines.push(linePrefix);
+
+	return formattedLines.join("\n");
+};
+
 // Log a simple status update with a style similar to the clack spinner
 export const updateStatus = (msg: string, printNewLine = true) => {
-	const lines = msg.split("\n");
-	const restLines = lines
-		.slice(1)
-		.map((ln) => `${gray(shapes.bar)} ${white(ln)}`);
-	logRaw(`${gray(shapes.leftT)} ${lines[0]}`);
-	if (restLines.length) {
-		logRaw(restLines.join("\n"));
-	}
-
-	if (printNewLine) newline();
+	logRaw(
+		format(msg, {
+			firstLinePrefix: gray(shapes.leftT),
+			linePrefix: gray(shapes.bar),
+			newlineAfter: printNewLine,
+		})
+	);
 };
 
 export const startSection = (
@@ -101,19 +122,64 @@ export const endSection = (heading: string, subheading?: string) => {
 	);
 };
 
-export const cancel = (msg: string) => {
-	newline();
-	logRaw(`${gray(shapes.corners.bl)} ${white.bgRed(` X `)} ${dim(msg)}`);
+export const cancel = (
+	msg: string,
+	{
+		// current default is backcompat and makes sense going forward too
+		shape = shapes.corners.bl,
+		// current default for backcompat -- TODO: change default to true once all callees have been updated
+		multiline = false,
+	} = {}
+) => {
+	logRaw(
+		format(msg, {
+			firstLinePrefix: `${gray(shape)} ${status.cancel}`,
+			linePrefix: gray(shapes.bar),
+			newlineBefore: true,
+			formatLine: (line) => dim(line), // for backcompat but it's not ideal for this to be "dim"
+			multiline,
+		})
+	);
 };
 
-export const warn = (msg: string) => {
-	newline();
-	logRaw(`${gray(shapes.corners.bl)} ${status.warning} ${dim(msg)}`);
+export const warn = (
+	msg: string,
+	{
+		// current default for backcompat -- TODO: change default to shapes.bar once all callees have been updated
+		shape = shapes.corners.bl,
+		// current default for backcompat -- TODO: change default to true once all callees have been updated
+		multiline = false,
+	} = {}
+) => {
+	logRaw(
+		format(msg, {
+			firstLinePrefix: gray(shape) + space() + status.warning,
+			linePrefix: gray(shapes.bar),
+			newlineBefore: true,
+			formatLine: (line) => dim(line), // for backcompat but it's not ideal for this to be "dim"
+			multiline,
+		})
+	);
 };
 
-export const success = (msg: string) => {
-	newline();
-	logRaw(`${gray(shapes.corners.bl)} ${status.success} ${dim(msg)}`);
+export const success = (
+	msg: string,
+	{
+		// current default for backcompat -- TODO: change default to shapes.bar once all callees have been updated
+		shape = shapes.corners.bl,
+		// current default for backcompat -- TODO: change default to true once all callees have been updated
+		multiline = false,
+	} = {}
+) => {
+	logRaw(
+		format(msg, {
+			firstLinePrefix: gray(shape) + space() + status.success,
+			linePrefix: gray(shapes.bar),
+			newlineBefore: true,
+			formatLine: (line) => dim(line), // for backcompat but it's not ideal for this to be "dim"
+			multiline,
+		})
+	);
 };
 
 // Strip the ansi color characters out of the line when calculating

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -74,7 +74,10 @@ describe("versions deploy", () => {
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
-			Uploaded tmp-e2e-wrangler (TIMINGS)"
+			Uploaded tmp-e2e-wrangler (TIMINGS)
+			To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
+			NOTE: Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment. Use the command wrangler versions deploy --experimental-versions to deploy these changes
+			NOTE: Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"
 		`);
 	});
 
@@ -185,7 +188,10 @@ describe("versions deploy", () => {
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
-			Uploaded tmp-e2e-wrangler (TIMINGS)"
+			Uploaded tmp-e2e-wrangler (TIMINGS)
+			To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
+			NOTE: Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment. Use the command wrangler versions deploy --experimental-versions to deploy these changes
+			NOTE: Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"
 		`);
 
 		const versionsList =

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -319,7 +319,10 @@ describe("versions deploy", () => {
 			│ Message Rollback via e2e test
 			│
 			│
-			╰  WARNING  You are about to rollback to Worker Version 00000000-0000-0000-0000-000000000000:
+			├  WARNING  You are about to rollback to Worker Version 00000000-0000-0000-0000-000000000000.
+			│ This will immediately replace the current deployment and become the active deployment across all your deployed triggers.
+			│ However, your local development environment will not be affected by this rollback.
+			│ Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).
 			│
 			│ (100%) 00000000-0000-0000-0000-000000000000
 			│       Created:  TIMESTAMP
@@ -427,7 +430,10 @@ describe("versions deploy", () => {
 			│ Message Rollback to old version
 			│
 			│
-			╰  WARNING  You are about to rollback to Worker Version 00000000-0000-0000-0000-000000000000:
+			├  WARNING  You are about to rollback to Worker Version 00000000-0000-0000-0000-000000000000.
+			│ This will immediately replace the current deployment and become the active deployment across all your deployed triggers.
+			│ However, your local development environment will not be affected by this rollback.
+			│ Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).
 			│
 			│ (100%) 00000000-0000-0000-0000-000000000000
 			│       Created:  TIMESTAMP

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -271,7 +271,7 @@ describe("deployments", () => {
 
 			it("should successfully rollback and output a success message", async () => {
 				mockConfirm({
-					text: "This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, R2, KV, etc.).",
+					text: "This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).",
 					result: true,
 				});
 
@@ -295,7 +295,7 @@ describe("deployments", () => {
 
 			it("should early exit from rollback if user denies continuing", async () => {
 				mockConfirm({
-					text: "This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, R2, KV, etc.).",
+					text: "This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).",
 					result: false,
 				});
 
@@ -317,7 +317,7 @@ describe("deployments", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 			"🚧\`wrangler rollback\` is a beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
 
-			? This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, R2, KV, etc.).
+			? This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).
 			🤖 Using fallback value in non-interactive context: yes
 			? Please provide a message for this rollback (120 characters max)
 			🤖 Using default value in non-interactive context:
@@ -363,7 +363,7 @@ describe("deployments", () => {
 
 			it("should automatically rollback to previous deployment when id is not specified", async () => {
 				mockConfirm({
-					text: "This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, R2, KV, etc.).",
+					text: "This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).",
 					result: true,
 				});
 
@@ -395,7 +395,7 @@ describe("deployments", () => {
 
 			it("should automatically rollback to previous deployment with specified name", async () => {
 				mockConfirm({
-					text: "This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, R2, KV, etc.).",
+					text: "This deployment 3mEgaU1T will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. Note: Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).",
 					result: true,
 				});
 

--- a/packages/wrangler/src/deployments.ts
+++ b/packages/wrangler/src/deployments.ts
@@ -178,7 +178,7 @@ export async function rollbackDeployment(
 					firstHash
 				)} will immediately replace the current deployment and become the active deployment across all your deployed routes and domains. However, your local development environment will not be affected by this rollback. ${chalk.blue.bold(
 					"Note:"
-				)} Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, R2, KV, etc.).`
+				)} Rolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).`
 			))
 		) {
 			return;

--- a/packages/wrangler/src/versions/rollback/index.ts
+++ b/packages/wrangler/src/versions/rollback/index.ts
@@ -88,7 +88,10 @@ export async function versionsRollbackHandler(args: VersionsRollbackArgs) {
 	});
 
 	const version = await fetchVersion(accountId, workerName, versionId);
-	cli.warn(`You are about to rollback to Worker Version ${versionId}:`);
+	cli.warn(
+		`You are about to rollback to Worker Version ${versionId}.\nThis will immediately replace the current deployment and become the active deployment across all your deployed triggers.\nHowever, your local development environment will not be affected by this rollback.\nRolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).`,
+		{ multiline: true, shape: cli.shapes.leftT }
+	);
 	const rollbackTraffic = new Map([[versionId, 100]]);
 	printVersions([version], rollbackTraffic);
 
@@ -102,7 +105,7 @@ export async function versionsRollbackHandler(args: VersionsRollbackArgs) {
 	});
 
 	if (!confirm) {
-		cli.log("Aborting rollback...");
+		cli.cancel("Aborting rollback...");
 		return;
 	}
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -511,9 +511,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		gray(`
 To deploy this version to production traffic use the command ${cmdVersionsDeploy}
 
-NOTE: Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment. Use the command ${cmdVersionsDeploy} to deploy these changes
+Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command ${cmdVersionsDeploy}
 
-NOTE: Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command ${cmdTriggersDeploy}
+Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command ${cmdTriggersDeploy}
 `)
 	);
 }

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { URLSearchParams } from "node:url";
+import { blue, gray } from "@cloudflare/cli/colors";
 import { fetchResult } from "../cfetch";
 import { printBindings } from "../config";
 import { bundleWorker } from "../deployment-bundle/bundle";
@@ -499,6 +500,22 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	const uploadMs = Date.now() - start;
 
 	logger.log("Uploaded", workerName, formatTime(uploadMs));
+
+	const cmdVersionsDeploy = blue(
+		"wrangler versions deploy --experimental-versions"
+	);
+	const cmdTriggersDeploy = blue(
+		"wrangler triggers deploy --experimental-versions"
+	);
+	logger.info(
+		gray(`
+To deploy this version to production traffic use the command ${cmdVersionsDeploy}
+
+NOTE: Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment. Use the command ${cmdVersionsDeploy} to deploy these changes
+
+NOTE: Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command ${cmdTriggersDeploy}
+`)
+	);
 }
 
 export function helpIfErrorIsSizeOrScriptStartup(


### PR DESCRIPTION
## What this PR solves / how to test

This PR adds helpful logging to `--experimental-versions` commands.

The changes in packages/cli are a refactor and do not effect the output by default but now there are options to override the default formatting.

CR: https://jira.cfdata.org/browse/CR-850334

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: chore

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
