### PR TITLE
ci: ensure that both C3 and DevProd accounts are cleaned up after e2e…

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -73,6 +73,13 @@ See below for a summary of this repo's Actions
 - Actions
   - Generates changesets for the affected package.
 
+### E2E Project Cleanup (e2e-project-cleanup.yml)
+
+- Triggers
+  - Scheduled to run at 3am each day.
+- Actions
+  - Deletes any Workers and Pages projects that were not properly cleaned up by the E2E tests.
+
 ## Main branch actions
 
 ### Handle Changesets (changesets.yml)
@@ -126,10 +133,3 @@ See below for a summary of this repo's Actions
   - Updates to PRs, by the dependabot user, which touch c3-frameworks-update changesets.
 - Actions
   - Runs the all the C3 E2E (including quarantined) tests for the framework that was updated.
-
-### C3 E2E Project Cleanup (c3-e2e-project-cleanup.yml)
-
-- Triggers
-  - Scheduled to run at 3am each day.
-- Actions
-  - Deletes any Workers and Pages projects that were not properly cleaned up by the C3 E2E tests.

--- a/.github/workflows/e2e-project-cleanup.yml
+++ b/.github/workflows/e2e-project-cleanup.yml
@@ -22,8 +22,14 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: Cleanup E2E test projects
-        run: pnpm run --filter create-cloudflare test:e2e:cleanup
+      - name: Cleanup C3 E2E test projects
+        run: node -r esbuild-register tools/e2e/e2eCleanup.ts
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.C3_TEST_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.C3_TEST_CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Cleanup E2E test projects
+        run: node -r esbuild-register tools/e2e/e2eCleanup.ts
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -32,7 +32,6 @@
 		"check:type": "tsc",
 		"lint": "eslint",
 		"prepublishOnly": "pnpm -w run build",
-		"test:e2e:cleanup": "node -r esbuild-register scripts/e2eCleanup.ts",
 		"test:e2e:npm": "pnpm run build && cross-env TEST_PM=npm vitest run --config ./vitest-e2e.config.ts",
 		"test:e2e:pnpm": "pnpm run build && cross-env TEST_PM=pnpm vitest run --config ./vitest-e2e.config.ts",
 		"test:e2e:bun": "pnpm run build && cross-env TEST_PM=bun vitest run --config ./vitest-e2e.config.ts",

--- a/packages/create-cloudflare/scripts/common.ts
+++ b/packages/create-cloudflare/scripts/common.ts
@@ -1,9 +1,5 @@
 import { fetch } from "undici";
 
-type ApiErrorBody = {
-	errors: string[];
-};
-
 type ApiSuccessBody = {
 	result: any[];
 };
@@ -45,45 +41,6 @@ const apiFetch = async (
 	return json.result;
 };
 
