### PR TITLE
Update blob/<commit-hash> links to blob/main.

### DIFF
--- a/packages/create-cloudflare/templates/next/README.md
+++ b/packages/create-cloudflare/templates/next/README.md
@@ -23,7 +23,7 @@ Besides the `dev` script mentioned above `c3` has added a few extra scripts that
   - `preview` to locally preview your Pages application using the [Wrangler](https://developers.cloudflare.com/workers/wrangler/) CLI
   - `deploy` to deploy your Pages application using the [Wrangler](https://developers.cloudflare.com/workers/wrangler/) CLI
 
-> __Note:__ while the `dev` script is optimal for local development you should preview your Pages application as well (periodically or before deployments) in order to make sure that it can properly work in the Pages environment (for more details see the [`@cloudflare/next-on-pages` recommended workflow](https://github.com/cloudflare/next-on-pages/blob/05b6256/internal-packages/next-dev/README.md#recommended-workflow))
+> __Note:__ while the `dev` script is optimal for local development you should preview your Pages application as well (periodically or before deployments) in order to make sure that it can properly work in the Pages environment (for more details see the [`@cloudflare/next-on-pages` recommended workflow](https://github.com/cloudflare/next-on-pages/blob/main/internal-packages/next-dev/README.md#recommended-development-workflow))
 
 ### Bindings
 

--- a/packages/create-cloudflare/templates/next/c3.ts
+++ b/packages/create-cloudflare/templates/next/c3.ts
@@ -63,7 +63,7 @@ const updateNextConfig = () => {
 
 		// Here we use the @cloudflare/next-on-pages next-dev module to allow us to use bindings during local development
 		// (when running the application with \`next dev\`), for more information see:
-		// https://github.com/cloudflare/next-on-pages/blob/5712c57ea7/internal-packages/next-dev/README.md
+		// https://github.com/cloudflare/next-on-pages/blob/main/internal-packages/next-dev/README.md
 		if (process.env.NODE_ENV === 'development') {
 		  await setupDevPlatform();
 		}


### PR DESCRIPTION
Fixes #6094

There are other links with this format mentioned in #6094. But this PR only addresses links to resources I was actively using. These two files would seem to benefit from this update.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Updating md.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: Updating md.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: This only affects links to github. Not rendered cloudflare-docs pages.
