### PR TITLE
fix: define defineWorkersConfig using overload signatures

### DIFF
--- a/packages/vitest-pool-workers/src/config/index.ts
+++ b/packages/vitest-pool-workers/src/config/index.ts
@@ -31,25 +31,25 @@ globalThis.structuredClone ??= function (value, options) {
 	return message.message;
 };
 
-type ConfigFn<T extends UserConfig> = ((env: ConfigEnv) => T | Promise<T>);
+type ConfigFn<T extends UserConfig> = (env: ConfigEnv) => T | Promise<T>;
 
 export type AnyConfigExport<T extends UserConfig> =
 	| T
 	| Promise<T>
-	| ConfigFn<T>
+	| ConfigFn<T>;
 
 function mapAnyConfigExport<T extends UserConfig, U extends UserConfig>(
 	f: (t: T) => U,
 	config: T
-): U
+): U;
 function mapAnyConfigExport<T extends UserConfig, U extends UserConfig>(
 	f: (t: T) => U,
 	config: Promise<T>
-): Promise<U>
+): Promise<U>;
 function mapAnyConfigExport<T extends UserConfig, U extends UserConfig>(
 	f: (t: T) => U,
 	config: ConfigFn<T>
-): ConfigFn<U>
+): ConfigFn<U>;
 function mapAnyConfigExport<T extends UserConfig, U extends UserConfig>(
 	f: (t: T) => U,
 	config: AnyConfigExport<T>
@@ -178,17 +178,17 @@ function ensureWorkersConfig<T extends UserConfig>(config: T): T {
 
 export function defineWorkersConfig(
 	config: WorkersUserConfigExport
-): WorkersUserConfigExport
+): WorkersUserConfigExport;
 export function defineWorkersConfig(
 	config: Promise<WorkersUserConfigExport>
-): Promise<WorkersUserConfigExport>
+): Promise<WorkersUserConfigExport>;
 export function defineWorkersConfig(
 	config: ConfigFn<WorkersUserConfigExport>
-): ConfigFn<WorkersUserConfigExport>
+): ConfigFn<WorkersUserConfigExport>;
 export function defineWorkersConfig(
 	config: AnyConfigExport<WorkersUserConfigExport>
 ): AnyConfigExport<WorkersUserConfigExport> {
-	if (typeof config === 'function') {
+	if (typeof config === "function") {
 		return mapAnyConfigExport(ensureWorkersConfig, config);
 	} else if (config instanceof Promise) {
 		return mapAnyConfigExport(ensureWorkersConfig, config);
@@ -198,17 +198,17 @@ export function defineWorkersConfig(
 
 export function defineWorkersProject(
 	config: WorkersProjectConfigExport
-): WorkersProjectConfigExport
+): WorkersProjectConfigExport;
 export function defineWorkersProject(
 	config: Promise<WorkersProjectConfigExport>
-): Promise<WorkersProjectConfigExport>
+): Promise<WorkersProjectConfigExport>;
 export function defineWorkersProject(
 	config: ConfigFn<WorkersProjectConfigExport>
-): ConfigFn<WorkersProjectConfigExport>
+): ConfigFn<WorkersProjectConfigExport>;
 export function defineWorkersProject(
 	config: AnyConfigExport<WorkersProjectConfigExport>
 ): AnyConfigExport<WorkersProjectConfigExport> {
-	if (typeof config === 'function') {
+	if (typeof config === "function") {
 		return mapAnyConfigExport(ensureWorkersConfig, config);
 	} else if (config instanceof Promise) {
 		return mapAnyConfigExport(ensureWorkersConfig, config);

--- a/packages/vitest-pool-workers/src/config/index.ts
+++ b/packages/vitest-pool-workers/src/config/index.ts
@@ -31,10 +31,25 @@ globalThis.structuredClone ??= function (value, options) {
 	return message.message;
 };
 
+type ConfigFn<T extends UserConfig> = ((env: ConfigEnv) => T | Promise<T>);
+
 export type AnyConfigExport<T extends UserConfig> =
 	| T
 	| Promise<T>
-	| ((env: ConfigEnv) => T | Promise<T>);
+	| ConfigFn<T>
+
+function mapAnyConfigExport<T extends UserConfig, U extends UserConfig>(
+	f: (t: T) => U,
+	config: T
+): U
+function mapAnyConfigExport<T extends UserConfig, U extends UserConfig>(
+	f: (t: T) => U,
+	config: Promise<T>
+): Promise<U>
+function mapAnyConfigExport<T extends UserConfig, U extends UserConfig>(
+	f: (t: T) => U,
+	config: ConfigFn<T>
+): ConfigFn<U>
 function mapAnyConfigExport<T extends UserConfig, U extends UserConfig>(
 	f: (t: T) => U,
 	config: AnyConfigExport<T>
@@ -162,14 +177,42 @@ function ensureWorkersConfig<T extends UserConfig>(config: T): T {
 }
 
 export function defineWorkersConfig(
+	config: WorkersUserConfigExport
+): WorkersUserConfigExport
+export function defineWorkersConfig(
+	config: Promise<WorkersUserConfigExport>
+): Promise<WorkersUserConfigExport>
+export function defineWorkersConfig(
+	config: ConfigFn<WorkersUserConfigExport>
+): ConfigFn<WorkersUserConfigExport>
+export function defineWorkersConfig(
 	config: AnyConfigExport<WorkersUserConfigExport>
 ): AnyConfigExport<WorkersUserConfigExport> {
+	if (typeof config === 'function') {
+		return mapAnyConfigExport(ensureWorkersConfig, config);
+	} else if (config instanceof Promise) {
+		return mapAnyConfigExport(ensureWorkersConfig, config);
+	}
 	return mapAnyConfigExport(ensureWorkersConfig, config);
 }
 
 export function defineWorkersProject(
+	config: WorkersProjectConfigExport
+): WorkersProjectConfigExport
+export function defineWorkersProject(
+	config: Promise<WorkersProjectConfigExport>
+): Promise<WorkersProjectConfigExport>
+export function defineWorkersProject(
+	config: ConfigFn<WorkersProjectConfigExport>
+): ConfigFn<WorkersProjectConfigExport>
+export function defineWorkersProject(
 	config: AnyConfigExport<WorkersProjectConfigExport>
 ): AnyConfigExport<WorkersProjectConfigExport> {
+	if (typeof config === 'function') {
+		return mapAnyConfigExport(ensureWorkersConfig, config);
+	} else if (config instanceof Promise) {
+		return mapAnyConfigExport(ensureWorkersConfig, config);
+	}
 	return mapAnyConfigExport(ensureWorkersConfig, config);
 }
 


### PR DESCRIPTION
## What this PR solves / how to test
The type definition of `defineWorkersConfig` doesn't work with `mergeConfig` of `vitest/config` because of type mismatch
This function should be an overload function like [defineConfig](https://github.com/vitest-dev/vitest/blob/f15b4e99da1d8e5531ecc900792e3bb490fe1c7a/packages/vitest/src/config.ts#L23-L29)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] ~Not necessary because:~ Sorry but I'm not sure if I need to write additional tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: no breaking change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
