### PR TITLE
[C3] Skip empty summary rows

### DIFF
--- a/.changeset/quick-cheetahs-attack.md
+++ b/.changeset/quick-cheetahs-attack.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Skip empty next steps in the output summary. Previously, they would log undefined undefined.

--- a/.changeset/quick-cheetahs-attack.md
+++ b/.changeset/quick-cheetahs-attack.md
@@ -2,4 +2,4 @@
 "create-cloudflare": patch
 ---
 
-Skip empty next steps in the output summary. Previously, they would log undefined undefined.
+fix: make sure that using the current directory doesn't generate an `undefined undefined` log in the output summary.

--- a/packages/create-cloudflare/src/summary.ts
+++ b/packages/create-cloudflare/src/summary.ts
@@ -59,7 +59,7 @@ export const printSummary = async (ctx: C3Context) => {
 	}
 
 	newline();
-	nextSteps.forEach((entry) => {
+	nextSteps.filter(entry => entry.length > 0).forEach((entry) => {
 		log(`${dim(entry[0])} ${blue(entry[1])}`);
 	});
 	newline();

--- a/packages/create-cloudflare/src/summary.ts
+++ b/packages/create-cloudflare/src/summary.ts
@@ -12,9 +12,9 @@ export const printSummary = async (ctx: C3Context) => {
 
 	const dirRelativePath = relative(ctx.originalCWD, ctx.project.path);
 	const nextSteps = [
-		dirRelativePath
-			? ["Navigate to the new directory", `cd ${dirRelativePath}`]
-			: [],
+		...(dirRelativePath
+			? [["Navigate to the new directory", `cd ${dirRelativePath}`]]
+			: []),
 		[
 			"Run the development server",
 			quoteShellArgs([npm, "run", ctx.template.devScript ?? "start"]),
@@ -59,7 +59,7 @@ export const printSummary = async (ctx: C3Context) => {
 	}
 
 	newline();
-	nextSteps.filter(entry => entry.length > 0).forEach((entry) => {
+	nextSteps.forEach((entry) => {
 		log(`${dim(entry[0])} ${blue(entry[1])}`);
 	});
 	newline();


### PR DESCRIPTION
## What this PR solves / how to test

Hi :wave:,

Before getting side-tracked with #5482, I found that when using `.` as the project location, there was nowhere to `cd` to, so the first line in the next steps output summary was skipped. Instead of being properly skipped, `undefined undefined` was printed (see screenshot). This change should skip over these lines where a step is excluded.

![image](https://github.com/cloudflare/workers-sdk/assets/6977583/33cf2b8e-755e-4327-af41-950187b177f1)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Didn't see any tests for the summary
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bugfix

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
