### PR TITLE
fix(wrangler): Watch for external dependencies changes in `pages dev`

### DIFF
--- a/.changeset/gorgeous-oranges-brake.md
+++ b/.changeset/gorgeous-oranges-brake.md
@@ -1,0 +1,22 @@
+---
+"wrangler": patch
+---
+
+fix: Fix `pages dev` watch mode [Functions]
+
+The watch mode in `pages dev` for Pages Functions projects is currently partially broken, as it only watches for file system changes in the
+"/functions" directory, but not for changes in any of the Functions' dependencies. This means that given a Pages Function `math-is-fun.ts`, defined as follows:
+
+```
+import { ADD } from "../math/add";
+
+export async function onRequest() {
+	return new Response(`${ADD} is fun!`);
+}
+```
+
+`pages dev` will reload for any changes in `math-is-fun.ts` itself, but not for any changes in `math/add.ts`, which is its dependency.
+
+Similarly, `pages dev` will not reload for any changes in non-JS module imports, such as wasm/html/binary module imports.
+
+This commit fixes all these things, plus adds some extra polish to the `pages dev` watch mode experience.

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -9,7 +9,7 @@ import {
 	noopModuleCollector,
 } from "../../deployment-bundle/module-collection";
 import { FatalError } from "../../errors";
-import { logger } from "../../logger";
+import { logBuildFailure, logger } from "../../logger";
 import { getBasePath } from "../../paths";
 import { getPagesProjectRoot, getPagesTmpDir } from "../utils";
 import type { BundleResult } from "../../deployment-bundle/bundle";
@@ -351,19 +351,13 @@ export function buildNotifierPlugin(onEnd: () => void): Plugin {
 		name: "wrangler notifier and monitor",
 		setup(pluginBuild) {
 			pluginBuild.onEnd((result) => {
-				if (result.errors.length > 0) {
-					logger.error(
-						`${result.errors.length} error(s) and ${result.warnings.length} warning(s) when compiling Worker.`
-					);
-				} else if (result.warnings.length > 0) {
-					logger.warn(
-						`${result.warnings.length} warning(s) when compiling Worker.`
-					);
-					onEnd();
+				if (result.errors.length > 0 || result.warnings.length > 0) {
+					logBuildFailure(result.errors, result.warnings);
 				} else {
 					logger.log("✨ Compiled Worker successfully");
-					onEnd();
 				}
+
+				onEnd();
 			});
 		},
 	};

--- a/packages/wrangler/src/pages/utils.ts
+++ b/packages/wrangler/src/pages/utils.ts
@@ -75,3 +75,22 @@ export function getPagesTmpDir(): string {
 	tmpDirCacheProjectRoot = projectRoot;
 	return tmpDirCache;
 }
+
+/**
+ * Creates a basic debounced function that delays invoking `fn` until after
+ * `delayMs` milliseconds have elapsed since the last time the debounced
+ * function was invoked.
+ */
+export function debounce(fn: () => void, delayMs = 100) {
+	let crrTimeoutId: NodeJS.Timeout | undefined;
+
+	return () => {
+		if (crrTimeoutId) {
+			clearTimeout(crrTimeoutId);
+		}
+
+		crrTimeoutId = setTimeout(() => {
+			fn();
+		}, delayMs);
+	};
+}


### PR DESCRIPTION
## What this PR solves / how to test

The watch mode in `pages dev` for Pages Functions projects is currently partially broken, as it only watches for file system changes in the `/functions` directory, but not for changes in any of the Functions' dependencies. This means that given a Pages Function `math-is-fun.ts`, defined as follows:

```
import { ADD } from "../math/add";

export async function onRequest() {
  return new Response(`${ADD} is fun!`);
}
```

`pages dev` will reload for any changes in `math-is-fun.ts` itself, but not for any changes in `math/add.ts`, which is its dependency.

Similarly, `pages dev` will not reload for any changes in non-JS module imports, such as wasm/html/binary module
imports.

This PR fixes all these things, plus adds some extra polish to the `pages dev` watch mode experience.

Fixes [#3840](https://github.com/cloudflare/workers-sdk/issues/3840)

## Solutions we considered

Pages Functions projects cannot rely on esbuild's watch mode alone. That's because the watch mode that's built into esbuild is designed specifically for only triggering a rebuild when esbuild's build inputs are changed (see https://github.com/evanw/esbuild/issues/3705). With Functions, we would actually want to trigger a rebuild every time a new file is added to the "/functions" directory.

One solution would be to use an esbuild plugin, and "teach" esbuild to watch the "/functions" directory. But it's more complicated than that. When we build Functions, one of the steps is to generate the routes based on the file tree (see [generateConfigFileFromTree](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/pages/buildFunctions.ts#L74-L77)). These routes are then injected into the esbuild entrypoint (see [templates/pages-template-worker.ts](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/templates/pages-template-worker.ts)). Delegating the "/functions" dir watching to an esbuild plugin, would mean delegating the routes generation to that plugin as well. This gets very hairy very quickly.

Another solution, is to use a combination of dependencies watching, via esbuild, and file system watching, via chokidar. The downside of this approach is that a lot of syncing between the two watch modes must be put in place, in order to avoid triggering building Functions multiple times over one single change (like for example renaming file that's part of the
dependency graph).

Another solution, which is the one we opted for here, is to delegate file watching entirely to a file system watcher, chokidar in this case. While not entirely downside-free
  - we still rely on esbuild to provide us with the dependency graph
  - we need some logic in place to pre-process and filter the dependencies we pass to chokidar
  - we need to keep track of which dependencies are being watched 
  
this solution keeps all things watch mode in one place, makes things easier to read, reason about and maintain, separates Pages <-> esbuild concerns better, and gives all the flexibility we need.

## How we tested the changes
This PR comes with e2e tests, but in addition to them, we've manually tested these changes in the following scenarios:

- add/change/delete Function file in `functions`
- add/change/delete Function file in `functions/<subdir>/**/<subdir>`
- add/change/delete `_middleware.ts` in `functions`
- add/change/delete `_middleware.ts` in `functions/<subdir>/**/<subdir>`
- change in external dependency (eg `import { ADD } from "../<dir>/**/<dir>/add"`)
- change in external module (eg `import html from "../<dir>/**/<dir>/my-html.html"`)
- bulk file add/delete
- bulk directory add/delete


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: watch mode is not documented afaik

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
