### PR TITLE
run react eslint rules only where needed

### DIFF
--- a/packages/eslint-config-worker/index.js
+++ b/packages/eslint-config-worker/index.js
@@ -18,19 +18,7 @@ module.exports = {
 		sourceType: "module",
 		project: true,
 	},
-	settings: {
-		react: {
-			version: "detect",
-		},
-	},
-	plugins: [
-		"@typescript-eslint",
-		"eslint-plugin-react",
-		"eslint-plugin-react-hooks",
-		"import",
-		"unused-imports",
-		"no-only-tests",
-	],
+	plugins: ["@typescript-eslint", "import", "unused-imports", "no-only-tests"],
 	extends: ["turbo"],
 	overrides: [
 		{
@@ -38,8 +26,6 @@ module.exports = {
 			extends: [
 				"eslint:recommended",
 				"plugin:@typescript-eslint/recommended",
-				"plugin:react/recommended",
-				"plugin:react-hooks/recommended",
 				"plugin:import/typescript",
 				"turbo",
 			],

--- a/packages/eslint-config-worker/react.js
+++ b/packages/eslint-config-worker/react.js
@@ -1,0 +1,11 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+	extends: ["turbo", "@cloudflare/eslint-config-worker"],
+	plugins: ["eslint-plugin-react", "eslint-plugin-react-hooks"],
+	overrides: [
+		{
+			files: ["*.ts", "*.tsx"],
+			extends: ["plugin:react/recommended", "plugin:react-hooks/recommended"],
+		},
+	],
+};

--- a/packages/workers-playground/.eslintrc.js
+++ b/packages/workers-playground/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+	root: true,
+	extends: ["@cloudflare/eslint-config-worker/react"],
+	settings: {
+		react: {
+			version: "detect",
+		},
+	},
+};

--- a/packages/workers-playground/tsconfig.json
+++ b/packages/workers-playground/tsconfig.json
@@ -16,10 +16,7 @@
 		"allowSyntheticDefaultImports": true,
 
 		/* Linting */
-		"strict": true,
-		"paths": {
-			"react": ["./node_modules/@types/react"]
-		}
+		"strict": true
 	},
 	"include": ["src"],
 	"references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/wrangler/.eslintrc.js
+++ b/packages/wrangler/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	root: true,
-	extends: ["@cloudflare/eslint-config-worker"],
+	extends: ["@cloudflare/eslint-config-worker/react"],
 	ignorePatterns: [
 		"vendor",
 		"*-dist",
@@ -8,6 +8,11 @@ module.exports = {
 		"templates",
 		"emitted-types",
 	],
+	settings: {
+		react: {
+			version: "detect",
+		},
+	},
 	overrides: [
 		{
 			// TODO: add linting for `startDevWorker` workers in `templates/startDevWorker`


### PR DESCRIPTION
Our default eslint config includes react linting, and was applied to every package. However that meant we kept seeing warnings about react not being detected etc. This patch splits out the react part, and applies it only where required.
