### PR TITLE
fix: avoid esbuild warning when running dev/bundle

### DIFF
--- a/.changeset/famous-chicken-glow.md
+++ b/.changeset/famous-chicken-glow.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+fix: avoid esbuild warning when running dev/bundle
+
+I've been experimenting with esbuild 0.21.4 with wrangler. It's mostly been fine. But I get this warning every time
+
+```
+▲ [WARNING] Import "__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__" will always be undefined because there is no matching export in "src/index.ts" [import-is-undefined]
+
+    .wrangler/tmp/bundle-Z3YXTd/middleware-insertion-facade.js:8:23:
+      8 │ .....(OTHER_EXPORTS.__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__ ?? []),
+        ╵
+```
+
+This is because esbuild@0.18.5 enabled a warning by default whenever an undefined import is accessed on an imports object. However we abuse imports to inject stuff in `middleware.test.ts`. We should probably fix that with a better solution, but an immediate fix to this warning is to make that access not be statically analyzable. This patch does so by defining the export name as a regular variable and using that when reading from it.

--- a/packages/wrangler/src/__tests__/middleware.test.ts
+++ b/packages/wrangler/src/__tests__/middleware.test.ts
@@ -861,7 +861,19 @@ describe("middleware", () => {
 					.replace(/\/\/ .*/g, "")
 					.trim()
 			).toMatchInlineSnapshot(`
-				"var src_default = {
+				"var __defProp = Object.defineProperty;
+				var __export = (target, all) => {
+				  for (var name in all)
+				    __defProp(target, name, { get: all[name], enumerable: true });
+				};
+
+
+				var src_exports = {};
+				__export(src_exports, {
+				  DurableObjectExample: () => DurableObjectExample,
+				  default: () => src_default
+				});
+				var src_default = {
 				  async fetch(request, env) {
 				    return Response.json(env);
 				  }
@@ -875,8 +887,9 @@ describe("middleware", () => {
 				};
 
 
+				var testingMiddlewareExportName = \\"__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__\\";
 				var __INTERNAL_WRANGLER_MIDDLEWARE__ = [
-				  ...void 0 ?? []
+				  ...src_exports[testingMiddlewareExportName] ?? []
 				];
 				var middleware_insertion_facade_default = src_default;
 

--- a/packages/wrangler/src/deployment-bundle/apply-middleware.ts
+++ b/packages/wrangler/src/deployment-bundle/apply-middleware.ts
@@ -67,8 +67,10 @@ export async function applyMiddlewareLoaderFacade(
 
 				export * from "${prepareFilePath(entry.file)}";
 
+				const testingMiddlewareExportName = "__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__";
+
 				export const __INTERNAL_WRANGLER_MIDDLEWARE__ = [
-					...(OTHER_EXPORTS.__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__ ?? []),
+					...(OTHER_EXPORTS[testingMiddlewareExportName] ?? []),
 					${middlewareFns}
 				]
 				export default worker;


### PR DESCRIPTION
I've been experimenting with esbuild 0.21.4 with wrangler. It's mostly been fine. But I get this warning every time

```
▲ [WARNING] Import "__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__" will always be undefined because there is no matching export in "src/index.ts" [import-is-undefined]

    .wrangler/tmp/bundle-Z3YXTd/middleware-insertion-facade.js:8:23:
      8 │ .....(OTHER_EXPORTS.__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__ ?? []),
        ╵
```

This is because esbuild@0.18.5 enabled a warning by default whenever an undefined import is accessed on an imports object. However we abuse imports to inject stuff in `middleware.test.ts`. We should probably fix that with a better solution, but an immediate fix to this warning is to make that access not be statically analyzable. This patch does so by defining the export name as a regular variable and using that when reading from it.

