### PR TITLE
ci: only run C3 quarantined tests in dependabot PRs if targeted

### DIFF
--- a/.github/workflows/c3-e2e-dependabot.yml
+++ b/.github/workflows/c3-e2e-dependabot.yml
@@ -79,3 +79,15 @@ jobs:
           accountId: ${{ secrets.C3_TEST_CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.C3_TEST_CLOUDFLARE_API_TOKEN }}
           saveDiffs: false
+          quarantine: false
+
+      - name: E2E Tests (quarantined)
+        uses: ./.github/actions/run-c3-e2e
+        with:
+          packageManager: ${{ matrix.pm.name }}
+          packageManagerVersion: ${{ matrix.pm.version }}
+          framework: ${{ needs.get-dependabot-bumped-framework.outputs.bumped-framework-cli }}
+          accountId: ${{ secrets.C3_TEST_CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ secrets.C3_TEST_CLOUDFLARE_API_TOKEN }}
+          saveDiffs: false
+          quarantine: true

--- a/.github/workflows/c3-e2e-quarantine.yml
+++ b/.github/workflows/c3-e2e-quarantine.yml
@@ -18,7 +18,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}
       cancel-in-progress: true
     name: ${{ format('E2E (quarantined) ({0}@{1} on {2})', matrix.pm.name, matrix.pm.version, matrix.os) }}
-    if: ${{ github.repository_owner == 'cloudflare' }}
+    if: github.repository_owner == 'cloudflare' && github.event.pull_request.user.login != 'dependabot[bot]'
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
Avoid running all the C3 quarantined tests for all frameworks in dependabot PRs
