### PR TITLE
[C3] fix: add missing `pre-existing` type and `--existing-script` to help message

### DIFF
--- a/.changeset/tiny-cameras-tease.md
+++ b/.changeset/tiny-cameras-tease.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: add missing `pre-existing` type and `--existing-script` to help message

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -91,8 +91,9 @@ const cliDefinition: ArgumentsDefinition = {
 				},
 				{
 					name: "pre-existing",
-					description: "Fetch a Worker initialized from the Cloudflare dashboard."
-				}
+					description:
+						"Fetch a Worker initialized from the Cloudflare dashboard.",
+				},
 			],
 		},
 		{

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -89,6 +89,10 @@ const cliDefinition: ArgumentsDefinition = {
 					name: "openapi",
 					description: "A Worker implementing an OpenAPI REST endpoint.",
 				},
+				{
+					name: "pre-existing",
+					description: "Fetch a Worker initialized from the Cloudflare dashboard."
+				}
 			],
 		},
 		{
@@ -146,13 +150,12 @@ const cliDefinition: ArgumentsDefinition = {
 		},
 		{
 			name: "existing-script",
-			description: `The name of an existing Cloudflare Workers script to clone locally.
+			description: `The name of an existing Cloudflare Workers script to clone locally (when using this option "--type" is coerced to "pre-existing").
 
         When "--existing-script" is specified, "deploy" will be ignored.
         `,
 			type: "string",
 			requiresArg: true,
-			hidden: true,
 		},
 		{
 			name: "template",


### PR DESCRIPTION
This adds missing info to the C3 help message:
![Screenshot 2024-05-30 at 19 22 39](https://github.com/cloudflare/workers-sdk/assets/61631103/147681f5-1505-4a4f-8c51-04561e5b8b8a)

![Screenshot 2024-05-30 at 19 22 48](https://github.com/cloudflare/workers-sdk/assets/61631103/ca33dcdf-243d-4c85-adc7-04f604c6be0b)


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: the help message is not tested
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: minor low risk change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: the `pre-existing` `type` is already in the [c3 docs](https://developers.cloudflare.com/pages/get-started/c3/#cli-arguments), the `--existing-script` option will be added in https://github.com/cloudflare/cloudflare-docs/pull/14814

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
