### PR TITLE
ci: don't run c3 checks on non-cloudflare repos

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -23,7 +23,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.pm }}
       cancel-in-progress: true
     name: ${{ format('E2E ({0} on {1})', matrix.pm, matrix.os) }}
-    if: ${{ github.repository_owner == 'cloudflare' && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: github.repository_owner == 'cloudflare' && github.event.pull_request.user.login != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What this PR solves / how to test

Tries to avoid running C3 e2e tests on 3rd party forks, which will never pass.

