### PR TITLE
fix: wrangler versions list deployable versions

### DIFF
--- a/packages/wrangler/src/versions/api.ts
+++ b/packages/wrangler/src/versions/api.ts
@@ -87,13 +87,13 @@ export async function fetchLatestDeploymentVersions(
 	return [versions, versionTraffic];
 }
 
-export async function fetchLatestUploadedVersions(
+export async function fetchDeployableVersions(
 	accountId: string,
 	workerName: string,
 	versionCache: VersionCache
 ): Promise<ApiVersion[]> {
 	const { items: versions } = await fetchResult<{ items: ApiVersion[] }>(
-		`/accounts/${accountId}/workers/scripts/${workerName}/versions`
+		`/accounts/${accountId}/workers/scripts/${workerName}/versions?deployable=true`
 	);
 
 	for (const version of versions) {

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -16,8 +16,8 @@ import { requireAuth } from "../user";
 import formatLabelledValues from "../utils/render-labelled-values";
 import {
 	createDeployment,
+	fetchDeployableVersions,
 	fetchLatestDeploymentVersions,
-	fetchLatestUploadedVersions,
 	fetchVersions,
 	patchNonVersionedScriptSettings,
 } from "./api";
@@ -269,7 +269,7 @@ async function promptVersionsToDeploy(
 	await spinnerWhile({
 		startMessage: "Fetching deployable versions",
 		async promise() {
-			await fetchLatestUploadedVersions(accountId, workerName, versionCache);
+			await fetchDeployableVersions(accountId, workerName, versionCache);
 			await fetchVersions(
 				accountId,
 				workerName,

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -6,7 +6,7 @@ import * as metrics from "../metrics";
 import { printWranglerBanner } from "../update-check";
 import { requireAuth } from "../user";
 import formatLabelledValues from "../utils/render-labelled-values";
-import { fetchLatestUploadedVersions } from "./api";
+import { fetchDeployableVersions } from "./api";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -57,7 +57,7 @@ export async function versionsListHandler(args: VersionsListArgs) {
 	}
 
 	const versionCache: VersionCache = new Map();
-	const versions = await fetchLatestUploadedVersions(
+	const versions = await fetchDeployableVersions(
 		accountId,
 		workerName,
 		versionCache


### PR DESCRIPTION
## What this PR solves / how to test

Updates existing `wrangler versions` API call to fetch deployable versions. It should be a more trust-worthy source of usable / available versions.