-export const listTmpE2EProjects = async () => {
-	const pageSize = 10;
-	let page = 1;
-
-	const projects: Project[] = [];
-	while (projects.length % pageSize === 0) {
-		try {
-			const res = await apiFetch(
-				`/pages/projects`,
-				{ method: "GET" },
-				{
-					per_page: pageSize,
-					page,
-				}
-			);
-			projects.push(...res);
-			page++;
-			if (res.length < pageSize) {
-				break;
-			}
-		} catch (e) {
-			const { url, init, response } = e as any;
-			console.error("Failed to fetch project list");
-			console.error(url, init);
-			console.error(`(${response.status}) ${response.statusText}`);
-			const body = (await response.json()) as ApiErrorBody;
-			console.error(body.errors);
-			process.exit(1);
-		}
-	}
-
-	return projects.filter(
-		(p) =>
-			p.name.startsWith("tmp-e2e-") &&
-			// Projects are more than an hour old
-			Date.now() - new Date(p.created_on).valueOf() > 1000 * 60 * 60
-	);
-};
-
 export const deleteProject = async (project: string) => {
 	try {
 		await apiFetch(`/pages/projects/${project}`, {
@@ -94,30 +51,12 @@ export const deleteProject = async (project: string) => {
 	}
 };
 
-export const listTmpE2EWorkers = async () => {
-	try {
-		const res: Worker[] = await apiFetch(`/workers/scripts`, { method: "GET" });
-		return res.filter(
-			(p) =>
-				p.id.startsWith("tmp-e2e-") &&
-				// Workers are more than an hour old
-				Date.now() - new Date(p.created_on).valueOf() > 1000 * 60 * 60
-		);
-	} catch (e) {
-		const { url, init, response } = e as any;
-		console.error("Failed to fetch workers list");
-		console.error(url, init);
-		console.error(`(${response.status}) ${response.statusText}`);
-		const body = (await response.json()) as ApiErrorBody;
-		console.error(body.errors);
-		process.exit(1);
-	}
-};
-
 export const deleteWorker = async (id: string) => {
 	try {
 		await apiFetch(`/workers/scripts/${id}`, {
 			method: "DELETE",
 		});
-	} catch {}
+	} catch {
+		// Ignore errors
+	}
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1867,6 +1867,9 @@ importers:
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0
+      undici:
+        specifier: 5.28.3
+        version: 5.28.3
 
 packages:
 

--- a/tools/e2e/__tests__/common.test.ts
+++ b/tools/e2e/__tests__/common.test.ts
@@ -1,0 +1,162 @@
+import { getGlobalDispatcher, MockAgent, setGlobalDispatcher } from "undici";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+	deleteProject,
+	deleteWorker,
+	listTmpE2EProjects,
+	listTmpE2EWorkers,
+} from "../common";
+
+const originalAccountID = process.env.CLOUDFLARE_ACCOUNT_ID;
+const MOCK_CLOUDFLARE_ACCOUNT_ID = "mock-cloudflare-account";
+
+const now = new Date();
+const nowStr = now.toJSON();
+const oldTime = new Date();
+oldTime.setMinutes(oldTime.getMinutes() - 100);
+const oldTimeStr = oldTime.toJSON();
+
+const originalDispatcher = getGlobalDispatcher();
+let agent: MockAgent;
+
+beforeEach(() => {
+	// Mock out the undici Agent
+	agent = new MockAgent();
+	agent.disableNetConnect();
+	setGlobalDispatcher(agent);
+	process.env.CLOUDFLARE_ACCOUNT_ID = MOCK_CLOUDFLARE_ACCOUNT_ID;
+});
+
+afterEach(() => {
+	agent.assertNoPendingInterceptors();
+	setGlobalDispatcher(originalDispatcher);
+	process.env.CLOUDFLARE_ACCOUNT_ID = originalAccountID;
+});
+
+describe("listTmpE2EProjects()", () => {
+	it("makes paged REST requests and returns a filtered list of projects", async ({
+		expect,
+	}) => {
+		agent
+			.get("https://api.cloudflare.com")
+			.intercept({
+				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/pages/projects`,
+				query: {
+					per_page: 10,
+					page: 1,
+				},
+			})
+			.reply(
+				200,
+				JSON.stringify({
+					result: [
+						{ name: "pages-project-1", created_on: nowStr },
+						{ name: "pages-project-2", created_on: oldTimeStr },
+						{ name: "tmp-e2e-project-1", created_on: nowStr },
+						{ name: "tmp-e2e-project-2", created_on: oldTimeStr },
+						{ name: "pages-project-3", created_on: nowStr },
+						{ name: "pages-project-4", created_on: oldTimeStr },
+						{ name: "tmp-e2e-project-3", created_on: nowStr },
+						{ name: "tmp-e2e-project-4", created_on: oldTimeStr },
+						{ name: "pages-project-5", created_on: nowStr },
+						{ name: "pages-project-6", created_on: oldTimeStr },
+					],
+				})
+			);
+
+		agent
+			.get("https://api.cloudflare.com")
+			.intercept({
+				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/pages/projects`,
+				query: {
+					per_page: 10,
+					page: 2,
+				},
+			})
+			.reply(
+				200,
+				JSON.stringify({
+					result: [
+						{ name: "tmp-e2e-project-5", created_on: nowStr },
+						{ name: "tmp-e2e-project-6", created_on: oldTimeStr },
+					],
+				})
+			);
+
+		const result = await listTmpE2EProjects();
+		expect(result.map((p) => p.name)).toMatchInlineSnapshot(`
+			[
+			  "tmp-e2e-project-2",
+			  "tmp-e2e-project-4",
+			  "tmp-e2e-project-6",
+			]
+		`);
+	});
+});
+
+describe("deleteProject()", () => {
+	it("makes a REST request to delete the given project", async () => {
+		const MOCK_PROJECT = "mock-pages-project";
+		agent
+			.get("https://api.cloudflare.com")
+			.intercept({
+				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/pages/projects/${MOCK_PROJECT}`,
+				method: "DELETE",
+			})
+			.reply(200, JSON.stringify({ result: [] }));
+		await deleteProject(MOCK_PROJECT);
+	});
+});
+
+describe("listTmpE2EWorkers()", () => {
+	it("makes a REST request and returns a filtered list of workers", async ({
+		expect,
+	}) => {
+		agent
+			.get("https://api.cloudflare.com")
+			.intercept({
+				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/workers/scripts`,
+				method: "GET",
+			})
+			.reply(
+				200,
+				JSON.stringify({
+					result: [
+						{ id: "wprker-1", created_on: nowStr },
+						{ id: "wprker-2", created_on: oldTimeStr },
+						{ id: "tmp-e2e-worker-1", created_on: nowStr },
+						{ id: "tmp-e2e-worker-2", created_on: oldTimeStr },
+						{ id: "wprker-3", created_on: nowStr },
+						{ id: "wprker-4", created_on: oldTimeStr },
+						{ id: "tmp-e2e-worker-3", created_on: nowStr },
+						{ id: "tmp-e2e-worker-4", created_on: oldTimeStr },
+						{ id: "wprker-5", created_on: nowStr },
+						{ id: "wprker-6", created_on: oldTimeStr },
+					],
+				})
+			);
+
+		const result = await listTmpE2EWorkers();
+
+		expect(result.map((p) => p.id)).toMatchInlineSnapshot(`
+			[
+			  "tmp-e2e-worker-2",
+			  "tmp-e2e-worker-4",
+			]
+		`);
+	});
+});
+
+describe("deleteWorker()", () => {
+	it("makes a REST request to delete the given project", async () => {
+		const MOCK_WORKER = "mock-worker";
+		agent
+			.get("https://api.cloudflare.com")
+			.intercept({
+				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${MOCK_WORKER}`,
+				method: "DELETE",
+			})
+			.reply(200, JSON.stringify({ result: [] }));
+		await deleteWorker(MOCK_WORKER);
+	});
+});

--- a/tools/e2e/common.ts
+++ b/tools/e2e/common.ts
@@ -21,10 +21,16 @@ export type Worker = {
 
 class ApiError extends Error {
 	constructor(
-		public readonly url: string,
-		public readonly init: RequestInit,
-		public readonly response: Response
+		readonly url: string,
+		readonly init: RequestInit,
+		readonly response: Response
 	) {
+		super();
+	}
+}
+
+class FatalError extends Error {
+	constructor(readonly exitCode: number) {
 		super();
 	}
 }
@@ -35,9 +41,10 @@ const apiFetch = async (
 	queryParams = {}
 ) => {
 	const baseUrl = `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}`;
-	const queryString = queryParams
-		? `?${new URLSearchParams(queryParams).toString()}`
-		: "";
+	let queryString = new URLSearchParams(queryParams).toString();
+	if (queryString) {
+		queryString = "?" + queryString;
+	}
 	const url = `${baseUrl}${path}${queryString}`;
 
 	const response = await fetch(url, {
@@ -86,7 +93,7 @@ export const listTmpE2EProjects = async () => {
 			} else {
 				console.error(e);
 			}
-			process.exit(1);
+			throw new FatalError(1);
 		}
 	}
 
@@ -129,7 +136,7 @@ export const listTmpE2EWorkers = async () => {
 		} else {
 			console.error(e);
 		}
-		process.exit(1);
+		throw new FatalError(1);
 	}
 };
 

--- a/tools/e2e/common.ts
+++ b/tools/e2e/common.ts
@@ -1,0 +1,142 @@
+import { fetch } from "undici";
+import type { RequestInit, Response } from "undici";
+
+type ApiErrorBody = {
+	errors: string[];
+};
+
+type ApiSuccessBody = {
+	result: unknown[];
+};
+
+export type Project = {
+	name: string;
+	created_on: string;
+};
+
+export type Worker = {
+	id: string;
+	created_on: string;
+};
+
+class ApiError extends Error {
+	constructor(
+		public readonly url: string,
+		public readonly init: RequestInit,
+		public readonly response: Response
+	) {
+		super();
+	}
+}
+
+const apiFetch = async (
+	path: string,
+	init = { method: "GET" },
+	queryParams = {}
+) => {
+	const baseUrl = `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}`;
+	const queryString = queryParams
+		? `?${new URLSearchParams(queryParams).toString()}`
+		: "";
+	const url = `${baseUrl}${path}${queryString}`;
+
+	const response = await fetch(url, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
+		},
+	});
+
+	if (response.status >= 400) {
+		throw { url, init, response };
+	}
+
+	const json = (await response.json()) as ApiSuccessBody;
+
+	return json.result;
+};
+
+export const listTmpE2EProjects = async () => {
+	const pageSize = 10;
+	let page = 1;
+
+	const projects: Project[] = [];
+	while (projects.length % pageSize === 0) {
+		try {
+			const res = (await apiFetch(
+				`/pages/projects`,
+				{ method: "GET" },
+				{
+					per_page: pageSize,
+					page,
+				}
+			)) as Project[];
+			projects.push(...res);
+			page++;
+			if (res.length < pageSize) {
+				break;
+			}
+		} catch (e) {
+			if (e instanceof ApiError) {
+				console.error("Failed to fetch project list");
+				console.error(e.url, e.init);
+				console.error(`(${e.response.status}) ${e.response.statusText}`);
+				const body = (await e.response.json()) as ApiErrorBody;
+				console.error(body.errors);
+			} else {
+				console.error(e);
+			}
+			process.exit(1);
+		}
+	}
+
+	return projects.filter(
+		(p) =>
+			p.name.startsWith("tmp-e2e-") &&
+			// Projects are more than an hour old
+			Date.now() - new Date(p.created_on).valueOf() > 1000 * 60 * 60
+	);
+};
+
+export const deleteProject = async (project: string) => {
+	try {
+		await apiFetch(`/pages/projects/${project}`, {
+			method: "DELETE",
+		});
+	} catch {
+		// Ignore errors
+	}
+};
+
+export const listTmpE2EWorkers = async () => {
+	try {
+		const res = (await apiFetch(`/workers/scripts`, {
+			method: "GET",
+		})) as Worker[];
+		return res.filter(
+			(p) =>
+				p.id.startsWith("tmp-e2e-") &&
+				// Workers are more than an hour old
+				Date.now() - new Date(p.created_on).valueOf() > 1000 * 60 * 60
+		);
+	} catch (e) {
+		if (e instanceof ApiError) {
+			console.error("Failed to fetch workers list");
+			console.error(e.url, e.init);
+			console.error(`(${e.response.status}) ${e.response.statusText}`);
+			const body = (await e.response.json()) as ApiErrorBody;
+			console.error(body.errors);
+		} else {
+			console.error(e);
+		}
+		process.exit(1);
+	}
+};
+
+export const deleteWorker = async (id: string) => {
+	try {
+		await apiFetch(`/workers/scripts/${id}`, {
+			method: "DELETE",
+		});
+	} catch {}
+};

--- a/tools/e2e/e2eCleanup.ts
+++ b/tools/e2e/e2eCleanup.ts
@@ -15,7 +15,11 @@ if (!process.env.CLOUDFLARE_ACCOUNT_ID) {
 	process.exit(1);
 }
 
-void run();
+run().catch((e) => {
+	if ("code" in e) {
+		process.exit(e.code);
+	}
+});
 
 async function run() {
 	const projectsToDelete = await listTmpE2EProjects();

--- a/tools/e2e/e2eCleanup.ts
+++ b/tools/e2e/e2eCleanup.ts
@@ -3,7 +3,6 @@ import {
 	deleteWorker,
 	listTmpE2EProjects,
 	listTmpE2EWorkers,
-	Project,
 } from "./common";
 
 if (!process.env.CLOUDFLARE_API_TOKEN) {
@@ -16,7 +15,9 @@ if (!process.env.CLOUDFLARE_ACCOUNT_ID) {
 	process.exit(1);
 }
 
-const run = async () => {
+void run();
+
+async function run() {
 	const projectsToDelete = await listTmpE2EProjects();
 
 	for (const project of projectsToDelete) {
@@ -42,6 +43,4 @@ const run = async () => {
 	} else {
 		console.log(`Successfully deleted ${workersToDelete.length} workers`);
 	}
-};
-
-run();
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -12,6 +12,7 @@
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@typescript-eslint/eslint-plugin": "^5.55.0",
 		"@typescript-eslint/parser": "^5.55.0",
-		"ts-dedent": "^2.2.0"
+		"ts-dedent": "^2.2.0",
+		"undici": "5.28.3"
 	}
 }

--- a/tools/turbo.json
+++ b/tools/turbo.json
@@ -4,7 +4,11 @@
 
 	"pipeline": {
 		"build": {
-			"env": ["CLOUDFLARE_API_TOKEN", "PUBLISHED_PACKAGES"]
+			"env": [
+				"CLOUDFLARE_API_TOKEN",
+				"PUBLISHED_PACKAGES",
+				"CLOUDFLARE_ACCOUNT_ID"
+			]
 		}
 	}
 }

--- a/tools/vitest.config.ts
+++ b/tools/vitest.config.ts
@@ -6,6 +6,7 @@ export default mergeConfig(
 	defineProject({
 		test: {
 			include: ["**/__tests__/*.test.ts"],
+			retry: 0,
 		},
 	})
 );


### PR DESCRIPTION
… tests

## What this PR solves / how to test

Previously we were only deleting stale projects/workers from the C3 test account.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: CI change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: CI change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: CI change
