### PR TITLE
fix(vitest-pool-workers): ignore sqlite shm and wal files (#5629)

### DIFF
--- a/packages/vitest-pool-workers/src/pool/loopback.ts
+++ b/packages/vitest-pool-workers/src/pool/loopback.ts
@@ -246,6 +246,9 @@ async function pushStackedStorage(intoDepth: number, persistPath: string) {
 			}
 			const namePath = path.join(keyPath, name);
 			const stackFrameNamePath = path.join(stackFrameKeyPath, name);
+			// from workerd.capnp:
+			// in certain situations extra files with the extensions `.sqlite-wal`, and `.sqlite-shm` may also be present.
+			if (name.endsWith(".sqlite-shm") || name.endsWith(".sqlite-wal")) continue;
 			assert(name.endsWith(".sqlite"), `Expected .sqlite, got ${namePath}`);
 			await fs.copyFile(namePath, stackFrameNamePath);
 		}
@@ -261,6 +264,9 @@ async function popStackedStorage(fromDepth: number, persistPath: string) {
 			// If this is a blobs directory, it shouldn't contain any `.sqlite` files
 			if (name === BLOBS_DIR_NAME) break;
 			const namePath = path.join(keyPath, name);
+			// from workerd.capnp:
+			// in certain situations extra files with the extensions `.sqlite-wal`, and `.sqlite-shm` may also be present.
+			if (name.endsWith(".sqlite-shm") || name.endsWith(".sqlite-wal")) continue;
 			assert(name.endsWith(".sqlite"), `Expected .sqlite, got ${namePath}`);
 			await fs.unlink(namePath);
 		}


### PR DESCRIPTION
See https://github.com/cloudflare/workerd/blob/d3b5b16588cc33c930584064995c4a3635d07c28/src/workerd/server/workerd.capnp#L613

Not sure if tests are needed, and how they should be set up, because I do not know how to set up sqlite to generate .sqlite-shm files

## What this PR solves / how to test

Fixes #5629

## Author has addressed the following

- Tests
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because: 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: trivial
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: should just work

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
