### PR TITLE
Expose more info from `wrangler pages functions build-env`

### DIFF
--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -27,7 +27,7 @@ describe("pages-build-env", () => {
 		  "debug": "",
 		  "err": "",
 		  "info": "",
-		  "out": "{}",
+		  "out": "{\\"vars\\":{},\\"pages_build_output_dir\\":\\"dist\\"}",
 		  "warn": "",
 		}
 	`);
@@ -141,7 +141,7 @@ describe("pages-build-env", () => {
 		  "debug": "",
 		  "err": "",
 		  "info": "",
-		  "out": "{\\"VAR1\\":\\"VALUE1\\",\\"VAR2\\":\\"VALUE2\\"}",
+		  "out": "{\\"vars\\":{\\"VAR1\\":\\"VALUE1\\",\\"VAR2\\":\\"VALUE2\\"},\\"pages_build_output_dir\\":\\"dist\\"}",
 		  "warn": "",
 		}
 	`);
@@ -180,7 +180,7 @@ describe("pages-build-env", () => {
 		  "debug": "",
 		  "err": "",
 		  "info": "",
-		  "out": "{\\"VAR1\\":\\"PROD_VALUE1\\",\\"VAR2\\":\\"PROD_VALUE2\\",\\"PROD_VAR3\\":\\"PROD_VALUE3\\"}",
+		  "out": "{\\"vars\\":{\\"VAR1\\":\\"PROD_VALUE1\\",\\"VAR2\\":\\"PROD_VALUE2\\",\\"PROD_VAR3\\":\\"PROD_VALUE3\\"},\\"pages_build_output_dir\\":\\"dist\\"}",
 		  "warn": "",
 		}
 	`);
@@ -220,7 +220,7 @@ describe("pages-build-env", () => {
 		  "debug": "",
 		  "err": "",
 		  "info": "",
-		  "out": "{\\"VAR1\\":\\"PREVIEW_VALUE1\\",\\"VAR2\\":\\"PREVIEW_VALUE2\\",\\"PREVIEW_VAR3\\":\\"PREVIEW_VALUE3\\"}",
+		  "out": "{\\"vars\\":{\\"VAR1\\":\\"PREVIEW_VALUE1\\",\\"VAR2\\":\\"PREVIEW_VALUE2\\",\\"PREVIEW_VAR3\\":\\"PREVIEW_VALUE3\\"},\\"pages_build_output_dir\\":\\"dist\\"}",
 		  "warn": "",
 		}
 	`);

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -32,6 +32,20 @@ export function readConfig<CommandArgs>(
 	// Include command specific args as well as the wrangler global flags
 	args: CommandArgs &
 		Pick<OnlyCamelCase<CommonYargsOptions>, "experimentalJsonConfig">,
+	requirePagesConfig: true
+): Omit<Config, "pages_build_output_dir"> & { pages_build_output_dir: string };
+export function readConfig<CommandArgs>(
+	configPath: string | undefined,
+	// Include command specific args as well as the wrangler global flags
+	args: CommandArgs &
+		Pick<OnlyCamelCase<CommonYargsOptions>, "experimentalJsonConfig">,
+	requirePagesConfig?: boolean
+): Config;
+export function readConfig<CommandArgs>(
+	configPath: string | undefined,
+	// Include command specific args as well as the wrangler global flags
+	args: CommandArgs &
+		Pick<OnlyCamelCase<CommonYargsOptions>, "experimentalJsonConfig">,
 	requirePagesConfig?: boolean
 ): Config {
 	let rawConfig: RawConfig = {};

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -46,5 +46,13 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 		Object.entries(config.vars).filter(([_, v]) => typeof v === "string")
 	);
 
-	logger.log(JSON.stringify(textVars));
+	logger.log(
+		JSON.stringify({
+			vars: textVars,
+			pages_build_output_dir: path.relative(
+				args.projectDir,
+				config.pages_build_output_dir
+			),
+		})
+	);
 };


### PR DESCRIPTION
## What this PR solves / how to test
This PR exposes the `pages_build_output_dir` from `wrangler pages build-env` as well as just the config vars
## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: Not a documented command

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
