### PR TITLE
fix(wrangler) wrangler kv:key put does not work as expected

### DIFF
--- a/.changeset/purple-cars-run.md
+++ b/.changeset/purple-cars-run.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: correctly handle non-text based files for kv put
+
+The current version of the kv:key put command with the --path argument will treat file contents as a string because it is not one of Blob or File when passed to the form helper library. We should turn it into a Blob so it's not mangling inputs.

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -505,6 +505,29 @@ describe("wrangler", () => {
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
+			it("should put a key with a binary value and metadata", async () => {
+				const buf = Buffer.from(
+					"iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAiSURBVHgB7coxEQAACMPAgH/PgAM6dGwu49fA/deIBXrgAj2cAhIFT4QxAAAAAElFTkSuQmCC",
+					"base64"
+				);
+				writeFileSync("test.png", buf);
+				const requests = mockKeyPutRequest("some-namespace-id", {
+					key: "another-my-key",
+					value: buf,
+					metadata: {
+						mKey: "mValue",
+					},
+				});
+				await runWrangler(
+					`kv:key put another-my-key --namespace-id some-namespace-id --path test.png --metadata '{"mKey":"mValue"}'`
+				);
+				expect(requests.count).toEqual(1);
+				expect(std.out).toMatchInlineSnapshot(
+					`"Writing the contents of test.png to the key \\"another-my-key\\" on namespace some-namespace-id with metadata \\"{\\"mKey\\":\\"mValue\\"}\\"."`
+				);
+				expect(std.err).toMatchInlineSnapshot(`""`);
+			});
+
 			it("should error if no key is provided", async () => {
 				await expect(
 					runWrangler("kv:key put")

--- a/packages/wrangler/src/kv/helpers.ts
+++ b/packages/wrangler/src/kv/helpers.ts
@@ -1,3 +1,4 @@
+import { Blob } from "node:buffer";
 import { URLSearchParams } from "node:url";
 import { Miniflare } from "miniflare";
 import { FormData } from "undici";
@@ -200,7 +201,7 @@ function asFormData(fields: Record<string, unknown>): FormData {
 	const formData = new FormData();
 
 	for (const [name, value] of Object.entries(fields)) {
-		formData.append(name, value);
+		formData.append(name, Buffer.isBuffer(value) ? new Blob([value]) : value);
 	}
 
 	return formData;


### PR DESCRIPTION
## What this PR solves / how to test

Currently, when passing a path to `kv:key put --path`, the contents of the file are read in as a Buffer, which would normally be fine - however, when we *also* have `--metadata` defined, the payload is transformed into `FormData`. `FormData` can take a `string`, `Blob` or `File`, and will fall back to `string` for everything else. Because we loaded the file as a Buffer, the file contents are then transformed into a string by the library being used (`undici`). *Normally* this is okay *unless* you are not uploading a text-based document, e.g an image file.

Fixes #2911.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: 

Minor change correcting behaviour to what is expected

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
