### PR TITLE
chore: add launch.json to debug single (current) test file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Debug Current Test File",
+			"type": "node",
+			"request": "launch",
+			"runtimeExecutable": "pnpm",
+			"args": ["test:file", "${file}"],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen",
+			"skipFiles": ["<node_internals>/**"],
+			"cwd": "${workspaceFolder}/tools"
+		}
+	]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1856,6 +1856,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5.55.0
         version: 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+      find-up:
+        specifier: ^6.3.0
+        version: 6.3.0
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0

--- a/tools/package.json
+++ b/tools/package.json
@@ -14,6 +14,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.55.0",
 		"@typescript-eslint/parser": "^5.55.0",
 		"ts-dedent": "^2.2.0",
-		"undici": "5.28.4"
+		"undici": "5.28.4",
+		"find-up": "^6.3.0"
 	}
 }

--- a/tools/package.json
+++ b/tools/package.json
@@ -5,7 +5,8 @@
 	"scripts": {
 		"check:type": "tsc",
 		"test:ci": "vitest run",
-		"check:lint": "eslint ."
+		"check:lint": "eslint .",
+		"test:file": "node -r esbuild-register test/run-test-file.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",

--- a/tools/test/run-test-file.ts
+++ b/tools/test/run-test-file.ts
@@ -23,7 +23,9 @@ testProcess.on("close", (code) => {
 	process.exit(code ?? 1);
 });
 
-// Function to find the nearest package.json
+/**
+ * Finds the nearest parent package.json to the provided file.
+ */
 function findNearestPackageJson(file: string) {
 	let dir = path.dirname(file);
 

--- a/tools/test/run-test-file.ts
+++ b/tools/test/run-test-file.ts
@@ -1,0 +1,38 @@
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+
+const currentFile = process.argv[2];
+const packageJsonPath = findNearestPackageJson(currentFile);
+
+if (!packageJsonPath) {
+	console.error("No package.json found.");
+	process.exit(1);
+}
+
+const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
+const packageJson = JSON.parse(packageJsonContent);
+const packageName = packageJson.name;
+
+const command = `pnpm`;
+const args = ["test", "-F", packageName, "--", currentFile];
+
+const testProcess = spawn(command, args, { stdio: "inherit" });
+
+testProcess.on("close", (code) => {
+	process.exit(code ?? 1);
+});
+
+// Function to find the nearest package.json
+function findNearestPackageJson(file: string) {
+	let dir = path.dirname(file);
+
+	while (dir !== path.resolve(dir, "..")) {
+		const jsonPath = path.join(dir, "package.json");
+		if (fs.existsSync(jsonPath)) {
+			return jsonPath;
+		}
+		dir = path.resolve(dir, "..");
+	}
+	return null;
+}

--- a/tools/test/run-test-file.ts
+++ b/tools/test/run-test-file.ts
@@ -1,9 +1,12 @@
 import { spawn } from "child_process";
 import fs from "fs";
 import path from "path";
+import { findUpSync } from "find-up";
 
 const currentFile = process.argv[2];
-const packageJsonPath = findNearestPackageJson(currentFile);
+const currentDirectory = path.dirname(currentFile);
+
+const packageJsonPath = findUpSync("package.json", { cwd: currentDirectory });
 
 if (!packageJsonPath) {
 	console.error("No package.json found.");
@@ -22,19 +25,3 @@ const testProcess = spawn(command, args, { stdio: "inherit" });
 testProcess.on("close", (code) => {
 	process.exit(code ?? 1);
 });
-
-/**
- * Finds the nearest parent package.json to the provided file.
- */
-function findNearestPackageJson(file: string) {
-	let dir = path.dirname(file);
-
-	while (dir !== path.resolve(dir, "..")) {
-		const jsonPath = path.join(dir, "package.json");
-		if (fs.existsSync(jsonPath)) {
-			return jsonPath;
-		}
-		dir = path.resolve(dir, "..");
-	}
-	return null;
-}


### PR DESCRIPTION
## What this PR solves / how to test

This is a quality-of-life improvement for debugging and testing packages locally. If you're using VSCode, and your current buffer is a test file, you can select the debug panel and you will see a "Debug Current Test File" option:

<img width="1169" alt="Screenshot 2024-06-05 at 15 34 19" src="https://github.com/cloudflare/workers-sdk/assets/1304307/af62d74d-7019-4328-874f-d1cc59b29bdc">


Hit `f5` or click the green triangle and the test will start to run in the VSCode console:

<img width="767" alt="Screenshot 2024-06-05 at 15 37 48" src="https://github.com/cloudflare/workers-sdk/assets/1304307/b74cd78a-82f0-44ee-876c-e7c32c3233d5">

This specific implementation runs as a command attached to the `tools` package, running it with `pnpm` as with any other package.json script in the repo.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: QoL update - no user-facing code touched.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: as above ^
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: as above ^ 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: as above ^