### PR TITLE
Write build-env to file

### DIFF
--- a/.changeset/real-students-chew.md
+++ b/.changeset/real-students-chew.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Write `wrangler pages functions build-env` to file rather than stdout

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -2240,7 +2240,7 @@ describe("normalizeAndValidateConfig()", () => {
 					{ env: undefined }
 				);
 
-				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			"Processing wrangler configuration:
 			  - \\"hyperdrive[0]\\" bindings should have a string \\"binding\\" field but got {}.

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -35,13 +35,7 @@ describe("hyperdrive help", () => {
 		  -c, --config                    Path to .toml configuration file  [string]
 		  -e, --env                       Environment to use for operations and .env files  [string]
 		  -h, --help                      Show help  [boolean]
-		  -v, --version                   Show version number  [boolean]
-
-		--------------------
-		📣 Hyperdrive is currently in open beta
-		📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		📣 To give feedback, visit https://discord.gg/cloudflaredev
-		--------------------"
+		  -v, --version                   Show version number  [boolean]"
 	`);
 	});
 
@@ -73,13 +67,7 @@ describe("hyperdrive help", () => {
 		  -c, --config                    Path to .toml configuration file  [string]
 		  -e, --env                       Environment to use for operations and .env files  [string]
 		  -h, --help                      Show help  [boolean]
-		  -v, --version                   Show version number  [boolean]
-
-		--------------------
-		📣 Hyperdrive is currently in open beta
-		📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-		📣 To give feedback, visit https://discord.gg/cloudflaredev
-		--------------------"
+		  -v, --version                   Show version number  [boolean]"
 	`);
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -23,7 +23,11 @@ describe("pages build env", () => {
 			vars: {},
 		});
 		await runWrangler("pages functions build-env . --outfile data.json");
-		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+		"Reading build configuration from your wrangler.toml file...
+		Build environment variables: (none found)
+		pages_build_output_dir: dist"
+	`);
 		expect(readFileSync("data.json", "utf8")).toMatchInlineSnapshot(
 			`"{\\"vars\\":{},\\"pages_build_output_dir\\":\\"dist\\"}"`
 		);
@@ -154,7 +158,13 @@ describe("pages build env", () => {
 			},
 		});
 		await runWrangler("pages functions build-env . --outfile data.json");
-		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+		"Reading build configuration from your wrangler.toml file...
+		Build environment variables:
+		  - VAR1: VALUE1
+		  - VAR2: VALUE2
+		pages_build_output_dir: dist"
+	`);
 		expect(readFileSync("data.json", "utf8")).toMatchInlineSnapshot(
 			`"{\\"vars\\":{\\"VAR1\\":\\"VALUE1\\",\\"VAR2\\":\\"VALUE2\\"},\\"pages_build_output_dir\\":\\"dist\\"}"`
 		);
@@ -188,7 +198,14 @@ describe("pages build env", () => {
 			},
 		});
 		await runWrangler("pages functions build-env . --outfile data.json");
-		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+		"Reading build configuration from your wrangler.toml file...
+		Build environment variables:
+		  - VAR1: PROD_VALUE1
+		  - VAR2: PROD_VALUE2
+		  - PROD_VAR3: PROD_VALUE3
+		pages_build_output_dir: dist"
+	`);
 		expect(readFileSync("data.json", "utf8")).toMatchInlineSnapshot(
 			`"{\\"vars\\":{\\"VAR1\\":\\"PROD_VALUE1\\",\\"VAR2\\":\\"PROD_VALUE2\\",\\"PROD_VAR3\\":\\"PROD_VALUE3\\"},\\"pages_build_output_dir\\":\\"dist\\"}"`
 		);
@@ -223,7 +240,14 @@ describe("pages build env", () => {
 			},
 		});
 		await runWrangler("pages functions build-env . --outfile data.json");
-		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+		"Reading build configuration from your wrangler.toml file...
+		Build environment variables:
+		  - VAR1: PREVIEW_VALUE1
+		  - VAR2: PREVIEW_VALUE2
+		  - PREVIEW_VAR3: PREVIEW_VALUE3
+		pages_build_output_dir: dist"
+	`);
 		expect(readFileSync("data.json", "utf8")).toMatchInlineSnapshot(
 			`"{\\"vars\\":{\\"VAR1\\":\\"PREVIEW_VALUE1\\",\\"VAR2\\":\\"PREVIEW_VALUE2\\",\\"PREVIEW_VAR3\\":\\"PREVIEW_VALUE3\\"},\\"pages_build_output_dir\\":\\"dist\\"}"`
 		);

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
@@ -22,24 +22,31 @@ describe("pages build env", () => {
 			pages_build_output_dir: "./dist",
 			vars: {},
 		});
