### PR TITLE
chore: remove no longer used ai dependency

### DIFF
--- a/fixtures/ai-app/package.json
+++ b/fixtures/ai-app/package.json
@@ -14,7 +14,6 @@
 	"devDependencies": {
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*",
-		"@cloudflare/workers-tsconfig": "workspace:^",
-		"@cloudflare/ai": "^1.0.35"
+		"@cloudflare/workers-tsconfig": "workspace:^"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,9 +113,6 @@ importers:
 
   fixtures/ai-app:
     devDependencies:
-      '@cloudflare/ai':
-        specifier: ^1.0.35
-        version: 1.0.41
       '@cloudflare/workers-tsconfig':
         specifier: workspace:^
         version: link:../../packages/workers-tsconfig
@@ -3797,10 +3794,6 @@ packages:
     dev: true
     bundledDependencies:
       - is-unicode-supported
-
-  /@cloudflare/ai@1.0.41:
-    resolution: {integrity: sha512-n6ViGS7Q2X62d0Gf2UcPB6a6iJPC5xoDnRWyS+IbxyTWmJk9fiNdlK6Ft9koLdF/X+CeIzphg+mrVH3nvPpT6g==}
-    dev: true
 
   /@cloudflare/cloudflare-brand-assets@4.7.7:
     resolution: {integrity: sha512-L4EqYWkvse0265YIzraYUlkvvjW7Cr5LELiAiBStctENBoqRhMuR4Ff2X4g/r1BwsQ7S0LTECwLLbM6BNzhv3g==}


### PR DESCRIPTION
## What this PR solves / how to test

This simply removes the unneeded dev dependency on `@cloudflare/ai`, with this now being a native binding.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no functional changes
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: only used in fixtures
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: only used in fixtures, no public changes

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
