### PR TITLE
Check if middleware is an array

### DIFF
--- a/.changeset/funny-drinks-destroy.md
+++ b/.changeset/funny-drinks-destroy.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Require user-specified exported middleware to be an array

--- a/.changeset/funny-drinks-destroy.md
+++ b/.changeset/funny-drinks-destroy.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-fix: Require user-specified exported middleware to be an array
+fix: Don't use `ExportedHandler["middleware"]` for injecting middleware

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -897,7 +897,7 @@ describe("middleware", () => {
 
 			src_default.middleware = [
 			  ,
-			  ...src_default.middleware ?? []
+			  ...Array.isArray(src_default.middleware) ? src_default.middleware : []
 			].filter(Boolean);
 			var middleware_insertion_facade_default = src_default;
 

--- a/packages/wrangler/src/deployment-bundle/apply-middleware.ts
+++ b/packages/wrangler/src/deployment-bundle/apply-middleware.ts
@@ -62,12 +62,12 @@ export async function applyMiddlewareLoaderFacade(
 			dedent/*javascript*/ `
 				import worker, * as OTHER_EXPORTS from "${prepareFilePath(entry.file)}";
 				${imports}
-				
+
 				worker.middleware = [
 					${middlewareFns.join(",")},
-					...(worker.middleware ?? []),
+					...(Array.isArray(worker.middleware) ? worker.middleware : []),
 				].filter(Boolean);
-				
+
 				export * from "${prepareFilePath(entry.file)}";
 				export default worker;
 			`

--- a/packages/wrangler/src/deployment-bundle/apply-middleware.ts
+++ b/packages/wrangler/src/deployment-bundle/apply-middleware.ts
@@ -54,7 +54,9 @@ export async function applyMiddlewareLoaderFacade(
 		)
 		.join("\n");
 
-	const middlewareFns = middlewareIdentifiers.map(([m]) => `${m}.default`);
+	const middlewareFns = middlewareIdentifiers
+		.map(([m]) => `${m}.default`)
+		.join(",");
 
 	if (entry.format === "modules") {
 		await fs.promises.writeFile(
@@ -63,12 +65,9 @@ export async function applyMiddlewareLoaderFacade(
 				import worker, * as OTHER_EXPORTS from "${prepareFilePath(entry.file)}";
 				${imports}
 
-				worker.middleware = [
-					${middlewareFns.join(",")},
-					...(Array.isArray(worker.middleware) ? worker.middleware : []),
-				].filter(Boolean);
-
 				export * from "${prepareFilePath(entry.file)}";
+
+				export const __INTERNAL_WRANGLER_MIDDLEWARE__ = [${middlewareFns}]
 				export default worker;
 			`
 		);

--- a/packages/wrangler/src/deployment-bundle/apply-middleware.ts
+++ b/packages/wrangler/src/deployment-bundle/apply-middleware.ts
@@ -67,7 +67,10 @@ export async function applyMiddlewareLoaderFacade(
 
 				export * from "${prepareFilePath(entry.file)}";
 
-				export const __INTERNAL_WRANGLER_MIDDLEWARE__ = [${middlewareFns}]
+				export const __INTERNAL_WRANGLER_MIDDLEWARE__ = [
+					...(OTHER_EXPORTS.__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__ ?? []),
+					${middlewareFns}
+				]
 				export default worker;
 			`
 		);

--- a/packages/wrangler/templates/facade.d.ts
+++ b/packages/wrangler/templates/facade.d.ts
@@ -3,10 +3,10 @@ declare module "__ENTRY_POINT__" {
 	import { WorkerEntrypoint } from "cloudflare:workers";
 
 	export type WorkerEntrypointConstructor = typeof WorkerEntrypoint;
-	export type WithMiddleware<T> = T & { middleware?: Middleware[] };
 
-	const worker: WithMiddleware<ExportedHandler | WorkerEntrypointConstructor>;
+	const worker: ExportedHandler | WorkerEntrypointConstructor;
 	export default worker;
+	export const __INTERNAL_WRANGLER_MIDDLEWARE__: Middleware[];
 }
 
 declare module "__KV_ASSET_HANDLER__" {

--- a/packages/wrangler/templates/middleware/loader-modules.ts
+++ b/packages/wrangler/templates/middleware/loader-modules.ts
@@ -3,12 +3,9 @@
 // export dynamically through wrangler, or we can potentially let users directly
 // add them as a sort of "plugin" system.
 
-import ENTRY from "__ENTRY_POINT__";
+import ENTRY, { __INTERNAL_WRANGLER_MIDDLEWARE__ } from "__ENTRY_POINT__";
 import { __facade_invoke__, __facade_register__, Dispatcher } from "./common";
-import type {
-	WithMiddleware,
-	WorkerEntrypointConstructor,
-} from "__ENTRY_POINT__";
+import type { WorkerEntrypointConstructor } from "__ENTRY_POINT__";
 
 // Preserve all the exports from the worker
 export * from "__ENTRY_POINT__";
@@ -33,15 +30,16 @@ class __Facade_ScheduledController__ implements ScheduledController {
 	}
 }
 
-function wrapExportedHandler(
-	worker: WithMiddleware<ExportedHandler>
-): ExportedHandler {
+function wrapExportedHandler(worker: ExportedHandler): ExportedHandler {
 	// If we don't have any middleware defined, just return the handler as is
-	if (worker.middleware === undefined || worker.middleware.length === 0) {
+	if (
+		__INTERNAL_WRANGLER_MIDDLEWARE__ === undefined ||
+		__INTERNAL_WRANGLER_MIDDLEWARE__.length === 0
+	) {
 		return worker;
 	}
 	// Otherwise, register all middleware once
-	for (const middleware of worker.middleware) {
+	for (const middleware of __INTERNAL_WRANGLER_MIDDLEWARE__) {
 		__facade_register__(middleware);
 	}
 
@@ -75,14 +73,17 @@ function wrapExportedHandler(
 }
 
 function wrapWorkerEntrypoint(
-	klass: WithMiddleware<WorkerEntrypointConstructor>
+	klass: WorkerEntrypointConstructor
 ): WorkerEntrypointConstructor {
 	// If we don't have any middleware defined, just return the handler as is
-	if (klass.middleware === undefined || klass.middleware.length === 0) {
+	if (
+		__INTERNAL_WRANGLER_MIDDLEWARE__ === undefined ||
+		__INTERNAL_WRANGLER_MIDDLEWARE__.length === 0
+	) {
 		return klass;
 	}
 	// Otherwise, register all middleware once
-	for (const middleware of klass.middleware) {
+	for (const middleware of __INTERNAL_WRANGLER_MIDDLEWARE__) {
 		__facade_register__(middleware);
 	}
 


### PR DESCRIPTION
## What this PR solves / how to test

Use the named export `__INTERNAL_WRANGLER_MIDDLEWARE__` for listing the middleware to be injected in module-format workers. To inject middleware for testing, use `__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__`.

This removes support for adding a `middleware` array to your exported handler.

Fixes #5420.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: not a documented feature

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
