### PR TITLE
Fix: vitest-pool-workers use env in .dev.vars

### DIFF
--- a/.changeset/itchy-bags-shake.md
+++ b/.changeset/itchy-bags-shake.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Fix: pass env to getBindings to support reading `.dev.vars.{environment}`
+
+https://github.com/cloudflare/workers-sdk/pull/5612 added support for selecting the environment of config used, but it missed passing it to the code that reads `.dev.vars.{environment}`
+
+Closes #5641

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -237,7 +237,7 @@ export type SourcelessWorkerOptions = Omit<
 
 export function unstable_getMiniflareWorkerOptions(
 	configPath: string,
-	environment?: string
+	env?: string
 ): {
 	workerOptions: SourcelessWorkerOptions;
 	define: Record<string, string>;
@@ -245,7 +245,7 @@ export function unstable_getMiniflareWorkerOptions(
 } {
 	const config = readConfig(configPath, {
 		experimentalJsonConfig: true,
-		env: environment,
+		env,
 	});
 
 	const modulesRules: ModuleRule[] = config.rules
@@ -256,7 +256,6 @@ export function unstable_getMiniflareWorkerOptions(
 			fallthrough: rule.fallthrough,
 		}));
 
-	const env = undefined;
 	const bindings = getBindings(config, env, true, {});
 	const { bindingOptions } = buildMiniflareBindingOptions({
 		name: undefined,


### PR DESCRIPTION
## What this PR solves / how to test

https://github.com/cloudflare/workers-sdk/pull/5612 added support for selecting the environment of config used, but it missed passing it to the code that reads `.dev.vars.{environment}`

Fixes #5641 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
