### PR TITLE
Bump to TS 5

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -15,6 +15,6 @@
 		"^[.]/index$",
 		"<TYPES>"
 	],
-	"importOrderTypeScriptVersion": "4.8.4",
+	"importOrderTypeScriptVersion": "5.4.5",
 	"importOrderParserPlugins": ["typescript", "jsx", "decorators"]
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"jsonc-parser": "^3.2.0",
 		"prettier-plugin-packagejson": "^2.2.18",
 		"rimraf": "^5.0.1",
-		"typescript": "^4.8.4",
+		"typescript": "^5.4.5",
 		"vite": "^5.0.12",
 		"vitest": "^1.2.2"
 	},

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -79,7 +79,6 @@
 		"pnpm": "^8.10.0",
 		"recast": "^0.22.0",
 		"semver": "^7.5.1",
-		"typescript": "^5.0.2",
 		"undici": "5.28.3",
 		"vite-tsconfig-paths": "^4.0.8",
 		"which-pm-runs": "^1.1.0",

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -15,7 +15,6 @@
 		"promjs": "^0.4.2",
 		"toucan-js": "^3.2.3",
 		"tsconfig": "*",
-		"typescript": "^5.0.2",
 		"wrangler": "workspace:*",
 		"zod": "^3.22.3"
 	}

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -86,7 +86,6 @@
 		"kleur": "^4.1.5",
 		"rimraf": "^3.0.2",
 		"source-map": "^0.6.0",
-		"typescript": "^5.4.5",
 		"which": "^2.0.2"
 	},
 	"engines": {

--- a/packages/prerelease-registry/package.json
+++ b/packages/prerelease-registry/package.json
@@ -19,7 +19,6 @@
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20240512.0",
-		"typescript": "^4.5.5",
 		"wrangler": "workspace:*"
 	}
 }

--- a/packages/quick-edit-extension/package.json
+++ b/packages/quick-edit-extension/package.json
@@ -43,8 +43,7 @@
 		"@cloudflare/workers-tsconfig": "workspace:^",
 		"@cloudflare/workers-types": "^4.20240512.0",
 		"esbuild": "0.16.3",
