### PR TITLE
chore: turn on prettier for package.json files and fix them

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,10 @@
 	"semi": true,
 	"useTabs": true,
 	"trailingComma": "es5",
-	"plugins": ["@ianvs/prettier-plugin-sort-imports"],
+	"plugins": [
+		"@ianvs/prettier-plugin-sort-imports",
+		"prettier-plugin-packagejson"
+	],
 	"importOrder": [
 		"<BUILTIN_MODULES>",
 		"<THIRD_PARTY_MODULES>",

--- a/fixtures/dev-env/package.json
+++ b/fixtures/dev-env/package.json
@@ -11,6 +11,7 @@
 		"test:watch": "npx vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
+	"dependencies": {},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
 		"@types/ws": "^8.5.7",
@@ -20,7 +21,6 @@
 		"wrangler": "workspace:*",
 		"ws": "^8.14.2"
 	},
-	"dependencies": {},
 	"volta": {
 		"extends": "../../package.json"
 	}

--- a/fixtures/external-service-bindings-app/package.json
+++ b/fixtures/external-service-bindings-app/package.json
@@ -3,13 +3,13 @@
 	"private": true,
 	"description": "A test for external service bindings",
 	"scripts": {
+		"dev": "npx concurrently -s first -k 'npm run mod-a-dev' 'npm run mod-b-dev' 'npm run ser-a-dev' 'npm run mod-c-dev' 'npm run mod-d-dev' 'npm run pages-dev'",
 		"mod-a-dev": "wrangler dev module-worker-a/index.ts --local --port 8500",
 		"mod-b-dev": "wrangler dev module-worker-b/index.ts --local --port 8501",
-		"ser-a-dev": "wrangler dev service-worker-a/index.ts --local --port 8502",
 		"mod-c-dev": "wrangler dev module-worker-c/index.ts --local --port 8503 --env staging",
 		"mod-d-dev": "wrangler dev module-worker-d/index.ts --local --port 8504 --env production",
 		"pages-dev": "cd pages-functions-app && npx wrangler pages dev public --port 8505 --service MODULE_A_SERVICE=module-worker-a MODULE_B_SERVICE=module-worker-b SERVICE_A_SERVICE=service-worker-a STAGING_MODULE_C_SERVICE=module-worker-c@staging STAGING_MODULE_D_SERVICE=module-worker-d@staging",
-		"dev": "npx concurrently -s first -k 'npm run mod-a-dev' 'npm run mod-b-dev' 'npm run ser-a-dev' 'npm run mod-c-dev' 'npm run mod-d-dev' 'npm run pages-dev'",
+		"ser-a-dev": "wrangler dev service-worker-a/index.ts --local --port 8502",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc --noEmit"

--- a/fixtures/import-wasm-example/package.json
+++ b/fixtures/import-wasm-example/package.json
@@ -10,13 +10,13 @@
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
+	"dependencies": {
+		"import-wasm-static": "workspace:^"
+	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
 		"undici": "^5.28.4",
 		"wrangler": "workspace:*"
-	},
-	"dependencies": {
-		"import-wasm-static": "workspace:^"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/nodejs-hybrid-app/package.json
+++ b/fixtures/nodejs-hybrid-app/package.json
@@ -2,8 +2,8 @@
 	"name": "nodejs-hybrid-app",
 	"private": true,
 	"scripts": {
-		"dev": "wrangler dev",
 		"build": "wrangler deploy --dry-run --outdir=./dist",
+		"dev": "wrangler dev",
 		"test:ci": "vitest run",
 		"test:watch": "vitest"
 	},

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -10,6 +10,9 @@
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
+	"dependencies": {
+		"is-odd": "^3.0.1"
+	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20240605.0",
@@ -19,9 +22,6 @@
 	},
 	"engines": {
 		"node": ">=16.13"
-	},
-	"dependencies": {
-		"is-odd": "^3.0.1"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-plugin-mounted-on-root-app/package.json
+++ b/fixtures/pages-plugin-mounted-on-root-app/package.json
@@ -10,6 +10,9 @@
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
+	"dependencies": {
+		"is-odd": "^3.0.1"
+	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20240605.0",
@@ -19,9 +22,6 @@
 	},
 	"engines": {
 		"node": ">=16.13"
-	},
-	"dependencies": {
-		"is-odd": "^3.0.1"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/worker-app/package.json
+++ b/fixtures/worker-app/package.json
@@ -11,14 +11,14 @@
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
+	"dependencies": {
+		"cookie": "^0.6.0",
+		"isomorphic-random-example": "workspace:^"
+	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
 		"undici": "^5.28.4",
 		"wrangler": "workspace:*"
-	},
-	"dependencies": {
-		"cookie": "^0.6.0",
-		"isomorphic-random-example": "workspace:^"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
 		"check:type": "dotenv -- turbo check:type type:tests",
 		"dev": "dotenv -- turbo dev",
 		"fix": "dotenv -- turbo check:lint -- --fix && pnpm run prettify",
+		"gen:package": "turbo gen package",
 		"prettify": "prettier . --write --ignore-unknown",
 		"test": "vitest run --no-file-parallelism && dotenv -- turbo test --filter=wrangler --filter=miniflare --filter=kv-asset-handler --filter=@cloudflare/vitest-pool-workers --filter=@cloudflare/vitest-pool-workers-examples",
 		"test:ci": "dotenv -- turbo test:ci",
 		"test:e2e": "dotenv -- turbo test:e2e --log-order=stream",
 		"test:watch": "turbo test:watch",
-		"type:tests": "dotenv -- turbo type:tests",
-		"gen:package": "turbo gen package"
+		"type:tests": "dotenv -- turbo type:tests"
 	},
 	"dependencies": {
 		"@actions/artifact": "^2.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,19 +1,14 @@
 {
 	"name": "@cloudflare/cli",
 	"version": "1.1.1",
-	"description": "An SDK to build workers-sdk CLIs",
 	"private": true,
+	"description": "An SDK to build workers-sdk CLIs",
 	"keywords": [
 		"cloudflare",
 		"workers",
 		"cloudflare workers",
 		"cli"
 	],
-	"scripts": {
-		"check:type": "tsc",
-		"test:ci": "vitest run",
-		"check:lint": "eslint ."
-	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/cloudflare/workers-sdk.git",
@@ -21,6 +16,11 @@
 	},
 	"license": "MIT OR Apache-2.0",
 	"author": "wrangler@cloudflare.com",
+	"scripts": {
+		"check:lint": "eslint .",
+		"check:type": "tsc",
+		"test:ci": "vitest run"
+	},
 	"devDependencies": {
 		"@clack/core": "^0.3.2",
 		"@clack/prompts": "^0.6.3",

--- a/packages/devprod-status-bot/package.json
+++ b/packages/devprod-status-bot/package.json
@@ -3,9 +3,9 @@
 	"version": "1.1.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler deploy",
 		"check:lint": "eslint .",
-		"check:type": "tsc"
+		"check:type": "tsc",
+		"deploy": "wrangler deploy"
 	},
 	"devDependencies": {
 		"@octokit/types": "^13.5.0",

--- a/packages/edge-preview-authenticated-proxy/package.json
+++ b/packages/edge-preview-authenticated-proxy/package.json
@@ -4,11 +4,11 @@
 	"private": true,
 	"scripts": {
 		"check:lint": "eslint .",
+		"check:type": "tsc",
 		"deploy": "wrangler deploy",
 		"start": "wrangler dev",
 		"test:ci": "vitest run",
-		"type:tests": "tsc -p ./tests/tsconfig.json",
-		"check:type": "tsc"
+		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",

--- a/packages/eslint-config-worker/package.json
+++ b/packages/eslint-config-worker/package.json
@@ -14,13 +14,13 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"eslint-plugin-unused-imports": "^3.0.0"
 	},
+	"devDependencies": {
+		"@typescript-eslint/eslint-plugin": "^6.9.0"
+	},
 	"peerDependencies": {
 		"@typescript-eslint/eslint-plugin": "^6.9.0"
 	},
 	"volta": {
 		"extends": "../../package.json"
-	},
-	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^6.9.0"
 	}
 }

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -3,11 +3,11 @@
 	"version": "0.0.2",
 	"private": true,
 	"scripts": {
-		"check:lint": "eslint .",
-		"deploy": "wrangler deploy",
 		"build": "wrangler build",
-		"start": "wrangler dev",
-		"check:type": "tsc"
+		"check:lint": "eslint .",
+		"check:type": "tsc",
+		"deploy": "wrangler deploy",
+		"start": "wrangler dev"
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",

--- a/packages/kv-asset-handler/package.json
+++ b/packages/kv-asset-handler/package.json
@@ -2,22 +2,6 @@
 	"name": "@cloudflare/kv-asset-handler",
 	"version": "0.3.3",
 	"description": "Routes requests to KV assets",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"prepack": "npm run build",
-		"build": "tsc -d",
-		"pretest": "npm run build",
-		"test": "ava dist/test/*.js --verbose",
-		"test:ci": "npm run build && ava dist/test/*.js --verbose",
-		"check:lint": "eslint .",
-		"check:type": "tsc"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/cloudflare/workers-sdk.git",
-		"directory": "packages/kv-asset-handler"
-	},
 	"keywords": [
 		"kv",
 		"cloudflare",
@@ -25,18 +9,34 @@
 		"wrangler",
 		"assets"
 	],
+	"homepage": "https://github.com/cloudflare/workers-sdk#readme",
+	"bugs": {
+		"url": "https://github.com/cloudflare/workers-sdk/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/cloudflare/workers-sdk.git",
+		"directory": "packages/kv-asset-handler"
+	},
+	"license": "MIT OR Apache-2.0",
+	"author": "wrangler@cloudflare.com",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
 		"src",
 		"dist",
 		"!src/test",
 		"!dist/test"
 	],
-	"author": "wrangler@cloudflare.com",
-	"license": "MIT OR Apache-2.0",
-	"bugs": {
-		"url": "https://github.com/cloudflare/workers-sdk/issues"
+	"scripts": {
+		"build": "tsc -d",
+		"check:lint": "eslint .",
+		"check:type": "tsc",
+		"prepack": "npm run build",
+		"pretest": "npm run build",
+		"test": "ava dist/test/*.js --verbose",
+		"test:ci": "npm run build && ava dist/test/*.js --verbose"
 	},
-	"homepage": "https://github.com/cloudflare/workers-sdk#readme",
 	"dependencies": {
 		"mime": "^3.0.0"
 	},
@@ -52,13 +52,13 @@
 	"engines": {
 		"node": ">=16.13"
 	},
+	"volta": {
+		"extends": "../../package.json"
+	},
 	"publishConfig": {
 		"access": "public"
 	},
 	"workers-sdk": {
 		"prerelease": true
-	},
-	"volta": {
-		"extends": "../../package.json"
 	}
 }

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -22,6 +22,9 @@
 	"author": "MrBBot <me@mrbbot.dev>",
 	"main": "./dist/src/index.js",
 	"types": "./dist/src/index.d.ts",
+	"bin": {
+		"miniflare": "bootstrap.js"
+	},
 	"files": [
 		"dist/src",
 		"bootstrap.js"
@@ -29,17 +32,14 @@
 	"scripts": {
 		"build": "node scripts/build.mjs && pnpm run types:build",
 		"capnp:workerd": "capnpc -o ts src/runtime/config/workerd.capnp",
+		"check:lint": "eslint --max-warnings=0 \"{src,test}/**/*.ts\" \"scripts/**/*.{js,mjs}\" \"types/**/*.ts\"",
+		"check:type": "tsc",
 		"clean": "rimraf ./dist ./dist-types",
 		"dev": "concurrently -n esbuild,typechk,typewrk -c yellow,blue,blue.dim \"node scripts/build.mjs watch\" \"node scripts/types.mjs tsconfig.json watch\" \"node scripts/types.mjs src/workers/tsconfig.json watch\"",
+		"lint:fix": "pnpm run check:lint --fix",
 		"test": "node scripts/build.mjs && ava && rimraf ./.tmp",
 		"test:ci": "pnpm run test",
-		"check:type": "tsc",
-		"check:lint": "eslint --max-warnings=0 \"{src,test}/**/*.ts\" \"scripts/**/*.{js,mjs}\" \"types/**/*.ts\"",
-		"lint:fix": "pnpm run check:lint --fix",
 		"types:build": "node scripts/types.mjs tsconfig.json && node scripts/types.mjs src/workers/tsconfig.json"
-	},
-	"bin": {
-		"miniflare": "bootstrap.js"
 	},
 	"dependencies": {
 		"@cspotcode/source-map-support": "0.8.1",

--- a/packages/pages-shared/package.json
+++ b/packages/pages-shared/package.json
@@ -13,8 +13,8 @@
 		"metadata-generator/**/*"
 	],
 	"scripts": {
-		"check:type": "tsc",
 		"check:lint": "eslint .",
+		"check:type": "tsc",
 		"test": "vitest run",
 		"test:ci": "vitest run"
 	},
@@ -31,10 +31,10 @@
 		"concurrently": "^8.2.2",
 		"glob": "^10.3.3"
 	},
-	"workers-sdk": {
-		"prerelease": true
-	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"prerelease": true
 	}
 }

--- a/packages/quick-edit-extension/package.json
+++ b/packages/quick-edit-extension/package.json
@@ -50,12 +50,12 @@
 	"engines": {
 		"vscode": "^1.76.0"
 	},
+	"volta": {
+		"extends": "../../package.json"
+	},
 	"enabledApiProposals": [
 		"fileSearchProvider",
 		"textSearchProvider",
 		"ipc"
-	],
-	"volta": {
-		"extends": "../../package.json"
-	}
+	]
 }

--- a/packages/quick-edit/package.json
+++ b/packages/quick-edit/package.json
@@ -10,12 +10,12 @@
 	"license": "BSD-3-Clause",
 	"author": "workers-devprod@cloudflare.com",
 	"scripts": {
-		"custom:build": "./build.sh",
 		"check:lint": "eslint functions",
 		"check:type": "tsc",
+		"custom:build": "./build.sh",
+		"deploy": "CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 pnpm exec wrangler pages deploy --project-name quick-edit ./web",
 		"dev": "concurrently 'pnpm exec wrangler pages dev ./web' 'npm --prefix web/quick-edit-extension run watch-web' 'yarn --cwd ../../vendor/vscode watch' 'yarn --cwd ../../vendor/vscode watch-web'",
-		"setup": "rm -rf web/assets web/quick-edit-extension && ./setup.sh",
-		"deploy": "CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 pnpm exec wrangler pages deploy --project-name quick-edit ./web"
+		"setup": "rm -rf web/assets web/quick-edit-extension && ./setup.sh"
 	},
 	"dependencies": {
 		"yarn": "^1.22.19"

--- a/packages/turbo-r2-archive/package.json
+++ b/packages/turbo-r2-archive/package.json
@@ -12,10 +12,10 @@
 	],
 	"scripts": {
 		"build": "wrangler deploy -j --dry-run --outdir=./dist",
+		"check:lint": "eslint .",
 		"deploy": "wrangler deploy -j",
 		"start": "wrangler dev -j",
-		"type:check": "tsc",
-		"check:lint": "eslint ."
+		"type:check": "tsc"
 	},
 	"dependencies": {
 		"@hono/zod-validator": "^0.1.8",

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -25,8 +25,6 @@
 		"directory": "packages/vitest-pool-workers"
 	},
 	"license": "MIT",
-	"main": "dist/pool/index.mjs",
-	"types": "types/cloudflare-test.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/pool/index.mjs",
@@ -38,18 +36,30 @@
 			"types": "./dist/config/index.d.ts"
 		}
 	},
