### PR TITLE
chore: allow VSCode to correctly parse tsconfig.json for ESLint tooling in sub-folders

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,5 +73,10 @@
 	},
 	"[ignore]": {
 		"editor.defaultFormatter": "foxundermoon.shell-format"
-	}
+	},
+	"eslint.workingDirectories": [
+		{
+			"mode": "auto"
+		}
+	]
 }


### PR DESCRIPTION
## What this PR solves / how to test

Currently, the VSCode ESLint extension cannot locate the `tsconfig.json` file if it is located in a sub-folder of its `package.json`. E.g.

```
/packages
  /vitest-pool-workers
    /src
      /worker
        tsconfig.json <-- not in package root
    package.json
```

For example, head to `/packages/vitest-pool-workers/src/worker/index.ts` and you will probably see this error on the first token (`import`):

```
Parsing error: Cannot read file '/path/to/workers-sdk/src/worker/tsconfig.json'.eslint
```

The ESLint extension has the `workingDirectories` setting, which we can use to tell it about these sub-folders. There are probably two options available. The first is to specify all the working directories. The downside of this is that we would have to manually update it when adding or moving folders.

The second option (the one in this PR) is to add `"mode": "auto"` and defer the decision to the extension. In some circumstances this might not work, but having tested this locally, it seems to work fine for our config structure.

I suppose there is a third option, which would be to extract the `vitest-pool-workers/src/worker` module to its own package.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: It doesn't touch released code.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: Same reason as above - not touching released code.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Same reason ^.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: Same reason ^.