-		"esbuild-register": "^3.4.2",
-		"typescript": "^4.9.5"
+		"esbuild-register": "^3.4.2"
 	},
 	"engines": {
 		"vscode": "^1.76.0"

--- a/packages/vitest-pool-workers/.eslintrc.js
+++ b/packages/vitest-pool-workers/.eslintrc.js
@@ -1,11 +1,6 @@
 module.exports = {
 	root: true,
 	extends: ["@cloudflare/eslint-config-worker"],
-	parserOptions: {
-		ecmaVersion: 2022,
-		sourceType: "module",
-		project: "tsconfig.json",
-	},
 	overrides: [
 		{
 			files: "src/worker/**/*.ts",
@@ -22,6 +17,14 @@ module.exports = {
 				ecmaVersion: 2022,
 				sourceType: "module",
 				project: "test/tsconfig.json",
+			},
+		},
+		{
+			files: "test/**/vitest.config.ts",
+			parserOptions: {
+				ecmaVersion: 2022,
+				sourceType: "module",
+				project: "tsconfig.json",
 			},
 		},
 	],

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -464,12 +464,12 @@ function buildProjectWorkerOptions(
 	return workers;
 }
 
-const SHARED_MINIFLARE_OPTIONS: Partial<MiniflareOptions> = {
+const SHARED_MINIFLARE_OPTIONS = {
 	log: mfLog,
 	verbose: true,
 	handleRuntimeStdio,
 	unsafeStickyBlobs: true,
-};
+} satisfies Partial<MiniflareOptions>;
 
 type ModuleFallbackService = NonNullable<
 	MiniflareOptions["unsafeModuleFallbackService"]

--- a/packages/workers-playground/package.json
+++ b/packages/workers-playground/package.json
@@ -60,7 +60,6 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"eslint-plugin-react-refresh": "^0.4.1",
 		"tsx": "^3.12.8",
-		"typescript": "^5.0.2",
 		"undici": "5.28.4",
 		"vite-plugin-rewrite-all": "^1.0.1",
 		"wrangler": "workspace:^"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)
       '@turbo/gen':
         specifier: ^1.10.13
-        version: 1.13.3(@types/node@20.1.7)(typescript@5.4.5)
+        version: 1.10.14(@types/node@20.1.7)(typescript@5.4.5)
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.3.4
@@ -828,10 +828,10 @@ importers:
         version: 17.0.24
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.55.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+        version: 5.59.9(@typescript-eslint/parser@5.59.9(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser':
         specifier: ^5.55.0
-        version: 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+        version: 5.59.9(eslint@8.57.0)(typescript@5.4.5)
       chalk:
         specifier: ^5.2.0
         version: 5.2.0
@@ -888,7 +888,7 @@ importers:
         version: 5.28.3
       vite-tsconfig-paths:
         specifier: ^4.0.8
-        version: 4.3.2(typescript@5.4.5)(vite@5.0.12(@types/node@18.16.10))
+        version: 4.2.0(typescript@5.4.5)(vite@5.0.12(@types/node@18.16.10))
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1752,7 +1752,7 @@ importers:
         version: 5.1.0
       msw:
         specifier: ^0.49.1
-        version: 0.49.3(encoding@0.1.13)(supports-color@9.2.2)(typescript@4.9.5)
+        version: 0.49.1(encoding@0.1.13)(supports-color@9.2.2)(typescript@4.9.5)
       open:
         specifier: ^8.4.0
         version: 8.4.0
@@ -4610,12 +4610,12 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turbo/gen@1.13.3':
-    resolution: {integrity: sha512-l+EM1gGzckFMaaVQyj3BVRa0QJ+tpp8HfiHOhGpBWW3Vc0Hfj92AY87Di/7HGABa+HVY7ueatMi7DJG+zkJBYg==}
+  '@turbo/gen@1.10.14':
+    resolution: {integrity: sha512-g7ecPx0GCCTpnbH53blBGNk6pP4LhcWiTtR0kEprGkXpiHqjYDpOydz4JFoz9IC+Hj1Z28/+M7T/GfwJAjf0FQ==}
     hasBin: true
 
-  '@turbo/workspaces@1.13.3':
-    resolution: {integrity: sha512-QYZ8g3IVQebqNM8IsBlWYOWmOKjBZY55e6lx4EDOLuch1iWmyk+U8CLAI9UomMrSaKTs1Sx+PDkt63EgakvhUw==}
+  '@turbo/workspaces@1.10.14':
+    resolution: {integrity: sha512-MNJeCNJWIFdXQ0m7yp1VeZE/3edoFEeAFJlr9UxRiv6cge3TdhwI6OEuBewJDN73/4SZSeL4u6L+2DVULA0t+Q==}
     hasBin: true
 
   '@types/acorn@4.0.6':
@@ -4910,6 +4910,17 @@ packages:
   '@types/yoga-layout@1.9.2':
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
 
+  '@typescript-eslint/eslint-plugin@5.59.9':
+    resolution: {integrity: sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/eslint-plugin@5.62.0':
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4938,6 +4949,16 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
       eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/parser@5.59.9':
+    resolution: {integrity: sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -4988,6 +5009,16 @@ packages:
   '@typescript-eslint/scope-manager@6.7.2':
     resolution: {integrity: sha512-bgi6plgyZjEqapr7u2mhxGR6E8WCzKNUFWNh6fkpVe9+yzRZeYtDTbsIBzKbcxI+r1qVWt6VIoMSNZ4r2A+6Yw==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/type-utils@5.59.9':
+    resolution: {integrity: sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@typescript-eslint/type-utils@5.62.0':
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
@@ -8968,8 +8999,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@0.49.3:
-    resolution: {integrity: sha512-kRCbDNbNnRq5LC1H/NUceZlrPAvSrMH6Or0mirIuH69NY84xwDruPn/hkXTovIK1KwDwbk+ZdoSyJlpiekLxEA==}
+  msw@0.49.1:
+    resolution: {integrity: sha512-JpIIq4P65ofj0HVmDMkJuRwgP9s5kcdutpZ15evMTb2k91/USB7IKWRLV9J1Mzc3OqTdwNj4RwtOWJ5y/FulQQ==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
@@ -9981,6 +10012,9 @@ packages:
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
+  regenerator-runtime@0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
+
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -10546,9 +10580,6 @@ packages:
   strict-event-emitter@0.2.8:
     resolution: {integrity: sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==}
 
-  strict-event-emitter@0.4.6:
-    resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
-
   string-argv@0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
     engines: {node: '>=0.6.19'}
@@ -10864,12 +10895,12 @@ packages:
   ts-poet@4.15.0:
     resolution: {integrity: sha512-sLLR8yQBvHzi9d4R1F4pd+AzQxBfzOSSjfxiJxQhkUoH5bL7RsAC6wgvtVUQdGqiCsyS9rT6/8X2FI7ipdir5g==}
 
-  tsconfck@3.0.3:
-    resolution: {integrity: sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==}
-    engines: {node: ^18 || >=20}
+  tsconfck@2.1.1:
+    resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
+    engines: {node: ^14.13.1 || ^16 || >=18}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^4.3.5 || ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -11297,8 +11328,8 @@ packages:
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0
 
-  vite-tsconfig-paths@4.3.2:
-    resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
+  vite-tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
     peerDependencies:
       vite: '*'
     peerDependenciesMeta:
@@ -12923,7 +12954,7 @@ snapshots:
   '@babel/runtime-corejs3@7.22.15':
     dependencies:
       core-js-pure: 3.32.2
-      regenerator-runtime: 0.14.1
+      regenerator-runtime: 0.14.0
 
   '@babel/runtime@7.22.5':
     dependencies:
@@ -13935,7 +13966,7 @@ snapshots:
       debug: 4.3.4(supports-color@9.2.2)
       espree: 9.6.1
       globals: 13.20.0
-      ignore: 5.3.1
+      ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -15070,9 +15101,9 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/gen@1.13.3(@types/node@20.1.7)(typescript@5.4.5)':
+  '@turbo/gen@1.10.14(@types/node@20.1.7)(typescript@5.4.5)':
     dependencies:
-      '@turbo/workspaces': 1.13.3
+      '@turbo/workspaces': 1.10.14
       chalk: 2.4.2
       commander: 10.0.1
       fs-extra: 10.1.0
@@ -15090,12 +15121,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@turbo/workspaces@1.13.3':
+  '@turbo/workspaces@1.10.14':
     dependencies:
       chalk: 2.4.2
       commander: 10.0.1
       execa: 5.1.1
-      fast-glob: 3.3.2
+      fast-glob: 3.2.12
       fs-extra: 10.1.0
       gradient-string: 2.0.2
       inquirer: 8.2.4
@@ -15415,9 +15446,28 @@ snapshots:
 
   '@types/yoga-layout@1.9.2': {}
 
+  '@typescript-eslint/eslint-plugin@5.59.9(@typescript-eslint/parser@5.59.9(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/regexpp': 4.5.1
+      '@typescript-eslint/parser': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 5.59.9
+      '@typescript-eslint/type-utils': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
+      debug: 4.3.4(supports-color@9.2.2)
+      eslint: 8.57.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.0
+      natural-compare-lite: 1.4.0
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.42.0)(typescript@4.9.5))(eslint@8.42.0)(typescript@4.9.5)':
     dependencies:
-      '@eslint-community/regexpp': 4.10.0
+      '@eslint-community/regexpp': 4.5.1
       '@typescript-eslint/parser': 5.62.0(eslint@8.42.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.42.0)(typescript@4.9.5)
@@ -15425,7 +15475,7 @@ snapshots:
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.42.0
       graphemer: 1.4.0
-      ignore: 5.3.1
+      ignore: 5.2.0
       natural-compare-lite: 1.4.0
       semver: 7.5.4
       tsutils: 3.21.0(typescript@4.9.5)
@@ -15436,7 +15486,7 @@ snapshots:
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.49.0)(typescript@5.4.5))(eslint@8.49.0)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/regexpp': 4.10.0
+      '@eslint-community/regexpp': 4.5.1
       '@typescript-eslint/parser': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
@@ -15444,7 +15494,7 @@ snapshots:
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.49.0
       graphemer: 1.4.0
-      ignore: 5.3.1
+      ignore: 5.2.0
       natural-compare-lite: 1.4.0
       semver: 7.5.4
       tsutils: 3.21.0(typescript@5.4.5)
@@ -15507,6 +15557,18 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.5.4
       ts-api-utils: 1.0.3(typescript@5.4.5)
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@5.59.9(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.59.9
+      '@typescript-eslint/types': 5.59.9
+      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.4.5)
+      debug: 4.3.4(supports-color@9.2.2)
+      eslint: 8.57.0
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -15594,6 +15656,18 @@ snapshots:
       '@typescript-eslint/types': 6.7.2
       '@typescript-eslint/visitor-keys': 6.7.2
 
+  '@typescript-eslint/type-utils@5.59.9(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
+      debug: 4.3.4(supports-color@9.2.2)
+      eslint: 8.57.0
+      tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/type-utils@5.62.0(eslint@8.42.0)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
@@ -15676,6 +15750,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@5.59.9(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/types': 5.59.9
+      '@typescript-eslint/visitor-keys': 5.59.9
+      debug: 4.3.4(supports-color@9.2.2)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -15741,6 +15829,21 @@ snapshots:
       '@typescript-eslint/types': 5.59.9
       '@typescript-eslint/typescript-estree': 5.59.9(typescript@4.9.5)
       eslint: 8.42.0
+      eslint-scope: 5.1.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@5.59.9(eslint@8.57.0)(typescript@5.4.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.13
+      '@types/semver': 7.5.1
+      '@typescript-eslint/scope-manager': 5.59.9
+      '@typescript-eslint/types': 5.59.9
+      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.4.5)
+      eslint: 8.57.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -19028,7 +19131,7 @@ snapshots:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.2
+      fast-glob: 3.2.12
       glob: 7.2.3
       ignore: 5.3.1
       merge2: 1.4.1
@@ -19047,7 +19150,7 @@ snapshots:
     dependencies:
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.3.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
 
@@ -19055,7 +19158,7 @@ snapshots:
     dependencies:
       '@sindresorhus/merge-streams': 2.1.0
       fast-glob: 3.3.2
-      ignore: 5.3.1
+      ignore: 5.2.4
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
@@ -21000,7 +21103,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@0.49.3(encoding@0.1.13)(supports-color@9.2.2)(typescript@4.9.5):
+  msw@0.49.1(encoding@0.1.13)(supports-color@9.2.2)(typescript@4.9.5):
     dependencies:
       '@mswjs/cookies': 0.2.2
       '@mswjs/interceptors': 0.17.6(supports-color@9.2.2)
@@ -21018,7 +21121,7 @@ snapshots:
       node-fetch: 2.6.11(encoding@0.1.13)
       outvariant: 1.3.0
       path-to-regexp: 6.2.0
-      strict-event-emitter: 0.4.6
+      strict-event-emitter: 0.2.8
       type-fest: 2.19.0
       yargs: 17.7.2
     optionalDependencies:
@@ -21124,7 +21227,7 @@ snapshots:
       isbinaryfile: 4.0.10
       lodash.get: 4.4.2
       mkdirp: 0.5.6
-      resolve: 1.22.8
+      resolve: 1.22.2
 
   node-polyglot@2.5.0:
     dependencies:
@@ -22141,6 +22244,8 @@ snapshots:
 
   regenerator-runtime@0.13.11: {}
 
+  regenerator-runtime@0.14.0: {}
+
   regenerator-runtime@0.14.1: {}
 
   regenerator-transform@0.15.1:
@@ -22764,8 +22869,6 @@ snapshots:
     dependencies:
       events: 3.3.0
 
-  strict-event-emitter@0.4.6: {}
-
   string-argv@0.3.1: {}
 
   string-hash@1.1.3: {}
@@ -23156,7 +23259,7 @@ snapshots:
       lodash: 4.17.21
       prettier: 2.7.1
 
-  tsconfck@3.0.3(typescript@5.4.5):
+  tsconfck@2.1.1(typescript@5.4.5):
     optionalDependencies:
       typescript: 5.4.5
 
@@ -23622,11 +23725,11 @@ snapshots:
       connect-history-api-fallback: 1.6.0
       vite: 5.0.12(@types/node@20.8.3)
 
-  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.0.12(@types/node@18.16.10)):
+  vite-tsconfig-paths@4.2.0(typescript@5.4.5)(vite@5.0.12(@types/node@18.16.10)):
     dependencies:
       debug: 4.3.4(supports-color@9.2.2)
       globrex: 0.1.2
-      tsconfck: 3.0.3(typescript@5.4.5)
+      tsconfck: 2.1.1(typescript@5.4.5)
     optionalDependencies:
       vite: 5.0.12(@types/node@18.16.10)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       typescript:
-        specifier: ^4.8.4
-        version: 4.9.5
+        specifier: ^5.4.5
+        version: 5.4.5
       vite:
         specifier: ^5.0.12
         version: 5.0.12(@types/node@20.1.7)
@@ -79,7 +79,7 @@ importers:
         version: 4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)
       '@turbo/gen':
         specifier: ^1.10.13
-        version: 1.10.14(@types/node@20.1.7)(typescript@4.9.5)
+        version: 1.10.14(@types/node@20.1.7)(typescript@5.4.5)
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.3.4
@@ -828,10 +828,10 @@ importers:
         version: 17.0.24
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.55.0
-        version: 5.59.9(@typescript-eslint/parser@5.59.9(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+        version: 5.59.9(@typescript-eslint/parser@5.59.9)(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser':
         specifier: ^5.55.0
-        version: 5.59.9(eslint@8.57.0)(typescript@5.0.3)
+        version: 5.59.9(eslint@8.57.0)(typescript@5.4.5)
       chalk:
         specifier: ^5.2.0
         version: 5.2.0
@@ -883,15 +883,12 @@ importers:
       semver:
         specifier: ^7.5.1
         version: 7.5.1
-      typescript:
-        specifier: ^5.0.2
-        version: 5.0.3
       undici:
         specifier: 5.28.3
         version: 5.28.3
       vite-tsconfig-paths:
         specifier: ^4.0.8
-        version: 4.2.0(typescript@5.0.3)(vite@5.0.12(@types/node@18.16.10))
+        version: 4.2.0(typescript@5.4.5)(vite@5.0.12)
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -982,9 +979,6 @@ importers:
       tsconfig:
         specifier: '*'
         version: 7.0.0
-      typescript:
-        specifier: ^5.0.2
-        version: 5.0.3
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -1149,9 +1143,6 @@ importers:
       source-map:
         specifier: ^0.6.0
         version: 0.6.1
-      typescript:
-        specifier: ^5.4.5
-        version: 5.4.5
       which:
         specifier: ^2.0.2
         version: 2.0.2
@@ -1239,9 +1230,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20240512.0
         version: 4.20240512.0
-      typescript:
-        specifier: ^4.5.5
-        version: 4.9.5
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -1279,9 +1267,6 @@ importers:
       esbuild-register:
         specifier: ^3.4.2
         version: 3.4.2(esbuild@0.16.3)
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
 
   packages/solarflare-theme: {}
 
@@ -1487,10 +1472,10 @@ importers:
         version: 9.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.61.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.49.0)(typescript@5.0.3))(eslint@8.49.0)(typescript@5.0.3)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/parser':
         specifier: ^5.61.0
-        version: 5.62.0(eslint@8.49.0)(typescript@5.0.3)
+        version: 5.62.0(eslint@8.49.0)(typescript@5.4.5)
       '@vitejs/plugin-react':
         specifier: ^4.0.1
         version: 4.0.4(vite@5.0.12(@types/node@20.8.3))
@@ -1506,9 +1491,6 @@ importers:
       tsx:
         specifier: ^3.12.8
         version: 3.12.10
-      typescript:
-        specifier: ^5.0.2
-        version: 5.0.3
       undici:
         specifier: 5.28.4
         version: 5.28.4
@@ -1770,7 +1752,7 @@ importers:
         version: 5.1.0
       msw:
         specifier: ^0.49.1
-        version: 0.49.1(encoding@0.1.13)(supports-color@9.2.2)(typescript@4.9.5)
+        version: 0.49.1(supports-color@9.2.2)(typescript@5.4.5)
       open:
         specifier: ^8.4.0
         version: 8.4.0
@@ -15124,7 +15106,9 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/gen@1.10.14(@types/node@20.1.7)(typescript@4.9.5)':
+  /@turbo/gen@1.10.14(@types/node@20.1.7)(typescript@5.4.5):
+    resolution: {integrity: sha512-g7ecPx0GCCTpnbH53blBGNk6pP4LhcWiTtR0kEprGkXpiHqjYDpOydz4JFoz9IC+Hj1Z28/+M7T/GfwJAjf0FQ==}
+    hasBin: true
     dependencies:
       '@turbo/workspaces': 1.10.14
       chalk: 2.4.2
@@ -15134,7 +15118,7 @@ snapshots:
       minimatch: 9.0.1
       node-plop: 0.26.3
       proxy-agent: 6.3.1
-      ts-node: 10.9.2(@types/node@20.1.7)(typescript@4.9.5)
+      ts-node: 10.9.2(@types/node@20.1.7)(typescript@5.4.5)
       update-check: 1.5.4
       validate-npm-package-name: 5.0.0
     transitivePeerDependencies:
@@ -15469,22 +15453,30 @@ snapshots:
 
   '@types/yoga-layout@1.9.2': {}
 
-  '@typescript-eslint/eslint-plugin@5.59.9(@typescript-eslint/parser@5.59.9(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)':
+  /@typescript-eslint/eslint-plugin@5.59.9(@typescript-eslint/parser@5.59.9)(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.9(eslint@8.57.0)(typescript@5.0.3)
+      '@typescript-eslint/parser': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 5.59.9
-      '@typescript-eslint/type-utils': 5.59.9(eslint@8.57.0)(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.59.9(eslint@8.57.0)(typescript@5.0.3)
+      '@typescript-eslint/type-utils': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.57.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.3)
-    optionalDependencies:
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15507,22 +15499,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.49.0)(typescript@5.0.3))(eslint@8.49.0)(typescript@5.0.3)':
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.49.0)(typescript@5.0.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.49.0)(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.0.3)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.49.0
       graphemer: 1.4.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.3)
-    optionalDependencies:
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15585,15 +15585,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.59.9(eslint@8.57.0)(typescript@5.0.3)':
+  /@typescript-eslint/parser@5.59.9(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@typescript-eslint/scope-manager': 5.59.9
       '@typescript-eslint/types': 5.59.9
-      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.4.5)
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.57.0
-    optionalDependencies:
-      typescript: 5.0.3
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15609,15 +15616,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@8.49.0)(typescript@5.0.3)':
+  /@typescript-eslint/parser@5.62.0(eslint@8.49.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.49.0
-    optionalDependencies:
-      typescript: 5.0.3
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15679,15 +15693,22 @@ snapshots:
       '@typescript-eslint/types': 6.7.2
       '@typescript-eslint/visitor-keys': 6.7.2
 
-  '@typescript-eslint/type-utils@5.59.9(eslint@8.57.0)(typescript@5.0.3)':
+  /@typescript-eslint/type-utils@5.59.9(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.59.9(eslint@8.57.0)(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.57.0
-      tsutils: 3.21.0(typescript@5.0.3)
-    optionalDependencies:
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15703,15 +15724,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@8.49.0)(typescript@5.0.3)':
+  /@typescript-eslint/type-utils@5.62.0(eslint@8.49.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.49.0
-      tsutils: 3.21.0(typescript@5.0.3)
-    optionalDependencies:
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15773,7 +15801,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.59.9(typescript@5.0.3)':
+  /@typescript-eslint/typescript-estree@5.59.9(typescript@5.4.5):
+    resolution: {integrity: sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@typescript-eslint/types': 5.59.9
       '@typescript-eslint/visitor-keys': 5.59.9
@@ -15781,9 +15816,8 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.3)
-    optionalDependencies:
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.4.5)
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15801,21 +15835,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.0.3)':
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4(supports-color@9.2.2)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.3)
-    optionalDependencies:
-      typescript: 5.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.5)':
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.5):
+    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -15872,14 +15899,18 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.59.9(eslint@8.57.0)(typescript@5.0.3)':
+  /@typescript-eslint/utils@5.59.9(eslint@8.57.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.13
       '@types/semver': 7.5.1
       '@typescript-eslint/scope-manager': 5.59.9
       '@typescript-eslint/types': 5.59.9
-      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.4.5)
       eslint: 8.57.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -15902,14 +15933,18 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.49.0)(typescript@5.0.3)':
