### PR TITLE
fix: onBundleStart dependency array

### DIFF
--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -603,11 +603,12 @@ function DevSession(props: DevSessionProps) {
 	]);
 
 	const onBundleStart = useCallback(() => {
-		// NOTE: this callback won't be called if props.experimentalDevEnv
-		devEnv.proxy.onBundleStart({
-			type: "bundleStart",
-			config: startDevWorkerOptions,
-		});
+		if (!props.experimentalDevEnv) {
+			devEnv.proxy.onBundleStart({
+				type: "bundleStart",
+				config: startDevWorkerOptions,
+			});
+		}
 	}, [devEnv, startDevWorkerOptions, props.experimentalDevEnv]);
 	const onBundleComplete = useCallback(
 		(bundle: EsbuildBundle) => {


### PR DESCRIPTION
## What this PR solves / how to test

Fixes extraneous item in onBundleStart dependency array. Addresses comment [here](https://github.com/cloudflare/workers-sdk/pull/6001/files#r1648173873).

This prop was left in the dependency array after removing a redundant surrounding if-condition using the prop. It was decided the comment was enough but I am putting the redundant if-condition back to be ultra specific for readers of the code – the interim period where we're faking some events, but not when the experimental flag is on, is admittedly a bit confusing.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: tested by existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no change in behaviour
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
