### PR TITLE
chore: move kv-asset-handler to devDependencies in sites-app fixture

### DIFF
--- a/fixtures/sites-app/package.json
+++ b/fixtures/sites-app/package.json
@@ -6,7 +6,7 @@
 	"license": "ISC",
 	"author": "",
 	"main": "index.js",
-	"dependencies": {
+	"devDependencies": {
 		"@cloudflare/kv-asset-handler": "workspace:*"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -662,7 +662,7 @@ importers:
         version: link:../../packages/wrangler
 
   fixtures/sites-app:
-    dependencies:
+    devDependencies:
       '@cloudflare/kv-asset-handler':
         specifier: workspace:*
         version: link:../../packages/kv-asset-handler


### PR DESCRIPTION
## What this PR solves / how to test

In the Version Packages PR we saw a weird changelog addition

![image](https://github.com/cloudflare/workers-sdk/assets/15655/626ae4be-da25-4210-8a42-e87309fe48a7)

I believe this is because the sites-app had kv-asset-handler as a runtime dependency rather than a devDependency.

This PR changes that so hopefully this should resolve the changelog weirdness.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: fixture config change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: fixture config change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: fixture config change

