### PR TITLE
fix(wrangler): `pages functions build-env` should throw if invalid Pages config file

### DIFF
--- a/.changeset/giant-pears-tie.md
+++ b/.changeset/giant-pears-tie.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+fix: `pages functions build-env` should throw error if invalid Pages config file is found

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -64,9 +64,19 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 			true
 		);
 	} catch (err) {
-		logger.debug("wrangler.toml file is invalid. Exiting.");
-		process.exitCode = EXIT_CODE_INVALID_PAGES_CONFIG;
-		return;
+		// found `wrangler.toml` but `pages_build_output_dir` is not specififed
+		if (
+			err instanceof FatalError &&
+			err.code === EXIT_CODE_INVALID_PAGES_CONFIG
+		) {
+			logger.debug("wrangler.toml file is invalid. Exiting.");
+			process.exitCode = EXIT_CODE_INVALID_PAGES_CONFIG;
+			return;
+		}
+
+		// found `wrangler.toml` with `pages_build_output_dir` specified, but
+		// file contains invalid configuration
+		throw err;
 	}
 
 	// Ensure JSON variables are not included


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: fix PR

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
