### PR TITLE
Update actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/actions/run-c3-e2e/action.yml
+++ b/.github/actions/run-c3-e2e/action.yml
@@ -61,7 +61,7 @@ runs:
         CI_OS: ${{ runner.os }}
 
     - name: Upload Logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: e2e-logs-${{matrix.os}}
@@ -69,7 +69,7 @@ runs:
 
     - name: Upload Framework Diffs
       if: ${{ steps.run-e2e.outcome == 'success' && inputs.saveDiffs == 'true' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: e2e-framework-diffs
         path: packages/create-cloudflare/.e2e-diffs

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -31,7 +31,7 @@ jobs:
         run: node .github/extract-runtime-versions.mjs # extract versions before modifying version to include commit hash
 
       - name: Upload runtime versions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: runtime-versions.md
           path: runtime-versions.md

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,14 +64,14 @@ jobs:
 
       - name: Upload debug logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-debug-logs-${{ matrix.os }}-${{ matrix.node }}
           path: ${{ runner.temp }}/wrangler-debug-logs/
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-report-${{ matrix.os }}-${{ matrix.node }}
           path: ${{ runner.temp }}/test-report/

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -93,14 +93,14 @@ jobs:
 
       - name: Upload debug logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-debug-logs-${{ matrix.os }}-${{ matrix.node }}
           path: ${{ runner.temp }}/wrangler-debug-logs/
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-report-${{ matrix.os }}-${{ matrix.node }}
           path: ${{ runner.temp }}/test-report/


### PR DESCRIPTION
This removes the warning about it using an outdated version of node. 

I don't think we need to make any changes here, but here's a reference https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md