### PR TITLE
chore: bump workerd and workers-types deps

### DIFF
--- a/.changeset/friendly-students-fly.md
+++ b/.changeset/friendly-students-fly.md
@@ -1,0 +1,12 @@
+---
+"miniflare": patch
+---
+
+chore: update dependencies of "miniflare" package
+
+The following dependency versions have been updated:
+
+| Dependency                | From          | To            |
+| ------------------------- | ------------- | ------------- |
+| workerd                   | 1.20240524.0  | 1.20240603.0  |
+| @cloudflare/workers-types | ^4.20240524.0 | ^4.20240603.0 |

--- a/.changeset/friendly-students-fly.md
+++ b/.changeset/friendly-students-fly.md
@@ -8,5 +8,5 @@ The following dependency versions have been updated:
 
 | Dependency                | From          | To            |
 | ------------------------- | ------------- | ------------- |
-| workerd                   | 1.20240524.0  | 1.20240603.0  |
-| @cloudflare/workers-types | ^4.20240524.0 | ^4.20240603.0 |
+| workerd                   | 1.20240524.0  | 1.20240605.0  |
+| @cloudflare/workers-types | ^4.20240524.0 | ^4.20240605.0 |

--- a/fixtures/additional-modules/package.json
+++ b/fixtures/additional-modules/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	}

--- a/fixtures/additional-modules/package.json
+++ b/fixtures/additional-modules/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	}

--- a/fixtures/external-durable-objects-app/package.json
+++ b/fixtures/external-durable-objects-app/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"undici": "^5.28.3",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/fixtures/external-durable-objects-app/package.json
+++ b/fixtures/external-durable-objects-app/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"undici": "^5.28.3",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/fixtures/external-service-bindings-app/package.json
+++ b/fixtures/external-service-bindings-app/package.json
@@ -18,7 +18,7 @@
 		"undici": "^5.28.3",
 		"concurrently": "^8.2.1",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/fixtures/external-service-bindings-app/package.json
+++ b/fixtures/external-service-bindings-app/package.json
@@ -18,7 +18,7 @@
 		"undici": "^5.28.3",
 		"concurrently": "^8.2.1",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/fixtures/get-bindings-proxy/package.json
+++ b/fixtures/get-bindings-proxy/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"wrangler": "workspace:*",
 		"undici": "^5.28.3"
 	}

--- a/fixtures/get-bindings-proxy/package.json
+++ b/fixtures/get-bindings-proxy/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"wrangler": "workspace:*",
 		"undici": "^5.28.3"
 	}

--- a/fixtures/get-platform-proxy/package.json
+++ b/fixtures/get-platform-proxy/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"wrangler": "workspace:*",
 		"undici": "^5.28.3"
 	}

--- a/fixtures/get-platform-proxy/package.json
+++ b/fixtures/get-platform-proxy/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"wrangler": "workspace:*",
 		"undici": "^5.28.3"
 	}

--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -14,7 +14,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@types/node": "^17.0.33",
 		"buffer": "^6.0.3",
 		"wrangler": "workspace:*"

--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -14,7 +14,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@types/node": "^17.0.33",
 		"buffer": "^6.0.3",
 		"wrangler": "workspace:*"

--- a/fixtures/node-app-pages/package.json
+++ b/fixtures/node-app-pages/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	},

--- a/fixtures/node-app-pages/package.json
+++ b/fixtures/node-app-pages/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	},

--- a/fixtures/pages-dev-proxy-with-script/package.json
+++ b/fixtures/pages-dev-proxy-with-script/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	},

--- a/fixtures/pages-dev-proxy-with-script/package.json
+++ b/fixtures/pages-dev-proxy-with-script/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	},

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"pages-plugin-example": "workspace:*",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"pages-plugin-example": "workspace:*",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"

--- a/fixtures/pages-functions-with-routes-app/package.json
+++ b/fixtures/pages-functions-with-routes-app/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	},

--- a/fixtures/pages-functions-with-routes-app/package.json
+++ b/fixtures/pages-functions-with-routes-app/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	},

--- a/fixtures/pages-plugin-mounted-on-root-app/package.json
+++ b/fixtures/pages-plugin-mounted-on-root-app/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"pages-plugin-example": "workspace:*",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"

--- a/fixtures/pages-plugin-mounted-on-root-app/package.json
+++ b/fixtures/pages-plugin-mounted-on-root-app/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"pages-plugin-example": "workspace:*",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"

