### PR TITLE
Swallow parsing errors

### DIFF
--- a/.changeset/kind-apples-tap.md
+++ b/.changeset/kind-apples-tap.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Swallow parsing errors when a pages config file is required.

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
+import { writeFileSync } from "node:fs";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
@@ -72,6 +73,16 @@ describe("pages build env", () => {
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`"Your wrangler.toml is not a valid Pages config file"`
 		);
+	});
+	it("should fail correctly with an unparseable config file", async () => {
+		writeFileSync("./wrangler.toml", 'INVALID "FILE');
+		// This error is specifically handled by the caller of build-env
+		await expect(
+			runWrangler("pages functions build-env .")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Your wrangler.toml is not a valid Pages config file"`
+		);
+		expect(std.err).toContain("ParseError");
 	});
 	it("should fail correctly with a non-pages config file w/ invalid environment", async () => {
 		writeWranglerToml({


### PR DESCRIPTION
## What this PR solves / how to test

Swallow parsing errors when a pages config file is required. This prevents builds failing with invalid non-pages config files. It also means that invalid config file that were intended for Pages will be ignored, which is slightly unfortunate, but we should err on the side of not breaking existing users.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: Not documented yet

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
