### PR TITLE
chore: remove eslint config from workers-playground

### DIFF
--- a/packages/eslint-config-worker/react.js
+++ b/packages/eslint-config-worker/react.js
@@ -8,4 +8,9 @@ module.exports = {
 			extends: ["plugin:react/recommended", "plugin:react-hooks/recommended"],
 		},
 	],
+	settings: {
+		react: {
+			version: "detect",
+		},
+	},
 };

--- a/packages/workers-playground/.eslintrc.js
+++ b/packages/workers-playground/.eslintrc.js
@@ -1,9 +1,0 @@
-module.exports = {
-	root: true,
-	extends: ["@cloudflare/eslint-config-worker/react"],
-	settings: {
-		react: {
-			version: "detect",
-		},
-	},
-};

--- a/packages/wrangler/.eslintrc.js
+++ b/packages/wrangler/.eslintrc.js
@@ -8,11 +8,6 @@ module.exports = {
 		"templates",
 		"emitted-types",
 	],
-	settings: {
-		react: {
-			version: "detect",
-		},
-	},
 	overrides: [
 		{
 			// TODO: add linting for `startDevWorker` workers in `templates/startDevWorker`


### PR DESCRIPTION
We don't actually lint this package, so removing it for now. Followup issue: https://github.com/cloudflare/workers-sdk/issues/6074

