### PR TITLE
fix(wrangler): Fix `pages dev` watch mode [_worker.js]

### DIFF
--- a/.changeset/poor-ads-poke.md
+++ b/.changeset/poor-ads-poke.md
@@ -1,0 +1,22 @@
+---
+"wrangler": patch
+---
+
+fix: Fix `pages dev` watch mode [_worker.js]
+
+The watch mode in `pages dev` for Advanced Mode projects is currently partially broken, as it only watches for changes in the "\_worker.js" file, but not for changes in any of its imported dependencies. This means that given the following "\_worker.js" file
+
+```
+import { graham } from "./graham-the-dog";
+export default {
+	fetch(request, env) {
+		return new Response(graham)
+	}
+}
+```
+
+`pages dev` will reload for any changes in the `_worker.js` file itself, but not for any changes in `graham-the-dog.js`, which is its dependency.
+
+Similarly, `pages dev` will not reload for any changes in non-JS module imports, such as wasm/html/binary module imports.
+
+This commit fixes all the aforementioned issues.

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -188,7 +188,7 @@ describe("pages dev", () => {
 
 		await setTimeout(5_000);
 
-		await worker.readUntil(/Error while attempting to build/);
+		await worker.readUntil(/Failed to build/);
 
 		// And then make sure Wrangler hasn't crashed
 		await helper.seed({
@@ -234,7 +234,7 @@ describe("pages dev", () => {
 
 		await setTimeout(5_000);
 
-		await worker.readUntil(/Unexpected error building Functions directory/);
+		await worker.readUntil(/Failed to build Functions/);
 
 		// And then make sure Wrangler hasn't crashed
 		await helper.seed({

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -1,6 +1,6 @@
 import { execSync, spawn } from "node:child_process";
 import { existsSync, lstatSync, readFileSync } from "node:fs";
-import { join, normalize, resolve } from "node:path";
+import { dirname, join, normalize, resolve } from "node:path";
 import { watch } from "chokidar";
 import * as esbuild from "esbuild";
 import { unstable_dev } from "../api";
@@ -402,7 +402,20 @@ export const Handler = async (args: PagesDevArguments) => {
 			}
 		});
 	} else if (usingWorkerScript) {
+		/*
+		 * Delegate watching for file changes to chokidar entirely. This gives
+		 * us a bit more flexibility and control as opposed to esbuild watch
+		 * mode, and keeps things consistent with the Functions implementation
+		 */
+		// always watch _worker.js
+		const watcher = watch([workerScriptPath], {
+			persistent: true,
+			ignoreInitial: true,
+		});
+		let watchedBundleDependencies: string[] = [];
+
 		scriptPath = workerScriptPath;
+
 		let runBuild = async () => {
 			await checkRawWorker(workerScriptPath, nodejsCompatMode, () =>
 				scriptReadyResolve()
@@ -417,37 +430,126 @@ export const Handler = async (args: PagesDevArguments) => {
 				getPagesTmpDir(),
 				`./bundledWorker-${Math.random()}.mjs`
 			);
+
 			runBuild = async () => {
-				try {
-					await buildRawWorker({
-						workerScriptPath: usingWorkerDirectory
-							? join(workerScriptPath, "index.js")
-							: workerScriptPath,
-						outfile: scriptPath,
-						directory: directory ?? ".",
-						nodejsCompatMode,
-						local: true,
-						sourcemap: true,
-						watch: false,
-						onEnd: () => scriptReadyResolve(),
-						defineNavigatorUserAgent,
-					});
-				} catch (e: unknown) {
-					logger.warn("Failed to bundle _worker.js.", e);
+				const workerScriptDirectory = dirname(workerScriptPath);
+				let currentBundleDependencies: string[] = [];
+
+				const bundle = await buildRawWorker({
+					workerScriptPath: usingWorkerDirectory
+						? join(workerScriptPath, "index.js")
+						: workerScriptPath,
+					outfile: scriptPath,
+					directory: directory ?? ".",
+					nodejsCompatMode,
+					local: true,
+					sourcemap: true,
+					watch: false,
+					onEnd: () => scriptReadyResolve(),
+					defineNavigatorUserAgent,
+				});
+
+				/*
+				 * EXCLUDE:
+				 *   - "_worker.js" because we're already watching it
+				 *   - everything in "./.wrangler", as it's mostly cache and
+				 *     temporary files
+				 *   - anything outside of the current working directory, since we
+				 *     are expecting `wrangler pages dev` to be run from the Pages
+				 *     project root folder
+				 */
+				const bundleDependencies = Object.keys(bundle.dependencies)
+					.map((dep) => resolve(workerScriptDirectory, dep))
+					.filter(
+						(resolvedDep) =>
+							!resolvedDep.includes(normalize(singleWorkerScriptPath)) &&
+							!resolvedDep.includes(normalize("/.wrangler/")) &&
+							resolvedDep.includes(resolve(process.cwd()))
+					);
+
+				// handle non-JS module dependencies, such as wasm/html/binary imports
+				const bundleModules = bundle.modules
+					.filter((module) => !!module.filePath)
+					.map((module) =>
+						resolve(workerScriptDirectory, module.filePath as string)
+					);
+
+				/*
+				 *`bundle.dependencies` and `bundle.modules` combined, will always
+				 * provide us with the most up-to-date list of dependencies we need
+				 * to watch, since they reflect the latest built Worker bundle.
+				 * Therefore, we can safely unwatch all dependencies we have been
+				 * watching so far, and add all the new ones.
+				 */
+				currentBundleDependencies = [...bundleDependencies, ...bundleModules];
+
+				if (watchedBundleDependencies.length) {
+					watcher.unwatch(watchedBundleDependencies);
 				}
+				watcher.add(currentBundleDependencies);
+				watchedBundleDependencies = [...currentBundleDependencies];
 			};
 		}
 
-		await runBuild();
-		watch([workerScriptPath], {
-			persistent: true,
-			ignoreInitial: true,
-		}).on("all", async (event) => {
-			if (event === "unlink") {
-				return;
-			}
+		/*
+		 * Improve developer experience by debouncing the re-building
+		 * of the Worker script, in case file changes are trigerred
+		 * at a high rate (for example if code editor runs auto-saves
+		 * at very short intervals)
+		 *
+		 * "Debouncing ensures that exactly one signal is sent for an
+		 * event that may be happening several times — or even several
+		 * hundreds of times over an extended period. As long as the
+		 * events are occurring fast enough to happen at least once in
+		 * every detection period, the signal will not be sent!"
+		 * (http://unscriptable.com/2009/03/20/debouncing-javascript-methods/)
+		 */
+		const debouncedRunBuild = (delayMS = 50) => {
+			const debounceFn = debounce(async () => {
+				try {
+					await runBuild();
+				} catch (e) {
+					/*
+					 * don't break developer flow in watch mode by throwing an error
+					 * here. Many times errors will be just the result of unfinished
+					 * typing. Instead, log the error, point out we are still serving
+					 * the last successfully built Worker, and allow developers to
+					 * write their code to completion
+					 */
+					logger.error(
+						`Error while attempting to build ${singleWorkerScriptPath}. Skipping to last successfully built version of the Worker.\n` +
+							`${e}`
+					);
+				}
+			}, delayMS);
+
+			debounceFn();
+		};
+
+		try {
 			await runBuild();
-		});
+
+			watcher.on("all", async (eventName, path) => {
+				logger.debug(`🌀 "${eventName}" event detected at ${path}.`);
+
+				// if "_worker.js" was deleted wait for 5s before re-building. It
+				// might be we are dealing with a temporary delete (as part of some
+				// frameworks-related process - see ...), and the file will be
+				// re-added immediately
+				const delayMS =
+					eventName === "unlink" && path.includes(workerScriptPath) ? 5000 : 50;
+				debouncedRunBuild(delayMS);
+			});
+		} catch (e: unknown) {
+			/*
+			 * fail early if we encounter errors while attempting to build the
+			 * Worker. These flag underlying issues in the _worker.js code, and
+			 * should be addressed before starting the dev process
+			 */
+			throw new FatalError(
+				`Error while attempting to build ${singleWorkerScriptPath}\n` + `${e}`
+			);
+		}
 	} else if (usingFunctions) {
 		// Try to use Functions
 		scriptPath = join(
@@ -462,7 +564,6 @@ export const Handler = async (args: PagesDevArguments) => {
 		logger.debug(`Compiling worker to "${scriptPath}"...`);
 
 		const onEnd = () => scriptReadyResolve();
-		const watchedBundleDependencies: Set<string> = new Set();
 
 		/*
 		 * Pages Functions projects cannot rely on esbuild's watch mode alone.
@@ -504,124 +605,111 @@ export const Handler = async (args: PagesDevArguments) => {
 			persistent: true,
 			ignoreInitial: true,
 		});
+		let watchedBundleDependencies: string[] = [];
 
-		try {
-			const buildFn = async () => {
-				const currentBundleDependencies = new Set();
+		const buildFn = async () => {
+			let currentBundleDependencies: string[] = [];
 
-				const bundle = await buildFunctions({
-					outfile: scriptPath,
-					functionsDirectory,
-					sourcemap: true,
-					watch: false,
-					onEnd,
-					buildOutputDirectory: directory,
-					nodejsCompatMode,
-					local: true,
-					routesModule,
-					defineNavigatorUserAgent,
-				});
+			const bundle = await buildFunctions({
+				outfile: scriptPath,
+				functionsDirectory,
+				sourcemap: true,
+				watch: false,
+				onEnd,
+				buildOutputDirectory: directory,
+				nodejsCompatMode,
+				local: true,
+				routesModule,
+				defineNavigatorUserAgent,
+			});
 
-				for (const dep in bundle.dependencies) {
-					const resolvedDep = resolve(functionsDirectory, dep);
-					/*
-					 * EXCLUDE:
-					 *   - the "/functions" directory because we're already watching it
-					 *   - everything in "./.wrangler", as it's mostly cache and
-					 *     temporary files
-					 *   - any bundle dependencies we are already watching
-					 *   - anything outside of the current working directory, since we
-					 *     are expecting `wrangler pages dev` to be run from the Pages
-					 *     project root folder
-					 */
-					if (
+			/*
+			 * EXCLUDE:
+			 *   - the "/functions" directory because we're already watching it
+			 *   - everything in "./.wrangler", as it's mostly cache and
+			 *     temporary files
+			 *   - any bundle dependencies we are already watching
+			 *   - anything outside of the current working directory, since we
+			 *     are expecting `wrangler pages dev` to be run from the Pages
+			 *     project root folder
+			 */
+			const bundleDependencies = Object.keys(bundle.dependencies)
+				.map((dep) => resolve(functionsDirectory, dep))
+				.filter(
+					(resolvedDep) =>
 						!resolvedDep.includes(normalize("/functions/")) &&
 						!resolvedDep.includes(normalize("/.wrangler/")) &&
 						resolvedDep.includes(resolve(process.cwd()))
-					) {
-						currentBundleDependencies.add(resolvedDep);
+				);
 
-						if (!watchedBundleDependencies.has(resolvedDep)) {
-							watchedBundleDependencies.add(resolvedDep);
-							watcher.add(resolvedDep);
-						}
-					}
-				}
-
-				// handle non-JS module dependencies, such as wasm/html/binary imports
-				for (const module of bundle.modules) {
-					if (module.filePath) {
-						const resolvedDep = resolve(functionsDirectory, module.filePath);
-						currentBundleDependencies.add(resolvedDep);
-
-						if (!watchedBundleDependencies.has(resolvedDep)) {
-							watchedBundleDependencies.add(resolvedDep);
-							watcher.add(resolvedDep);
-						}
-					}
-				}
-
-				/*
-				 *`bundle.dependencies` and `bundle.modules` will always contain the
-				 * latest dependency list of the current bundle. If we are currently
-				 * watching any dependency files not in that list, we should remove
-				 * them, as they are no longer relevant to the compiled Functions.
-				 */
-				watchedBundleDependencies.forEach(async (path) => {
-					if (!currentBundleDependencies.has(path)) {
-						watchedBundleDependencies.delete(path);
-						watcher.unwatch(path);
-					}
-				});
-
-				await metrics.sendMetricsEvent("build pages functions");
-			};
+			// handle non-JS module dependencies, such as wasm/html/binary imports
+			const bundleModules = bundle.modules
+				.filter((module) => !!module.filePath)
+				.map((module) =>
+					resolve(functionsDirectory, module.filePath as string)
+				);
 
 			/*
-			 * Improve developer experience by debouncing the re-building
-			 * of Functions.
-			 *
-			 * "Debouncing ensures that exactly one signal is sent for an
-			 * event that may be happening several times — or even several
-			 * hundreds of times over an extended period. As long as the
-			 * events are occurring fast enough to happen at least once in
-			 * every detection period, the signal will not be sent!"
-			 * (http://unscriptable.com/2009/03/20/debouncing-javascript-methods/)
-			 *
-			 * This handles use cases such as bulk file/directory changes
-			 * (such as copy/pasting multiple files/directories), where
-			 * chokidar will trigger a change event per each changed file/
-			 * directory. In such use cases, we want to ensure that we
-			 * re-build Functions once, as opposed to once per change event.
+			 *`bundle.dependencies` and `bundle.modules` will always contain the
+			 * latest dependency list of the current bundle. If we are currently
+			 * watching any dependency files not in that list, we should remove
+			 * them, as they are no longer relevant to the compiled Functions.
 			 */
-			const debouncedBuildFn = debounce(async () => {
-				try {
-					await buildFn();
-				} catch (e) {
-					if (e instanceof FunctionsNoRoutesError) {
-						logger.error(
-							getFunctionsNoRoutesWarning(functionsDirectory, "skipping")
-						);
-					} else if (e instanceof FunctionsBuildError) {
-						logger.error(
-							getFunctionsBuildWarning(functionsDirectory, e.message)
-						);
-					} else {
-						/*
-						 * don't break developer flow in watch mode by throwing an error
-						 * here. Many times errors will be just the result of unfinished
-						 * typing. Instead, log the error, point out we are still serving
-						 * the last successfully built Functions, and allow developers to
-						 * write their code to completion
-						 */
-						logger.error(
-							`Error while attempting to build the Functions directory ${functionsDirectory}. Skipping to last successfully built version of Functions.\n` +
-								`${e}`
-						);
-					}
-				}
-			}, 50);
+			currentBundleDependencies = [...bundleDependencies, ...bundleModules];
 
+			if (watchedBundleDependencies.length) {
+				watcher.unwatch(watchedBundleDependencies);
+			}
+			watcher.add(currentBundleDependencies);
+			watchedBundleDependencies = [...currentBundleDependencies];
+
+			await metrics.sendMetricsEvent("build pages functions");
+		};
+
+		/*
+		 * Improve developer experience by debouncing the re-building
+		 * of Functions.
+		 *
+		 * "Debouncing ensures that exactly one signal is sent for an
+		 * event that may be happening several times — or even several
+		 * hundreds of times over an extended period. As long as the
+		 * events are occurring fast enough to happen at least once in
+		 * every detection period, the signal will not be sent!"
+		 * (http://unscriptable.com/2009/03/20/debouncing-javascript-methods/)
+		 *
+		 * This handles use cases such as bulk file/directory changes
+		 * (such as copy/pasting multiple files/directories), where
+		 * chokidar will trigger a change event per each changed file/
+		 * directory. In such use cases, we want to ensure that we
+		 * re-build Functions once, as opposed to once per change event.
+		 */
+		const debouncedBuildFn = debounce(async () => {
+			try {
+				await buildFn();
+			} catch (e) {
+				if (e instanceof FunctionsNoRoutesError) {
+					logger.error(
+						getFunctionsNoRoutesWarning(functionsDirectory, "skipping")
+					);
+				} else if (e instanceof FunctionsBuildError) {
+					logger.error(getFunctionsBuildWarning(functionsDirectory, e.message));
+				} else {
+					/*
+					 * don't break developer flow in watch mode by throwing an error
+					 * here. Many times errors will be just the result of unfinished
+					 * typing. Instead, log the error, point out we are still serving
+					 * the last successfully built Functions, and allow developers to
+					 * write their code to completion
+					 */
+					logger.error(
+						`Error while attempting to build the Functions directory ${functionsDirectory}. Skipping to last successfully built version of Functions.\n` +
+							`${e}`
+					);
+				}
+			}
+		}, 50);
+
+		try {
 			await buildFn();
 
 			// If Functions found routes, continue using Functions
@@ -630,7 +718,7 @@ export const Handler = async (args: PagesDevArguments) => {
 
 				debouncedBuildFn();
 			});
-		} catch (e) {
+		} catch (e: unknown) {
 			// If there are no Functions, then Pages will only serve assets.
 			if (e instanceof FunctionsNoRoutesError) {
 				logger.error(


### PR DESCRIPTION
## What this PR solves / how to test

The watch mode in `pages dev` for Advanced Mode projects is currently partially broken, as it only watches for changes in the `_worker.js` file, but not for changes in any of its imported dependencies. This means that given the following `_worker.js` file

```
import { graham } from "./graham-the-dog";
export default {
    fetch(request, env) {
	return new Response(graham)
    }
}
```

`pages dev` will reload for any changes in the `_worker.js` file itself, but not for any changes in `graham-the-dog.js`, which is its dependency.

Similarly, `pages dev` will not reload for any changes in non-JS module imports, such as wasm/html/binary module imports.

This commit addresses all the aforementioned issues.

Fixes #4824

## Solutions we considered
Our original solution was implemented using esbuild's `watch` mode (see https://github.com/cloudflare/workers-sdk/pull/6150/commits/dd6cd19707f2070d7dba63e8d79872fce9887d82), which basically meant just enabling the `watch` flag in `buildRawWorker()`. Turned out though (via failed test in CI), that this solution introduced a regression for a frameworks corner case...the deletion of `_worker.js` itself (please see https://github.com/cloudflare/workers-sdk/pull/4877 and https://github.com/cloudflare/workers-sdk/issues/3886). 

When used in the context of frameworks, the assets directory served by `pages dev` gets rebuilt (removed + added back with updated assets) by a separate process, external to wrangler (I'm no expert here on the exact details, but I assume this more or less to be the case). This affects key Pages files, such as `_worker.js` and `_routes.json`, which get deleted/added back as part of that assets directory, which in turn, triggers a `_worker.js` rebuild. If the `_worker.js` re-build is triggered before the external process gets a chance to add the file back, `pages dev` will show a bunch of errors in the terminal, which, while accurate, seem to be confusing/annoying for our users. This was fixed by https://github.com/cloudflare/workers-sdk/pull/4877 by completely turning off Worker rebuilds for chokidar "unlink` events.

Unfortunately, the behaviour for this particular use case is very hard to port to esbuild watch mode, since esbuild gives us very limited information wrt to what changed ....so here we are 😢 

This lead us to the second implementation (see https://github.com/cloudflare/workers-sdk/pull/6150/commits/5c8fcf02018607b0308e595dd63f69ec33274756), which, [similar to Functions](https://github.com/cloudflare/workers-sdk/pull/6022), delegates the entirety of the watch mechanism to `chokidar`. 

## How we tested the changes
This PR comes with e2e tests, but in addition to them, we've manually tested these changes in the following scenarios:

- change/remove/add `_worker.js`
- change in external dependency (eg import { ADD } from "../<dir>/**/<dir>/add")
- change in external module (eg import html from "../<dir>/**/<dir>/my-html.html")
- adding/removing external dependencies
- errors in `_worker.js`
- errors in dependencies


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: watch mode is not documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
