### PR TITLE
chore: ensure playground-preview-worker uses the workspace dependency…

### DIFF
--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -25,6 +25,6 @@
 		"promjs": "^0.4.2",
 		"toucan-js": "^3.2.2",
 		"undici": "5.28.4",
-		"wrangler": "^3.32.0"
+		"wrangler": "workspace:*"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1210,8 +1210,8 @@ importers:
         specifier: 5.28.4
         version: 5.28.4
       wrangler:
-        specifier: ^3.32.0
-        version: 3.55.0(@cloudflare/workers-types@4.20240512.0)
+        specifier: workspace:*
+        version: link:../wrangler
 
   packages/prerelease-registry:
     dependencies:


### PR DESCRIPTION
… of wrangler

Without this change the changesets tooling breaks when trying to update both this package and wrangler at the same time.

The error that can be seen was:

```
ERR_PNPM_NO_MATCHING_VERSION No matching version found for wrangler@^3.57.0

This error happened while installing a direct dependency of /home/runner/work/workers-sdk/workers-sdk/packages/playground-preview-worker

The latest release of wrangler is "3.56.0".
```

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: config change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: config change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: config change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: config change
