### PR TITLE
chore: fail build on eslint warnings

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
 	"license": "MIT OR Apache-2.0",
 	"author": "wrangler@cloudflare.com",
 	"scripts": {
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"test:ci": "vitest run"
 	},

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -28,7 +28,7 @@
 	"scripts": {
 		"build": "node -r esbuild-register scripts/build.ts",
 		"dev:codemod": "node -r esbuild-register scripts/codemodDev.ts",
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"prepublishOnly": "pnpm -w run build",
 		"test:e2e": "vitest run --config ./vitest-e2e.config.ts",

--- a/packages/devprod-status-bot/package.json
+++ b/packages/devprod-status-bot/package.json
@@ -3,7 +3,7 @@
 	"version": "1.1.0",
 	"private": true,
 	"scripts": {
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"deploy": "wrangler deploy"
 	},

--- a/packages/edge-preview-authenticated-proxy/package.json
+++ b/packages/edge-preview-authenticated-proxy/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.4",
 	"private": true,
 	"scripts": {
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"deploy": "wrangler deploy",
 		"start": "wrangler dev",

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"build": "wrangler build",
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"deploy": "wrangler deploy",
 		"start": "wrangler dev"

--- a/packages/kv-asset-handler/package.json
+++ b/packages/kv-asset-handler/package.json
@@ -30,7 +30,7 @@
 	],
 	"scripts": {
 		"build": "tsc -d",
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"prepack": "npm run build",
 		"pretest": "npm run build",

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -13,7 +13,7 @@
 		"metadata-generator/**/*"
 	],
 	"scripts": {
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"test": "vitest run",
 		"test:ci": "vitest run"

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -6,7 +6,7 @@
 		"build-middleware": "pnpm run build-middleware:common && pnpm run build-middleware:loader",
 		"build-middleware:common": "pnpm dlx esbuild ../wrangler/templates/middleware/common.ts --outfile=src/middleware/common.module.template",
 		"build-middleware:loader": "pnpm dlx esbuild ../wrangler/templates/middleware/loader-modules.ts --outfile=src/middleware/loader.module.template",
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"deploy": "wrangler -j deploy",
 		"deploy:testing": "wrangler -j deploy -e testing",

--- a/packages/prerelease-registry/package.json
+++ b/packages/prerelease-registry/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/index.js",
 	"scripts": {
 		"build": "wrangler pages functions build --fallback-service='' ./functions/routes --outdir=dist",
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"predeploy": "pnpm run build",
 		"deploy": "wrangler deploy dist/index.js",

--- a/packages/quick-edit-extension/package.json
+++ b/packages/quick-edit-extension/package.json
@@ -10,7 +10,7 @@
 	"publisher": "cloudflare",
 	"browser": "./dist/extension.js",
 	"scripts": {
-		"check:lint": "eslint src",
+		"check:lint": "eslint src --max-warnings=0",
 		"check:type": "tsc",
 		"package-web": "node -r esbuild-register scripts/bundle.ts",
 		"vscode:prepublish": "pnpm run package-web",

--- a/packages/quick-edit/package.json
+++ b/packages/quick-edit/package.json
@@ -10,7 +10,7 @@
 	"license": "BSD-3-Clause",
 	"author": "workers-devprod@cloudflare.com",
 	"scripts": {
-		"check:lint": "eslint functions",
+		"check:lint": "eslint functions --max-warnings=0",
 		"check:type": "tsc",
 		"custom:build": "./build.sh",
 		"deploy": "CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 pnpm exec wrangler pages deploy --project-name quick-edit ./web",

--- a/packages/turbo-r2-archive/package.json
+++ b/packages/turbo-r2-archive/package.json
@@ -12,7 +12,7 @@
 	],
 	"scripts": {
 		"build": "wrangler deploy -j --dry-run --outdir=./dist",
-		"check:lint": "eslint .",
+		"check:lint": "eslint .  --max-warnings=0",
 		"deploy": "wrangler deploy -j",
 		"start": "wrangler dev -j",
 		"type:check": "tsc"

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -45,7 +45,7 @@
 	"scripts": {
 		"build": "node scripts/bundle.mjs && tsc -p tsconfig.emit.json",
 		"capnp:rtti": "capnpc -o ts scripts/rtti/rtti.capnp",
-		"check:lint": "eslint .",
+		"check:lint": "eslint .  --max-warnings=0",
 		"check:type": "tsc && tsc -p src/worker/tsconfig.json && tsc -p types/tsconfig.json",
 		"dev": "node scripts/bundle.mjs watch",
 		"test": "vitest run",

--- a/packages/workers-playground/package.json
+++ b/packages/workers-playground/package.json
@@ -7,7 +7,7 @@
 		"build": "tsc && vite build",
 		"build:testing": "tsc && vite build -m development",
 		"check": "pnpm exec tsx ./generate-default-hashes.ts check",
-		"check:lint": "eslint src",
+		"check:lint": "eslint src --max-warnings=0",
 		"check:type": "tsc",
 		"deploy": "CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 wrangler pages deploy --project-name workers-playground ./dist",
 		"dev": "vite",

--- a/packages/workers.new/package.json
+++ b/packages/workers.new/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"deploy": "CLOUDFLARE_ACCOUNT_ID=$WORKERS_NEW_CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN=$WORKERS_NEW_CLOUDFLARE_API_TOKEN wrangler deploy",
 		"dev": "wrangler dev",
 		"test": "vitest run",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -53,7 +53,7 @@
 		"assert-git-version": "node -r esbuild-register scripts/assert-git-version.ts",
 		"build": "pnpm run clean && pnpm run bundle && pnpm run emit-types && pnpm run generate-json-schema",
 		"bundle": "node -r esbuild-register scripts/bundle.ts",
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"clean": "rimraf wrangler-dist miniflare-dist emitted-types",
 		"dev": "pnpm run clean && concurrently -c black,blue --kill-others-on-fail false \"pnpm run bundle --watch\" \"pnpm run check:type --watch --preserveWatchOutput\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13242,7 +13242,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
@@ -15830,7 +15830,7 @@ snapshots:
       enhanced-resolve: 5.14.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       get-tsconfig: 4.6.0
       globby: 13.1.4
       is-core-module: 2.13.0
@@ -15931,7 +15931,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1

--- a/tools/package.json
+++ b/tools/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"description": "Tooling for this monorepo CI",
 	"scripts": {
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"test:ci": "vitest run",
 		"test:file": "node -r esbuild-register test/run-test-file.ts"

--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
     "build": "echo 'No build step configured'",
-		"check:lint": "eslint .",
+		"check:lint": "eslint . --max-warnings=0",
     "check:type": "tsc",
     "test": "vitest run",
 		"test:ci": "vitest run"


### PR DESCRIPTION
Modify all the eslint commands to fail if any warnings are present.

--- 
This should fail, and pass once https://github.com/cloudflare/workers-sdk/pull/6001/files#r1648173873 is resolved 

