### PR TITLE
chore: pass lint/typechecks for kv-asset-handler

### DIFF
--- a/.changeset/healthy-snails-heal.md
+++ b/.changeset/healthy-snails-heal.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/kv-asset-handler": patch
+---
+
+chore: pass lint/typechecks for kv-asset-handler
+
+Followup from https://github.com/cloudflare/workers-sdk/pull/6090, this enables typechecking and linting in kv-asset-handler, and fixes any failures.

--- a/packages/kv-asset-handler/package.json
+++ b/packages/kv-asset-handler/package.json
@@ -9,7 +9,9 @@
 		"build": "tsc -d",
 		"pretest": "npm run build",
 		"test": "ava dist/test/*.js --verbose",
-		"test:ci": "npm run build && ava dist/test/*.js --verbose"
+		"test:ci": "npm run build && ava dist/test/*.js --verbose",
+		"check:lint": "eslint .",
+		"check:type": "tsc"
 	},
 	"repository": {
 		"type": "git",
@@ -43,6 +45,7 @@
 		"@cloudflare/workers-types": "^4.20240605.0",
 		"@types/mime": "^3.0.4",
 		"@types/node": "20.8.3",
+		"@types/service-worker-mock": "^2.0.1",
 		"ava": "^6.0.1",
 		"service-worker-mock": "^2.0.5"
 	},