-		await runWrangler("pages functions build-env .");
-		expect(std).toMatchInlineSnapshot(`
-		Object {
-		  "debug": "",
-		  "err": "",
-		  "info": "",
-		  "out": "{\\"vars\\":{},\\"pages_build_output_dir\\":\\"dist\\"}",
-		  "warn": "",
-		}
-	`);
+		await runWrangler("pages functions build-env . --outfile data.json");
+		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(readFileSync("data.json", "utf8")).toMatchInlineSnapshot(
+			`"{\\"vars\\":{},\\"pages_build_output_dir\\":\\"dist\\"}"`
+		);
 	});
 
 	it("should fail with no config file", async () => {
 		await expect(
-			runWrangler("pages functions build-env .")
+			runWrangler("pages functions build-env . --outfile data.json")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`"No Pages config file found"`
 		);
+	});
+	it("should fail with no project dir", async () => {
+		await expect(
+			runWrangler("pages functions build-env")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"No Pages project location specified"`
+		);
+	});
+	it("should fail with no outfile", async () => {
+		await expect(
+			runWrangler("pages functions build-env .")
+		).rejects.toThrowErrorMatchingInlineSnapshot(`"No outfile specified"`);
 	});
 	it("should fail correctly with a non-pages config file", async () => {
 		writeWranglerToml({
@@ -69,7 +76,7 @@ describe("pages build env", () => {
 		});
 		// This error is specifically handled by the caller of build-env
 		await expect(
-			runWrangler("pages functions build-env .")
+			runWrangler("pages functions build-env . --outfile data.json")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`"Your wrangler.toml is not a valid Pages config file"`
 		);
@@ -78,7 +85,7 @@ describe("pages build env", () => {
 		writeFileSync("./wrangler.toml", 'INVALID "FILE');
 		// This error is specifically handled by the caller of build-env
 		await expect(
-			runWrangler("pages functions build-env .")
+			runWrangler("pages functions build-env . --outfile data.json")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`"Your wrangler.toml is not a valid Pages config file"`
 		);
@@ -112,7 +119,7 @@ describe("pages build env", () => {
 		});
 		// This error is specifically handled by the caller of build-env
 		await expect(
-			runWrangler("pages functions build-env .")
+			runWrangler("pages functions build-env . --outfile data.json")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`"Your wrangler.toml is not a valid Pages config file"`
 		);
@@ -146,16 +153,11 @@ describe("pages build env", () => {
 				},
 			},
 		});
-		await runWrangler("pages functions build-env .");
-		expect(std).toMatchInlineSnapshot(`
-		Object {
-		  "debug": "",
-		  "err": "",
-		  "info": "",
-		  "out": "{\\"vars\\":{\\"VAR1\\":\\"VALUE1\\",\\"VAR2\\":\\"VALUE2\\"},\\"pages_build_output_dir\\":\\"dist\\"}",
-		  "warn": "",
-		}
-	`);
+		await runWrangler("pages functions build-env . --outfile data.json");
+		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(readFileSync("data.json", "utf8")).toMatchInlineSnapshot(
+			`"{\\"vars\\":{\\"VAR1\\":\\"VALUE1\\",\\"VAR2\\":\\"VALUE2\\"},\\"pages_build_output_dir\\":\\"dist\\"}"`
+		);
 	});
 	it("should return production", async () => {
 		process.env.PAGES_ENVIRONMENT = "production";
@@ -185,16 +187,11 @@ describe("pages build env", () => {
 				},
 			},
 		});
-		await runWrangler("pages functions build-env .");
-		expect(std).toMatchInlineSnapshot(`
-		Object {
-		  "debug": "",
-		  "err": "",
-		  "info": "",
-		  "out": "{\\"vars\\":{\\"VAR1\\":\\"PROD_VALUE1\\",\\"VAR2\\":\\"PROD_VALUE2\\",\\"PROD_VAR3\\":\\"PROD_VALUE3\\"},\\"pages_build_output_dir\\":\\"dist\\"}",
-		  "warn": "",
-		}
-	`);
+		await runWrangler("pages functions build-env . --outfile data.json");
+		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(readFileSync("data.json", "utf8")).toMatchInlineSnapshot(
+			`"{\\"vars\\":{\\"VAR1\\":\\"PROD_VALUE1\\",\\"VAR2\\":\\"PROD_VALUE2\\",\\"PROD_VAR3\\":\\"PROD_VALUE3\\"},\\"pages_build_output_dir\\":\\"dist\\"}"`
+		);
 	});
 
 	it("should return preview", async () => {
@@ -225,15 +222,10 @@ describe("pages build env", () => {
 				},
 			},
 		});
-		await runWrangler("pages functions build-env .");
-		expect(std).toMatchInlineSnapshot(`
-		Object {
-		  "debug": "",
-		  "err": "",
-		  "info": "",
-		  "out": "{\\"vars\\":{\\"VAR1\\":\\"PREVIEW_VALUE1\\",\\"VAR2\\":\\"PREVIEW_VALUE2\\",\\"PREVIEW_VAR3\\":\\"PREVIEW_VALUE3\\"},\\"pages_build_output_dir\\":\\"dist\\"}",
-		  "warn": "",
-		}
-	`);
+		await runWrangler("pages functions build-env . --outfile data.json");
+		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(readFileSync("data.json", "utf8")).toMatchInlineSnapshot(
+			`"{\\"vars\\":{\\"VAR1\\":\\"PREVIEW_VALUE1\\",\\"VAR2\\":\\"PREVIEW_VALUE2\\",\\"PREVIEW_VAR3\\":\\"PREVIEW_VALUE3\\"},\\"pages_build_output_dir\\":\\"dist\\"}"`
+		);
 	});
 });

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2,7 +2,6 @@ import assert from "node:assert";
 import path from "node:path";
 import TOML from "@iarna/toml";
 import { getConstellationWarningFromEnv } from "../constellation/utils";
-import { getHyperdriveWarningFromEnv } from "../hyperdrive/utils";
 import { Diagnostics } from "./diagnostics";
 import {
 	all,
@@ -2575,11 +2574,6 @@ const validateHyperdriveBinding: ValidatorFn = (diagnostics, field, value) => {
 			)}.`
 		);
 		isValid = false;
-	}
-	if (isValid && getHyperdriveWarningFromEnv() === undefined) {
-		diagnostics.warnings.push(
-			"Hyperdrive Bindings are currently in beta to allow the API to evolve before general availability.\nPlease report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose"
-		);
 	}
 	return isValid;
 };

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -1,7 +1,6 @@
 import { readConfig } from "../config";
 import { logger } from "../logger";
 import { createConfig } from "./client";
