### PR TITLE
fix: ensure `console.log()`s displayed in `SELF` integration tests

### DIFF
--- a/.changeset/funny-frogs-sneeze.md
+++ b/.changeset/funny-frogs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: ensure `console.log()`s displayed in `SELF` integration tests

--- a/packages/vitest-pool-workers/src/worker/events.ts
+++ b/packages/vitest-pool-workers/src/worker/events.ts
@@ -1,4 +1,5 @@
 import { env } from "./env";
+import { registerGlobalWaitUntil, waitForWaitUntil } from "./wait-until";
 
 // `workerd` doesn't allow these internal classes to be constructed directly.
 // To replicate this behaviour require this unique symbol to be specified as the
@@ -10,49 +11,6 @@ const kConstructFlag = Symbol("kConstructFlag");
 // =============================================================================
 // `ExecutionContext`
 // =============================================================================
-
-/**
- * Empty array and wait for all promises to resolve until no more added.
- * If a single promise rejects, the rejection will be passed-through.
- * If multiple promises reject, the rejections will be aggregated.
- */
-async function waitForWaitUntil(/* mut */ waitUntil: unknown[]): Promise<void> {
-	const errors: unknown[] = [];
-
-	while (waitUntil.length > 0) {
-		const results = await Promise.allSettled(waitUntil.splice(0));
-		// Record all rejected promises
-		for (const result of results) {
-			if (result.status === "rejected") {
-				errors.push(result.reason);
-			}
-		}
-	}
-
-	if (errors.length === 1) {
-		// If there was only one rejection, rethrow it
-		throw errors[0];
-	} else if (errors.length > 1) {
-		// If there were more rejections, rethrow them all
-		throw new AggregateError(errors);
-	}
-}
-
-// If isolated storage is enabled, we ensure all `waitUntil()`s are `await`ed at
-// the end of each test, as these may contain storage calls (e.g. caching
-// responses). Note we can't wait at the end of `.concurrent` tests, as we can't
-// track which `waitUntil()`s belong to which tests.
-//
-// If isolated storage is disabled, we ensure all `waitUntil()`s are `await`ed
-// at the end of each test *file*. This ensures we don't try to dispose the
-// runtime until all `waitUntil()`s complete.
-const globalWaitUntil: unknown[] = [];
-export function registerGlobalWaitUntil(promise: unknown) {
-	globalWaitUntil.push(promise);
-}
-export function waitForGlobalWaitUntil(): Promise<void> {
-	return waitForWaitUntil(globalWaitUntil);
-}
 
 const kWaitUntil = Symbol("kWaitUntil");
 class ExecutionContext {

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -9,8 +9,9 @@ import {
 	importModule,
 	internalEnv,
 	maybeHandleRunRequest,
-	registerGlobalWaitUntil,
+	registerHandlerAndGlobalWaitUntil,
 	runInRunnerObject,
+	runWithHandlerContext,
 	setEnv,
 	stripInternalEnv,
 } from "cloudflare:test-internal";
@@ -44,29 +45,85 @@ Object.setPrototypeOf(process, events.EventEmitter.prototype); // Required by `v
 
 globalThis.__console = console;
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+function getCallerFileName(of: Function) {
+	const originalStackTraceLimit = Error.stackTraceLimit;
+	const originalPrepareStackTrace = Error.prepareStackTrace;
+	try {
+		let fileName: string | undefined;
+		Error.stackTraceLimit = 1;
+		Error.prepareStackTrace = (_error, callSites) => {
+			fileName = callSites[0]?.getFileName();
+			return "";
+		};
+		const error: { stack?: string } = {};
+		Error.captureStackTrace(error, of);
+		void error.stack; // Access to generate stack trace
+		return fileName;
+	} finally {
+		Error.stackTraceLimit = originalStackTraceLimit;
+		Error.prepareStackTrace = originalPrepareStackTrace;
+	}
+}
+
 const originalSetTimeout = globalThis.setTimeout;
 const originalClearTimeout = globalThis.clearTimeout;
 
-// HACK: `vitest/dist/vendor/vi.js` attempts to call `setTimeout` when setting
-// up global mocks. Unfortunately, the runner Durable Object's IO context isn't
-// preserved through `import()` so this fails. To get around this, look for
-// the `setTimeout()` call and return a recognisable timeout value that's still
-// `number` typed.
-// @ts-expect-error __promisify__ types only required for Node.js
-globalThis.setTimeout = (...args: Parameters<typeof setTimeout>) => {
-	if (
-		args[1] === 0 &&
-		args[0].toString().replace(/\s/g, "") === "function(){returnundefined;}"
-	) {
+const timeoutPromiseResolves = new Map<unknown, () => void>();
+const monkeypatchedSetTimeout = (...args: Parameters<typeof setTimeout>) => {
+	const [callback, delay, ...restArgs] = args;
+	const callbackName = args[0]?.name ?? "";
+	const callerFileName = getCallerFileName(monkeypatchedSetTimeout);
+	const fromVitest = callerFileName?.includes("/node_modules/vitest/");
+
+	// If this `setTimeout()` isn't from Vitest, or has a non-zero delay,
+	// just call the original function
+	if (!fromVitest || delay) {
+		return originalSetTimeout.apply(globalThis, args);
+	}
+
+	// HACK: `vitest/dist/vendor/vi.js` attempts to call `setTimeout` when setting
+	// up global mocks. Unfortunately, the runner Durable Object's IO context
+	// isn't preserved through `import()` so this fails. To get around this, look
+	// for the `setTimeout()` call and return a recognisable timeout value that's
+	// still `number` typed
+	// (https://github.com/sinonjs/fake-timers/blob/c85ef142837afdbc732b0f73fdba30c3bd037965/src/fake-timers-src.js#L154)
+	if (callbackName === "NOOP") {
 		return -0.5;
 	}
-	return originalSetTimeout.apply(globalThis, args);
+
+	// Make sure `setTimeout()`s from Vitest without delays are `waitUntil()`ed
+	// if we're running within an `export default` handler. This ensures all
+	// `console.log()`s are displayed, as Vitest uses `setTimeout()` for grouping.
+	let promiseResolve: (() => void) | undefined;
+	const promise = new Promise<void>((resolve) => {
+		promiseResolve = resolve;
+	});
+	assert(promiseResolve !== undefined);
+	registerHandlerAndGlobalWaitUntil(promise);
+	const id = originalSetTimeout.call(globalThis, () => {
+		promiseResolve?.();
+		callback?.(...restArgs);
+	});
+	timeoutPromiseResolves.set(id, promiseResolve);
+	return id;
 };
+// @ts-expect-error __promisify__ types only required for Node.js
+globalThis.setTimeout = monkeypatchedSetTimeout;
 // @ts-expect-error overload types not compatible
 globalThis.clearTimeout = (...args: Parameters<typeof clearTimeout>) => {
-	if (args[0] === -0.5) {
+	const id = args[0];
+	if (id === -0.5) {
 		return;
 	}
+
+	// Make sure we resolve any timeout promises we're clearing
+	// (e.g. `console.log()`ing twice, the 2nd will clear the timeout set by the
+	// first, but we'll still be `waitUntil()`ing on the original `Promise`)
+	const maybePromiseResolve = timeoutPromiseResolves.get(id);
+	timeoutPromiseResolves.delete(id);
+	maybePromiseResolve?.();
+
 	return originalClearTimeout.apply(globalThis, args);
 };
 
@@ -101,13 +158,12 @@ class WebSocketMessagePort extends events.EventEmitter {
 	}
 
 	postMessage(data: unknown) {
-		if (this.socket.readyState !== WebSocket.READY_STATE_OPEN) {
-			return;
-		}
-
 		const stringified = structuredSerializableStringify(data);
 		try {
-			this.#chunkingSocket.post(stringified);
+			// Accessing `readyState` may also throw different I/O context error
+			if (this.socket.readyState === WebSocket.READY_STATE_OPEN) {
+				this.#chunkingSocket.post(stringified);
+			}
 		} catch (error) {
 			// If the user tried to perform a dynamic `import()` or `console.log()`
 			// from inside a `export default { fetch() { ... } }` handler using `SELF`
@@ -118,11 +174,12 @@ class WebSocketMessagePort extends events.EventEmitter {
 			// the RPC message though, so if we detect this, we try resend the message
 			// from the runner object.
 			if (isDifferentIOContextError(error)) {
-				void runInRunnerObject(internalEnv, () =>
-					this.#chunkingSocket.post(stringified)
-				).catch((e) => {
+				const promise = runInRunnerObject(internalEnv, () => {
+					this.#chunkingSocket.post(stringified);
+				}).catch((e) => {
 					__console.error("Error sending to pool inside runner:", e, data);
 				});
+				registerHandlerAndGlobalWaitUntil(promise);
 			} else {
 				__console.error("Error sending to pool:", error, data);
 			}
@@ -262,8 +319,6 @@ export class RunnerObject implements DurableObject {
 	}
 }
 
-const patchedContexts = new WeakSet<ExecutionContext>();
-
 function createHandlerWrapper<K extends keyof ExportedHandler>(
 	key: K
 ): NonNullable<ExportedHandler<Record<string, unknown> & Env>[K]> {
@@ -286,16 +341,9 @@ function createHandlerWrapper<K extends keyof ExportedHandler>(
 			(defaultExport as Record<string, unknown>)[key];
 		if (typeof handlerFunction === "function") {
 			const userEnv = stripInternalEnv(env);
-			// Ensure calls to `ctx.waitUntil()` registered with global wait-until
-			if (!patchedContexts.has(ctx)) {
-				patchedContexts.add(ctx);
-				const originalWaitUntil = ctx.waitUntil;
-				ctx.waitUntil = (promise: Promise<unknown>) => {
-					registerGlobalWaitUntil(promise);
-					return originalWaitUntil.call(ctx, promise);
-				};
-			}
-			return handlerFunction.call(defaultExport, thing, userEnv, ctx);
+			return runWithHandlerContext(ctx, () =>
+				handlerFunction.call(defaultExport, thing, userEnv, ctx)
+			);
 		} else {
 			let message = `Handler does not export a ${key}() function.`;
 			if (!defaultExport) {

--- a/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-internal.ts
+++ b/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-internal.ts
@@ -5,3 +5,4 @@ export * from "../../durable-objects";
 export * from "../../env";
 export * from "../../events";
 export * from "../../fetch-mock";
+export * from "../../wait-until";

--- a/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-runner.ts
+++ b/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-runner.ts
@@ -5,6 +5,7 @@ import {
 	fetchMock,
 	getSerializedOptions,
 	internalEnv,
+	registerHandlerAndGlobalWaitUntil,
 	waitForGlobalWaitUntil,
 } from "cloudflare:test-internal";
 import { VitestTestRunner } from "vitest/runners";
@@ -87,6 +88,28 @@ interface TryState {
 }
 const tryStates = new WeakMap<Test, TryState>();
 
+// Wrap RPC calls to register all RPC promises with handler `waitUntil()`s.
+// This ensures all messages created in an `export default` request context are
+// sent, rather than being silently discarded.
+const waitUntilPatchedRpc = new WeakSet<WorkerRPC>();
+export function createWaitUntilRpc(rpc: WorkerRPC): WorkerRPC {
+	return new Proxy(rpc, {
+		get(target, key, handler) {
+			if (key === "then") {
+				return;
+			}
+			const sendCall = Reflect.get(target, key, handler);
+			const waitUntilSendCall = async (...args: unknown[]) => {
+				const promise = sendCall(...args);
+				registerHandlerAndGlobalWaitUntil(promise);
+				return promise;
+			};
+			waitUntilSendCall.asEvent = sendCall.asEvent;
+			return waitUntilSendCall;
+		},
+	});
+}
+
 export default class WorkersTestRunner extends VitestTestRunner {
 	readonly state: WorkerGlobalState;
 	readonly isolatedStorage: boolean;
@@ -105,6 +128,11 @@ export default class WorkersTestRunner extends VitestTestRunner {
 		const opts = state.config.snapshotOptions;
 		if (!(opts.snapshotEnvironment instanceof WorkersSnapshotEnvironment)) {
 			opts.snapshotEnvironment = new WorkersSnapshotEnvironment(state.rpc);
+		}
+
+		if (!waitUntilPatchedRpc.has(state.rpc)) {
+			waitUntilPatchedRpc.add(state.rpc);
+			state.rpc = createWaitUntilRpc(state.rpc);
 		}
 
 		// If this is the first run in this isolate, store a reference to the state.

--- a/packages/vitest-pool-workers/src/worker/wait-until.ts
+++ b/packages/vitest-pool-workers/src/worker/wait-until.ts
@@ -1,0 +1,74 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Empty array and wait for all promises to resolve until no more added.
+ * If a single promise rejects, the rejection will be passed-through.
+ * If multiple promises reject, the rejections will be aggregated.
+ */
+export async function waitForWaitUntil(
+	/* mut */ waitUntil: unknown[]
+): Promise<void> {
+	const errors: unknown[] = [];
+
+	while (waitUntil.length > 0) {
+		const results = await Promise.allSettled(waitUntil.splice(0));
+		// Record all rejected promises
+		for (const result of results) {
+			if (result.status === "rejected") {
+				errors.push(result.reason);
+			}
+		}
+	}
+
+	if (errors.length === 1) {
+		// If there was only one rejection, rethrow it
+		throw errors[0];
+	} else if (errors.length > 1) {
+		// If there were more rejections, rethrow them all
+		throw new AggregateError(errors);
+	}
+}
+
+// If isolated storage is enabled, we ensure all `waitUntil()`s are `await`ed at
+// the end of each test, as these may contain storage calls (e.g. caching
+// responses). Note we can't wait at the end of `.concurrent` tests, as we can't
+// track which `waitUntil()`s belong to which tests.
+//
+// If isolated storage is disabled, we ensure all `waitUntil()`s are `await`ed
+// at the end of each test *file*. This ensures we don't try to dispose the
+// runtime until all `waitUntil()`s complete.
+const globalWaitUntil: unknown[] = [];
+export function registerGlobalWaitUntil(promise: unknown) {
+	globalWaitUntil.push(promise);
+}
+export function waitForGlobalWaitUntil(): Promise<void> {
+	return waitForWaitUntil(globalWaitUntil);
+}
+
+const handlerContextStore = new AsyncLocalStorage<ExecutionContext>();
+const patchedHandlerContexts = new WeakSet<ExecutionContext>();
+export function runWithHandlerContext<T>(
+	ctx: ExecutionContext,
+	callback: () => T
+): T {
+	// Ensure calls to `ctx.waitUntil()` registered with global wait-until
+	if (!patchedHandlerContexts.has(ctx)) {
+		patchedHandlerContexts.add(ctx);
+		const originalWaitUntil = ctx.waitUntil;
+		ctx.waitUntil = (promise: Promise<unknown>) => {
+			registerGlobalWaitUntil(promise);
+			return originalWaitUntil.call(ctx, promise);
+		};
+	}
+	return handlerContextStore.run(ctx, callback);
+}
+export function registerHandlerAndGlobalWaitUntil(promise: Promise<unknown>) {
+	const handlerContext = handlerContextStore.getStore();
+	if (handlerContext === undefined) {
+		registerGlobalWaitUntil(promise);
+	} else {
+		// `runWithHandlerContext()` ensures handler `waitUntil()` calls
+		// `registerGlobalWaitUntil()` too
+		handlerContext.waitUntil(promise);
+	}
+}

--- a/packages/vitest-pool-workers/test/console.test.ts
+++ b/packages/vitest-pool-workers/test/console.test.ts
@@ -52,3 +52,50 @@ test.skipIf(process.platform === "win32")(
 		});
 	}
 );
+
+test("console.logs() inside `export default`ed handlers with SELF", async ({
+	expect,
+	seed,
+	vitestRun,
+}) => {
+	await seed({
+		"vitest.config.ts": dedent`
+			import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+			export default defineWorkersConfig({
+				test: {
+					poolOptions: {
+						workers: {
+							main: "./index.ts",
+							singleWorker: true,
+							miniflare: {
+								compatibilityDate: "2024-01-01",
+								compatibilityFlags: ["nodejs_compat"],
+							},
+						},
+					},
+				}
+			});
+		`,
+		"index.ts": dedent`
+			export default {
+				fetch() {
+					console.log("one");
+					console.log("two");
+					return new Response();
+				}
+			}
+		`,
+		"index.test.ts": dedent`
+			import { SELF } from "cloudflare:test";
+			import { expect, it } from "vitest";
+			it("sends request", async () => {
+				const response = await SELF.fetch("https://example.com");
+				expect(response.ok).toBe(true);
+			});
+		`,
+	});
+	const result = await vitestRun();
+	expect(result.stdout).toMatch(
+		"stdout | index.test.ts > sends request\none\ntwo\n"
+	);
+});


### PR DESCRIPTION
## What this PR solves / how to test

https://github.com/cloudflare/workers-sdk/pull/5508/commits/491f5b0f780e9c58bb93e4ddbc98a5b6801fd0fe#diff-22197b5883e04a7de7c11ce6ed06e43617d41efcd785b3ed54a8bcad4610d89d

Fixes #5385 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: covered by fixture test and doesn't affect e2e tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bug fix

