### PR TITLE
test: add checks of uploads of very large number of Pages assets

### DIFF
--- a/packages/wrangler/src/__tests__/pages/project-upload.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-upload.test.ts
@@ -519,7 +519,7 @@ describe("pages project upload", () => {
 	it("should handle a very large number of assets", async () => {
 		const assets = new Set<string>();
 		// Create a large number of asset files to upload
-		for (let i = 0; i < 10_000; i++) {
+		for (let i = 0; i < 10_019; i++) {
 			const path = `file-${i}.txt`;
 			const content = `contents of file-${i}.txt`;
 			assets.add(content);


### PR DESCRIPTION
## What this PR solves / how to test

Adds a test to avoid accidentally breaking Pages uploads for large numbers of assets.

**This test would have failed after the #5632 change.**

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: just a new non-e2e test added
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: just adding a test
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: just adding a test

