### PR TITLE
fix: do not allow non-string values in bulk secret uploads

### DIFF
--- a/.changeset/real-waves-wave.md
+++ b/.changeset/real-waves-wave.md
@@ -1,0 +1,12 @@
+---
+"wrangler": patch
+---
+
+fix: do not allow non-string values in bulk secret uploads
+
+Prior to Wrangler 3.4.0 we displayed an error if the user tried to upload a
+JSON file that contained non-string secrets, since these are not supported
+by the Cloudflare backend.
+
+This change reintroduces that check to give the user a helpful error message
+rather than a cryptic `workers.api.error.invalid_script_config` error code.

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -571,7 +571,7 @@ describe("wrangler secret", () => {
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should create secret:bulk", async () => {
+		it("should create secrets from JSON file", async () => {
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -612,6 +612,31 @@ describe("wrangler secret", () => {
 					✨ 2 secrets successfully uploaded"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should fail if file is not valid JSON", async () => {
+			writeFileSync("secret.json", "bad file content");
+
+			await expect(
+				runWrangler("secret:bulk ./secret.json --name script-name")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`"The contents of \\"./secret.json\\" is not valid JSON: \\"ParseError: Unexpected token b\\""`
+			);
+		});
+
+		it("should fail if JSON file contains a record with non-string values", async () => {
+			writeFileSync(
+				"secret.json",
+				JSON.stringify({
+					"invalid-secret": 999,
+				})
+			);
+
+			await expect(
+				runWrangler("secret:bulk ./secret.json --name script-name")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`"The value for \\"invalid-secret\\" in \\"./secret.json\\" is not a \\"string\\" instead it is of type \\"number\\""`
+			);
 		});
 
 		it("should count success and network failure on secret:bulk", async () => {


### PR DESCRIPTION
## What this PR solves / how to test

Prior to Wrangler 3.4.0 we displayed an error if the user tried to upload a JSON file that contained non-string secrets, since these are not supported by the Cloudflare backend.

This change reintroduces that check to give the user a helpful error message rather than a cryptic `workers.api.error.invalid_script_config` error code.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: e2e tests do not check this aspect of Wrangler (yet)
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bug fix
