### PR TITLE
test: improve Windows reliability of e2e tests

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+	"MD010": false,
+	"MD013": false
+}

--- a/packages/wrangler/e2e/README.md
+++ b/packages/wrangler/e2e/README.md
@@ -118,7 +118,7 @@ it(`can modify worker during ${cmd}`, async () => {
 			{
 				"name": "worker",
 				"version": "0.0.0",
-			  	"private": true
+				"private": true
 			}
 		`,
 	});

--- a/packages/wrangler/e2e/README.md
+++ b/packages/wrangler/e2e/README.md
@@ -47,24 +47,24 @@ describe("uploading Worker versions", () => {
 	beforeAll(async () => {
 		await helper.seed({
 			"wrangler.toml": dedent`
-			name = "${workerName}"
-			main = "src/index.ts"
-			compatibility_date = "2023-01-01"
-		`,
+				name = "${workerName}"
+				main = "src/index.ts"
+				compatibility_date = "2023-01-01"
+			`,
 			"src/index.ts": dedent`
-			export default {
-			fetch(request) {
-				return new Response("Hello World!")
-			}
-			}
-		`,
+				export default {
+					fetch(request) {
+						return new Response("Hello World!")
+					}
+				}
+			`,
 			"package.json": dedent`
-			{
-			"name": "${workerName}",
-			"version": "0.0.0",
-			"private": true
-			}
-		`,
+				{
+					"name": "${workerName}",
+					"version": "0.0.0",
+					"private": true
+				}
+			`,
 		});
 	});
 	it("deploy worker", async () => {

--- a/packages/wrangler/e2e/README.md
+++ b/packages/wrangler/e2e/README.md
@@ -9,7 +9,7 @@ You can then run the e2e test suite with the following commands (run them in roo
 ```zsh
 pnpm i
 pnpm build
-CLOUDFLARE_ACCOUNT_ID=8d783f274e1f82dc46744c297b015a2f CLOUDFLARE_API_TOKEN=<cloudflare-testing-api-token> WRANGLER="node --no-warnings $PWD/.tmp/wrangler/bin/wrangler.js" WRANGLER_IMPORT="$PWD/.tmp/wrangler/wrangler-dist/cli.js" pnpm --filter wrangler run test:e2e --retry 0
+CLOUDFLARE_ACCOUNT_ID=8d783f274e1f82dc46744c297b015a2f CLOUDFLARE_API_TOKEN=<cloudflare-testing-api-token> WRANGLER="node --no-warnings $PWD/packages/wrangler/bin/wrangler.js" WRANGLER_IMPORT="$PWD/packages/wrangler/wrangler-dist/cli.js" pnpm --filter wrangler run test:e2e
 ```
 
 > Make sure to replace `<cloudflare-testing-api-token>` with the actual API token you generated.

--- a/packages/wrangler/e2e/README.md
+++ b/packages/wrangler/e2e/README.md
@@ -47,24 +47,24 @@ describe("uploading Worker versions", () => {
 	beforeAll(async () => {
 		await helper.seed({
 			"wrangler.toml": dedent`
-        name = "${workerName}"
-        main = "src/index.ts"
-        compatibility_date = "2023-01-01"
-      `,
+			name = "${workerName}"
+			main = "src/index.ts"
+			compatibility_date = "2023-01-01"
+		`,
 			"src/index.ts": dedent`
-        export default {
-          fetch(request) {
-            return new Response("Hello World!")
-          }
-        }
-      `,
+			export default {
+			fetch(request) {
+				return new Response("Hello World!")
+			}
+			}
+		`,
 			"package.json": dedent`
-        {
-          "name": "${workerName}",
-          "version": "0.0.0",
-          "private": true
-        }
-      `,
+			{
+			"name": "${workerName}",
+			"version": "0.0.0",
+			"private": true
+			}
+		`,
 		});
 	});
 	it("deploy worker", async () => {
@@ -76,13 +76,13 @@ describe("uploading Worker versions", () => {
 		);
 		// Check the output looks correct
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
-      "Total Upload: xx KiB / gzip: xx KiB
-      Worker Version ID: 00000000-0000-0000-0000-000000000000
-      Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
-      To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
-      Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy --experimental-versions
-      Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"
-    `);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Worker Version ID: 00000000-0000-0000-0000-000000000000
+			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
+			To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
+			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy --experimental-versions
+			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"
+	`);
 	});
 });
 ```
@@ -100,27 +100,27 @@ it(`can modify worker during ${cmd}`, async () => {
 	const helper = new WranglerE2ETestHelper();
 	await helper.seed({
 		"wrangler.toml": dedent`
-            name = "worker"
-            main = "src/index.ts"
-            compatibility_date = "2023-01-01"
-            compatibility_flags = ["nodejs_compat"]
+			name = "worker"
+			main = "src/index.ts"
+			compatibility_date = "2023-01-01"
+			compatibility_flags = ["nodejs_compat"]
 
-            [vars]
-            KEY = "value"
-        `,
+			[vars]
+			KEY = "value"
+		`,
 		"src/index.ts": dedent`
-            export default {
-              fetch(request) {
-                return new Response("Hello World!")
-              }
-            }`,
+			export default {
+			  fetch(request) {
+				return new Response("Hello World!")
+			  }
+			}`,
 		"package.json": dedent`
-            {
-              "name": "worker",
-              "version": "0.0.0",
-              "private": true
-            }
-            `,
+			{
+			  "name": "worker",
+			  "version": "0.0.0",
+			  "private": true
+			}
+			`,
 	});
 	const worker = helper.runLongLived(cmd);
 
@@ -130,11 +130,11 @@ it(`can modify worker during ${cmd}`, async () => {
 
 	await helper.seed({
 		"src/index.ts": dedent`
-          export default {
-            fetch(request, env) {
-              return new Response("Updated Worker! " + env.KEY)
-            }
-          }`,
+		  export default {
+			fetch(request, env) {
+			  return new Response("Updated Worker! " + env.KEY)
+			}
+		  }`,
 	});
 
 	await worker.waitForReload();

--- a/packages/wrangler/e2e/README.md
+++ b/packages/wrangler/e2e/README.md
@@ -110,17 +110,17 @@ it(`can modify worker during ${cmd}`, async () => {
 		`,
 		"src/index.ts": dedent`
 			export default {
-			  fetch(request) {
-				return new Response("Hello World!")
-			  }
+				fetch(request) {
+					return new Response("Hello World!")
+				}
 			}`,
 		"package.json": dedent`
 			{
-			  "name": "worker",
-			  "version": "0.0.0",
-			  "private": true
+				"name": "worker",
+				"version": "0.0.0",
+			  	"private": true
 			}
-			`,
+		`,
 	});
 	const worker = helper.runLongLived(cmd);
 
@@ -130,11 +130,12 @@ it(`can modify worker during ${cmd}`, async () => {
 
 	await helper.seed({
 		"src/index.ts": dedent`
-		  export default {
-			fetch(request, env) {
-			  return new Response("Updated Worker! " + env.KEY)
+			export default {
+				fetch(request, env) {
+					return new Response("Updated Worker! " + env.KEY)
+				}
 			}
-		  }`,
+		`,
 	});
 
 	await worker.waitForReload();

--- a/packages/wrangler/e2e/README.md
+++ b/packages/wrangler/e2e/README.md
@@ -6,69 +6,139 @@ You can also run these tests locally, but you'll need access to the `8d783f274e1
 
 You can then run the e2e test suite with the following commands (run them in root of the repo):
 
-```sh
-rm -rf .tmp
-pnpm --filter wrangler deploy .tmp/wrangler
-rm .tmp/wrangler/templates/tsconfig.json
-CLOUDFLARE_ACCOUNT_ID=8d783f274e1f82dc46744c297b015a2f CLOUDFLARE_API_TOKEN=$CLOUDFLARE_TESTING_API_TOKEN WRANGLER="node --no-warnings $PWD/.tmp/wrangler/bin/wrangler.js" WRANGLER_IMPORT="$PWD/.tmp/wrangler/wrangler-dist/cli.js" pnpm --filter wrangler run test:e2e --retry 0
+```zsh
+pnpm i
+pnpm build
+CLOUDFLARE_ACCOUNT_ID=8d783f274e1f82dc46744c297b015a2f CLOUDFLARE_API_TOKEN=<cloudflare-testing-api-token> WRANGLER="node --no-warnings $PWD/.tmp/wrangler/bin/wrangler.js" WRANGLER_IMPORT="$PWD/.tmp/wrangler/wrangler-dist/cli.js" pnpm --filter wrangler run test:e2e --retry 0
 ```
 
-> Make sure to replace `$CLOUDFLARE_TESTING_API_TOKEN` with the actual API token you generated, and make sure you've built Wrangler (with `pnpm build`).
+> Make sure to replace `<cloudflare-testing-api-token>` with the actual API token you generated.
 
 ## How tests are written
 
-The main thing to keep in mind is that tests should be written with the custom `e2eTest()` test fixture (see https://vitest.dev/guide/test-context.html#test-extend for more details). This is defined in https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts, and is used to define tests exactly as you'd use Vitest's default `test()` function:
+These e2e tests are designed to run the actual Wrangler binary from a temporary directory containing test files.
+
+There is a helper class `WranglerE2ETestHelper` that will create a context in which to run the Wrangler binary from a temporary directory.
+This is defined in [packages/wrangler/e2e/helpers/e2e-wrangler-test.ts](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts).
+
+There are two common patterns for using this class.
+
+- Create a new instance inside each `it()` block so that the test is isolated from other tests in the file.
+- Create an instance in a `describe()` block and then use it within the contained `it()` blocks can share the context.
+
+There are four main properties of this class:
+
+- `tmpPath`: the temporary directory created for this instance.
+- `seed()`: used to write test files to the temporary directory.
+- `run()`: used to run simple Wrangler commands, such as creating a KV namespace. It returns a promise to the result of the command.
+- `runLongLived()`: used to run Wrangler commands that do not exit, such as `wrangler dev` and `wrangler tail`. It returns an object can be used to monitor and interact with the running command.
+
+### Example of simple command test
+
+This example shows the helper class being shared across `it()` blocks, so that each test can build on the previous one.
+It is using the `seed()` method to create test files in the temporary directory.
+And then uses the `run()` method to execute simple Wrangler commands and get their output.
 
 ```ts
-e2eTest("can fetch worker", async ({ run, seed }) => {
-	await seed({
-		"wrangler.toml": dedent`
-                name = "worker"
-                main = "src/index.ts"
-                compatibility_date = "2023-01-01"
-        `,
-		"src/index.ts": dedent/* javascript */ `
-            export default{
-                fetch() {
-                    return new Response("hello world");
-                },
-            };
-        `,
-		"package.json": dedent`
-            {
-                "name": "worker",
-                "version": "0.0.0",
-                "private": true
-            }
-            `,
+describe("uploading Worker versions", () => {
+	const workerName = generateResourceName();
+	const helper = new WranglerE2ETestHelper();
+
+	beforeAll(async () => {
+		await helper.seed({
+			"wrangler.toml": dedent`
+        name = "${workerName}"
+        main = "src/index.ts"
+        compatibility_date = "2023-01-01"
+      `,
+			"src/index.ts": dedent`
+        export default {
+          fetch(request) {
+            return new Response("Hello World!")
+          }
+        }
+      `,
+			"package.json": dedent`
+        {
+          "name": "${workerName}",
+          "version": "0.0.0",
+          "private": true
+        }
+      `,
+		});
 	});
-	const worker = run("wrangler dev");
-
-	const { url } = await waitForReady(worker);
-
-	await expect(fetch(url).then((r) => r.text())).resolves.toMatchInlineSnapshot(
-		'"hello world"'
-	);
+	it("deploy worker", async () => {
+		await helper.run("wrangler deploy");
+	});
+	it("upload a version", async () => {
+		const upload = await helper.run(
+			`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload"  --x-versions`
+		);
+		// Check the output looks correct
+		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
+      "Total Upload: xx KiB / gzip: xx KiB
+      Worker Version ID: 00000000-0000-0000-0000-000000000000
+      Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
+      To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
+      Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy --experimental-versions
+      Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"
+    `);
+	});
 });
 ```
 
-The above code snippet demonstrates the two main features of the `e2eTest()` fixture: `run()` and `seed()`. The `e2eTest()` fixture also provisions a temporary directory for each test run, which both `seed()` and `run()` use.
+### Example of long-lived command test
 
-### `seed()`
+This test is checking the `wrangler dev` command will watch files and rebuild them when changed.
+It is using an instance of the helper class within the `it()` block to isolate its files from other tests.
+It is using the `seed()` method to create test files in the temporary directory.
+And then uses the `runLongLived()` method to execute the `wrangler dev` command and then methods on the returned object to monitor the output from the command.
+In particular the `worker.waitForReady()` and `worker.waitForReload()` commands watch the stream of output from the process for text that indicates that the Worker is ready to receive requests and that the Worker has been rebuilt, respectively.
 
-This command allows you to seed the filesystem for a test run. It takes a single argument representing an object mapping from (relative) file paths to file contents.
+```ts
+it(`can modify worker during ${cmd}`, async () => {
+	const helper = new WranglerE2ETestHelper();
+	await helper.seed({
+		"wrangler.toml": dedent`
+            name = "worker"
+            main = "src/index.ts"
+            compatibility_date = "2023-01-01"
+            compatibility_flags = ["nodejs_compat"]
 
-### `run()`
+            [vars]
+            KEY = "value"
+        `,
+		"src/index.ts": dedent`
+            export default {
+              fetch(request) {
+                return new Response("Hello World!")
+              }
+            }`,
+		"package.json": dedent`
+            {
+              "name": "worker",
+              "version": "0.0.0",
+              "private": true
+            }
+            `,
+	});
+	const worker = helper.runLongLived(cmd);
 
-`run()` is the way to run a Wrangler command. It takes two parameters:
+	const { url } = await worker.waitForReady();
 
-- `cmd: string` This is the command that will be run. It must start with the string `wrangler` (which will be replaced with the path to the actual Wrangler executable, depending on how the e2e tests are being run).
-- `options: { debug, env, cwd }`:
-  - `debug` turns on Wrangler's debug log level, which can be helpful when asserting against Wrangler's output
-  - `env` sets the environment for the Wrangler command (it defaults to `process.env`)
-  - `cwd` sets the folder in which the Wrangler command will be run (it defaults to the temporary directory that `e2eTest()` provisions)
+	await expect(fetch(url).then((r) => r.text())).resolves.toMatchSnapshot();
 
-Depending on the type of Wrangler command you're running, there are two ways to use `run()`:
+	await helper.seed({
+		"src/index.ts": dedent`
+          export default {
+            fetch(request, env) {
+              return new Response("Updated Worker! " + env.KEY)
+            }
+          }`,
+	});
 
-1. If the Wrangler command is expected to exit quickly (i.e. `wrangler deploy`), you can await the call to `run()` (i.e. `await run("wrangler deploy")`). This will resolve with the string output resulting from running `cmd` (mixed `stdout` and `stderr`)
-2. If the Wrangler command is expected to be long-running, you can instead call `run()` _without_ `await`-ing it. See `e2e/dev.test.ts` for examples of this.
+	await worker.waitForReload();
+
+	await expect(fetchText(url)).resolves.toMatchSnapshot();
+});
+```

--- a/packages/wrangler/e2e/README.md
+++ b/packages/wrangler/e2e/README.md
@@ -31,7 +31,7 @@ There are four main properties of this class:
 - `tmpPath`: the temporary directory created for this instance.
 - `seed()`: used to write test files to the temporary directory.
 - `run()`: used to run simple Wrangler commands, such as creating a KV namespace. It returns a promise to the result of the command.
-- `runLongLived()`: used to run Wrangler commands that do not exit, such as `wrangler dev` and `wrangler tail`. It returns an object can be used to monitor and interact with the running command.
+- `runLongLived()`: used to run Wrangler commands that do not exit, such as `wrangler dev` and `wrangler tail`. It returns an object that can be used to monitor and interact with the running command.
 
 ### Example of simple command test
 

--- a/packages/wrangler/e2e/c3-integration.test.ts
+++ b/packages/wrangler/e2e/c3-integration.test.ts
@@ -1,30 +1,24 @@
+import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import shellac from "shellac";
 import { fetch } from "undici";
-import { beforeAll, describe, expect } from "vitest";
-import { e2eTest } from "./helpers/e2e-wrangler-test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
-import { makeRoot } from "./helpers/setup";
 
 describe("c3 integration", () => {
-	let workerName: string;
-	let root: string;
+	const helper = new WranglerE2ETestHelper();
+	const workerName = generateResourceName("c3");
 	let c3Packed: string;
 
 	beforeAll(async () => {
-		root = await makeRoot();
-		workerName = generateResourceName("c3");
-
 		const pathToC3 = path.resolve(__dirname, "../../create-cloudflare");
-		const { stdout: version } = await shellac.in(pathToC3)`
-			$ pnpm pack --pack-destination ./pack
-			$ ls pack`;
-
+		execSync("pnpm pack --pack-destination ./pack", { cwd: pathToC3 });
+		const version = execSync("ls pack", { encoding: "utf-8", cwd: pathToC3 });
 		c3Packed = path.join(pathToC3, "pack", version);
 	});
 
-	e2eTest("init project via c3", async ({ run }) => {
+	it("init project via c3", async () => {
 		const env = {
 			...process.env,
 			WRANGLER_C3_COMMAND: `--package ${c3Packed} dlx create-cloudflare`,
@@ -34,23 +28,21 @@ describe("c3 integration", () => {
 			GIT_COMMITTER_EMAIL: "test-user@cloudflare.com",
 		};
 
-		const init = await run(`wrangler init ${workerName} --yes`, {
+		const init = await helper.run(`wrangler init ${workerName} --yes`, {
 			env,
-			cwd: root,
 		});
 
-		expect(init).toContain("APPLICATION CREATED");
+		expect(init.stdout).toContain("APPLICATION CREATED");
 
-		expect(existsSync(path.join(root, workerName))).toBe(true);
+		expect(existsSync(path.join(helper.tmpPath, workerName))).toBe(true);
 	});
 
-	e2eTest(
-		"can run `wrangler dev` on generated worker",
-		async ({ run, waitForReady }) => {
-			const worker = run(`wrangler dev`, { cwd: path.join(root, workerName) });
-			const { url } = await waitForReady(worker);
-			const res = await fetch(url);
-			expect(await res.text()).toBe("Hello World!");
-		}
-	);
+	it("can run `wrangler dev` on generated worker", async () => {
+		const worker = helper.runLongLived(`wrangler dev`, {
+			cwd: path.join(helper.tmpPath, workerName),
+		});
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+		expect(await res.text()).toBe("Hello World!");
+	});
 });

--- a/packages/wrangler/e2e/dev-env.test.ts
+++ b/packages/wrangler/e2e/dev-env.test.ts
@@ -1,17 +1,15 @@
-import shellac from "shellac";
+import { execSync } from "child_process";
 import dedent from "ts-dedent";
 import { beforeEach, describe, expect, it } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { makeRoot, seed } from "./helpers/setup";
 import { WRANGLER_IMPORT } from "./helpers/wrangler";
 
-// TODO(DEVX-1262): re-enable when we have set an API token with the proper AI permissions
 describe("switching runtimes", () => {
-	let run: typeof shellac;
+	let root: string;
 	beforeEach(async () => {
-		const root = await makeRoot();
+		root = await makeRoot();
 
-		run = shellac.in(root).env(process.env);
 		await seed(root, {
 			"wrangler.toml": dedent`
 					name = "dev-env-app"
@@ -116,11 +114,21 @@ describe("switching runtimes", () => {
 		});
 	});
 	it("can switch from local to remote, with first fetch returning remote", async () => {
-		const { stdout } = await run`$ node index.mjs local`;
+		const stdout = execSync(`node index.mjs local`, {
+			timeout: 20_000,
+			encoding: "utf-8",
+			cwd: root,
+			stdio: "pipe",
+		});
 		expect(stdout).toContain("Hello World remote runtime");
 	});
 	it("can switch from remote to local, with first fetch returning local", async () => {
-		const { stdout } = await run`$ node index.mjs remote`;
+		const stdout = execSync(`node index.mjs remote`, {
+			timeout: 20_000,
+			encoding: "utf-8",
+			cwd: root,
+			stdio: "pipe",
+		});
 		expect(stdout).toContain("Hello World local runtime");
 	});
 });

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -22,7 +22,7 @@ const WASM_ADD_MODULE = Buffer.from(
 	"base64"
 );
 
-describe.skip.each(RUNTIMES)("Core: $flags", ({ runtime, flags }) => {
+describe.each(RUNTIMES)("Core: $flags", ({ runtime, flags }) => {
 	const isLocal = runtime === "local";
 
 	let helper: WranglerE2ETestHelper;
@@ -539,15 +539,12 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 	it.skipIf(isLocal).todo("exposes mTLS bindings");
 });
 
-describe.skip.each(RUNTIMES)(
-	"Multi-Worker Bindings: $runtime",
-	({ runtime }) => {
-		const isLocal = runtime === "local";
-		const _flags = isLocal ? [] : ["--remote"];
+describe.each(RUNTIMES)("Multi-Worker Bindings: $runtime", ({ runtime }) => {
+	const isLocal = runtime === "local";
+	const _flags = isLocal ? [] : ["--remote"];
 
-		// TODO(soon): we already have tests for service bindings in `dev.test.ts`,
-		//  but would be good to get some more for Durable Objects
-		it.todo("exposes service bindings to other workers");
-		it.todo("exposes Durable Object bindings to other workers");
-	}
-);
+	// TODO(soon): we already have tests for service bindings in `dev.test.ts`,
+	//  but would be good to get some more for Durable Objects
+	it.todo("exposes service bindings to other workers");
+	it.todo("exposes Durable Object bindings to other workers");
+});

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -3,14 +3,10 @@ import events from "node:events";
 import getPort from "get-port";
 import dedent from "ts-dedent";
 import { Agent, fetch } from "undici";
-import { afterEach, beforeEach, describe, expect } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
-import { e2eTest } from "./helpers/e2e-wrangler-test";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
-import { killAllWranglerDev } from "./helpers/wrangler";
-
-beforeEach(killAllWranglerDev);
-afterEach(killAllWranglerDev);
 
 const RUNTIMES = [
 	{ flags: "", runtime: "local" },
@@ -26,20 +22,23 @@ const WASM_ADD_MODULE = Buffer.from(
 	"base64"
 );
 
-describe.each(RUNTIMES)("Core: $flags", ({ runtime, flags }) => {
+describe.skip.each(RUNTIMES)("Core: $flags", ({ runtime, flags }) => {
 	const isLocal = runtime === "local";
 
-	e2eTest(
-		"works with basic modules format worker",
-		async ({ seed, run, waitForReady }) => {
-			const workerName = generateResourceName();
-			await seed({
-				"wrangler.toml": dedent`
+	let helper: WranglerE2ETestHelper;
+	beforeEach(() => {
+		helper = new WranglerE2ETestHelper();
+	});
+
+	it("works with basic modules format worker", async () => {
+		const workerName = generateResourceName();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					fetch(request, env, ctx) {
 						const { pathname } = new URL(request.url);
@@ -53,37 +52,34 @@ describe.each(RUNTIMES)("Core: $flags", ({ runtime, flags }) => {
 					}
 				}
 			`,
-			});
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			let res = await fetch(url);
+		});
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		let res = await fetch(url);
 
-			expect(await res.text()).toBe("modules");
+		expect(await res.text()).toBe("modules");
 
-			res = await fetch(new URL("/error", url), {
-				headers: { Accept: "text/plain" },
-			});
-			const text = await res.text();
-			if (isLocal) {
-				expect(text).toContain("Error: 🙈");
-				expect(text).toContain("src/index.ts:7:10");
-			}
-			await worker.readUntil(/Error: 🙈/);
-			await worker.readUntil(/src\/index\.ts:7:10/);
+		res = await fetch(new URL("/error", url), {
+			headers: { Accept: "text/plain" },
+		});
+		const text = await res.text();
+		if (isLocal) {
+			expect(text).toContain("Error: 🙈");
+			expect(text).toContain("src/index.ts:7:10");
 		}
-	);
+		await worker.readUntil(/Error: 🙈/, 30_000);
+		await worker.readUntil(/src\/index\.ts:7:10/, 30_000);
+	});
 
-	e2eTest(
-		"works with basic service worker",
-		async ({ seed, run, waitForReady }) => {
-			const workerName = generateResourceName();
-			await seed({
-				"wrangler.toml": dedent`
+	it("works with basic service worker", async () => {
+		const workerName = generateResourceName();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				addEventListener("fetch", (event) => {
 					const { pathname } = new URL(event.request.url);
 					if (pathname === "/") {
@@ -95,44 +91,41 @@ describe.each(RUNTIMES)("Core: $flags", ({ runtime, flags }) => {
 					}
 				});
 			`,
-			});
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			let res = await fetch(url);
-			expect(await res.text()).toBe("service worker");
+		});
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		let res = await fetch(url);
+		expect(await res.text()).toBe("service worker");
 
-			res = await fetch(new URL("/error", url), {
-				headers: { Accept: "text/plain" },
-			});
-			const text = await res.text();
-			if (isLocal) {
-				expect(text).toContain("Error: 🙈");
-				expect(text).toContain("src/index.ts:6:9");
-			}
-			await worker.readUntil(/Error: 🙈/);
-			await worker.readUntil(/src\/index\.ts:6:9/);
+		res = await fetch(new URL("/error", url), {
+			headers: { Accept: "text/plain" },
+		});
+		const text = await res.text();
+		if (isLocal) {
+			expect(text).toContain("Error: 🙈");
+			expect(text).toContain("src/index.ts:6:9");
 		}
-	);
+		await worker.readUntil(/Error: 🙈/, 30_000);
+		await worker.readUntil(/src\/index\.ts:6:9/, 30_000);
+	});
 
-	e2eTest.todo("workers with no bundle");
-	e2eTest.todo("workers with find additional modules");
+	it.todo("workers with no bundle");
+	it.todo("workers with find additional modules");
 
-	e2eTest(
-		"respects compatibility settings",
-		async ({ seed, run, waitForReady }) => {
-			const workerName = generateResourceName();
-			// `global_navigator` enabled on `2022-03-21`: https://developers.cloudflare.com/workers/configuration/compatibility-dates/#global-navigator
-			// `http_headers_getsetcookie` enabled on `2023-03-01`: https://developers.cloudflare.com/workers/configuration/compatibility-dates/#headers-supports-getsetcookie
-			// `2022-03-22` should enable `global_navigator` but disable `http_headers_getsetcookie`
-			// `nodejs_compat` has no default-on-date
-			await seed({
-				"wrangler.toml": dedent`
+	it("respects compatibility settings", async () => {
+		const workerName = generateResourceName();
+		// `global_navigator` enabled on `2022-03-21`: https://developers.cloudflare.com/workers/configuration/compatibility-dates/#global-navigator
+		// `http_headers_getsetcookie` enabled on `2023-03-01`: https://developers.cloudflare.com/workers/configuration/compatibility-dates/#headers-supports-getsetcookie
+		// `2022-03-22` should enable `global_navigator` but disable `http_headers_getsetcookie`
+		// `nodejs_compat` has no default-on-date
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2022-03-22"
 				compatibility_flags = ["nodejs_compat"]
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				import { Buffer } from "node:buffer";
 				export default {
 					fetch() {
@@ -148,51 +141,47 @@ describe.each(RUNTIMES)("Core: $flags", ({ runtime, flags }) => {
 					}
 				}
 			`,
-			});
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			const res = await fetch(url);
-			expect(await res.json()).toEqual({
-				userAgent: "Cloudflare-Workers",
-				cookies: "😈", // No cookies for you!
-				encoded: "8J+nog==",
-			});
-		}
-	);
+		});
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+		expect(await res.json()).toEqual({
+			userAgent: "Cloudflare-Workers",
+			cookies: "😈", // No cookies for you!
+			encoded: "8J+nog==",
+		});
+	});
 
-	e2eTest(
-		"starts inspector and allows debugging",
-		async ({ seed, run, waitForReady }) => {
-			const inspectorPort = await getPort();
-			const workerName = generateResourceName();
-			await seed({
-				"wrangler.toml": dedent`
+	it("starts inspector and allows debugging", async () => {
+		const inspectorPort = await getPort();
+		const workerName = generateResourceName();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					fetch(request, env, ctx) { return new Response("body"); }
 				}
 			`,
-			});
-			const worker = run(
-				`wrangler dev ${flags} --inspector-port=${inspectorPort}`
-			);
-			await waitForReady(worker);
-			const inspectorUrl = new URL(`ws://127.0.0.1:${inspectorPort}`);
-			const ws = new WebSocket(inspectorUrl);
-			await events.once(ws, "open");
-			ws.close();
-			// TODO(soon): once we have inspector proxy worker, write basic tests here,
-			//  messages currently too non-deterministic to do this reliably
-		}
-	);
+		});
+		const worker = helper.runLongLived(
+			`wrangler dev ${flags} --inspector-port=${inspectorPort}`
+		);
+		await worker.waitForReady();
+		const inspectorUrl = new URL(`ws://127.0.0.1:${inspectorPort}`);
+		const ws = new WebSocket(inspectorUrl);
+		await events.once(ws, "open");
+		ws.close();
+		// TODO(soon): once we have inspector proxy worker, write basic tests here,
+		//  messages currently too non-deterministic to do this reliably
+	});
 
-	e2eTest("starts https server", async ({ seed, run, waitForReady }) => {
+	it("starts https server", async () => {
 		const workerName = generateResourceName();
-		await seed({
+		await helper.seed({
 			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
@@ -204,8 +193,10 @@ describe.each(RUNTIMES)("Core: $flags", ({ runtime, flags }) => {
 				}
 			`,
 		});
-		const worker = run(`wrangler dev ${flags} --local-protocol=https`);
-		const { url } = await waitForReady(worker);
+		const worker = helper.runLongLived(
+			`wrangler dev ${flags} --local-protocol=https`
+		);
+		const { url } = await worker.waitForReady();
 		const parsedURL = new URL(url);
 		expect(parsedURL.protocol).toBe("https:");
 		const res = await fetch(url, {
@@ -214,29 +205,28 @@ describe.each(RUNTIMES)("Core: $flags", ({ runtime, flags }) => {
 		expect(await res.text()).toBe("🔐");
 	});
 
-	e2eTest.skipIf(!isLocal)(
-		"uses configured upstream inside worker",
-		async ({ seed, run, waitForReady }) => {
-			const workerName = generateResourceName();
-			await seed({
-				"wrangler.toml": dedent`
+	it.skipIf(!isLocal)("uses configured upstream inside worker", async () => {
+		const workerName = generateResourceName();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					fetch(request, env, ctx) { return new Response(request.url); }
 				}
 			`,
-			});
-			// TODO(soon): explore using `--host` for remote mode in this test
-			const worker = run(`wrangler dev ${flags} --local-upstream=example.com`);
-			const { url } = await waitForReady(worker);
-			const res = await fetch(url);
-			expect(await res.text()).toBe("http://example.com/");
-		}
-	);
+		});
+		// TODO(soon): explore using `--host` for remote mode in this test
+		const worker = helper.runLongLived(
+			`wrangler dev ${flags} --local-upstream=example.com`
+		);
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+		expect(await res.text()).toBe("http://example.com/");
+	});
 });
 
 describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
@@ -244,14 +234,17 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 	const resourceFlags = isLocal ? "--local" : "";
 	const d1ResourceFlags = isLocal ? "" : "--remote";
 
-	e2eTest(
-		"exposes basic bindings in service workers",
-		async ({ seed, run, waitForReady }) => {
-			const workerName = generateResourceName();
-			await seed({
-				"data/text.txt": "👋",
-				"data/binary.bin": "🌊",
-				"wrangler.toml": dedent`
+	let helper: WranglerE2ETestHelper;
+	beforeEach(() => {
+		helper = new WranglerE2ETestHelper();
+	});
+
+	it("exposes basic bindings in service workers", async () => {
+		const workerName = generateResourceName();
+		await helper.seed({
+			"data/text.txt": "👋",
+			"data/binary.bin": "🌊",
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -263,7 +256,7 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 				[data_blobs]
 				DATA_BLOB = "data/binary.bin"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				addEventListener("fetch", (event) => {
 					const res = Response.json({
 						TEXT,
@@ -274,57 +267,51 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 					event.respondWith(res);
 				});
 			`,
-			});
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			const res = await fetch(url);
-			expect(await res.json()).toEqual({
-				TEXT: "📄",
-				OBJECT: { charts: "📊" },
-				TEXT_BLOB: "👋",
-				DATA_BLOB: "🌊",
-			});
-		}
-	);
+		});
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+		expect(await res.json()).toEqual({
+			TEXT: "📄",
+			OBJECT: { charts: "📊" },
+			TEXT_BLOB: "👋",
+			DATA_BLOB: "🌊",
+		});
+	});
 
-	e2eTest(
-		"exposes WebAssembly module bindings in service workers",
-		async ({ seed, run, waitForReady }) => {
-			const workerName = generateResourceName();
-			await seed({
-				"add.wasm": WASM_ADD_MODULE,
-				"wrangler.toml": dedent`
+	it("exposes WebAssembly module bindings in service workers", async () => {
+		const workerName = generateResourceName();
+		await helper.seed({
+			"add.wasm": WASM_ADD_MODULE,
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				[wasm_modules]
 				ADD_MODULE = "add.wasm"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				addEventListener("fetch", (event) => {
 					const instance = new WebAssembly.Instance(ADD_MODULE);
 					event.respondWith(new Response(instance.exports.add(1, 2)));
 				});
 			`,
-			});
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			const res = await fetch(url);
-			expect(await res.text()).toBe("3");
-		}
-	);
+		});
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+		expect(await res.text()).toBe("3");
+	});
 
-	e2eTest(
-		"exposes KV namespace bindings",
-		async ({ kv, run, seed, waitForReady }) => {
-			const ns = await kv(isLocal);
-			await run(
-				`wrangler kv key put ${resourceFlags} --namespace-id=${ns} existing-key existing-value`
-			);
+	it("exposes KV namespace bindings", async () => {
+		const ns = await helper.kv(isLocal);
+		await helper.runLongLived(
+			`wrangler kv key put ${resourceFlags} --namespace-id=${ns} existing-key existing-value`
+		);
 
-			const workerName = generateResourceName();
-			await seed({
-				"wrangler.toml": dedent`
+		const workerName = generateResourceName();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -332,7 +319,7 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 					{ binding = "NAMESPACE", id = "${ns}", preview_id = "${ns}" }
 				]
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					async fetch(request, env, ctx) {
 						console.log(await env.NAMESPACE.list())
@@ -342,34 +329,31 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 					}
 				}
 			`,
-			});
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			const res = await fetch(url);
-			expect(await res.text()).toBe("existing-value");
+		});
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+		expect(await res.text()).toBe("existing-value");
 
-			const result = await run(
-				`wrangler kv key get ${resourceFlags} --namespace-id=${ns} new-key`
-			);
-			expect(result).toBe("new-value");
-		}
-	);
+		const result = await helper.run(
+			`wrangler kv key get ${resourceFlags} --namespace-id=${ns} new-key`
+		);
+		expect(result.stdout).toBe("new-value");
+	});
 
-	e2eTest(
-		"supports Workers Sites bindings",
-		async ({ seed, run, waitForReady }) => {
-			const workerName = generateResourceName();
-			const kvAssetHandler = require.resolve("@cloudflare/kv-asset-handler");
-			await seed({
-				"public/index.html": "<h1>👋</h1>",
-				"wrangler.toml": dedent`
+	it("supports Workers Sites bindings", async () => {
+		const workerName = generateResourceName();
+		const kvAssetHandler = require.resolve("@cloudflare/kv-asset-handler");
+		await helper.seed({
+			"public/index.html": "<h1>👋</h1>",
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				[site]
 				bucket = "./public"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				import { getAssetFromKV, KVError } from ${JSON.stringify(kvAssetHandler)};
 				import manifestJSON from "__STATIC_CONTENT_MANIFEST";
 				const manifest = JSON.parse(manifestJSON);
@@ -391,47 +375,46 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 					}
 				}
 			`,
-			});
+		});
 
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			const res = await fetch(url);
-			expect(await res.text()).toBe("<h1>👋</h1>");
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+		expect(await res.text()).toBe("<h1>👋</h1>");
 
-			// Try to clean up created remote Workers Sites namespace
-			if (!isLocal) {
-				const listResult = await run(`wrangler kv namespace list`);
-				const list = JSON.parse(
-					// Ignore extra debug output
-					listResult.substring(
-						listResult.indexOf("["),
-						listResult.lastIndexOf("]") + 1
-					)
+		// Try to clean up created remote Workers Sites namespace
+		if (!isLocal) {
+			const listResult = await helper.run(`wrangler kv namespace list`);
+			const list = JSON.parse(
+				// Ignore extra debug output
+				listResult.stdout.substring(
+					listResult.stdout.indexOf("["),
+					listResult.stdout.lastIndexOf("]") + 1
+				)
+			);
+			assert(Array.isArray(list));
+			const ns = list.find(({ title }) => title.includes(workerName));
+			if (ns === undefined) {
+				console.warn("Couldn't find Workers Sites namespace to delete");
+			} else {
+				await helper.run(
+					`wrangler kv namespace delete --namespace-id ${ns.id}`
 				);
-				assert(Array.isArray(list));
-				const ns = list.find(({ title }) => title.includes(workerName));
-				if (ns === undefined) {
-					console.warn("Couldn't find Workers Sites namespace to delete");
-				} else {
-					await run(`wrangler kv namespace delete --namespace-id ${ns.id}`);
-				}
 			}
 		}
-	);
+	});
 
-	e2eTest(
-		"exposes R2 bucket bindings",
-		async ({ seed, run, r2, waitForReady }) => {
-			await seed({ "test.txt": "existing-value" });
+	it("exposes R2 bucket bindings", async () => {
+		await helper.seed({ "test.txt": "existing-value" });
 
-			const name = await r2(isLocal);
-			await run(
-				`wrangler r2 object put ${resourceFlags} ${name}/existing-key --file test.txt`
-			);
+		const name = await helper.r2(isLocal);
+		await helper.run(
+			`wrangler r2 object put ${resourceFlags} ${name}/existing-key --file test.txt`
+		);
 
-			const workerName = generateResourceName();
-			await seed({
-				"wrangler.toml": dedent`
+		const workerName = generateResourceName();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -439,7 +422,7 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 					{ binding = "BUCKET", bucket_name = "${name}", preview_bucket_name = "${name}" }
 				]
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					async fetch(request, env, ctx) {
 						const value = await env.BUCKET.get("existing-key");
@@ -448,32 +431,31 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 					}
 				}
 			`,
-			});
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			const res = await fetch(url);
-			expect(await res.text()).toBe("existing-value");
+		});
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+		expect(await res.text()).toBe("existing-value");
 
-			const result = await run(
-				`wrangler r2 object get ${resourceFlags} ${name}/new-key --pipe`
-			);
-			// TODO(soon): make this `toBe()` once we remove `Logs were written` message
-			expect(result).toContain("new-value");
+		const result = await helper.run(
+			`wrangler r2 object get ${resourceFlags} ${name}/new-key --pipe`
+		);
+		// TODO(soon): make this `toBe()` once we remove `Logs were written` message
+		expect(result.stdout).toContain("new-value");
 
-			await run(
-				`wrangler r2 object delete ${resourceFlags} ${name}/existing-key`
-			);
-			await run(`wrangler r2 object delete ${resourceFlags} ${name}/new-key`);
-		}
-	);
+		await helper.run(
+			`wrangler r2 object delete ${resourceFlags} ${name}/existing-key`
+		);
+		await helper.run(
+			`wrangler r2 object delete ${resourceFlags} ${name}/new-key`
+		);
+	});
 
-	e2eTest(
-		"exposes D1 database bindings",
-		async ({ seed, run, d1, waitForReady }) => {
-			const { id, name } = await d1(isLocal);
-			const workerName = generateResourceName();
-			await seed({
-				"wrangler.toml": dedent`
+	it("exposes D1 database bindings", async () => {
+		const { id, name } = await helper.d1(isLocal);
+		const workerName = generateResourceName();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -482,11 +464,11 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 				database_name = "${name}"
 				database_id = "${id}"
 			`,
-				"schema.sql": dedent`
+			"schema.sql": dedent`
 				CREATE TABLE entries (key TEXT PRIMARY KEY, value TEXT);
 				INSERT INTO entries (key, value) VALUES ('key1', 'value1');
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					async fetch(request, env, ctx) {
 						await env.DB.prepare("INSERT INTO entries (key, value) VALUES (?, ?)").bind("key2", "value2").run();
@@ -495,30 +477,29 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 					}
 				}
 			`,
-			});
+		});
 
-			// D1 defaults to `--local`, so we deliberately use `flags`, not `resourceFlags`
-			await run(`wrangler d1 execute ${d1ResourceFlags} DB --file schema.sql`);
+		// D1 defaults to `--local`, so we deliberately use `flags`, not `resourceFlags`
+		await helper.run(
+			`wrangler d1 execute ${d1ResourceFlags} DB --file schema.sql`
+		);
 
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			const res = await fetch(url);
-			expect(await res.json()).toEqual([{ key: "key1", value: "value1" }]);
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+		expect(await res.json()).toEqual([{ key: "key1", value: "value1" }]);
 
-			const result = await run(
-				`wrangler d1 execute ${d1ResourceFlags} DB --command "SELECT * FROM entries WHERE key = 'key2'"`
-			);
-			expect(result).toContain("value2");
-		}
-	);
+		const result = await helper.run(
+			`wrangler d1 execute ${d1ResourceFlags} DB --command "SELECT * FROM entries WHERE key = 'key2'"`
+		);
+		expect(result.stdout).toContain("value2");
+	});
 
-	e2eTest.skipIf(!isLocal)(
-		"exposes queue producer/consumer bindings",
-		async ({ seed, run, waitForReady }) => {
-			const queueName = generateResourceName("queue");
-			const workerName = generateResourceName();
-			await seed({
-				"wrangler.toml": dedent`
+	it.skipIf(!isLocal)("exposes queue producer/consumer bindings", async () => {
+		const queueName = generateResourceName("queue");
+		const workerName = generateResourceName();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -529,7 +510,7 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 				queue = "${queueName}"
 				max_batch_timeout = 0
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					async fetch(request, env, ctx) {
 						await env.QUEUE.send("✉️");
@@ -540,31 +521,33 @@ describe.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 					}
 				}
 			`,
-			});
-			const worker = run(`wrangler dev ${flags}`);
-			const { url } = await waitForReady(worker);
-			await fetch(url);
-			await worker.readUntil(/✉️/);
-		}
-	);
+		});
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		await fetch(url);
+		await worker.readUntil(/✉️/);
+	});
 
 	// TODO(soon): implement E2E tests for other bindings
-	e2eTest.todo("exposes hyperdrive bindings");
-	e2eTest.skipIf(isLocal).todo("exposes send email bindings");
-	e2eTest.skipIf(isLocal).todo("exposes browser bindings");
-	e2eTest.skipIf(isLocal).todo("exposes Workers AI bindings");
-	e2eTest.skipIf(isLocal).todo("exposes Vectorize bindings");
-	e2eTest.skipIf(isLocal).todo("exposes Analytics Engine bindings");
-	e2eTest.skipIf(isLocal).todo("exposes dispatch namespace bindings");
-	e2eTest.skipIf(isLocal).todo("exposes mTLS bindings");
+	it.todo("exposes hyperdrive bindings");
+	it.skipIf(isLocal).todo("exposes send email bindings");
+	it.skipIf(isLocal).todo("exposes browser bindings");
+	it.skipIf(isLocal).todo("exposes Workers AI bindings");
+	it.skipIf(isLocal).todo("exposes Vectorize bindings");
+	it.skipIf(isLocal).todo("exposes Analytics Engine bindings");
+	it.skipIf(isLocal).todo("exposes dispatch namespace bindings");
+	it.skipIf(isLocal).todo("exposes mTLS bindings");
 });
 
-describe.each(RUNTIMES)("Multi-Worker Bindings: $runtime", ({ runtime }) => {
-	const isLocal = runtime === "local";
-	const _flags = isLocal ? [] : ["--remote"];
+describe.skip.each(RUNTIMES)(
+	"Multi-Worker Bindings: $runtime",
+	({ runtime }) => {
+		const isLocal = runtime === "local";
+		const _flags = isLocal ? [] : ["--remote"];
 
-	// TODO(soon): we already have tests for service bindings in `dev.test.ts`,
-	//  but would be good to get some more for Durable Objects
-	e2eTest.todo("exposes service bindings to other workers");
-	e2eTest.todo("exposes Durable Object bindings to other workers");
-});
+		// TODO(soon): we already have tests for service bindings in `dev.test.ts`,
+		//  but would be good to get some more for Durable Objects
+		it.todo("exposes service bindings to other workers");
+		it.todo("exposes Durable Object bindings to other workers");
+	}
+);

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -4,27 +4,22 @@ import * as nodeNet from "node:net";
 import { setTimeout } from "node:timers/promises";
 import dedent from "ts-dedent";
 import { fetch } from "undici";
-import { afterEach, beforeEach, describe, expect } from "vitest";
-import { e2eTest } from "./helpers/e2e-wrangler-test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
 import { retry } from "./helpers/retry";
 import { seed as baseSeed, makeRoot } from "./helpers/setup";
-import { killAllWranglerDev } from "./helpers/wrangler";
 
-beforeEach(killAllWranglerDev);
-afterEach(killAllWranglerDev);
-
-e2eTest(
-	"can import URL from 'url' in node_compat mode",
-	async ({ run, seed, waitForReady }) => {
-		await seed({
-			"wrangler.toml": dedent`
+it("can import URL from 'url' in node_compat mode", async () => {
+	const helper = new WranglerE2ETestHelper();
+	await helper.seed({
+		"wrangler.toml": dedent`
 				name = "worker"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				node_compat = true
 		`,
-			"src/index.ts": dedent`
+		"src/index.ts": dedent`
 				const { URL } = require('url');
 				const { URL: nURL } = require('node:url');
 
@@ -35,16 +30,15 @@ e2eTest(
 						return new Response(url + nUrl)
 					}
 				}`,
-		});
-		const worker = run(`wrangler dev`);
+	});
+	const worker = helper.runLongLived(`wrangler dev`);
 
-		const { url } = await waitForReady(worker);
+	const { url } = await worker.waitForReady();
 
-		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
-			`"postgresql://user:password@example.com:12345/dbname?sslmode=disablepostgresql://user:password@example.com:12345/dbname?sslmode=disable"`
-		);
-	}
-);
+	await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
+		`"postgresql://user:password@example.com:12345/dbname?sslmode=disablepostgresql://user:password@example.com:12345/dbname?sslmode=disable"`
+	);
+});
 
 describe.each([
 	{ cmd: "wrangler dev" },
@@ -52,11 +46,10 @@ describe.each([
 	{ cmd: "wrangler dev --x-dev-env" },
 	{ cmd: "wrangler dev --remote --x-dev-env" },
 ])("basic js dev: $cmd", ({ cmd }) => {
-	e2eTest(
-		`can modify worker during ${cmd}`,
-		async ({ run, seed, waitForReady, waitForReload }) => {
-			await seed({
-				"wrangler.toml": dedent`
+	it(`can modify worker during ${cmd}`, async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 							name = "worker"
 							main = "src/index.ts"
 							compatibility_date = "2023-01-01"
@@ -65,40 +58,39 @@ describe.each([
 							[vars]
 							KEY = "value"
 					`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 							export default {
 								fetch(request) {
 									return new Response("Hello World!")
 								}
 							}`,
-				"package.json": dedent`
+			"package.json": dedent`
 							{
 								"name": "worker",
 								"version": "0.0.0",
 								"private": true
 							}
 							`,
-			});
-			const worker = run(cmd);
+		});
+		const worker = helper.runLongLived(cmd);
 
-			const { url } = await waitForReady(worker);
+		const { url } = await worker.waitForReady();
 
-			await expect(fetch(url).then((r) => r.text())).resolves.toMatchSnapshot();
+		await expect(fetch(url).then((r) => r.text())).resolves.toMatchSnapshot();
 
-			await seed({
-				"src/index.ts": dedent`
+		await helper.seed({
+			"src/index.ts": dedent`
 						export default {
 							fetch(request, env) {
 								return new Response("Updated Worker! " + env.KEY)
 							}
 						}`,
-			});
+		});
 
-			await waitForReload(worker);
+		await worker.waitForReload();
 
-			await expect(fetchText(url)).resolves.toMatchSnapshot();
-		}
-	);
+		await expect(fetchText(url)).resolves.toMatchSnapshot();
+	});
 });
 
 describe.each([
@@ -106,115 +98,111 @@ describe.each([
 	{ cmd: "wrangler dev --remote" },
 	{ cmd: "wrangler dev --x-dev-env" },
 	{ cmd: "wrangler dev --remote --x-dev-env" },
-])("basic python dev: $cmd", ({ cmd }) => {
-	e2eTest(
-		`can modify entrypoint during ${cmd}`,
-		async ({ run, seed, waitForReady, waitForReload }) => {
-			await seed({
-				"wrangler.toml": dedent`
+])("basic python dev: $cmd", { timeout: 90_000 }, ({ cmd }) => {
+	it(`can modify entrypoint during ${cmd}`, async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 					name = "worker"
 					main = "index.py"
 					compatibility_date = "2023-01-01"
 					compatibility_flags = ["python_workers"]
 			`,
-				"arithmetic.py": dedent`
+			"arithmetic.py": dedent`
 					def mul(a,b):
 						return a*b`,
-				"index.py": dedent`
+			"index.py": dedent`
 					from arithmetic import mul
 
 					from js import Response
 					def on_fetch(request):
 						return Response.new(f"py hello world {mul(2,3)}")`,
-				"package.json": dedent`
+			"package.json": dedent`
 					{
 						"name": "worker",
 						"version": "0.0.0",
 						"private": true
 					}
 					`,
-			});
-			const worker = run(cmd);
+		});
+		const worker = helper.runLongLived(cmd);
 
-			const { url } = await waitForReady(worker);
+		const { url } = await worker.waitForReady();
 
-			await expect(fetchText(url)).resolves.toBe("py hello world 6");
+		await expect(fetchText(url)).resolves.toBe("py hello world 6");
 
-			await seed({
-				"index.py": dedent`
+		await helper.seed({
+			"index.py": dedent`
 					from js import Response
 					def on_fetch(request):
 						return Response.new('Updated Python Worker value')`,
-			});
+		});
 
-			await waitForReload(worker);
+		await worker.waitForReload();
 
-			// TODO(soon): work out why python workers need this retry before returning new content
-			const { text } = await retry(
-				(s) => s.status !== 200 || s.text === "py hello world 6",
-				async () => {
-					const r = await fetch(url);
-					return { text: await r.text(), status: r.status };
-				}
-			);
+		// TODO(soon): work out why python workers need this retry before returning new content
+		const { text } = await retry(
+			(s) => s.status !== 200 || s.text === "py hello world 6",
+			async () => {
+				const r = await fetch(url);
+				return { text: await r.text(), status: r.status };
+			}
+		);
 
-			expect(text).toBe("Updated Python Worker value");
-		}
-	);
+		expect(text).toBe("Updated Python Worker value");
+	});
 
-	e2eTest(
-		`can modify imports during ${cmd}`,
-		async ({ run, seed, waitForReady, waitForReload }) => {
-			await seed({
-				"wrangler.toml": dedent`
+	it(`can modify imports during ${cmd}`, async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 					name = "worker"
 					main = "index.py"
 					compatibility_date = "2023-01-01"
 					compatibility_flags = ["python_workers"]
 			`,
-				"arithmetic.py": dedent`
+			"arithmetic.py": dedent`
 					def mul(a,b):
 						return a*b`,
-				"index.py": dedent`
+			"index.py": dedent`
 					from arithmetic import mul
 
 					from js import Response
 					def on_fetch(request):
 						return Response.new(f"py hello world {mul(2,3)}")`,
-				"package.json": dedent`
+			"package.json": dedent`
 					{
 						"name": "worker",
 						"version": "0.0.0",
 						"private": true
 					}
 					`,
-			});
-			const worker = run(cmd);
+		});
+		const worker = helper.runLongLived(cmd);
 
-			const { url } = await waitForReady(worker);
+		const { url } = await worker.waitForReady();
 
-			await expect(fetchText(url)).resolves.toBe("py hello world 6");
+		await expect(fetchText(url)).resolves.toBe("py hello world 6");
 
-			await seed({
-				"arithmetic.py": dedent`
+		await helper.seed({
+			"arithmetic.py": dedent`
 					def mul(a,b):
 						return a+b`,
-			});
+		});
 
-			await waitForReload(worker);
+		await worker.waitForReload();
 
-			// TODO(soon): work out why python workers need this retry before returning new content
-			const { text } = await retry(
-				(s) => s.status !== 200 || s.text === "py hello world 6",
-				async () => {
-					const r = await fetch(url);
-					return { text: await r.text(), status: r.status };
-				}
-			);
+		// TODO(soon): work out why python workers need this retry before returning new content
+		const { text } = await retry(
+			(s) => s.status !== 200 || s.text === "py hello world 6",
+			async () => {
+				const r = await fetch(url);
+				return { text: await r.text(), status: r.status };
+			}
+		);
 
-			expect(text).toBe("py hello world 5");
-		}
-	);
+		expect(text).toBe("py hello world 5");
+	});
 });
 
 describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --x-dev-env" }])(
@@ -222,13 +210,16 @@ describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --x-dev-env" }])(
 	({ cmd }) => {
 		let a: string;
 		let b: string;
+		let helper: WranglerE2ETestHelper;
 
 		beforeEach(async () => {
+			helper = new WranglerE2ETestHelper();
 			a = await makeRoot();
 			await baseSeed(a, {
 				"wrangler.toml": dedent`
 					name = "a"
 					main = "src/index.ts"
+					compatibility_date = "2023-01-01"
 
 					[[services]]
 					binding = "BEE"
@@ -274,50 +265,44 @@ describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --x-dev-env" }])(
 			});
 		});
 
-		e2eTest("can fetch b", async ({ run, waitForReady }) => {
-			const worker = run(cmd, { cwd: b });
+		it("can fetch b", async () => {
+			const worker = helper.runLongLived(cmd, { cwd: b });
 
-			const { url } = await waitForReady(worker);
+			const { url } = await worker.waitForReady();
 
 			await expect(fetch(url).then((r) => r.text())).resolves.toBe(
 				"hello world"
 			);
 		});
 
-		e2eTest(
-			"can fetch b through a (start b, start a)",
-			async ({ run, waitForReady, waitForReload }) => {
-				const workerB = run(cmd, { cwd: b });
-				// We don't need b's URL, but ensure that b starts up before a
-				await waitForReady(workerB);
+		it("can fetch b through a (start b, start a)", async () => {
+			const workerB = helper.runLongLived(cmd, { cwd: b });
+			// We don't need b's URL, but ensure that b starts up before a
+			await workerB.waitForReady();
 
-				const workerA = run(cmd, { cwd: a });
-				const { url } = await waitForReady(workerA);
+			const workerA = helper.runLongLived(cmd, { cwd: a });
+			const { url } = await workerA.waitForReady();
 
-				await waitForReload(workerA);
-				// Give the dev registry some time to settle
-				await setTimeout(500);
+			await workerA.waitForReload();
+			// Give the dev registry some time to settle
+			await setTimeout(500);
 
-				await expect(fetchText(url)).resolves.toBe("hello world");
-			}
-		);
+			await expect(fetchText(url)).resolves.toBe("hello world");
+		});
 
-		e2eTest(
-			"can fetch b through a (start a, start b)",
-			async ({ run, waitForReady, waitForReload }) => {
-				const workerA = run(cmd, { cwd: a });
-				const { url } = await waitForReady(workerA);
+		it("can fetch b through a (start a, start b)", async () => {
+			const workerA = helper.runLongLived(cmd, { cwd: a });
+			const { url } = await workerA.waitForReady();
 
-				const workerB = run(cmd, { cwd: b });
-				await waitForReady(workerB);
+			const workerB = helper.runLongLived(cmd, { cwd: b });
+			await workerB.waitForReady();
 
-				await waitForReload(workerA);
-				// Give the dev registry some time to settle
-				await setTimeout(500);
+			await workerA.waitForReload();
+			// Give the dev registry some time to settle
+			await setTimeout(500);
 
-				await expect(fetchText(url)).resolves.toBe("hello world");
-			}
-		);
+			await expect(fetchText(url)).resolves.toBe("hello world");
+		});
 	}
 );
 
@@ -328,15 +313,14 @@ describe("hyperdrive dev tests", () => {
 		server = nodeNet.createServer().listen();
 	});
 
-	e2eTest(
-		"matches expected configuration parameters",
-		async ({ run, seed, waitForReady }) => {
-			let port = 5432;
-			if (server.address() && typeof server.address() !== "string") {
-				port = (server.address() as nodeNet.AddressInfo).port;
-			}
-			await seed({
-				"wrangler.toml": dedent`
+	it("matches expected configuration parameters", async () => {
+		const helper = new WranglerE2ETestHelper();
+		let port = 5432;
+		if (server.address() && typeof server.address() !== "string") {
+			port = (server.address() as nodeNet.AddressInfo).port;
+		}
+		await helper.seed({
+			"wrangler.toml": dedent`
 					name = "worker"
 					main = "src/index.ts"
 					compatibility_date = "2023-10-25"
@@ -346,7 +330,7 @@ describe("hyperdrive dev tests", () => {
 					id = "hyperdrive_id"
 					localConnectionString = "postgresql://user:%21pass@127.0.0.1:${port}/some_db"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 					export default {
 						async fetch(request, env) {
 							if (request.url.includes("connect")) {
@@ -356,33 +340,33 @@ describe("hyperdrive dev tests", () => {
 							return new Response(env.HYPERDRIVE?.connectionString ?? "no")
 						}
 					}`,
-				"package.json": dedent`
+			"package.json": dedent`
 					{
 						"name": "worker",
 						"version": "0.0.0",
 						"private": true
 					}
 					`,
-			});
-			const worker = run("wrangler dev");
-			const { url } = await waitForReady(worker);
+		});
+		const worker = helper.runLongLived("wrangler dev");
+		const { url } = await worker.waitForReady();
 
-			const text = await fetchText(url);
+		const text = await fetchText(url);
 
-			const hyperdrive = new URL(text);
-			expect(hyperdrive.pathname).toBe("/some_db");
-			expect(hyperdrive.username).toBe("user");
-			expect(hyperdrive.password).toBe("!pass");
-			expect(hyperdrive.host).not.toBe("localhost");
-		}
-	);
+		const hyperdrive = new URL(text);
+		expect(hyperdrive.pathname).toBe("/some_db");
+		expect(hyperdrive.username).toBe("user");
+		expect(hyperdrive.password).toBe("!pass");
+		expect(hyperdrive.host).not.toBe("localhost");
+	});
 
-	e2eTest("connects to a socket", async ({ run, seed, waitForReady }) => {
+	it("connects to a socket", async () => {
+		const helper = new WranglerE2ETestHelper();
 		let port = 5432;
 		if (server.address() && typeof server.address() !== "string") {
 			port = (server.address() as nodeNet.AddressInfo).port;
 		}
-		await seed({
+		await helper.seed({
 			"wrangler.toml": dedent`
 					name = "worker"
 					main = "src/index.ts"
@@ -421,24 +405,23 @@ describe("hyperdrive dev tests", () => {
 			});
 		});
 
-		const worker = run("wrangler dev");
+		const worker = helper.runLongLived("wrangler dev");
 
-		const { url } = await waitForReady(worker);
+		const { url } = await worker.waitForReady();
 
 		await fetch(`${url}/connect`);
 
 		await socketMsgPromise;
 	});
 
-	e2eTest(
-		"uses HYPERDRIVE_LOCAL_CONNECTION_STRING for the localConnectionString variable in the binding",
-		async ({ run, seed, waitForReady }) => {
-			let port = 5432;
-			if (server.address() && typeof server.address() !== "string") {
-				port = (server.address() as nodeNet.AddressInfo).port;
-			}
-			await seed({
-				"wrangler.toml": dedent`
+	it("uses HYPERDRIVE_LOCAL_CONNECTION_STRING for the localConnectionString variable in the binding", async () => {
+		const helper = new WranglerE2ETestHelper();
+		let port = 5432;
+		if (server.address() && typeof server.address() !== "string") {
+			port = (server.address() as nodeNet.AddressInfo).port;
+		}
+		await helper.seed({
+			"wrangler.toml": dedent`
 					name = "worker"
 					main = "src/index.ts"
 					compatibility_date = "2023-10-25"
@@ -447,7 +430,7 @@ describe("hyperdrive dev tests", () => {
 					binding = "HYPERDRIVE"
 					id = "hyperdrive_id"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 					export default {
 						async fetch(request, env) {
 							if (request.url.includes("connect")) {
@@ -457,37 +440,36 @@ describe("hyperdrive dev tests", () => {
 							return new Response(env.HYPERDRIVE?.connectionString ?? "no")
 						}
 					}`,
-				"package.json": dedent`
+			"package.json": dedent`
 					{
 						"name": "worker",
 						"version": "0.0.0",
 						"private": true
 					}
 					`,
-			});
+		});
 
-			const worker = run("wrangler dev", {
-				env: {
-					...process.env,
-					WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: `postgresql://user:pass@127.0.0.1:${port}/some_db`,
-				},
-			});
+		const worker = helper.runLongLived("wrangler dev", {
+			env: {
+				...process.env,
+				WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: `postgresql://user:pass@127.0.0.1:${port}/some_db`,
+			},
+		});
 
-			const { url } = await waitForReady(worker);
-			const socketMsgPromise = new Promise((resolve, _) => {
-				server.on("connection", (sock) => {
-					sock.on("data", (data) => {
-						expect(new TextDecoder().decode(data)).toBe("test string");
-						server.close();
-						resolve({});
-					});
+		const { url } = await worker.waitForReady();
+		const socketMsgPromise = new Promise((resolve, _) => {
+			server.on("connection", (sock) => {
+				sock.on("data", (data) => {
+					expect(new TextDecoder().decode(data)).toBe("test string");
+					server.close();
+					resolve({});
 				});
 			});
-			await fetch(`${url}/connect`);
+		});
+		await fetch(`${url}/connect`);
 
-			await socketMsgPromise;
-		}
-	);
+		await socketMsgPromise;
+	});
 
 	afterEach(() => {
 		if (server.listening) {
@@ -497,11 +479,10 @@ describe("hyperdrive dev tests", () => {
 });
 
 describe("queue dev tests", () => {
-	e2eTest(
-		"matches expected configuration parameters",
-		async ({ run, seed, waitForReady }) => {
-			await seed({
-				"wrangler.toml": dedent`
+	it("matches expected configuration parameters", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 					name = "worker"
 					main = "src/index.ts"
 					compatibility_date = "2024-04-04"
@@ -511,33 +492,33 @@ describe("queue dev tests", () => {
 					queue = "test-queue"
 					delivery_delay = 2
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 					export default {
 						async fetch(request, env) {
 							env.QUEUE.send();
 							return new Response('sent');
 						}
 					}`,
-				"package.json": dedent`
+			"package.json": dedent`
 					{
 						"name": "worker",
 						"version": "0.0.0",
 						"private": true
 					}
 					`,
-			});
-			const worker = run("wrangler dev");
-			const { url } = await waitForReady(worker);
+		});
+		const worker = helper.runLongLived("wrangler dev");
+		const { url } = await worker.waitForReady();
 
-			const text = await fetchText(url);
-			expect(text).toBe("sent");
-		}
-	);
+		const text = await fetchText(url);
+		expect(text).toBe("sent");
+	});
 });
 
 describe("writes debug logs to hidden file", () => {
-	e2eTest("writes to file when --log-level = debug", async ({ run, seed }) => {
-		await seed({
+	it("writes to file when --log-level = debug", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
 			"wrangler.toml": dedent`
 					name = "a"
 					main = "src/index.ts"
@@ -558,7 +539,7 @@ describe("writes debug logs to hidden file", () => {
 					}
 					`,
 		});
-		const worker = run("wrangler dev --log-level debug");
+		const worker = helper.runLongLived("wrangler dev --log-level debug");
 
 		const match = await worker.readUntil(
 			/🪵 {2}Writing logs to "(?<filepath>.+\.log)"/
@@ -572,76 +553,73 @@ describe("writes debug logs to hidden file", () => {
 		expect(existsSync(filepath)).toBe(true);
 	});
 
-	e2eTest(
-		"does NOT write to file when --log-level != debug",
-		async ({ run, seed, waitForReady }) => {
-			await seed({
-				"wrangler.toml": dedent`
+	it("does NOT write to file when --log-level != debug", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "a"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 			`,
-				"src/index.ts": dedent/* javascript */ `
+			"src/index.ts": dedent/* javascript */ `
 				export default {
 					fetch(req, env) {
 						return new Response('A' + req.url);
 					},
 				};
 				`,
-				"package.json": dedent`
+			"package.json": dedent`
 				{
 					"name": "a",
 					"version": "0.0.0",
 					"private": true
 				}
 				`,
-			});
+		});
 
-			const worker = run("wrangler dev");
+		const worker = helper.runLongLived("wrangler dev");
 
-			await waitForReady(worker);
+		await worker.waitForReady();
 
-			expect(worker.output).not.toContain("Writing logs to");
-		}
-	);
+		expect(worker.output).not.toContain("Writing logs to");
+	});
 });
 
 describe("zone selection", () => {
-	e2eTest(
-		"defaults to a workers.dev preview",
-		async ({ run, seed, waitForReady }) => {
-			await seed({
-				"wrangler.toml": dedent`
+	it("defaults to a workers.dev preview", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "worker"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				compatibility_flags = ["nodejs_compat"]`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					fetch(request) {
 						return new Response(request.url)
 					}
 				}`,
-				"package.json": dedent`
+			"package.json": dedent`
 				{
 					"name": "worker",
 					"version": "0.0.0",
 					"private": true
 				}
 				`,
-			});
-			const worker = run("wrangler dev --remote");
+		});
+		const worker = helper.runLongLived("wrangler dev --remote");
 
-			const { url } = await waitForReady(worker);
+		const { url } = await worker.waitForReady();
 
-			const text = await fetchText(url);
+		const text = await fetchText(url);
 
-			expect(text).toContain(`devprod-testing7928.workers.dev`);
-		}
-	);
+		expect(text).toContain(`devprod-testing7928.workers.dev`);
+	});
 
-	e2eTest("respects dev.host setting", async ({ run, seed, waitForReady }) => {
-		await seed({
+	it("respects dev.host setting", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
 			"wrangler.toml": dedent`
 				name = "worker"
 				main = "src/index.ts"
@@ -664,9 +642,9 @@ describe("zone selection", () => {
 				}
 				`,
 		});
-		const worker = run("wrangler dev --remote");
+		const worker = helper.runLongLived("wrangler dev --remote");
 
-		const { url } = await waitForReady(worker);
+		const { url } = await worker.waitForReady();
 
 		const text = await fetchText(url);
 
@@ -674,11 +652,11 @@ describe("zone selection", () => {
 			`"https://wrangler-testing.testing.devprod.cloudflare.dev/"`
 		);
 	});
-	e2eTest(
-		"infers host from first route",
-		async ({ run, seed, waitForReady }) => {
-			await seed({
-				"wrangler.toml": dedent`
+
+	it("infers host from first route", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "worker"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -688,36 +666,35 @@ describe("zone selection", () => {
 				pattern = "wrangler-testing.testing.devprod.cloudflare.dev/*"
 				zone_name = "testing.devprod.cloudflare.dev"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					fetch(request) {
 						return new Response(request.url)
 					}
 				}`,
-				"package.json": dedent`
+			"package.json": dedent`
 				{
 					"name": "worker",
 					"version": "0.0.0",
 					"private": true
 				}
 				`,
-			});
-			const worker = run("wrangler dev --remote");
+		});
+		const worker = helper.runLongLived("wrangler dev --remote");
 
-			const { url } = await waitForReady(worker);
+		const { url } = await worker.waitForReady();
 
-			const text = await fetchText(url);
+		const text = await fetchText(url);
 
-			expect(text).toMatchInlineSnapshot(
-				`"https://wrangler-testing.testing.devprod.cloudflare.dev/"`
-			);
-		}
-	);
-	e2eTest(
-		"fails with useful error message if host is not routable",
-		async ({ run, seed }) => {
-			await seed({
-				"wrangler.toml": dedent`
+		expect(text).toMatchInlineSnapshot(
+			`"https://wrangler-testing.testing.devprod.cloudflare.dev/"`
+		);
+	});
+
+	it("fails with useful error message if host is not routable", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 				name = "worker"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
@@ -727,66 +704,63 @@ describe("zone selection", () => {
 				pattern = "not-a-domain.testing.devprod.cloudflare.dev/*"
 				zone_name = "testing.devprod.cloudflare.dev"
 			`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 				export default {
 					fetch(request) {
 						return new Response(request.url)
 					}
 				}`,
-				"package.json": dedent`
+			"package.json": dedent`
 				{
 					"name": "worker",
 					"version": "0.0.0",
 					"private": true
 				}
 				`,
-			});
-			const worker = run("wrangler dev --remote");
+		});
+		const worker = helper.runLongLived("wrangler dev --remote");
 
-			await worker.readUntil(
-				/Could not access `not-a-domain.testing.devprod.cloudflare.dev`. Make sure the domain is set up to be proxied by Cloudflare/
-			);
-		}
-	);
+		await worker.readUntil(
+			/Could not access `not-a-domain.testing.devprod.cloudflare.dev`. Make sure the domain is set up to be proxied by Cloudflare/
+		);
+	});
 });
 
 describe("custom builds", () => {
-	e2eTest(
-		"does not hang when custom build does not cause esbuild to run",
-		async ({ run, seed, waitForReady }) => {
-			await seed({
-				"wrangler.toml": dedent`
+	it("does not hang when custom build does not cause esbuild to run", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"wrangler.toml": dedent`
 						name = "worker"
 						compatibility_date = "2023-01-01"
 						main = "src/index.ts"
 						build.command = "echo 'hello'"
 						build.watch_dir = "custom_src"
 				`,
-				"src/index.ts": dedent`
+			"src/index.ts": dedent`
 						export default {
 							async fetch(request) {
 								return new Response("Hello, World!")
 							}
 						}`,
-			});
-			const worker = run("wrangler dev");
+		});
+		const worker = helper.runLongLived("wrangler dev");
 
-			const { url } = await waitForReady(worker);
+		const { url } = await worker.waitForReady();
 
-			await fetch(url);
+		await fetch(url);
 
-			let text = await fetchText(url);
+		let text = await fetchText(url);
 
-			expect(text).toMatchInlineSnapshot(`"Hello, World!"`);
+		expect(text).toMatchInlineSnapshot(`"Hello, World!"`);
 
-			await seed({
-				"custom_src/foo.txt": "",
-			});
+		await helper.seed({
+			"custom_src/foo.txt": "",
+		});
 
-			await worker.readUntil(/echo 'hello'/);
+		await worker.readUntil(/echo 'hello'/);
 
-			text = await fetchText(url);
-			expect(text).toMatchInlineSnapshot(`"Hello, World!"`);
-		}
-	);
+		text = await fetchText(url);
+		expect(text).toMatchInlineSnapshot(`"Hello, World!"`);
+	});
 });

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -1,4 +1,4 @@
-import shellac from "shellac";
+import { execSync } from "child_process";
 import dedent from "ts-dedent";
 import { beforeEach, describe, expect, it } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
@@ -7,11 +7,10 @@ import { WRANGLER_IMPORT } from "./helpers/wrangler";
 
 // TODO(DEVX-1262): re-enable when we have set an API token with the proper AI permissions
 describe.skip("getPlatformProxy()", () => {
-	let run: typeof shellac;
+	let root: string;
 	beforeEach(async () => {
-		const root = await makeRoot();
+		root = await makeRoot();
 
-		run = shellac.in(root).env(process.env);
 		await seed(root, {
 			"wrangler.toml": dedent`
 					name = "ai-app"
@@ -52,7 +51,7 @@ describe.skip("getPlatformProxy()", () => {
 		});
 	});
 	it("can run ai inference", async () => {
-		const { stdout } = await run`$ node index.mjs`;
+		const stdout = execSync(`node index.mjs`, { cwd: root, encoding: "utf-8" });
 		expect(stdout).toContain("Workers AI");
 	});
 });

--- a/packages/wrangler/e2e/helpers/command.ts
+++ b/packages/wrangler/e2e/helpers/command.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert";
+import { spawn, spawnSync } from "node:child_process";
+import events from "node:events";
+import rl from "node:readline";
+import { PassThrough } from "node:stream";
+import { ReadableStream } from "node:stream/web";
+import { setTimeout } from "node:timers/promises";
+import treeKill from "tree-kill";
+import dedent from "ts-dedent";
+import { readUntil } from "./read-until";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+const DEFAULT_TIMEOUT = 50_000;
+
+export type CommandOptions = {
+	cwd?: string;
+	env?: typeof process.env;
+	timeout?: number;
+};
+
+/**
+ * Run a command till it exits and return its status and output.
+ *
+ * Options:
+ *  - If you specify a timeout the command will abort if it runs too long.
+ *  - Override the current working directory or env vars (if not provided it just inherits from the current process).
+ *
+ * Returns the result (status, stdout and stderr) from running the command.
+ */
+export function runCommand(
+	command: string,
+	{ cwd, env, timeout = DEFAULT_TIMEOUT }: CommandOptions = {}
+) {
+	try {
+		const { status, stdout, stderr } = spawnSync(command, [], {
+			shell: true,
+			cwd,
+			stdio: "pipe",
+			env,
+			encoding: "utf8",
+			timeout,
+		});
+		// eslint-disable-next-line turbo/no-undeclared-env-vars
+		if (process.env.VITEST_MODE === "WATCH") {
+			if (stdout.length) {
+				console.log(stdout);
+			}
+			if (stderr.length) {
+				console.error(stderr);
+			}
+		}
+		return { status, stdout, stderr };
+	} catch (e) {
+		if (isTimedOutError(e)) {
+			throw new Error(dedent`
+				Running ${JSON.stringify(command)} took too long (${timeout}).
+				stdout: ${e.stdout}
+				stderr: ${e.stderr}
+				`);
+		} else {
+			throw e;
+		}
+	}
+}
+
+/**
+ * Run a long-lived command that does not exit.
+ *
+ * Options:
+ *  - If you specify a timeout the command will abort if it runs too long.
+ *  - Override the current working directory or env vars (if not provided it just inherits from the current process).
+ */
+export class LongLivedCommand {
+	private lines: string[] = [];
+	private stream: ReadableStream;
+	private exitPromise: Promise<unknown>;
+	private commandProcess: ChildProcessWithoutNullStreams;
+
+	constructor(
+		private command: string,
+		{ cwd, env, timeout }: CommandOptions
+	) {
+		const signal = createTimeoutSignal(timeout);
+		this.commandProcess = spawn(command, [], {
+			shell: true,
+			cwd,
+			stdio: "pipe",
+			env,
+			signal,
+		});
+
+		this.exitPromise = events.once(this.commandProcess, "exit");
+
+		// Merge the stdout and stderr into a single output stream
+		const output = new PassThrough();
+		this.commandProcess.stdout.pipe(output);
+		this.commandProcess.stderr.pipe(output);
+
+		const lineInterface = rl.createInterface(output);
+		this.stream = new ReadableStream<string>({
+			start: (controller) => {
+				lineInterface.on("line", (line) => {
+					// eslint-disable-next-line turbo/no-undeclared-env-vars
+					if (process.env.VITEST_MODE === "WATCH") {
+						console.log(line);
+					}
+					this.lines.push(line);
+					try {
+						controller.enqueue(line);
+					} catch {
+						// occasionally the enqueue can throw if the stream has already been closed
+						// but we don't care and can just move on.
+					}
+				});
+				void this.exitPromise
+					.catch(() =>
+						this.lines.unshift(`Failed to run ${JSON.stringify(command)}:`)
+					)
+					.finally(() => controller.close());
+			},
+			cancel() {
+				lineInterface.close();
+			},
+		});
+	}
+
+	// Wait for changes in the output of this process.
+	async readUntil(
+		regexp: RegExp,
+		readTimeout?: number
+	): Promise<RegExpMatchArray> {
+		return readUntil(this.stream, regexp, readTimeout);
+	}
+
+	// Return a snapshot of the output so far
+	get currentOutput() {
+		return this.lines.join("\n");
+	}
+
+	get output() {
+		return this.exitPromise.then(() => this.lines.join("\n"));
+	}
+
+	get exitCode() {
+		return this.exitPromise;
+	}
+
+	async stop() {
+		return new Promise<void>((resolve) => {
+			assert(
+				this.commandProcess.pid,
+				`Command "${this.command}" had no process id`
+			);
+			treeKill(this.commandProcess.pid, (e) => {
+				if (e) {
+					console.error(
+						"Failed to kill command: " + this.command,
+						this.commandProcess.pid,
+						e
+					);
+				}
+				resolve();
+			});
+		});
+	}
+}
+
+interface TimedOutError extends Error {
+	code: "ETIMEDOUT";
+	stdout: string;
+	stderr: string;
+}
+function isTimedOutError(e: unknown): e is TimedOutError {
+	return e instanceof Error && "code" in e && e.code === "ETIMEDOUT";
+}
+
+function createTimeoutSignal(timeout: number | undefined) {
+	if (timeout === undefined) {
+		return undefined;
+	}
+	const ctrl = new AbortController();
+	void setTimeout(timeout).then(() => ctrl.abort());
+	return ctrl.signal;
+}

--- a/packages/wrangler/e2e/helpers/setup.ts
+++ b/packages/wrangler/e2e/helpers/setup.ts
@@ -1,9 +1,10 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtempSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-export async function makeRoot() {
-	return await mkdtemp(path.join(os.tmpdir(), "wrangler-smoke-"));
+export function makeRoot() {
+	return mkdtempSync(path.join(os.tmpdir(), "wrangler-smoke-"));
 }
 
 // Seeds the `root` directory on the file system with some data. Use in

--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -1,89 +1,90 @@
 import crypto from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { beforeAll, describe, expect } from "vitest";
-import { e2eTest } from "./helpers/e2e-wrangler-test";
+import { describe, expect, it } from "vitest";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
 
 describe("r2", () => {
-	let bucketName: string;
-	let fileContents: string;
-	let normalize: (str: string) => string;
+	const bucketName = generateResourceName("r2");
+	const fileContents = crypto.randomBytes(64).toString("hex");
+	const normalize = (str: string) =>
+		normalizeOutput(str, {
+			[bucketName]: "tmp-e2e-r2",
+			[process.env.CLOUDFLARE_ACCOUNT_ID as string]: "CLOUDFLARE_ACCOUNT_ID",
+		});
+	const helper = new WranglerE2ETestHelper();
 
-	beforeAll(async () => {
-		bucketName = generateResourceName("r2");
-		normalize = (str) =>
-			normalizeOutput(str, {
-				[bucketName]: "tmp-e2e-r2",
-				[process.env.CLOUDFLARE_ACCOUNT_ID as string]: "CLOUDFLARE_ACCOUNT_ID",
-			});
-		fileContents = crypto.randomBytes(64).toString("hex");
-	});
+	it("create bucket", async () => {
+		const output = await helper.run(`wrangler r2 bucket create ${bucketName}`);
 
-	e2eTest("create bucket", async ({ run }) => {
-		const output = await run(`wrangler r2 bucket create ${bucketName}`);
-
-		expect(normalize(output)).toMatchInlineSnapshot(`
+		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
 			"Creating bucket tmp-e2e-r2-00000000-0000-0000-0000-000000000000 with default storage class set to Standard.
 			Created bucket tmp-e2e-r2-00000000-0000-0000-0000-000000000000 with default storage class set to Standard."
 		`);
 	});
 
-	e2eTest("create object", async ({ seed, run }) => {
-		await seed({
+	it("create object", async () => {
+		await helper.seed({
 			"test-r2.txt": fileContents,
 		});
-		const output = await run(
+		const output = await helper.run(
 			`wrangler r2 object put ${bucketName}/testr2 --file test-r2.txt --content-type text/html`
 		);
-		expect(normalize(output)).toMatchInlineSnapshot(`
+		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
 			"Creating object "testr2" in bucket "tmp-e2e-r2-00000000-0000-0000-0000-000000000000".
 			Upload complete."
 		`);
 	});
 
-	e2eTest("download object", async ({ run, tmpPath }) => {
-		const output = await run(
+	it("download object", async () => {
+		const output = await helper.run(
 			`wrangler r2 object get ${bucketName}/testr2 --file test-r2o.txt`
 		);
-		expect(normalize(output)).toMatchInlineSnapshot(`
+		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
 			"Downloading "testr2" from "tmp-e2e-r2-00000000-0000-0000-0000-000000000000".
 			Download complete."
 		`);
-		const file = await readFile(path.join(tmpPath, "test-r2o.txt"), "utf8");
+		const file = await readFile(
+			path.join(helper.tmpPath, "test-r2o.txt"),
+			"utf8"
+		);
 		expect(file).toBe(fileContents);
 	});
-	e2eTest("delete object", async ({ run }) => {
-		const output = await run(`wrangler r2 object delete ${bucketName}/testr2`);
-		expect(normalize(output)).toMatchInlineSnapshot(`
+
+	it("delete object", async () => {
+		const output = await helper.run(
+			`wrangler r2 object delete ${bucketName}/testr2`
+		);
+		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
 			"Deleting object "testr2" from bucket "tmp-e2e-r2-00000000-0000-0000-0000-000000000000".
 			Delete complete."
 		`);
 	});
 
-	e2eTest("check object deleted", async ({ run }) => {
-		const { readUntil } = run(
+	it("check object deleted", async () => {
+		const output = await helper.run(
 			`wrangler r2 object get ${bucketName}/testr2 --file test-r2o.txt`
 		);
-		await readUntil(/The specified key does not exist/);
+		expect(output.stderr).toContain("The specified key does not exist");
 	});
 
-	e2eTest("delete bucket", async ({ run }) => {
-		const output = await run(`wrangler r2 bucket delete ${bucketName}`);
-		expect(normalize(output)).toMatchInlineSnapshot(`
+	it("delete bucket", async () => {
+		const output = await helper.run(`wrangler r2 bucket delete ${bucketName}`);
+		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
 			"Deleting bucket tmp-e2e-r2-00000000-0000-0000-0000-000000000000.
 			Deleted bucket tmp-e2e-r2-00000000-0000-0000-0000-000000000000."
 		`);
 	});
 
-	e2eTest("check bucket deleted", async ({ run, seed }) => {
-		await seed({
+	it("check bucket deleted", async () => {
+		await helper.seed({
 			"test-r2.txt": fileContents,
 		});
-		const { readUntil } = run(
+		const output = await helper.run(
 			`wrangler r2 object put ${bucketName}/testr2 --file test-r2.txt --content-type text/html`
 		);
-		await readUntil(/The specified bucket does not exist/);
+		expect(output.stderr).toContain("The specified bucket does not exist");
 	});
 });

--- a/packages/wrangler/e2e/tsconfig.json
+++ b/packages/wrangler/e2e/tsconfig.json
@@ -3,6 +3,6 @@
 	"compilerOptions": {
 		"types": ["node"]
 	},
-	"include": ["**/*.ts", "../src/*.d.ts"],
+	"include": ["vitest.config.mts", "**/*.ts", "../src/*.d.ts"],
 	"exclude": []
 }

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -1,77 +1,69 @@
-import crypto from "node:crypto";
-import path from "node:path";
-import shellac from "shellac";
 import dedent from "ts-dedent";
-import { beforeAll, chai, describe, expect, it } from "vitest";
+import { chai, describe, expect, it } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
+import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
-import { makeRoot, seed } from "./helpers/setup";
-import { WRANGLER } from "./helpers/wrangler";
 
 chai.config.truncateThreshold = 1e6;
 
-function matchWhoamiEmail(stdout: string): string {
-	return stdout.match(/associated with the email (.+?@.+?)!/)?.[1] as string;
-}
 function matchVersionId(stdout: string): string {
 	return stdout.match(/Version ID:\s+([a-f\d-]+)/)?.[1] as string;
 }
-function countOccurences(stdout: string, substring: string) {
+function countOccurrences(stdout: string, substring: string) {
 	return stdout.split(substring).length - 1;
 }
 
-describe("versions deploy", () => {
-	let root: string;
-	let workerName: string;
-	let workerPath: string;
-	let runInRoot: typeof shellac;
-	let runInWorker: typeof shellac;
-	let normalize: (str: string) => string;
+const TIMEOUT = 50_000;
+const workerName = generateResourceName();
+const normalize = (str: string) =>
+	normalizeOutput(str, {
+		[CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
+	}).replaceAll(/^Author:(\s+).+@.+$/gm, "Author:$1person@example.com");
+
+describe("versions deploy", { timeout: TIMEOUT }, () => {
 	let versionId0: string;
 	let versionId1: string;
 	let versionId2: string;
+	const helper = new WranglerE2ETestHelper();
 
-	beforeAll(async () => {
-		root = await makeRoot();
-		workerName = `tmp-e2e-wrangler-${crypto.randomBytes(4).toString("hex")}`;
-		workerPath = path.join(root, workerName);
-		runInRoot = shellac.in(root).env(process.env);
-		runInWorker = shellac.in(workerPath).env(process.env);
-		const email = matchWhoamiEmail(
-			(await runInRoot`$ ${WRANGLER} whoami`).stdout
-		);
-		normalize = (str) =>
-			normalizeOutput(str, {
-				[workerName]: "tmp-e2e-wrangler",
-				[email]: "person@example.com",
-				[CLOUDFLARE_ACCOUNT_ID]: "CLOUDFLARE_ACCOUNT_ID",
-			});
-	}, 50_000);
-
-	it("should init Worker", async () => {
-		const init =
-			await runInRoot`$ ${WRANGLER} init ${workerName} --yes --no-delegate-c3`;
-
-		expect(normalize(init.stdout)).toContain(
-			"To publish your Worker to the Internet, run `npm run deploy`"
-		);
-
+	it("deploy worker", async () => {
+		await helper.seed({
+			"wrangler.toml": dedent`
+							name = "${workerName}"
+							main = "src/index.ts"
+							compatibility_date = "2023-01-01"
+					`,
+			"src/index.ts": dedent`
+							export default {
+								fetch(request) {
+									return new Response("Hello World!")
+								}
+							}`,
+			"package.json": dedent`
+							{
+								"name": "${workerName}",
+								"version": "0.0.0",
+								"private": true
+							}
+							`,
+		});
 		// TEMP: regular deploy needed for the first time to *create* the worker (will create 1 extra version + deployment in snapshots below)
-		const deploy = await runInWorker`$ ${WRANGLER} deploy`;
-
+		const deploy = await helper.run("wrangler deploy");
 		versionId0 = matchVersionId(deploy.stdout);
 	});
 
 	it("should upload 1st Worker version", async () => {
-		const upload =
-			await runInWorker`$ ${WRANGLER} versions upload --message "Upload via e2e test" --tag "e2e-upload"  --x-versions`;
+		const upload = await helper.run(
+			`wrangler versions upload --message "Upload via e2e test" --tag "e2e-upload"  --x-versions`
+		);
 
 		versionId1 = matchVersionId(upload.stdout);
 
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
-			Uploaded tmp-e2e-wrangler (TIMINGS)
+			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy --experimental-versions
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"
@@ -79,7 +71,7 @@ describe("versions deploy", () => {
 	});
 
 	it("should list 1 version", async () => {
-		const list = await runInWorker`$ ${WRANGLER} versions list  --x-versions`;
+		const list = await helper.run(`wrangler versions list  --x-versions`);
 
 		expect(normalize(list.stdout)).toMatchInlineSnapshot(`
 			"Version ID:  00000000-0000-0000-0000-000000000000
@@ -101,8 +93,9 @@ describe("versions deploy", () => {
 	});
 
 	it("should deploy 1st Worker version", async () => {
-		const deploy =
-			await runInWorker`$ ${WRANGLER} versions deploy ${versionId1}@100% --message "Deploy via e2e test" --yes  --x-versions`;
+		const deploy = await helper.run(
+			`wrangler versions deploy ${versionId1}@100% --message "Deploy via e2e test" --yes  --x-versions`
+		);
 
 		expect(normalize(deploy.stdout)).toMatchInlineSnapshot(`
 			"╭ Deploy Worker Versions by splitting traffic between multiple versions
@@ -136,13 +129,12 @@ describe("versions deploy", () => {
 			│
 			│ No non-versioned settings to sync. Skipping...
 			│
-			╰  SUCCESS  Deployed tmp-e2e-wrangler version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+			╰  SUCCESS  Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);
 	});
 
 	it("should list 1 deployment", async () => {
-		const list =
-			await runInWorker`$ ${WRANGLER} deployments list  --x-versions`;
+		const list = await helper.run(`wrangler deployments list  --x-versions`);
 
 		expect(normalize(list.stdout)).toMatchInlineSnapshot(`
 			"Created:     TIMESTAMP
@@ -162,13 +154,12 @@ describe("versions deploy", () => {
 			                     Tag:  -
 			                 Message:  -"
 		`);
-		expect(list.stderr).toMatchInlineSnapshot('""');
 
 		expect(list.stdout).toContain(versionId1);
 	});
 
 	it("should modify & upload 2nd Worker version", async () => {
-		await seed(workerPath, {
+		await helper.seed({
 			"src/index.ts": dedent`
 				export default {
 					fetch(request) {
@@ -177,22 +168,24 @@ describe("versions deploy", () => {
 				}`,
 		});
 
-		const upload =
-			await runInWorker`$ ${WRANGLER} versions upload --message "Upload AGAIN via e2e test" --tag "e2e-upload-AGAIN"  --x-versions`;
+		const upload = await helper.run(
+			`wrangler versions upload --message "Upload AGAIN via e2e test" --tag "e2e-upload-AGAIN"  --x-versions`
+		);
 
 		versionId2 = matchVersionId(upload.stdout);
 
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
-			Uploaded tmp-e2e-wrangler (TIMINGS)
+			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy --experimental-versions
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"
 		`);
 
-		const versionsList =
-			await runInWorker`$ ${WRANGLER} versions list  --x-versions`;
+		const versionsList = await helper.run(
+			`wrangler versions list  --x-versions`
+		);
 
 		expect(normalize(versionsList.stdout)).toMatchInlineSnapshot(`
 			"Version ID:  00000000-0000-0000-0000-000000000000
@@ -220,11 +213,13 @@ describe("versions deploy", () => {
 	});
 
 	it("should deploy 2nd Worker version", async () => {
-		const deploy =
-			await runInWorker`$ ${WRANGLER} versions deploy ${versionId2}@100% --message "Deploy AGAIN via e2e test" --yes  --x-versions`;
+		const deploy = await helper.run(
+			`wrangler versions deploy ${versionId2}@100% --message "Deploy AGAIN via e2e test" --yes  --x-versions`
+		);
 
-		const deploymentsList =
-			await runInWorker`$ ${WRANGLER} deployments list  --x-versions`;
+		const deploymentsList = await helper.run(
+			`wrangler deployments list  --x-versions`
+		);
 
 		expect(normalize(deploy.stdout)).toMatchInlineSnapshot(`
 			"╭ Deploy Worker Versions by splitting traffic between multiple versions
@@ -258,7 +253,7 @@ describe("versions deploy", () => {
 			│
 			│ No non-versioned settings to sync. Skipping...
 			│
-			╰  SUCCESS  Deployed tmp-e2e-wrangler version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
+			╰  SUCCESS  Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 		`);
 
 		// list 2 deployments (+ old deployment)
@@ -288,22 +283,24 @@ describe("versions deploy", () => {
 			                     Tag:  -
 			                 Message:  -"
 		`);
-		expect(deploymentsList.stderr).toMatchInlineSnapshot('""');
 
-		expect(countOccurences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
-		expect(countOccurences(deploymentsList.stdout, versionId1)).toBe(1); // once for versions deploy, only
-		expect(countOccurences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
+		expect(countOccurrences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
+		expect(countOccurrences(deploymentsList.stdout, versionId1)).toBe(1); // once for versions deploy, only
+		expect(countOccurrences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
 	});
 
 	it("should rollback to implicit Worker version (1st version)", async () => {
-		const rollback =
-			await runInWorker`$ ${WRANGLER} rollback --message "Rollback via e2e test" --yes  --x-versions`;
+		const rollback = await helper.run(
+			`wrangler rollback --message "Rollback via e2e test" --yes  --x-versions`
+		);
 
-		const versionsList =
-			await runInWorker`$ ${WRANGLER} versions list  --x-versions`;
+		const versionsList = await helper.run(
+			`wrangler versions list  --x-versions`
+		);
 
-		const deploymentsList =
-			await runInWorker`$ ${WRANGLER} deployments list  --x-versions`;
+		const deploymentsList = await helper.run(
+			`wrangler deployments list  --x-versions`
+		);
 
 		expect(normalize(rollback.stdout)).toMatchInlineSnapshot(`
 			"├ Fetching latest deployment
@@ -400,20 +397,23 @@ describe("versions deploy", () => {
 			                 Message:  -"
 		`);
 
-		expect(countOccurences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
-		expect(countOccurences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
-		expect(countOccurences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
+		expect(countOccurrences(deploymentsList.stdout, versionId0)).toBe(1); // once for regular deploy, only
+		expect(countOccurrences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
+		expect(countOccurrences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
 	});
 
 	it("should rollback to specific Worker version (0th version)", async () => {
-		const rollback =
-			await runInWorker`$ ${WRANGLER} rollback ${versionId0} --message "Rollback to old version" --yes  --x-versions`;
+		const rollback = await helper.run(
+			`wrangler rollback ${versionId0} --message "Rollback to old version" --yes  --x-versions`
+		);
 
-		const versionsList =
-			await runInWorker`$ ${WRANGLER} versions list  --x-versions`;
+		const versionsList = await helper.run(
+			`wrangler versions list  --x-versions`
+		);
 
-		const deploymentsList =
-			await runInWorker`$ ${WRANGLER} deployments list  --x-versions`;
+		const deploymentsList = await helper.run(
+			`wrangler deployments list  --x-versions`
+		);
 
 		expect(normalize(rollback.stdout)).toMatchInlineSnapshot(`
 			"├ Fetching latest deployment
@@ -515,19 +515,18 @@ describe("versions deploy", () => {
 			                 Message:  -"
 		`);
 
-		expect(countOccurences(deploymentsList.stdout, versionId0)).toBe(2); // once for regular deploy, once for rollback
-		expect(countOccurences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
-		expect(countOccurences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
+		expect(countOccurrences(deploymentsList.stdout, versionId0)).toBe(2); // once for regular deploy, once for rollback
+		expect(countOccurrences(deploymentsList.stdout, versionId1)).toBe(2); // once for versions deploy, once for rollback
+		expect(countOccurrences(deploymentsList.stdout, versionId2)).toBe(1); // once for versions deploy, only
 	});
 
-	it("should delete the Worker", async () => {
-		const { stdout, stderr } = await runInWorker`$ ${WRANGLER} delete`;
+	it("should delete Worker", async () => {
+		const { stdout } = await helper.run(`wrangler delete`);
 
 		expect(normalize(stdout)).toMatchInlineSnapshot(`
-			"? Are you sure you want to delete tmp-e2e-wrangler? This action cannot be undone.
+			"? Are you sure you want to delete tmp-e2e-worker-00000000-0000-0000-0000-000000000000? This action cannot be undone.
 			🤖 Using fallback value in non-interactive context: yes
-			Successfully deleted tmp-e2e-wrangler"
+			Successfully deleted tmp-e2e-worker-00000000-0000-0000-0000-000000000000"
 		`);
-		expect(stderr).toMatchInlineSnapshot('""');
 	});
 });

--- a/packages/wrangler/e2e/vitest.config.mts
+++ b/packages/wrangler/e2e/vitest.config.mts
@@ -3,17 +3,17 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		testTimeout: 120_000,
+		testTimeout: 90_000,
 		poolOptions: {
 			threads: {
 				singleThread: true,
 			},
 		},
-		retry: 2,
 		include: ["e2e/**/*.test.ts"],
 		// eslint-disable-next-line turbo/no-undeclared-env-vars
 		outputFile: process.env.TEST_REPORT_PATH ?? ".e2e-test-report/index.html",
 		globalSetup: path.resolve(__dirname, "./validate-environment.ts"),
 		reporters: ["verbose", "html"],
+		bail: 1,
 	},
 });

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -163,6 +163,7 @@
 		"strip-ansi": "^7.1.0",
 		"supports-color": "^9.2.2",
 		"timeago.js": "^4.0.2",
+		"tree-kill": "^1.2.2",
 		"ts-dedent": "^2.2.0",
 		"ts-json-schema-generator": "^1.5.0",
 		"undici": "^5.28.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1842,6 +1842,9 @@ importers:
       timeago.js:
         specifier: ^4.0.2
         version: 4.0.2
+      tree-kill:
+        specifier: ^1.2.2
+        version: 1.2.2
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0


### PR DESCRIPTION
## What this PR solves / how to test

- `child_process.kill()` doesn't really work on Windows. Using `kill-tree` library instead
- `killAllWranglerDev()` helper could mess up parallel tests since it kills all wrangler/workerd processes regardless of whether they are part of the current test
- `shellac` library has issues on Windows when running background tasks. Using simple `execSync` and `spawn` functions instead
- tightened up the timeouts a bit to avoid long running false negatives
- reworked the helpers to use a class `WranglerE2ETestHelper` rather than the `e2eTest` extension.


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: test refactor
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: test refactor
