### PR TITLE
fix DO migration docs links

### DIFF
--- a/packages/create-cloudflare/templates/hello-world-durable-object/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/ts/wrangler.toml
@@ -48,13 +48,13 @@ compatibility_date = "<TBD>"
 
 # Bind a Durable Object. Durable objects are a scale-to-zero compute primitive based on the actor model.
 # Durable Objects can live for as long as needed. Use these when you need a long-running "server", such as in realtime apps.
-# Docs: https://developers.cloudflare.com/workers/runtime-apis/durable-objects
+# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
 [[durable_objects.bindings]]
 name = "MY_DURABLE_OBJECT"
 class_name = "MyDurableObject"
 
 # Durable Object migrations.
-# Docs: https://developers.cloudflare.com/workers/learning/using-durable-objects#configure-durable-object-classes-with-migrations
+# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#migrations
 [[migrations]]
 tag = "v1"
 new_classes = ["MyDurableObject"]

--- a/templates/worker-typescript/wrangler.toml
+++ b/templates/worker-typescript/wrangler.toml
@@ -39,13 +39,13 @@ compatibility_date = "2022-10-10"
 
 # Bind a Durable Object. Durable objects are a scale-to-zero compute primitive based on the actor model.
 # Durable Objects can live for as long as needed. Use these when you need a long-running "server", such as in realtime apps.
-# Docs: https://developers.cloudflare.com/workers/runtime-apis/durable-objects
-# [[durable_objects.bindings]]
-# name = "MY_DURABLE_OBJECT"
-# class_name = "MyDurableObject"
+# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
+#[[durable_objects.bindings]]
+#name = "MY_DURABLE_OBJECT"
+#class_name = "MyDurableObject"
 
 # Durable Object migrations.
-# Docs: https://developers.cloudflare.com/workers/learning/using-durable-objects#configure-durable-object-classes-with-migrations
-# [[migrations]]
-# tag = "v1"
-# new_classes = ["MyDurableObject"]
+# Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#migrations
+#[[migrations]]
+#tag = "v1"
+#new_classes = ["MyDurableObject"]


### PR DESCRIPTION
This brings it in line with the wrangler.toml defined in most places.

Specifically this brings the 2 touched files in line with the config link at /packages/create-cloudflare/templates/hello-world-durable-object/js/wrangler.toml

## What this PR solves / how to test

Old links are broken/not as good.

Didn't open an issue

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Comment changes
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [X] Not necessary because: Comment changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: Comment changes

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
