### PR TITLE
[wrangler] fix: improve the `getPlatformProxy` `configPath` option ts-doc comment to clarify its behavior

### DIFF
--- a/.changeset/wicked-birds-itch.md
+++ b/.changeset/wicked-birds-itch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: improve the `getPlatformProxy` `configPath` option ts-doc comment to clarify its behavior

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -26,7 +26,12 @@ export type GetPlatformProxyOptions = {
 	 */
 	environment?: string;
 	/**
-	 * The path to the config object to use (default `wrangler.toml`)
+	 * The path to the config file to use.
+	 * If no path is specified the default behavior consists in a search from the
+	 * current directory up the filesystem for a `wrangler.toml` to use.
+	 *
+	 * Note: this field is optional but if a path is specified such path must
+	 *       point to a valid file on the filesystem
 	 */
 	configPath?: string;
 	/**


### PR DESCRIPTION

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: this is a simple ts-doc change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: this is a simple ts-doc change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
