### PR TITLE
Use new Discord server url

### DIFF
--- a/.changeset/wise-beds-buy.md
+++ b/.changeset/wise-beds-buy.md
@@ -1,0 +1,10 @@
+---
+"create-cloudflare": patch
+"format-errors": patch
+"@cloudflare/kv-asset-handler": patch
+"miniflare": patch
+"workers-playground": patch
+"wrangler": patch
+---
+
+Show new Discord url everywhere for consistency. The old URL still works, but https://discord.cloudflare.com is preferred.

--- a/.changeset/wise-beds-buy.md
+++ b/.changeset/wise-beds-buy.md
@@ -7,4 +7,4 @@
 "wrangler": patch
 ---
 
-Show new Discord url everywhere for consistency. The old URL still works, but https://discord.cloudflare.com is preferred.
+docs: show new Discord url everywhere for consistency. The old URL still works, but https://discord.cloudflare.com is preferred.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Support
-    url: https://discord.gg/CloudflareDev
+    url: https://discord.cloudflare.com
     about: "Join us on Discord!"

--- a/packages/create-cloudflare/src/summary.ts
+++ b/packages/create-cloudflare/src/summary.ts
@@ -35,7 +35,7 @@ export const printSummary = async (ctx: C3Context) => {
 			"Read the documentation",
 			`https://developers.cloudflare.com/${ctx.template.platform}`,
 		],
