### PR TITLE
Add cloudchamber registry {list, remove}

### DIFF
--- a/.changeset/selfish-pumas-mate.md
+++ b/.changeset/selfish-pumas-mate.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feature: Add list and remove subcommands to cloudchamber registries command.


### PR DESCRIPTION
## What this PR solves / how to test
Adds list and remove subcommands to cloudchamber registries command.

Example usage:

`wrangler cloudchamber registries list`
`wrangler cloudchamber registries remove your.registry`

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: The cloudchamber subcommand is not documented in that repo.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
