### PR TITLE
chore: bump `workerd` to `1.20240329.0`

### DIFF
--- a/.changeset/quick-insects-perform.md
+++ b/.changeset/quick-insects-perform.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+chore: bump `workerd` to [`1.20240329.0`](https://github.com/cloudflare/workerd/releases/tag/v1.20240329.0)

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240320.1",
+		"@cloudflare/workers-types": "^4.20240329.0",
 		"@types/node": "20.8.3",
 		"jose": "^5.2.2",
 		"miniflare": "workspace:*",

--- a/fixtures/vitest-pool-workers-examples/queues/test/queue-consumer-integration-self.test.ts
+++ b/fixtures/vitest-pool-workers-examples/queues/test/queue-consumer-integration-self.test.ts
@@ -14,11 +14,13 @@ it("consumes queue messages", async () => {
 		{
 			id: randomBytes(16).toString("hex"),
 			timestamp: new Date(1000),
+			attempts: 1,
 			body: { key: "/1", value: "one" },
 		},
 		{
 			id: randomBytes(16).toString("hex"),
 			timestamp: new Date(2000),
+			attempts: 1,
 			body: { key: "/2", value: "two" },
 		},
 	];

--- a/fixtures/vitest-pool-workers-examples/queues/test/queue-consumer-unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/queues/test/queue-consumer-unit.test.ts
@@ -14,11 +14,13 @@ it("consumes queue messages", async () => {
 		{
 			id: randomBytes(16).toString("hex"),
 			timestamp: new Date(1000),
+			attempts: 1,
 			body: { key: "/1", value: "one" },
 		},
 		{
 			id: randomBytes(16).toString("hex"),
 			timestamp: new Date(2000),
+			attempts: 1,
 			body: { key: "/2", value: "two" },
 		},
 	];

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -49,7 +49,7 @@
 		"glob-to-regexp": "^0.4.1",
 		"stoppable": "^1.1.0",
 		"undici": "^5.28.2",
-		"workerd": "1.20240320.1",
+		"workerd": "1.20240329.0",
 		"ws": "^8.11.0",
 		"youch": "^3.2.2",
 		"zod": "^3.20.6"
@@ -57,7 +57,7 @@
 	"devDependencies": {
 		"@ava/typescript": "^4.0.0",
 		"@cloudflare/kv-asset-handler": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240320.1",
+		"@cloudflare/workers-types": "^4.20240329.0",
 		"@microsoft/api-extractor": "^7.36.3",
 		"@types/debug": "^4.1.7",
 		"@types/estree": "^1.0.0",

--- a/packages/miniflare/src/workers/node.d.ts
+++ b/packages/miniflare/src/workers/node.d.ts
@@ -152,3 +152,7 @@ declare module "node:crypto" {
 
 	export function createHash(algorithm: string): Hash;
 }
+
+interface SymbolConstructor {
+	readonly dispose: unique symbol;
+}

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -1175,8 +1175,8 @@ test("Miniflare: getWorker() allows dispatching events directly", async (t) => {
 
 	// Check `Fetcher#queue()`
 	let queueResult = await fetcher.queue("needy", [
-		{ id: "a", timestamp: new Date(1000), body: "a" },
-		{ id: "b", timestamp: new Date(2000), body: { b: 1 } },
+		{ id: "a", timestamp: new Date(1000), body: "a", attempts: 1 },
+		{ id: "b", timestamp: new Date(2000), body: { b: 1 }, attempts: 1 },
 	]);
 	t.deepEqual(queueResult, {
 		outcome: "ok",
@@ -1188,14 +1188,24 @@ test("Miniflare: getWorker() allows dispatching events directly", async (t) => {
 		retryMessages: [],
 	});
 	queueResult = await fetcher.queue("queue", [
-		{ id: "c", timestamp: new Date(3000), body: new Uint8Array([1, 2, 3]) },
-		{ id: "perfect", timestamp: new Date(4000), body: new Date(5000) },
+		{
+			id: "c",
+			timestamp: new Date(3000),
+			body: new Uint8Array([1, 2, 3]),
+			attempts: 1,
+		},
+		{
+			id: "perfect",
+			timestamp: new Date(4000),
+			body: new Date(5000),
+			attempts: 1,
+		},
 	]);
 	t.deepEqual(queueResult, {
 		outcome: "ok",
 		ackAll: false,
 		retryBatch: {
-			retry: false
+			retry: false,
 		},
 		explicitAcks: ["perfect"],
 		retryMessages: [],

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -54,7 +54,7 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240320.1",
+		"@cloudflare/workers-types": "^4.20240329.0",
 		"@types/node": "20.8.3",
 		"capnp-ts": "^0.7.0",
 		"capnpc-ts": "^0.7.0",

--- a/packages/vitest-pool-workers/src/worker/events.ts
+++ b/packages/vitest-pool-workers/src/worker/events.ts
@@ -146,6 +146,7 @@ class QueueMessage<Body = unknown> /* Message */ {
 	readonly id!: string;
 	readonly timestamp!: Date;
 	readonly body!: Body;
+	readonly attempts!: number;
 	[kRetry] = false;
 	[kAck] = false;
 
@@ -171,6 +172,16 @@ class QueueMessage<Body = unknown> /* Message */ {
 			);
 		}
 
+		let attempts: number;
+		// noinspection SuspiciousTypeOfGuard
+		if (typeof message.attempts === "number") {
+			attempts = message.attempts;
+		} else {
+			throw new TypeError(
+				"Incorrect type for the 'attempts' field on 'ServiceBindingQueueMessage': the provided value is not of type 'number'."
+			);
+		}
+
 		if ("serializedBody" in message) {
 			throw new TypeError(
 				"Cannot use `serializedBody` with `createMessageBatch()`"
@@ -193,6 +204,11 @@ class QueueMessage<Body = unknown> /* Message */ {
 			body: {
 				get() {
 					return body;
+				},
+			},
+			attempts: {
+				get() {
+					return attempts;
 				},
 			},
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -638,8 +638,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest-pool-workers
       '@cloudflare/workers-types':
-        specifier: ^4.20240320.1
-        version: 4.20240320.1
+        specifier: ^4.20240329.0
+        version: 4.20240329.0
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
@@ -997,8 +997,8 @@ importers:
         specifier: ^5.28.2
         version: 5.28.3
       workerd:
-        specifier: 1.20240320.1
-        version: 1.20240320.1
+        specifier: 1.20240329.0
+        version: 1.20240329.0
       ws:
         specifier: ^8.11.0
         version: 8.14.2
@@ -1016,8 +1016,8 @@ importers:
         specifier: workspace:*
         version: link:../kv-asset-handler
       '@cloudflare/workers-types':
-        specifier: ^4.20240320.1
-        version: 4.20240320.1
+        specifier: ^4.20240329.0
+        version: 4.20240329.0
       '@microsoft/api-extractor':
         specifier: ^7.36.3
         version: 7.38.2(@types/node@18.16.10)
@@ -1294,8 +1294,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240320.1
-        version: 4.20240320.1
+        specifier: ^4.20240329.0
+        version: 4.20240329.0
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
@@ -4127,8 +4127,8 @@ packages:
       marked: 0.3.19
     dev: false
 
-  /@cloudflare/workerd-darwin-64@1.20240320.1:
-    resolution: {integrity: sha512-ioG5k2M17xyiAlK/k3L21NZLMVeSHMjwlmGtZyCyzSLL5/zGINcgZ5yPLV0UuWiysw07/6Jjzm5Sx94hzMVybg==}
+  /@cloudflare/workerd-darwin-64@1.20240329.0:
+    resolution: {integrity: sha512-/raHmsHrYjoC5am84wqyiZIDCRrrYN6YDFb4zchwWQzJ0ZHleUeY6IzNdjujrS/gYey/+Db9oyl2PD1xAZt4gA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -4136,8 +4136,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-darwin-arm64@1.20240320.1:
-    resolution: {integrity: sha512-Ga6RDdnFEIsN4WuWsaP9bLGvK9K7pEIVoSIgmw6vweVlD8UK/a2MPGrsF1ogwdeCTCOMY8wUh9poL/Yu48IPpg==}
+  /@cloudflare/workerd-darwin-arm64@1.20240329.0:
+    resolution: {integrity: sha512-3wnwVdfFDt+JUhlA6NWW+093ryGNF0HMuBmkOh0PG6j4GMRH8Y+EDsqzqrzT3ZoGGXbI9x1H7k15VKb3LAN/KA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -4145,8 +4145,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-64@1.20240320.1:
-    resolution: {integrity: sha512-KFof5H8eU0NXv+pUAU7Lk/OLtOmfsioTJqu0v6kPL7QsTGsgzj5sEQNcQ8DONSze549Yflu5W00qpA2cPz9eWQ==}
+  /@cloudflare/workerd-linux-64@1.20240329.0:
+    resolution: {integrity: sha512-E909ZIXgjdr2iuq5bF/vq02elizDlPQoYRiKojdvODC7w8rbnpwnuptajS4xK5kmKh4XBiU2o9NDhut/W1kfyw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -4154,8 +4154,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-linux-arm64@1.20240320.1:
-    resolution: {integrity: sha512-t+kGc6dGdkKvVMGcHCPhlCsUZF5dj8xbAFvLB7DAJ8T79ys30rmY2Lu/C8vKlhjH9TJhbzgKmPaJ0wC/K4euvw==}
+  /@cloudflare/workerd-linux-arm64@1.20240329.0:
+    resolution: {integrity: sha512-PELA3FVW75pKchsSI5o40oiClFY2Uiq+KUx/f/srwz2pIJoM5YWLmFrv+s8feKoEwuabxIGSzHxy7QA++HyprQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -4163,8 +4163,8 @@ packages:
     dev: false
     optional: true
 
-  /@cloudflare/workerd-windows-64@1.20240320.1:
-    resolution: {integrity: sha512-9xDylCOsuzWqGuANkuUByiJ5RHeMqgw37FiI7rn8I6zdGAc/alOB9B4Bh7B73WC2uEpFL+XCEjcHZ6NmsO4NaQ==}
+  /@cloudflare/workerd-windows-64@1.20240329.0:
+    resolution: {integrity: sha512-/T+AcjVqTuqAeGBQmjAF4TOTm8sv3BSO/NtUPa1ghCvsp1sb03L6/c3wFc9ZonSdRYeBb0XDX7PnenGCvjr/Tw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -4177,6 +4177,10 @@ packages:
 
   /@cloudflare/workers-types@4.20240320.1:
     resolution: {integrity: sha512-CiYtVpQURPgQqtBKkmOAnfPElVZuD7Xyf1IxKtKp2B4aB9gnooapwJhzeY8c4Ls4u17SgMS0MprOkrgYwzZ6xg==}
+    dev: true
+
+  /@cloudflare/workers-types@4.20240329.0:
+    resolution: {integrity: sha512-AbzgvSQjG8Nci4xxQEcjTTVjiWXgOQnFIbIHtEZXteHiMGDXMWGegjWBo5JHGsZCq+U5V/SD5EnlypQnUQEoig==}
     dev: true
 
   /@cnakazawa/watch@1.0.4:
@@ -20810,17 +20814,17 @@ packages:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
 
-  /workerd@1.20240320.1:
-    resolution: {integrity: sha512-nuavAGGjh0qqM6RF5zxTHyUwEqdLCHchodbrpbh/xlJpFGnJVY5C1YgSi2S9aLkJJoa0/25Ta/+EzXEbApA/3w==}
+  /workerd@1.20240329.0:
+    resolution: {integrity: sha512-6wWuMOwWsp3K6447XsI/MZYFq0KlpV2zVbbNFEkv3N7UgJJKaHGwL/hilr6RlS4UFLU4co8nrF2lc5uR781HKg==}
     engines: {node: '>=16'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20240320.1
-      '@cloudflare/workerd-darwin-arm64': 1.20240320.1
-      '@cloudflare/workerd-linux-64': 1.20240320.1
-      '@cloudflare/workerd-linux-arm64': 1.20240320.1
-      '@cloudflare/workerd-windows-64': 1.20240320.1
+      '@cloudflare/workerd-darwin-64': 1.20240329.0
+      '@cloudflare/workerd-darwin-arm64': 1.20240329.0
+      '@cloudflare/workerd-linux-64': 1.20240329.0
+      '@cloudflare/workerd-linux-arm64': 1.20240329.0
+      '@cloudflare/workerd-windows-64': 1.20240329.0
     dev: false
 
   /wrap-ansi@6.2.0:


### PR DESCRIPTION
## What this PR solves / how to test

This PR upgrades `workerd` to [`1.20240329.0`](https://github.com/cloudflare/workerd/releases/tag/v1.20240329.0). This version contains some breaking changes to the experimental `Fetcher#queue()` method. It also introduces an accidental bump in the minimum supported TypeScript version to TypeScript 5.2 for `@cloudflare/workers-types` due to `Symbol.dispose` use. I did consider compatibility with older versions when making those types changes, but I missed a couple uses. 🙁 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: should pass existing
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bumping dependency, `workerd` changes tracked elsewhere

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
