### PR TITLE
Fix typo - "Databas" -> "Database"

### DIFF
--- a/.changeset/unlucky-hairs-train.md
+++ b/.changeset/unlucky-hairs-train.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: typo in `wrangler d1 execute` saying "Databas" instead of "Database"

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -448,7 +448,7 @@ async function executeRemotely({
 						"Total queries executed": numQueries,
 						"Rows read": meta.rows_read,
 						"Rows written": meta.rows_written,
-						"Databas size (MB)": (meta.size_after / 1_000_000).toFixed(2),
+						"Database size (MB)": (meta.size_after / 1_000_000).toFixed(2),
 					},
 				],
 				success: true,


### PR DESCRIPTION
## What this PR solves / how to test

Fixes typo in `d1 execute`

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no existing test and small typo fix
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no e2e tests covering
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: just a typo fix
