### PR TITLE
Remove Hyperdrive warning log indicating that Hyperdrive local binding does not work

### DIFF
--- a/.changeset/thirty-kings-serve.md
+++ b/.changeset/thirty-kings-serve.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Update Hyperdrive logs to reflect that bindings are now supported in local dev
+Update Hyperdrive logs to reflect that hyperdrive bindings are now supported in local dev

--- a/.changeset/thirty-kings-serve.md
+++ b/.changeset/thirty-kings-serve.md
@@ -2,4 +2,6 @@
 "wrangler": patch
 ---
 
-Update Hyperdrive logs to reflect that hyperdrive bindings are now supported in local dev
+fix: remove Hyperdrive warning for local development.
+
+Hyperdrive bindings are now supported when developing locally with Hyperdrive. We should update our logs to reflect this.

--- a/.changeset/thirty-kings-serve.md
+++ b/.changeset/thirty-kings-serve.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Update Hyperdrive logs to reflect that bindings are now supported in local dev

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -433,12 +433,6 @@ function DevSession(props: DevSessionProps) {
 		);
 	}
 
-	if (props.local && props.bindings.hyperdrive?.length) {
-		logger.warn(
-			"Hyperdrive does not currently support 'wrangler dev' in local mode at this stage of the beta. Use the '--remote' flag to test a Hyperdrive configuration before deploying."
-		);
-	}
-
 	const announceAndOnReady: typeof props.onReady = async (
 		finalIp,
 		finalPort,


### PR DESCRIPTION
Hyperdrive is supported locally (see https://github.com/cloudflare/workerd/pull/1266) and this warning is not longer accurate. It was added while the support was in progress to avoid confusion (https://github.com/cloudflare/workers-sdk/commit/54800f6f2dc52b921e7dd1d9a57bb437e2094bb0), but now that local support for Hyperdrive bindings has been added, this log is incorrect and should be removed


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [X] Not necessary because: This is a log bugfix that does not have implications on the functionality.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [X] Not required because: This is a log bugfix that does not have implications on the functionality, and warning logs are not verified in e2e tests.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [X] Included
  - [ ] Not necessary because: 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [X] Not necessary because: This is a log bugfix.


