### PR TITLE
C3: add test command to JS template. update failing test example in js template.

### DIFF
--- a/.changeset/polite-shirts-obey.md
+++ b/.changeset/polite-shirts-obey.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: update failing test and add test command to package.json in C3 Hello World JS template.

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -5,7 +5,8 @@
 	"scripts": {
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",
-		"start": "wrangler dev"
+		"start": "wrangler dev",
+		"test": "vitest"
 	},
 	"devDependencies": {
 		"wrangler": "^3.0.0",

--- a/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
+++ b/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
@@ -14,7 +14,7 @@ describe("Hello World worker", () => {
   });
 
   it("responds with Hello World! (integration style)", async () => {
-   const response = await SELF.fetch(request, env, ctx);
+   const response = await SELF.fetch("http://example.com");
    expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
  });
 });

--- a/packages/create-cloudflare/templates/hello-world/ts/test/index.spec.ts
+++ b/packages/create-cloudflare/templates/hello-world/ts/test/index.spec.ts
@@ -19,7 +19,7 @@ describe("Hello World worker", () => {
   });
 
   it("responds with Hello World! (integration style)", async () => {
-   const response = await SELF.fetch("https://example.com");
-   expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+    const response = await SELF.fetch("https://example.com");
+    expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
  });
 });


### PR DESCRIPTION
## What this PR solves / how to test

- add test command to JS template. update failing test example in js template.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: no docs needed
