### PR TITLE
ci: use a separate GH token for adding labels

### DIFF
--- a/.github/workflows/pr-add-e2e-label.yml
+++ b/.github/workflows/pr-add-e2e-label.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: actions/labeler@v5
         with:
           configuration-path: .github/pr-add-e2e-label.config.yml
+          repo-token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
Actions cannot trigger other actions if they use the same GH account.
The problem here was that the automated adding of e2e label did not trigger the e2e test run.