### PR TITLE
quarantine C3 astro e2e test

### DIFF
--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -71,6 +71,7 @@ const { name: pm, npx } = detectPackageManager();
 const frameworkTests: Record<string, FrameworkTestConfig> = {
 	astro: {
 		testCommitMessage: true,
+		quarantine: true,
 		unsupportedOSs: ["win32"],
 		verifyDeploy: {
 			route: "/",


### PR DESCRIPTION
## What this PR solves / how to test

C3 astro e2e test started failing in CI for no obvious reasons since Mon 24 June 2024. We tried everything, like increasing timeouts, debugging, reproducing locally (which we can't) to no avail. We are quite confident that the test failures are not caused by any changes in wrangler (we verified this by running the tests against a PR where they were consistently green, but did fail on the re-run, without any changes to the branch).

As this is blocking our release, we decided to quarantine these tests, do the release, while continuing to look into why the tests are failing.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
