### PR TITLE
test: fix vitest-pool-workers tests that rely on local workspace packages

### DIFF
--- a/packages/vitest-pool-workers/test/global-setup.ts
+++ b/packages/vitest-pool-workers/test/global-setup.ts
@@ -28,9 +28,13 @@ export default async function ({ provide }: GlobalSetupContext) {
 		await fs.mkdtemp(path.join(os.tmpdir(), "vitest-pool-workers"))
 	);
 
-	// Pack `miniflare`, `wrangler` and `vitest-pool-workers` into tarballs
+	// Pack `miniflare`, `wrangler`, `kv-asset-handler` and `vitest-pool-workers` into tarballs
 	const packDestinationPath = path.join(tmpPath, "packed");
 	const packagesRoot = path.resolve(__dirname, "../..");
+	const kvAssetHandlerTarballPath = packPackage(
+		packDestinationPath,
+		path.join(packagesRoot, "kv-asset-handler")
+	);
 	const miniflareTarballPath = packPackage(
 		packDestinationPath,
 		path.join(packagesRoot, "miniflare")
@@ -70,6 +74,7 @@ export default async function ({ provide }: GlobalSetupContext) {
 		},
 		pnpm: {
 			overrides: {
+				"@cloudflare/kv-asset-handler": kvAssetHandlerTarballPath,
 				miniflare: miniflareTarballPath,
 				wrangler: wranglerTarballPath,
 			},


### PR DESCRIPTION
## What this PR solves / how to test

These tests create a fake package that relies upon the local versions of vitest-pool-workers and its dependencies. To make this work we package up all the local dependencies and add them to pnpm overrides.

Unfortunately we missed the transitive `@cloudflare/kv-asset-handler` dependency, so when that got a version bump the tests broke.

This is the simple, naive fix - adding in this package to those being packed. We ought to find a better solution that doesn't require manual dependency tracking.


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: it is fixing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: it is only touching non-e2e tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: just a test fix
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: just a test fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
