### PR TITLE
C3: Improve cron/scheduled template docs

### DIFF
--- a/.changeset/ninety-trainers-attack.md
+++ b/.changeset/ninety-trainers-attack.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+fix: provide a simple fetch handler to the scheduled template to avoid confusing error messages.
+
+Fixes #4560

--- a/packages/create-cloudflare/templates/scheduled/js/package.json
+++ b/packages/create-cloudflare/templates/scheduled/js/package.json
@@ -4,8 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev",
-		"start": "wrangler dev"
+		"dev": "wrangler dev --test-scheduled",
+		"start": "wrangler dev --test-scheduled"
 	},
 	"devDependencies": {
 		"wrangler": "^3.0.0"

--- a/packages/create-cloudflare/templates/scheduled/js/src/index.js
+++ b/packages/create-cloudflare/templates/scheduled/js/src/index.js
@@ -6,7 +6,7 @@
  * https://developers.cloudflare.com/workers/platform/triggers/cron-triggers/
  *
  * - Run `npm run dev` in your terminal to start a development server
- * - Open a browser tab at http://localhost:8787/ to see your worker in action
+ * - Run `curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"` to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *
  * Learn more at https://developers.cloudflare.com/workers/

--- a/packages/create-cloudflare/templates/scheduled/js/src/index.js
+++ b/packages/create-cloudflare/templates/scheduled/js/src/index.js
@@ -13,6 +13,13 @@
  */
 
 export default {
+	async fetch(req) {
+		const url = new URL(req.url)
+		url.pathname = "/__scheduled";
+		url.searchParams.append("cron", "* * * * *");
+		return new Response(`To test the scheduled handler, ensure you have used the "--test-scheduled" then try running "curl ${url.href}".`);
+	},
+
 	// The scheduled handler is invoked at the interval set in our wrangler.toml's
 	// [[triggers]] configuration.
 	async scheduled(event, env, ctx) {

--- a/packages/create-cloudflare/templates/scheduled/ts/package.json
+++ b/packages/create-cloudflare/templates/scheduled/ts/package.json
@@ -4,8 +4,8 @@
 	"private": true,
 	"scripts": {
 		"deploy": "wrangler deploy",
-		"dev": "wrangler dev",
-		"start": "wrangler dev",
+		"dev": "wrangler dev --test-scheduled",
+		"start": "wrangler dev --test-scheduled",
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {

--- a/packages/create-cloudflare/templates/scheduled/ts/src/index.ts
+++ b/packages/create-cloudflare/templates/scheduled/ts/src/index.ts
@@ -6,7 +6,7 @@
  * https://developers.cloudflare.com/workers/platform/triggers/cron-triggers/
  *
  * - Run `npm run dev` in your terminal to start a development server
- * - Open a browser tab at http://localhost:8787/ to see your worker in action
+ * - Run `curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"` to see your worker in action
  * - Run `npm run deploy` to publish your worker
  *
  * Bind resources to your worker in `wrangler.toml`. After adding bindings, a type definition for the


### PR DESCRIPTION
## What this PR solves / how to test

First time starting to do a scheduled worker locally so I use the template: get all obscure warnings and error messages as per #4720. Really not intuitive to the uninitiated. This doesn't solve that issue completely but should hopefully help.

https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/

Fixes #4720, #4560

![image](https://github.com/cloudflare/workers-sdk/assets/10026538/0c5cd4ee-d103-4de9-9105-44e2e906f012)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: changing template docs
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: trivial change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: changing template docs

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
