### PR TITLE
fix: avoid injecting esbuild watch stubs into production Worker code

### DIFF
--- a/.changeset/popular-ravens-add.md
+++ b/.changeset/popular-ravens-add.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+fix: avoid injecting esbuild watch stubs into production Worker code
+
+When we added the ability to include additional modules in the deployed bundle of a Worker,
+we inadvertently also included some boiler plate code that is only needed at development time.
+
+This fix ensures that this code is only injected if we are running esbuild in watch mode
+(e.g. `wrangler dev`) and not when building for deployment.
+
+It is interesting to note that this boilerplate only gets included in the production code
+if there is an import of CommonJS code in the Worker, which esbuild needs to convert to an
+ESM import.
+
+Fixes [#4269](https://github.com/cloudflare/workers-sdk/issues/4269)

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -266,10 +266,12 @@ export async function bundleWorker(
 		inject.push(...(result.inject ?? []));
 	}
 
-	// `esbuild` doesn't support returning `watch*` options from `onStart()`
-	// plugin callbacks. Instead, we define an empty virtual module that is
-	// imported in this injected module. Importing that module registers watchers.
-	inject.push(path.resolve(getBasePath(), "templates/modules-watch-stub.js"));
+	if (watch) {
+		// `esbuild` doesn't support returning `watch*` options from `onStart()`
+		// plugin callbacks. Instead, we define an empty virtual module that is
+		// imported in this injected module. Importing that module registers watchers.
+		inject.push(path.resolve(getBasePath(), "templates/modules-watch-stub.js"));
+	}
 
 	const buildOptions: esbuild.BuildOptions & { metafile: true } = {
 		// Don't use entryFile here as the file may have been changed when applying the middleware


### PR DESCRIPTION
## What this PR solves / how to test

When we added the ability to include additional modules in the deployed bundle of a Worker,
we inadvertently also included some boiler plate code that is only needed at development time.

This fix ensures that this code is only injected if we are running esbuild in watch mode
(e.g. `wrangler dev`) and not when building for deployment.

It is interesting to note that this boilerplate only gets included in the production code
if there is an import of CommonJS code in the Worker, which esbuild needs to convert to an
ESM import.

Fixes [#4269](https://github.com/cloudflare/workers-sdk/issues/4269)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: covered by unit tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
