### PR TITLE
Remove builtin-wasm-modules from autogates passed to workerd

### DIFF
--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1273,12 +1273,7 @@ export class Miniflare {
 			);
 		}
 
-		const autogates = [
-			// Enables Python support in workerd.
-			// TODO(later): remove this once this gate is removed from workerd.
-			"workerd-autogate-builtin-wasm-modules",
-		];
-
+		const autogates = [];
 		return { services: servicesArray, sockets, extensions, autogates };
 	}
 


### PR DESCRIPTION
running e2e tests on behalf of #5823