### PR TITLE
[wrangler] fix: make sure `getPlatformProxy`'s `ctx` methods throw illegal invocation errors like workerd

### DIFF
--- a/.changeset/plenty-chicken-study.md
+++ b/.changeset/plenty-chicken-study.md
@@ -2,7 +2,7 @@
 "wrangler": patch
 ---
 
-fix: make sure `getPlatformProxy`'s `ctx` method throw illegal invocation errors like workerd
+fix: make sure `getPlatformProxy`'s `ctx` methods throw illegal invocation errors like workerd
 
 in workerd detaching the `waitUntil` and `passThroughOnException` methods from the `ExecutionContext`
 object results in them throwing `illegal invocation` errors, such as for example:

--- a/.changeset/plenty-chicken-study.md
+++ b/.changeset/plenty-chicken-study.md
@@ -1,0 +1,19 @@
+---
+"wrangler": patch
+---
+
+fix: make sure `getPlatformProxy`'s `ctx` method throw illegal invocation errors like workerd
+
+in workerd detaching the `waitUntil` and `passThroughOnException` methods from the `ExecutionContext`
+object results in them throwing `illegal invocation` errors, such as for example:
+
+```js
+export default {
+	async fetch(_request, _env, { waitUntil }) {
+		waitUntil(() => {}); // <-- throws an illegal invocation error
+		return new Response("Hello World!");
+	},
+};
+```
+
+make sure that the same behavior is applied to the `ctx` object returned by `getPlatformProxy`

--- a/packages/wrangler/src/api/integrations/platform/executionContext.ts
+++ b/packages/wrangler/src/api/integrations/platform/executionContext.ts
@@ -1,5 +1,13 @@
 export class ExecutionContext {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any, unused-imports/no-unused-vars
-	waitUntil(promise: Promise<any>): void {}
-	passThroughOnException(): void {}
+	waitUntil(promise: Promise<any>): void {
+		if (!(this instanceof ExecutionContext)) {
+			throw new Error("Illegal invocation");
+		}
+	}
+	passThroughOnException(): void {
+		if (!(this instanceof ExecutionContext)) {
+			throw new Error("Illegal invocation");
+		}
+	}
 }


### PR DESCRIPTION
## What this PR solves / how to test

in workerd detaching the `waitUntil` and `passThroughOnException` methods from the `ExecutionContext`
object results in them throwing `illegal invocation` errors, such as for example:

```js
export default {
	async fetch(_request, _env, { waitUntil }) {
		waitUntil(() => {}); // <-- throws an illegal invocation error
		return new Response("Hello World!");
	},
};
```

this PR makes sure that the same behavior is applied to the `ctx` object returned by `getPlatformProxy`

To test it simply use the prerelease and try destructuring and calling the methods of the `getPlatformProxy`'s`ctx` object 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: just aligning the local dev behavior with the production one

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->

> [!NOTE]
> The same sort of logic would ideally need to be applied to bindings, that however involves the magic proxy so it likely won't be as straightforward as it was here for `ctx`, thus I thought not to cram both in this PR, so I'll try to do the bindings one in a followup PR (see: https://github.com/cloudflare/workers-sdk/issues/6200)
