### PR TITLE
Fix Global Contribution badge

### DIFF
--- a/.github/holopin.yml
+++ b/.github/holopin.yml
@@ -1,7 +1,7 @@
 organization: cloudflare
 stickers:
   - id: cltg4w6r612040fl2r7vweuvv
-    alias: outstanding contribution
+    alias: "[automation] outstanding contribution"
 
 holobytes:
   - evolvingStickerId: cltg4rlqc39020fl51scnguhb

--- a/.github/workflows/holopin.yml
+++ b/.github/workflows/holopin.yml
@@ -1,9 +1,13 @@
+name: Holopin
 on:
   pull_request_target:
-    types: [closed]
+    types:
+      - closed
+      - labeled
 
 jobs:
   issue_lava_lamp_holobyte:
+    name: Issue Lava Lamp Holobyte
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged }}
     steps:
@@ -13,3 +17,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.pull_request.number }}
           LABELS: contribution
+  issue_global_contribution_badge:
+    name: Issue Global Contribution badge
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'outstanding contribution'
+    steps:
+      - run: gh pr edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.HOLOPIN_LABELER }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          LABELS: "[automation] outstanding contribution"


### PR DESCRIPTION
We need workers-devprod to issue it, so I hacked this little loop around where we monitor for `outstanding contribution` labels being applied, and then just also apply the `[automation] outstanding contribution` label to do the actual issuing.