### PR TITLE
Support `mtls_certificate` and `browser` bindings for Pages

### DIFF
--- a/.changeset/purple-terms-tell.md
+++ b/.changeset/purple-terms-tell.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Support `mtls_certificates` and `browser` bindings

--- a/.changeset/purple-terms-tell.md
+++ b/.changeset/purple-terms-tell.md
@@ -2,4 +2,4 @@
 "wrangler": minor
 ---
 
-feat: Support `mtls_certificates` and `browser` bindings
+feat: Support `mtls_certificates` and `browser` bindings when using `wrangler.toml` with a Pages project

--- a/packages/wrangler/src/__tests__/config-validation-pages.test.ts
+++ b/packages/wrangler/src/__tests__/config-validation-pages.test.ts
@@ -171,6 +171,8 @@ describe("validatePagesConfig()", () => {
 						{ binding: "TEST_AED_BINDING", dataset: "test-dataset" },
 					],
 					ai: { binding: "TEST_AI_BINDING" },
+					browser: { binding: "MY_BROWSER" },
+					mtls_certificates: [{ binding: "CERT", certificate_id: "some - id" }],
 					dev: {
 						ip: "127.0.0.0",
 						port: 1234,

--- a/packages/wrangler/src/config/validation-pages.ts
+++ b/packages/wrangler/src/config/validation-pages.ts
@@ -34,6 +34,8 @@ const supportedPagesConfigFields = [
 	"ai",
 	"version_metadata",
 	"dev",
+	"mtls_certificates",
+	"browser",
 	// normalizeAndValidateConfig() sets this value
 	"configPath",
 ] as const;


### PR DESCRIPTION
## What this PR solves / how to test

Support `mtls_certificate` and `browser` bindings for Pages projects with a `wrangler.toml` file. The backend support for this has already landed.

Fixes [DEVX-1270](https://jira.cfdata.org/browse/DEVX-1270)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
