### PR TITLE
[miniflare] fix: make the magic proxy able to proxy objects containing functions

### DIFF
--- a/.changeset/wet-taxis-share.md
+++ b/.changeset/wet-taxis-share.md
@@ -2,4 +2,4 @@
 "miniflare": patch
 ---
 
-fix: make the magic proxy able to serialize objects containing functions
+fix: make the magic proxy able to proxy objects containing functions

--- a/.changeset/wet-taxis-share.md
+++ b/.changeset/wet-taxis-share.md
@@ -2,4 +2,6 @@
 "miniflare": patch
 ---
 
-fix: make the magic proxy able to proxy objects containing functions
+fix: Allow the magic proxy to proxy objects containing functions
+
+This was previously prevented but this change removes that restriction.

--- a/.changeset/wet-taxis-share.md
+++ b/.changeset/wet-taxis-share.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: make the magic proxy able to serialize objects containing functions

--- a/packages/miniflare/src/workers/core/proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/proxy.worker.ts
@@ -55,12 +55,37 @@ function isPlainObject(value: unknown) {
 	if(value?.constructor?.name === 'RpcStub') {
 		return false;
 	}
+	if(isObject(value)) {
+		const valueAsRecord = value as Record<string, unknown>;
+		if (objectContainsFunctions(valueAsRecord)){
+			return false;
+		}
+	}
 	return (
 		proto === Object.prototype ||
 		proto === null ||
 		Object.getOwnPropertyNames(proto).sort().join("\0") === objectProtoNames
 	);
 }
+function objectContainsFunctions(obj: Record<string, unknown>): boolean {
+	for(const [, entry] of Object.entries(obj)) {
+		if(typeof entry === 'function') {
+			return true;
+		}
+		if(isObject(entry)) {
+			if(objectContainsFunctions(entry as Record<string, unknown>)) {
+				return false;
+			}
+		}
+	}
+
+	return false;
+}
+
+function isObject(value: unknown) {
+	return value && typeof value === 'object';
+}
+
 function getType(value: unknown) {
 	return Object.prototype.toString.call(value).slice(8, -1); // `[object <type>]`
 }

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -1378,14 +1378,14 @@ test("Miniflare: getBindings() returns wrapped bindings", async (t) => {
 
 	interface Env {
 		Greeter: {
-			sayHello: (str: string) => string,
-		},
-	};
+			sayHello: (str: string) => string;
+		};
+	}
 	const { Greeter } = await mf.getBindings<Env>();
 
-	const helloWorld = Greeter.sayHello('World');
+	const helloWorld = Greeter.sayHello("World");
 
-	t.is(helloWorld, 'Hello World');
+	t.is(helloWorld, "Hello World");
 });
 test("Miniflare: getBindings() handles wrapped bindings returning objects containing functions", async (t) => {
 	const mf = new Miniflare({
@@ -1405,8 +1405,9 @@ test("Miniflare: getBindings() handles wrapped bindings returning objects contai
 				script: `
 					export default function (env) {
 						const objWithFunction = {
-							sayHello: (name) => {
-								return "Hello " + name;
+							greeting: "Hello",
+							sayHello(name) {
+								return this.greeting + ' ' + name;
 							}
 						};
 						return objWithFunction;
@@ -1419,14 +1420,16 @@ test("Miniflare: getBindings() handles wrapped bindings returning objects contai
 
 	interface Env {
 		Greeter: {
-			sayHello: (str: string) => string,
-		},
-	};
+			greeting: string;
+			sayHello: (str: string) => string;
+		};
+	}
 	const { Greeter } = await mf.getBindings<Env>();
 
-	const helloWorld = Greeter.sayHello('World');
+	const helloWorld = Greeter.sayHello("World");
 
-	t.is(helloWorld, 'Hello World');
+	t.is(helloWorld, "Hello World");
+	t.is(Greeter.greeting, "Hello");
 });
 test("Miniflare: getBindings() handles wrapped bindings returning objects containing nested functions", async (t) => {
 	const mf = new Miniflare({
@@ -1467,17 +1470,17 @@ test("Miniflare: getBindings() handles wrapped bindings returning objects contai
 			obj: {
 				obj1: {
 					obj2: {
-						sayHello: (str: string) => string,
-					}
-				}
-			}
-		},
-	};
+						sayHello: (str: string) => string;
+					};
+				};
+			};
+		};
+	}
 	const { Greeter } = await mf.getBindings<Env>();
 
-	const helloWorld = Greeter.obj.obj1.obj2.sayHello('World');
+	const helloWorld = Greeter.obj.obj1.obj2.sayHello("World");
 
-	t.is(helloWorld, 'Hello World from a nested function');
+	t.is(helloWorld, "Hello World from a nested function");
 });
 test("Miniflare: getWorker() allows dispatching events directly", async (t) => {
 	const mf = new Miniflare({


### PR DESCRIPTION
## What this PR solves / how to test

This PR makes it so that "magic" proxy objects can contain functions, something that is not currently possible.

To test the changes in this PR you can try this [minimal reproduction/example](https://github.com/dario-piotrowicz/miniflare-wrappedBindings-getBindings-function-stringification-error-repro) with both the latest version of miniflare and this PR's miniflare prerelease. You can see how the example errors with the former but succeeds with the latter.

> [!NOTE]
> This improves the situation but the magic proxy's handling of functions is not yet perfect, for example functions inside arrays (e.g. `return [() => 'Hello']`) still don't work. Also functions returning functions do not work either.
>
> In any case I believe that the changes here improve the situation and are unlikely to conflict with any fix for the above points, so I think that it should be safe to proceed with these changes (and address the other points separately).


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bugfix

