### PR TITLE
fix: hybrid nodejs compat now supports requiring the default export of a CJS module

### DIFF
--- a/.changeset/afraid-mails-kneel.md
+++ b/.changeset/afraid-mails-kneel.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: hybrid nodejs compat now supports requiring the default export of a CJS module
+
+Fixes [#6028](https://github.com/cloudflare/workers-sdk/issues/6028)

--- a/fixtures/nodejs-hybrid-app/src/dep.cjs
+++ b/fixtures/nodejs-hybrid-app/src/dep.cjs
@@ -1,0 +1,4 @@
+const Stream = require("stream");
+
+const s = new Stream();
+module.exports.s = s;

--- a/fixtures/nodejs-hybrid-app/src/index.ts
+++ b/fixtures/nodejs-hybrid-app/src/index.ts
@@ -1,7 +1,11 @@
 // node:assert/strict is currently an unenv alias to node:assert
 // this is not very common, but happens and we need to support it
 import assert from "node:assert/strict";
+import { Stream } from "node:stream";
 import { Client } from "pg";
+import { s } from "./dep.cjs";
+
+assert(s instanceof Stream, "expected s to be an instance of Stream");
 
 assert(true, "the world is broken");
 

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -1,5 +1,6 @@
 import { builtinModules } from "node:module";
 import nodePath from "node:path";
+import dedent from "ts-dedent";
 import { cloudflare, env, nodeless } from "unenv";
 import { getBasePath } from "../../paths";
 import type { Plugin, PluginBuild } from "esbuild";
@@ -39,7 +40,9 @@ function handleRequireCallsToNodeJSBuiltins(build: PluginBuild) {
 		{ filter: /.*/, namespace: REQUIRED_NODE_BUILT_IN_NAMESPACE },
 		({ path }) => {
 			return {
-				contents: `export * from '${path}'`,
+				contents: dedent`
+        import libDefault from '${path}';
+        module.exports = libDefault;`,
 				loader: "js",
 			};
 		}


### PR DESCRIPTION
## What this PR solves / how to test

Fixes [#6028](https://github.com/cloudflare/workers-sdk/issues/6028)

There is a change to the nodejs_hybrid_app fixture that demonstrates the problem and the fix.
Without this fix you get:

```
✘ [ERROR] service core:user:nodejs-hybrid-app: Uncaught TypeError: Stream2 is not a constructor

    at null.<anonymous> (index.js:8765:14) in src/dep.cjs
    at null.<anonymous> (index.js:19:50) in __require2
    at null.<anonymous> (index.js:8788:26)
```

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
