### PR TITLE
fix: do not report D1 user errors to Sentry

### DIFF
--- a/.changeset/eighty-donuts-wonder.md
+++ b/.changeset/eighty-donuts-wonder.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: do not report D1 user errors to Sentry


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: D1 has no e2e tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: no user facing change

