### PR TITLE
Refine README to align with latest project guidelines and reviewer fe…

### DIFF
--- a/templates/worker-router/README.md
+++ b/templates/worker-router/README.md
@@ -1,26 +1,44 @@
-## Template: worker-router
+## Template: Worker-Router 
+
+This template demonstrates how to use the [`itty-router`](https://github.com/kwhitley/itty-router) package to implement routing in a Cloudflare Workers project.
+
+### Deploy with Workers
 
 [![Deploy with Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-router)
 
-This template demonstrates using the [`itty-router`](https://github.com/kwhitley/itty-router) package to add routing to your Cloudflare Workers.
+### Prerequisites
 
-[`index.js`](https://github.com/cloudflare/worker-template-router/blob/master/index.js) is the content of the Workers script.
-
-## Setup
-
-To create a `my-project` directory using this template, run:
+Before you begin, if you don't have `wrangler` installed, you can use `npx` which will install it temporarily when needed. If you prefer to install it permanently:
 
 ```sh
-$ npx wrangler generate my-project worker
-# or
-$ yarn wrangler generate my-project worker
-# or
-$ pnpm wrangler generate my-project worker
+npm install -g @cloudflare/wrangler
 ```
 
-Before publishing your code you need to edit `wrangler.toml` file and add your Cloudflare `account_id` - more information about configuring and publishing your code can be found [in the documentation](https://developers.cloudflare.com/workers/learning/getting-started).
+### Setup
 
-Once you are ready, you can publish your code by running the following command:
+To create a new project directory using this template, run one of the following commands based on your package manager preference:
+
+```sh
+$ npx wrangler generate my-project worker-prospector
+# or
+$ yarn wrangler generate my-project worker-prospector
+# or
+$ pnpm wrangler generate my-project worker-prospector
+```
+
+### Configuration
+
+With Wrangler v2+, configuration of the `account_id` is automated. Ensure that you are logged into your Cloudflare account through Wrangler by running:
+
+```sh
+wrangler login
+```
+
+This command will setup all necessary account details automatically.
+
+### Deployment
+
+To deploy your worker to Cloudflare, use the following commands based on your package manager:
 
 ```sh
 $ npm run deploy
@@ -28,4 +46,11 @@ $ npm run deploy
 $ yarn run deploy
 # or
 $ pnpm run deploy
+```
+
+Before deploying, make sure that your `wrangler.toml` is properly configured, which should be automatically handled by your login session.
+
+### More Information
+
+For more information on working with Cloudflare Workers and `itty-router`, visit the [Cloudflare Workers documentation](https://developers.cloudflare.com/workers/).
 ```


### PR DESCRIPTION
## What this PR solves / how to test

This PR updates the README.md with clearer and more accurate setup and deployment instructions for the Worker-Router template. It corrects the setup command from `npx wrangler generate my-project worker` to `npx wrangler generate my-project worker-prospector`, addressing an issue where the former command would result in errors. This ensures users correctly generate the project with the intended template.

To test, follow the updated README instructions to setup and deploy a worker using the `itty-router`. This ensures that new users can smoothly start projects without encountering the command error.

## Author has addressed the following

- Tests
  - [ ] Not necessary because: The changes are solely to the documentation, not affecting the executable code of the Workers themselves.
  
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] Not required because: This submission does not alter the functionality or operational integrity of the Cloudflare Workers, only the documentation.

- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] Not necessary because: Only documentation was updated, no changes were made to the codebase that would affect the end users or require a new version release.

- Public documentation
  - [ ] Not necessary because: The changes are contained within the repository itself and do not affect external documentation that requires separate updates.

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->