-import { hyperdriveBetaWarning } from "./utils";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -36,8 +35,7 @@ export function options(yargs: CommonYargsArgv) {
 				describe:
 					"Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled",
 			},
-		})
-		.epilogue(hyperdriveBetaWarning);
+		});
 }
 
 export async function handler(

--- a/packages/wrangler/src/hyperdrive/delete.ts
+++ b/packages/wrangler/src/hyperdrive/delete.ts
@@ -1,20 +1,17 @@
 import { readConfig } from "../config";
 import { logger } from "../logger";
 import { deleteConfig } from "./client";
-import { hyperdriveBetaWarning } from "./utils";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
 
 export function options(yargs: CommonYargsArgv) {
-	return yargs
-		.positional("id", {
-			type: "string",
-			demandOption: true,
-			description: "The ID of the Hyperdrive config",
-		})
-		.epilogue(hyperdriveBetaWarning);
+	return yargs.positional("id", {
+		type: "string",
+		demandOption: true,
+		description: "The ID of the Hyperdrive config",
+	});
 }
 
 export async function handler(

--- a/packages/wrangler/src/hyperdrive/get.ts
+++ b/packages/wrangler/src/hyperdrive/get.ts
@@ -1,20 +1,17 @@
 import { readConfig } from "../config";
 import { logger } from "../logger";
 import { getConfig } from "./client";
-import { hyperdriveBetaWarning } from "./utils";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
 
 export function options(yargs: CommonYargsArgv) {
-	return yargs
-		.positional("id", {
-			type: "string",
-			demandOption: true,
-			description: "The ID of the Hyperdrive config",
-		})
-		.epilogue(hyperdriveBetaWarning);
+	return yargs.positional("id", {
+		type: "string",
+		demandOption: true,
+		description: "The ID of the Hyperdrive config",
+	});
 }
 
 export async function handler(

--- a/packages/wrangler/src/hyperdrive/index.ts
+++ b/packages/wrangler/src/hyperdrive/index.ts
@@ -3,7 +3,6 @@ import { handler as deleteHandler, options as deleteOptions } from "./delete";
 import { handler as getHandler, options as getOptions } from "./get";
 import { handler as listHandler, options as listOptions } from "./list";
 import { handler as updateHandler, options as updateOptions } from "./update";
-import { hyperdriveBetaWarning } from "./utils";
 import type { CommonYargsArgv } from "../yargs-types";
 
 export function hyperdrive(yargs: CommonYargsArgv) {
@@ -27,6 +26,5 @@ export function hyperdrive(yargs: CommonYargsArgv) {
 			"Update a Hyperdrive config",
 			updateOptions,
 			updateHandler
-		)
-		.epilogue(hyperdriveBetaWarning);
+		);
 }

--- a/packages/wrangler/src/hyperdrive/list.ts
+++ b/packages/wrangler/src/hyperdrive/list.ts
@@ -1,14 +1,13 @@
 import { readConfig } from "../config";
 import { logger } from "../logger";
 import { listConfigs } from "./client";
-import { hyperdriveBetaWarning } from "./utils";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
 
 export function options(yargs: CommonYargsArgv) {
-	return yargs.epilogue(hyperdriveBetaWarning);
+	return yargs;
 }
 
 export async function handler(

--- a/packages/wrangler/src/hyperdrive/update.ts
+++ b/packages/wrangler/src/hyperdrive/update.ts
@@ -2,7 +2,6 @@ import { readConfig } from "../config";
 import { UserError } from "../errors";
 import { logger } from "../logger";
 import { patchConfig } from "./client";
-import { hyperdriveBetaWarning } from "./utils";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -58,8 +57,7 @@ export function options(yargs: CommonYargsArgv) {
 				describe:
 					"Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled",
 			},
-		})
-		.epilogue(hyperdriveBetaWarning);
+		});
 }
 
 const requiredOriginOptions = [

--- a/packages/wrangler/src/hyperdrive/utils.ts
+++ b/packages/wrangler/src/hyperdrive/utils.ts
@@ -1,9 +1,0 @@
-import { getEnvironmentVariableFactory } from "../environment-variables/factory";
-
-export const getHyperdriveWarningFromEnv = getEnvironmentVariableFactory({
-	variableName: "NO_HYPERDRIVE_WARNING",
-});
-
-export const hyperdriveBetaWarning = process.env.NO_HYPERDRIVE_WARNING
-	? ""
-	: "--------------------\n📣 Hyperdrive is currently in open beta\n📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose\n📣 To give feedback, visit https://discord.gg/cloudflaredev\n--------------------\n";

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -1,8 +1,7 @@
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { readConfig } from "../config";
 import { FatalError } from "../errors";
-import { logger } from "../logger";
 import { EXIT_CODE_NO_CONFIG_FOUND } from "./errors";
 import type {
 	CommonYargsArgv,
@@ -12,16 +11,27 @@ import type {
 export type PagesBuildEnvArgs = StrictYargsOptionsToInterface<typeof Options>;
 
 export function Options(yargs: CommonYargsArgv) {
-	return yargs.positional("projectDir", {
-		type: "string",
-		description: "The location of the Pages project",
-	});
+	return yargs
+		.positional("projectDir", {
+			type: "string",
+			description: "The location of the Pages project",
+		})
+		.options({
+			outfile: {
+				type: "string",
+				description: "The location to write the build environment file",
+			},
+		});
 }
 
 export const Handler = async (args: PagesBuildEnvArgs) => {
 	if (!args.projectDir) {
 		throw new FatalError("No Pages project location specified");
 	}
+	if (!args.outfile) {
+		throw new FatalError("No outfile specified");
+	}
+
 	const configPath = path.resolve(args.projectDir, "wrangler.toml");
 	// Fail early if the config file doesn't exist
 	if (!existsSync(configPath)) {
@@ -46,7 +56,8 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 		Object.entries(config.vars).filter(([_, v]) => typeof v === "string")
 	);
 
-	logger.log(
+	writeFileSync(
+		args.outfile,
 		JSON.stringify({
 			vars: textVars,
 			pages_build_output_dir: path.relative(


### PR DESCRIPTION
## What this PR solves / how to test

This ensures that `wrangler pages functions build-env` outputs to a file, rather than stdout.

Fixes #5525 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: internal only

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
