### PR TITLE
fix(wrangler) Clean `pages dev` terminal output

### DIFF
--- a/.changeset/long-planets-provide.md
+++ b/.changeset/long-planets-provide.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Clean `pages dev` terminal ouput
+
+This work includes a series of improvements to the `pages dev` terminal output, in an attempt to make this output more structured, organised, cleaner, easier to follow, and therefore more helpful for our users <3

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -572,7 +572,8 @@ describe("pages dev", () => {
 			);
 
 			expect(prestartOutput).toMatchInlineSnapshot(`
-				"▲ [WARNING] WARNING: You have Durable Object bindings that are not defined locally in the worker being developed.
+				"✨ Compiled Worker successfully
+				▲ [WARNING] WARNING: You have Durable Object bindings that are not defined locally in the worker being developed.
 				  Be aware that changes to the data stored in these Durable Objects will be permanent and affect the live instances.
 				  Remote Durable Objects that are affected:
 				  - {"name":"DO_BINDING_1_TOML","class_name":"DO_1_TOML","script_name":"DO_SCRIPT_1_TOML"}

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -27,9 +27,18 @@ describe("pages dev", () => {
 			const worker = run(`wrangler pages dev --port ${port} .`);
 			const { url } = await waitForReady(worker);
 			const text = await fetchText(url);
+			const currentDate = new Date().toISOString().substring(0, 10);
+			const output = worker.output.replaceAll(currentDate, "<current-date>");
+
 			expect(text).toMatchInlineSnapshot('"Testing [--compatibility_date]"');
-			expect(worker.output).toContain(
-				`No compatibility_date was specified. Using today's date`
+			expect(output).toContain(
+				`No compatibility_date was specified. Using today's date: <current-date>.`
+			);
+			expect(output).toContain(
+				`❯❯ Add one to your wrangler.toml file: compatibility_date = "<current-date>", or`
+			);
+			expect(output).toContain(
+				`❯❯ Pass it in your terminal: wrangler pages dev [<DIRECTORY>] --compatibility-date=<current-date>`
 			);
 		}
 	);

--- a/packages/wrangler/src/__tests__/api-dev.test.ts
+++ b/packages/wrangler/src/__tests__/api-dev.test.ts
@@ -2,9 +2,7 @@ import * as fs from "node:fs";
 import { Request } from "undici";
 import { vi } from "vitest";
 import { unstable_dev } from "../api";
-import { printWranglerBanner } from "../update-check";
 import { runInTempDir } from "./helpers/run-in-tmp";
-import type { Mock } from "vitest";
 
 vi.unmock("child_process");
 vi.unmock("undici");
