### PR TITLE
add configuration section with local workerd linking to Miniflare readme

### DIFF
--- a/.changeset/cold-berries-raise.md
+++ b/.changeset/cold-berries-raise.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+docs: add configuration section with local workerd linking to main readme

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -823,3 +823,15 @@ defined at the top-level.
 
   Returns the same object returned from incoming `Request`'s `cf` property. This
   object depends on the `cf` property from `SharedOptions`.
+
+## Configuration
+
+### Local `workerd`
+
+You can override the `workerd` binary being used by miniflare with a your own local build by setting the `MINIFLARE_WORKERD_PATH` environment variable.
+
+For example:
+
+```shell
+$ export MINIFLARE_WORKERD_PATH="<WORKERD_REPO_DIR>/bazel-bin/src/workerd/server/workerd"
+```


### PR DESCRIPTION
This PR is simply adding info about the `MINIFLARE_WORKERD_PATH` env variable in the main Miniflare readme
(each time I need to use the env variable I need to dig through the code for it etc... I figured it could be worth to properly document this?)


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: this is a simple md change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: this is a simple md change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included (maybe it shouldn't be... 🤷 I'm totally happy with removing it if it's incorrect here)
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: this is a simple md change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