+	"main": "dist/pool/index.mjs",
+	"types": "types/cloudflare-test.d.ts",
 	"files": [
 		"dist",
 		"types/cloudflare-test.d.ts"
 	],
 	"scripts": {
 		"build": "node scripts/bundle.mjs && tsc -p tsconfig.emit.json",
-		"dev": "node scripts/bundle.mjs watch",
+		"capnp:rtti": "capnpc -o ts scripts/rtti/rtti.capnp",
 		"check:lint": "eslint .",
 		"check:type": "tsc && tsc -p src/worker/tsconfig.json && tsc -p types/tsconfig.json",
+		"dev": "node scripts/bundle.mjs watch",
 		"test": "vitest run",
-		"test:ci": "vitest run",
-		"capnp:rtti": "capnpc -o ts scripts/rtti/rtti.capnp"
+		"test:ci": "vitest run"
+	},
+	"dependencies": {
+		"birpc": "0.2.14",
+		"cjs-module-lexer": "^1.2.3",
+		"devalue": "^4.3.0",
+		"esbuild": "0.17.19",
+		"miniflare": "workspace:*",
+		"semver": "^7.5.1",
+		"wrangler": "workspace:*",
+		"zod": "^3.22.3"
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
@@ -66,25 +76,15 @@
 		"undici": "^5.28.4",
 		"vitest": "1.5.0"
 	},
