### PR TITLE
fix: remove invalid queueProducers schema

### DIFF
--- a/packages/miniflare/src/plugins/queues/index.ts
+++ b/packages/miniflare/src/plugins/queues/index.ts
@@ -23,11 +23,7 @@ import {
 
 export const QueuesOptionsSchema = z.object({
 	queueProducers: z
-		.union([
-			z.record(QueueProducerOptionsSchema),
-			z.string().array(),
-			z.record(z.string()),
-		])
+		.union([z.record(QueueProducerOptionsSchema), z.string().array()])
 		.optional(),
 	queueConsumers: z
 		.union([z.record(QueueConsumerOptionsSchema), z.string().array()])


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #5908.

The following commit changes the schema for queueProducers in miniflare but the zod schema still accepts the old `Record<string, string>` schema which will cause sending to the queue to fail with a non-descriptive error.
https://github.com/cloudflare/workers-sdk/commit/66bdad08834b403100d1e4d6cd507978cc50eaba#diff-0a38fa706f017d0142050f5bcd28eaed913461608cec13a4fa1461af12ff2d65L537

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
