### PR TITLE
chore(cloudflare:test): improve `runInDurableObject` type

### DIFF
--- a/packages/vitest-pool-workers/types/cloudflare-test.d.ts
+++ b/packages/vitest-pool-workers/types/cloudflare-test.d.ts
@@ -45,7 +45,7 @@ declare module "cloudflare:test" {
 	 * Objects defined in the `main` worker.
 	 */
 	export function runInDurableObject<O extends DurableObject, R>(
-		stub: DurableObjectStub,
+		stub: O,
 		callback: (instance: O, state: DurableObjectState) => R | Promise<R>
 	): Promise<R>;
 	/**


### PR DESCRIPTION
## What this PR solves / how to test

This improves the `runInDurableObject` type, from `cloudflare:test`

This insures the callback's `instance` parameter infers the stub's type, which will include any typed RPC methods if they exist

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
