### PR TITLE
Use spaces for yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,6 @@ root = true
 end_of_line = lf
 indent_style = tab
 
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## What this PR solves / how to test

YAML needs space indentation. We use it for GitHub Actions. This tells IDEs to use spaces by default in yml/yaml files.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: non-functional change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: non-functional change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: non-functional change

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
