### PR TITLE
ignore workerd CODE_MOVED error

### DIFF
--- a/.changeset/twenty-mangos-develop.md
+++ b/.changeset/twenty-mangos-develop.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: ignore workerd output (error: CODE_MOVED) not intended for end-user devs


### PR DESCRIPTION
## What this PR solves / how to test

This PR adds a heuristic to ignore the kind of output that can spuriously show up:
![image](https://github.com/cloudflare/workers-sdk/assets/5822355/fa5fc104-dada-4c2d-b52d-99846b01413a)


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: cannot reliably reproduce this specific workerd output
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
