### PR TITLE
c3: use latest dependencies for hello-world templates

### DIFF
--- a/.changeset/tough-poets-deliver.md
+++ b/.changeset/tough-poets-deliver.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+c3: use latest dependencies for hello-world templates
+
+When generating a plain hello world worker, we're picking up older versions of vitest/pool-workers. this updates the package.jsons to pick up newer versions instead. Ideally we should automate this, but we can do that later. I also updated the wrangler deps to the current version so it's clearer for developers what they're using (still not accurate, but better than showing 3.0.0). Again, this should be automated, but we can do that later.

--- a/packages/create-cloudflare/templates/common/js/package.json
+++ b/packages/create-cloudflare/templates/common/js/package.json
@@ -9,6 +9,6 @@
 	},
 	"devDependencies": {
 		"itty-router": "^3.0.12",
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/common/ts/package.json
+++ b/packages/create-cloudflare/templates/common/ts/package.json
@@ -11,6 +11,6 @@
 	"devDependencies": {
 		"itty-router": "^3.0.12",
 		"typescript": "^5.4.5",
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world-durable-object/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/js/package.json
@@ -8,6 +8,6 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world-durable-object/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/ts/package.json
@@ -10,6 +10,6 @@
 	},
 	"devDependencies": {
 		"typescript": "^5.4.5",
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world-python/py/package.json
+++ b/packages/create-cloudflare/templates/hello-world-python/py/package.json
@@ -8,6 +8,6 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -9,8 +9,8 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"wrangler": "^3.0.0",
-		"vitest": "1.3.0",
-		"@cloudflare/vitest-pool-workers": "^0.1.0"
+		"@cloudflare/vitest-pool-workers": "^0.4.6",
+		"wrangler": "^3.60.3",
+		"vitest": "1.5.0"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -9,7 +9,7 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.6",
+		"@cloudflare/vitest-pool-workers": "^0.4.5",
 		"wrangler": "^3.60.3",
 		"vitest": "1.5.0"
 	}

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -10,9 +10,9 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
+		"@cloudflare/vitest-pool-workers": "^0.4.6",
 		"typescript": "^5.4.5",
-		"wrangler": "^3.0.0",
-		"vitest": "1.3.0",
-		"@cloudflare/vitest-pool-workers": "^0.1.0"
+		"vitest": "1.5.0",
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -10,7 +10,7 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.6",
+		"@cloudflare/vitest-pool-workers": "^0.4.5",
 		"typescript": "^5.4.5",
 		"vitest": "1.5.0",
 		"wrangler": "^3.60.3"

--- a/packages/create-cloudflare/templates/openapi/ts/package.json
+++ b/packages/create-cloudflare/templates/openapi/ts/package.json
@@ -14,6 +14,6 @@
 	"devDependencies": {
 		"@types/node": "20.8.3",
 		"@types/service-worker-mock": "^2.0.1",
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/pre-existing/js/package.json
+++ b/packages/create-cloudflare/templates/pre-existing/js/package.json
@@ -8,6 +8,6 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/queues/js/package.json
+++ b/packages/create-cloudflare/templates/queues/js/package.json
@@ -8,6 +8,6 @@
 		"start": "wrangler dev"
 	},
 	"devDependencies": {
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/queues/ts/package.json
+++ b/packages/create-cloudflare/templates/queues/ts/package.json
@@ -10,6 +10,6 @@
 	},
 	"devDependencies": {
 		"typescript": "^5.4.5",
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/scheduled/js/package.json
+++ b/packages/create-cloudflare/templates/scheduled/js/package.json
@@ -8,6 +8,6 @@
 		"start": "wrangler dev --test-scheduled"
 	},
 	"devDependencies": {
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/scheduled/ts/package.json
+++ b/packages/create-cloudflare/templates/scheduled/ts/package.json
@@ -10,6 +10,6 @@
 	},
 	"devDependencies": {
 		"typescript": "^5.4.5",
-		"wrangler": "^3.0.0"
+		"wrangler": "^3.60.3"
 	}
 }


### PR DESCRIPTION
When generating a plain hello world worker, we're picking up older versions of vitest/pool-workers. this updates the package.jsons to pick up newer versions instead. Ideally we should automate this, but we can do that later. I also updated the wrangler deps to the current version so it's clearer for developers what they're using (still not accurate, but better than showing 3.0.0). Again, this should be automated, but we can do that later.

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: alreacy covered by tests 
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: already covered 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: no functional change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