-	"dependencies": {
-		"birpc": "0.2.14",
-		"cjs-module-lexer": "^1.2.3",
-		"devalue": "^4.3.0",
-		"esbuild": "0.17.19",
-		"miniflare": "workspace:*",
-		"semver": "^7.5.1",
-		"wrangler": "workspace:*",
-		"zod": "^3.22.3"
-	},
 	"peerDependencies": {
 		"@vitest/runner": "1.3.x - 1.5.x",
 		"@vitest/snapshot": "1.3.x - 1.5.x",
 		"vitest": "1.3.x - 1.5.x"
 	},
-	"workers-sdk": {
-		"prerelease": true
-	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"prerelease": true
 	}
 }

--- a/packages/workers-playground/package.json
+++ b/packages/workers-playground/package.json
@@ -6,12 +6,12 @@
 	"scripts": {
 		"build": "tsc && vite build",
 		"build:testing": "tsc && vite build -m development",
+		"check": "pnpm exec tsx ./generate-default-hashes.ts check",
 		"check:lint": "eslint src",
 		"check:type": "tsc",
+		"deploy": "CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 wrangler pages deploy --project-name workers-playground ./dist",
 		"dev": "vite",
-		"generate:default-hashes": "pnpm exec tsx ./generate-default-hashes.ts && pnpm exec prettier --write ./src/QuickEditor/defaultHashes.ts",
-		"check": "pnpm exec tsx ./generate-default-hashes.ts check",
-		"deploy": "CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 wrangler pages deploy --project-name workers-playground ./dist"
+		"generate:default-hashes": "pnpm exec tsx ./generate-default-hashes.ts && pnpm exec prettier --write ./src/QuickEditor/defaultHashes.ts"
 	},
 	"dependencies": {
 		"@cloudflare/component-button": "^7.0.11",

--- a/packages/wrangler-devtools/package.json
+++ b/packages/wrangler-devtools/package.json
@@ -7,11 +7,11 @@
 	"bugs": {
 		"url": "https://github.com/cloudflare/workers-sdk/issues"
 	},
+	"license": "BSD-3-Clause",
+	"author": "workers-devprod@cloudflare.com",
 	"scripts": {
 		"deploy": "CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 make publish"
 	},
-	"license": "BSD-3-Clause",
-	"author": "workers-devprod@cloudflare.com",
 	"devDependencies": {
 		"patch-package": "^6.5.1",
 		"wrangler": "^3.0.0"

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -125,8 +125,8 @@
 		"clipboardy": "^3.0.0",
 		"cmd-shim": "^4.1.0",
 		"command-exists": "^1.2.9",
-		"deepmerge": "^4.3.1",
 		"concurrently": "^8.2.2",
+		"deepmerge": "^4.3.1",
 		"devtools-protocol": "^0.0.1182435",
 		"dotenv": "^16.0.0",
 		"es-module-lexer": "^1.3.0",
@@ -176,9 +176,6 @@
 		"yargs": "^17.7.2",
 		"yoga-layout": "file:../../vendor/yoga-layout-2.0.0-beta.1.tgz"
 	},
-	"optionalDependencies": {
-		"fsevents": "~2.3.2"
-	},
 	"peerDependencies": {
 		"@cloudflare/workers-types": "^4.20240605.0"
 	},
@@ -187,13 +184,16 @@
 			"optional": true
 		}
 	},
+	"optionalDependencies": {
+		"fsevents": "~2.3.2"
+	},
 	"engines": {
 		"node": ">=16.17.0"
 	},
-	"workers-sdk": {
-		"prerelease": true
-	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"prerelease": true
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13250,8 +13250,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
@@ -15835,13 +15835,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.4(supports-color@9.2.2)
       enhanced-resolve: 5.14.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       get-tsconfig: 4.6.0
       globby: 13.1.4
       is-core-module: 2.13.0
@@ -15853,14 +15853,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15942,7 +15942,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
@@ -15951,7 +15951,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "tools",
-	"description": "Tooling for this monorepo CI",
 	"private": true,
+	"description": "Tooling for this monorepo CI",
 	"scripts": {
+		"check:lint": "eslint .",
 		"check:type": "tsc",
 		"test:ci": "vitest run",
-		"check:lint": "eslint .",
 		"test:file": "node -r esbuild-register test/run-test-file.ts"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## What this PR solves / how to test

Simply turns and fixes up the package.json prettier plugin that we had installed but not running.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: formatting
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: formatting
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: formatting
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: formatting

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
