### PR TITLE
Deprecate "deployment" in metadata binding

### DIFF
--- a/.changeset/smart-actors-allow.md
+++ b/.changeset/smart-actors-allow.md
@@ -1,0 +1,14 @@
+---
+"wrangler": minor
+---
+
+chore: Deprecate usage of the deployment object on the unsafe metadata binding in favor of the new version_metadata binding.
+
+If you're currently using the old binding, please move over to the new version_metadata binding by adding:
+
+```toml
+[version_metadata]
+binding = "CF_VERSION_METADATA"
+```
+
+and updating your usage accordingly. You can find the docs for the new binding here: https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -852,6 +852,48 @@ describe("normalizeAndValidateConfig()", () => {
 		        `);
 			});
 		});
+
+		it("should warn on unsafe binding metadata usage", () => {
+			const expectedConfig: RawConfig = {
+				unsafe: {
+					bindings: [
+						{
+							type: "metadata",
+							name: "METADATA",
+						},
+					],
+				},
+			};
+
+			const { config, diagnostics } = normalizeAndValidateConfig(
+				expectedConfig,
+				"project/wrangler.toml",
+				{ env: undefined }
+			);
+
+			expect(config).toEqual(
+				expect.objectContaining({
+					unsafe: {
+						bindings: [
+							{
+								type: "metadata",
+								name: "METADATA",
+							},
+						],
+					},
+				})
+			);
+			expect(diagnostics.hasErrors()).toBe(false);
+			expect(diagnostics.hasWarnings()).toBe(true);
+
+			expect(normalizeSlashes(diagnostics.renderWarnings()))
+				.toMatchInlineSnapshot(`
+"Processing project/wrangler.toml configuration:
+  - \\"unsafe\\" fields are experimental and may change or break at any time.
+  - \\"unsafe.bindings[0]\\": {\\"type\\":\\"metadata\\",\\"name\\":\\"METADATA\\"}
+    - The deployment object in the metadata binding is now deprecated. Please switch using the version_metadata binding for access to version specific fields: https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata"
+`);
+		});
 	});
 
 	describe("top-level environment configuration", () => {

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2185,6 +2185,17 @@ const validateUnsafeBinding: ValidatorFn = (diagnostics, field, value) => {
 					"For more details, see https://developers.cloudflare.com/workers/cli-wrangler/configuration"
 			);
 		}
+
+		if (
+			value.type === "metadata" &&
+			isRequiredProperty(value, "name", "string")
+		) {
+			diagnostics.warnings.push(
+				"The deployment object in the metadata binding is now deprecated. " +
+					"Please switch using the version_metadata binding for access to version specific fields: " +
+					"https://developers.cloudflare.com/workers/runtime-apis/bindings/version-metadata"
+			);
+		}
 	} else {
 		diagnostics.errors.push(`binding should have a string "type" field.`);
 		isValid = false;


### PR DESCRIPTION
## What this PR solves / how to test

WC-1755

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: Doesn't impact e2e tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/14580
  - [ ] Not necessary because:
