### PR TITLE
ci: fix deployment of local Wrangler for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,48 +45,20 @@ jobs:
           NODE_ENV: "production"
           CI_OS: ${{ runner.os }}
 
-      - name: Pack Miniflare
-        run: pnpm pack --pack-destination $HOME
-        env:
-          NODE_ENV: "production"
-        working-directory: packages/miniflare
-
-      - name: Modify wrangler package.json miniflare dependency
-        run: pnpm add $(ls $HOME/miniflare-*.tgz)
-        working-directory: packages/wrangler
-
-      - name: Pack Wrangler
-        run: pnpm pack --pack-destination $HOME
-        env:
-          NODE_ENV: "production"
-        working-directory: packages/wrangler
-
-      - name: Find Wrangler
-        shell: bash
-        id: "find-wrangler"
-        run: echo "dir=$(ls $HOME/wrangler-*.tgz)" >> $GITHUB_OUTPUT;
-
-      - name: Run tests (unix)
-        if: matrix.os == 'macos-13' || matrix.os == 'ubuntu-22.04'
+      - name: Deploy a local version of Wrangler
         run: |
-          pnpm add ${{ steps.find-wrangler.outputs.dir}} --global
-          pnpm run --filter wrangler test:e2e
+          pnpm --filter wrangler deploy ${{ github.workspace}}/temp/wrangler
+          rm ${{ github.workspace}}/temp/wrangler/templates/tsconfig.json
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER: wrangler
-          WRANGLER_IMPORT: ${{ github.workspace }}/packages/wrangler/wrangler-dist/cli.js
-          NODE_OPTIONS: "--max_old_space_size=8192"
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
+          NODE_ENV: "production"
 
-      - name: Run tests (windows)
-        if: matrix.os == 'windows-2022'
+      - name: Run tests
         run: pnpm run --filter wrangler test:e2e
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER: pnpm --silent --package ${{ steps.find-wrangler.outputs.dir}} dlx wrangler
-          WRANGLER_IMPORT: ${{ github.workspace }}/packages/wrangler/wrangler-dist/cli.js
+          WRANGLER: node ${{ github.workspace}}/temp/wrangler/bin/wrangler.js
+          WRANGLER_IMPORT: ${{ github.workspace}}/temp/wrangler/wrangler-dist/cli.js
           NODE_OPTIONS: "--max_old_space_size=8192"
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
 

--- a/packages/wrangler/e2e/helpers/wrangler.ts
+++ b/packages/wrangler/e2e/helpers/wrangler.ts
@@ -1,2 +1,5 @@
-export const WRANGLER = process.env.WRANGLER as string;
-export const WRANGLER_IMPORT = process.env.WRANGLER_IMPORT as string;
+// Replace all backslashes with forward slashes to ensure that their use
+// in shellac scripts doesn't break.
+export const WRANGLER = process.env.WRANGLER?.replaceAll("\\", "/") ?? "";
+export const WRANGLER_IMPORT =
+	process.env.WRANGLER_IMPORT?.replaceAll("\\", "/") ?? "";


### PR DESCRIPTION
## What this PR solves / how to test

Fixes problems with packaging up a local Wrangler for use in e2e tests.
Previously we had to manually pack Wrangler and its "workspace" dependencies to make it available as a command in e2e tests.
But pnpm now has a `deploy` command (https://pnpm.io/cli/deploy) that can capture these workspace dependencies into a local directory, which we can then use in e2e tests.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: CI change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: CI change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: CI change