+  /@typescript-eslint/utils@5.62.0(eslint@8.49.0)(typescript@5.4.5):
+    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.49.0)
       '@types/json-schema': 7.0.13
       '@types/semver': 7.5.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       eslint: 8.49.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -21140,7 +21175,16 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@0.49.1(encoding@0.1.13)(supports-color@9.2.2)(typescript@4.9.5):
+  /msw@0.49.1(supports-color@9.2.2)(typescript@5.4.5):
+    resolution: {integrity: sha512-JpIIq4P65ofj0HVmDMkJuRwgP9s5kcdutpZ15evMTb2k91/USB7IKWRLV9J1Mzc3OqTdwNj4RwtOWJ5y/FulQQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.4.x <= 4.9.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@mswjs/cookies': 0.2.2
       '@mswjs/interceptors': 0.17.6(supports-color@9.2.2)
@@ -21160,6 +21204,7 @@ snapshots:
       path-to-regexp: 6.2.0
       strict-event-emitter: 0.2.8
       type-fest: 2.19.0
+      typescript: 5.4.5
       yargs: 17.7.2
     optionalDependencies:
       typescript: 4.9.5
@@ -23235,26 +23280,19 @@ snapshots:
       safe-stable-stringify: 2.4.3
       typescript: 5.3.3
 
-  ts-node@10.9.2(@types/node@18.16.10)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.16.10
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.2(@types/node@20.1.7)(typescript@4.9.5):
+  /ts-node@10.9.2(@types/node@20.1.7)(typescript@5.4.5):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -23268,7 +23306,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.4.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -23296,9 +23334,18 @@ snapshots:
       lodash: 4.17.21
       prettier: 2.7.1
 
-  tsconfck@2.1.1(typescript@5.0.3):
-    optionalDependencies:
-      typescript: 5.0.3
+  /tsconfck@2.1.1(typescript@5.4.5):
+    resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
+    engines: {node: ^14.13.1 || ^16 || >=18}
+    hasBin: true
+    peerDependencies:
+      typescript: ^4.3.5 || ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.4.5
+    dev: true
 
   tsconfig-paths@3.14.1:
     dependencies:
@@ -23329,12 +23376,11 @@ snapshots:
       tslib: 1.14.1
       typescript: 4.9.5
 
-  tsutils@3.21.0(typescript@5.0.3):
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.0.3
-
-  tsutils@3.21.0(typescript@5.4.5):
+  /tsutils@3.21.0(typescript@5.4.5):
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
       typescript: 5.4.5
@@ -23463,9 +23509,11 @@ snapshots:
 
   typescript@4.2.4: {}
 
-  typescript@4.9.5: {}
-
-  typescript@5.0.3: {}
+  /typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
 
   typescript@5.0.4: {}
 
@@ -23769,13 +23817,18 @@ snapshots:
       connect-history-api-fallback: 1.6.0
       vite: 5.0.12(@types/node@20.8.3)
 
-  vite-tsconfig-paths@4.2.0(typescript@5.0.3)(vite@5.0.12(@types/node@18.16.10)):
+  /vite-tsconfig-paths@4.2.0(typescript@5.4.5)(vite@5.0.12):
+    resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
     dependencies:
       debug: 4.3.4(supports-color@9.2.2)
       globrex: 0.1.2
-      tsconfck: 2.1.1(typescript@5.0.3)
-    optionalDependencies:
-      vite: 5.0.12(@types/node@18.16.10)
+      tsconfck: 2.1.1(typescript@5.4.5)
+      vite: 5.0.12(@types/node@20.1.7)
     transitivePeerDependencies:
       - supports-color
       - typescript

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)
       '@turbo/gen':
         specifier: ^1.10.13