-		["Stuck? Join us at", "https://discord.gg/cloudflaredev"],
+		["Stuck? Join us at", "https://discord.cloudflare.com"],
 	];
 
 	if (ctx.deployment.url) {

--- a/packages/format-errors/src/index.ts
+++ b/packages/format-errors/src/index.ts
@@ -111,7 +111,7 @@ export async function handlePrettyErrorRequest({
 	youch.addLink(() => {
 		return [
 			'<a href="https://developers.cloudflare.com/workers/" target="_blank" style="text-decoration:none">📚 Workers Docs</a>',
-			'<a href="https://discord.gg/cloudflaredev" target="_blank" style="text-decoration:none">💬 Workers Discord</a>',
+			'<a href="https://discord.cloudflare.com" target="_blank" style="text-decoration:none">💬 Workers Discord</a>',
 		].join("");
 	});
 	return new Response(await youch.toHTML(), {

--- a/packages/kv-asset-handler/README.md
+++ b/packages/kv-asset-handler/README.md
@@ -12,7 +12,7 @@ Most users and sites will not need these customizations, and just want to serve 
 
 For users who _do_ want to customize their assets, and want to build complex experiences on top of their static assets, `kv-asset-handler` (and the default [Workers Sites template](https://github.com/cloudflare/worker-sites-template), which is provided for use with Wrangler + Workers Sites) allows you to customize caching behavior, headers, and anything else about how your Workers function loads the static assets for your site stored in Workers KV.
 
-The Cloudflare Workers Discord server is an active place where Workers users get help, share feedback, and collaborate on making our platform better. The `#workers` channel in particular is a great place to chat about `kv-asset-handler`, and building cool experiences for your users using these tools! If you have questions, want to share what you're working on, or give feedback, [join us in Discord and say hello](https://discord.gg/cloudflaredev)!
+The Cloudflare Workers Discord server is an active place where Workers users get help, share feedback, and collaborate on making our platform better. The `#workers` channel in particular is a great place to chat about `kv-asset-handler`, and building cool experiences for your users using these tools! If you have questions, want to share what you're working on, or give feedback, [join us in Discord and say hello](https://discord.cloudflare.com)!
 
 - [Installation](#installation)
 - [Usage](#usage)

--- a/packages/miniflare/src/plugins/core/errors/index.ts
+++ b/packages/miniflare/src/plugins/core/errors/index.ts
@@ -266,7 +266,7 @@ export async function handlePrettyErrorRequest(
 	youch.addLink(() => {
 		return [
 			'<a href="https://developers.cloudflare.com/workers/" target="_blank" style="text-decoration:none">📚 Workers Docs</a>',
-			'<a href="https://discord.gg/cloudflaredev" target="_blank" style="text-decoration:none">💬 Workers Discord</a>',
+			'<a href="https://discord.cloudflare.com" target="_blank" style="text-decoration:none">💬 Workers Discord</a>',
 		].join("");
 	});
 	return new Response(await youch.toHTML(), {

--- a/packages/workers-playground/src/QuickEditor/ToolsPane.tsx
+++ b/packages/workers-playground/src/QuickEditor/ToolsPane.tsx
@@ -69,7 +69,7 @@ export default function ToolsPane() {
 									title="Join Cloudflare’s developer Discord"
 									target="_blank"
 									display={"inline-flex"}
-									href={`https://discord.gg/cloudflaredev`}
+									href={`https://discord.cloudflare.com`}
 								>
 									<Icon
 										type="discord"

--- a/packages/wrangler/README.md
+++ b/packages/wrangler/README.md
@@ -3,7 +3,7 @@
 <a href="https://www.npmjs.com/package/wrangler"><img alt="npm"  src="https://img.shields.io/npm/dw/wrangler?style=flat-square"></a>
 <img alt="GitHub contributors" src="https://img.shields.io/github/contributors/cloudflare/workers-sdk?style=flat-square">
 <img alt="GitHub commit activity (branch)" src="https://img.shields.io/github/commit-activity/w/cloudflare/workers-sdk/main?style=flat-square">
-<a href="https://discord.gg/CloudflareDev"><img alt="Discord" src="https://img.shields.io/discord/595317990191398933?color=%23F48120&style=flat-square"></a>
+<a href="https://discord.cloudflare.com"><img alt="Discord" src="https://img.shields.io/discord/595317990191398933?color=%23F48120&style=flat-square"></a>
 </section>
 
 `wrangler` is a command line tool for building [Cloudflare Workers](https://workers.cloudflare.com/).

--- a/packages/wrangler/src/__tests__/constellation.test.ts
+++ b/packages/wrangler/src/__tests__/constellation.test.ts
@@ -92,7 +92,7 @@ describe("constellation commands", () => {
 		"--------------------
 		🚧 Constellation is currently in open alpha and is not recommended for production data and traffic
 		🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		🚧 To give feedback, visit https://discord.gg/cloudflaredev
+		🚧 To give feedback, visit https://discord.cloudflare.com
 		--------------------
 
 		✅ Successfully created Project \\"new_project3\\"!"
@@ -106,7 +106,7 @@ describe("constellation commands", () => {
 		"--------------------
 		🚧 Constellation is currently in open alpha and is not recommended for production data and traffic
 		🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		🚧 To give feedback, visit https://discord.gg/cloudflaredev
+		🚧 To give feedback, visit https://discord.cloudflare.com
 		--------------------
 
 		┌──────────────────────────────────────┬──────────────┬─────────┬─────────────────────────────┐
@@ -129,7 +129,7 @@ describe("constellation commands", () => {
 		"--------------------
 		🚧 Constellation is currently in open alpha and is not recommended for production data and traffic
 		🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		🚧 To give feedback, visit https://discord.gg/cloudflaredev
+		🚧 To give feedback, visit https://discord.cloudflare.com
 		--------------------
 
 		About to delete Project 'new_project3' (4806cdcf-9aa7-4fa2-b6a1-77fe9e196680).
@@ -145,7 +145,7 @@ describe("constellation commands", () => {
 		"--------------------
 		🚧 Constellation is currently in open alpha and is not recommended for production data and traffic
 		🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		🚧 To give feedback, visit https://discord.gg/cloudflaredev
+		🚧 To give feedback, visit https://discord.cloudflare.com
 		--------------------
 
 		┌──────────────────────────────────────┬──────────────────────┬─────────────────┬───────────────┐
@@ -163,7 +163,7 @@ describe("constellation commands", () => {
 		"--------------------
 		🚧 Constellation is currently in open alpha and is not recommended for production data and traffic
 		🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		🚧 To give feedback, visit https://discord.gg/cloudflaredev
+		🚧 To give feedback, visit https://discord.cloudflare.com
 		--------------------
 
 		┌─────────┐
@@ -186,7 +186,7 @@ describe("constellation commands", () => {
 		"--------------------
 		🚧 Constellation is currently in open alpha and is not recommended for production data and traffic
 		🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		🚧 To give feedback, visit https://discord.gg/cloudflaredev
+		🚧 To give feedback, visit https://discord.cloudflare.com
 		--------------------
 
 		✅ Successfully uploaded Model \\"model2\\"!"
@@ -200,7 +200,7 @@ describe("constellation commands", () => {
 		"--------------------
 		🚧 Constellation is currently in open alpha and is not recommended for production data and traffic
 		🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		🚧 To give feedback, visit https://discord.gg/cloudflaredev
+		🚧 To give feedback, visit https://discord.cloudflare.com
 		--------------------
 
 		┌──────────────────────────────────────┬──────────────────────────────────────┬────────┬─────────────┬─────────────────────────────┐
@@ -225,7 +225,7 @@ describe("constellation commands", () => {
 		"--------------------
 		🚧 Constellation is currently in open alpha and is not recommended for production data and traffic
 		🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		🚧 To give feedback, visit https://discord.gg/cloudflaredev
+		🚧 To give feedback, visit https://discord.cloudflare.com
 		--------------------
 
 		About to delete Model 'model2' (2dd35b4e-0c7a-4c7a-a9e2-e33c0e17bc02).

--- a/packages/wrangler/src/constellation/utils.ts
+++ b/packages/wrangler/src/constellation/utils.ts
@@ -11,7 +11,7 @@ export const getConstellationWarningFromEnv = getEnvironmentVariableFactory({
 export const constellationBetaWarning =
 	getConstellationWarningFromEnv() !== undefined
 		? ""
-		: "--------------------\n🚧 Constellation is currently in open alpha and is not recommended for production data and traffic\n🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose\n🚧 To give feedback, visit https://discord.gg/cloudflaredev\n--------------------\n";
+		: "--------------------\n🚧 Constellation is currently in open alpha and is not recommended for production data and traffic\n🚧 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose\n🚧 To give feedback, visit https://discord.cloudflare.com\n--------------------\n";
 
 export const getProjectByName = async (
 	config: Config,


### PR DESCRIPTION
## What this PR solves / how to test

Hi :wave:,

I was originally reproducing and fixing a completely unrelated bug in c3, but noticed the old url in the summary after creating a project. Since the new URL is preferred, I thought I'd PR it, and a quick search found another 20 or so matches.

The only remaining instances of the old .gg/cloudflaredev one are in changelog entries, which I didn't want to modify.

The changeset for this is a patch to every touched package, not sure if this is worth releasing kv-asset-handler for. Also since Hyperdrive is now GA (🎉), the banner might go away so if this would cause merge conflicts, happy to undo any conflicting ones (also Constellation).

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included, but something broke and didn't run locally so 🤞 
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: most places in the docs repo already use the new link

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
