### PR TITLE
run eslint (with react config) on workers-playground/wrangler

### DIFF
--- a/.changeset/red-seahorses-smoke.md
+++ b/.changeset/red-seahorses-smoke.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+chore: run eslint (with react config) on workers-playground/wrangler
+
+This enables eslint (with our react config) for the workers-playground project. Additionally, this enables the react-jsx condition in relevant tsconfig/eslint config, letting us write jsx without having React in scope.

--- a/fixtures/dev-env/tests/tsconfig.json
+++ b/fixtures/dev-env/tests/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
 	"compilerOptions": {
 		"types": ["node"],
-		"jsx": "react"
+		"jsx": "react-jsx"
 	},
 	"include": [
 		"**/*.ts",

--- a/packages/create-cloudflare/templates/common/ts/tsconfig.json
+++ b/packages/create-cloudflare/templates/common/ts/tsconfig.json
@@ -13,7 +13,7 @@
 		/* Language and Environment */
 		"target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		"lib": ["es2021"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
+		"jsx": "react-jsx" /* Specify what JSX code is generated. */,
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
 		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */

--- a/packages/create-cloudflare/templates/hello-world-durable-object/ts/tsconfig.json
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/ts/tsconfig.json
@@ -13,7 +13,7 @@
 		/* Language and Environment */
 		"target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		"lib": ["es2021"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
+		"jsx": "react-jsx" /* Specify what JSX code is generated. */,
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
 		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */

--- a/packages/create-cloudflare/templates/hello-world/ts/tsconfig.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/tsconfig.json
@@ -13,7 +13,7 @@
 		/* Language and Environment */
 		"target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		"lib": ["es2021"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
+		"jsx": "react-jsx" /* Specify what JSX code is generated. */,
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
 		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */

--- a/packages/create-cloudflare/templates/queues/ts/tsconfig.json
+++ b/packages/create-cloudflare/templates/queues/ts/tsconfig.json
@@ -13,7 +13,7 @@
 		/* Language and Environment */
 		"target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		"lib": ["es2021"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
+		"jsx": "react-jsx" /* Specify what JSX code is generated. */,
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
 		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */

--- a/packages/create-cloudflare/templates/scheduled/ts/tsconfig.json
+++ b/packages/create-cloudflare/templates/scheduled/ts/tsconfig.json
@@ -13,7 +13,7 @@
 		/* Language and Environment */
 		"target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		"lib": ["es2021"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
+		"jsx": "react-jsx" /* Specify what JSX code is generated. */,
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
 		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */

--- a/packages/eslint-config-worker/react.js
+++ b/packages/eslint-config-worker/react.js
@@ -4,8 +4,12 @@ module.exports = {
 	plugins: ["eslint-plugin-react", "eslint-plugin-react-hooks"],
 	overrides: [
 		{
-			files: ["*.ts", "*.tsx"],
-			extends: ["plugin:react/recommended", "plugin:react-hooks/recommended"],
+			files: ["**/*.ts", "**/*.tsx"],
+			extends: [
+				"plugin:react/recommended",
+				"plugin:react/jsx-runtime",
+				"plugin:react-hooks/recommended",
+			],
 		},
 	],
 	settings: {

--- a/packages/format-errors/tsconfig.json
+++ b/packages/format-errors/tsconfig.json
@@ -5,7 +5,7 @@
 		"lib": [
 			"es2022"
 		] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
+		"jsx": "react-jsx" /* Specify what JSX code is generated. */,
 
 		/* Modules */
 		"module": "es2022" /* Specify what module code is generated. */,

--- a/packages/workers-playground/.eslintrc.cjs
+++ b/packages/workers-playground/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+	root: true,
+	extends: ["@cloudflare/eslint-config-worker/react"],
+};

--- a/packages/workers-playground/src/QuickEditor/DevtoolsIframe.tsx
+++ b/packages/workers-playground/src/QuickEditor/DevtoolsIframe.tsx
@@ -1,8 +1,9 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 import Frame from "./Frame";
 import FrameErrorBoundary from "./FrameErrorBoundary";
 import { ServiceContext } from "./QuickEditor";
 import { DragContext } from "./SplitPane";
+import type React from "react";
 
 function getDevtoolsIframeUrl(inspectorUrl: string) {
 	const url = new URL(`https://devtools.devprod.cloudflare.dev/js_app`);

--- a/packages/workers-playground/src/QuickEditor/HTTPTab/HTTPTab.tsx
+++ b/packages/workers-playground/src/QuickEditor/HTTPTab/HTTPTab.tsx
@@ -6,20 +6,15 @@ import { Toast } from "@cloudflare/component-toast";
 import { Div, Form, Label, Output } from "@cloudflare/elements";
 import { isDarkMode, theme } from "@cloudflare/style-const";
 import { createStyledComponent } from "@cloudflare/style-container";
-import React, {
-	useCallback,
-	useContext,
-	useEffect,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { FrameError } from "../FrameErrorBoundary";
 import { InputField } from "../InputField";
 import { ServiceContext } from "../QuickEditor";
-import SplitPane from "../SplitPane";
 import { fetchWorker } from "./fetchWorker";
-import RequestHeaders, { HeaderEntry } from "./RequestHeaders";
+import RequestHeaders from "./RequestHeaders";
 import ResponseView from "./ResponseView";
+import type { HeaderEntry } from "./RequestHeaders";
+import type React from "react";
 
 const HTTP_METHODS = [
 	"GET",
@@ -167,7 +162,9 @@ export function HTTPTab() {
 								Headers{" "}
 							</StyledLabel>
 							<Button
-								onClick={() => setHeaders((headers) => [...headers, ["", ""]])}
+								onClick={() =>
+									setHeaders((prevHeaders) => [...prevHeaders, ["", ""]])
+								}
 								ml="auto"
 								type="plain"
 							>
@@ -191,7 +188,7 @@ export function HTTPTab() {
 								p={2}
 								rows={5}
 								value={body}
-								onChange={(e: any) => setBody(e.target.value)}
+								onChange={(e) => setBody(e.target.value)}
 							/>
 						</Div>
 					)}
@@ -212,7 +209,7 @@ export function HTTPTab() {
 						<ResponseView response={response} loading={isLoading} />
 					) : (
 						<Toast type="info">
-							Send a request to test your Worker's response.
+							Send a request to test your Worker&apos;s response.
 						</Toast>
 					)}
 				</Output>

--- a/packages/workers-playground/src/QuickEditor/HTTPTab/RequestHeaders.tsx
+++ b/packages/workers-playground/src/QuickEditor/HTTPTab/RequestHeaders.tsx
@@ -1,8 +1,8 @@
 import { Button } from "@cloudflare/component-button";
 import { Icon } from "@cloudflare/component-icon";
 import { Div } from "@cloudflare/elements";
-import React from "react";
 import { InputField } from "../InputField";
+import type React from "react";
 
 export type HeaderEntry = [string, string];
 
@@ -35,7 +35,7 @@ const RequestHeaders: React.FC<Props> = ({ headers, onChange }) => {
 	return (
 		<Div mb={1} display="flex" flexDirection="column" gap={2}>
 			{headers.map((header, index) => (
-				<Div display="flex" gap={2} flexGrow={0}>
+				<Div display="flex" gap={2} flexGrow={0} key={header[0]}>
 					<InputField
 						name={`Header name ${index}`}
 						marginBottom={0}

--- a/packages/workers-playground/src/QuickEditor/HTTPTab/ResponseView.tsx
+++ b/packages/workers-playground/src/QuickEditor/HTTPTab/ResponseView.tsx
@@ -1,6 +1,7 @@
 import CodeBlock from "@cloudflare/component-code-block";
 import { Div } from "@cloudflare/elements";
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type React from "react";
 
 type Props = {
 	response: Response;
@@ -41,10 +42,14 @@ function maybeGetLanguage(
 }
 
 const ResponseView: React.FC<Props> = ({ response, loading }) => {
-	const { status, statusCode } = useMemo(() => {
-		const status = response.headers.get("cf-ew-status") || "";
-		const statusCode = window.parseInt(status, 10);
-		return { status, statusCode };
+	const { status, statusCode } = useMemo((): {
+		status: string;
+		statusCode: number;
+	} => {
+		return {
+			status: response.headers.get("cf-ew-status") || "",
+			statusCode: window.parseInt(status, 10),
+		};
 	}, [response]);
 
 	const headers = useMemo(

--- a/packages/workers-playground/src/QuickEditor/PreviewTab/PreviewTab.tsx
+++ b/packages/workers-playground/src/QuickEditor/PreviewTab/PreviewTab.tsx
@@ -14,7 +14,7 @@ export function getPreviewIframeUrl(edgePreview: string, previewUrl: string) {
 	return url.href;
 }
 
-function PreviewTab() {
+function PreviewTabImplementation() {
 	const draftWorker = useContext(ServiceContext);
 
 	const previewSrc = useMemo(() => {
@@ -89,8 +89,10 @@ function PreviewTab() {
 	);
 }
 
-export default () => (
-	<FrameErrorBoundary fallback={"Invalid URL"}>
-		<PreviewTab />
-	</FrameErrorBoundary>
-);
+export default function PreviewTab() {
+	return (
+		<FrameErrorBoundary fallback={"Invalid URL"}>
+			<PreviewTabImplementation />
+		</FrameErrorBoundary>
+	);
+}

--- a/packages/workers-playground/src/QuickEditor/PreviewTab/UrlBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/PreviewTab/UrlBar.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@cloudflare/component-button";
 import { Div } from "@cloudflare/elements";
 import { createComponent } from "@cloudflare/style-container";
-import React, { useState } from "react";
+import { useState } from "react";
 import { InputField } from "../InputField";
+import type React from "react";
 
 const StyledForm = createComponent(
 	({ theme }) => ({

--- a/packages/workers-playground/src/QuickEditor/PreviewTab/useInjectSources.tsx
+++ b/packages/workers-playground/src/QuickEditor/PreviewTab/useInjectSources.tsx
@@ -1,11 +1,7 @@
 import { useCallback } from "react";
-import {
-	Channel,
-	FromErrorPage,
-	SourcesLoadedMessage,
-	ToErrorPage,
-} from "../ipc";
-import { TypedModule } from "../useDraftWorker";
+import { Channel } from "../ipc";
+import type { FromErrorPage, SourcesLoadedMessage, ToErrorPage } from "../ipc";
+import type { TypedModule } from "../useDraftWorker";
 
 function getFilesFromModules(modules: Record<string, TypedModule>) {
 	return Object.entries(modules)

--- a/packages/workers-playground/src/QuickEditor/QuickEditor.tsx
+++ b/packages/workers-playground/src/QuickEditor/QuickEditor.tsx
@@ -1,5 +1,9 @@
 import { Div } from "@cloudflare/elements";
-import { isDarkMode, observeDarkMode, theme } from "@cloudflare/style-const";
+import {
+	isDarkMode,
+	observeDarkMode,
+	theme as styleTheme,
+} from "@cloudflare/style-const";
 import { createComponent } from "@cloudflare/style-container";
 import React, { createContext, useEffect, useState } from "react";
 import { BACKGROUND_GRAY } from "./constants";
@@ -92,7 +96,7 @@ export default function QuickEditor() {
 						minSize={50}
 						maxSize={-50}
 						style={{ backgroundColor: BACKGROUND_GRAY }}
-						paneStyle={{ backgroundColor: theme.colors.background }}
+						paneStyle={{ backgroundColor: styleTheme.colors.background }}
 					>
 						<EditorPane />
 						<ToolsPane />

--- a/packages/workers-playground/src/QuickEditor/SplitPane.tsx
+++ b/packages/workers-playground/src/QuickEditor/SplitPane.tsx
@@ -1,8 +1,10 @@
 import { isDarkMode, theme } from "@cloudflare/style-const";
-import React, { createContext, useContext, useState } from "react";
-// @ts-expect-error Types are wrong
-import ReactSplitPane, { Props as ReactSplitPaneProps } from "react-split-pane";
+import { createContext, useContext, useState } from "react";
+import ReactSplitPane from "react-split-pane";
 import { BORDER_GRAY } from "./constants";
+import type React from "react";
+// @ts-expect-error Types are wrong
+import type { Props as ReactSplitPaneProps } from "react-split-pane";
 
 export const DragContext = createContext(false);
 

--- a/packages/workers-playground/src/QuickEditor/TabBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/TabBar.tsx
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { isDarkMode, variables as theme } from "@cloudflare/style-const";
+import { isDarkMode, variables } from "@cloudflare/style-const";
 import { createComponent } from "@cloudflare/style-container";
 import {
 	Tab as ReactTab,
 	TabList as ReactTabList,
 	TabPanel as ReactTabPanel,
-	TabProps as ReactTabProps,
 	Tabs as ReactTabs,
 } from "react-tabs";
 import { BORDER_GRAY, STYLED_TAB_HEIGHT } from "./constants";
+import type { TabProps as ReactTabProps } from "react-tabs";
 
-const HIGHLIGHT_BLUE = theme.colors.blue[4];
+const HIGHLIGHT_BLUE = variables.colors.blue[4];
 
 type StyledTabProps = {
 	showHighlightBar?: boolean;
@@ -99,7 +99,9 @@ export const TabBar = createComponent(() => ({
 	display: "flex",
 	alignItems: "center",
 	justifyContent: "space-between",
-	backgroundColor: isDarkMode() ? theme.colors.white : theme.colors.gray[9],
+	backgroundColor: isDarkMode()
+		? variables.colors.white
+		: variables.colors.gray[9],
 	flex: "none",
 }));
 
@@ -117,7 +119,9 @@ export const TabList = createComponent(
 export const TabBarContent = createComponent(() => ({
 	flex: "1 0 auto",
 	borderBottom: "none",
-	backgroundColor: isDarkMode() ? theme.colors.white : theme.colors.gray[9],
+	backgroundColor: isDarkMode()
+		? variables.colors.white
+		: variables.colors.gray[9],
 }));
 
 export const Tabs = createComponent(

--- a/packages/workers-playground/src/QuickEditor/TopBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/TopBar.tsx
@@ -119,7 +119,7 @@ export function TopBar() {
 				<Button
 					type="primary"
 					inverted={true}
-					disabled={!Boolean(previewHash?.serialised)}
+					disabled={!previewHash?.serialised}
 					onClick={() => {
 						void navigator.clipboard.writeText(location.href);
 						setHasCopied(!hasCopied);
@@ -137,7 +137,7 @@ export function TopBar() {
 			>
 				<Button
 					type="primary"
-					disabled={!Boolean(previewHash?.serialised)}
+					disabled={!previewHash?.serialised}
 					tabIndex={-1}
 				>
 					Deploy

--- a/packages/workers-playground/src/QuickEditor/VSCodeEditor.tsx
+++ b/packages/workers-playground/src/QuickEditor/VSCodeEditor.tsx
@@ -3,15 +3,15 @@ import { Div } from "@cloudflare/elements";
 import { isDarkMode } from "@cloudflare/style-const";
 import { useContext, useEffect, useRef, useState } from "react";
 import Frame from "./Frame";
-import {
-	Channel,
+import { Channel } from "./ipc";
+import { DragContext } from "./SplitPane";
+import type {
 	FromQuickEditMessage,
 	ToQuickEditMessage,
 	WorkerLoadedMessage,
 	WrappedChannel,
 } from "./ipc";
-import { DragContext } from "./SplitPane";
-import { TypedModule } from "./useDraftWorker";
+import type { TypedModule } from "./useDraftWorker";
 
 function stripSlashPrefix(path: string) {
 	return path[0] === "/" ? path.slice(1) : path;
@@ -90,7 +90,7 @@ export function VSCodeEditor({ content, onChange }: Props) {
 	}, []);
 
 	useEffect(() => {
-		if (quickEdit !== null)
+		if (quickEdit !== null) {
 			quickEdit.onMessage((data) => {
 				if (!content?.name) {
 					return;
@@ -137,6 +137,7 @@ export function VSCodeEditor({ content, onChange }: Props) {
 					});
 				}
 			});
+		}
 	}, [content, onChange, quickEdit]);
 
 	useEffect(() => {

--- a/packages/workers-playground/src/QuickEditor/WorkersLogo.tsx
+++ b/packages/workers-playground/src/QuickEditor/WorkersLogo.tsx
@@ -1,3 +1,8 @@
+// maybe the right thing to do here is to use the .svg logo directly
+// but I'm not aware why this was done in the first place, so leaving
+// the plain html attributes as is
+
+/* eslint-disable react/no-unknown-property */
 import { Div } from "@cloudflare/elements";
 import { createComponent } from "@cloudflare/style-container";
 

--- a/packages/workers-playground/src/QuickEditor/getPlaygroundWorker.ts
+++ b/packages/workers-playground/src/QuickEditor/getPlaygroundWorker.ts
@@ -1,5 +1,5 @@
 import lzstring from "lz-string";
-import { TypedModule, Worker } from "./useDraftWorker";
+import type { TypedModule, Worker } from "./useDraftWorker";
 
 // Parse a serialised FormData representation of a (very!) simple worker
 // Importantly, this only supports a subset of worker config relevant to Playground workers

--- a/packages/workers-playground/src/QuickEditor/module-collection.ts
+++ b/packages/workers-playground/src/QuickEditor/module-collection.ts
@@ -1,6 +1,6 @@
 // Adapted from https://github.com/cloudflare/workers-sdk/blob/0a77990457652af36c60c52bf9c38c3a69945de4/packages/wrangler/src/module-collection.ts
 import globToRegExp from "glob-to-regexp";
-import { TypedModule } from "./useDraftWorker";
+import type { TypedModule } from "./useDraftWorker";
 
 type ConfigModuleRuleType =
 	| "ESModule"

--- a/packages/workers-playground/src/QuickEditor/useDraftWorker.ts
+++ b/packages/workers-playground/src/QuickEditor/useDraftWorker.ts
@@ -1,4 +1,4 @@
-import { eg, TypeFromCodec } from "@cloudflare/util-en-garde";
+import { eg } from "@cloudflare/util-en-garde";
 import { useDebounce } from "@cloudflare/util-hooks";
 import lzstring from "lz-string";
 import { useEffect, useRef, useState } from "react";
@@ -6,6 +6,7 @@ import useSWR from "swr";
 import { v4 } from "uuid";
 import { getPlaygroundWorker } from "./getPlaygroundWorker";
 import { matchFiles, parseRules, toMimeType } from "./module-collection";
+import type { TypeFromCodec } from "@cloudflare/util-en-garde";
 
 const decoder = new TextDecoder();
 const encoder = new TextEncoder();
@@ -218,7 +219,9 @@ export function useDraftWorker(
 				setDevtoolsUrl(hash.devtoolsUrl);
 			} catch (e: unknown) {
 				console.error(e);
-				if (e instanceof Error) setPreviewError(String(e.message));
+				if (e instanceof Error) {
+					setPreviewError(String(e.message));
+				}
 			} finally {
 				setIsPreviewUpdating(false);
 			}
@@ -233,7 +236,7 @@ export function useDraftWorker(
 			setIsPreviewUpdating(true);
 			void updatePreview(worker).then(() => setIsPreviewUpdating(false));
 		}
-	}, [worker]);
+	}, [updatePreview, worker]);
 
 	return {
 		isLoading,

--- a/packages/workers-playground/src/main.tsx
+++ b/packages/workers-playground/src/main.tsx
@@ -15,7 +15,7 @@ function syncDarkModeWithSystem() {
 	const inSystemDarkMode =
 		window.matchMedia &&
 		window.matchMedia("(prefers-color-scheme: dark)").matches;
-	var classList = document.documentElement.classList;
+	const classList = document.documentElement.classList;
 	if (inSystemDarkMode) {
 		classList.add("dark-mode");
 	} else {
@@ -24,6 +24,7 @@ function syncDarkModeWithSystem() {
 }
 syncDarkModeWithSystem();
 setDarkMode(DarkModeSettings.SYSTEM);
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 ReactDOM.createRoot(document.getElementById("root")!).render(
 	<React.StrictMode>
 		<StyleProvider renderer={felaRenderer}>

--- a/packages/workers-playground/turbo.json
+++ b/packages/workers-playground/turbo.json
@@ -3,7 +3,8 @@
 	"extends": ["//"],
 	"pipeline": {
 		"build": {
-			"outputs": ["dist/**"]
+			"outputs": ["dist/**"],
+			"env": ["NODE_ENV", "VITE_PLAYGROUND_PREVIEW", "VITE_PLAYGROUND_ROOT"]
 		}
 	}
 }

--- a/packages/wrangler/src/d1/backups.tsx
+++ b/packages/wrangler/src/d1/backups.tsx
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import * as path from "path";
 import Table from "ink-table";
-import React from "react";
 import { fetchResult } from "../cfetch";
 import { performApiFetch } from "../cfetch/internal";
 import { withConfig } from "../config";

--- a/packages/wrangler/src/d1/create.tsx
+++ b/packages/wrangler/src/d1/create.tsx
@@ -1,5 +1,4 @@
 import { Box, Text } from "ink";
-import React from "react";
 import { printWranglerBanner } from "..";
 import { fetchResult } from "../cfetch";
 import { withConfig } from "../config";

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -7,7 +7,6 @@ import { Static, Text } from "ink";
 import Table from "ink-table";
 import md5File from "md5-file";
 import { Miniflare } from "miniflare";
-import React from "react";
 import { fetch } from "undici";
 import { printWranglerBanner } from "../";
 import { fetchResult } from "../cfetch";

--- a/packages/wrangler/src/d1/info.tsx
+++ b/packages/wrangler/src/d1/info.tsx
@@ -1,6 +1,5 @@
 import Table from "ink-table";
 import prettyBytes from "pretty-bytes";
-import React from "react";
 import { printWranglerBanner } from "..";
 import { fetchGraphqlResult } from "../cfetch";
 import { withConfig } from "../config";

--- a/packages/wrangler/src/d1/list.tsx
+++ b/packages/wrangler/src/d1/list.tsx
@@ -1,5 +1,4 @@
 import Table from "ink-table";
-import React from "react";
 import { printWranglerBanner } from "..";
 import { fetchResult } from "../cfetch";
 import { withConfig } from "../config";

--- a/packages/wrangler/src/d1/migrations/apply.tsx
+++ b/packages/wrangler/src/d1/migrations/apply.tsx
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import path from "path";
 import { Box, Text } from "ink";
 import Table from "ink-table";
-import React from "react";
 import { printWranglerBanner } from "../..";
 import { withConfig } from "../../config";
 import { confirm } from "../../dialogs";

--- a/packages/wrangler/src/d1/migrations/create.tsx
+++ b/packages/wrangler/src/d1/migrations/create.tsx
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "path";
 import { Box, Text } from "ink";
-import React from "react";
 import { printWranglerBanner } from "../..";
 import { withConfig } from "../../config";
 import { UserError } from "../../errors";

--- a/packages/wrangler/src/d1/migrations/list.tsx
+++ b/packages/wrangler/src/d1/migrations/list.tsx
@@ -1,7 +1,6 @@
 import path from "path";
 import { Box, Text } from "ink";
 import Table from "ink-table";
-import React from "react";
 import { printWranglerBanner } from "../..";
 import { withConfig } from "../../config";
 import { UserError } from "../../errors";

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -3,7 +3,6 @@ import { isWebContainer } from "@webcontainer/env";
 import { watch } from "chokidar";
 import getPort from "get-port";
 import { render } from "ink";
-import React from "react";
 import { findWranglerToml, printBindings, readConfig } from "./config";
 import { getEntry } from "./deployment-bundle/entry";
 import { validateNodeCompat } from "./deployment-bundle/node-compat";
@@ -43,6 +42,7 @@ import type {
 	StrictYargsOptionsToInterface,
 } from "./yargs-types";
 import type { Json } from "miniflare";
+import type React from "react";
 
 export function devOptions(yargs: CommonYargsArgv) {
 	return (

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -5,13 +5,7 @@ import { watch } from "chokidar";
 import clipboardy from "clipboardy";
 import commandExists from "command-exists";
 import { Box, Text, useApp, useInput, useStdin } from "ink";
-import React, {
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useErrorHandler, withErrorBoundary } from "react-error-boundary";
 import onExit from "signal-exit";
 import { fetch } from "undici";

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import path from "node:path";
 import { Text } from "ink";
 import SelectInput from "ink-select-input";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import { helpIfErrorIsSizeOrScriptStartup } from "../deploy/deploy";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";

--- a/packages/wrangler/src/pages/deploy.tsx
+++ b/packages/wrangler/src/pages/deploy.tsx
@@ -1,7 +1,6 @@
 import { execSync } from "node:child_process";
 import { render, Text } from "ink";
 import SelectInput from "ink-select-input";
-import React from "react";
 import { deploy } from "../api/pages/deploy";
 import { fetchResult } from "../cfetch";
 import { findWranglerToml, readConfig } from "../config";

--- a/packages/wrangler/src/pages/deployments.tsx
+++ b/packages/wrangler/src/pages/deployments.tsx
@@ -1,5 +1,4 @@
 import Table from "ink-table";
-import React from "react";
 import { format as timeagoFormat } from "timeago.js";
 import { fetchResult } from "../cfetch";
 import { getConfigCache, saveToConfigCache } from "../config-cache";

--- a/packages/wrangler/src/pages/projects.tsx
+++ b/packages/wrangler/src/pages/projects.tsx
@@ -1,6 +1,5 @@
 import { execSync } from "node:child_process";
 import Table from "ink-table";
-import React from "react";
 import { format as timeagoFormat } from "timeago.js";
 import { fetchResult } from "../cfetch";
 import { getConfigCache, saveToConfigCache } from "../config-cache";

--- a/packages/wrangler/src/pages/prompt-select-project.tsx
+++ b/packages/wrangler/src/pages/prompt-select-project.tsx
@@ -1,6 +1,5 @@
 import { render, Text } from "ink";
 import SelectInput from "ink-select-input";
-import React from "react";
 import { listProjects } from "./projects";
 
 export async function promptSelectProject({

--- a/packages/wrangler/src/pages/upload.tsx
+++ b/packages/wrangler/src/pages/upload.tsx
@@ -3,7 +3,6 @@ import { dirname } from "node:path";
 import { render, Text } from "ink";
 import Spinner from "ink-spinner";
 import PQueue from "p-queue";
-import React from "react";
 import { fetchResult } from "../cfetch";
 import { FatalError } from "../errors";
 import isInteractive from "../is-interactive";

--- a/packages/wrangler/templates/tsconfig.init.json
+++ b/packages/wrangler/templates/tsconfig.init.json
@@ -15,7 +15,7 @@
 		"lib": [
 			"es2021"
 		] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
+		"jsx": "react-jsx" /* Specify what JSX code is generated. */,
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
 		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */

--- a/packages/wrangler/tsconfig.json
+++ b/packages/wrangler/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"module": "CommonJS",
 		"types": ["node"],
-		"jsx": "react"
+		"jsx": "react-jsx"
 	},
 	"include": ["**/*.ts", "**/*.tsx", "**/*.js"],
 	"exclude": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13237,7 +13237,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
@@ -15825,7 +15825,7 @@ snapshots:
       enhanced-resolve: 5.14.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       get-tsconfig: 4.6.0
       globby: 13.1.4
       is-core-module: 2.13.0
@@ -15926,7 +15926,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1

--- a/templates/pages-example-forum-app/worker-durable/tsconfig.json
+++ b/templates/pages-example-forum-app/worker-durable/tsconfig.json
@@ -15,7 +15,7 @@
 		"lib": [
 			"es2021"
 		] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
+		"jsx": "react-jsx" /* Specify what JSX code is generated. */,
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
 		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
 		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */


### PR DESCRIPTION
This enables eslint (with our react config) for the workers-playground project. Additionally, this enables the react-jsx condition in relevant tsconfig/eslint configs, letting us write jsx without having React in scope.

## What this PR solves / how to test

Fixes https://github.com/cloudflare/workers-sdk/issues/6074

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: No functional changes
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: already covered 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: No public changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
