### PR TITLE
Update R2 CreateBucket to include storage class in request body

### DIFF
--- a/.changeset/odd-squids-fly.md
+++ b/.changeset/odd-squids-fly.md
@@ -2,4 +2,4 @@
 "wrangler": minor
 ---
 
-Update R2 CreateBucket action to include the storage class in the request body.
+feat: update R2 CreateBucket action to include the storage class in the request body

--- a/.changeset/odd-squids-fly.md
+++ b/.changeset/odd-squids-fly.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Update R2 CreateBucket action to include the storage class in the request body.

--- a/packages/wrangler/src/__tests__/helpers/msw/handlers/r2.ts
+++ b/packages/wrangler/src/__tests__/helpers/msw/handlers/r2.ts
@@ -25,20 +25,17 @@ export const mswR2handlers = [
 	),
 	rest.post(
 		"*/accounts/:accountId/r2/buckets",
-		(request, response, context) => {
-			const storageClassValue = request.headers.get("cf-r2-storage-class");
-			if (
-				storageClassValue !== null &&
-				!isValidStorageClass(storageClassValue)
-			) {
+		async (request, response, context) => {
+			const { storageClass } = await request.json();
+			if (storageClass !== null && !isValidStorageClass(storageClass)) {
 				return response.once(
 					context.status(400),
 					context.json({
 						success: false,
 						errors: [
 							{
-								code: 10062,
-								message: "The storage class specified is not valid.",
+								code: 10040,
+								message: "The JSON you provided was not well formed.",
 							},
 						],
 						messages: [],

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -223,7 +223,7 @@ describe("r2", () => {
 
 				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/r2/buckets) failed.[0m
 
-				  The storage class specified is not valid. [code: 10062]
+				  The JSON you provided was not well formed. [code: 10040]
 
 				  If you think this is a bug, please open an issue at:
 				  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -56,12 +56,12 @@ export async function createR2Bucket(
 	if (jurisdiction !== undefined) {
 		headers["cf-r2-jurisdiction"] = jurisdiction;
 	}
-	if (storageClass !== undefined) {
-		headers["cf-r2-storage-class"] = storageClass;
-	}
 	return await fetchResult<void>(`/accounts/${accountId}/r2/buckets`, {
 		method: "POST",
-		body: JSON.stringify({ name: bucketName }),
+		body: JSON.stringify({
+			name: bucketName,
+			...(storageClass !== undefined && { storageClass }),
+		}),
 		headers,
 	});
 }


### PR DESCRIPTION
## What this PR solves / how to test

Fixes R2-1963. A small fix to update the `CreateBucket` to include the storage class in the request body. Manually tested creating a bucket with a storage class.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: same as https://github.com/cloudflare/workers-sdk/pull/5429. 


