### PR TITLE
Use proper type for AI binding in wrangler types

### DIFF
--- a/.changeset/thick-parrots-rest.md
+++ b/.changeset/thick-parrots-rest.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: use correct type for AI binding instead of unknown

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -297,7 +297,7 @@ describe("generateTypes()", () => {
 			HYPERDRIVE_BINDING: Hyperdrive;
 			MTLS_BINDING: Fetcher;
 			BROWSER_BINDING: Fetcher;
-			AI_BINDING: unknown;
+			AI_BINDING: Ai;
 			VERSION_METADATA_BINDING: { id: string; tag: string };
 		}
 		declare module \\"*.txt\\" {

--- a/packages/wrangler/src/type-generation.ts
+++ b/packages/wrangler/src/type-generation.ts
@@ -326,7 +326,7 @@ async function generateTypes(
 	}
 
 	if (configToDTS.ai) {
-		envTypeStructure.push(constructType(configToDTS.ai.binding, "unknown"));
+		envTypeStructure.push(constructType(configToDTS.ai.binding, "Ai"));
 	}
 
 	if (configToDTS.version_metadata) {


### PR DESCRIPTION
## What this PR solves / how to test

This PR updates Wrangler CLI to use `Ai` type for the `AI` binding.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: it doesn't affect any of the documented behavior

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
