### PR TITLE
test: quarantine nuxt framework in C3 e2e tests

### DIFF
--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -266,6 +266,7 @@ const frameworkTests: Record<string, FrameworkTestConfig> = {
 	nuxt: {
 		testCommitMessage: true,
 		timeout: LONG_TIMEOUT,
+		quarantine: true,
 		unsupportedOSs: ["win32"],
 		verifyDeploy: {
 			route: "/",


### PR DESCRIPTION
## What this PR solves / how to test

Nuxt is currently broken - so sending to quarantine. See https://github.com/cloudflare/workers-sdk/issues/6155
