### PR TITLE
chore: run eslint and tsc in missing packages

### DIFF
--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -30,7 +30,6 @@
 		"dev:codemod": "node -r esbuild-register scripts/codemodDev.ts",
 		"check:lint": "eslint .",
 		"check:type": "tsc",
-		"lint": "eslint",
 		"prepublishOnly": "pnpm -w run build",
 		"test:e2e": "vitest run --config ./vitest-e2e.config.ts",
 		"test:e2e:npm": "pnpm run build && cross-env TEST_PM=npm vitest run --config ./vitest-e2e.config.ts",

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -6,7 +6,8 @@
 		"check:lint": "eslint .",
 		"deploy": "wrangler deploy",
 		"build": "wrangler build",
-		"start": "wrangler dev"
+		"start": "wrangler dev",
+		"check:type": "tsc"
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",

--- a/packages/kv-asset-handler/.eslintrc.js
+++ b/packages/kv-asset-handler/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+	root: true,
+	extends: ["@cloudflare/eslint-config-worker"],
+};

--- a/packages/kv-asset-handler/src/index.ts
+++ b/packages/kv-asset-handler/src/index.ts
@@ -1,15 +1,15 @@
 import * as mime from "mime";
 import {
-	AssetManifestType,
 	CacheControl,
 	InternalError,
 	MethodNotAllowedError,
 	NotFoundError,
 	Options,
 } from "./types";
