### PR TITLE
fix(wrangler): Display correct global flags in `wrangler pages --help`

### DIFF
--- a/.changeset/quiet-wolves-camp.md
+++ b/.changeset/quiet-wolves-camp.md
@@ -1,0 +1,19 @@
+---
+"wrangler": minor
+---
+
+fix: Display correct global flags in `wrangler pages --help`
+
+Running `wrangler pages --help` will list, amongst others, the following global flags:
+
+```
+-j, --experimental-json-config
+-c, --config
+-e, --env
+-h, --help
+-v, --version
+```
+
+This is not accurate, since flags such as `--config`, `--experimental-json-config`, or `env` are not supported by Pages.
+
+This commit ensures we display the correct global flags that apply to Pages.

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -58,10 +58,8 @@ describe("pages deploy", () => {
 		  directory  The directory of static files to upload  [string]
 
 		Flags:
-		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
-		  -e, --env                       Environment to use for operations and .env files  [string]
-		  -h, --help                      Show help  [boolean]
-		  -v, --version                   Show version number  [boolean]
+		  -h, --help     Show help  [boolean]
+		  -v, --version  Show version number  [boolean]
 
 		Options:
 		      --project-name    The name of the project you want to deploy to  [string]
@@ -87,6 +85,30 @@ describe("pages deploy", () => {
 			runWrangler("pages deploy public")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			`"Must specify a project name."`
+		);
+	});
+
+	it("should error if the [--config] command line arg was specififed", async () => {
+		await expect(
+			runWrangler("pages deploy public --config=/path/to/wrangler.toml")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Pages does not support custom paths for the \`wrangler.toml\` configuration file"`
+		);
+	});
+
+	it("should error if the [--experimental-json-config] command line arg was specififed", async () => {
+		await expect(
+			runWrangler("pages deploy public --experimental-json-config")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Pages does not support \`wrangler.json\`"`
+		);
+	});
+
+	it("should error if the [--env] command line arg was specififed", async () => {
+		await expect(
+			runWrangler("pages deploy public --env=production")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Pages does not support imperatively targeting a particular environment"`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -33,4 +33,20 @@ describe("pages dev", () => {
 			`"Pages does not support custom paths for the \`wrangler.toml\` configuration file"`
 		);
 	});
+
+	it("should error if the [--experimental-json-config] command line arg was specififed", async () => {
+		await expect(
+			runWrangler("pages dev public --experimental-json-config")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Pages does not support \`wrangler.json\`"`
+		);
+	});
+
+	it("should error if the [--env] command line arg was specififed", async () => {
+		await expect(
+			runWrangler("pages dev public --env=production")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`"Pages does not support imperatively targeting a particular environment"`
+		);
+	});
 });

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -31,11 +31,8 @@ describe("pages", () => {
 		  wrangler pages download                        ⚡️ Download settings from your project
 
 		Flags:
-		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
-		  -c, --config                    Path to .toml configuration file  [string]
-		  -e, --env                       Environment to use for operations and .env files  [string]
-		  -h, --help                      Show help  [boolean]
-		  -v, --version                   Show version number  [boolean]"
+		  -h, --help     Show help  [boolean]
+		  -v, --version  Show version number  [boolean]"
 	`);
 	});
 

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -432,6 +432,10 @@ export function createCLIParser(argv: string[]) {
 
 	// pages
 	wrangler.command("pages", "⚡️ Configure Cloudflare Pages", (pagesYargs) => {
+		// Pages does not support the `--config`, `--experimental-json-config`,
+		// and `--env` flags, therefore hiding them from the global flags list.
+		pagesYargs.hide("config").hide("env").hide("experimental-json-config");
+
 		return pages(pagesYargs, subHelp);
 	});
 

--- a/packages/wrangler/src/pages/deploy.tsx
+++ b/packages/wrangler/src/pages/deploy.tsx
@@ -101,6 +101,17 @@ export const Handler = async (args: PagesDeployArgs) => {
 		);
 	}
 
+	if (args.experimentalJsonConfig) {
+		throw new FatalError("Pages does not support `wrangler.json`", 1);
+	}
+
+	if (args.env) {
+		throw new FatalError(
+			"Pages does not support targeting an environment with the --env flag. Use the --branch flag to target your production or preview branch",
+			1
+		);
+	}
+
 	let config: Config | undefined;
 	const configPath = findWranglerToml(process.cwd(), false);
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -263,6 +263,17 @@ export const Handler = async (args: PagesDevArguments) => {
 		);
 	}
 
+	if (args.experimentalJsonConfig) {
+		throw new FatalError("Pages does not support `wrangler.json`", 1);
+	}
+
+	if (args.env) {
+		throw new FatalError(
+			"Pages does not support targeting an environment with the --env flag. Use the --branch flag to target your production or preview branch",
+			1
+		);
+	}
+
 	if (args.scriptPath !== undefined) {
 		logger.warn(
 			`\`--script-path\` is deprecated and will be removed in a future version of Wrangler.\nThe Worker script should be named \`_worker.js\` and located in the build output directory of your project (specified with \`wrangler pages dev <directory>\`).`


### PR DESCRIPTION
## What this PR solves / how to test

Running `wrangler pages --help` will list, amongst others, the following global flags:

<img width="764" alt="Screenshot 2024-05-13 at 19 18 22" src="https://github.com/cloudflare/workers-sdk/assets/4638332/4deedc4d-4075-44ca-92c9-394e29513f14">

Some of these global flags however, such as `--env`, `--config` or `--experimental-json-config`, are not supported by Pages, and therefore listing them as if they were gets users confused.

This PR ensures we only list the relevant flags when running `wrangler pages --help`

Fixes #5725.

**Before**
`wrangler --help`
<img width="764" alt="Screenshot 2024-05-13 at 19 18 22" src="https://github.com/cloudflare/workers-sdk/assets/4638332/4deedc4d-4075-44ca-92c9-394e29513f14">

`wrangler pages --help`
<img width="1046" alt="Screenshot 2024-05-13 at 19 27 59" src="https://github.com/cloudflare/workers-sdk/assets/4638332/e904d466-e096-416b-a178-0eb48575ba54">


**After**
`wrangler --help`
<img width="764" alt="Screenshot 2024-05-13 at 19 18 22" src="https://github.com/cloudflare/workers-sdk/assets/4638332/4deedc4d-4075-44ca-92c9-394e29513f14">

`wrangler pages --help`
<img width="1001" alt="Screenshot 2024-05-13 at 19 24 59" src="https://github.com/cloudflare/workers-sdk/assets/4638332/593241fd-4922-477d-97fe-e7d69b8c4fe0">

`wrangler pages dev --help`
<img width="553" alt="Screenshot 2024-05-13 at 19 25 34" src="https://github.com/cloudflare/workers-sdk/assets/4638332/9ace0851-5b0e-48ae-9b73-723b6218dcdc">


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: changes are covered by unit tests and that's enough
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): [<https://github.com/cloudflare/cloudflare-docs/pull/>...](https://github.com/cloudflare/cloudflare-docs/pull/14591)
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
