### PR TITLE
remove extra quote from pages deploy message

### DIFF
--- a/packages/wrangler/src/pages/deploy.tsx
+++ b/packages/wrangler/src/pages/deploy.tsx
@@ -226,7 +226,7 @@ export const Handler = async (args: PagesDeployArgs) => {
 		 * to create that project for them
 		 */
 		if (projectName !== undefined && !isExistingProject) {
-			const message = `The project you specified does not exist: "${projectName}". Would you like to create it?"`;
+			const message = `The project you specified does not exist: "${projectName}". Would you like to create it?`;
 			const items: NewOrExistingItem[] = [
 				{
 					key: "new",


### PR DESCRIPTION
## What this PR solves / how to test

Just fixing a typo I noticed when running `wrangler pages deploy`

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: this is just a typo fix (too trivial)
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: this is just a typo fix (too trivial)
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: this is just a typo fix (too trivial)
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: this is just a typo fix (too trivial)

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
