### PR TITLE
fix(pages-shared) Remove request method from cache key

### DIFF
--- a/.changeset/old-students-kneel.md
+++ b/.changeset/old-students-kneel.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/pages-shared": patch
+---
+
+fix: Remove request method from cache key
+
+Reverts a change that added the request method to the cache key when reading/writing to cache.

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -480,13 +480,6 @@ export async function generateHandler<
 
 	return await attachHeaders(await generateResponse());
 
-	/** We have non-standard cache behavior, so strip out all headers but keep the method */
-	function getCacheKey(): Request {
-		return new Request(request.url, {
-			method: request.method,
-		});
-	}
-
 	async function serveAsset(
 		servingAssetEntry: AssetEntry,
 		options = { preserve: true }
@@ -580,7 +573,7 @@ export async function generateHandler<
 								preservedResponse.headers.set("x-robots-tag", "noindex");
 
 								await assetPreservationCacheV2.put(
-									getCacheKey(),
+									request.url,
 									preservedResponse
 								);
 							}
@@ -621,12 +614,12 @@ export async function generateHandler<
 					ASSET_PRESERVATION_CACHE_V2
 				);
 				let preservedResponse = await assetPreservationCacheV2.match(
-					getCacheKey()
+					request.url
 				);
 
 				// Continue serving from V1 preservation cache for some time to
 				// prevent 404s during the migration to V2
-				const cutoffDate = new Date("2024-05-10");
+				const cutoffDate = new Date("2024-05-17");
 				if (!preservedResponse && Date.now() < cutoffDate.getTime()) {
 					const assetPreservationCacheV1 = await caches.open(
 						ASSET_PRESERVATION_CACHE_V1


### PR DESCRIPTION
## What this PR solves / how to test

Fixes BANDAOPS-41
Reverts a previous change where we added the HTTP method to the cache key, which caused issues because only GET requests can be written to the cache key.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: reverts previous change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [ x] Not necessary because:

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
