### PR TITLE
[wrangler] Made D1 BEGIN and CASE regex case insensitive

### DIFF
--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -274,6 +274,39 @@ describe("splitSqlQuery()", () => {
 		    END",
 		]
 	`);
+
+		expect(
+			splitSqlQuery(`
+	CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+	begin
+		DELETE FROM updates WHERE item_id=old.id;
+	END;
+	CREATE TRIGGER IF NOT EXISTS actors_search_fts_update AFTER UPDATE ON actors
+	begin
+		DELETE FROM search_fts WHERE rowid=old.rowid;
+		INSERT INTO search_fts (rowid, type, name, preferredUsername)
+		VALUES (new.rowid,
+				new.type,
+				json_extract(new.properties, '$.name'),
+				json_extract(new.properties, '$.preferredUsername'));
+	END;`)
+		).toMatchInlineSnapshot(`
+		Array [
+		  "CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+		  begin
+				DELETE FROM updates WHERE item_id=old.id;
+			END",
+		  "CREATE TRIGGER IF NOT EXISTS actors_search_fts_update AFTER UPDATE ON actors
+		  begin
+				DELETE FROM search_fts WHERE rowid=old.rowid;
+				INSERT INTO search_fts (rowid, type, name, preferredUsername)
+				VALUES (new.rowid,
+						new.type,
+						json_extract(new.properties, '$.name'),
+						json_extract(new.properties, '$.preferredUsername'));
+			END",
+		]
+	`);
 	});
 
 	it("should handle compound statements for CASEs", () => {
@@ -320,5 +353,49 @@ describe("splitSqlQuery()", () => {
 						END ; END",
 		]
 	`);
+
+		expect(
+			splitSqlQuery(`
+			CREATE TRIGGER test_after_insert_trigger AFTER
+			INSERT ON test BEGIN
+			SELECT case
+					WHEN NOT EXISTS
+								(SELECT 1
+									FROM pragma_table_list(new."table")) THEN RAISE (
+																																	ABORT,
+																																	'Exception, table does not exist')
+			END ; END ;
+
+			CREATE TRIGGER test_after_insert_trigger AFTER
+			INSERT ON test BEGIN
+			SELECT case
+					WHEN NOT EXISTS
+								(SELECT 1
+									FROM pragma_table_list(new."table")) THEN RAISE (
+																																	ABORT,
+																																	'Exception, table does not exist')
+			END ; END ;`)
+		).toMatchInlineSnapshot(`
+	Array [
+	  "CREATE TRIGGER test_after_insert_trigger AFTER
+					INSERT ON test BEGIN
+					SELECT case
+							WHEN NOT EXISTS
+										(SELECT 1
+											FROM pragma_table_list(new.\\"table\\")) THEN RAISE (
+																																			ABORT,
+																																			'Exception, table does not exist')
+					END ; END",
+	  "CREATE TRIGGER test_after_insert_trigger AFTER
+					INSERT ON test BEGIN
+					SELECT case
+							WHEN NOT EXISTS
+										(SELECT 1
+											FROM pragma_table_list(new.\\"table\\")) THEN RAISE (
+																																			ABORT,
+																																			'Exception, table does not exist')
+					END ; END",
+	]
+`);
 	});
 });

--- a/packages/wrangler/src/__tests__/d1/splitter.test.ts
+++ b/packages/wrangler/src/__tests__/d1/splitter.test.ts
@@ -291,22 +291,22 @@ describe("splitSqlQuery()", () => {
 				json_extract(new.properties, '$.preferredUsername'));
 	END;`)
 		).toMatchInlineSnapshot(`
-		Array [
-		  "CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
-		  begin
-				DELETE FROM updates WHERE item_id=old.id;
-			END",
-		  "CREATE TRIGGER IF NOT EXISTS actors_search_fts_update AFTER UPDATE ON actors
-		  begin
-				DELETE FROM search_fts WHERE rowid=old.rowid;
-				INSERT INTO search_fts (rowid, type, name, preferredUsername)
-				VALUES (new.rowid,
-						new.type,
-						json_extract(new.properties, '$.name'),
-						json_extract(new.properties, '$.preferredUsername'));
-			END",
-		]
-	`);
+			Array [
+			  "CREATE TRIGGER IF NOT EXISTS update_trigger AFTER UPDATE ON items
+				begin
+					DELETE FROM updates WHERE item_id=old.id;
+				END",
+			  "CREATE TRIGGER IF NOT EXISTS actors_search_fts_update AFTER UPDATE ON actors
+				begin
+					DELETE FROM search_fts WHERE rowid=old.rowid;
+					INSERT INTO search_fts (rowid, type, name, preferredUsername)
+					VALUES (new.rowid,
+							new.type,
+							json_extract(new.properties, '$.name'),
+							json_extract(new.properties, '$.preferredUsername'));
+				END",
+			]
+		`);
 	});
 
 	it("should handle compound statements for CASEs", () => {
@@ -376,26 +376,26 @@ describe("splitSqlQuery()", () => {
 																																	'Exception, table does not exist')
 			END ; END ;`)
 		).toMatchInlineSnapshot(`
-	Array [
-	  "CREATE TRIGGER test_after_insert_trigger AFTER
-					INSERT ON test BEGIN
-					SELECT case
-							WHEN NOT EXISTS
-										(SELECT 1
-											FROM pragma_table_list(new.\\"table\\")) THEN RAISE (
-																																			ABORT,
-																																			'Exception, table does not exist')
-					END ; END",
-	  "CREATE TRIGGER test_after_insert_trigger AFTER
-					INSERT ON test BEGIN
-					SELECT case
-							WHEN NOT EXISTS
-										(SELECT 1
-											FROM pragma_table_list(new.\\"table\\")) THEN RAISE (
-																																			ABORT,
-																																			'Exception, table does not exist')
-					END ; END",
-	]
-`);
+			Array [
+			  "CREATE TRIGGER test_after_insert_trigger AFTER
+						INSERT ON test BEGIN
+						SELECT case
+								WHEN NOT EXISTS
+											(SELECT 1
+												FROM pragma_table_list(new.\\"table\\")) THEN RAISE (
+																																				ABORT,
+																																				'Exception, table does not exist')
+						END ; END",
+			  "CREATE TRIGGER test_after_insert_trigger AFTER
+						INSERT ON test BEGIN
+						SELECT case
+								WHEN NOT EXISTS
+											(SELECT 1
+												FROM pragma_table_list(new.\\"table\\")) THEN RAISE (
+																																				ABORT,
+																																				'Exception, table does not exist')
+						END ; END",
+			]
+		`);
 	});
 });

--- a/packages/wrangler/src/d1/splitter.ts
+++ b/packages/wrangler/src/d1/splitter.ts
@@ -155,7 +155,7 @@ function isDollarQuoteIdentifier(str: string) {
  * Returns true if the `str` ends with a compound statement `BEGIN` or `CASE` marker.
  */
 function isCompoundStatementStart(str: string) {
-	return /\s(BEGIN|CASE)\s$/.test(str);
+	return /\s(BEGIN|CASE)\s$/i.test(str);
 }
 
 /**


### PR DESCRIPTION
## What this PR solves / how to test

Follows sqlite spec for case insensitive BEGIN and CASE [(discussed in Discord)](https://discord.com/channels/595317990191398933/992060581832032316/1242554524548464650)

Solves not using these operators not in caps leading into a wrangler exception.
```
✘ [ERROR] incomplete input
```

## Author has addressed the following

- Tests
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because: Tests should still work with this change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [X] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [X] Not necessary because: it's a small change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [X] Not necessary because: Nothing has changed to be redocumented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