--- a/fixtures/pages-simple-assets/package.json
+++ b/fixtures/pages-simple-assets/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	},

--- a/fixtures/pages-simple-assets/package.json
+++ b/fixtures/pages-simple-assets/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"undici": "^5.28.3",
 		"wrangler": "workspace:*"
 	},

--- a/fixtures/remix-pages-app/package.json
+++ b/fixtures/remix-pages-app/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@remix-run/cloudflare": "^1.17.0",
 		"@remix-run/dev": "^1.17.0",
 		"@remix-run/eslint-config": "^1.17.0",

--- a/fixtures/remix-pages-app/package.json
+++ b/fixtures/remix-pages-app/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@remix-run/cloudflare": "^1.17.0",
 		"@remix-run/dev": "^1.17.0",
 		"@remix-run/eslint-config": "^1.17.0",

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@types/node": "20.8.3",
 		"jose": "^5.2.2",
 		"miniflare": "workspace:*",

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@types/node": "20.8.3",
 		"jose": "^5.2.2",
 		"miniflare": "workspace:*",

--- a/fixtures/worker-ts/package.json
+++ b/fixtures/worker-ts/package.json
@@ -6,7 +6,7 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/fixtures/worker-ts/package.json
+++ b/fixtures/worker-ts/package.json
@@ -6,7 +6,7 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@changesets/changelog-github": "^0.5.0",
 		"@changesets/cli": "^2.27.1",
 		"@changesets/parse": "^0.4.0",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@ianvs/prettier-plugin-sort-imports": "4.2.1",
 		"@turbo/gen": "^1.10.13",
 		"@vue/compiler-sfc": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@changesets/changelog-github": "^0.5.0",
 		"@changesets/cli": "^2.27.1",
 		"@changesets/parse": "^0.4.0",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@ianvs/prettier-plugin-sort-imports": "4.2.1",
 		"@turbo/gen": "^1.10.13",
 		"@vue/compiler-sfc": "^3.3.4",

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -49,7 +49,7 @@
 		"@cloudflare/cli": "workspace:*",
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@iarna/toml": "^3.0.0",
 		"@types/command-exists": "^1.2.0",
 		"@types/cross-spawn": "^6.0.2",

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -49,7 +49,7 @@
 		"@cloudflare/cli": "workspace:*",
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@iarna/toml": "^3.0.0",
 		"@types/command-exists": "^1.2.0",
 		"@types/cross-spawn": "^6.0.2",

--- a/packages/edge-preview-authenticated-proxy/package.json
+++ b/packages/edge-preview-authenticated-proxy/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@types/cookie": "^0.6.0",
 		"cookie": "^0.6.0",
 		"promjs": "^0.4.2",

--- a/packages/edge-preview-authenticated-proxy/package.json
+++ b/packages/edge-preview-authenticated-proxy/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@types/cookie": "^0.6.0",
 		"cookie": "^0.6.0",
 		"promjs": "^0.4.2",

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"mustache": "^4.2.0",
 		"promjs": "^0.4.2",
 		"toucan-js": "^3.2.3",

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"mustache": "^4.2.0",
 		"promjs": "^0.4.2",
 		"toucan-js": "^3.2.3",

--- a/packages/kv-asset-handler/package.json
+++ b/packages/kv-asset-handler/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@ava/typescript": "^4.1.0",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@types/mime": "^3.0.4",
 		"@types/node": "^18.11.12",
 		"ava": "^6.0.1",

--- a/packages/kv-asset-handler/package.json
+++ b/packages/kv-asset-handler/package.json
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"@ava/typescript": "^4.1.0",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@types/mime": "^3.0.4",
 		"@types/node": "^18.11.12",
 		"ava": "^6.0.1",

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -49,7 +49,7 @@
 		"glob-to-regexp": "^0.4.1",
 		"stoppable": "^1.1.0",
 		"undici": "^5.28.2",
-		"workerd": "1.20240524.0",
+		"workerd": "1.20240603.0",
 		"ws": "^8.11.0",
 		"youch": "^3.2.2",
 		"zod": "^3.20.6"
