### PR TITLE
Partially fix #3160 by properly handling resultsFormat query

### DIFF
--- a/.changeset/little-jars-train.md
+++ b/.changeset/little-jars-train.md
@@ -4,5 +4,5 @@
 
 fix: D1's JOIN behaviour when selecting columns with the same name.
 
-Properly handle the `resultsFormat` query that `workerd` sends. This fixes [the JOIN bug](https://github.com/cloudflare/workers-sdk/issues/3160) and makes the behaviour of `raw` consistent with the `workerd` behaviour.
+Properly handle the `resultsFormat` query that `workerd` sends. This partially fixes [the JOIN bug](https://github.com/cloudflare/workers-sdk/issues/3160) and makes the behaviour of `raw` consistent with the `workerd` behaviour.
 

--- a/.changeset/little-jars-train.md
+++ b/.changeset/little-jars-train.md
@@ -5,4 +5,3 @@
 fix: D1's JOIN behaviour when selecting columns with the same name.
 
 Properly handle the `resultsFormat` query that `workerd` sends. This partially fixes [the JOIN bug](https://github.com/cloudflare/workers-sdk/issues/3160) and makes the behaviour of `raw` consistent with the `workerd` behaviour.
-

--- a/.changeset/little-jars-train.md
+++ b/.changeset/little-jars-train.md
@@ -6,4 +6,3 @@ fix: D1's JOIN behaviour when selecting columns with the same name.
 
 Properly handle the `resultsFormat` query that `workerd` sends. This fixes [the JOIN bug](https://github.com/cloudflare/workers-sdk/issues/3160) and makes the behaviour of `raw` consistent with the `workerd` behaviour.
 
-Closes https://github.com/cloudflare/workers-sdk/issues/3160

--- a/.changeset/little-jars-train.md
+++ b/.changeset/little-jars-train.md
@@ -5,3 +5,5 @@
 fix: D1's JOIN behaviour when selecting columns with the same name.
 
 Properly handle the `resultsFormat` query that `workerd` sends. This fixes [the JOIN bug](https://github.com/cloudflare/workers-sdk/issues/3160) and makes the behaviour of `raw` consistent with the `workerd` behaviour.
+
+Closes https://github.com/cloudflare/workers-sdk/issues/3160

--- a/.changeset/little-jars-train.md
+++ b/.changeset/little-jars-train.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+---
+
+Fix JOIN behaviour when selecting columns with the same name.
+
+Properly handle the `resultsFormat` query that `workerd` sends. This fixes [the JOIN bug](https://github.com/cloudflare/workers-sdk/issues/3160) and makes the behaviour of `raw`, `exec`, and `run` consistent with the `workerd` behaviour.

--- a/.changeset/little-jars-train.md
+++ b/.changeset/little-jars-train.md
@@ -4,4 +4,4 @@
 
 Fix JOIN behaviour when selecting columns with the same name.
 
-Properly handle the `resultsFormat` query that `workerd` sends. This fixes [the JOIN bug](https://github.com/cloudflare/workers-sdk/issues/3160) and makes the behaviour of `raw`, `exec`, and `run` consistent with the `workerd` behaviour.
+Properly handle the `resultsFormat` query that `workerd` sends. This fixes [the JOIN bug](https://github.com/cloudflare/workers-sdk/issues/3160) and makes the behaviour of `raw` consistent with the `workerd` behaviour.

--- a/.changeset/little-jars-train.md
+++ b/.changeset/little-jars-train.md
@@ -2,6 +2,6 @@
 "miniflare": minor
 ---
 
-Fix JOIN behaviour when selecting columns with the same name.
+fix: D1's JOIN behaviour when selecting columns with the same name.
 
 Properly handle the `resultsFormat` query that `workerd` sends. This fixes [the JOIN bug](https://github.com/cloudflare/workers-sdk/issues/3160) and makes the behaviour of `raw` consistent with the `workerd` behaviour.

--- a/packages/miniflare/src/workers/d1/database.worker.ts
+++ b/packages/miniflare/src/workers/d1/database.worker.ts
@@ -143,8 +143,10 @@ export class D1DatabaseObject extends MiniflareDurableObject {
 		const rows = convertRows(Array.from(cursor.raw()));
 
 		let results = undefined;
-		if (format === "ARRAY_OF_OBJECTS") results = rowsToObjects(columns, rows);
-		else if (format === "ROWS_AND_COLUMNS") results = { columns, rows };
+		if (format === "ROWS_AND_COLUMNS") results = { columns, rows };
+		else results = rowsToObjects(columns, rows);
+		// Note that the "NONE" format behaviour here is inconsistent with workerd.
+		// See comment: https://github.com/cloudflare/workers-sdk/pull/5917#issuecomment-2133313156
 
 		const afterTime = performance.now();
 		const afterSize = this.state.storage.sql.databaseSize;

--- a/packages/miniflare/src/workers/d1/database.worker.ts
+++ b/packages/miniflare/src/workers/d1/database.worker.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert";
 import {
-	all,
 	get,
 	HttpError,
 	MiniflareDurableObject,

--- a/packages/miniflare/test/plugins/d1/suite.ts
+++ b/packages/miniflare/test/plugins/d1/suite.ts
@@ -223,6 +223,11 @@ test("D1PreparedStatement: run", async (t) => {
 	t.true(result.meta.duration >= 0);
 	t.deepEqual(result, {
 		success: true,
+		results: [
+			{ id: 1, name: "red", rgb: 16711680 },
+			{ id: 2, name: "green", rgb: 65280 },
+			{ id: 3, name: "blue", rgb: 255 },
+		],
 		meta: {
 			changed_db: false,
 			changes: 0,
@@ -246,6 +251,7 @@ test("D1PreparedStatement: run", async (t) => {
 		.run();
 	t.true(result.meta.duration >= 0);
 	t.deepEqual(result, {
+		results: [{ id: 4, name: "yellow", rgb: 16776960 }],
 		success: true,
 		meta: {
 			changed_db: true,
@@ -278,6 +284,7 @@ test("D1PreparedStatement: run", async (t) => {
 		.run();
 	t.true(result.meta.duration >= 0);
 	t.deepEqual(result, {
+		results: [],
 		success: true,
 		meta: {
 			changed_db: true,
@@ -467,18 +474,4 @@ test("it properly handles ROWS_AND_COLUMNS results format", async (t) => {
 
 	const expectedResults = [["blue", "Night"]];
 	t.deepEqual(results, expectedResults);
-});
-
-test("it properly handles NONE results format", async (t) => {
-	const { tablePalettes } = t.context;
-	const db = await getDatabase(t.context.mf);
-
-	const response = await db
-		.prepare(
-			`INSERT INTO ${tablePalettes} (id, name, colour_id) VALUES (2, 'Sunset', 3)`
-		)
-		.run();
-
-	// @ts-expect-error: `results` where [] before we started handling "NONE"
-	t.deepEqual(response.results, undefined);
 });

--- a/packages/miniflare/test/plugins/d1/test.ts
+++ b/packages/miniflare/test/plugins/d1/test.ts
@@ -18,6 +18,7 @@ export interface Context extends MiniflareTestContext {
 	db: D1Database;
 	tableColours: string;
 	tableKitchenSink: string;
+	tablePalettes: string
 }
 
 export let binding: string;

--- a/packages/miniflare/test/plugins/d1/test.ts
+++ b/packages/miniflare/test/plugins/d1/test.ts
@@ -19,6 +19,7 @@ export interface Context extends MiniflareTestContext {
 	tableColours: string;
 	tableKitchenSink: string;
 	tablePalettes: string;
+	bindings: Record<string, unknown>;
 }
 
 export let binding: string;

--- a/packages/miniflare/test/plugins/d1/test.ts
+++ b/packages/miniflare/test/plugins/d1/test.ts
@@ -18,7 +18,7 @@ export interface Context extends MiniflareTestContext {
 	db: D1Database;
 	tableColours: string;
 	tableKitchenSink: string;
-	tablePalettes: string
+	tablePalettes: string;
 }
 
 export let binding: string;


### PR DESCRIPTION
TL;DR: Cloudflare D1 has a critical bug in Workers SDK reproducible on the Cloudflare D1 Console and when running D1 through Wrangler. The PR fixes the bug and also improves compatibility with `workerd`.

### The problem

The essence of the problem is selecting two columns with similar names:

```sql
SELECT
    projects.name,
    organizations.name
FROM
    projects
    JOIN organizations ON projects.organization_id = organizations.id;
```

...must return in the row containing both columns (tested on PostgreSQL v16.3):

```
test=# SELECT projects.name, organizations.name
        FROM projects
        JOIN organizations ON projects.organization_id = organizations.id;
    name    |    name    
------------+------------
 Cloudflare | Cloudflare
(1 row)
```

SQLite (on a database created by Wrangler) gives a similar result:

```
sqlite> SELECT
    projects.name,
    organizations.name
FROM
    projects
    JOIN organizations ON projects.organization_id = organizations.id;
Daisy Chain|Daisy Chain
Fake Daisy Chain|Fake Org
Mind Control|Daisy Chain
sqlite> 
```

I also [added a test](https://github.com/cloudflare/workerd/pull/2166) for this behavior to [workerd](https://github.com/cloudflare/workerd) that is passing:

```ts
await itShould(
  // ...
  () =>
    DB.prepare(
      `SELECT projects.name, organizations.name
      FROM projects
      JOIN organizations ON projects.organization_id = organizations.id;`
    ).raw(),
  [['Cloudflare', 'Cloudflare']]
)
```

However, when sending the same request through Workers SDK, I get:

```
| name       |
| Cloudflare |
```

As both columns have the same name, `name`, they got squashed into a single column. 

A GitHub user [raised the issue a year ago](https://github.com/cloudflare/workers-sdk/issues/3160) and since then it [got fixed in `workerd`](https://github.com/cloudflare/workers-sdk/issues/3160#issuecomment-1915805490) ([that my test confirms](https://github.com/cloudflare/workerd/pull/2166)), but it is still present in Workers SDK.

The problem is also reproducible in Cloudflare D1 Console, where I get the same data:

```
| name       |
| Cloudflare |
```

It [breaks people's code in unexpected ways](https://github.com/drizzle-team/drizzle-orm/issues/555) and creates an impression of D1 as an unreliable product that might behave differently in production.

In my opinion, it's a critical bug that must be prioritized.

### The source

I chased the bug through `wrangler` → `workerd` → `miniflare` [to these line](https://github.com/cloudflare/workers-sdk/blob/81dfb1746a2b2a17c06f809b2da9f937810ca701/packages/miniflare/src/workers/d1/database.worker.ts#L123-L124) in `database.worker.ts`:

```ts
const cursor = this.db.prepare(query.sql)(...params);
const results = convertResults(all(cursor));
```

When running [the test](https://github.com/cloudflare/workers-sdk/pull/5917/commits/022971e9299d25e1e4eb183434a6b1a3779b3f2c#diff-e0656c74bcb20ddb6d1bcec2603532d76a82cbe87475aa3efecf13c5c05b1064R465-R481):

```ts
await db
  .prepare(
	`SELECT ${tableColours}.name, ${tablePalettes}.name FROM ${tableColours} JOIN ${tablePalettes} ON ${tableColours}.id = ${tablePalettes}.colour_id`
  )
  .raw();
```

...the `cursor` object passed through `all` results in the given structure:

```
[{ name: "Night" }]
```

You can see that at this point, the information is already lost, and the `name` columns have been reduced to one property.

After further researching I found that [`workerd` sends the `resultsFormat` query](https://github.com/cloudflare/workerd/blob/1d89f3b8e9cdcd898ea486656d72d9551e79f4a3/src/cloudflare/internal/d1-api.ts#L319) that determines the format of the `results`.

It worked before only because `workerd` handles the case when the API always returns an array of objects either by sheer luck or as a workaround for Workers SDK behavior.

### The solution

The PR fixes the problem and adds proper handling of the `resultsFormat` query.

It makes `raw` preserve columns with the same name, addressing the original problem.

It also adds handling of `NONE` which `workerd` sends with [`run`](https://github.com/cloudflare/workerd/blob/1d89f3b8e9cdcd898ea486656d72d9551e79f4a3/src/cloudflare/internal/d1-api.ts#L295) and [`exec`](https://github.com/cloudflare/workerd/blob/1d89f3b8e9cdcd898ea486656d72d9551e79f4a3/src/cloudflare/internal/d1-api.ts#L103) (hence the change in existing test cases).

### Extras

Here's the SQL I used to test the behavior:

```sql
CREATE TABLE organizations (id INTEGER PRIMARY KEY, name TEXT);

CREATE TABLE projects (
    id INTEGER PRIMARY KEY,
    name TEXT,
    organization_id INTEGER,
    FOREIGN KEY (organization_id) REFERENCES organizations(id)
);

INSERT INTO
    organizations (id, name)
VALUES
    (1, 'Cloudflare');
    
INSERT INTO
    projects (id, name, organization_id)
VALUES
    (1, 'Cloudflare', 1);
    
SELECT
    projects.name,
    organizations.name
FROM
    projects
    JOIN organizations ON projects.organization_id = organizations.id;
```

## What this PR solves / how to test

The PR fixes #3160.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: it is expected behavior