### PR TITLE
chore: miniflare worker-metafiles are outputs not inputs

### DIFF
--- a/packages/miniflare/turbo.json
+++ b/packages/miniflare/turbo.json
@@ -7,12 +7,11 @@
 				"src/**",
 				"scripts/**",
 				"types/**",
-				"worker-metafiles/**",
 				"*.mjs",
 				"*.js",
 				"*.json"
 			],
-			"outputs": ["dist/**", "bootstrap.js"],
+			"outputs": ["dist/**", "bootstrap.js", "worker-metafiles/**"],
 			"env": [
 				"CI_OS"
 			]


### PR DESCRIPTION
## What this PR solves / how to test

The update to narrow the turbo inputs to miniflare included files that are actually outputs!

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: turbo config change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: turbo config change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: turbo config change

