### PR TITLE
chore: Fix issue with target branch of docs repo in C3 docs PR workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -72,4 +72,4 @@ jobs:
           token: ${{ secrets.C3_DIFF_TOOL_GH_TOKEN }}
           releaseBranch: "changeset-release/main"
           targetHeadBranch: c3-diffs-${{ github.sha }}
-          targetBaseBranch: master
+          targetBaseBranch: production


### PR DESCRIPTION
## What this PR solves / how to test

Fixes an issue where the C3 diff PR workflow was trying to checkout the cloudflare-docs repo on the `master` branch instead of `production`.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: github workflow -- non-testable
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: not a user facing change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: not a user facing change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: not a user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
