### PR TITLE
Don't check expiry dates on custom certs

### DIFF
--- a/.changeset/chatty-candles-smoke.md
+++ b/.changeset/chatty-candles-smoke.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Don't check expiry dates on custom certs
+
+Fixes https://github.com/cloudflare/workers-sdk/issues/5964
+
+For `wrangler dev`, we don't have to check whether certificates have expired when they're provided by the user.

--- a/packages/wrangler/src/https-options.ts
+++ b/packages/wrangler/src/https-options.ts
@@ -37,9 +37,7 @@ export function getHttpsOptions(
 				"Missing Custom Certificate File at " + customHttpsCertPath
 			);
 		}
-		if (hasCertificateExpired(customHttpsKeyPath, customHttpsCertPath)) {
-			throw new UserError("Custom Certificate is invalid");
-		}
+
 		logger.log("Using custom certificate at ", customHttpsKeyPath);
 
 		return {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/5964

For `wrangler dev`, we don't have to check whether certificates have expired when they're provided by the user.