+import type { AssetManifestType } from "./types";
 
 declare global {
-	var __STATIC_CONTENT: any, __STATIC_CONTENT_MANIFEST: string;
+	const __STATIC_CONTENT: unknown, __STATIC_CONTENT_MANIFEST: string;
 }
 
 const defaultCacheControl: CacheControl = {
@@ -116,7 +116,7 @@ function serveSinglePageApp(
 
 type Evt = {
 	request: Request;
-	waitUntil: (promise: Promise<any>) => void;
+	waitUntil: (promise: Promise<unknown>) => void;
 };
 
 const getAssetFromKV = async (
@@ -177,7 +177,7 @@ const getAssetFromKV = async (
 	// pathKey is the file path to look up in the manifest
 	let pathKey = pathname.replace(/^\/+/, ""); // remove prepended /
 
-	// @ts-ignore
+	// @ts-expect-error we should pick cf types here
 	const cache = caches.default;
 	let mimeType = mime.getType(pathKey) || options.defaultMimeType;
 	if (mimeType.startsWith("text") || mimeType === "application/javascript") {
@@ -195,7 +195,7 @@ const getAssetFromKV = async (
 	}
 
 	// TODO this excludes search params from cache, investigate ideal behavior
-	let cacheKey = new Request(`${parsedUrl.origin}/${pathKey}`, request);
+	const cacheKey = new Request(`${parsedUrl.origin}/${pathKey}`, request);
 
 	// if argument passed in for cacheControl is a function then
 	// evaluate that function. otherwise return the Object passed in
@@ -216,7 +216,7 @@ const getAssetFromKV = async (
 	// the potentially disastrous scenario where the value of the Etag resp
 	// header is "null". Could be modified in future to base64 encode etc
 	const formatETag = (
-		entityId: any = pathKey,
+		entityId: string = pathKey,
 		validatorType: string = options.defaultETag
 	) => {
 		if (!entityId) {
@@ -274,7 +274,7 @@ const getAssetFromKV = async (
 			response = new Response(null, response);
 		} else {
 			// fixes #165
-			let opts = {
+			const opts = {
 				headers: new Headers(response.headers),
 				status: 0,
 				statusText: "",
@@ -322,9 +322,9 @@ const getAssetFromKV = async (
 	response.headers.set("Content-Type", mimeType);
 
 	if (response.status === 304) {
-		let etag = formatETag(response.headers.get("etag"));
-		let ifNoneMatch = cacheKey.headers.get("if-none-match");
-		let proxyCacheStatus = response.headers.get("CF-Cache-Status");
+		const etag = formatETag(response.headers.get("etag"));
+		const ifNoneMatch = cacheKey.headers.get("if-none-match");
+		const proxyCacheStatus = response.headers.get("CF-Cache-Status");
 		if (etag) {
 			if (ifNoneMatch && ifNoneMatch === etag && proxyCacheStatus === "MISS") {
 				response.headers.set("CF-Cache-Status", "EXPIRED");

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -33,6 +33,7 @@
 		"dev": "concurrently -n esbuild,typechk,typewrk -c yellow,blue,blue.dim \"node scripts/build.mjs watch\" \"node scripts/types.mjs tsconfig.json watch\" \"node scripts/types.mjs src/workers/tsconfig.json watch\"",
 		"test": "node scripts/build.mjs && ava && rimraf ./.tmp",
 		"test:ci": "pnpm run test",
+		"check:type": "tsc",
 		"check:lint": "eslint --max-warnings=0 \"{src,test}/**/*.ts\" \"scripts/**/*.{js,mjs}\" \"types/**/*.ts\"",
 		"lint:fix": "pnpm run check:lint --fix",
 		"types:build": "node scripts/types.mjs tsconfig.json && node scripts/types.mjs src/workers/tsconfig.json"

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -7,6 +7,7 @@
 		"build-middleware:common": "pnpm dlx esbuild ../wrangler/templates/middleware/common.ts --outfile=src/middleware/common.module.template",
 		"build-middleware:loader": "pnpm dlx esbuild ../wrangler/templates/middleware/loader-modules.ts --outfile=src/middleware/loader.module.template",
 		"check:lint": "eslint .",
+		"check:type": "tsc",
 		"deploy": "wrangler -j deploy",
 		"deploy:testing": "wrangler -j deploy -e testing",
 		"start": "wrangler -j dev",

--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -89,6 +89,7 @@ async function handleRawHttp(request: Request, url: URL, env: Env) {
 
 	// The client needs the raw headers from the worker
 	// Prefix them with `cf-ew-raw-`, so that response headers from _this_ worker don't interfere
+	// @ts-expect-error https://github.com/cloudflare/workerd/issues/2273
 	const setCookieHeader = responseHeaders.getSetCookie();
 	for (const cookie of setCookieHeader) {
 		rawHeaders.append("cf-ew-raw-set-cookie", cookie);
@@ -135,7 +136,7 @@ app.use("*", async (c, next) => {
 		"sentry",
 		setupSentry(
 			c.req.raw,
-			c.executionCtx,
+			c.executionCtx as ExecutionContext, // TODO: fix hono's types?
 			c.env.SENTRY_DSN,
 			c.env.SENTRY_ACCESS_CLIENT_ID,
 			c.env.SENTRY_ACCESS_CLIENT_SECRET

--- a/packages/playground-preview-worker/src/user.do.ts
+++ b/packages/playground-preview-worker/src/user.do.ts
@@ -168,7 +168,7 @@ export class UserSession {
 			throw new BadUpload(`Expected valid form data`, String(e));
 		}
 
-		const m = worker.get("metadata");
+		const m = worker.get("metadata") as unknown;
 		if (!(m instanceof File)) {
 			throw new BadUpload("Expected metadata file to be defined");
 		}
@@ -209,7 +209,9 @@ export class UserSession {
 		let entrypoint = uploadedMetadata.main_module;
 		let additionalModules = new FormData();
 
-		const entrypointModule = worker.get(uploadedMetadata.main_module);
+		const entrypointModule = worker.get(
+			uploadedMetadata.main_module
+		) as unknown;
 
 		// Only apply middleware if the entrypoint is an ES6 module
 		if (
@@ -224,7 +226,7 @@ export class UserSession {
 		metadata.main_module = entrypoint;
 
 		for (const [path, additionalModule] of additionalModules.entries()) {
-			assert(additionalModule instanceof File);
+			assert((additionalModule as unknown) instanceof File);
 			worker.set(path, additionalModule);
 		}
 

--- a/packages/playground-preview-worker/tsconfig.json
+++ b/packages/playground-preview-worker/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "es2021",
 		"lib": ["es2021"],
-		"module": "es2022",
+		"module": "NodeNext",
 		"moduleResolution": "nodenext",
 		"types": ["@cloudflare/workers-types/experimental"],
 		"noEmit": true,

--- a/packages/quick-edit-extension/.eslintrc.js
+++ b/packages/quick-edit-extension/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+	root: true,
+	extends: ["@cloudflare/eslint-config-worker"],
+};

--- a/packages/quick-edit-extension/package.json
+++ b/packages/quick-edit-extension/package.json
@@ -10,6 +10,8 @@
 	"publisher": "cloudflare",
 	"browser": "./dist/extension.js",
 	"scripts": {
+		"check:lint": "eslint src",
+		"check:type": "tsc",
 		"package-web": "node -r esbuild-register scripts/bundle.ts",
 		"vscode:prepublish": "pnpm run package-web",
 		"watch-web": "pnpm run package-web -- --watch"

--- a/packages/quick-edit-extension/src/cfs.ts
+++ b/packages/quick-edit-extension/src/cfs.ts
@@ -259,7 +259,7 @@ declare module "*.bin" {
 		if (!entry) {
 			entry = new File(uri, basename);
 			parent.entries.set(basename, entry);
-			if (!options.suppressChannelUpdate)
+			if (!options.suppressChannelUpdate) {
 				this.channel.postMessage({
 					type: "CreateFile",
 					body: {
@@ -267,6 +267,7 @@ declare module "*.bin" {
 						contents: content,
 					},
 				});
+			}
 			this._fireSoon({ type: FileChangeType.Created, uri });
 		}
 		entry.mtime = Date.now();
@@ -275,7 +276,7 @@ declare module "*.bin" {
 		if (options.readOnly) {
 			entry.setReadOnly();
 		}
-		if (!options.suppressChannelUpdate)
+		if (!options.suppressChannelUpdate) {
 			this.channel.postMessage({
 				type: "UpdateFile",
 				body: {
@@ -283,6 +284,7 @@ declare module "*.bin" {
 					contents: content,
 				},
 			});
+		}
 		this._fireSoon({ type: FileChangeType.Changed, uri });
 	}
 

--- a/packages/quick-edit/.eslintrc.js
+++ b/packages/quick-edit/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+	root: true,
+	extends: ["@cloudflare/eslint-config-worker"],
+};

--- a/packages/quick-edit/functions/_middleware.ts
+++ b/packages/quick-edit/functions/_middleware.ts
@@ -62,7 +62,9 @@ export const onRequest = async ({
 			/\{\{([^}]+)\}\}/g,
 			(_, key) => values[key as keyof typeof values] ?? "undefined"
 		);
-		if (!isLocalDev) body = body.replace("/node_modules/", "/modules/");
+		if (!isLocalDev) {
+			body = body.replace("/node_modules/", "/modules/");
+		}
 
 		return new Response(body, {
 			headers: {

--- a/packages/quick-edit/package.json
+++ b/packages/quick-edit/package.json
@@ -11,6 +11,8 @@
 	"author": "workers-devprod@cloudflare.com",
 	"scripts": {
 		"custom:build": "./build.sh",
+		"check:lint": "eslint functions",
+		"check:type": "tsc",
 		"dev": "concurrently 'pnpm exec wrangler pages dev ./web' 'npm --prefix web/quick-edit-extension run watch-web' 'yarn --cwd ../../vendor/vscode watch' 'yarn --cwd ../../vendor/vscode watch-web'",
 		"setup": "rm -rf web/assets web/quick-edit-extension && ./setup.sh",
 		"deploy": "CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 pnpm exec wrangler pages deploy --project-name quick-edit ./web"

--- a/packages/turbo-r2-archive/package.json
+++ b/packages/turbo-r2-archive/package.json
@@ -14,7 +14,8 @@
 		"build": "wrangler deploy -j --dry-run --outdir=./dist",
 		"deploy": "wrangler deploy -j",
 		"start": "wrangler dev -j",
-		"type:check": "tsc --noEmit"
+		"type:check": "tsc",
+		"check:lint": "eslint ."
 	},
 	"dependencies": {
 		"@hono/zod-validator": "^0.1.8",

--- a/packages/workers-playground/package.json
+++ b/packages/workers-playground/package.json
@@ -6,6 +6,8 @@
 	"scripts": {
 		"build": "tsc && vite build",
 		"build:testing": "tsc && vite build -m development",
+		"check:lint": "eslint src",
+		"check:type": "tsc",
 		"dev": "vite",
 		"generate:default-hashes": "pnpm exec tsx ./generate-default-hashes.ts && pnpm exec prettier --write ./src/QuickEditor/defaultHashes.ts",
 		"check": "pnpm exec tsx ./generate-default-hashes.ts check",

--- a/packages/workers-playground/src/QuickEditor/PreviewTab/useRefreshableIframe.tsx
+++ b/packages/workers-playground/src/QuickEditor/PreviewTab/useRefreshableIframe.tsx
@@ -42,6 +42,7 @@ export function useRefreshableIframe(
 				second.removeEventListener("load", onLoadEvent);
 			};
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [onLoad]);
 
 	function listen() {
@@ -69,6 +70,7 @@ export function useRefreshableIframe(
 		if (src) {
 			setUrl(src);
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [src]);
 	const isLoading = isLoadingContent;
 	return {


### PR DESCRIPTION
Some of our packages didn't have a lint/typecheck rule setup, so I added it. Also fixed a couple of failures along the way. I _didn't_ enable linting for kv-asset-handler because that looks like a bit more work, which we can do later.

No changeset / tests for this, no functional changes.