### PR TITLE
fix(wrangler): avoid path collisions between performance and Performance polyfills

### DIFF
--- a/.changeset/lazy-cycles-pull.md
+++ b/.changeset/lazy-cycles-pull.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: avoid path collisions between performance and Performance Node.js polyfills
+
+It turns out that ESBuild paths are case insensitive, which can result in path collisions between polyfills for `globalThis.performance` and `globalThis.Performance`, etc.
+
+This change ensures that we encode all global names to lowercase and decode them appropriately.

--- a/fixtures/nodejs-hybrid-app/src/index.ts
+++ b/fixtures/nodejs-hybrid-app/src/index.ts
@@ -14,6 +14,20 @@ assert(buffer2.toJSON().data[0] === 1, "global.Buffer is broken");
 const buffer3 = globalThis.Buffer.of(1);
 assert(buffer3.toJSON().data[0] === 1, "globalThis.Buffer is broken");
 
+assert(performance !== undefined, "performance is missing");
+assert(global.performance !== undefined, "global.performance is missing");
+assert(
+	globalThis.performance !== undefined,
+	"globalThis.performance is missing"
+);
+
+assert(Performance !== undefined, "Performance is missing");
+assert(global.Performance !== undefined, "global.Performance is missing");
+assert(
+	globalThis.Performance !== undefined,
+	"globalThis.Performance is missing"
+);
+
 export default {
 	async fetch(
 		request: Request,

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -181,18 +181,21 @@ function handleNodeJSGlobals(
 }
 
 /**
- * Converts a case sensitive string to lowercase string by prefixing all uppercase letters
+ * Encodes a case sensitive string to lowercase string by prefixing all uppercase letters
  * with $ and turning them into lowercase letters.
  *
  * This function exists because ESBuild requires that all resolved paths are case insensitive.
  * Without this transformation, ESBuild will clobber /foo/bar.js with /foo/Bar.js
+ *
+ * This is important to support `inject` config for `performance` and `Performance` introduced
+ * in https://github.com/unjs/unenv/pull/257
  */
 function encodeToLowerCase(str: string): string {
 	return str.replaceAll(/[A-Z]/g, (letter) => `$${letter.toLowerCase()}`);
 }
 
 /**
- * decodes string lowercased using `encodeToLowerCase` to the original strings
+ * Decodes a string lowercased using `encodeToLowerCase` to the original strings
  */
 function decodeFromLowerCase(str: string): string {
 	return str.replaceAll(

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -95,7 +95,7 @@ function handleNodeJSGlobals(
 		...Object.keys(inject).map((globalName) =>
 			nodePath.resolve(
 				getBasePath(),
-				`_virtual_unenv_global_polyfill-${globalName}.js`
+				`_virtual_unenv_global_polyfill-${encodeToLowerCase(globalName)}.js`
 			)
 		),
 	];
@@ -104,7 +104,7 @@ function handleNodeJSGlobals(
 
 	build.onLoad({ filter: UNENV_GLOBALS_RE }, ({ path }) => {
 		// eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
-		const globalName = path.match(UNENV_GLOBALS_RE)![1];
+		const globalName = decodeFromLowerCase(path.match(UNENV_GLOBALS_RE)![1]);
 		const globalMapping = inject[globalName];
 
 		if (typeof globalMapping === "string") {
@@ -132,11 +132,6 @@ function handleNodeJSGlobals(
 									*/ ""
 									}
 									/* @__PURE__ */ (() => {
-										${
-											/*
-										// TODO: should we try to preserve globalThis.${globalName} if it exists?
-										*/ ""
-										}
 										return globalThis.${globalName} = globalVar;
 									})();
 
@@ -172,11 +167,6 @@ function handleNodeJSGlobals(
 								*/ ""
 								}
 								/* @__PURE__ */ (() => {
-									${
-										/*
-									// TODO: should we try to preserve globalThis.${globalName} if it exists?
-									*/ ""
-									}
 									return globalThis.${globalName} = ${exportName};
 							})();
 
@@ -188,4 +178,25 @@ function handleNodeJSGlobals(
 						`,
 		};
 	});
+}
+
+/**
+ * Converts a case sensitive string to lowercase string by prefixing all uppercase letters
+ * with $ and turning them into lowercase letters.
+ *
+ * This function exists because ESBuild requires that all resolved paths are case insensitive.
+ * Without this transformation, ESBuild will clobber /foo/bar.js with /foo/Bar.js
+ */
+function encodeToLowerCase(str: string): string {
+	return str.replaceAll(/[A-Z]/g, (letter) => `$${letter.toLowerCase()}`);
+}
+
+/**
+ * decodes string lowercased using `encodeToLowerCase` to the original strings
+ */
+function decodeFromLowerCase(str: string): string {
+	return str.replaceAll(
+		/\$([a-z])/g,
+		(match, letter) => `${letter.toUpperCase()}`
+	);
 }


### PR DESCRIPTION
It turns out that ESBuild paths are case insensitive, which can result in path collisions between polyfills for globalThis.performance and globalThis.Performance.

This change ensures that we encode all global names to lowercase and decode them appropriately.

The version of unenv used at HEAD currently doesn't suffer from this path collision, but if not fixed the change introduced in https://github.com/unjs/unenv/pull/257/files would result in Node.js API coverage regressions. This change prevents those regressions from happening.

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