--- a/packages/kv-asset-handler/src/index.ts
+++ b/packages/kv-asset-handler/src/index.ts
@@ -9,7 +9,8 @@ import {
 import type { AssetManifestType } from "./types";
 
 declare global {
-	const __STATIC_CONTENT: unknown, __STATIC_CONTENT_MANIFEST: string;
+	const __STATIC_CONTENT: KVNamespace | undefined,
+		__STATIC_CONTENT_MANIFEST: string;
 }
 
 const defaultCacheControl: CacheControl = {

--- a/packages/kv-asset-handler/src/test/getAssetFromKV-optional.ts
+++ b/packages/kv-asset-handler/src/test/getAssetFromKV-optional.ts
@@ -1,24 +1,18 @@
 import test from "ava";
-import {
-	getEvent,
-	mockGlobalScope,
-	mockKV,
-	mockManifest,
-	mockRequestScope,
-	sleep,
-} from "../mocks";
+import { getEvent, mockGlobalScope, mockRequestScope } from "../mocks";
 
 mockGlobalScope();
 
-const { getAssetFromKV, mapRequestToAsset } = require("../index");
-
+// @ts-expect-error we use a require for a mock
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getAssetFromKV } = require("../index");
 // manually reset manifest global, to test optional behaviour
-Object.assign(global, { __STATIC_CONTENT_MANIFEST: undefined });
+Object.assign(globalThis, { __STATIC_CONTENT_MANIFEST: undefined });
 
 test("getAssetFromKV return correct val from KV without manifest", async (t) => {
 	mockRequestScope();
 	// manually reset manifest global, to test optional behaviour
-	Object.assign(global, { __STATIC_CONTENT_MANIFEST: undefined });
+	Object.assign(globalThis, { __STATIC_CONTENT_MANIFEST: undefined });
 
 	const event = getEvent(new Request("https://blah.com/key1.123HASHBROWN.txt"));
 	const res = await getAssetFromKV(event);

--- a/packages/kv-asset-handler/src/test/mapRequestToAsset.ts
+++ b/packages/kv-asset-handler/src/test/mapRequestToAsset.ts
@@ -6,33 +6,33 @@ mockGlobalScope();
 
 test("mapRequestToAsset() correctly changes /about -> /about/index.html", async (t) => {
 	mockRequestScope();
-	let path = "/about";
-	let request = new Request(`https://foo.com${path}`);
-	let newRequest = mapRequestToAsset(request);
+	const path = "/about";
+	const request = new Request(`https://foo.com${path}`);
+	const newRequest = mapRequestToAsset(request);
 	t.is(newRequest.url, request.url + "/index.html");
 });
 
 test("mapRequestToAsset() correctly changes /about/ -> /about/index.html", async (t) => {
 	mockRequestScope();
-	let path = "/about/";
-	let request = new Request(`https://foo.com${path}`);
-	let newRequest = mapRequestToAsset(request);
+	const path = "/about/";
+	const request = new Request(`https://foo.com${path}`);
+	const newRequest = mapRequestToAsset(request);
 	t.is(newRequest.url, request.url + "index.html");
 });
 
 test("mapRequestToAsset() correctly changes /about.me/ -> /about.me/index.html", async (t) => {
 	mockRequestScope();
-	let path = "/about.me/";
-	let request = new Request(`https://foo.com${path}`);
-	let newRequest = mapRequestToAsset(request);
+	const path = "/about.me/";
+	const request = new Request(`https://foo.com${path}`);
+	const newRequest = mapRequestToAsset(request);
 	t.is(newRequest.url, request.url + "index.html");
 });
 
 test("mapRequestToAsset() correctly changes /about -> /about/default.html", async (t) => {
 	mockRequestScope();
-	let path = "/about";
-	let request = new Request(`https://foo.com${path}`);
-	let newRequest = mapRequestToAsset(request, {
+	const path = "/about";
+	const request = new Request(`https://foo.com${path}`);
+	const newRequest = mapRequestToAsset(request, {
 		defaultDocument: "default.html",
 	});
 	t.is(newRequest.url, request.url + "/default.html");

--- a/packages/kv-asset-handler/src/test/serveSinglePageApp.ts
+++ b/packages/kv-asset-handler/src/test/serveSinglePageApp.ts
@@ -6,39 +6,39 @@ mockGlobalScope();
 
 function testRequest(path: string) {
 	mockRequestScope();
-	let url = new URL("https://example.com");
+	const url = new URL("https://example.com");
 	url.pathname = path;
-	let request = new Request(url.toString());
+	const request = new Request(url.toString());
 
 	return request;
 }
 
 test("serveSinglePageApp returns root asset path when request path ends in .html", async (t) => {
-	let path = "/foo/thing.html";
-	let request = testRequest(path);
+	const path = "/foo/thing.html";
+	const request = testRequest(path);
 
-	let expected_request = testRequest("/index.html");
-	let actual_request = serveSinglePageApp(request);
+	const expected_request = testRequest("/index.html");
+	const actual_request = serveSinglePageApp(request);
 
 	t.deepEqual(expected_request, actual_request);
 });
 
 test("serveSinglePageApp returns root asset path when request path does not have extension", async (t) => {
-	let path = "/foo/thing";
-	let request = testRequest(path);
+	const path = "/foo/thing";
+	const request = testRequest(path);
 
-	let expected_request = testRequest("/index.html");
-	let actual_request = serveSinglePageApp(request);
+	const expected_request = testRequest("/index.html");
+	const actual_request = serveSinglePageApp(request);
 
 	t.deepEqual(expected_request, actual_request);
 });
 
 test("serveSinglePageApp returns requested asset when request path has non-html extension", async (t) => {
-	let path = "/foo/thing.js";
-	let request = testRequest(path);
+	const path = "/foo/thing.js";
+	const request = testRequest(path);
 
-	let expected_request = request;
-	let actual_request = serveSinglePageApp(request);
+	const expected_request = request;
+	const actual_request = serveSinglePageApp(request);
 
 	t.deepEqual(expected_request, actual_request);
 });

--- a/packages/kv-asset-handler/src/types.ts
+++ b/packages/kv-asset-handler/src/types.ts
@@ -10,7 +10,7 @@ export type Options = {
 	cacheControl:
 		| ((req: Request) => Partial<CacheControl>)
 		| Partial<CacheControl>;
-	ASSET_NAMESPACE: any;
+	ASSET_NAMESPACE: KVNamespace;
 	ASSET_MANIFEST: AssetManifestType | string;
 	mapRequestToAsset?: (req: Request, options?: Partial<Options>) => Request;
 	defaultMimeType: string;

--- a/packages/kv-asset-handler/tsconfig.json
+++ b/packages/kv-asset-handler/tsconfig.json
@@ -2,11 +2,12 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"noImplicitAny": true,
-		"target": "ES2017",
+		"target": "ES2022",
 		"allowJs": false,
-		"lib": ["WebWorker", "ES5", "ScriptHost"],
-		"module": "commonjs",
-		"moduleResolution": "node"
+		"types": ["@cloudflare/workers-types"],
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"skipLibCheck": true
 	},
 	"include": [
 		"./src/*.ts",

--- a/packages/wrangler/.eslintrc.js
+++ b/packages/wrangler/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
 		"pages/functions/template-worker.ts",
 		"templates",
 		"emitted-types",
+		"kv-asset-handler.js",
 	],
 	overrides: [
 		{

--- a/packages/wrangler/tsconfig.json
+++ b/packages/wrangler/tsconfig.json
@@ -13,6 +13,7 @@
 		"src/miniflare-cli",
 		"templates",
 		"**/__tests__",
-		"**/*.test.ts"
+		"**/*.test.ts",
+		"kv-asset-handler.js"
 	]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1036,6 +1036,9 @@ importers:
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
+      '@types/service-worker-mock':
+        specifier: ^2.0.1
+        version: 2.0.4
       ava:
         specifier: ^6.0.1
         version: 6.1.1(@ava/typescript@4.1.0)(encoding@0.1.13)
@@ -4522,6 +4525,9 @@ packages:
 
   '@types/serve-static@1.13.10':
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==}
+
+  '@types/service-worker-mock@2.0.4':
+    resolution: {integrity: sha512-MEBT2eiqYfhxjqYm/oAf2AvKLbPTPwJJAYrMdheKnGyz1yG9XBRfxCzi93h27qpSvI7jOYfXqFLVMLBXFDqo4A==}
 
   '@types/shell-quote@1.7.2':
     resolution: {integrity: sha512-p3SZxGp6LXB6RPdMpJmquKjaxQlN/ijyBLTKGPg9IJK6J2g2sJsMmtXP9kNR+Axxi6MDKN2e/76HCOUmvkIpcw==}
@@ -13242,8 +13248,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
@@ -13763,6 +13769,8 @@ snapshots:
     dependencies:
       '@types/mime': 1.3.2
       '@types/node': 20.8.3
+
+  '@types/service-worker-mock@2.0.4': {}
 
   '@types/shell-quote@1.7.2': {}
 
@@ -15827,13 +15835,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.4(supports-color@9.2.2)
       enhanced-resolve: 5.14.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       get-tsconfig: 4.6.0
       globby: 13.1.4
       is-core-module: 2.13.0
@@ -15845,14 +15853,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15934,7 +15942,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
@@ -15943,7 +15951,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3


### PR DESCRIPTION
Followup from https://github.com/cloudflare/workers-sdk/pull/6090, this enables typechecking and linting in kv-asset-handler, and fixes any failures.

