### PR TITLE
Add `demandCommand()` to R2 Commands

### DIFF
--- a/.changeset/chilled-ties-occur.md
+++ b/.changeset/chilled-ties-occur.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: Add help messages to all invalid `r2` commands

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import { http, HttpResponse } from "msw";
 import { MAX_UPLOAD_SIZE } from "../r2/constants";
 import { actionsForEventCategories } from "../r2/helpers";
+import { endEventLoop } from "./helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
@@ -14,7 +15,6 @@ import type {
 	R2EventableOperation,
 	R2EventType,
 } from "../r2/helpers";
-import { endEventLoop } from "./helpers/end-event-loop";
 
 describe("r2", () => {
 	const std = mockConsoleMethods();
@@ -77,9 +77,7 @@ describe("r2", () => {
 		mockApiToken();
 
 		it("should show help when the bucket command is passed", async () => {
-			await expect(() =>
-				runWrangler("r2 bucket")
-			).rejects.toThrow(
+			await expect(() => runWrangler("r2 bucket")).rejects.toThrow(
 				"Not enough non-option arguments: got 0, need at least 1"
 			);
 			expect(std.err).toMatchInlineSnapshot(`
@@ -1060,9 +1058,7 @@ describe("r2", () => {
 
 	describe("r2 object", () => {
 		it("should show help when the object command is passed", async () => {
-			await expect(() =>
-				runWrangler("r2 object")
-			).rejects.toThrow(
+			await expect(() => runWrangler("r2 object")).rejects.toThrow(
 				"Not enough non-option arguments: got 0, need at least 1"
 			);
 			expect(std.err).toMatchInlineSnapshot(`

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -14,6 +14,7 @@ import type {
 	R2EventableOperation,
 	R2EventType,
 } from "../r2/helpers";
+import { endEventLoop } from "./helpers/end-event-loop";
 
 describe("r2", () => {
 	const std = mockConsoleMethods();
@@ -21,9 +22,92 @@ describe("r2", () => {
 
 	runInTempDir();
 
+	it("should show help when no argument is passed", async () => {
+		await runWrangler("r2");
+		await endEventLoop();
+		expect(std.out).toMatchInlineSnapshot(`
+		"wrangler r2
+
+		📦 Manage R2 buckets & objects
+
+		COMMANDS
+		  wrangler r2 object  Manage R2 objects
+		  wrangler r2 bucket  Manage R2 buckets
+
+		GLOBAL FLAGS
+		  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+		  -c, --config                    Path to .toml configuration file  [string]
+		  -e, --env                       Environment to use for operations and .env files  [string]
+		  -h, --help                      Show help  [boolean]
+		  -v, --version                   Show version number  [boolean]"
+	`);
+	});
+
+	it("should show help when an invalid argument is passed", async () => {
+		await expect(() => runWrangler("r2 asdf")).rejects.toThrow(
+			"Unknown argument: asdf"
+		);
+		await endEventLoop();
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: asdf[0m
+
+			"
+		`);
+		expect(std.out).toMatchInlineSnapshot(`
+		"
+		wrangler r2
+
+		📦 Manage R2 buckets & objects
+
+		COMMANDS
+		  wrangler r2 object  Manage R2 objects
+		  wrangler r2 bucket  Manage R2 buckets
+
+		GLOBAL FLAGS
+		  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+		  -c, --config                    Path to .toml configuration file  [string]
+		  -e, --env                       Environment to use for operations and .env files  [string]
+		  -h, --help                      Show help  [boolean]
+		  -v, --version                   Show version number  [boolean]"
+	`);
+	});
+
 	describe("bucket", () => {
 		mockAccountId();
 		mockApiToken();
+
+		it("should show help when the bucket command is passed", async () => {
+			await expect(() =>
+				runWrangler("r2 bucket")
+			).rejects.toThrow(
+				"Not enough non-option arguments: got 0, need at least 1"
+			);
+			expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
+
+"`);
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				wrangler r2 bucket
+
+				Manage R2 buckets
+
+				COMMANDS
+				  wrangler r2 bucket create <name>  Create a new R2 bucket
+				  wrangler r2 bucket update         Update bucket state
+				  wrangler r2 bucket list           List R2 buckets
+				  wrangler r2 bucket delete <name>  Delete an R2 bucket
+				  wrangler r2 bucket sippy          Manage Sippy incremental migration on an R2 bucket
+				  wrangler r2 bucket notification   Manage event notifications for an R2 bucket
+
+				GLOBAL FLAGS
+				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+				  -c, --config                    Path to .toml configuration file  [string]
+				  -e, --env                       Environment to use for operations and .env files  [string]
+				  -h, --help                      Show help  [boolean]
+				  -v, --version                   Show version number  [boolean]"
+			`);
+		});
 
 		it("should show the correct help when an invalid command is passed", async () => {
 			await expect(() =>
@@ -975,6 +1059,35 @@ describe("r2", () => {
 	});
 
 	describe("r2 object", () => {
+		it("should show help when the object command is passed", async () => {
+			await expect(() =>
+				runWrangler("r2 object")
+			).rejects.toThrow(
+				"Not enough non-option arguments: got 0, need at least 1"
+			);
+			expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
+
+"`);
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				wrangler r2 object
+
+				Manage R2 objects
+
+				COMMANDS
+				  wrangler r2 object get <objectPath>     Fetch an object from an R2 bucket
+				  wrangler r2 object put <objectPath>     Create an object in an R2 bucket
+				  wrangler r2 object delete <objectPath>  Delete an object in an R2 bucket
+
+				GLOBAL FLAGS
+				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+				  -c, --config                    Path to .toml configuration file  [string]
+				  -e, --env                       Environment to use for operations and .env files  [string]
+				  -h, --help                      Show help  [boolean]
+				  -v, --version                   Show version number  [boolean]"
+			`);
+		});
 		describe("remote", () => {
 			// Only login for remote tests, local tests shouldn't require auth
 			mockAccountId();

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -532,7 +532,7 @@ export function createCLIParser(argv: string[]) {
 
 	// r2
 	wrangler.command("r2", "📦 Manage R2 buckets & objects", (r2Yargs) => {
-		return r2(r2Yargs.command(subHelp));
+		return r2(r2Yargs, subHelp);
 	});
 
 	// d1

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -24,7 +24,7 @@ import {
 } from "./helpers";
 import * as Notification from "./notification";
 import * as Sippy from "./sippy";
-import type { CommonYargsArgv } from "../yargs-types";
+import type { CommonYargsArgv, SubHelp } from "../yargs-types";
 import type { R2PutOptions } from "@cloudflare/workers-types/experimental";
 
 const CHUNK_SIZE = 1024;
@@ -50,10 +50,12 @@ async function createFileReadableStream(filePath: string) {
 	});
 }
 
-export function r2(r2Yargs: CommonYargsArgv) {
+export function r2(r2Yargs: CommonYargsArgv, subHelp: SubHelp) {
 	return r2Yargs
+		.command(subHelp)
 		.command("object", "Manage R2 objects", (r2ObjectYargs) => {
 			return r2ObjectYargs
+				.demandCommand()
 				.command(
 					"get <objectPath>",
 					"Fetch an object from an R2 bucket",
@@ -427,6 +429,7 @@ export function r2(r2Yargs: CommonYargsArgv) {
 		})
 
 		.command("bucket", "Manage R2 buckets", (r2BucketYargs) => {
+			r2BucketYargs.demandCommand();
 			r2BucketYargs.command(
 				"create <name>",
 				"Create a new R2 bucket",


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #5928.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Change affects noop command output only.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: Same as above
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Same as above
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: Same as above
