### PR TITLE
[miniflare] Allow the magic proxy to handle functions returning functions

### DIFF
--- a/.changeset/silent-spoons-hear.md
+++ b/.changeset/silent-spoons-hear.md
@@ -1,0 +1,19 @@
+---
+"miniflare": patch
+---
+
+fix: Allow the magic proxy to handle functions returning functions
+
+Previously functions returning functions would not be handled by the magic proxy,
+the changes here enable the above, allowing for code such as the following:
+
+```js
+	const mf = new Miniflare(/* ... */);
+
+	const { functionsFactory } = await mf.getBindings<Env>();
+	const fn = functionsFactory.getFunction();
+	const functionResult = fn();
+```
+
+This also works with the native workers RPC mechanism, allowing users to
+return functions in their RPC code.

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
@@ -157,13 +157,25 @@ describe("getPlatformProxy - env", () => {
 	});
 
 	type EntrypointService = Service<
-		Omit<NamedEntrypoint, "getCounter"> & Rpc.WorkerEntrypointBranded
+		Omit<NamedEntrypoint, "getCounter" | "getHelloWorldFn" | "getHelloFn"> &
+			Rpc.WorkerEntrypointBranded
 	> & {
 		getCounter: () => Promise<
 			Promise<{
 				value: Promise<number>;
 				increment: (amount: number) => Promise<number>;
 			}>
+		>;
+		getHelloWorldFn: () => Promise<() => Promise<string>>;
+		getHelloFn: () => Promise<
+			(
+				greet: string,
+				name: string,
+				options?: {
+					suffix?: string;
+					capitalize?: boolean;
+				}
+			) => Promise<string>
 		>;
 	};
 
@@ -190,6 +202,24 @@ describe("getPlatformProxy - env", () => {
 			expect(await counter.increment(4)).toMatchInlineSnapshot(`4`);
 			expect(await counter.increment(8)).toMatchInlineSnapshot(`12`);
 			expect(await counter.value).toMatchInlineSnapshot(`12`);
+		});
+		it("can obtain and interact with returned functions", async () => {
+			const helloWorldFn = await rpc.getHelloWorldFn();
+			expect(helloWorldFn()).toEqual("Hello World!");
+
+			const helloFn = await rpc.getHelloFn();
+			expect(await helloFn("hi", "world")).toEqual("hi world");
+			expect(
+				await helloFn("hi", "world", {
+					capitalize: true,
+				})
+			).toEqual("HI WORLD");
+			expect(
+				await helloFn("Sup", "world", {
+					capitalize: true,
+					suffix: "?!",
+				})
+			).toEqual("SUP WORLD?!");
 		});
 	});
 

--- a/fixtures/get-platform-proxy/workers/rpc-worker/index.ts
+++ b/fixtures/get-platform-proxy/workers/rpc-worker/index.ts
@@ -21,6 +21,30 @@ export class NamedEntrypoint extends WorkerEntrypoint {
 	getCounter() {
 		return new Counter();
 	}
+
+	getHelloWorldFn() {
+		return () => "Hello World!";
+	}
+
+	getHelloFn() {
+		return (
+			greet: string,
+			name: string,
+			{
+				suffix,
+				capitalize,
+			}: {
+				suffix?: string;
+				capitalize?: boolean;
+			} = {}
+		) => {
+			const result = `${greet} ${name}${suffix ?? ""}`;
+			if (capitalize) {
+				return result.toUpperCase();
+			}
+			return result;
+		};
+	}
 }
 
 class Counter extends RpcTarget {

--- a/packages/miniflare/src/plugins/core/proxy/client.ts
+++ b/packages/miniflare/src/plugins/core/proxy/client.ts
@@ -38,7 +38,7 @@ interface NativeTarget {
 	// `ProxyClientHandler`. Usually the `.constructor.name` of the object.
 	[kName]: string;
 	// Use `Symbol` for isFunction too, so we can use it as a unique property key in
-	// `ProxyClientHandler`. This is a field needed because we need to treat functions ad-hod.
+	// `ProxyClientHandler`. This is a field needed because we need to treat functions ad-hoc.
 	[kIsFunction]: boolean;
 }
 function isNativeTarget(value: unknown): value is NativeTarget {

--- a/packages/miniflare/src/workers/core/devalue.ts
+++ b/packages/miniflare/src/workers/core/devalue.ts
@@ -234,6 +234,11 @@ export function stringifyWithStreams<RS>(
 
 		...reducers,
 	};
+	if (typeof value === "function") {
+		value = new __MiniflareFunctionWrapper(
+			value as ConstructorParameters<typeof __MiniflareFunctionWrapper>[0]
+		);
+	}
 	const stringifiedValue = stringify(value, streamReducers);
 	// If we didn't need to buffer anything, we've just encoded correctly. Note
 	// `unbufferedStream` may be undefined if the `value` didn't contain streams.
@@ -270,6 +275,25 @@ export function stringifyWithStreams<RS>(
 		return { value: stringifiedValue, unbufferedStream };
 	});
 }
+
+// functions can't be stringified, so we wrap them into a class that we then use to pseudo-serialize them
+// we also add a proxy and make sure that properties set on the function object are accessible
+// (this is in particular necessary for RpcStubs)
+export class __MiniflareFunctionWrapper {
+	constructor(
+		fnWithProps: ((...args: unknown[]) => unknown) & {
+			[key: string | symbol]: unknown;
+		}
+	) {
+		return new Proxy(this, {
+			get: (_, key) => {
+				if (key === "__miniflareWrappedFunction") return fnWithProps;
+				return fnWithProps[key];
+			},
+		});
+	}
+}
+
 export function parseWithReadableStreams<RS>(
 	impl: PlatformImpl<RS>,
 	stringified: StringifiedWithStream<RS>,


### PR DESCRIPTION
## What this PR solves / how to test

The changes here allow the Miniflare Magic Proxy to handle functions returning functions.

You can usage examples in the tests added to miniflare and the `get-platform-proxy` fixture.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: all the functionality is tested within miniflare and get `get-platform-proxy` fixture
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
