### PR TITLE
fix: avoid esbuild warning when running dev/bundle

### DIFF
--- a/.changeset/rotten-pears-hope.md
+++ b/.changeset/rotten-pears-hope.md
@@ -1,0 +1,17 @@
+---
+"wrangler": patch
+---
+
+fix: avoid esbuild warning when running dev/bundle
+
+I've been experimenting with esbuild 0.21.4 with wrangler. It's mostly been fine. But I get this warning every time
+
+```
+▲ [WARNING] Import "__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__" will always be undefined because there is no matching export in "src/index.ts" [import-is-undefined]
+
+    .wrangler/tmp/bundle-Z3YXTd/middleware-insertion-facade.js:8:23:
+      8 │ .....(OTHER_EXPORTS.__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__ ?? []),
+        ╵
+```
+
+This is because esbuild@0.18.5 enabled a warning by default whenever an undefined import is accessed on an imports object. However we abuse imports to inject stuff in `middleware.test.ts`. A simple fix is to only inject that code in tests.

--- a/packages/wrangler/src/deployment-bundle/apply-middleware.ts
+++ b/packages/wrangler/src/deployment-bundle/apply-middleware.ts
@@ -68,7 +68,7 @@ export async function applyMiddlewareLoaderFacade(
 				export * from "${prepareFilePath(entry.file)}";
 
 				export const __INTERNAL_WRANGLER_MIDDLEWARE__ = [
-					...(OTHER_EXPORTS.__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__ ?? []),
+					${process.env.NODE_ENV === "test" ? `...(OTHER_EXPORTS.__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__ ?? []),` : ""}
 					${middlewareFns}
 				]
 				export default worker;


### PR DESCRIPTION
(Another simpler take on https://github.com/cloudflare/workers-sdk/pull/5999, inspired by https://github.com/cloudflare/workers-sdk/pull/6006)

I've been experimenting with esbuild 0.21.4 with wrangler. It's mostly been fine. But I get this warning every time

```
▲ [WARNING] Import "__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__" will always be undefined because there is no matching export in "src/index.ts" [import-is-undefined]

    .wrangler/tmp/bundle-Z3YXTd/middleware-insertion-facade.js:8:23:
      8 │ .....(OTHER_EXPORTS.__INJECT_FOR_TESTING_WRANGLER_MIDDLEWARE__ ?? []),
        ╵
```

This is because esbuild@0.18.5 enabled a warning by default whenever an undefined import is accessed on an imports object. However we abuse imports to inject stuff in `middleware.test.ts`. A simple fix is to only inject that code in tests.
