### PR TITLE
fix: custom build noop causes esbuild to skip bundling

### DIFF
--- a/.changeset/sixty-pans-nail.md
+++ b/.changeset/sixty-pans-nail.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: when using custom builds, the `wrangler dev` proxy server was sometimes left in a paused state
+
+This could be observed as the browser loading indefinitely, after saving a source file (unchanged) when using custom builds. This is now fixed by ensuring the proxy server is unpaused after a short timeout period.

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -975,7 +975,7 @@ describe("zone selection", () => {
 
 describe("custom builds", () => {
 	let worker: DevWorker;
-	let defaultScript = dedent`
+	const defaultScript = dedent`
 		export default {
 			async fetch(request) {
 				if (request.url.includes("/long")) {

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import { spawn } from "node:child_process";
 import * as path from "node:path";
 import * as util from "node:util";
@@ -342,7 +341,7 @@ function DevSession(props: DevSessionProps) {
 		return () => {
 			clearTimeout(esbuildStartTimeoutRef.current);
 		};
-	}, [devEnv, startDevWorkerOptions, latestReloadCompleteEvent]);
+	}, [devEnv, latestReloadCompleteEvent]);
 	const onEsbuildStart = useCallback(() => {
 		// see comment in onCustomBuildEnd
 		clearTimeout(esbuildStartTimeoutRef.current);
@@ -354,13 +353,13 @@ function DevSession(props: DevSessionProps) {
 		// we can just call onBundleStart unconditionally as emitting the event more than once is fine
 		// also, if the timeout fired before esbuild started, for some reason, firing this event again is needed
 		onBundleStart();
-	}, [esbuildStartTimeoutRef]);
+	}, [esbuildStartTimeoutRef, onBundleStart]);
 	const onReloadStart = useCallback(
-		(bundle: EsbuildBundle) => {
+		(esbuildBundle: EsbuildBundle) => {
 			devEnv.proxy.onReloadStart({
 				type: "reloadStart",
 				config: startDevWorkerOptions,
-				bundle,
+				bundle: esbuildBundle,
 			});
 		},
 		[devEnv, startDevWorkerOptions]
@@ -602,7 +601,7 @@ function useCustomBuild(
 		return () => {
 			void watcher?.close();
 		};
-	}, [build, expectedEntry, onStart]);
+	}, [build, expectedEntry, onStart, onEnd]);
 }
 
 function sleep(period: number) {

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -325,7 +325,8 @@ function DevSession(props: DevSessionProps) {
 		// (esbuild will definitely produce a new one)
 		if (!bundle) return;
 
-		esbuildStartTimeoutRef.current ??= setTimeout(() => {
+		clearTimeout(esbuildStartTimeoutRef.current);
+		esbuildStartTimeoutRef.current = setTimeout(() => {
 			// esbuild did not start within a reasonable time of the custom build finishing
 			// so we can assume that the custom build produced the same output
 			// and esbuild is choosing not to rebuild the same bundle

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -338,7 +338,7 @@ function DevSession(props: DevSessionProps) {
 		return () => {
 			clearTimeout(esbuildStartTimeoutRef.current);
 		};
-	}, [devEnv, startDevWorkerOptions]);
+	}, [devEnv, startDevWorkerOptions, bundle]);
 	const onEsbuildStart = useCallback(() => {
 		// see comment in onCustomBuildEnd
 		clearTimeout(esbuildStartTimeoutRef.current);

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -326,7 +326,7 @@ function DevSession(props: DevSessionProps) {
 	const latestReloadCompleteEvent = useRef<ReloadCompleteEvent>();
 	const bundle = useRef<ReturnType<typeof useEsbuild>>();
 	const onCustomBuildEnd = useCallback(() => {
-		const TIMEOUT = 500; // TODO: find a lower bound for this value
+		const TIMEOUT = 300; // TODO: find a lower bound for this value
 
 		clearTimeout(esbuildStartTimeoutRef.current);
 		esbuildStartTimeoutRef.current = setTimeout(() => {

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -57,7 +57,7 @@ export function useEsbuild({
 	testScheduled,
 	experimentalLocal,
 	projectRoot,
-	onBundleStart,
+	onStart,
 	defineNavigatorUserAgent,
 }: {
 	entry: Entry;
@@ -84,7 +84,7 @@ export function useEsbuild({
 	testScheduled: boolean;
 	experimentalLocal: boolean | undefined;
 	projectRoot: string | undefined;
-	onBundleStart: () => void;
+	onStart: () => void;
 	defineNavigatorUserAgent: boolean;
 }): EsbuildBundle | undefined {
 	const [bundle, setBundle] = useState<EsbuildBundle>();
@@ -136,7 +136,7 @@ export function useEsbuild({
 			name: "on-end",
 			setup(b: PluginBuild) {
 				b.onStart(() => {
-					onBundleStart();
+					onStart();
 				});
 				b.onEnd(async (result: BuildResult) => {
 					const errors = result.errors;
@@ -271,7 +271,7 @@ export function useEsbuild({
 		testScheduled,
 		experimentalLocal,
 		projectRoot,
-		onBundleStart,
+		onStart,
 		defineNavigatorUserAgent,
 	]);
 	return bundle;


### PR DESCRIPTION
now, if esbuild doesn't start bundling within a timeout of the custom build finishing, we assume it has decided to skip bundling and continue with the previous bundle output

This is alternative fix from #5741 but the guarantee of requests using your latest code changes is maintained

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ ] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
