### PR TITLE
chore: Define expected package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"vite": "^5.0.12",
 		"vitest": "^1.2.2"
 	},
+	"packageManager": "pnpm@9.1.3",
 	"engines": {
 		"node": ">=18.20.0",
 		"pnpm": "^9.1.3"


### PR DESCRIPTION
The "packageManager" field defines which package manager is expected to be used when working on the current project. It can set to any of the supported package managers, and will ensure that your teams use the exact same package manager versions without having to install anything else than Node.js. See https://nodejs.org/dist/latest-v16.x/docs/api/all.html#all_packages_packagemanager for more information.

This commit sets the expected package manager in `workers-sdk` to `pnpm@9.1.3`. We're also secretly hoping, as per https://github.com/dependabot/dependabot-core/issues/9682#issuecomment-2172950223, that this will fix our dependabot-updater issues 😋 🤞 

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: sets package manager
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: sets package manager
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: sets package manager
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: sets package manager

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
