### PR TITLE
ci: shard tests by workspace type

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -70,13 +70,14 @@ jobs:
   test:
     timeout-minutes: 60
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-test
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.filter }}-test
       cancel-in-progress: true
 
     name: "Tests"
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        filter: ["./fixtures/*", "./packages/*", "./tools"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
@@ -104,7 +105,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm run test:ci
+        run: pnpm run test:ci --filter=${{ matrix.filter }}
         env:
           TMP_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TMP_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## What this PR solves / how to test

By splitting the tests into shards we can potentially avoid timeouts and memory issues.

Once merged, we need to:
- [ ] update the branch rules to point to these new job names

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: CI config change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: CI config change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: CI config change
