### PR TITLE
Handle invalid wrangler.toml files

### DIFF
--- a/.changeset/small-bees-brush.md
+++ b/.changeset/small-bees-brush.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Improve messaging for invalid Pages `wrangler.toml` files

--- a/packages/wrangler/src/__tests__/pages/functions-build.test.ts
+++ b/packages/wrangler/src/__tests__/pages/functions-build.test.ts
@@ -547,144 +547,101 @@ describe("functions build w/ config", () => {
 	});
 
 	beforeEach(() => {
+		// eslint-disable-next-line turbo/no-undeclared-env-vars
+		process.env.PAGES_ENVIRONMENT = "production";
+	});
+
+	it("should include all config in the _worker.bundle metadata", async () => {
 		// Write an example wrangler.toml file with a _lot_ of config
 		writeFileSync(
 			"wrangler.toml",
 			dedent`
-		name = "project-name"
-		pages_build_output_dir = "dist-test"
-		compatibility_date = "2023-02-14"
-		placement = { mode = "smart" }
-		limits = { cpu_ms = 50 }
+				name = "project-name"
+				pages_build_output_dir = "dist-test"
+				compatibility_date = "2023-02-14"
+				placement = { mode = "smart" }
+				limits = { cpu_ms = 50 }
 
-		[vars]
-		TEST_JSON_PREVIEW = """
-		{
-		json: "value"
-		}"""
-		TEST_PLAINTEXT_PREVIEW = "PLAINTEXT"
+				[env.production.vars]
+				TEST_JSON_PREVIEW = """
+				{
+				json: "value"
+				}"""
+				TEST_PLAINTEXT_PREVIEW = "PLAINTEXT"
 
-		[[kv_namespaces]]
-		id = "kv-id"
-		binding = "KV_PREVIEW"
+				[[env.production.kv_namespaces]]
+				id = "kv-id"
+				binding = "KV_PREVIEW"
 
-		[[kv_namespaces]]
-		id = "kv-id"
-		binding = "KV_PREVIEW2"
+				[[env.production.kv_namespaces]]
+				id = "kv-id"
+				binding = "KV_PREVIEW2"
 
-		[[durable_objects.bindings]]
-		name = "DO_PREVIEW"
-		class_name = "some-class-do-id"
-		script_name = "some-script-do-id"
-		environment = "some-environment-do-id"
+				[[env.production.durable_objects.bindings]]
+				name = "DO_PREVIEW"
+				class_name = "some-class-do-id"
+				script_name = "some-script-do-id"
+				environment = "some-environment-do-id"
 
-		[[durable_objects.bindings]]
-		name = "DO_PREVIEW2"
-		class_name = "some-class-do-id"
-		script_name = "some-script-do-id"
-		environment = "some-environment-do-id"
+				[[env.production.durable_objects.bindings]]
+				name = "DO_PREVIEW2"
+				class_name = "some-class-do-id"
+				script_name = "some-script-do-id"
+				environment = "some-environment-do-id"
 
-		[[durable_objects.bindings]]
-		name = "DO_PREVIEW3"
-		class_name = "do-class"
-		script_name = "do-s"
-		environment = "do-e"
+				[[env.production.durable_objects.bindings]]
+				name = "DO_PREVIEW3"
+				class_name = "do-class"
+				script_name = "do-s"
+				environment = "do-e"
 
-		[[d1_databases]]
-		database_id = "d1-id"
-		binding = "D1_PREVIEW"
-		database_name = "D1_PREVIEW"
+				[[env.production.d1_databases]]
+				database_id = "d1-id"
+				binding = "D1_PREVIEW"
+				database_name = "D1_PREVIEW"
 
-		[[d1_databases]]
-		database_id = "d1-id"
-		binding = "D1_PREVIEW2"
-		database_name = "D1_PREVIEW2"
+				[[env.production.d1_databases]]
+				database_id = "d1-id"
+				binding = "D1_PREVIEW2"
+				database_name = "D1_PREVIEW2"
 
-		[[r2_buckets]]
-		bucket_name = "r2-name"
-		binding = "R2_PREVIEW"
+				[[env.production.r2_buckets]]
+				bucket_name = "r2-name"
+				binding = "R2_PREVIEW"
 
-		[[r2_buckets]]
-		bucket_name = "r2-name"
-		binding = "R2_PREVIEW2"
+				[[env.production.r2_buckets]]
+				bucket_name = "r2-name"
+				binding = "R2_PREVIEW2"
 
-		[[services]]
-		binding = "SERVICE_PREVIEW"
-		service = "service"
-		environment = "production"
+				[[env.production.services]]
+				binding = "SERVICE_PREVIEW"
+				service = "service"
+				environment = "production"
 
-		[[services]]
-		binding = "SERVICE_PREVIEW2"
-		service = "service"
-		environment = "production"
+				[[env.production.services]]
+				binding = "SERVICE_PREVIEW2"
+				service = "service"
+				environment = "production"
 
-		[[queues.producers]]
-		binding = "QUEUE_PREVIEW"
-		queue = "q-id"
+				[[env.production.queues.producers]]
+				binding = "QUEUE_PREVIEW"
+				queue = "q-id"
 
-		[[queues.producers]]
-		binding = "QUEUE_PREVIEW2"
-		queue = "q-id"
+				[[env.production.queues.producers]]
+				binding = "QUEUE_PREVIEW2"
+				queue = "q-id"
 
-		[[analytics_engine_datasets]]
-		binding = "AE_PREVIEW"
-		dataset = "data"
+				[[env.production.analytics_engine_datasets]]
+				binding = "AE_PREVIEW"
+				dataset = "data"
 
-		[[analytics_engine_datasets]]
-		binding = "AE_PREVIEW2"
-		dataset = "data"
+				[[env.production.analytics_engine_datasets]]
+				binding = "AE_PREVIEW2"
+				dataset = "data"
 
-		[ai]
-		binding = "AI_PREVIEW"
-
-		[env.production]
-		compatibility_date = "2024-02-14"
-
-		  [env.production.vars]
-		  TEST_JSON = """
-		{
-		json: "value"
-		}"""
-		  TEST_PLAINTEXT = "PLAINTEXT"
-
-		  [[env.production.kv_namespaces]]
-		  id = "kv-id"
-		  binding = "KV"
-
-		[[env.production.durable_objects.bindings]]
-		name = "DO"
-		class_name = "some-class-do-id"
-		script_name = "some-script-do-id"
-		environment = "some-environment-do-id"
-
-		  [[env.production.d1_databases]]
-		  database_id = "d1-id"
-		  binding = "D1"
-		  database_name = "D1"
-
-		  [[env.production.r2_buckets]]
-		  bucket_name = "r2-name"
-		  binding = "R2"
-
-		  [[env.production.services]]
-		  binding = "SERVICE"
-		  service = "service"
-		  environment = "production"
-
-		[[env.production.queues.producers]]
-		binding = "QUEUE"
-		queue = "q-id"
-
-		  [[env.production.analytics_engine_datasets]]
-		  binding = "AE"
-		  dataset = "data"
-
-		  [env.production.ai]
-		  binding = "AI"`
+				[env.production.ai]
+				binding = "AI_PREVIEW"`
 		);
-	});
-
-	it("should include all config in the _worker.bundle metadata", async () => {
 		/* ---------------------------- */
 		/*       Set up js files        */
 		/* ---------------------------- */
@@ -760,8 +717,343 @@ export default {
 	`);
 		const buildMetadataContents = readFileSync("build-metadata.json", "utf-8");
 		expect(buildMetadataContents).toMatchInlineSnapshot(
-			`"{\\"wrangler_config_hash\\":\\"49290f05177579eac4442a3cfd403a84429c189fc57e75697605eca07eb49d26\\",\\"build_output_directory\\":\\"dist-test\\"}"`
+			`"{\\"wrangler_config_hash\\":\\"75b267c678474945699c162b6d75e5e4a88fb8b491fc0650a390e097186031ab\\",\\"build_output_directory\\":\\"dist-test\\"}"`
 		);
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should ignore config with a non-pages config file", async () => {
+		writeFileSync(
+			"wrangler.toml",
+			dedent`
+				name = "project-name"
+				compatibility_date = "2023-02-14"
+				placement = { mode = "smart" }
+				limits = { cpu_ms = 50 }
+
+				[env.production.vars]
+				TEST_JSON_PREVIEW = """
+				{
+				json: "value"
+				}"""
+				TEST_PLAINTEXT_PREVIEW = "PLAINTEXT"
+
+				[[env.production.kv_namespaces]]
+				id = "kv-id"
+				binding = "KV_PREVIEW"
+
+				[[env.production.kv_namespaces]]
+				id = "kv-id"
+				binding = "KV_PREVIEW2"
+
+				[[env.production.durable_objects.bindings]]
+				name = "DO_PREVIEW"
+				class_name = "some-class-do-id"
+				script_name = "some-script-do-id"
+				environment = "some-environment-do-id"
+
+				[[env.production.durable_objects.bindings]]
+				name = "DO_PREVIEW2"
+				class_name = "some-class-do-id"
+				script_name = "some-script-do-id"
+				environment = "some-environment-do-id"
+
+				[[env.production.durable_objects.bindings]]
+				name = "DO_PREVIEW3"
+				class_name = "do-class"
+				script_name = "do-s"
+				environment = "do-e"
+
+				[[env.production.d1_databases]]
+				database_id = "d1-id"
+				binding = "D1_PREVIEW"
+				database_name = "D1_PREVIEW"
+
+				[[env.production.d1_databases]]
+				database_id = "d1-id"
+				binding = "D1_PREVIEW2"
+				database_name = "D1_PREVIEW2"
+
+				[[env.production.r2_buckets]]
+				bucket_name = "r2-name"
+				binding = "R2_PREVIEW"
+
+				[[env.production.r2_buckets]]
+				bucket_name = "r2-name"
+				binding = "R2_PREVIEW2"
+
+				[[env.production.services]]
+				binding = "SERVICE_PREVIEW"
+				service = "service"
+				environment = "production"
+
+				[[env.production.services]]
+				binding = "SERVICE_PREVIEW2"
+				service = "service"
+				environment = "production"
+
+				[[env.production.queues.producers]]
+				binding = "QUEUE_PREVIEW"
+				queue = "q-id"
+
+				[[env.production.queues.producers]]
+				binding = "QUEUE_PREVIEW2"
+				queue = "q-id"
+
+				[[env.production.analytics_engine_datasets]]
+				binding = "AE_PREVIEW"
+				dataset = "data"
+
+				[[env.production.analytics_engine_datasets]]
+				binding = "AE_PREVIEW2"
+				dataset = "data"
+
+				[env.production.ai]
+				binding = "AI_PREVIEW"`
+		);
+		/* ---------------------------- */
+		/*       Set up js files        */
+		/* ---------------------------- */
+		mkdirSync("utils");
+		writeFileSync(
+			"utils/meaning-of-life.js",
+			`
+export const MEANING_OF_LIFE = 21;
+`
+		);
+
+		/* ---------------------------- */
+		/*       Set up _worker.js      */
+		/* ---------------------------- */
+		mkdirSync("dist-test");
+		writeFileSync(
+			"dist-test/_worker.js",
+			`
+import { MEANING_OF_LIFE } from "./../utils/meaning-of-life.js";
+
+export default {
+  async fetch(request, env) {
+    return new Response("Hello from _worker.js. The meaning of life is " + MEANING_OF_LIFE);
+  },
+};`
+		);
+
+		/* --------------------------------- */
+		/*     Run cmd & make assertions     */
+		/* --------------------------------- */
+		await runWrangler(
+			`pages functions build --build-output-directory dist-test --outfile=_worker.bundle --build-metadata-path build-metadata.json --project-directory .`
+		);
+		expect(existsSync("_worker.bundle")).toBe(true);
+		expect(std.out).toMatchInlineSnapshot(`"✨ Compiled Worker successfully"`);
+
+		// some values in workerBundleContents, such as the undici form boundary
+		// or the file hashes, are randomly generated. Let's replace them
+		// with static values so we can test the file contents
+		const workerBundleContents = readFileSync("_worker.bundle", "utf-8");
+		const workerBundleWithConstantData = replaceRandomWithConstantData(
+			workerBundleContents,
+			[
+				[/------formdata-undici-0.[0-9]*/g, "------formdata-undici-0.test"],
+				[/functionsWorker-0.[0-9]*.js/g, "functionsWorker-0.test.js"],
+			]
+		);
+
+		expect(workerBundleWithConstantData).toMatchInlineSnapshot(`
+		"------formdata-undici-0.test
+		Content-Disposition: form-data; name=\\"metadata\\"
+
+		{\\"main_module\\":\\"functionsWorker-0.test.js\\"}
+		------formdata-undici-0.test
+		Content-Disposition: form-data; name=\\"functionsWorker-0.test.js\\"; filename=\\"functionsWorker-0.test.js\\"
+		Content-Type: application/javascript+module
+
+		// ../utils/meaning-of-life.js
+		var MEANING_OF_LIFE = 21;
+
+		// _worker.js
+		var worker_default = {
+		  async fetch(request, env) {
+		    return new Response(\\"Hello from _worker.js. The meaning of life is \\" + MEANING_OF_LIFE);
+		  }
+		};
+		export {
+		  worker_default as default
+		};
+
+		------formdata-undici-0.test--"
+	`);
+		const buildMetadataExists = existsSync("build-metadata.json");
+		// build-metadata should not exist
+		expect(buildMetadataExists).toBeFalsy();
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+	it("should ignore config with a non-pages config file w/ invalid environment", async () => {
+		writeFileSync(
+			"wrangler.toml",
+			dedent`
+				name = "project-name"
+				compatibility_date = "2023-02-14"
+				placement = { mode = "smart" }
+				limits = { cpu_ms = 50 }
+
+				[env.staging.vars]
+				TEST_JSON_PREVIEW = """
+				{
+				json: "value"
+				}"""
+				TEST_PLAINTEXT_PREVIEW = "PLAINTEXT"
+
+				[[env.staging.kv_namespaces]]
+				id = "kv-id"
+				binding = "KV_PREVIEW"
+
+				[[env.staging.kv_namespaces]]
+				id = "kv-id"
+				binding = "KV_PREVIEW2"
+
+				[[env.staging.durable_objects.bindings]]
+				name = "DO_PREVIEW"
+				class_name = "some-class-do-id"
+				script_name = "some-script-do-id"
+				environment = "some-environment-do-id"
+
+				[[env.staging.durable_objects.bindings]]
+				name = "DO_PREVIEW2"
+				class_name = "some-class-do-id"
+				script_name = "some-script-do-id"
+				environment = "some-environment-do-id"
+
+				[[env.staging.durable_objects.bindings]]
+				name = "DO_PREVIEW3"
+				class_name = "do-class"
+				script_name = "do-s"
+				environment = "do-e"
+
+				[[env.staging.d1_databases]]
+				database_id = "d1-id"
+				binding = "D1_PREVIEW"
+				database_name = "D1_PREVIEW"
+
+				[[env.staging.d1_databases]]
+				database_id = "d1-id"
+				binding = "D1_PREVIEW2"
+				database_name = "D1_PREVIEW2"
+
+				[[env.staging.r2_buckets]]
+				bucket_name = "r2-name"
+				binding = "R2_PREVIEW"
+
+				[[env.staging.r2_buckets]]
+				bucket_name = "r2-name"
+				binding = "R2_PREVIEW2"
+
+				[[env.staging.services]]
+				binding = "SERVICE_PREVIEW"
+				service = "service"
+				environment = "production"
+
+				[[env.staging.services]]
+				binding = "SERVICE_PREVIEW2"
+				service = "service"
+				environment = "production"
+
+				[[env.staging.queues.producers]]
+				binding = "QUEUE_PREVIEW"
+				queue = "q-id"
+
+				[[env.staging.queues.producers]]
+				binding = "QUEUE_PREVIEW2"
+				queue = "q-id"
+
+				[[env.staging.analytics_engine_datasets]]
+				binding = "AE_PREVIEW"
+				dataset = "data"
+
+				[[env.staging.analytics_engine_datasets]]
+				binding = "AE_PREVIEW2"
+				dataset = "data"
+
+				[env.staging.ai]
+				binding = "AI_PREVIEW"`
+		);
+		/* ---------------------------- */
+		/*       Set up js files        */
+		/* ---------------------------- */
+		mkdirSync("utils");
+		writeFileSync(
+			"utils/meaning-of-life.js",
+			`
+export const MEANING_OF_LIFE = 21;
+`
+		);
+
+		/* ---------------------------- */
+		/*       Set up _worker.js      */
+		/* ---------------------------- */
+		mkdirSync("dist-test");
+		writeFileSync(
+			"dist-test/_worker.js",
+			`
+import { MEANING_OF_LIFE } from "./../utils/meaning-of-life.js";
+
+export default {
+  async fetch(request, env) {
+    return new Response("Hello from _worker.js. The meaning of life is " + MEANING_OF_LIFE);
+  },
+};`
+		);
+
+		/* --------------------------------- */
+		/*     Run cmd & make assertions     */
+		/* --------------------------------- */
+		await runWrangler(
+			`pages functions build --build-output-directory dist-test --outfile=_worker.bundle --build-metadata-path build-metadata.json --project-directory .`
+		);
+		expect(existsSync("_worker.bundle")).toBe(true);
+		expect(std.out).toMatchInlineSnapshot(`"✨ Compiled Worker successfully"`);
+
+		// some values in workerBundleContents, such as the undici form boundary
+		// or the file hashes, are randomly generated. Let's replace them
+		// with static values so we can test the file contents
+		const workerBundleContents = readFileSync("_worker.bundle", "utf-8");
+		const workerBundleWithConstantData = replaceRandomWithConstantData(
+			workerBundleContents,
+			[
+				[/------formdata-undici-0.[0-9]*/g, "------formdata-undici-0.test"],
+				[/functionsWorker-0.[0-9]*.js/g, "functionsWorker-0.test.js"],
+			]
+		);
+
+		expect(workerBundleWithConstantData).toMatchInlineSnapshot(`
+		"------formdata-undici-0.test
+		Content-Disposition: form-data; name=\\"metadata\\"
+
+		{\\"main_module\\":\\"functionsWorker-0.test.js\\"}
+		------formdata-undici-0.test
+		Content-Disposition: form-data; name=\\"functionsWorker-0.test.js\\"; filename=\\"functionsWorker-0.test.js\\"
+		Content-Type: application/javascript+module
+
+		// ../utils/meaning-of-life.js
+		var MEANING_OF_LIFE = 21;
+
+		// _worker.js
+		var worker_default = {
+		  async fetch(request, env) {
+		    return new Response(\\"Hello from _worker.js. The meaning of life is \\" + MEANING_OF_LIFE);
+		  }
+		};
+		export {
+		  worker_default as default
+		};
+
+		------formdata-undici-0.test--"
+	`);
+		const buildMetadataExists = existsSync("build-metadata.json");
+		// build-metadata should not exist
+		expect(buildMetadataExists).toBeFalsy();
 
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -12,6 +12,9 @@ describe("pages-build-env", () => {
 	afterEach(() => {
 		process.env = originalEnv;
 	});
+	beforeEach(() => {
+		process.env.PAGES_ENVIRONMENT = "production";
+	});
 
 	it("should render empty object", async () => {
 		writeWranglerToml({
@@ -37,8 +40,75 @@ describe("pages-build-env", () => {
 			`"No Pages config file found"`
 		);
 	});
+	it("should fail correctly with a non-pages config file", async () => {
+		writeWranglerToml({
+			vars: {
+				VAR1: "VALUE1",
+				VAR2: "VALUE2",
+				JSON: { json: true },
+			},
+			env: {
+				production: {
+					vars: {
+						VAR1: "PROD_VALUE1",
+						VAR2: "PROD_VALUE2",
+						PROD_VAR3: "PROD_VALUE3",
+						JSON: { json: true },
+					},
+				},
+				preview: {
+					vars: {
+						VAR1: "PREVIEW_VALUE1",
+						VAR2: "PREVIEW_VALUE2",
+						PREVIEW_VAR3: "PREVIEW_VALUE3",
+						JSON: { json: true },
+					},
+				},
+			},
+		});
+		// This error is specifically handled by the caller of build-env
+		await expect(
+			runWrangler("pages functions build-env .")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Your wrangler.toml is not a valid Pages config file"`
+		);
+	});
+	it("should fail correctly with a non-pages config file w/ invalid environment", async () => {
+		writeWranglerToml({
+			vars: {
+				VAR1: "VALUE1",
+				VAR2: "VALUE2",
+				JSON: { json: true },
+			},
+			env: {
+				other: {
+					vars: {
+						VAR1: "PROD_VALUE1",
+						VAR2: "PROD_VALUE2",
+						PROD_VAR3: "PROD_VALUE3",
+						JSON: { json: true },
+					},
+				},
+				staging: {
+					vars: {
+						VAR1: "PREVIEW_VALUE1",
+						VAR2: "PREVIEW_VALUE2",
+						PREVIEW_VAR3: "PREVIEW_VALUE3",
+						JSON: { json: true },
+					},
+				},
+			},
+		});
+		// This error is specifically handled by the caller of build-env
+		await expect(
+			runWrangler("pages functions build-env .")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Your wrangler.toml is not a valid Pages config file"`
+		);
+	});
 
 	it("should return top-level by default", async () => {
+		process.env.PAGES_ENVIRONMENT = "";
 		writeWranglerToml({
 			pages_build_output_dir: "./dist",
 			vars: {

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -5,7 +5,7 @@ import { FatalError, UserError } from "../errors";
 import { logger } from "../logger";
 import { EXIT_CODE_INVALID_PAGES_CONFIG } from "../pages/errors";
 import { parseJSONC, parseTOML, readFileSync } from "../parse";
-import { normalizeAndValidateConfig } from "./validation";
+import { isPagesConfig, normalizeAndValidateConfig } from "./validation";
 import { validatePagesConfig } from "./validation-pages";
 import type { CfWorkerInit } from "../deployment-bundle/worker";
 import type { CommonYargsOptions } from "../yargs-types";
@@ -56,15 +56,15 @@ export function readConfig<CommandArgs>(
 	 * Pages projects currently have support for `wrangler.toml` only,
 	 * so we should error if `wrangler.json` is detected in a Pages project
 	 */
-	const isPagesConfig = rawConfig.pages_build_output_dir !== undefined;
-	if (!isPagesConfig && requirePagesConfig) {
+	const isPagesConfigFile = isPagesConfig(rawConfig);
+	if (!isPagesConfigFile && requirePagesConfig) {
 		throw new FatalError(
 			"Your wrangler.toml is not a valid Pages config file",
 			EXIT_CODE_INVALID_PAGES_CONFIG
 		);
 	}
 	if (
-		isPagesConfig &&
+		isPagesConfigFile &&
 		(configPath?.endsWith("json") || args.experimentalJsonConfig)
 	) {
 		throw new UserError(
@@ -91,7 +91,7 @@ export function readConfig<CommandArgs>(
 
 	// If we detected a Pages project, run config file validation against
 	// Pages specific validation rules
-	if (isPagesConfig) {
+	if (isPagesConfigFile) {
 		logger.debug(
 			`Configuration file belonging to ⚡️ Pages ⚡️ project detected.`
 		);

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -1,13 +1,9 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { readConfig } from "../config";
-import { isPagesConfig } from "../config/validation";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
-import {
-	EXIT_CODE_INVALID_PAGES_CONFIG,
-	EXIT_CODE_NO_CONFIG_FOUND,
-} from "./errors";
+import { EXIT_CODE_NO_CONFIG_FOUND } from "./errors";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -35,17 +31,15 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 		);
 	}
 
-	const config = readConfig(path.resolve(args.projectDir, "wrangler.toml"), {
-		...args,
-		// eslint-disable-next-line turbo/no-undeclared-env-vars
-		env: process.env.PAGES_ENVIRONMENT,
-	});
-	if (!isPagesConfig(config)) {
-		throw new FatalError(
-			"Your wrangler.toml is not a valid Pages config file",
-			EXIT_CODE_INVALID_PAGES_CONFIG
-		);
-	}
+	const config = readConfig(
+		path.resolve(args.projectDir, "wrangler.toml"),
+		{
+			...args,
+			// eslint-disable-next-line turbo/no-undeclared-env-vars
+			env: process.env.PAGES_ENVIRONMENT,
+		},
+		true
+	);
 
 	// Ensure JSON variables are not included
 	const textVars = Object.fromEntries(


### PR DESCRIPTION
## What this PR solves / how to test

Handle non-Pages wrangler.toml files better. This PR ensures that `wrangler pages functions build-env` and `wrangler pages functions build` fail fast with the appropriate error message if a non-pages wrangler.toml file is found. This ensure that config validation isn't run, which was inadvertently throwing errors for non-pages wrangler.toml files.

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: Not yet documented

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
