### PR TITLE
fix(wrangler): Make jest inline snapshots work with prettier 3

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -94,7 +94,8 @@
 		"snapshotFormat": {
 			"escapeString": true,
 			"printBasicPrototype": true
-		}
+		},
+		"prettierPath": null
 	},
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "workspace:*",


### PR DESCRIPTION
Jest inline snapshots do not work with prettier verision `3`. For more details please refer to
https://github.com/jestjs/jest/issues/14305.

This commit fixes that by applying the recommended fix as per GitHub issue thread above.

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: jest config change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: jest config change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: jest config change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: jest config change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
