### PR TITLE
add missing promptHandler to C3 docusaurus e2e

### DIFF
--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -106,6 +106,12 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 			expectedText: "Dinosaurs are cool",
 		},
 		flags: [`--package-manager`, pm],
+		promptHandlers: [
+			{
+				matcher: /Which language do you want to use\?/,
+				input: [keys.enter],
+			},
+		],
 	},
 	analog: {
 		testCommitMessage: true,


### PR DESCRIPTION
the docusaurus cli is now asking for the language to use, we are not handling that in the c3 e2es causing the docusaurus ones to time out (like [here](https://github.com/cloudflare/workers-sdk/actions/runs/9309087223/job/25623808631?pr=5944#step:4:327) and [here](https://github.com/cloudflare/workers-sdk/actions/runs/9318210394/job/25651828633?pr=5943#step:4:400)), this PR addresses this issue

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: only e2e changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: only e2e changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
