### PR TITLE
Set `Accept-Encoding: identity` for AI API requests

### DIFF
--- a/packages/wrangler/src/ai/fetcher.ts
+++ b/packages/wrangler/src/ai/fetcher.ts
@@ -19,6 +19,11 @@ export async function AIFetcher(request: Request): Promise<Response> {
 	request.headers.delete("Host");
 	request.headers.delete("Content-Length");
 
+	// Streaming doesn't currently work with `wrangler dev` if the responses are gzipped.
+	// We can explicitly opt out of gzip responses by setting
+	// `Accept-Encoding: identity` when making requests to the API.
+	request.headers.set("Accept-Encoding", "identity");
+
 	const res = await performApiFetch(`/accounts/${accountId}/ai/run/proxy`, {
 		method: "POST",
 		headers: Object.fromEntries(request.headers.entries()),


### PR DESCRIPTION
Streaming doesn't currently work with `wrangler dev` if the responses are gzipped. This may be due to workerd not being able to stream gzipped bodies – still under investigation. But in the meantime we can explicitly opt out of gzip responses by setting `Accept-Encoding: identity` when making requests to the API.

Due to miniflare/workerd's behaviour with gzipped bodies, you'll need to disable gzip encoding from your Worker/Pages output too – unless you can guarantee that your client (eg, curl) won't request with `accept-encoding: gzip`. Unfortunately most browsers will. Here's an example of how to do that:

```
    return new Response(stream, {
      headers: {
        'content-encoding': 'none',
        'content-type': 'text/event-stream',
      },
    });
```

## What this PR solves / how to test

Fixes #APIOPS-8486.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
