### PR TITLE
fix: Allow CJS to import index.js files using directory path

### DIFF
--- a/.changeset/spotty-donuts-jog.md
+++ b/.changeset/spotty-donuts-jog.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix[vitest-pool-workers]: Allow cjs to import index.js using directory path
+
+`maybeGetTargetFilePath` did not correctly deal with implicit import of
+index.js files.
+
+If target is a directory, we need to check if it has an index
+(js, mjs, cjs) file and return that file path if present.


### PR DESCRIPTION
`maybeGetTargetFilePath` did not correctly deal with implicit import of index.js files.

If target is a directory, we need to check if it has an index (js, mjs, cjs) file and return that file path if present.

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: This improves the resolve algorithm with node.js to allow better compat with existing code.

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
