### PR TITLE
Don't cache 404s from the asset-server

### DIFF
--- a/.changeset/unlucky-radios-fold.md
+++ b/.changeset/unlucky-radios-fold.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/pages-shared": patch
+---
+
+fix: no longer allow zone caching for responses that returned 404. This is to prevent some files in a new deployment from returning and subsequently caching 404s while the deployment propagates across the network.


### PR DESCRIPTION
## What this PR solves / how to test

Fixes WC-2233

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no e2e tests touched
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: we already tell users not to cache, this just prevents a common footgun when caching