@@ -57,7 +57,7 @@
 	"devDependencies": {
 		"@ava/typescript": "^4.0.0",
 		"@cloudflare/kv-asset-handler": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@microsoft/api-extractor": "^7.36.3",
 		"@types/debug": "^4.1.7",
 		"@types/estree": "^1.0.0",

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -49,7 +49,7 @@
 		"glob-to-regexp": "^0.4.1",
 		"stoppable": "^1.1.0",
 		"undici": "^5.28.2",
-		"workerd": "1.20240603.0",
+		"workerd": "1.20240605.0",
 		"ws": "^8.11.0",
 		"youch": "^3.2.2",
 		"zod": "^3.20.6"
@@ -57,7 +57,7 @@
 	"devDependencies": {
 		"@ava/typescript": "^4.0.0",
 		"@cloudflare/kv-asset-handler": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@microsoft/api-extractor": "^7.36.3",
 		"@types/debug": "^4.1.7",
 		"@types/estree": "^1.0.0",

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -24,7 +24,7 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@miniflare/storage-memory": "^2.14.2",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@miniflare/cache": "^2.14.2",
 		"@miniflare/core": "^2.14.2",
 		"@miniflare/html-rewriter": "^2.14.2",

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -24,7 +24,7 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@miniflare/storage-memory": "^2.14.2",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@miniflare/cache": "^2.14.2",
 		"@miniflare/core": "^2.14.2",
 		"@miniflare/html-rewriter": "^2.14.2",

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -18,7 +18,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@types/cookie": "^0.5.1",
 		"cookie": "^0.5.0",
 		"itty-router": "^4.0.13",

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -18,7 +18,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@types/cookie": "^0.5.1",
 		"cookie": "^0.5.0",
 		"itty-router": "^4.0.13",

--- a/packages/prerelease-registry/package.json
+++ b/packages/prerelease-registry/package.json
@@ -18,7 +18,7 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/packages/prerelease-registry/package.json
+++ b/packages/prerelease-registry/package.json
@@ -18,7 +18,7 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/packages/quick-edit-extension/package.json
+++ b/packages/quick-edit-extension/package.json
@@ -41,7 +41,7 @@
 	],
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"esbuild": "0.16.3",
 		"esbuild-register": "^3.4.2"
 	},

--- a/packages/quick-edit-extension/package.json
+++ b/packages/quick-edit-extension/package.json
@@ -41,7 +41,7 @@
 	],
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"esbuild": "0.16.3",
 		"esbuild-register": "^3.4.2"
 	},

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -54,7 +54,7 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@types/node": "20.8.3",
 		"@types/semver": "^7.5.1",
 		"capnp-ts": "^0.7.0",

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -54,7 +54,7 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@types/node": "20.8.3",
 		"@types/semver": "^7.5.1",
 		"capnp-ts": "^0.7.0",

--- a/packages/workers.new/package.json
+++ b/packages/workers.new/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/packages/workers.new/package.json
+++ b/packages/workers.new/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"wrangler": "workspace:*"
 	}
 }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -90,7 +90,7 @@
 		"@cloudflare/pages-shared": "workspace:^",
 		"@cloudflare/types": "^6.18.4",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240603.0",
+		"@cloudflare/workers-types": "^4.20240605.0",
 		"@cspotcode/source-map-support": "0.8.1",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
