### PR TITLE
Limit turbo concurrency to the number of processors available

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"fix": "pnpm run prettify && dotenv -- turbo check:lint -- --fix",
 		"prettify": "prettier . --write --ignore-unknown",
 		"test": "vitest run --no-file-parallelism && dotenv -- turbo test --filter=wrangler --filter=miniflare --filter=kv-asset-handler --filter=@cloudflare/vitest-pool-workers --filter=@cloudflare/vitest-pool-workers-examples",
-		"test:ci": "dotenv -- turbo test:ci",
+		"test:ci": "dotenv -- turbo test:ci --concurrency 100%",
 		"test:e2e": "dotenv -- turbo test:e2e --filter=wrangler",
 		"test:watch": "turbo test:watch",
 		"type:tests": "dotenv -- turbo type:tests",


### PR DESCRIPTION
## What this PR solves / how to test

Limit turbo concurrency to the number of processors available, which will hopefully reduce flakiness

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: n/a
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: not public facing
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: not public facing

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
