### PR TITLE
Improve error message when updating secret for a non-deployed latest version

### DIFF
--- a/.changeset/fluffy-carrots-peel.md
+++ b/.changeset/fluffy-carrots-peel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: improve error message when updating secret for a non-deployed latest version.

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -181,7 +181,6 @@ function throwFetchError(
 	// so consumers can use it for specific behaviour
 	const code = response.errors[0]?.code;
 	if (code) {
-		//@ts-expect-error non-standard property on Error
 		error.code = code;
 	}
 	throw error;

--- a/packages/wrangler/src/parse.ts
+++ b/packages/wrangler/src/parse.ts
@@ -72,6 +72,8 @@ export class ParseError extends UserError implements Message {
 // Therefore, allow particular `ParseError`s to be marked `reportable`.
 export class APIError extends ParseError {
 	#status?: number;
+	code?: number;
+
 	constructor({ status, ...rest }: Message & { status?: number }) {
 		super(rest);
 		this.name = this.constructor.name;


### PR DESCRIPTION
## What this PR solves / how to test

Fixes WC-2184

<img width="1727" alt="image" src="https://github.com/cloudflare/workers-sdk/assets/8492901/56814e26-ba33-4a99-9eab-22c630a05940">

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no e2e coverage for this change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/>...
  - [x] Not necessary because: just updating an error message