@@ -176,7 +176,7 @@
 		"fsevents": "~2.3.2"
 	},
 	"peerDependencies": {
-		"@cloudflare/workers-types": "^4.20240603.0"
+		"@cloudflare/workers-types": "^4.20240605.0"
 	},
 	"peerDependenciesMeta": {
 		"@cloudflare/workers-types": {

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -90,7 +90,7 @@
 		"@cloudflare/pages-shared": "workspace:^",
 		"@cloudflare/types": "^6.18.4",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240524.0",
+		"@cloudflare/workers-types": "^4.20240603.0",
 		"@cspotcode/source-map-support": "0.8.1",
 		"@iarna/toml": "^3.0.0",
 		"@microsoft/api-extractor": "^7.28.3",
@@ -176,7 +176,7 @@
 		"fsevents": "~2.3.2"
 	},
 	"peerDependencies": {
-		"@cloudflare/workers-types": "^4.20240524.0"
+		"@cloudflare/workers-types": "^4.20240603.0"
 	},
 	"peerDependenciesMeta": {
 		"@cloudflare/workers-types": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.2.1
         version: 4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)
@@ -100,8 +100,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -199,8 +199,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       concurrently:
         specifier: ^8.2.1
         version: 8.2.1
@@ -217,8 +217,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -232,8 +232,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -285,8 +285,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@types/node':
         specifier: ^17.0.33
         version: 17.0.45
@@ -316,8 +316,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -343,8 +343,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -362,8 +362,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       pages-plugin-example:
         specifier: workspace:*
         version: link:../pages-plugin-example
@@ -404,8 +404,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -432,8 +432,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       pages-plugin-example:
         specifier: workspace:*
         version: link:../pages-plugin-example
@@ -465,8 +465,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -577,7 +577,7 @@ importers:
     dependencies:
       '@remix-run/cloudflare-pages':
         specifier: ^1.17.0
-        version: 1.17.0(@cloudflare/workers-types@4.20240603.0)
+        version: 1.17.0(@cloudflare/workers-types@4.20240605.0)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -595,11 +595,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@remix-run/cloudflare':
         specifier: ^1.17.0
-        version: 1.17.0(@cloudflare/workers-types@4.20240603.0)
+        version: 1.17.0(@cloudflare/workers-types@4.20240605.0)
       '@remix-run/dev':
         specifier: ^1.17.0
         version: 1.17.0(@types/node@20.12.12)(encoding@0.1.13)(ts-node@10.9.2(@types/node@20.12.12)(typescript@4.9.5))
@@ -674,8 +674,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest-pool-workers
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
@@ -722,8 +722,8 @@ importers:
   fixtures/worker-ts:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -786,8 +786,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@iarna/toml':
         specifier: ^3.0.0
         version: 3.0.0
@@ -912,8 +912,8 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-worker
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -966,8 +966,8 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-worker
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
@@ -997,8 +997,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@types/mime':
         specifier: ^3.0.4
         version: 3.0.4
@@ -1039,8 +1039,8 @@ importers:
         specifier: ^5.28.2
         version: 5.28.3
       workerd:
-        specifier: 1.20240603.0
-        version: 1.20240603.0
+        specifier: 1.20240605.0
+        version: 1.20240605.0
       ws:
         specifier: ^8.11.0
         version: 8.14.2
@@ -1058,8 +1058,8 @@ importers:
         specifier: workspace:*
         version: link:../kv-asset-handler
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@microsoft/api-extractor':
         specifier: ^7.36.3
         version: 7.38.2(@types/node@18.16.10)
@@ -1158,8 +1158,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@miniflare/cache':
         specifier: ^2.14.2
         version: 2.14.2
@@ -1192,8 +1192,8 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-worker
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@types/cookie':
         specifier: ^0.5.1
         version: 0.5.1
@@ -1229,8 +1229,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -1260,8 +1260,8 @@ importers:
         specifier: workspace:^
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       esbuild:
         specifier: 0.16.3
         version: 0.16.3
@@ -1333,8 +1333,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
@@ -1519,8 +1519,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -1590,8 +1590,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240603.0
-        version: 4.20240603.0
+        specifier: ^4.20240605.0
+        version: 4.20240605.0
       '@cspotcode/source-map-support':
         specifier: 0.8.1
         version: 0.8.1
@@ -1840,7 +1840,7 @@ importers:
         version: 6.5.1
       wrangler:
         specifier: ^3.0.0
-        version: 3.55.0(@cloudflare/workers-types@4.20240603.0)
+        version: 3.55.0(@cloudflare/workers-types@4.20240605.0)
 
   tools:
     devDependencies:
@@ -2930,8 +2930,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20240603.0':
-    resolution: {integrity: sha512-XwFsqRYpADfIZm8dFOift5r8qIjnnDaI8aRmUOapWFbKbVIN2x8t1W81WTj4c41sJms4SfiLkt5mzf8HnxI0Ow==}
+  '@cloudflare/workerd-darwin-64@1.20240605.0':
+    resolution: {integrity: sha512-6V4Uze6jEM1mPBdPO6AevPwAOG2s+auEG1vPzZilwbrpn3BbYklEpQqcAZj05uUXaM6rnffnXerW8X8Fc8l4qQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -2942,8 +2942,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20240603.0':
-    resolution: {integrity: sha512-Jwfl9ykMZ/BFbuGTCMNeaBXQWGPljqWFLBiFB1aKkSrqawNukH6FGspX/GYjv/RUd+g5vPVkLB8cpiGL6sbD7Q==}
+  '@cloudflare/workerd-darwin-arm64@1.20240605.0':
+    resolution: {integrity: sha512-ZNxjVSeMYUhTfVlrMsVjpN5eHA2kq3+S7ZMsGu5l44ZqFrDygsFDoc9C4anJVUEIHGFUB9LMu4ZTdS5S80hvPQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -2954,8 +2954,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20240603.0':
-    resolution: {integrity: sha512-Vkh80USJW4mHmPp3P8Zny6LjZLwKxrPbbP7RYJQkB8QeCnDhDvpnd8H4U/+VDOeOejSjuZuRdffAxl5OYN409g==}
+  '@cloudflare/workerd-linux-64@1.20240605.0':
+    resolution: {integrity: sha512-zqOWDrYEudW5JCcU8lxCFQ96UHJJHrM+uvGaRS4u5nJaEgMr2z7u9I2286+l1R3JWvJdqj9ehGuHQvZkaTADxw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -2966,8 +2966,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20240603.0':
-    resolution: {integrity: sha512-NXn7CF21f+MiHKphoomfraZi35yzqwHh6nte685WIbfuqAx3DGJuFpqyf/6TxOnWAR8eZVnTHsUtyKNvkoXMOQ==}
+  '@cloudflare/workerd-linux-arm64@1.20240605.0':
+    resolution: {integrity: sha512-qFTVNem7bMsU9P1dXUi+kb8EdU5aag1I9RQq6ZLS/zfiJ0a/UasihwQG8lrzT7k9x80VnpyCekNmd625qsVZjQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -2978,14 +2978,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20240603.0':
-    resolution: {integrity: sha512-gPX0h86evNicG0s0waG7PxomFk1F/cD36vo+LbQaFkoh7qkCgBs1lnFo68sPK05lz0L2Nek8IE1yXTJoom7ojQ==}
+  '@cloudflare/workerd-windows-64@1.20240605.0':
+    resolution: {integrity: sha512-s0U7d52ALQtb0enbHJ/AXmy+pyBQVoTIaAdAApy/PWrMiAnb8iJhf7A35pRTYfty5SUf7EX9BAPcKmeh+t3N5g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20240603.0':
-    resolution: {integrity: sha512-KmsjZcd/dPWM51FoT08cvUGCq9l3nFEriloQ12mcdJPoW911Gi5S/9Cq4xeFvTrtk9TJ2krvxP23IeobecRmOQ==}
+  '@cloudflare/workers-types@4.20240605.0':
+    resolution: {integrity: sha512-zJw4Q6CnkaQ5JZmHRkNiSs5GfiRgUIUL8BIHPQkd2XUHZkIBv9M9yc0LKEwMYGpCFC+oSOltet6c9RjP9uQ99g==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -10793,8 +10793,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20240603.0:
-    resolution: {integrity: sha512-dENyuV99Epo85kcJxeF84acM60K5Enu70k061k7iS1EZFSJY4aFExMbUJeG2AF548ISKHwMhSTAnf8pIDqgJ5Q==}
+  workerd@1.20240605.0:
+    resolution: {integrity: sha512-2yhzgaprAOFm7H988xlRFmU4rOLXhSsq24wh6ayucMB3ORfe/nYJ2ysFn1mzjB+UxEJVt5PhixgHkZLv1S8UPQ==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -12527,34 +12527,34 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20240603.0':
+  '@cloudflare/workerd-darwin-64@1.20240605.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20240603.0':
+  '@cloudflare/workerd-darwin-arm64@1.20240605.0':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20240603.0':
+  '@cloudflare/workerd-linux-64@1.20240605.0':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20240603.0':
+  '@cloudflare/workerd-linux-arm64@1.20240605.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20240603.0':
+  '@cloudflare/workerd-windows-64@1.20240605.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20240603.0': {}
+  '@cloudflare/workers-types@4.20240605.0': {}
 
   '@colors/colors@1.5.0':
     optional: true
@@ -13605,15 +13605,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.22
 
-  '@remix-run/cloudflare-pages@1.17.0(@cloudflare/workers-types@4.20240603.0)':
+  '@remix-run/cloudflare-pages@1.17.0(@cloudflare/workers-types@4.20240605.0)':
     dependencies:
-      '@cloudflare/workers-types': 4.20240603.0
-      '@remix-run/cloudflare': 1.17.0(@cloudflare/workers-types@4.20240603.0)
+      '@cloudflare/workers-types': 4.20240605.0
+      '@remix-run/cloudflare': 1.17.0(@cloudflare/workers-types@4.20240605.0)
 
-  '@remix-run/cloudflare@1.17.0(@cloudflare/workers-types@4.20240603.0)':
+  '@remix-run/cloudflare@1.17.0(@cloudflare/workers-types@4.20240605.0)':
     dependencies:
       '@cloudflare/kv-asset-handler': 0.1.3
-      '@cloudflare/workers-types': 4.20240603.0
+      '@cloudflare/workers-types': 4.20240605.0
       '@remix-run/server-runtime': 1.17.0
 
   '@remix-run/dev@1.17.0(@types/node@20.12.12)(encoding@0.1.13)(ts-node@10.9.2(@types/node@20.12.12)(typescript@4.9.5))':
@@ -21773,15 +21773,15 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20240419.0
       '@cloudflare/workerd-windows-64': 1.20240419.0
 
-  workerd@1.20240603.0:
+  workerd@1.20240605.0:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20240603.0
-      '@cloudflare/workerd-darwin-arm64': 1.20240603.0
-      '@cloudflare/workerd-linux-64': 1.20240603.0
-      '@cloudflare/workerd-linux-arm64': 1.20240603.0
-      '@cloudflare/workerd-windows-64': 1.20240603.0
+      '@cloudflare/workerd-darwin-64': 1.20240605.0
+      '@cloudflare/workerd-darwin-arm64': 1.20240605.0
+      '@cloudflare/workerd-linux-64': 1.20240605.0
+      '@cloudflare/workerd-linux-arm64': 1.20240605.0
+      '@cloudflare/workerd-windows-64': 1.20240605.0
 
-  wrangler@3.55.0(@cloudflare/workers-types@4.20240603.0):
+  wrangler@3.55.0(@cloudflare/workers-types@4.20240605.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.2
       '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
@@ -21798,7 +21798,7 @@ snapshots:
       source-map: 0.6.1
       xxhash-wasm: 1.0.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20240603.0
+      '@cloudflare/workers-types': 4.20240605.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.2.1
         version: 4.2.1(@vue/compiler-sfc@3.3.4)(prettier@3.2.5)
@@ -100,8 +100,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -184,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -199,8 +199,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       concurrently:
         specifier: ^8.2.1
         version: 8.2.1
@@ -217,8 +217,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -232,8 +232,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -285,8 +285,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@types/node':
         specifier: ^17.0.33
         version: 17.0.45
@@ -316,8 +316,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -343,8 +343,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -362,8 +362,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       pages-plugin-example:
         specifier: workspace:*
         version: link:../pages-plugin-example
@@ -404,8 +404,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -432,8 +432,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       pages-plugin-example:
         specifier: workspace:*
         version: link:../pages-plugin-example
@@ -465,8 +465,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       undici:
         specifier: ^5.28.3
         version: 5.28.3
@@ -577,7 +577,7 @@ importers:
     dependencies:
       '@remix-run/cloudflare-pages':
         specifier: ^1.17.0
-        version: 1.17.0(@cloudflare/workers-types@4.20240524.0)
+        version: 1.17.0(@cloudflare/workers-types@4.20240603.0)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -595,11 +595,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@remix-run/cloudflare':
         specifier: ^1.17.0
-        version: 1.17.0(@cloudflare/workers-types@4.20240524.0)
+        version: 1.17.0(@cloudflare/workers-types@4.20240603.0)
       '@remix-run/dev':
         specifier: ^1.17.0
         version: 1.17.0(@types/node@20.12.12)(encoding@0.1.13)(ts-node@10.9.2(@types/node@20.12.12)(typescript@4.9.5))
@@ -674,8 +674,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest-pool-workers
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
@@ -722,8 +722,8 @@ importers:
   fixtures/worker-ts:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -786,8 +786,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@iarna/toml':
         specifier: ^3.0.0
         version: 3.0.0
@@ -912,8 +912,8 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-worker
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
@@ -966,8 +966,8 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-worker
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
@@ -997,8 +997,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@types/mime':
         specifier: ^3.0.4
         version: 3.0.4
@@ -1039,8 +1039,8 @@ importers:
         specifier: ^5.28.2
         version: 5.28.3
       workerd:
-        specifier: 1.20240524.0
-        version: 1.20240524.0
+        specifier: 1.20240603.0
+        version: 1.20240603.0
       ws:
         specifier: ^8.11.0
         version: 8.14.2
@@ -1058,8 +1058,8 @@ importers:
         specifier: workspace:*
         version: link:../kv-asset-handler
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@microsoft/api-extractor':
         specifier: ^7.36.3
         version: 7.38.2(@types/node@18.16.10)
@@ -1158,8 +1158,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@miniflare/cache':
         specifier: ^2.14.2
         version: 2.14.2
@@ -1192,8 +1192,8 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-worker
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@types/cookie':
         specifier: ^0.5.1
         version: 0.5.1
@@ -1229,8 +1229,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -1260,8 +1260,8 @@ importers:
         specifier: workspace:^
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       esbuild:
         specifier: 0.16.3
         version: 0.16.3
@@ -1333,8 +1333,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
@@ -1519,8 +1519,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -1590,8 +1590,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240524.0
-        version: 4.20240524.0
+        specifier: ^4.20240603.0
+        version: 4.20240603.0
       '@cspotcode/source-map-support':
         specifier: 0.8.1
         version: 0.8.1
@@ -1840,7 +1840,7 @@ importers:
         version: 6.5.1
       wrangler:
         specifier: ^3.0.0
-        version: 3.55.0(@cloudflare/workers-types@4.20240524.0)
+        version: 3.55.0(@cloudflare/workers-types@4.20240603.0)
 
   tools:
     devDependencies:
@@ -2930,8 +2930,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20240524.0':
-    resolution: {integrity: sha512-ATaXjefbTsrv4mpn4Fdua114RRDXcX5Ky+Mv+f4JTUllgalmqC4CYMN4jxRz9IpJU/fNMN8IEfvUyuJBAcl9Iw==}
+  '@cloudflare/workerd-darwin-64@1.20240603.0':
+    resolution: {integrity: sha512-XwFsqRYpADfIZm8dFOift5r8qIjnnDaI8aRmUOapWFbKbVIN2x8t1W81WTj4c41sJms4SfiLkt5mzf8HnxI0Ow==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -2942,8 +2942,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20240524.0':
-    resolution: {integrity: sha512-wnbsZI4CS0QPCd+wnBHQ40C28A/2Qo4ESi1YhE2735G3UNcc876MWksZhsubd+XH0XPIra6eNFqyw6wRMpQOXA==}
+  '@cloudflare/workerd-darwin-arm64@1.20240603.0':
+    resolution: {integrity: sha512-Jwfl9ykMZ/BFbuGTCMNeaBXQWGPljqWFLBiFB1aKkSrqawNukH6FGspX/GYjv/RUd+g5vPVkLB8cpiGL6sbD7Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -2954,8 +2954,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20240524.0':
-    resolution: {integrity: sha512-E8mj+HPBryKwaJAiNsYzXtVjKCL0KvUBZbtxJxlWM4mLSQhT+uwGT3nydb/hFY59rZnQgZslw0oqEWht5TEYiQ==}
+  '@cloudflare/workerd-linux-64@1.20240603.0':
+    resolution: {integrity: sha512-Vkh80USJW4mHmPp3P8Zny6LjZLwKxrPbbP7RYJQkB8QeCnDhDvpnd8H4U/+VDOeOejSjuZuRdffAxl5OYN409g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -2966,8 +2966,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20240524.0':
-    resolution: {integrity: sha512-/Fr1W671t2triNCDCBWdStxngnbUfZunZ/2e4kaMLzJDJLYDtYdmvOUCBDzUD4ssqmIMbn9RCQQ0U+CLEoqBqw==}
+  '@cloudflare/workerd-linux-arm64@1.20240603.0':
+    resolution: {integrity: sha512-NXn7CF21f+MiHKphoomfraZi35yzqwHh6nte685WIbfuqAx3DGJuFpqyf/6TxOnWAR8eZVnTHsUtyKNvkoXMOQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -2978,14 +2978,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20240524.0':
-    resolution: {integrity: sha512-G+ThDEx57g9mAEKqhWnHaaJgpeGYtyhkmwM/BDpLqPks/rAY5YEfZbY4YL1pNk1kkcZDXGrwIsY8xe9Apf5JdA==}
+  '@cloudflare/workerd-windows-64@1.20240603.0':
+    resolution: {integrity: sha512-gPX0h86evNicG0s0waG7PxomFk1F/cD36vo+LbQaFkoh7qkCgBs1lnFo68sPK05lz0L2Nek8IE1yXTJoom7ojQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20240524.0':
-    resolution: {integrity: sha512-GpSr4uE7y39DU9f0+wmrL76xd03wn0jy1ClITaa3ZZltKjirAV8TW1GzHrvvKyVGx6u3lekrFnB1HzVHsCYHDQ==}
+  '@cloudflare/workers-types@4.20240603.0':
+    resolution: {integrity: sha512-KmsjZcd/dPWM51FoT08cvUGCq9l3nFEriloQ12mcdJPoW911Gi5S/9Cq4xeFvTrtk9TJ2krvxP23IeobecRmOQ==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -10793,8 +10793,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20240524.0:
-    resolution: {integrity: sha512-LWLe5D8PVHBcqturmBbwgI71r7YPpIMYZoVEH6S4G35EqIJ55cb0n3FipoSyraoIfpcCxCFxX1K6WsRHbP3pFA==}
+  workerd@1.20240603.0:
+    resolution: {integrity: sha512-dENyuV99Epo85kcJxeF84acM60K5Enu70k061k7iS1EZFSJY4aFExMbUJeG2AF548ISKHwMhSTAnf8pIDqgJ5Q==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -12527,34 +12527,34 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20240524.0':
+  '@cloudflare/workerd-darwin-64@1.20240603.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20240524.0':
+  '@cloudflare/workerd-darwin-arm64@1.20240603.0':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20240524.0':
+  '@cloudflare/workerd-linux-64@1.20240603.0':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20240524.0':
+  '@cloudflare/workerd-linux-arm64@1.20240603.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20240419.0':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20240524.0':
+  '@cloudflare/workerd-windows-64@1.20240603.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20240524.0': {}
+  '@cloudflare/workers-types@4.20240603.0': {}
 
   '@colors/colors@1.5.0':
     optional: true
@@ -13605,15 +13605,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.22
 
-  '@remix-run/cloudflare-pages@1.17.0(@cloudflare/workers-types@4.20240524.0)':
+  '@remix-run/cloudflare-pages@1.17.0(@cloudflare/workers-types@4.20240603.0)':
     dependencies:
-      '@cloudflare/workers-types': 4.20240524.0
-      '@remix-run/cloudflare': 1.17.0(@cloudflare/workers-types@4.20240524.0)
+      '@cloudflare/workers-types': 4.20240603.0
+      '@remix-run/cloudflare': 1.17.0(@cloudflare/workers-types@4.20240603.0)
 
-  '@remix-run/cloudflare@1.17.0(@cloudflare/workers-types@4.20240524.0)':
+  '@remix-run/cloudflare@1.17.0(@cloudflare/workers-types@4.20240603.0)':
     dependencies:
       '@cloudflare/kv-asset-handler': 0.1.3
-      '@cloudflare/workers-types': 4.20240524.0
+      '@cloudflare/workers-types': 4.20240603.0
       '@remix-run/server-runtime': 1.17.0
 
   '@remix-run/dev@1.17.0(@types/node@20.12.12)(encoding@0.1.13)(ts-node@10.9.2(@types/node@20.12.12)(typescript@4.9.5))':
@@ -21773,15 +21773,15 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20240419.0
       '@cloudflare/workerd-windows-64': 1.20240419.0
 
-  workerd@1.20240524.0:
+  workerd@1.20240603.0:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20240524.0
-      '@cloudflare/workerd-darwin-arm64': 1.20240524.0
-      '@cloudflare/workerd-linux-64': 1.20240524.0
-      '@cloudflare/workerd-linux-arm64': 1.20240524.0
-      '@cloudflare/workerd-windows-64': 1.20240524.0
+      '@cloudflare/workerd-darwin-64': 1.20240603.0
+      '@cloudflare/workerd-darwin-arm64': 1.20240603.0
+      '@cloudflare/workerd-linux-64': 1.20240603.0
+      '@cloudflare/workerd-linux-arm64': 1.20240603.0
+      '@cloudflare/workerd-windows-64': 1.20240603.0
 
-  wrangler@3.55.0(@cloudflare/workers-types@4.20240524.0):
+  wrangler@3.55.0(@cloudflare/workers-types@4.20240603.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.2
       '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
@@ -21798,7 +21798,7 @@ snapshots:
       source-map: 0.6.1
       xxhash-wasm: 1.0.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20240524.0
+      '@cloudflare/workers-types': 4.20240603.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## What this PR solves / how to test

Manually bumping `workerd` and `workers-types` versions because the `dependabot` version update job seems to be broken (due to https://github.com/dependabot/dependabot-core/issues/9682)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: deps bump
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: deps bump
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: deps bump

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