@@ -57,47 +55,6 @@ describe("unstable_dev", () => {
 		);
 		expect(worker.port).not.toBe(0);
 		await worker.stop();
-	});
-
-	describe("unstable_dev network calls", () => {
-		it("should not make a request to NPM without `updateCheck` being true", async () => {
-			const worker = await unstable_dev(
-				"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
-				{
-					ip: "127.0.0.1",
-					experimental: {
-						disableExperimentalWarning: true,
-						disableDevRegistry: true,
-					},
-				}
-			);
-			const resp = await worker.fetch();
-			expect(resp.status).toBe(200);
-
-			expect((printWranglerBanner as Mock).mock.calls[0][0]).toBe(false);
-
-			await worker.stop();
-		});
-
-		it("should make a request to NPM when `updateCheck` is true", async () => {
-			const worker = await unstable_dev(
-				"src/__tests__/helpers/worker-scripts/hello-world-worker.js",
-				{
-					ip: "127.0.0.1",
-					experimental: {
-						disableExperimentalWarning: true,
-						disableDevRegistry: true,
-					},
-					updateCheck: true,
-				}
-			);
-			const resp = await worker.fetch();
-			expect(resp.status).toBe(200);
-
-			expect((printWranglerBanner as Mock).mock.calls[0][0]).toBe(true);
-
-			await worker.stop();
-		});
 	});
 });
 

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -113,20 +113,15 @@ describe("wrangler dev", () => {
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn.replaceAll(currentDate, "<current-date>"))
 				.toMatchInlineSnapshot(`
-			        "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mNo compatibility_date was specified. Using the installed Workers runtime's latest supported date: <current-date>.[0m
+"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mNo compatibility_date was specified. Using the installed Workers runtime's latest supported date: <current-date>.[0m
 
-			          Add one to your wrangler.toml file:
-			          \`\`\`
-			          compatibility_date = \\"<current-date>\\"
-			          \`\`\`
-			          or pass it in your terminal:
-			          \`\`\`
-			          --compatibility-date=<current-date>
-			          \`\`\`
-			          See [4mhttps://developers.cloudflare.com/workers/platform/compatibility-dates/[0m for more information.
+  ❯❯ Add one to your wrangler.toml file: compatibility_date = \\"<current-date>\\", or
+  ❯❯ Pass it in your terminal: wrangler dev [<SCRIPT>] --compatibility-date=<current-date>
 
-			        "
-		      `);
+  See [4mhttps://developers.cloudflare.com/workers/platform/compatibility-dates/[0m for more information.
+
+"
+`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -10,7 +10,7 @@ describe("pages dev", () => {
 	runInTempDir();
 	mockConsoleMethods();
 
-	it("should error if neither [<directory>] nor [--<command>] command line args were specififed", async () => {
+	it("should error if neither [<directory>] nor [--<command>] command line args were specified", async () => {
 		await expect(
 			runWrangler("pages dev")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -18,7 +18,7 @@ describe("pages dev", () => {
 		);
 	});
 
-	it("should error if both [<directory>] and [--<command>] command line args were specififed", async () => {
+	it("should error if both [<directory>] and [--<command>] command line args were specified", async () => {
 		await expect(
 			runWrangler("pages dev public -- yarn dev")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -26,7 +26,7 @@ describe("pages dev", () => {
 		);
 	});
 
-	it("should error if the [--config] command line arg was specififed", async () => {
+	it("should error if the [--config] command line arg was specified", async () => {
 		await expect(
 			runWrangler("pages dev public --config=/path/to/wrangler.toml")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -34,7 +34,7 @@ describe("pages dev", () => {
 		);
 	});
 
-	it("should error if the [--experimental-json-config] command line arg was specififed", async () => {
+	it("should error if the [--experimental-json-config] command line arg was specified", async () => {
 		await expect(
 			runWrangler("pages dev public --experimental-json-config")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -42,7 +42,7 @@ describe("pages dev", () => {
 		);
 	});
 
-	it("should error if the [--env] command line arg was specififed", async () => {
+	it("should error if the [--env] command line arg was specified", async () => {
 		await expect(
 			runWrangler("pages dev public --env=production")
 		).rejects.toThrowErrorMatchingInlineSnapshot(

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -64,7 +64,6 @@ export interface UnstableDevOptions {
 	inspect?: boolean;
 	local?: boolean;
 	accountId?: string;
-	updateCheck?: boolean;
 	experimental?: {
 		processEntrypoint?: boolean;
 		additionalModules?: CfModule[];
@@ -213,7 +212,6 @@ export async function unstable_dev(
 		...options,
 		logLevel: options?.logLevel ?? defaultLogLevel,
 		port: options?.port ?? 0,
-		updateCheck: options?.updateCheck ?? false,
 		experimentalVersions: undefined,
 		experimentalDevEnv: devEnv,
 	};

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -301,6 +301,8 @@ export function devOptions(yargs: CommonYargsArgv) {
 type DevArguments = StrictYargsOptionsToInterface<typeof devOptions>;
 
 export async function devHandler(args: DevArguments) {
+	await printWranglerBanner();
+
 	if (isWebContainer()) {
 		logger.error(
 			`Oh no! 😟 You tried to run \`wrangler dev\` in a StackBlitz WebContainer. 🤯
@@ -379,7 +381,6 @@ export type StartDevOptions = DevArguments &
 		disableDevRegistry?: boolean;
 		enablePagesAssetsServiceBinding?: EnablePagesAssetsServiceBindingOptions;
 		onReady?: (ip: string, port: number, proxyData: ProxyData) => void;
-		updateCheck?: boolean;
 	};
 
 export async function startDev(args: StartDevOptions) {
@@ -389,7 +390,7 @@ export async function startDev(args: StartDevOptions) {
 		if (args.logLevel) {
 			logger.loggerLevel = args.logLevel;
 		}
-		await printWranglerBanner(args.updateCheck);
+
 		if (args.local) {
 			logger.warn(
 				"--local is no longer required and will be removed in a future version.\n`wrangler dev` now uses the local Cloudflare Workers runtime by default. 🎉"
@@ -549,7 +550,6 @@ export async function startApiDev(args: StartDevOptions) {
 	if (args.logLevel) {
 		logger.loggerLevel = args.logLevel;
 	}
-	await printWranglerBanner(args.updateCheck);
 
 	const configPath =
 		args.config || (args.script && findWranglerToml(path.dirname(args.script)));

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -927,14 +927,8 @@ export function getDevCompatibilityDate(
 	if (config.configPath !== undefined && compatibilityDate === undefined) {
 		logger.warn(
 			`No compatibility_date was specified. Using the installed Workers runtime's latest supported date: ${currentDate}.\n` +
-				"Add one to your wrangler.toml file:\n" +
-				"```\n" +
-				`compatibility_date = "${currentDate}"\n` +
-				"```\n" +
-				"or pass it in your terminal:\n" +
-				"```\n" +
-				`--compatibility-date=${currentDate}\n` +
-				"```\n" +
+				`❯❯ Add one to your wrangler.toml file: compatibility_date = "${currentDate}", or\n` +
+				`❯❯ Pass it in your terminal: wrangler dev [<SCRIPT>] --compatibility-date=${currentDate}\n\n` +
 				"See https://developers.cloudflare.com/workers/platform/compatibility-dates/ for more information."
 		);
 	}

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -167,6 +167,8 @@ async function generateAssetsFetch(
 	let metadata = createMetadataObject({
 		redirects,
 		headers,
+		headersFile,
+		redirectsFile,
 		logger: log,
 	});
 
@@ -191,6 +193,8 @@ async function generateAssetsFetch(
 			metadata = createMetadataObject({
 				redirects,
 				headers,
+				redirectsFile,
+				headersFile,
 				logger: log,
 			});
 		}

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -13,6 +13,7 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
 import { getBasePath } from "../paths";
+import { printWranglerBanner } from "../update-check";
 import * as shellquote from "../utils/shell-quote";
 import { buildFunctions } from "./buildFunctions";
 import { ROUTES_SPEC_VERSION, SECONDS_TO_WAIT_FOR_PROXY } from "./constants";
@@ -250,6 +251,8 @@ export const Handler = async (args: PagesDevArguments) => {
 	if (args.logLevel) {
 		logger.loggerLevel = args.logLevel;
 	}
+
+	await printWranglerBanner();
 
 	if (args.experimentalLocal) {
 		logger.warn(
@@ -665,7 +668,6 @@ export const Handler = async (args: PagesDevArguments) => {
 		persistTo: args.persistTo,
 		inspect: undefined,
 		logLevel: args.logLevel,
-		updateCheck: true,
 		experimental: {
 			processEntrypoint: true,
 			additionalModules: modules,

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -856,10 +856,8 @@ function resolvePagesDevServerSettings(
 		const currentDate = new Date().toISOString().substring(0, 10);
 		logger.warn(
 			`No compatibility_date was specified. Using today's date: ${currentDate}.\n` +
-				"Pass it in your terminal:\n" +
-				"```\n" +
-				`--compatibility-date=${currentDate}\n` +
-				"```\n" +
+				`❯❯ Add one to your wrangler.toml file: compatibility_date = "${currentDate}", or\n` +
+				`❯❯ Pass it in your terminal: wrangler pages dev [<DIRECTORY>] --compatibility-date=${currentDate}\n\n` +
 				"See https://developers.cloudflare.com/workers/platform/compatibility-dates/ for more information."
 		);
 		compatibilityDate = currentDate;

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -625,11 +625,8 @@ export const Handler = async (args: PagesDevArguments) => {
 
 					logger.error(error);
 					logger.warn(
-						`Falling back to the following _routes.json default: ${JSON.stringify(
-							defaultRoutesJSONSpec,
-							null,
-							2
-						)}`
+						`Ignoring provided _routes.json file, and falling back to the following default routes configuration:\n` +
+							`${JSON.stringify(defaultRoutesJSONSpec, null, 2)}`
 					);
 
 					routesJSONContents = JSON.stringify(defaultRoutesJSONSpec);

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -452,7 +452,8 @@ export const Handler = async (args: PagesDevArguments) => {
 			`./functionsRoutes-${Math.random()}.mjs`
 		);
 
-		logger.log(`Compiling worker to "${scriptPath}"...`);
+		logger.debug(`Compiling worker to "${scriptPath}"...`);
+
 		const onEnd = () => scriptReadyResolve();
 		try {
 			const buildFn = async () => {

--- a/packages/wrangler/src/update-check.ts
+++ b/packages/wrangler/src/update-check.ts
@@ -16,11 +16,13 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 	}
 
 	logger.log(
-		text +
+		"\n" +
+			text +
 			"\n" +
 			(supportsColor.stdout
 				? chalk.hex("#FF8800")("-".repeat(text.length))
-				: "-".repeat(text.length))
+				: "-".repeat(text.length)) +
+			"\n"
 	);
 
 	// Log a slightly more noticeable message if this is a major bump


### PR DESCRIPTION
## What this PR solves / how to test

The `wrangler pages dev` terminal output is currently a bit noisy and lacking a clearer, more organised structure. This PR cleans up the `pages dev` `stdout`/`stderr` logs in an attempt to make it more readable and easier to reason about for our users (and ourselves 😉 ) <3

<details>
<summary>After TLDR;</summary>

<img width="821" alt="Screenshot 2024-06-05 at 14 25 39" src="https://github.com/cloudflare/workers-sdk/assets/4638332/bd16f8a7-4937-4dfe-9741-c7fd60b380d4">
<img width="907" alt="Screenshot 2024-06-05 at 14 26 47" src="https://github.com/cloudflare/workers-sdk/assets/4638332/72dcef51-421a-4896-8cb0-d88542401543">
</details>

As part of this PR, the following issues were addressed:
<details>
<summary>1. `compatibility-date` warnings</summary>

**Before**
`wrangler dev`
<img width="989" alt="Screenshot 2024-05-27 at 16 34 51" src="https://github.com/cloudflare/workers-sdk/assets/4638332/6defc993-9301-4ff2-8f80-795cb21e26f0">

`wrangler pages dev`
<img width="866" alt="Screenshot 2024-05-27 at 16 33 46" src="https://github.com/cloudflare/workers-sdk/assets/4638332/16f01ee0-2c05-47d7-891c-a8a5f686bbf5">

**After**
`wrangler dev` 
<img width="990" alt="Screenshot 2024-05-27 at 17 31 51" src="https://github.com/cloudflare/workers-sdk/assets/4638332/21f25ac3-28cb-4bf3-86dc-f7b17a360256">

`wrangler pages dev`
<img width="789" alt="Screenshot 2024-05-27 at 16 32 56" src="https://github.com/cloudflare/workers-sdk/assets/4638332/fe8bf4c1-b467-402a-8077-e8c833c34057">
</details>

<details>
<summary>2. wrangler logo display</summary>

**Before** 
`wrangler dev`
<img width="243" alt="Screenshot 2024-05-27 at 18 49 39" src="https://github.com/cloudflare/workers-sdk/assets/4638332/46993992-9934-4168-b039-0323790ad32e">

`wrangler pages dev`
<img width="1124" alt="Screenshot 2024-05-27 at 18 50 30" src="https://github.com/cloudflare/workers-sdk/assets/4638332/bbeae529-c732-4299-a4fd-115b15a27cf0">

**After**
`wrangler dev`
<img width="351" alt="Screenshot 2024-05-27 at 18 32 42" src="https://github.com/cloudflare/workers-sdk/assets/4638332/6323a678-1b99-46f9-8e1b-f89674c15f72">

`wrangler pages dev`
<img width="829" alt="Screenshot 2024-05-27 at 18 32 02" src="https://github.com/cloudflare/workers-sdk/assets/4638332/2fc57dc6-33ab-45b7-b45e-d0e17543cb5b">

</details>

<details>
<summary>3. `_headers` / `_redirects` parsing warnings</summary>

**Before**
<img width="1010" alt="Screenshot 2024-06-05 at 11 33 19" src="https://github.com/cloudflare/workers-sdk/assets/4638332/3c7ee048-5b3e-4df9-a9b3-81c36ea7ff2d">

**After**
<img width="688" alt="Screenshot 2024-06-05 at 11 37 09" src="https://github.com/cloudflare/workers-sdk/assets/4638332/0ebf9945-6dae-4bcd-9958-747d19ce6161">

</details>

<details>
<summary>4. verbiage in `_routes.json` warning</summary>

**Before**
<img width="545" alt="Screenshot 2024-06-05 at 13 07 58" src="https://github.com/cloudflare/workers-sdk/assets/4638332/fce14dd3-c9f1-411f-9ab4-1c61748f2db3">

**After**
<img width="919" alt="Screenshot 2024-06-05 at 13 07 13" src="https://github.com/cloudflare/workers-sdk/assets/4638332/7b907bee-b087-48d0-8c00-b5914a895a57">

</details>

<details>
<summary>5. Output "Compiling worker to..." to `debug` logs</summary>

**Before**
<img width="993" alt="Screenshot 2024-06-05 at 13 25 12" src="https://github.com/cloudflare/workers-sdk/assets/4638332/32e87c21-1e3f-432b-bc9e-d2ebe64f8729">

**After**
<img width="295" alt="Screenshot 2024-06-05 at 13 24 35" src="https://github.com/cloudflare/workers-sdk/assets/4638332/046d833e-0520-4bdc-a2ff-25fe4041b4a7">

</details>

Fixes #4265.

⚡️⚡️⚡️**Please review per commit, as each commit addresses a separate issue** 🙏 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: terminal output format is not documented anywhere AFAIK

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
