### PR TITLE
Auto add e2e label + PR description reminder for e2e

### DIFF
--- a/.github/pr-add-e2e-label.config.yml
+++ b/.github/pr-add-e2e-label.config.yml
@@ -1,0 +1,5 @@
+# add 'e2e' label to any changes within the 'packages/wrangler/e2e' directory
+e2e:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: "packages/wrangler/e2e/**/*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,10 @@ Fixes #[insert GH or internal issue number(s)].
   - [ ] TODO (before merge)
   - [ ] Included
   - [ ] Not necessary because:
+- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
+  - [ ] I don't know
+  - [ ] Required / Maybe required
+  - [ ] Not required because:
 - Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
   - [ ] TODO (before merge)
   - [ ] Included

--- a/.github/workflows/pr-add-e2e-label.yml
+++ b/.github/workflows/pr-add-e2e-label.yml
@@ -1,0 +1,17 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/pr-add-e2e-label.config.yml


### PR DESCRIPTION
## What this PR solves / how to test

Sometimes we review PRs that change snapshot values in unit-tests and e2e tests but we don't notice the e2e snapshots were updated.

This PR makes sure that the 'e2e' label is added to a PR if any files within wrangler's e2e/ directory are touched. If the e2e tests change, we undoubtedly want to run the job to make sure they still pass.

This PR also adds to the PR description a reminder for the author and the reviewers to check whether an e2e test run is required.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: github action workflow change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: internal repo change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: internal repo change

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
