### PR TITLE
chore: ensure `normalizeAndValidateConfig` args param is typed

### DIFF
--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -5,15 +5,12 @@ import { FatalError, UserError } from "../errors";
 import { logger } from "../logger";
 import { EXIT_CODE_INVALID_PAGES_CONFIG } from "../pages/errors";
 import { parseJSONC, parseTOML, readFileSync } from "../parse";
-import {
-	isPagesConfig,
-	normalizeAndValidateConfig,
-	NormalizeAndValidateConfigArgs,
-} from "./validation";
+import { isPagesConfig, normalizeAndValidateConfig } from "./validation";
 import { validatePagesConfig } from "./validation-pages";
 import type { CfWorkerInit } from "../deployment-bundle/worker";
 import type { CommonYargsOptions } from "../yargs-types";
 import type { Config, OnlyCamelCase, RawConfig } from "./config";
+import type { NormalizeAndValidateConfigArgs } from "./validation";
 
 export type {
 	Config,

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -5,7 +5,11 @@ import { FatalError, UserError } from "../errors";
 import { logger } from "../logger";
 import { EXIT_CODE_INVALID_PAGES_CONFIG } from "../pages/errors";
 import { parseJSONC, parseTOML, readFileSync } from "../parse";
-import { isPagesConfig, normalizeAndValidateConfig } from "./validation";
+import {
+	isPagesConfig,
+	normalizeAndValidateConfig,
+	NormalizeAndValidateConfigArgs,
+} from "./validation";
 import { validatePagesConfig } from "./validation-pages";
 import type { CfWorkerInit } from "../deployment-bundle/worker";
 import type { CommonYargsOptions } from "../yargs-types";
@@ -24,30 +28,30 @@ export type {
 	ConfigModuleRuleType,
 } from "./environment";
 
-type ReadConfigCommandArgs<CommandArgs> = CommandArgs &
-	Pick<OnlyCamelCase<CommonYargsOptions>, "experimentalJsonConfig"> &
-	Partial<Pick<OnlyCamelCase<CommonYargsOptions>, "env">>;
+type ReadConfigCommandArgs = NormalizeAndValidateConfigArgs & {
+	experimentalJsonConfig: boolean | undefined;
+};
 
 /**
  * Get the Wrangler configuration; read it from the give `configPath` if available.
  */
-export function readConfig<CommandArgs>(
+export function readConfig(
 	configPath: string | undefined,
 	// Include command specific args as well as the wrangler global flags
-	args: ReadConfigCommandArgs<CommandArgs>,
+	args: ReadConfigCommandArgs,
 	requirePagesConfig: true
 ): Omit<Config, "pages_build_output_dir"> & { pages_build_output_dir: string };
-export function readConfig<CommandArgs>(
+export function readConfig(
 	configPath: string | undefined,
 	// Include command specific args as well as the wrangler global flags
-	args: ReadConfigCommandArgs<CommandArgs>,
+	args: ReadConfigCommandArgs,
 	requirePagesConfig?: boolean,
 	hideWarnings?: boolean
 ): Config;
-export function readConfig<CommandArgs>(
+export function readConfig(
 	configPath: string | undefined,
 	// Include command specific args as well as the wrangler global flags
-	args: ReadConfigCommandArgs<CommandArgs>,
+	args: ReadConfigCommandArgs,
 	requirePagesConfig?: boolean,
 	hideWarnings: boolean = false
 ): Config {

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import TOML from "@iarna/toml";
 import { dedent } from "ts-dedent";
 import { getConstellationWarningFromEnv } from "../constellation/utils";
+import { CommonYargsOptions } from "../yargs-types";
 import { Diagnostics } from "./diagnostics";
 import {
 	all,
@@ -40,6 +41,12 @@ import type {
 } from "./environment";
 import type { ValidatorFn } from "./validation-helpers";
 
+export type NormalizeAndValidateConfigArgs = {
+	env?: string;
+	"legacy-env"?: boolean;
+	"dispatch-namespace"?: string;
+};
+
 const ENGLISH = new Intl.ListFormat("en-US");
 
 export function isPagesConfig(rawConfig: RawConfig): boolean {
@@ -57,7 +64,7 @@ export function isPagesConfig(rawConfig: RawConfig): boolean {
 export function normalizeAndValidateConfig(
 	rawConfig: RawConfig,
 	configPath: string | undefined,
-	args: Record<string, unknown>
+	args: NormalizeAndValidateConfigArgs
 ): {
 	config: Config;
 	diagnostics: Diagnostics;

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import TOML from "@iarna/toml";
 import { dedent } from "ts-dedent";
 import { getConstellationWarningFromEnv } from "../constellation/utils";
-import { CommonYargsOptions } from "../yargs-types";
 import { Diagnostics } from "./diagnostics";
 import {
 	all,


### PR DESCRIPTION
## What this PR solves / how to test

Closes [DEVX-1291](https://jira.cfdata.org/browse/DEVX-1291)

Replaces the `args: Record<string, unknown>` param of `normalizeAndValidateConfig` with a stricter type and threads it through via `readConfig`. This is a precursor to [DEVX-1295](https://jira.cfdata.org/browse/DEVX-1295)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: types refactor and covered by existing usage (type error if wrong, whereas did not type error before this PR)
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: types refactor
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: types refactor
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: types refactor

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
