### PR TITLE
Aligning wrangler create vector comment to d1 style

### DIFF
--- a/packages/wrangler/src/vectorize/create.tsx
+++ b/packages/wrangler/src/vectorize/create.tsx
@@ -114,8 +114,8 @@ export async function handler(
 				<Text>&nbsp;</Text>
 				<Text>[[vectorize]]</Text>
 				<Text>
-					binding = &quot;VECTORIZE_INDEX&quot; # available within your Worker
-					on env.VECTORIZE_INDEX
+					binding = &quot;VECTORIZE_INDEX&quot; # i.e. available in 
+					your Worker on env.VECTORIZE_INDEX
 				</Text>
 				<Text>index_name = &quot;{indexResult.name}&quot;</Text>
 			</Box>


### PR DESCRIPTION
Just aligning wrangler output comments for better devX

[[d1_databases]]
binding = "DB" # i.e. available in your Worker on env.DB ..

vs

[[vectorize]]
binding = "VECTORIZE_INDEX" # available within your Worker on env.VECTORIZE_INDEX index_name = "metrics-index"

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: Non functional change
