### PR TITLE
Multiline hotkeys

### DIFF
--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -29,29 +29,21 @@ export default function (
 			.filter((option) => !unwrapHook(option.disabled))
 			.map(({ keys, label }) => `[${keys[0]}] ${unwrapHook(label)}`);
 
-		let stringifiedInstructions = instructions.join(", ");
+		const stringifiedInstructions = instructions.join(", ");
 
 		const ADDITIONAL_CHARS = 6; // 3 chars on each side of the instructions for the box and spacing ("│  " and "  │")
 		const willWrap =
 			stringifiedInstructions.length + ADDITIONAL_CHARS >
 			process.stdout.columns;
 		if (willWrap) {
-			stringifiedInstructions = instructions.join("\n");
+			// unboxed, multiline
+			return "\n" + instructions.join("\n");
 		}
 
-		const maxLineLength = Math.max(
-			...stringifiedInstructions.split("\n").map((line) => line.length)
-		);
-
-		stringifiedInstructions = stringifiedInstructions
-			.split("\n")
-			.map((line) => `│  ${line.padEnd(maxLineLength, " ")}  │`)
-			.join("\n");
-
 		return (
-			`╭──${"─".repeat(maxLineLength)}──╮\n` +
-			stringifiedInstructions +
-			`\n╰──${"─".repeat(maxLineLength)}──╯`
+			`╭──${"─".repeat(stringifiedInstructions.length)}──╮\n` +
+			`│  ${stringifiedInstructions}  │\n` +
+			`╰──${"─".repeat(stringifiedInstructions.length)}──╯`
 		);
 	}
 

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -27,13 +27,31 @@ export default function (
 	function formatInstructions() {
 		const instructions = options
 			.filter((option) => !unwrapHook(option.disabled))
-			.map(({ keys, label }) => `[${keys[0]}] ${unwrapHook(label)}`)
-			.join(", ");
+			.map(({ keys, label }) => `[${keys[0]}] ${unwrapHook(label)}`);
+
+		let stringifiedInstructions = instructions.join(", ");
+
+		const ADDITIONAL_CHARS = 6; // 3 chars on each side of the instructions for the box and spacing ("│  " and "  │")
+		const willWrap =
+			stringifiedInstructions.length + ADDITIONAL_CHARS >
+			process.stdout.columns;
+		if (willWrap) {
+			stringifiedInstructions = instructions.join("\n");
+		}
+
+		const maxLineLength = Math.max(
+			...stringifiedInstructions.split("\n").map((line) => line.length)
+		);
+
+		stringifiedInstructions = stringifiedInstructions
+			.split("\n")
+			.map((line) => `│  ${line.padEnd(maxLineLength, " ")}  │`)
+			.join("\n");
 
 		return (
-			`╭──${"─".repeat(instructions.length)}──╮\n` +
-			`│  ${instructions}  │\n` +
-			`╰──${"─".repeat(instructions.length)}──╯`
+			`╭──${"─".repeat(maxLineLength)}──╮\n` +
+			stringifiedInstructions +
+			`\n╰──${"─".repeat(maxLineLength)}──╯`
 		);
 	}
 

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -29,21 +29,29 @@ export default function (
 			.filter((option) => !unwrapHook(option.disabled))
 			.map(({ keys, label }) => `[${keys[0]}] ${unwrapHook(label)}`);
 
-		const stringifiedInstructions = instructions.join(", ");
+		let stringifiedInstructions = instructions.join(", ");
 
 		const ADDITIONAL_CHARS = 6; // 3 chars on each side of the instructions for the box and spacing ("│  " and "  │")
 		const willWrap =
 			stringifiedInstructions.length + ADDITIONAL_CHARS >
 			process.stdout.columns;
 		if (willWrap) {
-			// unboxed, multiline
-			return "\n" + instructions.join("\n");
+			stringifiedInstructions = instructions.join("\n");
 		}
 
+		const maxLineLength = Math.max(
+			...stringifiedInstructions.split("\n").map((line) => line.length)
+		);
+
+		stringifiedInstructions = stringifiedInstructions
+			.split("\n")
+			.map((line) => `│  ${line.padEnd(maxLineLength, " ")}  │`)
+			.join("\n");
+
 		return (
-			`╭──${"─".repeat(stringifiedInstructions.length)}──╮\n` +
-			`│  ${stringifiedInstructions}  │\n` +
-			`╰──${"─".repeat(stringifiedInstructions.length)}──╯`
+			`╭──${"─".repeat(maxLineLength)}──╮\n` +
+			stringifiedInstructions +
+			`\n╰──${"─".repeat(maxLineLength)}──╯`
 		);
 	}
 


### PR DESCRIPTION
## What this PR solves / how to test

This PR contains two implementations for multiline hotkey instructions which will display when the boxed, single-line hotkey instructions do not fit on the screen without wrapping.

First implementation (checkout commit e138fd3508f13f0805ffeb5048595bec9be3eba2 to test):

![image](https://github.com/cloudflare/workers-sdk/assets/5822355/4ef46d17-cac2-4f8a-aecd-5e584386265c)

Second implementation (use PR prerelease to test):

![image](https://github.com/cloudflare/workers-sdk/assets/5822355/1053a480-a83b-42be-a6d7-66dab06aa334)

Multiline unboxed 

## Author has addressed the following

- Tests
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
