### PR TITLE
Fix incorrect error when using only fetchMock in vitest-pool-workers

### DIFF
--- a/.changeset/proud-adults-draw.md
+++ b/.changeset/proud-adults-draw.md
@@ -1,0 +1,8 @@
+---
+"miniflare": patch
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: miniflare fetchMock option incorrectly conflicting with outboundService
+
+Reported in https://github.com/cloudflare/workers-sdk/issues/5486

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -153,6 +153,7 @@ export const CoreOptionsSchema = CoreOptionsSchemaInput.transform((value) => {
 				"Only one of `outboundService` or `fetchMock` may be specified per worker"
 			);
 		}
+		value.fetchMock = undefined;
 		value.outboundService = (req) => fetch(req, { dispatcher: fetchMock });
 	}
 	return value;

--- a/packages/vitest-pool-workers/test/fetchMocking/env.d.ts
+++ b/packages/vitest-pool-workers/test/fetchMocking/env.d.ts
@@ -1,0 +1,7 @@
+declare module "vitest" {
+	interface Env {
+		WORKER: Fetcher
+	}
+}
+
+export {};

--- a/packages/vitest-pool-workers/test/fetchMocking/fetch-mock-override.test.ts
+++ b/packages/vitest-pool-workers/test/fetchMocking/fetch-mock-override.test.ts
@@ -1,0 +1,8 @@
+import { env } from "cloudflare:test"
+import { it, expect } from "vitest"
+
+it("vitestFetchMocking: works as expected", async () => {
+  const response = await env.WORKER.fetch("https://www.example.com/");
+  expect(await response.text()).toBe("fetch mocked")
+  expect(response.status).toBe(200)
+})

--- a/packages/vitest-pool-workers/test/fetchMocking/vitest.config.ts
+++ b/packages/vitest-pool-workers/test/fetchMocking/vitest.config.ts
@@ -1,0 +1,38 @@
+import { defineWorkersProject } from "@cloudflare/vitest-pool-workers/config";
+import { MockAgent } from "undici";
+
+const fetchMock = new MockAgent();
+
+fetchMock.get("https://example.com").intercept({ path: /.*/ }).reply(200, "fetch mocked")
+
+export default defineWorkersProject({
+	test: {
+		// @ts-expect-error `defineWorkersProject()` expects `pool` to be
+		//  `@cloudflare/vitest-pool-workers"` which won't work for us
+		pool: "../..",
+		poolOptions: {
+			workers: ({ inject }) => ({
+				isolatedStorage: false,
+				singleWorker: true,
+				miniflare: {
+					compatibilityDate: "2024-01-01",
+					compatibilityFlags: ["nodejs_compat"],
+					bindings: { KEY: "value" },
+					serviceBindings: {
+						WORKER: "worker",
+					},
+					// This doesn't actually do anything in tests
+					upstream: `http://localhost:${inject("port")}`,
+					workers: [
+						{
+							name: 'worker',
+							modules: true,
+							script: "export default { fetch: (req) => fetch('https://example.com') }",
+							fetchMock: fetchMock,
+						}
+					]
+				},
+			}),
+		},
+	},
+});


### PR DESCRIPTION
## What this PR solves / how to test

Fix incorrectly conflicting fetchMock and outboundService options as reported in https://github.com/cloudflare/workers-sdk/issues/5486.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: Updating bug in behaviour to match existing docs

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
