### PR TITLE
ConfigController minor internal renaming

### DIFF
--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -126,7 +126,7 @@ describe("Core", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			compatibilityFlags: ["nodejs_compat"],
 			compatibilityDate: "2023-10-01",
 		};
@@ -271,7 +271,7 @@ describe("Core", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 		};
 		const bundle: Bundle = {
 			type: "commonjs",
@@ -358,7 +358,7 @@ describe("Core", () => {
 		function update(version: number) {
 			const config: StartDevWorkerOptions = {
 				name: "worker",
-				entrypoint: unusable() as FilePath,
+				entrypoint: unusable<FilePath>(),
 				bindings: {
 					VERSION: { type: "json", value: version },
 				},
@@ -406,7 +406,7 @@ describe("Core", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			compatibilityDate: disabledDate,
 		};
 		const bundle = makeEsbuildBundle(dedent/*javascript*/ `
@@ -444,7 +444,7 @@ describe("Core", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 		};
 		const bundle = makeEsbuildBundle(dedent/*javascript*/ `
 				export default {
@@ -503,7 +503,7 @@ describe("Bindings", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			bindings: {
 				TEXT: { type: "plain_text", value: "text" },
 				OBJECT: { type: "json", value: { a: { b: 1 } } },
@@ -543,7 +543,7 @@ describe("Bindings", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			bindings: {
 				// `wasm-module` bindings aren't allowed in modules workers
 				WASM: { type: "wasm_module", source: { contents: WASM_ADD_MODULE } },
@@ -573,7 +573,7 @@ describe("Bindings", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			dev: { persist: { path: persist } },
 		};
 		const bundle = makeEsbuildBundle(`export default {
@@ -621,7 +621,7 @@ describe("Bindings", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			bindings: { NAMESPACE: { type: "kv_namespace", id: "ns" } },
 			dev: { persist: { path: persist } },
 		};
@@ -667,7 +667,7 @@ describe("Bindings", () => {
 
 		let config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			legacy: { site: { bucket: tmp, include: ["*.txt"] } },
 		};
 		const bundle = makeEsbuildBundle(`
@@ -722,7 +722,7 @@ describe("Bindings", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			bindings: { BUCKET: { type: "r2_bucket", bucket_name: "bucket" } },
 			dev: { persist: { path: persist } },
 		};
@@ -766,7 +766,7 @@ describe("Bindings", () => {
 
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			bindings: {
 				DB: { type: "d1", database_name: "db-name", database_id: "db" },
 			},
@@ -816,7 +816,7 @@ describe("Bindings", () => {
 		const reportPromise = new DeferredPromise<unknown>();
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			bindings: {
 				QUEUE: { type: "queue", queue_name: "queue" },
 				BATCH_REPORT: {
@@ -872,7 +872,7 @@ describe("Bindings", () => {
 		const localConnectionString = `postgres://username:password@127.0.0.1:${port}/db`;
 		const config: StartDevWorkerOptions = {
 			name: "worker",
-			entrypoint: unusable() as FilePath,
+			entrypoint: unusable<FilePath>(),
 			bindings: { DB: { type: "hyperdrive", id: "db", localConnectionString } },
 		};
 		const bundle = makeEsbuildBundle(`export default {

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -11,32 +11,32 @@ export type ConfigControllerEventMap = ControllerEventMap & {
 
 type Options = StartDevWorkerOptions;
 export class ConfigController extends Controller<ConfigControllerEventMap> {
-	config?: Options;
+	latestInput?: Options;
+	latestConfig?: Options;
 
 	public set(input: Options) {
-		const config = unwrapHook(input, this.latest);
+		const config = unwrapHook(input, this.latestInput);
 
 		this.#updateConfig(config);
 	}
 	public patch(input: Partial<Options>) {
 		assert(
-			this.latest,
+			this.latestInput,
 			"Cannot call updateConfig without previously calling setConfig"
 		);
 
 		const config: Options = {
-			...this.latest,
+			...this.latestInput,
 			...input,
 		};
 
 		this.#updateConfig(config);
 	}
 
-	latest?: Options;
 	#updateConfig(input: Options) {
 		const directory = input.directory;
 
-		this.config = {
+		this.latestConfig = {
 			directory,
 			build: {
 				moduleRules: [],
@@ -48,8 +48,8 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 			},
 			...input,
 		};
-		this.latest = input;
-		this.emitConfigUpdateEvent(this.config);
+		this.latestInput = input;
+		this.emitConfigUpdateEvent(this.latestConfig);
 	}
 
 	// ******************

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert";
 import { Controller } from "./BaseController";
-import { unwrapHook } from "./utils";
 import type { ControllerEventMap } from "./BaseController";
 import type { ConfigUpdateEvent } from "./events";
 import type { StartDevWorkerOptions } from "./types";
@@ -15,9 +14,7 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 	latestConfig?: Options;
 
 	public set(input: Options) {
-		const config = unwrapHook(input, this.latestInput);
-
-		this.#updateConfig(config);
+		this.#updateConfig(input);
 	}
 	public patch(input: Partial<Options>) {
 		assert(

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -150,7 +150,7 @@ export function createWorkerObject(devEnv: DevEnv): DevWorker {
 			return devEnv.proxy.ready.promise.then(() => undefined);
 		},
 		get config() {
-			return devEnv.config.config;
+			return devEnv.config.latestConfig;
 		},
 		setConfig(config) {
 			return devEnv.config.set(config);


### PR DESCRIPTION
## What this PR solves / how to test

Some minor internal refactors to the config controller, addressing some comments from a [previous PR](https://github.com/cloudflare/workers-sdk/pull/6124) where the relevant diff was cherry-picked into [another PR](https://github.com/cloudflare/workers-sdk/pull/6136) and merged before the comments had been addressed

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
