### PR TITLE
Improve `runInDurableObject` type

### DIFF
--- a/.changeset/hot-jokes-watch.md
+++ b/.changeset/hot-jokes-watch.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+chore(cloudflare:test) Improve `runInDurableObject` type
+
+[#5975](https://github.com/cloudflare/workers-sdk/pull/5975) updated the type for `runInDurableObject` to infer the stub's type correctly for RPC methods, however it used the wrong `DurableObjects` type. This PR fixes the type used to properly support RPC methods.

--- a/.changeset/hot-jokes-watch.md
+++ b/.changeset/hot-jokes-watch.md
@@ -2,6 +2,6 @@
 "@cloudflare/vitest-pool-workers": patch
 ---
 
-chore(cloudflare:test) Improve `runInDurableObject` type
+fix: improve `runInDurableObject` type
 
 [#5975](https://github.com/cloudflare/workers-sdk/pull/5975) updated the type for `runInDurableObject` to infer the stub's type correctly for RPC methods, however it used the wrong `DurableObjects` type. This PR fixes the type used to properly support RPC methods.

--- a/packages/vitest-pool-workers/types/cloudflare-test.d.ts
+++ b/packages/vitest-pool-workers/types/cloudflare-test.d.ts
@@ -44,7 +44,11 @@ declare module "cloudflare:test" {
 	 * persisted data. Note this can only be used with `stub`s pointing to Durable
 	 * Objects defined in the `main` worker.
 	 */
-	export function runInDurableObject<O extends DurableObject, R>(
+	import type * as Rpc from "cloudflare:workers";
+	export function runInDurableObject<
+		O extends DurableObject | Rpc.DurableObject,
+		R,
+	>(
 		stub: DurableObjectStub<O>,
 		callback: (instance: O, state: DurableObjectState) => R | Promise<R>
 	): Promise<R>;


### PR DESCRIPTION
## What this PR solves / how to test

[#5975](https://github.com/cloudflare/workers-sdk/pull/5975) updated the type for `runInDurableObject` to infer the stub's type correctly for RPC methods, however it used the wrong `DurableObjects` type. This PR fixes the type used to properly support RPC methods.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Types change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: Types change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: Type change

cc @RamIdeas 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
