### PR TITLE
fix(wrangler): fix `build-env` to exit with code rather than throw fatal error

### DIFF
--- a/.changeset/green-rats-serve.md
+++ b/.changeset/green-rats-serve.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+fix: fix `pages function build-env` to exit with code rather than throw fatal error
+
+Currently pages functions build-env throws a fatal error if a config file does not exit, or if it is invalid. This causes issues for the CI system. We should instead exit with a specific code, if any of those situations arises.

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -38,16 +38,11 @@ describe("pages build env", () => {
 	});
 
 	it("should exit with specific exit code if no config file is found", async () => {
-		const processExitMock = jest
-			.spyOn(process, "exit")
-			.mockImplementation(() => {
-				throw new Error("process exit mock");
-			});
-		await expect(
-			runWrangler("pages functions build-env . --outfile out.json")
-		).rejects.toThrowErrorMatchingInlineSnapshot(`"process exit mock"`);
-		expect(processExitMock).toHaveBeenCalledWith(EXIT_CODE_NO_CONFIG_FOUND);
-		processExitMock.mockRestore();
+		await runWrangler("pages functions build-env . --outfile out.json");
+		expect(std.out).toMatchInlineSnapshot(
+			`"No Pages configuration file found. Exiting."`
+		);
+		expect(process.exitCode).toEqual(EXIT_CODE_NO_CONFIG_FOUND);
 	});
 
 	it("should fail with no project dir", async () => {
@@ -65,11 +60,6 @@ describe("pages build env", () => {
 	});
 
 	it("should exit with specific code if a non-pages config file is found", async () => {
-		const processExitMock = jest
-			.spyOn(process, "exit")
-			.mockImplementation(() => {
-				throw new Error("process exit mock");
-			});
 		writeWranglerToml({
 			vars: {
 				VAR1: "VALUE1",
@@ -96,40 +86,27 @@ describe("pages build env", () => {
 			},
 		});
 		// This error is specifically handled by the caller of build-env
-		await expect(
-			runWrangler("pages functions build-env . --outfile data.json")
-		).rejects.toThrowErrorMatchingInlineSnapshot(`"process exit mock"`);
-		expect(processExitMock).toHaveBeenCalledWith(
-			EXIT_CODE_INVALID_PAGES_CONFIG
-		);
-		processExitMock.mockRestore();
+		await runWrangler("pages functions build-env . --outfile data.json");
+		expect(process.exitCode).toEqual(EXIT_CODE_INVALID_PAGES_CONFIG);
+		expect(std.out).toMatchInlineSnapshot(`
+		"Reading build configuration from your wrangler.toml file...
+		Invalid Pages configuration file found. Exiting."
+	`);
 	});
 
 	it("should exit correctly with an unparseable config file", async () => {
-		const processExitMock = jest
-			.spyOn(process, "exit")
-			.mockImplementation(() => {
-				throw new Error("process exit mock");
-			});
 		writeFileSync("./wrangler.toml", 'INVALID "FILE');
 		// This error is specifically handled by the caller of build-env
-		await expect(
-			runWrangler("pages functions build-env . --outfile data.json")
-		).rejects.toThrowErrorMatchingInlineSnapshot(`"process exit mock"`);
-		expect(processExitMock).toHaveBeenCalledWith(
-			EXIT_CODE_INVALID_PAGES_CONFIG
-		);
+		await runWrangler("pages functions build-env . --outfile data.json");
+		expect(process.exitCode).toEqual(EXIT_CODE_INVALID_PAGES_CONFIG);
 		expect(std.err).toContain("ParseError");
-		processExitMock.mockRestore();
+		expect(std.out).toMatchInlineSnapshot(`
+		"Reading build configuration from your wrangler.toml file...
+		Invalid Pages configuration file found. Exiting."
+	`);
 	});
 
 	it("should exit correctly with a non-pages config file w/ invalid environment", async () => {
-		const processExitMock = jest
-			.spyOn(process, "exit")
-			.mockImplementation(() => {
-				throw new Error("process exit mock");
-			});
-
 		writeWranglerToml({
 			vars: {
 				VAR1: "VALUE1",
@@ -156,13 +133,12 @@ describe("pages build env", () => {
 			},
 		});
 		// This error is specifically handled by the caller of build-env
-		await expect(
-			runWrangler("pages functions build-env . --outfile data.json")
-		).rejects.toThrowErrorMatchingInlineSnapshot(`"process exit mock"`);
-		expect(processExitMock).toHaveBeenCalledWith(
-			EXIT_CODE_INVALID_PAGES_CONFIG
-		);
-		processExitMock.mockRestore();
+		await runWrangler("pages functions build-env . --outfile data.json");
+		expect(process.exitCode).toEqual(EXIT_CODE_INVALID_PAGES_CONFIG);
+		expect(std.out).toMatchInlineSnapshot(`
+		"Reading build configuration from your wrangler.toml file...
+		Invalid Pages configuration file found. Exiting."
+	`);
 	});
 
 	it("should return top-level by default", async () => {

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -39,8 +39,9 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 
 	const configPath = path.resolve(args.projectDir, "wrangler.toml");
 	if (!existsSync(configPath)) {
-		logger.log("No Pages config file found. Skipping...");
-		process.exit(EXIT_CODE_NO_CONFIG_FOUND);
+		logger.log("No Pages configuration file found. Exiting.");
+		process.exitCode = EXIT_CODE_NO_CONFIG_FOUND;
+		return;
 	}
 
 	logger.log("Reading build configuration from your wrangler.toml file...");
@@ -59,8 +60,9 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 			true
 		);
 	} catch (err) {
-		logger.log("Invalid Pages config file found. Skipping...");
-		process.exit(EXIT_CODE_INVALID_PAGES_CONFIG);
+		logger.log("Invalid Pages configuration file found. Exiting.");
+		process.exitCode = EXIT_CODE_INVALID_PAGES_CONFIG;
+		return;
 	}
 
 	// Ensure JSON variables are not included

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -37,14 +37,18 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 		throw new FatalError("No outfile specified");
 	}
 
+	logger.log(
+		"Checking for configuration in a wrangler.toml configuration file (BETA)\n"
+	);
+
 	const configPath = path.resolve(args.projectDir, "wrangler.toml");
 	if (!existsSync(configPath)) {
-		logger.log("No Pages configuration file found. Exiting.");
+		logger.debug("No wrangler.toml configuration file found. Exiting.");
 		process.exitCode = EXIT_CODE_NO_CONFIG_FOUND;
 		return;
 	}
 
-	logger.log("Reading build configuration from your wrangler.toml file...");
+	logger.log("Found wrangler.toml file. Reading build configuration...");
 
 	let config: Omit<Config, "pages_build_output_dir"> & {
 		pages_build_output_dir: string;
@@ -60,7 +64,7 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 			true
 		);
 	} catch (err) {
-		logger.log("Invalid Pages configuration file found. Exiting.");
+		logger.debug("wrangler.toml file is invalid. Exiting.");
 		process.exitCode = EXIT_CODE_INVALID_PAGES_CONFIG;
 		return;
 	}
@@ -87,9 +91,9 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 		...vars.map(([key, value]) => `  - ${key}: ${value}`),
 	].join("\n");
 
-	logger.log(message);
-
 	logger.log(
 		`pages_build_output_dir: ${buildConfiguration.pages_build_output_dir}`
 	);
+
+	logger.log(message);
 };


### PR DESCRIPTION
## What this PR solves / how to test

Currently `pages functions build-env` throws a fatal error if a config file does not exit, or if it is
invalid. This causes issues for the CI system. We
should instead exit with a specific code, if any of those situations arises.

You can test by running `npx wrangler pages function build-env [directory] --outfile=<file-name.json>`

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: not public facing api

## How this PR was tested

- with valid Pages config file
<img width="580" alt="Screenshot 2024-04-11 at 12 06 05" src="https://github.com/cloudflare/workers-sdk/assets/4638332/2b6792ca-0ca4-4f1c-9b38-a98cce8ad7ce">

- with non-Pages config file + `WRANGLER_LOG="debug"`
<img width="597" alt="Screenshot 2024-04-11 at 12 07 08" src="https://github.com/cloudflare/workers-sdk/assets/4638332/ab6642ea-ee1e-406b-aa08-d9205f01aa26">

- with invalid Pages config file + `WRANGLER_LOG="debug"`
<img width="597" alt="Screenshot 2024-04-11 at 12 07 08" src="https://github.com/cloudflare/workers-sdk/assets/4638332/a1fa616f-b2cf-4f70-9f9f-1a08f35ae433">


- with invalid non-Pages config file + `WRANGLER_LOG="debug"`
<img width="597" alt="Screenshot 2024-04-11 at 12 07 08" src="https://github.com/cloudflare/workers-sdk/assets/4638332/7fc20b75-4ada-4b7c-b3d2-b185455914b6">


- with no config file + `WRANGLER_LOG="debug"`
<img width="594" alt="Screenshot 2024-04-11 at 12 06 42" src="https://github.com/cloudflare/workers-sdk/assets/4638332/ebf85a99-a410-4953-8a1d-6f81d18f2482">

PREVIEW OF CI ERR MESSAGING

<img width="1236" alt="Screenshot 2024-04-11 at 13 48 14" src="https://github.com/cloudflare/workers-sdk/assets/4638332/b35bafba-6491-47c3-bdea-13362f799989">

<img width="689" alt="Screenshot 2024-04-11 at 13 53 30" src="https://github.com/cloudflare/workers-sdk/assets/4638332/7b56a805-21e3-4806-aa25-dfcc7d1dae0d">


<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
