### PR TITLE
React-free hotkeys implementation

### DIFF
--- a/.changeset/few-days-tap.md
+++ b/.changeset/few-days-tap.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: React-free hotkeys implementation, behind the `--x-dev-env` flag

--- a/.changeset/few-days-tap.md
+++ b/.changeset/few-days-tap.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-feat: React-free hotkeys implementation, behind the `--x-dev-env` flag
+refactor: React-free hotkeys implementation, behind the `--x-dev-env` flag

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -197,6 +197,7 @@ function getStartedWorkerdProcesses(): Process[] {
 
 const devScripts = [
 	{ args: ["dev"], expectedBody: "body" },
+	{ args: ["dev", "--x-dev-env"], expectedBody: "body" },
 	{ args: ["pages", "dev", "public"], expectedBody: "<p>body</p>" },
 ];
 const exitKeys = [

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -66,10 +66,11 @@ export class Log {
 	}
 
 	protected log(message: string): void {
-		this.logWithBottomFloat(message);
+		Log.logWithBottomFloat(() => console.log(message));
 	}
 
 	private static _getBottomFloat?: () => string;
+	private static _previousBottomFloatLineCount = 0;
 	static registerGlobalBottomFloat(getBottomFloat: () => string) {
 		if (process.stdin.isTTY) {
 			Log._getBottomFloat = getBottomFloat;
@@ -78,19 +79,18 @@ export class Log {
 	static unregisterGlobalBottomFloat() {
 		Log._getBottomFloat = undefined;
 	}
-	private logWithBottomFloat(message: string) {
-		const bottomFloat = Log._getBottomFloat?.();
-		if (bottomFloat) {
-			const lines = bottomFloat.split("\n").length;
-
-			process.stdout.moveCursor(0, -lines);
+	static logWithBottomFloat(doLog: () => void) {
+		if (Log._previousBottomFloatLineCount) {
+			process.stdout.moveCursor(0, -Log._previousBottomFloatLineCount);
 			process.stdout.clearScreenDown();
 		}
 
-		console.log(message);
+		doLog();
 
+		const bottomFloat = Log._getBottomFloat?.();
 		if (bottomFloat) {
 			console.log(bottomFloat);
+			Log._previousBottomFloatLineCount = 3;
 		}
 	}
 

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -69,14 +69,17 @@ export class Log {
 		this.logWithBottomFloat(message);
 	}
 
-	static #getBottomFloat?: () => string;
+	private static _getBottomFloat?: () => string;
 	static registerGlobalBottomFloat(getBottomFloat: () => string) {
 		if (process.stdin.isTTY) {
-			Log.#getBottomFloat = getBottomFloat;
+			Log._getBottomFloat = getBottomFloat;
 		}
 	}
+	static unregisterGlobalBottomFloat() {
+		Log._getBottomFloat = undefined;
+	}
 	private logWithBottomFloat(message: string) {
-		const bottomFloat = Log.#getBottomFloat?.();
+		const bottomFloat = Log._getBottomFloat?.();
 		if (bottomFloat) {
 			const lines = bottomFloat.split("\n").length;
 

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -67,36 +67,18 @@ export class Log {
 	}
 
 	protected log(message: string): void {
-		Log.unsafe_logWithBottomFloat(() => console.log(message));
+		Log.#beforeLogHook?.();
+		console.log(message);
+		Log.#afterLogHook?.();
 	}
 
-	private static _getBottomFloat?: () => string;
-	private static _previousBottomFloatLineCount = 0;
-	static unsafe_registerGlobalBottomFloat(getBottomFloat: () => string) {
-		if (process.stdin.isTTY) {
-			Log._getBottomFloat = getBottomFloat;
-		}
+	static #beforeLogHook: (() => void) | undefined;
+	static unstable_registerBeforeLogHook(callback: (() => void) | undefined) {
+		this.#beforeLogHook = callback;
 	}
-	static unsafe_unregisterGlobalBottomFloat() {
-		Log._getBottomFloat = undefined;
-	}
-	static unsafe_logWithBottomFloat(doLog: () => void) {
-		if (Log._previousBottomFloatLineCount) {
-			readline.moveCursor(
-				process.stdout,
-				0,
-				-Log._previousBottomFloatLineCount
-			);
-			process.stdout.clearScreenDown();
-		}
-
-		doLog();
-
-		const bottomFloat = Log._getBottomFloat?.();
-		if (bottomFloat) {
-			console.log(bottomFloat);
-			Log._previousBottomFloatLineCount = 3;
-		}
+	static #afterLogHook: (() => void) | undefined;
+	static unstable_registerAfterLogHook(callback: (() => void) | undefined) {
+		this.#afterLogHook = callback;
 	}
 
 	logWithLevel(level: LogLevel, message: string): void {

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -66,7 +66,29 @@ export class Log {
 	}
 
 	protected log(message: string): void {
+		this.logWithBottomFloat(message);
+	}
+
+	static #getBottomFloat?: () => string;
+	static registerGlobalBottomFloat(getBottomFloat: () => string) {
+		if (process.stdin.isTTY) {
+			Log.#getBottomFloat = getBottomFloat;
+		}
+	}
+	private logWithBottomFloat(message: string) {
+		const bottomFloat = Log.#getBottomFloat?.();
+		if (bottomFloat) {
+			const lines = bottomFloat.split("\n").length;
+
+			process.stdout.moveCursor(0, -lines);
+			process.stdout.clearScreenDown();
+		}
+
 		console.log(message);
+
+		if (bottomFloat) {
+			console.log(bottomFloat);
+		}
 	}
 
 	logWithLevel(level: LogLevel, message: string): void {

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -66,20 +66,20 @@ export class Log {
 	}
 
 	protected log(message: string): void {
-		Log.logWithBottomFloat(() => console.log(message));
+		Log.unsafe_logWithBottomFloat(() => console.log(message));
 	}
 
 	private static _getBottomFloat?: () => string;
 	private static _previousBottomFloatLineCount = 0;
-	static registerGlobalBottomFloat(getBottomFloat: () => string) {
+	static unsafe_registerGlobalBottomFloat(getBottomFloat: () => string) {
 		if (process.stdin.isTTY) {
 			Log._getBottomFloat = getBottomFloat;
 		}
 	}
-	static unregisterGlobalBottomFloat() {
+	static unsafe_unregisterGlobalBottomFloat() {
 		Log._getBottomFloat = undefined;
 	}
-	static logWithBottomFloat(doLog: () => void) {
+	static unsafe_logWithBottomFloat(doLog: () => void) {
 		if (Log._previousBottomFloatLineCount) {
 			process.stdout.moveCursor(0, -Log._previousBottomFloatLineCount);
 			process.stdout.clearScreenDown();

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import readline from "readline";
 import { Colorize, dim, green, grey, red, reset, yellow } from "kleur/colors";
 import { LogLevel } from "../workers";
 

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import readline from "readline";
 import { Colorize, dim, green, grey, red, reset, yellow } from "kleur/colors";
 import { LogLevel } from "../workers";
 
@@ -81,7 +82,11 @@ export class Log {
 	}
 	static unsafe_logWithBottomFloat(doLog: () => void) {
 		if (Log._previousBottomFloatLineCount) {
-			process.stdout.moveCursor(0, -Log._previousBottomFloatLineCount);
+			readline.moveCursor(
+				process.stdout,
+				0,
+				-Log._previousBottomFloatLineCount
+			);
 			process.stdout.clearScreenDown();
 		}
 

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -1,0 +1,216 @@
+// import readline from "readline";
+// vi.spyOn(readline, "emitKeypressEvents");
+import { vitest } from "vitest";
+import hotkeys from "../cli-hotkeys";
+import { logger } from "../logger";
+import { mockConsoleMethods } from "./helpers/mock-console";
+
+const writeToMockedStdin = (input: string) => _internalKeyPressCallback(input);
+let _internalKeyPressCallback: (input: string) => void;
+vitest.mock("../utils/onKeyPress", async () => {
+	return {
+		onKeyPress(callback: () => void) {
+			_internalKeyPressCallback = callback;
+		},
+	};
+});
+
+describe("Hotkeys", () => {
+	describe("callbacks", () => {
+		it("calls handlers when a key is pressed", async () => {
+			const handlerA = vi.fn();
+			const handlerB = vi.fn();
+			const handlerC = vi.fn();
+			const options = [
+				{ keys: ["a"], label: "first option", handler: handlerA },
+				{ keys: ["b"], label: "second option", handler: handlerB },
+				{ keys: ["c"], label: "third option", handler: handlerC },
+			];
+
+			hotkeys(options);
+
+			writeToMockedStdin("a");
+			expect(handlerA).toHaveBeenCalledWith({
+				printInstructions: expect.any(Function),
+			});
+			expect(handlerB).not.toHaveBeenCalled();
+			expect(handlerC).not.toHaveBeenCalled();
+			handlerA.mockClear();
+
+			writeToMockedStdin("b");
+			expect(handlerA).not.toHaveBeenCalled();
+			expect(handlerB).toHaveBeenCalledWith({
+				printInstructions: expect.any(Function),
+			});
+			expect(handlerC).not.toHaveBeenCalled();
+			handlerB.mockClear();
+
+			writeToMockedStdin("c");
+			expect(handlerA).not.toHaveBeenCalled();
+			expect(handlerB).not.toHaveBeenCalled();
+			expect(handlerC).toHaveBeenCalledWith({
+				printInstructions: expect.any(Function),
+			});
+			handlerC.mockClear();
+		});
+
+		it("handles CAPSLOCK", async () => {
+			const handlerA = vi.fn();
+			const options = [
+				{ keys: ["a"], label: "first option", handler: handlerA },
+			];
+
+			hotkeys(options);
+
+			writeToMockedStdin("a");
+			expect(handlerA).toHaveBeenCalledWith({
+				printInstructions: expect.any(Function),
+			});
+			handlerA.mockClear();
+
+			writeToMockedStdin("A");
+			expect(handlerA).toHaveBeenCalledWith({
+				printInstructions: expect.any(Function),
+			});
+			handlerA.mockClear();
+		});
+
+		it("ignores unbound keys", async () => {
+			const handlerA = vi.fn();
+			const options = [
+				{ keys: ["a"], label: "first option", handler: handlerA },
+			];
+
+			hotkeys(options);
+
+			writeToMockedStdin("z");
+			expect(handlerA).not.toHaveBeenCalled();
+		});
+
+		it("calls handler if any additional key bindings are pressed", async () => {
+			const handlerA = vi.fn();
+			const options = [
+				{ keys: ["a", "b", "c"], label: "first option", handler: handlerA },
+			];
+
+			hotkeys(options);
+
+			writeToMockedStdin("a");
+			expect(handlerA).toHaveBeenCalledWith({
+				printInstructions: expect.any(Function),
+			});
+			handlerA.mockClear();
+
+			writeToMockedStdin("b");
+			expect(handlerA).toHaveBeenCalledWith({
+				printInstructions: expect.any(Function),
+			});
+			handlerA.mockClear();
+
+			writeToMockedStdin("c");
+			expect(handlerA).toHaveBeenCalledWith({
+				printInstructions: expect.any(Function),
+			});
+			handlerA.mockClear();
+		});
+	});
+
+	describe("instructions", () => {
+		const std = mockConsoleMethods();
+
+		it("prints instructions immediately", async () => {
+			const handlerA = vi.fn();
+			const handlerB = vi.fn();
+			const handlerC = vi.fn();
+			const options = [
+				{ keys: ["a"], label: "first option", handler: handlerA },
+				{ keys: ["b"], label: "second option", handler: handlerB },
+				{ keys: ["c"], label: () => "third option", handler: handlerC },
+			];
+
+			hotkeys(options);
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"╭─────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option  │
+				╰─────────────────────────────────────────────────────────╯
+				"
+			`);
+		});
+
+		it("handlers can reprint instructions", async () => {
+			const handlerA = vi.fn();
+			const handlerB = vi.fn();
+			const handlerC = vi.fn().mockImplementation(({ printInstructions }) => {
+				logger.log("triggered handlerC");
+				printInstructions();
+			});
+			const options = [
+				{ keys: ["a"], label: "first option", handler: handlerA },
+				{ keys: ["b"], label: "second option", handler: handlerB },
+				{
+					keys: ["c"],
+					label: () =>
+						`third option (called: ${handlerC.mock.calls.length} times)`,
+					handler: handlerC,
+				},
+			];
+
+			hotkeys(options);
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"╭───────────────────────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
+				╰───────────────────────────────────────────────────────────────────────────╯
+				"
+			`);
+
+			writeToMockedStdin("a");
+			expect(std.out).toMatchInlineSnapshot(`
+				"╭───────────────────────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
+				╰───────────────────────────────────────────────────────────────────────────╯
+				"
+			`);
+
+			writeToMockedStdin("b");
+			expect(std.out).toMatchInlineSnapshot(`
+				"╭───────────────────────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
+				╰───────────────────────────────────────────────────────────────────────────╯
+				"
+			`);
+
+			writeToMockedStdin("c");
+			expect(std.out).toMatchInlineSnapshot(`
+				"╭───────────────────────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
+				╰───────────────────────────────────────────────────────────────────────────╯
+
+				triggered handlerC
+				╭───────────────────────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option (called: 1 times)  │
+				╰───────────────────────────────────────────────────────────────────────────╯
+				"
+			`);
+
+			writeToMockedStdin("c");
+			expect(std.out).toMatchInlineSnapshot(`
+				"╭───────────────────────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
+				╰───────────────────────────────────────────────────────────────────────────╯
+
+				triggered handlerC
+				╭───────────────────────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option (called: 1 times)  │
+				╰───────────────────────────────────────────────────────────────────────────╯
+
+				triggered handlerC
+				╭───────────────────────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option (called: 2 times)  │
+				╰───────────────────────────────────────────────────────────────────────────╯
+				"
+			`);
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -2,6 +2,7 @@ import { setTimeout } from "node:timers/promises";
 import { Log } from "miniflare";
 import { vitest } from "vitest";
 import registerHotKeys from "../cli-hotkeys";
+import { logger } from "../logger";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import type { KeypressEvent } from "../utils/onKeyPress";
@@ -157,23 +158,26 @@ describe("Hot Keys", () => {
 				{ keys: ["c"], label: () => "third option", handler: handlerC },
 			];
 
-			const unregisterregisterHotKeys = registerHotKeys(options);
+			const unregisterHotKeys = registerHotKeys(options);
+			logger.log("something 1");
 
-			expect(
-				// @ts-expect-error _getBottomFloat is declared private
-				Log._getBottomFloat()
-			).toMatchInlineSnapshot(`
-				"╭─────────────────────────────────────────────────────────╮
+			expect(std.out).toMatchInlineSnapshot(`
+				"something 1
+				╭─────────────────────────────────────────────────────────╮
 				│  [a] first option, [b] second option, [c] third option  │
 				╰─────────────────────────────────────────────────────────╯"
 			`);
 
-			unregisterregisterHotKeys();
+			unregisterHotKeys();
+			logger.log("something 2");
 
-			expect(
-				// @ts-expect-error _getBottomFloat is declared private
-				Log._getBottomFloat
-			).toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"something 1
+				╭─────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option  │
+				╰─────────────────────────────────────────────────────────╯
+				something 2"
+			`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -1,7 +1,8 @@
 import { setTimeout } from "node:timers/promises";
+import { Log } from "miniflare";
 import { vitest } from "vitest";
 import hotkeys from "../cli-hotkeys";
-import { logger } from "../logger";
+import { Logger, logger } from "../logger";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 
@@ -143,11 +144,22 @@ describe("Hotkeys", () => {
 				{ keys: ["c"], label: () => "third option", handler: handlerC },
 			];
 
-			const result = hotkeys(options);
+			hotkeys(options);
 
-			expect(result.formatInstructions()).toMatchInlineSnapshot(`
-				"
-				╭─────────────────────────────────────────────────────────╮
+			expect(
+				// @ts-expect-error _getBottomFloat is declared Private
+				Logger._getBottomFloat()
+			).toMatchInlineSnapshot(`
+				"╭─────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option  │
+				╰─────────────────────────────────────────────────────────╯"
+			`);
+
+			expect(
+				// @ts-expect-error _getBottomFloat is declared Private
+				Log._getBottomFloat()
+			).toMatchInlineSnapshot(`
+				"╭─────────────────────────────────────────────────────────╮
 				│  [a] first option, [b] second option, [c] third option  │
 				╰─────────────────────────────────────────────────────────╯"
 			`);

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -2,7 +2,6 @@ import { setTimeout } from "node:timers/promises";
 import { Log } from "miniflare";
 import { vitest } from "vitest";
 import registerHotKeys from "../cli-hotkeys";
-import { Logger } from "../logger";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
 import type { KeypressEvent } from "../utils/onKeyPress";
@@ -29,7 +28,9 @@ vitest.mock("../utils/onKeyPress", async () => {
 describe("Hot Keys", () => {
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
-	setIsTTY(true);
+	beforeEach(() => {
+		setIsTTY(true);
+	});
 
 	describe("callbacks", () => {
 		it("calls handlers when a key is pressed", async () => {

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -1,5 +1,4 @@
 import { setTimeout } from "node:timers/promises";
-import { Log } from "miniflare";
 import { vitest } from "vitest";
 import registerHotKeys from "../cli-hotkeys";
 import { logger } from "../logger";

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -5,9 +5,17 @@ import registerHotKeys from "../cli-hotkeys";
 import { Logger } from "../logger";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
+import type { KeypressEvent } from "../utils/onKeyPress";
 
-const writeToMockedStdin = (input: string) => _internalKeyPressCallback(input);
-let _internalKeyPressCallback: (input: string) => void;
+const writeToMockedStdin = (input: string) =>
+	_internalKeyPressCallback({
+		name: input,
+		sequence: input,
+		ctrl: false,
+		meta: false,
+		shift: false,
+	});
+let _internalKeyPressCallback: (input: KeypressEvent) => void;
 vitest.mock("../utils/onKeyPress", async () => {
 	return {
 		onKeyPress(callback: () => void) {
@@ -152,15 +160,6 @@ describe("Hot Keys", () => {
 
 			expect(
 				// @ts-expect-error _getBottomFloat is declared private
-				Logger._getBottomFloat()
-			).toMatchInlineSnapshot(`
-				"╭─────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option  │
-				╰─────────────────────────────────────────────────────────╯"
-			`);
-
-			expect(
-				// @ts-expect-error _getBottomFloat is declared private
 				Log._getBottomFloat()
 			).toMatchInlineSnapshot(`
 				"╭─────────────────────────────────────────────────────────╮
@@ -169,11 +168,6 @@ describe("Hot Keys", () => {
 			`);
 
 			unregisterregisterHotKeys();
-
-			expect(
-				// @ts-expect-error _getBottomFloat is declared private
-				Logger._getBottomFloat
-			).toBeUndefined();
 
 			expect(
 				// @ts-expect-error _getBottomFloat is declared private

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -1,9 +1,10 @@
 import { setTimeout } from "node:timers/promises";
 import { Log } from "miniflare";
 import { vitest } from "vitest";
-import hotkeys from "../cli-hotkeys";
+import registerHotKeys from "../cli-hotkeys";
 import { Logger } from "../logger";
 import { mockConsoleMethods } from "./helpers/mock-console";
+import { useMockIsTTY } from "./helpers/mock-istty";
 
 const writeToMockedStdin = (input: string) => _internalKeyPressCallback(input);
 let _internalKeyPressCallback: (input: string) => void;
@@ -17,8 +18,10 @@ vitest.mock("../utils/onKeyPress", async () => {
 	};
 });
 
-describe("Hotkeys", () => {
+describe("Hot Keys", () => {
 	const std = mockConsoleMethods();
+	const { setIsTTY } = useMockIsTTY();
+	setIsTTY(true);
 
 	describe("callbacks", () => {
 		it("calls handlers when a key is pressed", async () => {
@@ -31,7 +34,7 @@ describe("Hotkeys", () => {
 				{ keys: ["c"], label: "third option", handler: handlerC },
 			];
 
-			hotkeys(options);
+			registerHotKeys(options);
 
 			writeToMockedStdin("a");
 			expect(handlerA).toHaveBeenCalled();
@@ -58,7 +61,7 @@ describe("Hotkeys", () => {
 				{ keys: ["a"], label: "first option", handler: handlerA },
 			];
 
-			hotkeys(options);
+			registerHotKeys(options);
 
 			writeToMockedStdin("a");
 			expect(handlerA).toHaveBeenCalled();
@@ -75,7 +78,7 @@ describe("Hotkeys", () => {
 				{ keys: ["a"], label: "first option", handler: handlerA },
 			];
 
-			hotkeys(options);
+			registerHotKeys(options);
 
 			writeToMockedStdin("z");
 			expect(handlerA).not.toHaveBeenCalled();
@@ -87,7 +90,7 @@ describe("Hotkeys", () => {
 				{ keys: ["a", "b", "c"], label: "first option", handler: handlerA },
 			];
 
-			hotkeys(options);
+			registerHotKeys(options);
 
 			writeToMockedStdin("a");
 			expect(handlerA).toHaveBeenCalled();
@@ -112,7 +115,7 @@ describe("Hotkeys", () => {
 				{ keys: ["b"], label: "second option", handler: handlerB },
 			];
 
-			hotkeys(options);
+			registerHotKeys(options);
 
 			writeToMockedStdin("a");
 			expect(std.err).toMatchInlineSnapshot(`
@@ -145,10 +148,10 @@ describe("Hotkeys", () => {
 				{ keys: ["c"], label: () => "third option", handler: handlerC },
 			];
 
-			const unregisterHotKeys = hotkeys(options);
+			const unregisterregisterHotKeys = registerHotKeys(options);
 
 			expect(
-				// @ts-expect-error _getBottomFloat is declared Private
+				// @ts-expect-error _getBottomFloat is declared private
 				Logger._getBottomFloat()
 			).toMatchInlineSnapshot(`
 				"╭─────────────────────────────────────────────────────────╮
@@ -157,7 +160,7 @@ describe("Hotkeys", () => {
 			`);
 
 			expect(
-				// @ts-expect-error _getBottomFloat is declared Private
+				// @ts-expect-error _getBottomFloat is declared private
 				Log._getBottomFloat()
 			).toMatchInlineSnapshot(`
 				"╭─────────────────────────────────────────────────────────╮
@@ -165,15 +168,15 @@ describe("Hotkeys", () => {
 				╰─────────────────────────────────────────────────────────╯"
 			`);
 
-			unregisterHotKeys();
+			unregisterregisterHotKeys();
 
 			expect(
-				// @ts-expect-error _getBottomFloat is declared Private
+				// @ts-expect-error _getBottomFloat is declared private
 				Logger._getBottomFloat
 			).toBeUndefined();
 
 			expect(
-				// @ts-expect-error _getBottomFloat is declared Private
+				// @ts-expect-error _getBottomFloat is declared private
 				Log._getBottomFloat
 			).toBeUndefined();
 		});

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -3,6 +3,7 @@ import { vitest } from "vitest";
 import hotkeys from "../cli-hotkeys";
 import { logger } from "../logger";
 import { mockConsoleMethods } from "./helpers/mock-console";
+import { useMockIsTTY } from "./helpers/mock-istty";
 
 const writeToMockedStdin = (input: string) => _internalKeyPressCallback(input);
 let _internalKeyPressCallback: (input: string) => void;
@@ -31,27 +32,21 @@ describe("Hotkeys", () => {
 			hotkeys(options);
 
 			writeToMockedStdin("a");
-			expect(handlerA).toHaveBeenCalledWith({
-				printInstructions: expect.any(Function),
-			});
+			expect(handlerA).toHaveBeenCalled();
 			expect(handlerB).not.toHaveBeenCalled();
 			expect(handlerC).not.toHaveBeenCalled();
 			handlerA.mockClear();
 
 			writeToMockedStdin("b");
 			expect(handlerA).not.toHaveBeenCalled();
-			expect(handlerB).toHaveBeenCalledWith({
-				printInstructions: expect.any(Function),
-			});
+			expect(handlerB).toHaveBeenCalled();
 			expect(handlerC).not.toHaveBeenCalled();
 			handlerB.mockClear();
 
 			writeToMockedStdin("c");
 			expect(handlerA).not.toHaveBeenCalled();
 			expect(handlerB).not.toHaveBeenCalled();
-			expect(handlerC).toHaveBeenCalledWith({
-				printInstructions: expect.any(Function),
-			});
+			expect(handlerC).toHaveBeenCalled();
 			handlerC.mockClear();
 		});
 
@@ -64,15 +59,11 @@ describe("Hotkeys", () => {
 			hotkeys(options);
 
 			writeToMockedStdin("a");
-			expect(handlerA).toHaveBeenCalledWith({
-				printInstructions: expect.any(Function),
-			});
+			expect(handlerA).toHaveBeenCalled();
 			handlerA.mockClear();
 
 			writeToMockedStdin("A");
-			expect(handlerA).toHaveBeenCalledWith({
-				printInstructions: expect.any(Function),
-			});
+			expect(handlerA).toHaveBeenCalled();
 			handlerA.mockClear();
 		});
 
@@ -97,21 +88,15 @@ describe("Hotkeys", () => {
 			hotkeys(options);
 
 			writeToMockedStdin("a");
-			expect(handlerA).toHaveBeenCalledWith({
-				printInstructions: expect.any(Function),
-			});
+			expect(handlerA).toHaveBeenCalled();
 			handlerA.mockClear();
 
 			writeToMockedStdin("b");
-			expect(handlerA).toHaveBeenCalledWith({
-				printInstructions: expect.any(Function),
-			});
+			expect(handlerA).toHaveBeenCalled();
 			handlerA.mockClear();
 
 			writeToMockedStdin("c");
-			expect(handlerA).toHaveBeenCalledWith({
-				printInstructions: expect.any(Function),
-			});
+			expect(handlerA).toHaveBeenCalled();
 			handlerA.mockClear();
 		});
 
@@ -148,7 +133,7 @@ describe("Hotkeys", () => {
 	});
 
 	describe("instructions", () => {
-		it("prints instructions immediately", async () => {
+		it("provides formatted instructions", async () => {
 			const handlerA = vi.fn();
 			const handlerB = vi.fn();
 			const handlerC = vi.fn();
@@ -158,88 +143,13 @@ describe("Hotkeys", () => {
 				{ keys: ["c"], label: () => "third option", handler: handlerC },
 			];
 
-			hotkeys(options);
+			const result = hotkeys(options);
 
-			expect(std.out).toMatchInlineSnapshot(`
-				"╭─────────────────────────────────────────────────────────╮
+			expect(result.formatInstructions()).toMatchInlineSnapshot(`
+				"
+				╭─────────────────────────────────────────────────────────╮
 				│  [a] first option, [b] second option, [c] third option  │
-				╰─────────────────────────────────────────────────────────╯
-				"
-			`);
-		});
-
-		it("handlers can reprint instructions", async () => {
-			const handlerA = vi.fn();
-			const handlerB = vi.fn();
-			const handlerC = vi.fn().mockImplementation(({ printInstructions }) => {
-				logger.log("triggered handlerC");
-				printInstructions();
-			});
-			const options = [
-				{ keys: ["a"], label: "first option", handler: handlerA },
-				{ keys: ["b"], label: "second option", handler: handlerB },
-				{
-					keys: ["c"],
-					label: () =>
-						`third option (called: ${handlerC.mock.calls.length} times)`,
-					handler: handlerC,
-				},
-			];
-
-			hotkeys(options);
-
-			expect(std.out).toMatchInlineSnapshot(`
-				"╭───────────────────────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
-				╰───────────────────────────────────────────────────────────────────────────╯
-				"
-			`);
-
-			writeToMockedStdin("a");
-			expect(std.out).toMatchInlineSnapshot(`
-				"╭───────────────────────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
-				╰───────────────────────────────────────────────────────────────────────────╯
-				"
-			`);
-
-			writeToMockedStdin("b");
-			expect(std.out).toMatchInlineSnapshot(`
-				"╭───────────────────────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
-				╰───────────────────────────────────────────────────────────────────────────╯
-				"
-			`);
-
-			writeToMockedStdin("c");
-			expect(std.out).toMatchInlineSnapshot(`
-				"╭───────────────────────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
-				╰───────────────────────────────────────────────────────────────────────────╯
-
-				triggered handlerC
-				╭───────────────────────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option (called: 1 times)  │
-				╰───────────────────────────────────────────────────────────────────────────╯
-				"
-			`);
-
-			writeToMockedStdin("c");
-			expect(std.out).toMatchInlineSnapshot(`
-				"╭───────────────────────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option (called: 0 times)  │
-				╰───────────────────────────────────────────────────────────────────────────╯
-
-				triggered handlerC
-				╭───────────────────────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option (called: 1 times)  │
-				╰───────────────────────────────────────────────────────────────────────────╯
-
-				triggered handlerC
-				╭───────────────────────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option (called: 2 times)  │
-				╰───────────────────────────────────────────────────────────────────────────╯
-				"
+				╰─────────────────────────────────────────────────────────╯"
 			`);
 		});
 	});

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -164,11 +164,22 @@ describe("Hot Keys", () => {
 				{ keys: ["d"], label: "disabled", disabled: true, handler: handlerD },
 			];
 
+			// should print instructions immediately
 			const unregisterHotKeys = registerHotKeys(options);
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"╭─────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option  │
+				╰─────────────────────────────────────────────────────────╯"
+			`);
+
 			logger.log("something 1");
 
 			expect(std.out).toMatchInlineSnapshot(`
-				"something 1
+				"╭─────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option  │
+				╰─────────────────────────────────────────────────────────╯
+				something 1
 				╭─────────────────────────────────────────────────────────╮
 				│  [a] first option, [b] second option, [c] third option  │
 				╰─────────────────────────────────────────────────────────╯"
@@ -178,7 +189,10 @@ describe("Hot Keys", () => {
 			logger.log("something 2");
 
 			expect(std.out).toMatchInlineSnapshot(`
-				"something 1
+				"╭─────────────────────────────────────────────────────────╮
+				│  [a] first option, [b] second option, [c] third option  │
+				╰─────────────────────────────────────────────────────────╯
+				something 1
 				╭─────────────────────────────────────────────────────────╮
 				│  [a] first option, [b] second option, [c] third option  │
 				╰─────────────────────────────────────────────────────────╯

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -83,14 +83,19 @@ describe("Hot Keys", () => {
 
 		it("ignores unbound keys", async () => {
 			const handlerA = vi.fn();
+			const handlerD = vi.fn();
 			const options = [
 				{ keys: ["a"], label: "first option", handler: handlerA },
+				{ keys: ["d"], label: "disabled", disabled: true, handler: handlerD },
 			];
 
 			registerHotKeys(options);
 
 			writeToMockedStdin("z");
 			expect(handlerA).not.toHaveBeenCalled();
+
+			writeToMockedStdin("d");
+			expect(handlerD).not.toHaveBeenCalled();
 		});
 
 		it("calls handler if any additional key bindings are pressed", async () => {
@@ -151,10 +156,12 @@ describe("Hot Keys", () => {
 			const handlerA = vi.fn();
 			const handlerB = vi.fn();
 			const handlerC = vi.fn();
+			const handlerD = vi.fn();
 			const options = [
 				{ keys: ["a"], label: "first option", handler: handlerA },
 				{ keys: ["b"], label: "second option", handler: handlerB },
 				{ keys: ["c"], label: () => "third option", handler: handlerC },
+				{ keys: ["d"], label: "disabled", disabled: true, handler: handlerD },
 			];
 
 			const unregisterHotKeys = registerHotKeys(options);

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -280,10 +280,14 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 	}
 
 	async teardown() {
-		await this.#customBuildWatcher?.close();
-		await this.#bundlerCleanup?.();
+		logger.debug("BundlerController teardown beginning...");
 		this.#customBuildAborter?.abort();
 		this.#tmpDir?.remove();
+		await Promise.all([
+			this.#bundlerCleanup?.(),
+			this.#customBuildWatcher?.close(),
+		]);
+		logger.debug("BundlerController teardown complete");
 	}
 
 	emitBundleStartEvent(config: StartDevWorkerOptions) {

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -379,7 +379,9 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 	// ******************
 
 	async teardown() {
+		logger.debug("ConfigController teardown beginning...");
 		await this.#configWatcher?.close();
+		logger.debug("ConfigController teardown complete");
 	}
 
 	// *********************

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -93,13 +93,23 @@ export class DevEnv extends EventEmitter {
 	// *********************
 
 	async teardown() {
+		logger.debug("DevEnv teardown beginning...");
+
 		await Promise.all([
 			this.config.teardown(),
 			this.bundler.teardown(),
 			...this.runtimes.map((runtime) => runtime.teardown()),
 			this.proxy.teardown(),
 		]);
+
+		this.config.removeAllListeners();
+		this.bundler.removeAllListeners();
+		this.runtimes.forEach((runtime) => runtime.removeAllListeners());
+		this.proxy.removeAllListeners();
+
 		this.emit("teardown");
+
+		logger.debug("DevEnv teardown complete");
 	}
 
 	emitErrorEvent(ev: ErrorEvent) {

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -239,12 +239,16 @@ export class LocalRuntimeController extends RuntimeController {
 	}
 
 	#teardown = async (): Promise<void> => {
+		logger.debug("LocalRuntimeController teardown beginning...");
+
 		if (this.#mf) {
 			logger.log(chalk.dim("⎔ Shutting down local server..."));
 		}
 
 		await this.#mf?.dispose();
 		this.#mf = undefined;
+
+		logger.debug("LocalRuntimeController teardown complete");
 	};
 	async teardown() {
 		return this.#mutex.runWith(this.#teardown);

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -485,7 +485,7 @@ export class ProxyController extends Controller<ProxyControllerEventMap> {
 
 	_torndown = false;
 	async teardown() {
-		logger.debug("ProxyController teardown");
+		logger.debug("ProxyController teardown beginning...");
 		this._torndown = true;
 
 		const { proxyWorker } = this;
@@ -499,6 +499,8 @@ export class ProxyController extends Controller<ProxyControllerEventMap> {
 					/* ignore */
 				}),
 		]);
+
+		logger.debug("ProxyController teardown complete");
 	}
 
 	// *********************

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -253,8 +253,10 @@ export class RemoteRuntimeController extends RuntimeController {
 	}
 
 	async teardown() {
+		logger.debug("RemoteRuntimeController teardown beginning...");
 		this.#session = undefined;
 		this.#abortController.abort();
+		logger.debug("RemoteRuntimeController teardown complete");
 	}
 
 	// *********************

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -267,7 +267,9 @@ export class RemoteRuntimeController extends RuntimeController {
 	}
 
 	async teardown() {
-		logger.log(chalk.dim("⎔ Shutting down remote preview..."));
+		if (this.#session) {
+			logger.log(chalk.dim("⎔ Shutting down remote preview..."));
+		}
 		logger.debug("RemoteRuntimeController teardown beginning...");
 		this.#session = undefined;
 		this.#abortController.abort();

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -1,0 +1,30 @@
+import readline from "readline";
+
+type KeypressEvent = {
+	name: string;
+	ctrl: boolean;
+};
+
+export function hotkeys(
+	callback: (key: string) => void,
+	stdin = process.stdin
+) {
+	if (stdin.isTTY) {
+		readline.emitKeypressEvents(stdin);
+		stdin.setRawMode(true);
+	}
+
+	const onKeyPress = (char: string, key: KeypressEvent) => {
+		if (key && key.ctrl && key.name == "c") {
+			char = "CTRL+C";
+		}
+
+		if (char) {
+			callback(char);
+		}
+	};
+
+	stdin.on("keypress", onKeyPress);
+
+	return () => stdin.off("keypress", onKeyPress);
+}

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -1,11 +1,66 @@
 import readline from "readline";
+import { unwrapHook } from "./api/startDevWorker/utils";
+import type { Hook } from "./api";
+import type { Logger } from "./logger";
 
-type KeypressEvent = {
-	name: string;
-	ctrl: boolean;
-};
+type KeypressEvent = { name: string; ctrl: boolean };
 
-export function hotkeys(
+export default function ({
+	options,
+	logger,
+	stdin,
+}: {
+	options: Array<{
+		keys: string[];
+		label: Hook<string>;
+		handler: (helpers: {
+			printIntructions: () => void;
+		}) => void | Promise<void>;
+	}>;
+	logger: Logger;
+	stdin?: typeof process.stdin;
+}) {
+	/**
+	 * Prints all options, comma-separated, prefixed by the first key in square brackets.
+	 *
+	 * Example output:
+	 *  ╭─────────────────────────────────────────────────────────╮
+	 *  │  [a] first option, [b] second option, [c] third option  │
+	 *  ╰─────────────────────────────────────────────────────────╯
+	 *
+	 * Limitations:
+	 *  - doesn't break nicely across lines
+	 */
+	function printIntructions() {
+		const instructions = options
+			.map(({ keys, label }) => `[${keys[0]}] ${unwrapHook(label)}`)
+			.join(", ");
+
+		logger.log(
+			`╭──${"─".repeat(instructions.length)}──╮\n` +
+				`│  ${instructions}  │\n` +
+				`╰──${"─".repeat(instructions.length)}──╯\n`
+		);
+	}
+
+	printIntructions();
+
+	return onKeyPress(async (key) => {
+		key = key.toLowerCase();
+
+		for (const { keys, handler } of options) {
+			if (keys.includes(key)) {
+				try {
+					await handler({ printIntructions });
+				} catch (error) {
+					logger.error(`Error while handling hotkey [${key}]\n`, error);
+				}
+			}
+		}
+	}, stdin);
+}
+
+export function onKeyPress(
 	callback: (key: string) => void,
 	stdin = process.stdin
 ) {
@@ -14,7 +69,7 @@ export function hotkeys(
 		stdin.setRawMode(true);
 	}
 
-	const onKeyPress = (char: string, key: KeypressEvent) => {
+	const handler = async (char: string, key: KeypressEvent) => {
 		if (key && key.ctrl && key.name == "c") {
 			char = "CTRL+C";
 		}
@@ -24,7 +79,7 @@ export function hotkeys(
 		}
 	};
 
-	stdin.on("keypress", onKeyPress);
+	stdin.on("keypress", handler);
 
-	return () => stdin.off("keypress", onKeyPress);
+	return () => stdin.off("keypress", handler);
 }

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -44,8 +44,8 @@ export default function (
 			if (keys.includes(key)) {
 				try {
 					await handler({ printInstructions });
-				} catch (error) {
-					logger.error(`Error while handling hotkey [${key}]\n`, error);
+				} catch {
+					logger.error(`Error while handling hotkey [${key}]`);
 				}
 			}
 		}

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -7,9 +7,7 @@ export default function (
 	options: Array<{
 		keys: string[];
 		label: Hook<string>;
-		handler: (helpers: {
-			printInstructions: () => void;
-		}) => void | Promise<void>;
+		handler: () => void | Promise<void>;
 	}>
 ) {
 	/**
@@ -23,31 +21,32 @@ export default function (
 	 * Limitations:
 	 *  - doesn't break nicely across lines
 	 */
-	function printInstructions() {
+	function formatInstructions() {
 		const instructions = options
 			.map(({ keys, label }) => `[${keys[0]}] ${unwrapHook(label)}`)
 			.join(", ");
 
-		logger.log(
+		return (
+			`\n` +
 			`╭──${"─".repeat(instructions.length)}──╮\n` +
-				`│  ${instructions}  │\n` +
-				`╰──${"─".repeat(instructions.length)}──╯\n`
+			`│  ${instructions}  │\n` +
+			`╰──${"─".repeat(instructions.length)}──╯`
 		);
 	}
 
-	printInstructions();
-
-	return onKeyPress(async (key) => {
+	const unregisterKeyPress = onKeyPress(async (key) => {
 		key = key.toLowerCase();
 
 		for (const { keys, handler } of options) {
 			if (keys.includes(key)) {
 				try {
-					await handler({ printInstructions });
+					await handler();
 				} catch {
 					logger.error(`Error while handling hotkey [${key}]`);
 				}
 			}
 		}
 	});
+
+	return { unregisterKeyPress, formatInstructions };
 }

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -1,5 +1,6 @@
+import { Log } from "miniflare";
 import { unwrapHook } from "./api/startDevWorker/utils";
-import { logger } from "./logger";
+import { Logger, logger } from "./logger";
 import { onKeyPress } from "./utils/onKeyPress";
 import type { Hook } from "./api";
 
@@ -11,7 +12,7 @@ export default function (
 	}>
 ) {
 	/**
-	 * Prints all options, comma-separated, prefixed by the first key in square brackets.
+	 * Formats all options, comma-separated, prefixed by the first key in square brackets.
 	 *
 	 * Example output:
 	 *  ╭─────────────────────────────────────────────────────────╮
@@ -27,7 +28,6 @@ export default function (
 			.join(", ");
 
 		return (
-			`\n` +
 			`╭──${"─".repeat(instructions.length)}──╮\n` +
 			`│  ${instructions}  │\n` +
 			`╰──${"─".repeat(instructions.length)}──╯`
@@ -48,5 +48,12 @@ export default function (
 		}
 	});
 
-	return { unregisterKeyPress, formatInstructions };
+	Logger.registerGlobalBottomFloat(formatInstructions);
+	Log.registerGlobalBottomFloat(formatInstructions);
+
+	return () => {
+		unregisterKeyPress();
+		Logger.unregisterGlobalBottomFloat();
+		Log.unregisterGlobalBottomFloat();
+	};
 }

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -8,7 +8,7 @@ import type { Hook } from "./api";
 export default function (
 	options: Array<{
 		keys: string[];
-		disabled?: boolean;
+		disabled?: Hook<boolean>;
 		label: Hook<string>;
 		handler: () => void | Promise<void>;
 	}>
@@ -26,7 +26,7 @@ export default function (
 	 */
 	function formatInstructions() {
 		const instructions = options
-			.filter((option) => !option.disabled)
+			.filter((option) => !unwrapHook(option.disabled))
 			.map(({ keys, label }) => `[${keys[0]}] ${unwrapHook(label)}`)
 			.join(", ");
 
@@ -51,7 +51,7 @@ export default function (
 		}
 
 		for (const { keys, handler, disabled } of options) {
-			if (disabled) {
+			if (unwrapHook(disabled)) {
 				continue;
 			}
 

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -58,12 +58,10 @@ export default function (
 		}
 	});
 
-	Logger.registerGlobalBottomFloat(formatInstructions);
 	Log.registerGlobalBottomFloat(formatInstructions);
 
 	return () => {
 		unregisterKeyPress();
-		Logger.unregisterGlobalBottomFloat();
 		Log.unregisterGlobalBottomFloat();
 	};
 }

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -58,10 +58,10 @@ export default function (
 		}
 	});
 
-	Log.registerGlobalBottomFloat(formatInstructions);
+	Log.unsafe_registerGlobalBottomFloat(formatInstructions);
 
 	return () => {
 		unregisterKeyPress();
-		Log.unregisterGlobalBottomFloat();
+		Log.unsafe_unregisterGlobalBottomFloat();
 	};
 }

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -63,7 +63,7 @@ export default function (
 	function clearPreviousInstructions() {
 		if (previousInstructionsLineCount) {
 			readline.moveCursor(process.stdout, 0, -previousInstructionsLineCount);
-			process.stdout.clearScreenDown();
+			readline.clearScreenDown(process.stdout);
 		}
 	}
 	function printInstructions() {

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -8,6 +8,7 @@ import type { Hook } from "./api";
 export default function (
 	options: Array<{
 		keys: string[];
+		disabled?: boolean;
 		label: Hook<string>;
 		handler: () => void | Promise<void>;
 	}>
@@ -25,6 +26,7 @@ export default function (
 	 */
 	function formatInstructions() {
 		const instructions = options
+			.filter((option) => !option.disabled)
 			.map(({ keys, label }) => `[${keys[0]}] ${unwrapHook(label)}`)
 			.join(", ");
 
@@ -48,7 +50,11 @@ export default function (
 			char = "shift+" + char;
 		}
 
-		for (const { keys, handler } of options) {
+		for (const { keys, handler, disabled } of options) {
+			if (disabled) {
+				continue;
+			}
+
 			if (keys.includes(char)) {
 				try {
 					await handler();

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -35,14 +35,24 @@ export default function (
 	}
 
 	const unregisterKeyPress = onKeyPress(async (key) => {
-		key = key.toLowerCase();
+		let char = key.name.toLowerCase();
+
+		if (key?.meta) {
+			char = "meta+" + char;
+		}
+		if (key?.ctrl) {
+			char = "ctrl+" + char;
+		}
+		if (key?.shift) {
+			char = "shift+" + char;
+		}
 
 		for (const { keys, handler } of options) {
-			if (keys.includes(key)) {
+			if (keys.includes(char)) {
 				try {
 					await handler();
 				} catch {
-					logger.error(`Error while handling hotkey [${key}]`);
+					logger.error(`Error while handling hotkey [${char}]`);
 				}
 			}
 		}

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -84,10 +84,11 @@ export default function (
 	Logger.registerAfterLogHook(printInstructions);
 	Log.unstable_registerBeforeLogHook(clearPreviousInstructions);
 	Log.unstable_registerAfterLogHook(printInstructions);
+	printInstructions();
 
 	return () => {
 		unregisterKeyPress();
-		// clearPreviousInstructions();
+		clearPreviousInstructions();
 		Logger.registerBeforeLogHook(undefined);
 		Logger.registerAfterLogHook(undefined);
 		Log.unstable_registerBeforeLogHook(undefined);

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -1,6 +1,6 @@
 import { Log } from "miniflare";
 import { unwrapHook } from "./api/startDevWorker/utils";
-import { Logger, logger } from "./logger";
+import { logger } from "./logger";
 import { onKeyPress } from "./utils/onKeyPress";
 import type { Hook } from "./api";
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -584,10 +584,9 @@ export async function startDev(args: StartDevOptions) {
 				});
 			}
 
-			const { forceLocal } = args;
 			let unregisterHotKeys: () => void;
 			if (!isNonInteractiveOrCI() && args.showInteractiveDevSession !== false) {
-				unregisterHotKeys = registerDevHotKeys(devEnv, { forceLocal });
+				unregisterHotKeys = registerDevHotKeys(devEnv, args);
 			}
 
 			await devEnv.config.set({
@@ -658,7 +657,7 @@ export async function startDev(args: StartDevOptions) {
 						if (!accountId) {
 							unregisterHotKeys?.();
 							accountId = await requireAuth({});
-							unregisterHotKeys = registerDevHotKeys(devEnv, { forceLocal });
+							unregisterHotKeys = registerDevHotKeys(devEnv, args);
 						}
 
 						return {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -22,7 +22,7 @@ import { maybeRegisterLocalWorker } from "./dev/local";
 import { startDevServer } from "./dev/start-server";
 import { UserError } from "./errors";
 import { run } from "./experimental-flags";
-import { isNonInteractiveOrCI } from "./is-interactive";
+import isInteractive from "./is-interactive";
 import { logger } from "./logger";
 import * as metrics from "./metrics";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";
@@ -585,7 +585,7 @@ export async function startDev(args: StartDevOptions) {
 			}
 
 			let unregisterHotKeys: () => void;
-			if (!isNonInteractiveOrCI() && args.showInteractiveDevSession !== false) {
+			if (isInteractive() && args.showInteractiveDevSession !== false) {
 				unregisterHotKeys = registerDevHotKeys(devEnv, args);
 			}
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -22,6 +22,7 @@ import { maybeRegisterLocalWorker } from "./dev/local";
 import { startDevServer } from "./dev/start-server";
 import { UserError } from "./errors";
 import { run } from "./experimental-flags";
+import { isNonInteractiveOrCI } from "./is-interactive";
 import { logger } from "./logger";
 import * as metrics from "./metrics";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";
@@ -585,7 +586,7 @@ export async function startDev(args: StartDevOptions) {
 
 			const { forceLocal } = args;
 			let unregisterHotKeys: () => void;
-			if (process.stdout.isTTY && args.showInteractiveDevSession !== false) {
+			if (!isNonInteractiveOrCI() && args.showInteractiveDevSession !== false) {
 				unregisterHotKeys = registerDevHotKeys(devEnv, { forceLocal });
 			}
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -610,6 +610,7 @@ export async function startDev(args: StartDevOptions) {
 					},
 					{
 						keys: ["l"],
+						disabled: args.forceLocal,
 						label: () =>
 							`turn ${devEnv.config.latestConfig?.dev?.remote ? "on" : "off"} local mode`,
 						handler: async () => {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -5,7 +5,6 @@ import util from "node:util";
 import { isWebContainer } from "@webcontainer/env";
 import { watch } from "chokidar";
 import { render } from "ink";
-import { Log } from "miniflare";
 import { DevEnv } from "./api";
 import {
 	convertCfWorkerInitBindingstoBindings,
@@ -24,7 +23,7 @@ import { maybeRegisterLocalWorker } from "./dev/local";
 import { startDevServer } from "./dev/start-server";
 import { UserError } from "./errors";
 import { run } from "./experimental-flags";
-import { Logger, logger } from "./logger";
+import { logger } from "./logger";
 import * as metrics from "./metrics";
 import openInBrowser from "./open-in-browser";
 import { getAssetPaths, getSiteAssetPaths } from "./sites";

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -585,7 +585,7 @@ export async function startDev(args: StartDevOptions) {
 				});
 			}
 
-			if (process.stdout.isTTY && (args.showInteractiveDevSession ?? true)) {
+			if (process.stdout.isTTY && args.showInteractiveDevSession !== false) {
 				const unregisterHotKeys = registerHotKeys([
 					{
 						keys: ["b"],

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -632,8 +632,8 @@ export async function startDev(args: StartDevOptions) {
 						keys: ["x", "q", "ctrl+c"],
 						label: "to exit",
 						handler: async () => {
-							await devEnv.teardown();
 							unregisterHotKeys();
+							await devEnv.teardown();
 						},
 					},
 				]);

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -11,7 +11,7 @@ import {
 	convertCfWorkerInitBindingstoBindings,
 	extractBindingsOfType,
 } from "./api/startDevWorker/utils";
-import cliHotkeys from "./cli-hotkeys";
+import registerHotKeys from "./cli-hotkeys";
 import { findWranglerToml, printBindings, readConfig } from "./config";
 import { getEntry } from "./deployment-bundle/entry";
 import { validateNodeCompat } from "./deployment-bundle/node-compat";
@@ -587,7 +587,7 @@ export async function startDev(args: StartDevOptions) {
 			}
 
 			if (process.stdout.isTTY && (args.showInteractiveDevSession ?? true)) {
-				const { unregisterKeyPress, formatInstructions } = cliHotkeys([
+				const unregisterHotKeys = registerHotKeys([
 					{
 						keys: ["b"],
 						label: "open a browser",
@@ -634,13 +634,10 @@ export async function startDev(args: StartDevOptions) {
 						label: "to exit",
 						handler: async () => {
 							await devEnv.teardown();
-							unregisterKeyPress();
+							unregisterHotKeys();
 						},
 					},
 				]);
-
-				Logger.registerGlobalBottomFloat(formatInstructions);
-				Log.registerGlobalBottomFloat(formatInstructions);
 			}
 
 			await devEnv.config.set({

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -1129,8 +1129,9 @@ export async function validateDevServerSettings(
 	// we want it to exit the Wrangler process early to allow the user to fix it. Calling it here forces
 	// the error to be thrown where it will correctly exit the Wrangler process
 	if (args.remote) {
-		const accountId =
-			args.accountId ?? config.account_id ?? (await getAccountId());
+		const accountId = await requireAuth({
+			account_id: args.accountId ?? config.account_id,
+		});
 		assert(accountId, "Account ID must be provided for remote dev");
 		await getZoneIdForPreview({ host, routes, accountId });
 	}

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -6,6 +6,7 @@ import { UserError } from "../errors";
 import { logger } from "../logger";
 import { ParseError, parseJSON } from "../parse";
 import { getAccessToken } from "../user/access";
+import { isAbortError } from "../utils/isAbortError";
 import type {
 	CfWorkerContext,
 	CfWorkerInit,
@@ -333,7 +334,7 @@ export async function createWorkerPreview(
 			}
 		},
 		(err) => {
-			if ((err as { code: string }).code !== "ABORT_ERR") {
+			if (isAbortError(err)) {
 				logger.warn("worker failed to prewarm: ", err);
 			}
 		}

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -6,7 +6,7 @@ import type { DevEnv } from "../api";
 
 export default function registerDevHotKeys(
 	devEnv: DevEnv,
-	{ forceLocal = false } = {}
+	args: { forceLocal?: boolean }
 ) {
 	const unregisterHotKeys = registerHotKeys([
 		{
@@ -32,7 +32,7 @@ export default function registerDevHotKeys(
 		},
 		{
 			keys: ["l"],
-			disabled: forceLocal,
+			disabled: () => args.forceLocal ?? false,
 			label: () =>
 				`turn ${devEnv.config.latestConfig?.dev?.remote ? "on" : "off"} local mode`,
 			handler: async () => {

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -1,0 +1,65 @@
+import registerHotKeys from "../cli-hotkeys";
+import { logger } from "../logger";
+import openInBrowser from "../open-in-browser";
+import { openInspector } from "./inspect";
+import type { DevEnv } from "../api";
+
+export default function registerDevHotKeys(
+	devEnv: DevEnv,
+	{ forceLocal = false } = {}
+) {
+	const unregisterHotKeys = registerHotKeys([
+		{
+			keys: ["b"],
+			label: "open a browser",
+			handler: async () => {
+				const { url } = await devEnv.proxy.ready.promise;
+				await openInBrowser(url.href);
+			},
+		},
+		{
+			keys: ["d"],
+			label: "open devtools",
+			handler: async () => {
+				const { inspectorUrl } = await devEnv.proxy.ready.promise;
+
+				// TODO: refactor this function to accept a whole URL (not just .port and assuming .hostname)
+				await openInspector(
+					parseInt(inspectorUrl.port),
+					devEnv.config.latestConfig?.name
+				);
+			},
+		},
+		{
+			keys: ["l"],
+			disabled: forceLocal,
+			label: () =>
+				`turn ${devEnv.config.latestConfig?.dev?.remote ? "on" : "off"} local mode`,
+			handler: async () => {
+				await devEnv.config.patch({
+					dev: {
+						...devEnv.config.latestConfig?.dev,
+						remote: !devEnv.config.latestConfig?.dev?.remote,
+					},
+				});
+			},
+		},
+		{
+			keys: ["c"],
+			label: "clear console",
+			handler: async () => {
+				logger.console("clear");
+			},
+		},
+		{
+			keys: ["x", "q", "ctrl+c"],
+			label: "to exit",
+			handler: async () => {
+				unregisterHotKeys();
+				await devEnv.teardown();
+			},
+		},
+	]);
+
+	return unregisterHotKeys;
+}

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -175,7 +175,11 @@ export function logConsoleMessage(
 	if (method in console) {
 		switch (method) {
 			case "dir":
-				logger.console("dir", ...args);
+				logger.console(
+					"dir",
+					// @ts-expect-error A spread argument must either have a tuple type or be passed to a rest parameter.
+					...args
+				);
 				break;
 			case "table":
 				logger.table(args.map((value) => ({ value })));

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -175,7 +175,7 @@ export function logConsoleMessage(
 	if (method in console) {
 		switch (method) {
 			case "dir":
-				logger.console("dir", args);
+				logger.console("dir", ...args);
 				break;
 			case "table":
 				logger.table(args.map((value) => ({ value })));

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -175,13 +175,13 @@ export function logConsoleMessage(
 	if (method in console) {
 		switch (method) {
 			case "dir":
-				logger.dir(args);
+				logger.console("dir", args);
 				break;
 			case "table":
 				logger.table(args.map((value) => ({ value })));
 				break;
 			default:
-				logger.log(...args);
+				logger.console(method, ...args);
 				break;
 		}
 	} else {

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -175,14 +175,13 @@ export function logConsoleMessage(
 	if (method in console) {
 		switch (method) {
 			case "dir":
-				console.dir(args);
+				logger.dir(args);
 				break;
 			case "table":
-				console.table(args);
+				logger.table(args.map((value) => ({ value })));
 				break;
 			default:
-				// eslint-disable-next-line prefer-spread
-				console[method].apply(console, args);
+				logger.log(...args);
 				break;
 		}
 	} else {

--- a/packages/wrangler/src/dev/proxy.ts
+++ b/packages/wrangler/src/dev/proxy.ts
@@ -8,6 +8,7 @@ import serveStatic from "serve-static";
 import { getHttpsOptions } from "../https-options";
 import { logger } from "../logger";
 import { getAccessToken } from "../user/access";
+import { castAsAbortError, isAbortError } from "../utils/isAbortError";
 import type { CfPreviewToken } from "./create-worker-preview";
 import type { HttpTerminator } from "http-terminator";
 import type {
@@ -197,7 +198,7 @@ export async function startPreviewServer({
 			},
 		};
 	} catch (err) {
-		if ((err as { code: string }).code !== "ABORT_ERR") {
+		if (isAbortError(err)) {
 			logger.error(`Failed to start server: ${err}`);
 		}
 		logger.error("Failed to create proxy server:", err);
@@ -336,7 +337,7 @@ export function usePreviewServer({
 				proxy.server.listen(port, ip === "*" ? "::" : ip);
 			})
 			.catch((err) => {
-				if ((err as { code: string }).code !== "ABORT_ERR") {
+				if (isAbortError(err)) {
 					logger.error(`Failed to start server: ${err}`);
 				}
 			});
@@ -667,7 +668,7 @@ export async function waitForPortToBeAvailable(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		options.abortSignal.addEventListener("abort", () => {
 			const abortError = new Error("waitForPortToBeAvailable() aborted");
-			(abortError as Error & { code: string }).code = "ABORT_ERR";
+			castAsAbortError(abortError);
 			doReject(abortError);
 		});
 

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -18,6 +18,7 @@ import {
 	saveAccountToCache,
 } from "../user";
 import { getAccessToken } from "../user/access";
+import { isAbortError } from "../utils/isAbortError";
 import { getZoneIdForPreview } from "../zones";
 import {
 	createPreviewSession,
@@ -51,7 +52,7 @@ export function handlePreviewSessionUploadError(
 	// since it could recover after the developer fixes whatever's wrong
 	// instead of logging the raw API error to the user,
 	// give them friendly instructions
-	if ((err as unknown as { code: string }).code !== "ABORT_ERR") {
+	if (isAbortError(err)) {
 		// code 10049 happens when the preview token expires
 		if ("code" in err && err.code === 10049) {
 			logger.log("Preview token expired, fetching a new one");
@@ -94,7 +95,7 @@ export function handlePreviewSessionCreationError(
 	}
 	// we want to log the error, but not end the process
 	// since it could recover after the developer fixes whatever's wrong
-	else if ((err as { code: string }).code !== "ABORT_ERR") {
+	else if (isAbortError(err)) {
 		logger.error("Error while creating remote dev session:", err);
 	}
 }
@@ -578,7 +579,7 @@ export async function getRemotePreviewToken(props: RemoteProps) {
 		// since it could recover after the developer fixes whatever's wrong
 		// instead of logging the raw API error to the user,
 		// give them friendly instructions
-		if ((err as unknown as { code: string })?.code !== "ABORT_ERR") {
+		if (isAbortError(err)) {
 			// code 10049 happens when the preview token expires
 			if (err.code === 10049) {
 				logger.log("Preview token expired, restart server to fetch a new one");

--- a/packages/wrangler/src/dialogs.ts
+++ b/packages/wrangler/src/dialogs.ts
@@ -1,14 +1,8 @@
 import chalk from "chalk";
 import prompts from "prompts";
 import { UserError } from "./errors";
-import { CI } from "./is-ci";
-import isInteractive from "./is-interactive";
+import { isNonInteractiveOrCI } from "./is-interactive";
 import { logger } from "./logger";
-
-// TODO: Use this function across the codebase.
-function isNonInteractiveOrCI(): boolean {
-	return !isInteractive() || CI.isCI();
-}
 
 export class NoDefaultValueProvided extends UserError {
 	constructor() {

--- a/packages/wrangler/src/is-interactive.ts
+++ b/packages/wrangler/src/is-interactive.ts
@@ -1,3 +1,5 @@
+import { CI } from "./is-ci";
+
 /**
  * Test whether the process is "interactive".
  * Reasons it may not be interactive: it could be running in CI,
@@ -13,4 +15,9 @@ export default function isInteractive(): boolean {
 	} catch {
 		return false;
 	}
+}
+
+// TODO: Use this function across the codebase.
+export function isNonInteractiveOrCI(): boolean {
+	return !isInteractive() || CI.isCI();
 }

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -85,19 +85,16 @@ export class Logger {
 		t.push(...data.map((row) => keys.map((k) => row[k])));
 		return this.doLog("log", [t.toString()]);
 	}
-	console<
-		M extends keyof Omit<Console, "Console">,
-		P extends Parameters<Console[M]>,
-	>(method: M, ...args: P) {
+	console<M extends Exclude<keyof Console, "Console">>(
+		method: M,
+		...args: Parameters<Console[M]>
+	) {
 		if (typeof console[method] !== "function") {
 			throw new Error(`console.${method}() is not a function`);
 		}
 
 		Logger.#beforeLogHook?.();
-		console[method](
-			// @ts-expect-error Parameters<Console[M]> isn't satisfying "A spread argument must either have a tuple type or be passed to a rest parameter"
-			...args
-		);
+		(console[method] as (...args: unknown[]) => unknown).apply(console, args);
 		Logger.#afterLogHook?.();
 	}
 

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -102,6 +102,7 @@ export class Logger {
 	}
 
 	private static _getBottomFloat?: () => string;
+	private static _previousBottomFloatLineCount = 0;
 	static registerGlobalBottomFloat(getBottomFloat: () => string) {
 		if (process.stdin.isTTY) {
 			Logger._getBottomFloat = getBottomFloat;
@@ -115,10 +116,8 @@ export class Logger {
 		message: string
 	) {
 		const bottomFloat = Logger._getBottomFloat?.();
-		if (bottomFloat) {
-			const lines = bottomFloat.split("\n").length;
-
-			process.stdout.moveCursor(0, -lines);
+		if (Logger._previousBottomFloatLineCount) {
+			process.stdout.moveCursor(0, -Logger._previousBottomFloatLineCount);
 			process.stdout.clearScreenDown();
 		}
 
@@ -126,6 +125,7 @@ export class Logger {
 
 		if (bottomFloat) {
 			console.log(bottomFloat);
+			Logger._previousBottomFloatLineCount = bottomFloat.split("\n").length;
 		}
 	}
 

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -97,7 +97,32 @@ export class Logger {
 
 		// only send logs to the terminal if their level is at least the configured log-level
 		if (LOGGER_LEVELS[this.loggerLevel] >= LOGGER_LEVELS[messageLevel]) {
-			console[messageLevel](message);
+			this.doLogWithBottomFloat(messageLevel, message);
+		}
+	}
+
+	static #getBottomFloat?: () => string;
+	static registerGlobalBottomFloat(getBottomFloat: () => string) {
+		if (process.stdin.isTTY) {
+			Logger.#getBottomFloat = getBottomFloat;
+		}
+	}
+	private doLogWithBottomFloat(
+		messageLevel: Exclude<LoggerLevel, "none">,
+		message: string
+	) {
+		const bottomFloat = Logger.#getBottomFloat?.();
+		if (bottomFloat) {
+			const lines = bottomFloat.split("\n").length;
+
+			process.stdout.moveCursor(0, -lines);
+			process.stdout.clearScreenDown();
+		}
+
+		console[messageLevel](message);
+
+		if (bottomFloat) {
+			console.log(bottomFloat);
 		}
 	}
 

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -87,7 +87,7 @@ export class Logger {
 		return this.doLog("log", [t.toString()]);
 	}
 	dir(...args: Parameters<(typeof console)["dir"]>) {
-		Log.logWithBottomFloat(() => console.dir(...args));
+		Log.unsafe_logWithBottomFloat(() => console.dir(...args));
 	}
 
 	private doLog(messageLevel: Exclude<LoggerLevel, "none">, args: unknown[]) {
@@ -101,7 +101,7 @@ export class Logger {
 
 		// only send logs to the terminal if their level is at least the configured log-level
 		if (LOGGER_LEVELS[this.loggerLevel] >= LOGGER_LEVELS[messageLevel]) {
-			Log.logWithBottomFloat(() => console[messageLevel](message));
+			Log.unsafe_logWithBottomFloat(() => console[messageLevel](message));
 		}
 	}
 

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -85,16 +85,19 @@ export class Logger {
 		t.push(...data.map((row) => keys.map((k) => row[k])));
 		return this.doLog("log", [t.toString()]);
 	}
-	console<M extends keyof Omit<Console, "Console">>(
-		method: M,
-		...args: Parameters<Console[M]>
-	) {
+	console<
+		M extends keyof Omit<Console, "Console">,
+		P extends Parameters<Console[M]>,
+	>(method: M, ...args: P) {
 		if (typeof console[method] !== "function") {
 			throw new Error(`console.${method}() is not a function`);
 		}
 
 		Logger.#beforeLogHook?.();
-		console[method](console, args);
+		console[method](
+			// @ts-expect-error Parameters<Console[M]> isn't satisfying "A spread argument must either have a tuple type or be passed to a rest parameter"
+			...args
+		);
 		Logger.#afterLogHook?.();
 	}
 

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -85,9 +85,16 @@ export class Logger {
 		t.push(...data.map((row) => keys.map((k) => row[k])));
 		return this.doLog("log", [t.toString()]);
 	}
-	dir(...args: Parameters<(typeof console)["dir"]>) {
+	console<M extends keyof Omit<Console, "Console">>(
+		method: M,
+		...args: Parameters<Console[M]>
+	) {
+		if (typeof console[method] !== "function") {
+			throw new Error(`console.${method}() is not a function`);
+		}
+
 		Logger.#beforeLogHook?.();
-		console.dir(...args);
+		console[method](console, args);
 		Logger.#afterLogHook?.();
 	}
 

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -2,7 +2,6 @@ import { format } from "node:util";
 import chalk from "chalk";
 import CLITable from "cli-table3";
 import { formatMessagesSync } from "esbuild";
-import { Log } from "miniflare";
 import { getEnvironmentVariableFactory } from "./environment-variables/factory";
 import { getSanitizeLogs } from "./environment-variables/misc-variables";
 import { appendToDebugLogFile } from "./utils/log-file";

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -101,17 +101,20 @@ export class Logger {
 		}
 	}
 
-	static #getBottomFloat?: () => string;
+	private static _getBottomFloat?: () => string;
 	static registerGlobalBottomFloat(getBottomFloat: () => string) {
 		if (process.stdin.isTTY) {
-			Logger.#getBottomFloat = getBottomFloat;
+			Logger._getBottomFloat = getBottomFloat;
 		}
+	}
+	static unregisterGlobalBottomFloat() {
+		Logger._getBottomFloat = undefined;
 	}
 	private doLogWithBottomFloat(
 		messageLevel: Exclude<LoggerLevel, "none">,
 		message: string
 	) {
-		const bottomFloat = Logger.#getBottomFloat?.();
+		const bottomFloat = Logger._getBottomFloat?.();
 		if (bottomFloat) {
 			const lines = bottomFloat.split("\n").length;
 

--- a/packages/wrangler/src/utils/isAbortError.ts
+++ b/packages/wrangler/src/utils/isAbortError.ts
@@ -1,0 +1,22 @@
+/**
+ * Checking whether an error is an AbortError has changed.
+ * There is a legacy use of `.code`
+ * and a (mdn status: experimental) use of `.name`
+ *
+ * See MDN for more information:
+ * https://developer.mozilla.org/en-US/docs/Web/API/DOMException#aborterror
+ */
+export function isAbortError(err: unknown) {
+	const legacyAbortErroCheck = (err as { code: string }).code !== "ABORT_ERR";
+	const abortErrorCheck = err instanceof Error && err.name == "AbortError";
+
+	return legacyAbortErroCheck || abortErrorCheck;
+}
+
+/**
+ * Mutate an Error instance so it passes either of the checks in isAbortError
+ */
+export function castAsAbortError(err: Error) {
+	(err as Error & { code: string }).code = "ABORT_ERR";
+	err.name = "AbortError";
+}

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -1,0 +1,27 @@
+import readline from "readline";
+
+type KeypressEvent = { name: string; ctrl: boolean };
+
+export function onKeyPress(
+	callback: (key: string) => void,
+	stdin = process.stdin
+) {
+	if (stdin.isTTY) {
+		readline.emitKeypressEvents(stdin);
+		stdin.setRawMode(true);
+	}
+
+	const handler = async (char: string, key: KeypressEvent) => {
+		if (key && key.ctrl && key.name == "c") {
+			char = "CTRL+C";
+		}
+
+		if (char) {
+			callback(char);
+		}
+	};
+
+	stdin.on("keypress", handler);
+
+	return () => stdin.off("keypress", handler);
+}

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -23,5 +23,7 @@ export function onKeyPress(
 
 	stdin.on("keypress", handler);
 
-	return () => stdin.off("keypress", handler);
+	return () => {
+		stdin.off("keypress", handler);
+	};
 }

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -8,6 +8,7 @@ export function onKeyPress(callback: (key: string) => void) {
 	// which keeps this nodejs process alive even after calling .off('keypress')
 	// WORKAROUND: piping stdin via a transform stream allows us to call stream.destroy()
 	// which then allows this nodejs process to close cleanly
+	// https://nodejs.org/api/process.html#signal-events:~:text=be%20used%20in-,%22old%22%20mode,-that%20is%20compatible
 	const stream = new Transform({
 		transform(chunk, encoding, cb) {
 			cb(null, chunk);

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -1,9 +1,15 @@
 import readline from "readline";
 import { Transform } from "stream";
 
-type KeypressEvent = { name: string; ctrl: boolean };
+type KeypressEvent = {
+	name: string;
+	sequence: string;
+	ctrl: boolean;
+	meta: boolean;
+	shift: boolean;
+};
 
-export function onKeyPress(callback: (key: string) => void) {
+export function onKeyPress(callback: (key: KeypressEvent) => void) {
 	// Listening for events on process.stdin (eg .on('keypress')) causes it to go into 'old mode'
 	// which keeps this nodejs process alive even after calling .off('keypress')
 	// WORKAROUND: piping stdin via a transform stream allows us to call stream.destroy()
@@ -21,13 +27,9 @@ export function onKeyPress(callback: (key: string) => void) {
 		process.stdin.setRawMode(true);
 	}
 
-	const handler = async (char: string, key: KeypressEvent) => {
-		if (key && key.ctrl && key.name == "c") {
-			char = "CTRL+C";
-		}
-
-		if (char) {
-			callback(char);
+	const handler = async (_char: string, key: KeypressEvent) => {
+		if (key) {
+			callback(key);
 		}
 	};
 

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -1,7 +1,7 @@
 import readline from "readline";
 import { Transform } from "stream";
 
-type KeypressEvent = {
+export type KeypressEvent = {
 	name: string;
 	sequence: string;
 	ctrl: boolean;

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -32,7 +32,9 @@ export function onKeyPress(callback: (key: KeypressEvent) => void) {
 	stream.on("keypress", handler);
 
 	return () => {
-		process.stdin.setRawMode(false);
+		if (process.stdin.isTTY) {
+			process.stdin.setRawMode(false);
+		}
 		stream.off("keypress", handler);
 		stream.destroy();
 	};

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -1,14 +1,23 @@
 import readline from "readline";
+import { Transform } from "stream";
 
 type KeypressEvent = { name: string; ctrl: boolean };
 
-export function onKeyPress(
-	callback: (key: string) => void,
-	stdin = process.stdin
-) {
-	if (stdin.isTTY) {
-		readline.emitKeypressEvents(stdin);
-		stdin.setRawMode(true);
+export function onKeyPress(callback: (key: string) => void) {
+	// Listening for events on process.stdin (eg .on('keypress')) causes it to go into 'old mode'
+	// which keeps this nodejs process alive even after calling .off('keypress')
+	// WORKAROUND: piping stdin via a transform stream allows us to call stream.destroy()
+	// which then allows this nodejs process to close cleanly
+	const stream = new Transform({
+		transform(chunk, encoding, cb) {
+			cb(null, chunk);
+		},
+	});
+	process.stdin.pipe(stream);
+
+	if (process.stdin.isTTY) {
+		readline.emitKeypressEvents(stream);
+		process.stdin.setRawMode(true);
 	}
 
 	const handler = async (char: string, key: KeypressEvent) => {
@@ -21,9 +30,11 @@ export function onKeyPress(
 		}
 	};
 
-	stdin.on("keypress", handler);
+	stream.on("keypress", handler);
 
 	return () => {
-		stdin.off("keypress", handler);
+		process.stdin.setRawMode(false);
+		stream.off("keypress", handler);
+		stream.destroy();
 	};
 }

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -1,5 +1,5 @@
 import readline from "readline";
-import { Transform } from "stream";
+import { PassThrough } from "stream";
 
 export type KeypressEvent = {
 	name: string;
@@ -15,11 +15,7 @@ export function onKeyPress(callback: (key: KeypressEvent) => void) {
 	// WORKAROUND: piping stdin via a transform stream allows us to call stream.destroy()
 	// which then allows this nodejs process to close cleanly
 	// https://nodejs.org/api/process.html#signal-events:~:text=be%20used%20in-,%22old%22%20mode,-that%20is%20compatible
-	const stream = new Transform({
-		transform(chunk, encoding, cb) {
-			cb(null, chunk);
-		},
-	});
+	const stream = new PassThrough();
 	process.stdin.pipe(stream);
 
 	if (process.stdin.isTTY) {

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -1,5 +1,6 @@
 import readline from "readline";
 import { PassThrough } from "stream";
+import { isNonInteractiveOrCI } from "../is-interactive";
 
 export type KeypressEvent = {
 	name: string;
@@ -18,7 +19,7 @@ export function onKeyPress(callback: (key: KeypressEvent) => void) {
 	const stream = new PassThrough();
 	process.stdin.pipe(stream);
 
-	if (process.stdin.isTTY) {
+	if (!isNonInteractiveOrCI()) {
 		readline.emitKeypressEvents(stream);
 		process.stdin.setRawMode(true);
 	}
@@ -32,7 +33,7 @@ export function onKeyPress(callback: (key: KeypressEvent) => void) {
 	stream.on("keypress", handler);
 
 	return () => {
-		if (process.stdin.isTTY) {
+		if (!isNonInteractiveOrCI()) {
 			process.stdin.setRawMode(false);
 		}
 		stream.off("keypress", handler);

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -1,6 +1,6 @@
 import readline from "readline";
 import { PassThrough } from "stream";
-import { isNonInteractiveOrCI } from "../is-interactive";
+import isInteractive from "../is-interactive";
 
 export type KeypressEvent = {
 	name: string;
@@ -19,7 +19,7 @@ export function onKeyPress(callback: (key: KeypressEvent) => void) {
 	const stream = new PassThrough();
 	process.stdin.pipe(stream);
 
-	if (!isNonInteractiveOrCI()) {
+	if (isInteractive()) {
 		readline.emitKeypressEvents(stream);
 		process.stdin.setRawMode(true);
 	}
@@ -33,7 +33,7 @@ export function onKeyPress(callback: (key: KeypressEvent) => void) {
 	stream.on("keypress", handler);
 
 	return () => {
-		if (!isNonInteractiveOrCI()) {
+		if (isInteractive()) {
 			process.stdin.setRawMode(false);
 		}
 		stream.off("keypress", handler);


### PR DESCRIPTION
## What this PR solves / how to test

Implements a React-free hotkeys implementation.

You can see both the implementations below – the React-free version with the `--x-dev-env` flag and the React/ink version with the flag:

![image](https://github.com/cloudflare/workers-sdk/assets/5822355/331d414f-5c71-4386-8bbb-fb2084cfc579)

I started with a simpler implementation in the [first commit](https://github.com/cloudflare/workers-sdk/commit/87c94c05646da58140563953e8af8098ca2e4622) but felt a higher-level API would allow for most consistency for other commands wanting to use hotkeys. The instructions printing logic has been moved inside the API and provides each handler with a `printInstructions` function if the handler wishes to reprint them.

UPDATE:
The instructions box now floats at the bottom (by making Wrangler's `Logger` and Miniflare's `Log` classes aware of a possible bottom float string). See image below for what it looks like now (note the worker logs are now above the instructions box):

![image](https://github.com/cloudflare/workers-sdk/assets/5822355/88f4b245-00c8-4361-a86d-aed9ae6a6c51)


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: hotkeys not currently tested with e2e
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: experimental

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
