### PR TITLE
rename `secret:bulk` top-level command to `secret bulk` subcommand

### DIFF
--- a/.changeset/calm-flowers-doubt.md
+++ b/.changeset/calm-flowers-doubt.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feature: rename the `wrangler secret:bulk` command to `wrangler secret bulk`
+
+The old command is now deprecated (but still functional) and will be removed in a future release. The new command is now more consistent with the rest of the wrangler CLI commands.

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -33,45 +33,44 @@ describe("wrangler", () => {
 			await runWrangler();
 
 			expect(std.out).toMatchInlineSnapshot(`
-			"wrangler
+				"wrangler
 
-			Commands:
-			  wrangler docs [command..]            📚 Open wrangler's docs in your browser
-			  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
-			  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/workers-sdk/tree/main/templates
-			  wrangler dev [script]                👂 Start a local server for developing your worker
-			  wrangler deploy [script]             🆙 Deploy your Worker to Cloudflare.  [aliases: publish]
-			  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
-			  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
-			  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
-			  wrangler secret:bulk [json]          🗄️  Bulk upload secrets for a Worker
-			  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
-			  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
-			  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
-			  wrangler pages                       ⚡️ Configure Cloudflare Pages
-			  wrangler queues                      🇶 Configure Workers Queues
-			  wrangler r2                          📦 Interact with an R2 store
-			  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
-			  wrangler d1                          🗄  Interact with a D1 database
-			  wrangler hyperdrive                  🚀 Configure Hyperdrive databases
-			  wrangler ai                          🤖 Interact with AI models
-			  wrangler vectorize                   🧮 Interact with Vectorize indexes
-			  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
-			  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
-			  wrangler login                       🔓 Login to Cloudflare
-			  wrangler logout                      🚪 Logout from Cloudflare
-			  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
-			  wrangler types [path]                📝 Generate types from bindings & module rules in config
-			  wrangler deployments                 🚢 List and view details for deployments
-			  wrangler rollback [deployment-id]    🔙 Rollback a deployment
+				Commands:
+				  wrangler docs [command..]            📚 Open wrangler's docs in your browser
+				  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
+				  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/workers-sdk/tree/main/templates
+				  wrangler dev [script]                👂 Start a local server for developing your worker
+				  wrangler deploy [script]             🆙 Deploy your Worker to Cloudflare.  [aliases: publish]
+				  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
+				  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
+				  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
+				  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
+				  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
+				  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
+				  wrangler pages                       ⚡️ Configure Cloudflare Pages
+				  wrangler queues                      🇶 Configure Workers Queues
+				  wrangler r2                          📦 Interact with an R2 store
+				  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
+				  wrangler d1                          🗄  Interact with a D1 database
+				  wrangler hyperdrive                  🚀 Configure Hyperdrive databases
+				  wrangler ai                          🤖 Interact with AI models
+				  wrangler vectorize                   🧮 Interact with Vectorize indexes
+				  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
+				  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
+				  wrangler login                       🔓 Login to Cloudflare
+				  wrangler logout                      🚪 Logout from Cloudflare
+				  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
+				  wrangler types [path]                📝 Generate types from bindings & module rules in config
+				  wrangler deployments                 🚢 List and view details for deployments
+				  wrangler rollback [deployment-id]    🔙 Rollback a deployment
 
-			Flags:
-			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
-			  -c, --config                    Path to .toml configuration file  [string]
-			  -e, --env                       Environment to use for operations and .env files  [string]
-			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]"
-		`);
+				Flags:
+				  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+				  -c, --config                    Path to .toml configuration file  [string]
+				  -e, --env                       Environment to use for operations and .env files  [string]
+				  -h, --help                      Show help  [boolean]
+				  -v, --version                   Show version number  [boolean]"
+			`);
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
@@ -86,46 +85,45 @@ describe("wrangler", () => {
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
-			"
-			wrangler
+				"
+				wrangler
 
-			Commands:
-			  wrangler docs [command..]            📚 Open wrangler's docs in your browser
-			  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
-			  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/workers-sdk/tree/main/templates
-			  wrangler dev [script]                👂 Start a local server for developing your worker
-			  wrangler deploy [script]             🆙 Deploy your Worker to Cloudflare.  [aliases: publish]
-			  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
-			  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
-			  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
-			  wrangler secret:bulk [json]          🗄️  Bulk upload secrets for a Worker
-			  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
-			  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
-			  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
-			  wrangler pages                       ⚡️ Configure Cloudflare Pages
-			  wrangler queues                      🇶 Configure Workers Queues
-			  wrangler r2                          📦 Interact with an R2 store
-			  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
-			  wrangler d1                          🗄  Interact with a D1 database
-			  wrangler hyperdrive                  🚀 Configure Hyperdrive databases
-			  wrangler ai                          🤖 Interact with AI models
-			  wrangler vectorize                   🧮 Interact with Vectorize indexes
-			  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
-			  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
-			  wrangler login                       🔓 Login to Cloudflare
-			  wrangler logout                      🚪 Logout from Cloudflare
-			  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
-			  wrangler types [path]                📝 Generate types from bindings & module rules in config
-			  wrangler deployments                 🚢 List and view details for deployments
-			  wrangler rollback [deployment-id]    🔙 Rollback a deployment
+				Commands:
+				  wrangler docs [command..]            📚 Open wrangler's docs in your browser
+				  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
+				  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/workers-sdk/tree/main/templates
+				  wrangler dev [script]                👂 Start a local server for developing your worker
+				  wrangler deploy [script]             🆙 Deploy your Worker to Cloudflare.  [aliases: publish]
+				  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
+				  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
+				  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
+				  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
+				  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
+				  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
+				  wrangler pages                       ⚡️ Configure Cloudflare Pages
+				  wrangler queues                      🇶 Configure Workers Queues
+				  wrangler r2                          📦 Interact with an R2 store
+				  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
+				  wrangler d1                          🗄  Interact with a D1 database
+				  wrangler hyperdrive                  🚀 Configure Hyperdrive databases
+				  wrangler ai                          🤖 Interact with AI models
+				  wrangler vectorize                   🧮 Interact with Vectorize indexes
+				  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
+				  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
+				  wrangler login                       🔓 Login to Cloudflare
+				  wrangler logout                      🚪 Logout from Cloudflare
+				  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
+				  wrangler types [path]                📝 Generate types from bindings & module rules in config
+				  wrangler deployments                 🚢 List and view details for deployments
+				  wrangler rollback [deployment-id]    🔙 Rollback a deployment
 
-			Flags:
-			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
-			  -c, --config                    Path to .toml configuration file  [string]
-			  -e, --env                       Environment to use for operations and .env files  [string]
-			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]"
-		`);
+				Flags:
+				  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+				  -c, --config                    Path to .toml configuration file  [string]
+				  -e, --env                       Environment to use for operations and .env files  [string]
+				  -h, --help                      Show help  [boolean]
+				  -v, --version                   Show version number  [boolean]"
+			`);
 			expect(std.err).toMatchInlineSnapshot(`
 			        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: invalid-command[0m
 
@@ -166,6 +164,7 @@ describe("wrangler", () => {
 			  wrangler secret put <key>     Create or update a secret variable for a Worker
 			  wrangler secret delete <key>  Delete a secret variable from a Worker
 			  wrangler secret list          List all secrets for a Worker
+			  wrangler secret bulk [json]   🗄️  Bulk upload secrets for a Worker
 
 			Flags:
 			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -564,12 +564,12 @@ describe("wrangler secret", () => {
 		});
 	});
 
-	describe("secret:bulk", () => {
-		it("should fail secret:bulk w/ no pipe or JSON input", async () => {
+	describe("bulk", () => {
+		it("should fail secret bulk w/ no pipe or JSON input", async () => {
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() => null as unknown as Interface
 			);
-			await runWrangler(`secret:bulk --name script-name`);
+			await runWrangler(`secret bulk --name script-name`);
 			expect(std.out).toMatchInlineSnapshot(
 				`"🌀 Creating the secrets for the Worker \\"script-name\\" "`
 			);
@@ -578,9 +578,10 @@ describe("wrangler secret", () => {
 
 			"
 		`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should use secret:bulk w/ pipe input", async () => {
+		it("should use secret bulk w/ pipe input", async () => {
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() =>
 					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
@@ -611,7 +612,7 @@ describe("wrangler secret", () => {
 				)
 			);
 
-			await runWrangler(`secret:bulk --name script-name`);
+			await runWrangler(`secret bulk --name script-name`);
 			expect(std.out).toMatchInlineSnapshot(`
 			"🌀 Creating the secrets for the Worker \\"script-name\\"
 			✨ Successfully created secret for key: secret1
@@ -621,6 +622,7 @@ describe("wrangler secret", () => {
 			✨ 2 secrets successfully uploaded"
 		`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
 		it("should create secrets from JSON file", async () => {
@@ -653,7 +655,7 @@ describe("wrangler secret", () => {
 				)
 			);
 
-			await runWrangler("secret:bulk ./secret.json --name script-name");
+			await runWrangler("secret bulk ./secret.json --name script-name");
 
 			expect(std.out).toMatchInlineSnapshot(`
 					"🌀 Creating the secrets for the Worker \\"script-name\\"
@@ -664,13 +666,14 @@ describe("wrangler secret", () => {
 					✨ 2 secrets successfully uploaded"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
 		it("should fail if file is not valid JSON", async () => {
 			writeFileSync("secret.json", "bad file content");
 
 			await expect(
-				runWrangler("secret:bulk ./secret.json --name script-name")
+				runWrangler("secret bulk ./secret.json --name script-name")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The contents of "./secret.json" is not valid JSON: "ParseError: Unexpected token b"]`
 			);
@@ -685,13 +688,13 @@ describe("wrangler secret", () => {
 			);
 
 			await expect(
-				runWrangler("secret:bulk ./secret.json --name script-name")
+				runWrangler("secret bulk ./secret.json --name script-name")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: The value for "invalid-secret" in "./secret.json" is not a "string" instead it is of type "number"]`
 			);
 		});
 
-		it("should count success and network failure on secret:bulk", async () => {
+		it("should count success and network failure on secret bulk", async () => {
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -727,7 +730,7 @@ describe("wrangler secret", () => {
 			);
 
 			await expect(async () => {
-				await runWrangler("secret:bulk ./secret.json --name script-name");
+				await runWrangler("secret bulk ./secret.json --name script-name");
 			}).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: 🚨 7 secrets failed to upload]`
 			);
@@ -745,9 +748,10 @@ describe("wrangler secret", () => {
 
 			"
 		`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should handle network failure on secret:bulk", async () => {
+		it("should handle network failure on secret bulk", async () => {
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -778,7 +782,7 @@ describe("wrangler secret", () => {
 			);
 
 			await expect(async () => {
-				await runWrangler("secret:bulk ./secret.json --name script-name");
+				await runWrangler("secret bulk ./secret.json --name script-name");
 			}).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: 🚨 2 secrets failed to upload]`
 			);
@@ -796,6 +800,7 @@ describe("wrangler secret", () => {
 
 			"
 		`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
 		it("should merge existing bindings and secrets when patching", async () => {
@@ -872,7 +877,7 @@ describe("wrangler secret", () => {
 				)
 			);
 
-			await runWrangler("secret:bulk ./secret.json --name script-name");
+			await runWrangler("secret bulk ./secret.json --name script-name");
 
 			expect(std.out).toMatchInlineSnapshot(`
 					"🌀 Creating the secrets for the Worker \\"script-name\\"
@@ -884,6 +889,31 @@ describe("wrangler secret", () => {
 					✨ 3 secrets successfully uploaded"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+	});
+
+	describe("secret:bulk [DEPRECATED]", () => {
+		test("is still registered and usable", async () => {
+			const result = runWrangler("secret:bulk --help");
+
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"wrangler secret:bulk [json]
+
+				Positionals:
+				  json  The JSON file of key-value pairs to upload, in form {\\"key\\": value, ...}  [string]
+
+				Flags:
+				  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+				  -c, --config                    Path to .toml configuration file  [string]
+				  -e, --env                       Environment to use for operations and .env files  [string]
+				  -h, --help                      Show help  [boolean]
+				  -v, --version                   Show version number  [boolean]
+
+				Options:
+				      --name  Name of the Worker  [string]"
+			`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -11,45 +11,44 @@ describe("versions --help", () => {
 		await expect(result).resolves.toBeUndefined();
 
 		expect(std.out).toMatchInlineSnapshot(`
-		"wrangler
+			"wrangler
 
-		Commands:
-		  wrangler docs [command..]            📚 Open wrangler's docs in your browser
-		  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
-		  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/workers-sdk/tree/main/templates
-		  wrangler dev [script]                👂 Start a local server for developing your worker
-		  wrangler deploy [script]             🆙 Deploy your Worker to Cloudflare.  [aliases: publish]
-		  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
-		  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
-		  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
-		  wrangler secret:bulk [json]          🗄️  Bulk upload secrets for a Worker
-		  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
-		  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
-		  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
-		  wrangler pages                       ⚡️ Configure Cloudflare Pages
-		  wrangler queues                      🇶 Configure Workers Queues
-		  wrangler r2                          📦 Interact with an R2 store
-		  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
-		  wrangler d1                          🗄  Interact with a D1 database
-		  wrangler hyperdrive                  🚀 Configure Hyperdrive databases
-		  wrangler ai                          🤖 Interact with AI models
-		  wrangler vectorize                   🧮 Interact with Vectorize indexes
-		  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
-		  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
-		  wrangler login                       🔓 Login to Cloudflare
-		  wrangler logout                      🚪 Logout from Cloudflare
-		  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
-		  wrangler types [path]                📝 Generate types from bindings & module rules in config
-		  wrangler deployments                 🚢 List and view details for deployments
-		  wrangler rollback [deployment-id]    🔙 Rollback a deployment
+			Commands:
+			  wrangler docs [command..]            📚 Open wrangler's docs in your browser
+			  wrangler init [name]                 📥 Initialize a basic Worker project, including a wrangler.toml file
+			  wrangler generate [name] [template]  ✨ Generate a new Worker project from an existing Worker template. See https://github.com/cloudflare/workers-sdk/tree/main/templates
+			  wrangler dev [script]                👂 Start a local server for developing your worker
+			  wrangler deploy [script]             🆙 Deploy your Worker to Cloudflare.  [aliases: publish]
+			  wrangler delete [script]             🗑  Delete your Worker from Cloudflare.
+			  wrangler tail [worker]               🦚 Starts a log tailing session for a published Worker.
+			  wrangler secret                      🤫 Generate a secret that can be referenced in a Worker
+			  wrangler kv:namespace                🗂️  Interact with your Workers KV Namespaces
+			  wrangler kv:key                      🔑 Individually manage Workers KV key-value pairs
+			  wrangler kv:bulk                     💪 Interact with multiple Workers KV key-value pairs at once
+			  wrangler pages                       ⚡️ Configure Cloudflare Pages
+			  wrangler queues                      🇶 Configure Workers Queues
+			  wrangler r2                          📦 Interact with an R2 store
+			  wrangler dispatch-namespace          📦 Interact with a dispatch namespace
+			  wrangler d1                          🗄  Interact with a D1 database
+			  wrangler hyperdrive                  🚀 Configure Hyperdrive databases
+			  wrangler ai                          🤖 Interact with AI models
+			  wrangler vectorize                   🧮 Interact with Vectorize indexes
+			  wrangler pubsub                      📮 Interact and manage Pub/Sub Brokers
+			  wrangler mtls-certificate            🪪 Manage certificates used for mTLS connections
+			  wrangler login                       🔓 Login to Cloudflare
+			  wrangler logout                      🚪 Logout from Cloudflare
+			  wrangler whoami                      🕵️  Retrieve your user info and test your auth config
+			  wrangler types [path]                📝 Generate types from bindings & module rules in config
+			  wrangler deployments                 🚢 List and view details for deployments
+			  wrangler rollback [deployment-id]    🔙 Rollback a deployment
 
-		Flags:
-		  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
-		  -c, --config                    Path to .toml configuration file  [string]
-		  -e, --env                       Environment to use for operations and .env files  [string]
-		  -h, --help                      Show help  [boolean]
-		  -v, --version                   Show version number  [boolean]"
-	`);
+			Flags:
+			  -j, --experimental-json-config  Experimental: Support wrangler.json  [boolean]
+			  -c, --config                    Path to .toml configuration file  [string]
+			  -e, --env                       Environment to use for operations and .env files  [string]
+			  -h, --help                      Show help  [boolean]
+			  -v, --version                   Show version number  [boolean]"
+		`);
 	});
 
 	test("shows versions help w/ --help and --experimental-versions flag", async () => {

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -396,9 +396,10 @@ export function createCLIParser(argv: string[]) {
 		}
 	);
 
+	// [DEPRECATED] secret:bulk
 	wrangler.command(
 		"secret:bulk [json]",
-		"🗄️  Bulk upload secrets for a Worker",
+		false,
 		secretBulkOptions,
 		secretBulkHandler
 	);

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -310,6 +310,12 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 					sendMetrics: config.send_metrics,
 				});
 			}
+		)
+		.command(
+			"bulk [json]",
+			"🗄️  Bulk upload secrets for a Worker",
+			secretBulkOptions,
+			secretBulkHandler
 		);
 };
 
@@ -376,6 +382,12 @@ type SecretBulkArgs = StrictYargsOptionsToInterface<typeof secretBulkOptions>;
 export const secretBulkHandler = async (secretBulkArgs: SecretBulkArgs) => {
 	await printWranglerBanner();
 	const config = readConfig(secretBulkArgs.config, secretBulkArgs);
+
+	if (secretBulkArgs._.includes("secret:bulk")) {
+		logger.warn(
+			"`wrangler secret:bulk` is deprecated and will be removed in a future major version.\nPlease use `wrangler secret bulk` instead, which accepts exactly the same arguments."
+		);
+	}
 
 	const scriptName = getLegacyScriptName(secretBulkArgs, config);
 	if (!scriptName) {


### PR DESCRIPTION
and deprecate `secret:bulk` – command still exists with same functionality but also with a deprecation notice

Fixes #5168

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: unit tested
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
