### PR TITLE
setup the npm registry url with setup-node config

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -25,6 +25,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: "pnpm"
+        registry-url: "https://registry.npmjs.org"
 
     - name: "Configure turbo repo cache environment variables"
       if: inputs.turbo-api

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -53,8 +53,6 @@ jobs:
 
       - name: E2E Tests
         uses: ./.github/actions/run-c3-e2e
-        env:
-          NPM_PUBLISH_TOKEN: NOT_USED
         with:
           packageManager: ${{ matrix.pm.name }}
           packageManagerVersion: ${{ matrix.pm.version }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -47,7 +47,7 @@ jobs:
           publish: pnpm exec changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_PUBLIC_KEY: ${{ secrets.ALGOLIA_PUBLIC_KEY }}
           SENTRY_DSN: "https://9edbb8417b284aa2bbead9b4c318918b@sentry10.cfdata.org/583"

--- a/.github/workflows/d1.yml
+++ b/.github/workflows/d1.yml
@@ -34,5 +34,5 @@ jobs:
         run: pnpm publish --tag d1
         env:
           NODE_ENV: "production"
-          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
         working-directory: packages/wrangler

--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -66,7 +66,6 @@ jobs:
           pnpm run deploy
         env:
           DEBIAN_FRONTEND: noninteractive
-          NPM_PUBLISH_TOKEN: NOT_USED # yarn will error if the env var from .npmrc can't be interpolated
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Deploy Workers Playground preview

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Publish wrangler@beta to NPM
         run: pnpm --filter wrangler publish --tag beta
         env:
-          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           # this is the "test/staging" key for sparrow analytics
           SPARROW_SOURCE_KEY: "5adf183f94b3436ba78d67f506965998"
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
@@ -57,7 +57,7 @@ jobs:
       - name: Publish create-cloudflare@beta to NPM
         run: pnpm --filter create-cloudflare publish --tag beta
         env:
-          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Get Package Version
         run: echo "WRANGLER_VERSION=$(npm view wrangler@beta version)" >> $GITHUB_ENV

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}
 git-checks=false


### PR DESCRIPTION
This should remove the `WARN  Issue while reading "/Users/***/dev/cloudflare/workers-sdk/.npmrc". Failed to replace env in config: ${NPM_PUBLISH_TOKEN} ` warning we always

