### PR TITLE
Cleanup: Remove builtin-wasm-modules from autogates passed to workerd

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1273,8 +1273,7 @@ export class Miniflare {
 			);
 		}
 
-		const autogates = [];
-		return { services: servicesArray, sockets, extensions, autogates };
+		return { services: servicesArray, sockets, extensions };
 	}
 
 	async #assembleAndUpdateConfig() {

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1273,12 +1273,7 @@ export class Miniflare {
 			);
 		}
 
-		const autogates = [
-			// Enables Python support in workerd.
-			// TODO(later): remove this once this gate is removed from workerd.
-			"workerd-autogate-builtin-wasm-modules",
-		];
-
+		const autogates = [];
 		return { services: servicesArray, sockets, extensions, autogates };
 	}
 


### PR DESCRIPTION
The builtin-wasm-modules autogate is no longer required.

## What this PR solves / how to test

Doesn't fix anything. Just a cleanup.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: cleanup
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: trivial cleanup

