### PR TITLE
fix: Correct semver key in changeset

### DIFF
--- a/.changeset/swift-steaks-cheat.md
+++ b/.changeset/swift-steaks-cheat.md
@@ -1,5 +1,5 @@
 ---
-"create-cloudflare": docs
+"create-cloudflare": patch
 ---
 
 chore: Update example `wrangler.toml` files to include a link to secrets documentation.


### PR DESCRIPTION
## What this PR solves / how to test

Fixes actions - changeset contains an invalid semver tag.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
