### PR TITLE
[wrangler] fix: fix local Durable Object proxies not working

### DIFF
--- a/.changeset/odd-guests-beam.md
+++ b/.changeset/odd-guests-beam.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: fix broken local Durable Object proxies

--- a/.changeset/odd-guests-beam.md
+++ b/.changeset/odd-guests-beam.md
@@ -2,4 +2,10 @@
 "wrangler": patch
 ---
 
-fix: fix broken local Durable Object proxies
+fix: fix broken Durable Object local proxying (when no `cf` property is present)
+
+A regression was introduced in wrangler 3.46.0 (https://github.com/cloudflare/workers-sdk/pull/5215)
+which made it so that missing `Request#cf` properties are serialized as `"undefined"`, this in turn
+throws a syntax parse error when such values are parsed via `JSON.parse` breaking the communication
+with Durable Object local proxies. Fix such issue by serializing missing `Request#cf` properties as
+`"{}"` instead.

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
@@ -207,7 +207,7 @@ describe("getPlatformProxy - bindings", () => {
 		await dispose();
 	});
 
-	it.skip("correctly obtains functioning DO bindings (provided by external local workers)", async () => {
+	it("correctly obtains functioning DO bindings (provided by external local workers)", async () => {
 		const { env, dispose } = await getPlatformProxy<Env>({
 			configPath: wranglerTomlFilePath,
 		});


### PR DESCRIPTION
## What this PR solves / how to test

This PR solves the regression of local Durable Object proxies not working (a regression introduced in wrangler 3.46.0, more specifically in https://github.com/cloudflare/workers-sdk/pull/5215)

To test the fix please try out the minimal reproductions of the linked issues 👇 with both the latest wrangler version and this [PR's prerelease](https://github.com/cloudflare/workers-sdk/pull/5669#issuecomment-2067679382) (the former will not work while the latter would work as intended)

Fixes #5620
Fixes #5658

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bug/regression fix

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
