### PR TITLE
feature: add version-id filter for Worker tailing

### DIFF
--- a/.changeset/young-cameras-repair.md
+++ b/.changeset/young-cameras-repair.md
@@ -1,0 +1,9 @@
+---
+"wrangler": minor
+---
+
+feature: Add version-id filter for Worker tailing to filter logs by scriptVersion in a gradual deployment
+
+This allows users to only get logs in a gradual deployment if you are troubleshooting issues
+specific to one deployment. Example:
+`npx wrangler tail --version-id 72d3f357-4e52-47c5-8805-90be978c403f`

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -332,6 +332,16 @@ describe("tail", () => {
 			});
 		});
 
+		it("sends version id filters", async () => {
+			const api = mockWebsocketAPIs();
+			const versionId = "87501bef-3ef2-4464-a3d6-35e548695742";
+
+			await runWrangler(`tail test-worker --version-id ${versionId}`);
+			expect(api.requests.creation[0]).toEqual({
+				filters: [{ scriptVersion: versionId }],
+			});
+		});
+
 		it("sends everything but the kitchen sink", async () => {
 			const api = mockWebsocketAPIs();
 			const sampling_rate = 0.69;
@@ -340,6 +350,7 @@ describe("tail", () => {
 			const header = "X-HELLO:world";
 			const client_ip = ["192.0.2.1", "self"];
 			const query = "onlyTheseMessagesPlease";
+			const versionId = "87501bef-3ef2-4464-a3d6-35e548695742";
 
 			const cliFilters =
 				`--sampling-rate ${sampling_rate} ` +
@@ -348,6 +359,7 @@ describe("tail", () => {
 				`--header ${header} ` +
 				client_ip.map((c) => `--ip ${c} `).join("") +
 				`--search ${query} ` +
+				`--version-id ${versionId} ` +
 				`--debug`;
 
 			const expectedWebsocketMessage = {
@@ -366,6 +378,7 @@ describe("tail", () => {
 					{ header: { key: "X-HELLO", query: "world" } },
 					{ client_ip: ["192.0.2.1", "self"] },
 					{ query: "onlyTheseMessagesPlease" },
+					{ scriptVersion: versionId },
 				],
 			};
 

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -70,6 +70,11 @@ export function tailOptions(yargs: CommonYargsArgv) {
 				'Filter by the IP address the request originates from. Use "self" to filter for your own IP',
 			array: true,
 		})
+		.option("version-id", {
+			type: "string",
+			requiresArg: true,
+			describe: "Filter by Worker version",
+		})
 		.option("debug", {
 			type: "boolean",
 			hidden: true,
@@ -122,6 +127,7 @@ export async function tailHandler(args: TailArgs) {
 		samplingRate: args.samplingRate,
 		search: args.search,
 		clientIp: args.ip,
+		versionId: args.versionId,
 	};
 	const scriptContent: string = await fetchScriptContent(
 		(!isLegacyEnv(config) ? args.env : undefined)


### PR DESCRIPTION
Adds the ability to filter by version in `wrangler tail`.

Fixes WP-797

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because: 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [0] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/13749
  - [ ] Not necessary because:
