### PR TITLE
Don't trigger bundle starts with custom builds

### DIFF
--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -327,7 +327,7 @@ function DevSession(props: DevSessionProps) {
 		[devEnv, startDevWorkerOptions]
 	);
 
-	useCustomBuild(props.entry, props.build, onBundleStart);
+	useCustomBuild(props.entry, props.build);
 
 	const directory = useTmpDir(props.projectRoot);
 
@@ -527,11 +527,7 @@ function useTmpDir(projectRoot: string | undefined): string | undefined {
 	return directory;
 }
 
-function useCustomBuild(
-	expectedEntry: Entry,
-	build: Config["build"],
-	onBundleStart: () => void
-): void {
+function useCustomBuild(expectedEntry: Entry, build: Config["build"]): void {
 	useEffect(() => {
 		if (!build.command) return;
 		let watcher: ReturnType<typeof watch> | undefined;
@@ -544,7 +540,6 @@ function useCustomBuild(
 					path.relative(expectedEntry.directory, expectedEntry.file) || ".";
 				//TODO: we should buffer requests to the proxy until this completes
 				logger.log(`The file ${filePath} changed, restarting build...`);
-				onBundleStart();
 				runCustomBuild(expectedEntry.file, relativeFile, build).catch((err) => {
 					logger.error("Custom build failed:", err);
 				});
@@ -554,7 +549,7 @@ function useCustomBuild(
 		return () => {
 			void watcher?.close();
 		};
-	}, [build, expectedEntry, onBundleStart]);
+	}, [build, expectedEntry]);
 }
 
 function sleep(period: number) {


### PR DESCRIPTION
## What this PR solves / how to test

Previously, running a custom build which didn't change the output file would cause Wrangler to hang, since we were relying on esbuild to run in order to update the proxy. However, esbuild will not re-run in watch mode if all that's changed about one of its input files is the modified time—it seems to require an actual content change. 

Fixes #5729 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: manually tested
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bugfix

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
