### PR TITLE
feat: allow for Pages projects to upload sourcemaps

### DIFF
--- a/.changeset/old-horses-push.md
+++ b/.changeset/old-horses-push.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: allow for Pages projects to upload sourcemaps
+
+Pages projects can now upload sourcemaps for server bundles to enable remapped stacktraces in realtime logs when deployed with `upload_source_map` set to `true` in `wrangler.toml`.

--- a/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
+++ b/packages/wrangler/src/api/pages/create-worker-bundle-contents.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { Response } from "undici";
 import { createWorkerUploadForm } from "../../deployment-bundle/create-worker-upload-form";
+import { loadSourceMaps } from "../../deployment-bundle/source-maps";
 import type { Config } from "../../config";
 import type { BundleResult } from "../../deployment-bundle/bundle";
 import type { CfPlacement, CfWorkerInit } from "../../deployment-bundle/worker";
@@ -86,7 +87,9 @@ function createWorkerBundleFormData(
 		keepVars: undefined,
 		keepSecrets: undefined,
 		logpush: undefined,
-		sourceMaps: undefined,
+		sourceMaps: config?.upload_source_maps
+			? loadSourceMaps(mainModule, workerBundle.modules, workerBundle)
+			: undefined,
 		placement: placement,
 		tail_consumers: undefined,
 		limits: config?.limits,

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -78,6 +78,10 @@ interface PagesDeployOptions {
 	 */
 	bundle?: boolean;
 	/**
+	 * Whether to upload any server-side sourcemaps with this deployment
+	 */
+	sourceMaps: boolean;
+	/**
 	 * Command line args passed to the `pages deploy` cmd
 	 */
 	args?: Record<string, unknown>;
@@ -103,6 +107,7 @@ export async function deploy({
 	commitDirty,
 	functionsDirectory: customFunctionsDirectory,
 	bundle,
+	sourceMaps,
 	args,
 }: PagesDeployOptions) {
 	let _headers: string | undefined,
@@ -205,6 +210,7 @@ export async function deploy({
 			workerBundle = await buildFunctions({
 				outputConfigPath,
 				functionsDirectory,
+				sourcemap: sourceMaps,
 				onEnd: () => {},
 				buildOutputDirectory: directory,
 				routesOutputPath,
@@ -309,6 +315,7 @@ export async function deploy({
 			buildOutputDirectory: directory,
 			nodejsCompat,
 			defineNavigatorUserAgent,
+			sourceMaps: sourceMaps,
 		});
 	} else if (_workerJS) {
 		if (bundle) {

--- a/packages/wrangler/src/config/validation-pages.ts
+++ b/packages/wrangler/src/config/validation-pages.ts
@@ -38,6 +38,7 @@ const supportedPagesConfigFields = [
 	"browser",
 	// normalizeAndValidateConfig() sets this value
 	"configPath",
+	"upload_source_maps",
 ] as const;
 
 export function validatePagesConfig(

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -50,6 +50,12 @@ export interface CfModule {
 	 */
 	content: string | Buffer;
 	/**
+	 * An optional sourcemap for this module if it's of a ESM or CJS type, this will only be present
+	 * if we're deploying with sourcemaps enabled. Since we copy extra modules that aren't bundled
+	 * we need to also copy the relevant sourcemaps into the final out directory.
+	 */
+	sourceMap?: CfWorkerSourceMap;
+	/**
 	 * The module type.
 	 *
 	 * If absent, will default to the main module's type.

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -235,6 +235,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 					buildOutputDirectory,
 					nodejsCompat,
 					defineNavigatorUserAgent,
+					sourceMaps: config?.upload_source_maps ?? sourcemap,
 				});
 			} else {
 				/**
@@ -248,7 +249,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 					outdir,
 					directory: buildOutputDirectory,
 					local: false,
-					sourcemap,
+					sourcemap: config?.upload_source_maps ?? sourcemap,
 					watch,
 					nodejsCompat,
 					defineNavigatorUserAgent,
@@ -268,7 +269,7 @@ export const Handler = async (args: PagesBuildArgs) => {
 					outputConfigPath,
 					functionsDirectory: directory,
 					minify,
-					sourcemap,
+					sourcemap: config?.upload_source_maps ?? sourcemap,
 					fallbackService,
 					watch,
 					plugin,

--- a/packages/wrangler/src/pages/deploy.tsx
+++ b/packages/wrangler/src/pages/deploy.tsx
@@ -81,6 +81,12 @@ export function Options(yargs: CommonYargsArgv) {
 				type: "string",
 				hidden: true,
 			},
+			"upload-source-maps": {
+				type: "boolean",
+				default: false,
+				description:
+					"Whether to upload any server-side sourcemaps with this deployment",
+			},
 		});
 }
 
@@ -348,6 +354,8 @@ export const Handler = async (args: PagesDeployArgs) => {
 		// TODO: Here lies a known bug. If you specify both `--bundle` and `--no-bundle`, this behavior is undefined and you will get unexpected results.
 		// There is no sane way to get the true value out of yargs, so here we are.
 		bundle: args.bundle ?? !args.noBundle,
+		// Sourcemaps from deploy arguments will take precedence so people can try it for one-off deployments without updating their wrangler.toml
+		sourceMaps: config?.upload_source_maps || args.uploadSourceMaps,
 		args,
 	});
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -363,6 +363,7 @@ export const Handler = async (args: PagesDevArguments) => {
 				buildOutputDirectory: directory ?? ".",
 				nodejsCompat,
 				defineNavigatorUserAgent,
+				sourceMaps: config?.upload_source_maps ?? false,
 			});
 			modules = bundleResult.modules;
 			scriptPath = bundleResult.resolvedEntryPointPath;

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -277,12 +277,14 @@ export async function produceWorkerBundleForWorkerJSDirectory({
 	buildOutputDirectory,
 	nodejsCompat,
 	defineNavigatorUserAgent,
+	sourceMaps,
 }: {
 	workerJSDirectory: string;
 	bundle: boolean;
 	buildOutputDirectory: string;
 	nodejsCompat?: boolean;
 	defineNavigatorUserAgent: boolean;
+	sourceMaps: boolean;
 }): Promise<BundleResult> {
 	const entrypoint = resolve(join(workerJSDirectory, "index.js"));
 
@@ -298,7 +300,8 @@ export async function produceWorkerBundleForWorkerJSDirectory({
 				type: "ESModule",
 				globs: ["**/*.js", "**/*.mjs"],
 			},
-		]
+		],
+		sourceMaps
 	);
 
 	if (!bundle) {


### PR DESCRIPTION
Adds the ability for Pages projects to use the new sourcemap support in Workers to get remapped stacktraces in the dashboard's real-time logs.

Fixes WP-959 WP-960 WP-961.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/14929