### PR TITLE
fix: Add missing changeset for #5976

### DIFF
--- a/.changeset/polite-bananas-cross.md
+++ b/.changeset/polite-bananas-cross.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: define defineWorkersConfig using overload signatures
+
+The type definition of `defineWorkersConfig` doesn't work with `mergeConfig` of `vitest/config` because of type mismatch.
+This function should be an overload function like `defineConfig`

--- a/.changeset/polite-bananas-cross.md
+++ b/.changeset/polite-bananas-cross.md
@@ -2,7 +2,7 @@
 "@cloudflare/vitest-pool-workers": patch
 ---
 
-fix: define defineWorkersConfig using overload signatures
+fix: define `defineWorkersConfig` using overload signatures
 
 The type definition of `defineWorkersConfig` doesn't work with `mergeConfig` of `vitest/config` because of type mismatch.
 This function should be an overload function like `defineConfig`


### PR DESCRIPTION
This commit adds a changeset for the changes introduced by https://github.com/cloudflare/workers-sdk/pull/5976

## What this PR solves / how to test

Adds a changeset for the changes introduced by https://github.com/cloudflare/workers-sdk/pull/5976

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: just adds changeset
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: just adds changeset
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: just adds changeset

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
