### PR TITLE
fix: add extra error logging to auth response errors

### DIFF
--- a/.changeset/tame-news-sleep.md
+++ b/.changeset/tame-news-sleep.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: add extra error logging to auth response errors


### PR DESCRIPTION
## What this PR solves / how to test

May help diagnosing issues like https://github.com/cloudflare/workers-sdk/issues/3672, https://github.com/cloudflare/workers-sdk/issues/5542 and https://jira.cfdata.org/browse/CUSTESC-42645

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: just adding logging for errors
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: just adding logging for errors that are not hit in e2e tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: just adding logging to errors
