### PR TITLE
chore: add tests for d1 export

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,6 +10,7 @@
 # D1 ownership
 /packages/wrangler/src/api/d1/ @cloudflare/d1 @cloudflare/wrangler
 /packages/wrangler/src/d1/ @cloudflare/d1 @cloudflare/wrangler
+/packages/wrangler/src/__tests__/d1/ @cloudflare/d1 @cloudflare/wrangler
 
 # Cloudchamber ownership
 /packages/wrangler/src/cloudchamber/ @cloudflare/cloudchamber @cloudflare/wrangler

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -1,0 +1,70 @@
+import fs from "fs";
+import { rest } from "msw";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { useMockIsTTY } from "../helpers/mock-istty";
+import { mockGetMemberships, mockOAuthFlow } from "../helpers/mock-oauth-flow";
+import { msw } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import writeWranglerToml from "../helpers/write-wrangler-toml";
+
+describe("execute", () => {
+	mockAccountId({ accountId: null });
+	mockApiToken();
+	mockConsoleMethods();
+	runInTempDir();
+	const { mockOAuthServerCallback } = mockOAuthFlow();
+	const { setIsTTY } = useMockIsTTY();
+	it("should throw if output is missing", async () => {
+		await expect(runWrangler("d1 export db --local")).rejects.toThrowError(
+			`Missing required argument: output`
+		);
+	});
+
+	it("should reject --local mode (for now)", async () => {
+		await expect(
+			runWrangler("d1 export db --local --output /tmp/test.sql")
+		).rejects.toThrowError(
+			`Local imports/exports will be coming in a future version of Wrangler.`
+		);
+	});
+
+	it("should handle remote", async () => {
+		setIsTTY(false);
+		writeWranglerToml({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+		mockOAuthServerCallback();
+		mockGetMemberships([
+			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+		]);
+		const mockSqlContent = "PRAGMA defer_foreign_keys=TRUE;";
+		msw.use(
+			rest.post(
+				"*/accounts/:accountId/d1/database/:databaseId/export",
+				async (_req, res, ctx) => {
+					return res(
+						ctx.status(200),
+						ctx.json({
+							result: { signedUrl: "https://example.com" },
+							success: true,
+							errors: [],
+							messages: [],
+						})
+					);
+				}
+			)
+		);
+		msw.use(
+			rest.get("https://example.com", async (req, res, ctx) => {
+				return res(ctx.status(200), ctx.text(mockSqlContent));
+			})
+		);
+
+		await runWrangler("d1 export db --remote --output /tmp/test.sql");
+		expect(fs.readFileSync("/tmp/test.sql", "utf8")).toBe(mockSqlContent);
+	});
+});


### PR DESCRIPTION
This PR adds tests for `wrangler d1 export`, and gives the D1 team codeownership of its own tests.

Closes [#5442](https://github.com/cloudflare/workers-sdk/issues/5442)