### PR TITLE
chore: use tabs for consistency in C3 templates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,6 +20,10 @@ packages/create-cloudflare/templates/**/*.*
 !packages/create-cloudflare/templates/**/c3.ts
 !packages/create-cloudflare/templates/**/test/**/*.ts
 !packages/create-cloudflare/templates/**/test/**/*.js
+# Format the hello-world template (negate previous exclusion above) for best practices, since we control these
+# but still exclude the worker-configuration.d.ts file, since it's generated
+!packages/create-cloudflare/templates/hello-world/**/*.*
+packages/create-cloudflare/templates/hello-world/**/worker-configuration.d.ts
 
 vscode.d.ts
 vscode.*.d.ts

--- a/packages/create-cloudflare/templates/hello-world/js/vitest.config.js
+++ b/packages/create-cloudflare/templates/hello-world/js/vitest.config.js
@@ -1,11 +1,11 @@
 import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 
 export default defineWorkersConfig({
-  test: {
-    poolOptions: {
-      workers: {
-        wrangler: { configPath: "./wrangler.toml" },
-      },
-    },
-  },
+	test: {
+		poolOptions: {
+			workers: {
+				wrangler: { configPath: "./wrangler.toml" },
+			},
+		},
+	},
 });

--- a/packages/create-cloudflare/templates/hello-world/js/vitest.config.js
+++ b/packages/create-cloudflare/templates/hello-world/js/vitest.config.js
@@ -1,10 +1,10 @@
-import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
 
 export default defineWorkersConfig({
 	test: {
 		poolOptions: {
 			workers: {
-				wrangler: { configPath: "./wrangler.toml" },
+				wrangler: { configPath: './wrangler.toml' },
 			},
 		},
 	},

--- a/packages/create-cloudflare/templates/hello-world/ts/test/tsconfig.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/test/tsconfig.json
@@ -1,10 +1,7 @@
 {
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
-		"types": [
-			"@cloudflare/workers-types/experimental",
-			"@cloudflare/vitest-pool-workers"
-		]
+		"types": ["@cloudflare/workers-types/experimental", "@cloudflare/vitest-pool-workers"]
 	},
 	"include": ["./**/*.ts", "../src/env.d.ts"],
 	"exclude": []

--- a/packages/create-cloudflare/templates/hello-world/ts/test/tsconfig.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/test/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "types": [
-      "@cloudflare/workers-types/experimental",
-      "@cloudflare/vitest-pool-workers"
-    ]
-  },
-  "include": ["./**/*.ts", "../src/env.d.ts"],
-  "exclude": []
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"types": [
+			"@cloudflare/workers-types/experimental",
+			"@cloudflare/vitest-pool-workers"
+		]
+	},
+	"include": ["./**/*.ts", "../src/env.d.ts"],
+	"exclude": []
 }

--- a/packages/create-cloudflare/templates/hello-world/ts/vitest.config.ts
+++ b/packages/create-cloudflare/templates/hello-world/ts/vitest.config.ts
@@ -1,11 +1,11 @@
 import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 
 export default defineWorkersConfig({
-  test: {
-    poolOptions: {
-      workers: {
-        wrangler: { configPath: "./wrangler.toml" },
-      },
-    },
-  },
+	test: {
+		poolOptions: {
+			workers: {
+				wrangler: { configPath: "./wrangler.toml" },
+			},
+		},
+	},
 });

--- a/packages/create-cloudflare/templates/hello-world/ts/vitest.config.ts
+++ b/packages/create-cloudflare/templates/hello-world/ts/vitest.config.ts
@@ -1,10 +1,10 @@
-import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
 
 export default defineWorkersConfig({
 	test: {
 		poolOptions: {
 			workers: {
-				wrangler: { configPath: "./wrangler.toml" },
+				wrangler: { configPath: './wrangler.toml' },
 			},
 		},
 	},


### PR DESCRIPTION
## What this PR solves / how to test

These templates use tabs throughout, so for consistency the vitest config and nested tsconfig.json should also. This way, on new projects, folks don't get a mix of indentation, quotes, etc.

It also makes sure that `packages/create-cloudflare/templates/hello-world/**/*.*` is included in prettier runs. I understand that other templates don't enforce this, but for the hello world one, it ships with best practices (tabs), and it would be ideal if that's maintained in this template moving forward.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no functional changes
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no functional changes
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no functional changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: no functional changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
