### PR TITLE
fix: reduce the number of parallel file reads on Windows to avoid EMFILE type errors

### DIFF
--- a/.changeset/twenty-jeans-matter.md
+++ b/.changeset/twenty-jeans-matter.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: reduce the number of parallel file reads on Windows to avoid EMFILE type errors
+
+Fixes #1586

--- a/packages/wrangler/src/__tests__/utils/create-batches.test.ts
+++ b/packages/wrangler/src/__tests__/utils/create-batches.test.ts
@@ -1,0 +1,30 @@
+import { createBatches } from "../../utils/create-batches";
+
+// split a template string into an array of chars (convenience util to make writing inputs/outputs easier)
+const s = (input: TemplateStringsArray) => input[0].split("");
+
+describe("createBatches", () => {
+	const data = [
+		{
+			input: s`abcde`,
+			batchSize: 2,
+			output: [s`ab`, s`cd`, s`e`],
+		},
+		{
+			input: s`abcdefgh`,
+			batchSize: 3,
+			output: [s`abc`, s`def`, s`gh`],
+		},
+		{
+			input: s`abcdefghijklmnopqrstuvwxyz`,
+			batchSize: 6,
+			output: [s`abcdef`, s`ghijkl`, s`mnopqr`, s`stuvwx`, s`yz`],
+		},
+	];
+
+	for (const { input, batchSize, output } of data) {
+		test(`${input} in batches of ${batchSize}`, () => {
+			expect([...createBatches(input, batchSize)]).toEqual(output);
+		});
+	}
+});

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -17,6 +17,7 @@ import { getPackageManager } from "./package-manager";
 import { parsePackageJSON, parseTOML, readFileSync } from "./parse";
 import { getBasePath } from "./paths";
 import { requireAuth } from "./user";
+import { createBatches } from "./utils/create-batches";
 import * as shellquote from "./utils/shell-quote";
 import { CommandLineArgsError, printWranglerBanner } from "./index";
 import type { RawConfig } from "./config";
@@ -1151,12 +1152,6 @@ export function mapBindings(bindings: WorkerMetadataBinding[]): RawConfig {
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			}, {} as RawConfig)
 	);
-}
-
-function* createBatches<T>(array: T[], size: number): IterableIterator<T[]> {
-	for (let i = 0; i < array.length; i += size) {
-		yield array.slice(i, i + size);
-	}
 }
 
 /** Assert that there is no type argument passed. */

--- a/packages/wrangler/src/pages/constants.ts
+++ b/packages/wrangler/src/pages/constants.ts
@@ -1,10 +1,12 @@
 import { version as wranglerVersion } from "../../package.json";
 
+const isWindows = process.platform === "win32";
+
 export const MAX_ASSET_COUNT = 20_000;
 export const MAX_ASSET_SIZE = 25 * 1024 * 1024;
 export const PAGES_CONFIG_CACHE_FILENAME = "pages.json";
 export const MAX_BUCKET_SIZE = 40 * 1024 * 1024;
-export const MAX_BUCKET_FILE_COUNT = 2000;
+export const MAX_BUCKET_FILE_COUNT = isWindows ? 1000 : 2000;
 export const BULK_UPLOAD_CONCURRENCY = 3;
 export const MAX_UPLOAD_ATTEMPTS = 5;
 export const MAX_UPLOAD_GATEWAY_ERRORS = 5;

--- a/packages/wrangler/src/pages/constants.ts
+++ b/packages/wrangler/src/pages/constants.ts
@@ -6,6 +6,8 @@ export const MAX_ASSET_COUNT = 20_000;
 export const MAX_ASSET_SIZE = 25 * 1024 * 1024;
 export const PAGES_CONFIG_CACHE_FILENAME = "pages.json";
 export const MAX_BUCKET_SIZE = 40 * 1024 * 1024;
+// Reduce the maximum number of files in a bucket on Windows
+// This helps to avoid EMFILE errors when reading them into memory.
 export const MAX_BUCKET_FILE_COUNT = isWindows ? 1000 : 2000;
 export const BULK_UPLOAD_CONCURRENCY = 3;
 export const MAX_UPLOAD_ATTEMPTS = 5;

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -9,7 +9,6 @@ import { FatalError } from "../errors";
 import isInteractive from "../is-interactive";
 import { logger } from "../logger";
 import { APIError } from "../parse";
-import { createBatches } from "../utils/create-batches";
 import {
 	BULK_UPLOAD_CONCURRENCY,
 	MAX_BUCKET_FILE_COUNT,
@@ -206,23 +205,16 @@ export const upload = async (
 		const doUpload = async (): Promise<void> => {
 			// Populate the payload only when actually uploading (this is limited to 3 concurrent uploads at 50 MiB per bucket meaning we'd only load in a max of ~150 MiB)
 			// This is so we don't run out of memory trying to upload the files.
-			const payload: UploadPayloadFile[] = [];
-
-			// only read up to 1000 files, from disk, at a time to avoid `EMFILE` error (on Windows)
-			for (const batch of createBatches(bucket.files, 1000)) {
-				payload.push(
-					...(await Promise.all(
-						batch.map(async (file) => ({
-							key: file.hash,
-							value: (await readFile(file.path)).toString("base64"),
-							metadata: {
-								contentType: file.contentType,
-							},
-							base64: true,
-						}))
-					))
-				);
-			}
+			const payload: UploadPayloadFile[] = await Promise.all(
+				bucket.files.map(async (file) => ({
+					key: file.hash,
+					value: (await readFile(file.path)).toString("base64"),
+					metadata: {
+						contentType: file.contentType,
+					},
+					base64: true,
+				}))
+			);
 
 			try {
 				logger.debug("POST /pages/assets/upload");

--- a/packages/wrangler/src/utils/create-batches.ts
+++ b/packages/wrangler/src/utils/create-batches.ts
@@ -1,0 +1,8 @@
+export function* createBatches<T>(
+	array: T[],
+	size: number
+): IterableIterator<T[]> {
+	for (let i = 0; i < array.length; i += size) {
+		yield array.slice(i, i + size);
+	}
+}


### PR DESCRIPTION
## What this PR solves / how to test

Reapplies the batching reverted in https://github.com/cloudflare/workers-sdk/pull/6002 but with a tested helper method to ensure batches are correctly compiled

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