-        version: 1.10.14(@types/node@20.1.7)(typescript@5.4.5)
+        version: 1.13.3(@types/node@20.1.7)(typescript@5.4.5)
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.3.4
@@ -828,10 +828,10 @@ importers:
         version: 17.0.24
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.55.0
-        version: 5.59.9(@typescript-eslint/parser@5.59.9)(eslint@8.57.0)(typescript@5.4.5)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser':
         specifier: ^5.55.0
-        version: 5.59.9(eslint@8.57.0)(typescript@5.4.5)
+        version: 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       chalk:
         specifier: ^5.2.0
         version: 5.2.0
@@ -888,7 +888,7 @@ importers:
         version: 5.28.3
       vite-tsconfig-paths:
         specifier: ^4.0.8
-        version: 4.2.0(typescript@5.4.5)(vite@5.0.12)
+        version: 4.3.2(typescript@5.4.5)(vite@5.0.12(@types/node@18.16.10))
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1472,7 +1472,7 @@ importers:
         version: 9.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.61.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(typescript@5.4.5)
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.49.0)(typescript@5.4.5))(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/parser':
         specifier: ^5.61.0
         version: 5.62.0(eslint@8.49.0)(typescript@5.4.5)
@@ -1752,7 +1752,7 @@ importers:
         version: 5.1.0
       msw:
         specifier: ^0.49.1
-        version: 0.49.1(supports-color@9.2.2)(typescript@5.4.5)
+        version: 0.49.3(encoding@0.1.13)(supports-color@9.2.2)(typescript@4.9.5)
       open:
         specifier: ^8.4.0
         version: 8.4.0
@@ -4610,12 +4610,12 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turbo/gen@1.10.14':
-    resolution: {integrity: sha512-g7ecPx0GCCTpnbH53blBGNk6pP4LhcWiTtR0kEprGkXpiHqjYDpOydz4JFoz9IC+Hj1Z28/+M7T/GfwJAjf0FQ==}
+  '@turbo/gen@1.13.3':
+    resolution: {integrity: sha512-l+EM1gGzckFMaaVQyj3BVRa0QJ+tpp8HfiHOhGpBWW3Vc0Hfj92AY87Di/7HGABa+HVY7ueatMi7DJG+zkJBYg==}
     hasBin: true
 
-  '@turbo/workspaces@1.10.14':
-    resolution: {integrity: sha512-MNJeCNJWIFdXQ0m7yp1VeZE/3edoFEeAFJlr9UxRiv6cge3TdhwI6OEuBewJDN73/4SZSeL4u6L+2DVULA0t+Q==}
+  '@turbo/workspaces@1.13.3':
+    resolution: {integrity: sha512-QYZ8g3IVQebqNM8IsBlWYOWmOKjBZY55e6lx4EDOLuch1iWmyk+U8CLAI9UomMrSaKTs1Sx+PDkt63EgakvhUw==}
     hasBin: true
 
   '@types/acorn@4.0.6':
@@ -4910,17 +4910,6 @@ packages:
   '@types/yoga-layout@1.9.2':
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
 
-  '@typescript-eslint/eslint-plugin@5.59.9':
-    resolution: {integrity: sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   '@typescript-eslint/eslint-plugin@5.62.0':
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4949,16 +4938,6 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
       eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/parser@5.59.9':
-    resolution: {integrity: sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -5009,16 +4988,6 @@ packages:
   '@typescript-eslint/scope-manager@6.7.2':
     resolution: {integrity: sha512-bgi6plgyZjEqapr7u2mhxGR6E8WCzKNUFWNh6fkpVe9+yzRZeYtDTbsIBzKbcxI+r1qVWt6VIoMSNZ4r2A+6Yw==}
     engines: {node: ^16.0.0 || >=18.0.0}
-
-  '@typescript-eslint/type-utils@5.59.9':
-    resolution: {integrity: sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@typescript-eslint/type-utils@5.62.0':
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
@@ -8999,8 +8968,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@0.49.1:
-    resolution: {integrity: sha512-JpIIq4P65ofj0HVmDMkJuRwgP9s5kcdutpZ15evMTb2k91/USB7IKWRLV9J1Mzc3OqTdwNj4RwtOWJ5y/FulQQ==}
+  msw@0.49.3:
+    resolution: {integrity: sha512-kRCbDNbNnRq5LC1H/NUceZlrPAvSrMH6Or0mirIuH69NY84xwDruPn/hkXTovIK1KwDwbk+ZdoSyJlpiekLxEA==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
@@ -10012,9 +9981,6 @@ packages:
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
-  regenerator-runtime@0.14.0:
-    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
-
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -10580,6 +10546,9 @@ packages:
   strict-event-emitter@0.2.8:
     resolution: {integrity: sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==}
 
+  strict-event-emitter@0.4.6:
+    resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
+
   string-argv@0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
     engines: {node: '>=0.6.19'}
@@ -10895,12 +10864,12 @@ packages:
   ts-poet@4.15.0:
     resolution: {integrity: sha512-sLLR8yQBvHzi9d4R1F4pd+AzQxBfzOSSjfxiJxQhkUoH5bL7RsAC6wgvtVUQdGqiCsyS9rT6/8X2FI7ipdir5g==}
 
-  tsconfck@2.1.1:
-    resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
-    engines: {node: ^14.13.1 || ^16 || >=18}
+  tsconfck@3.0.3:
+    resolution: {integrity: sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==}
+    engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
-      typescript: ^4.3.5 || ^5.0.0
+      typescript: ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -11065,11 +11034,6 @@ packages:
   typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
-    hasBin: true
-
-  typescript@5.0.3:
-    resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
-    engines: {node: '>=12.20'}
     hasBin: true
 
   typescript@5.0.4:
@@ -11333,8 +11297,8 @@ packages:
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0
 
-  vite-tsconfig-paths@4.2.0:
-    resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
+  vite-tsconfig-paths@4.3.2:
+    resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
     peerDependencies:
       vite: '*'
     peerDependenciesMeta:
@@ -12959,7 +12923,7 @@ snapshots:
   '@babel/runtime-corejs3@7.22.15':
     dependencies:
       core-js-pure: 3.32.2
-      regenerator-runtime: 0.14.0
+      regenerator-runtime: 0.14.1
 
   '@babel/runtime@7.22.5':
     dependencies:
@@ -13971,7 +13935,7 @@ snapshots:
       debug: 4.3.4(supports-color@9.2.2)
       espree: 9.6.1
       globals: 13.20.0
-      ignore: 5.2.4
+      ignore: 5.3.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -15106,11 +15070,9 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  /@turbo/gen@1.10.14(@types/node@20.1.7)(typescript@5.4.5):
-    resolution: {integrity: sha512-g7ecPx0GCCTpnbH53blBGNk6pP4LhcWiTtR0kEprGkXpiHqjYDpOydz4JFoz9IC+Hj1Z28/+M7T/GfwJAjf0FQ==}
-    hasBin: true
+  '@turbo/gen@1.13.3(@types/node@20.1.7)(typescript@5.4.5)':
     dependencies:
-      '@turbo/workspaces': 1.10.14
+      '@turbo/workspaces': 1.13.3
       chalk: 2.4.2
       commander: 10.0.1
       fs-extra: 10.1.0
@@ -15128,12 +15090,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@turbo/workspaces@1.10.14':
+  '@turbo/workspaces@1.13.3':
     dependencies:
       chalk: 2.4.2
       commander: 10.0.1
       execa: 5.1.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.2
       fs-extra: 10.1.0
       gradient-string: 2.0.2
       inquirer: 8.2.4
@@ -15453,36 +15415,9 @@ snapshots:
 
   '@types/yoga-layout@1.9.2': {}
 
-  /@typescript-eslint/eslint-plugin@5.59.9(@typescript-eslint/parser@5.59.9)(eslint@8.57.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/scope-manager': 5.59.9
-      '@typescript-eslint/type-utils': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
-      debug: 4.3.4(supports-color@9.2.2)
-      eslint: 8.57.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.0
-      natural-compare-lite: 1.4.0
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.42.0)(typescript@4.9.5))(eslint@8.42.0)(typescript@4.9.5)':
     dependencies:
-      '@eslint-community/regexpp': 4.5.1
+      '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.62.0(eslint@8.42.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.42.0)(typescript@4.9.5)
@@ -15490,7 +15425,7 @@ snapshots:
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.42.0
       graphemer: 1.4.0
-      ignore: 5.2.0
+      ignore: 5.3.1
       natural-compare-lite: 1.4.0
       semver: 7.5.4
       tsutils: 3.21.0(typescript@4.9.5)
@@ -15499,18 +15434,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.49.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.49.0)(typescript@5.4.5))(eslint@8.49.0)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/regexpp': 4.5.1
+      '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
@@ -15518,10 +15444,11 @@ snapshots:
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.49.0
       graphemer: 1.4.0
-      ignore: 5.2.0
+      ignore: 5.3.1
       natural-compare-lite: 1.4.0
       semver: 7.5.4
       tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -15585,25 +15512,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@5.59.9(eslint@8.57.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.59.9
-      '@typescript-eslint/types': 5.59.9
-      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.4.5)
-      debug: 4.3.4(supports-color@9.2.2)
-      eslint: 8.57.0
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@5.62.0(eslint@8.42.0)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
@@ -15616,21 +15524,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.49.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  '@typescript-eslint/parser@5.62.0(eslint@8.49.0)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.49.0
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -15693,25 +15594,6 @@ snapshots:
       '@typescript-eslint/types': 6.7.2
       '@typescript-eslint/visitor-keys': 6.7.2
 
-  /@typescript-eslint/type-utils@5.59.9(eslint@8.57.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.4.5)
-      '@typescript-eslint/utils': 5.59.9(eslint@8.57.0)(typescript@5.4.5)
-      debug: 4.3.4(supports-color@9.2.2)
-      eslint: 8.57.0
-      tsutils: 3.21.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@5.62.0(eslint@8.42.0)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
@@ -15724,21 +15606,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.49.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  '@typescript-eslint/type-utils@5.62.0(eslint@8.49.0)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.49.0)(typescript@5.4.5)
       debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.49.0
       tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -15801,26 +15676,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@5.59.9(typescript@5.4.5):
-    resolution: {integrity: sha512-pmM0/VQ7kUhd1QyIxgS+aRvMgw+ZljB3eDb+jYyp6d2bC0mQWLzUDF+DLwCTkQ3tlNyVsvZRXjFyV0LkU/aXjA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.59.9
-      '@typescript-eslint/visitor-keys': 5.59.9
-      debug: 4.3.4(supports-color@9.2.2)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -15835,14 +15690,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.5):
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -15899,25 +15747,6 @@ snapshots:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils@5.59.9(eslint@8.57.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@types/json-schema': 7.0.13
-      '@types/semver': 7.5.1
-      '@typescript-eslint/scope-manager': 5.59.9
-      '@typescript-eslint/types': 5.59.9
-      '@typescript-eslint/typescript-estree': 5.59.9(typescript@5.4.5)
-      eslint: 8.57.0
-      eslint-scope: 5.1.1
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@typescript-eslint/utils@5.62.0(eslint@8.42.0)(typescript@4.9.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.42.0)
@@ -15933,11 +15762,7 @@ snapshots:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.49.0)(typescript@5.4.5):
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  '@typescript-eslint/utils@5.62.0(eslint@8.49.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.49.0)
       '@types/json-schema': 7.0.13
@@ -19203,7 +19028,7 @@ snapshots:
       '@types/glob': 7.2.0
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.2
       glob: 7.2.3
       ignore: 5.3.1
       merge2: 1.4.1
@@ -19222,7 +19047,7 @@ snapshots:
     dependencies:
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.2.4
+      ignore: 5.3.1
       merge2: 1.4.1
       slash: 4.0.0
 
@@ -19230,7 +19055,7 @@ snapshots:
     dependencies:
       '@sindresorhus/merge-streams': 2.1.0
       fast-glob: 3.3.2
-      ignore: 5.2.4
+      ignore: 5.3.1
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
@@ -21175,16 +21000,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  /msw@0.49.1(supports-color@9.2.2)(typescript@5.4.5):
-    resolution: {integrity: sha512-JpIIq4P65ofj0HVmDMkJuRwgP9s5kcdutpZ15evMTb2k91/USB7IKWRLV9J1Mzc3OqTdwNj4RwtOWJ5y/FulQQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      typescript: '>= 4.4.x <= 4.9.x'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  msw@0.49.3(encoding@0.1.13)(supports-color@9.2.2)(typescript@4.9.5):
     dependencies:
       '@mswjs/cookies': 0.2.2
       '@mswjs/interceptors': 0.17.6(supports-color@9.2.2)
@@ -21202,9 +21018,8 @@ snapshots:
       node-fetch: 2.6.11(encoding@0.1.13)
       outvariant: 1.3.0
       path-to-regexp: 6.2.0
-      strict-event-emitter: 0.2.8
+      strict-event-emitter: 0.4.6
       type-fest: 2.19.0
-      typescript: 5.4.5
       yargs: 17.7.2
     optionalDependencies:
       typescript: 4.9.5
@@ -21309,7 +21124,7 @@ snapshots:
       isbinaryfile: 4.0.10
       lodash.get: 4.4.2
       mkdirp: 0.5.6
-      resolve: 1.22.2
+      resolve: 1.22.8
 
   node-polyglot@2.5.0:
     dependencies:
@@ -22326,8 +22141,6 @@ snapshots:
 
   regenerator-runtime@0.13.11: {}
 
-  regenerator-runtime@0.14.0: {}
-
   regenerator-runtime@0.14.1: {}
 
   regenerator-transform@0.15.1:
@@ -22951,6 +22764,8 @@ snapshots:
     dependencies:
       events: 3.3.0
 
+  strict-event-emitter@0.4.6: {}
+
   string-argv@0.3.1: {}
 
   string-hash@1.1.3: {}
@@ -23280,19 +23095,26 @@ snapshots:
       safe-stable-stringify: 2.4.3
       typescript: 5.3.3
 
-  /ts-node@10.9.2(@types/node@20.1.7)(typescript@5.4.5):
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
+  ts-node@10.9.2(@types/node@18.16.10)(typescript@4.9.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.16.10
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@20.1.7)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -23334,18 +23156,9 @@ snapshots:
       lodash: 4.17.21
       prettier: 2.7.1
 
-  /tsconfck@2.1.1(typescript@5.4.5):
-    resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
-    engines: {node: ^14.13.1 || ^16 || >=18}
-    hasBin: true
-    peerDependencies:
-      typescript: ^4.3.5 || ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
+  tsconfck@3.0.3(typescript@5.4.5):
+    optionalDependencies:
       typescript: 5.4.5
-    dev: true
 
   tsconfig-paths@3.14.1:
     dependencies:
@@ -23376,11 +23189,7 @@ snapshots:
       tslib: 1.14.1
       typescript: 4.9.5
 
-  /tsutils@3.21.0(typescript@5.4.5):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+  tsutils@3.21.0(typescript@5.4.5):
     dependencies:
       tslib: 1.14.1
       typescript: 5.4.5
@@ -23509,11 +23318,7 @@ snapshots:
 
   typescript@4.2.4: {}
 
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
+  typescript@4.9.5: {}
 
   typescript@5.0.4: {}
 
@@ -23817,18 +23622,13 @@ snapshots:
       connect-history-api-fallback: 1.6.0
       vite: 5.0.12(@types/node@20.8.3)
 
-  /vite-tsconfig-paths@4.2.0(typescript@5.4.5)(vite@5.0.12):
-    resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
+  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.0.12(@types/node@18.16.10)):
     dependencies:
       debug: 4.3.4(supports-color@9.2.2)
       globrex: 0.1.2
-      tsconfck: 2.1.1(typescript@5.4.5)
-      vite: 5.0.12(@types/node@20.1.7)
+      tsconfck: 3.0.3(typescript@5.4.5)
+    optionalDependencies:
+      vite: 5.0.12(@types/node@18.16.10)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
## What this PR solves / how to test

This PR bumps packages to the latest version of TS 5, which means that the entire repo can be checked with one TS version. Previously, Miniflare required a different version, which caused issues when typechecking in VSCode across multiple packages.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: typing change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: typing change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Not a public facing change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: internal refactoring

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
