### PR TITLE
[wrangler] Export URL from Node.js polyfills

### DIFF
--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -15,6 +15,7 @@ import { getEntryPointFromMetafile } from "./entry-point-from-metafile";
 import { cloudflareInternalPlugin } from "./esbuild-plugins/cloudflare-internal";
 import { configProviderPlugin } from "./esbuild-plugins/config-provider";
 import { nodejsCompatPlugin } from "./esbuild-plugins/nodejs-compat";
+import { standardURLPlugin } from "./esbuild-plugins/standard-url";
 import { writeAdditionalModules } from "./find-additional-modules";
 import { noopModuleCollector } from "./module-collection";
 import type { Config } from "../config";
@@ -342,7 +343,11 @@ export async function bundleWorker(
 		plugins: [
 			moduleCollector.plugin,
 			...(legacyNodeCompat
-				? [NodeGlobalsPolyfills({ buffer: true }), NodeModulesPolyfills()]
+				? [
+						NodeGlobalsPolyfills({ buffer: true }),
+						standardURLPlugin(),
+						NodeModulesPolyfills(),
+				  ]
 				: []),
 			nodejsCompatPlugin(!!nodejsCompat),
 			cloudflareInternalPlugin,

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/standard-url.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/standard-url.ts
@@ -1,0 +1,38 @@
+import type { Plugin } from "esbuild";
+
+/**
+ * An esbuild plugin that will export URL from the url polyfill
+ */
+export const standardURLPlugin: () => Plugin = () => ({
+	name: "standard URL plugin",
+	setup(pluginBuild) {
+		pluginBuild.onResolve({ filter: /^url$/ }, ({ importer }) => {
+			if (importer === "standard-url-plugin") return;
+			return {
+				path: "wrangler-url-polyfill",
+				namespace: "wrangler-url",
+			};
+		});
+		pluginBuild.onResolve(
+			{ filter: /^wrangler:url$/ },
+			async ({ kind, resolveDir }) => {
+				const result = await pluginBuild.resolve("url", {
+					kind,
+					resolveDir,
+					importer: "standard-url-plugin",
+				});
+
+				return result;
+			}
+		);
+		pluginBuild.onLoad(
+			{ filter: /^wrangler-url-polyfill$/, namespace: "wrangler-url" },
+			() => {
+				return {
+					loader: "js",
+					contents: `export * from "wrangler:url"; export const URL = globalThis.URL`,
+				};
+			}
+		);
+	},
+});


### PR DESCRIPTION
## What this PR solves / how to test

This patches the Node.js polyfills Wrangler uses to export `URL` (which is implemented in Workers on `globalThis`)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
