### PR TITLE
Add `--outfile` to `wrangler deploy` for generating a worker bundle

### DIFF
--- a/.changeset/rich-pots-mate.md
+++ b/.changeset/rich-pots-mate.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": feat
+"wrangler": minor
 ---
 
 feat: Add `--outfile` to `wrangler deploy` for generating a worker bundle

--- a/.changeset/rich-pots-mate.md
+++ b/.changeset/rich-pots-mate.md
@@ -1,0 +1,5 @@
+---
+"wrangler": feat
+---
+
+feat: Add `--outfile` to `wrangler deploy` for generating a worker bundle

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8477,7 +8477,6 @@ export default{
 	describe("--outfile", () => {
 		it("should generate worker bundle at --outfile if specified", async () => {
 			writeWranglerToml();
-			q;
 			writeWorkerSource();
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -60,6 +60,11 @@ export function deployOptions(yargs: CommonYargsArgv) {
 				type: "string",
 				requiresArg: true,
 			})
+			.option("outfile", {
+				describe: "Output file for the bundled worker",
+				type: "string",
+				requiresArg: true,
+			})
 			.option("format", {
 				choices: ["modules", "service-worker"] as const,
 				describe: "Choose an entry type",
@@ -250,6 +255,10 @@ export async function deployHandler(
 		);
 	}
 
+	if (args.outfile && args.outdir) {
+		throw new UserError("Cannot use `--outfile` and `--outdir` together");
+	}
+
 	if (args.assets) {
 		logger.warn(
 			"The --assets argument is experimental and may change or break at any time"
@@ -304,6 +313,7 @@ export async function deployHandler(
 		nodeCompat: args.nodeCompat,
 		isWorkersSite: Boolean(args.site || config.site),
 		outDir: args.outdir,
+		outFile: args.outfile,
 		dryRun: args.dryRun,
 		noBundle: !(args.bundle ?? !config.no_bundle),
 		keepVars: args.keepVars,


### PR DESCRIPTION
## What this PR solves / how to test

Step one of landing https://github.com/cloudflare/workers-sdk/pull/5580. This PR adds an `--outfile` option to `wrangler deploy` that generates a worker bundle instead of a directory of files. Follow up PRs will:
- Add support for deploying a worker bundle directly, skipping the Wrangler build process (for both Workers and Pages)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: This set of features should be documented together once it's all landed and ready

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
