### PR TITLE
fix: use account id for listing zones

### DIFF
--- a/.changeset/grumpy-bikes-prove.md
+++ b/.changeset/grumpy-bikes-prove.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: use account id for listing zones
+
+Fixes https://github.com/cloudflare/workers-sdk/issues/4944
+
+Trying to fetch `/zones` fails when it spans more than 500 zones. The fix to use an account id when doing so. This patch passes the account id to the zones call, threading it through all the functions that require it.

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -315,7 +315,7 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			├ Finding latest stable Worker Version to rollback to
 			│
 			│
-			? Please provide an optional message for this rollback (120 characters max)?
+			? Please provide an optional message for this rollback (120 characters max)
 			🤖 Using default value in non-interactive context: Rollback via e2e test
 			│
 			├  WARNING  You are about to rollback to Worker Version 00000000-0000-0000-0000-000000000000.
@@ -425,7 +425,7 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			│           Tag:  e2e-upload
 			│       Message:  Upload via e2e test
 			│
-			? Please provide an optional message for this rollback (120 characters max)?
+			? Please provide an optional message for this rollback (120 characters max)
 			🤖 Using default value in non-interactive context: Rollback to old version
 			│
 			├  WARNING  You are about to rollback to Worker Version 00000000-0000-0000-0000-000000000000.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -10400,12 +10400,19 @@ function mockUnauthorizedPublishRoutesRequest({
 	);
 }
 
-function mockGetZones(domain: string, zones: { id: string }[] = []) {
+function mockGetZones(
+	domain: string,
+	zones: { id: string }[] = [],
+	accountId = "some-account-id"
+) {
 	msw.use(
 		http.get("*/zones", ({ request }) => {
 			const url = new URL(request.url);
 
-			expect([...url.searchParams.entries()]).toEqual([["name", domain]]);
+			expect([...url.searchParams.entries()]).toEqual([
+				["name", domain],
+				["account.id", accountId],
+			]);
 
 			return HttpResponse.json(
 				{

--- a/packages/wrangler/src/__tests__/rollback.test.ts
+++ b/packages/wrangler/src/__tests__/rollback.test.ts
@@ -119,7 +119,7 @@ describe("rollback", () => {
 		mockPostDeployment();
 
 		mockPrompt({
-			text: "Please provide a message for this rollback (120 characters max, optional)?",
+			text: "Please provide an optional message for this rollback (120 characters max)",
 			result: "Test rollback",
 		});
 
@@ -168,7 +168,7 @@ describe("rollback", () => {
 		mockPostDeployment(true);
 
 		mockPrompt({
-			text: "Please provide a message for this rollback (120 characters max, optional)?",
+			text: "Please provide an optional message for this rollback (120 characters max)",
 			result: "Test rollback",
 		});
 

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -879,7 +879,13 @@ export async function publishRoutes(
 		workerUrl,
 		scriptName,
 		notProd,
-	}: { workerUrl: string; scriptName: string; notProd: boolean }
+		accountId,
+	}: {
+		workerUrl: string;
+		scriptName: string;
+		notProd: boolean;
+		accountId: string;
+	}
 ): Promise<string[]> {
 	try {
 		return await fetchResult(`${workerUrl}/routes`, {
@@ -898,7 +904,11 @@ export async function publishRoutes(
 		if (isAuthenticationError(e)) {
 			// An authentication error is probably due to a known issue,
 			// where the user is logged in via an API token that does not have "All Zones".
-			return await publishRoutesFallback(routes, { scriptName, notProd });
+			return await publishRoutesFallback(routes, {
+				scriptName,
+				notProd,
+				accountId,
+			});
 		} else {
 			throw e;
 		}
@@ -912,7 +922,11 @@ export async function publishRoutes(
  */
 async function publishRoutesFallback(
 	routes: Route[],
-	{ scriptName, notProd }: { scriptName: string; notProd: boolean }
+	{
+		scriptName,
+		notProd,
+		accountId,
+	}: { scriptName: string; notProd: boolean; accountId: string }
 ) {
 	if (notProd) {
 		throw new UserError(
@@ -933,7 +947,7 @@ async function publishRoutesFallback(
 	const activeZones = new Map<string, string>();
 	const routesToDeploy = new Map<string, string>();
 	for (const route of routes) {
-		const zone = await getZoneForRoute(route);
+		const zone = await getZoneForRoute({ route, accountId });
 		if (zone) {
 			activeZones.set(zone.id, zone.host);
 			routesToDeploy.set(

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -694,7 +694,11 @@ export async function getWorkerAccountAndContext(props: {
 	};
 
 	// What zone should the realish preview for this Worker run on?
-	const zoneId = await getZoneIdForPreview(props.host, props.routes);
+	const zoneId = await getZoneIdForPreview({
+		host: props.host,
+		routes: props.routes,
+		accountId: props.accountId,
+	});
 
 	const workerContext: CfWorkerContext = {
 		env: props.env,

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -99,9 +99,14 @@ export async function tailHandler(args: TailArgs) {
 
 	let scriptName;
 
+	const accountId = await requireAuth(config);
+
 	// Worker names can't contain "." (and most routes should), so use that as a discriminator
 	if (args.worker?.includes(".")) {
-		scriptName = await getWorkerForZone(args.worker);
+		scriptName = await getWorkerForZone({
+			worker: args.worker,
+			accountId,
+		});
 		if (args.format === "pretty") {
 			logger.log(`Connecting to worker ${scriptName} at route ${args.worker}`);
 		}
@@ -114,8 +119,6 @@ export async function tailHandler(args: TailArgs) {
 			"Required Worker name missing. Please specify the Worker name in wrangler.toml, or pass it as an argument with `wrangler tail <worker-name>`"
 		);
 	}
-
-	const accountId = await requireAuth(config);
 
 	const cliFilters: TailCLIFilters = {
 		status: args.status as ("ok" | "error" | "canceled")[] | undefined,

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -146,7 +146,7 @@ export default async function triggersDeploy(props: Props): Promise<void> {
 			// to bother with all the error handling tomfoolery.
 			const routesWithOtherBindings: Record<string, string[]> = {};
 			for (const route of routes) {
-				const zone = await getZoneForRoute(route);
+				const zone = await getZoneForRoute({ route, accountId });
 				if (!zone) {
 					continue;
 				}
@@ -194,7 +194,12 @@ export default async function triggersDeploy(props: Props): Promise<void> {
 	// Update routing table for the script.
 	if (routesOnly.length > 0) {
 		deployments.push(
-			publishRoutes(routesOnly, { workerUrl, scriptName, notProd }).then(() => {
+			publishRoutes(routesOnly, {
+				workerUrl,
+				scriptName,
+				notProd,
+				accountId,
+			}).then(() => {
 				if (routesOnly.length > 10) {
 					return routesOnly
 						.slice(0, 9)

--- a/packages/wrangler/src/versions/rollback/index.ts
+++ b/packages/wrangler/src/versions/rollback/index.ts
@@ -85,7 +85,7 @@ export async function versionsRollbackHandler(args: VersionsRollbackArgs) {
 		}));
 
 	const message = await prompt(
-		"Please provide an optional message for this rollback (120 characters max)?",
+		"Please provide an optional message for this rollback (120 characters max)",
 		{
 			defaultValue: args.message ?? "Rollback",
 		}


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/4944

Trying to fetch `/zones` fails when it spans more than 500 zones. The fix to use an account id when doing so. This patch passes the account id to the zones call, threading it through all the functions that require it.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included - updated
  - [ ] Not necessary because: already covered 
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because: already covered 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
