### PR TITLE
D1 export api change

### DIFF
--- a/.changeset/lovely-teachers-breathe.md
+++ b/.changeset/lovely-teachers-breathe.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Updating to match new D1 import/export API format

--- a/.changeset/lovely-teachers-breathe.md
+++ b/.changeset/lovely-teachers-breathe.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Updating to match new D1 import/export API format
+fix: Updating to match new D1 import/export API format

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -9,7 +9,7 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import writeWranglerToml from "../helpers/write-wrangler-toml";
 
-describe("execute", () => {
+describe("export", () => {
 	mockAccountId({ accountId: null });
 	mockApiToken();
 	mockConsoleMethods();
@@ -151,7 +151,7 @@ describe("execute", () => {
 									status: "complete",
 									result: {
 										filename: "xxxx-yyyy.sql",
-										signedUrl: "https://example.com/xxxx-yyyy.sql",
+										signed_url: "https://example.com/xxxx-yyyy.sql",
 									},
 									messages: [
 										"Uploaded part 3",

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -120,7 +120,7 @@ describe("export", () => {
 					const body = (await request.json()) as Record<string, unknown>;
 
 					// First request, initiates a new task
-					if (!body.currentBookmark) {
+					if (!body.current_bookmark) {
 						return HttpResponse.json(
 							{
 								success: true,

--- a/packages/wrangler/src/d1/execute.tsx
+++ b/packages/wrangler/src/d1/execute.tsx
@@ -400,10 +400,10 @@ async function executeRemotely({
 			startMessage: "Checking if file needs uploading",
 		});
 
-		// An init response usually returns a {filename, uploadUrl} pair, except if we've detected that file
+		// An init response usually returns a {filename, upload_url} pair, except if we've detected that file
 		// already exists and is valid, to save people reuploading. In which case `initResponse` has already
 		// kicked the import process off.
-		const uploadRequired = "uploadUrl" in initResponse;
+		const uploadRequired = "upload_url" in initResponse;
 		if (!uploadRequired) {
 			logger.log(`🌀 File already uploaded. Processing.`);
 		}
@@ -432,29 +432,29 @@ async function executeRemotely({
 		}
 
 		const {
-			result: { numQueries, finalBookmark, meta },
+			result: { num_queries, final_bookmark, meta },
 		} = finalResponse;
 		logger.log(
-			`🚣 Executed ${numQueries} queries in ${(meta.duration / 1000).toFixed(
+			`🚣 Executed ${num_queries} queries in ${(meta.duration / 1000).toFixed(
 				2
 			)} seconds (${meta.rows_read} rows read, ${
 				meta.rows_written
 			} rows written)\n` +
-				chalk.gray(`   Database is currently at bookmark ${finalBookmark}.`)
+				chalk.gray(`   Database is currently at bookmark ${final_bookmark}.`)
 		);
 
 		return [
 			{
 				results: [
 					{
-						"Total queries executed": numQueries,
+						"Total queries executed": num_queries,
 						"Rows read": meta.rows_read,
 						"Rows written": meta.rows_written,
 						"Database size (MB)": (meta.size_after / 1_000_000).toFixed(2),
 					},
 				],
 				success: true,
-				finalBookmark,
+				finalBookmark: final_bookmark,
 				meta,
 			},
 		];
@@ -474,12 +474,12 @@ async function uploadAndBeginIngestion(
 	etag: string,
 	initResponse: ImportInitResponse
 ) {
-	const { uploadUrl, filename } = initResponse;
+	const { upload_url, filename } = initResponse;
 
 	const { size } = await fs.stat(file);
 
 	const uploadResponse = await spinnerWhile({
-		promise: fetch(uploadUrl, {
+		promise: fetch(upload_url, {
 			method: "PUT",
 			headers: {
 				"Content-length": `${size}`,
@@ -542,7 +542,7 @@ async function pollUntilComplete(
 			"import",
 			{
 				action: "poll",
-				currentBookmark: response.at_bookmark,
+				current_bookmark: response.at_bookmark,
 			}
 		);
 		return await pollUntilComplete(newResponse, accountId, db);

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -219,6 +219,10 @@ async function pollExport(
 		`/accounts/${accountId}/d1/database/${db.uuid}/export`,
 		{
 			method: "POST",
+			headers: {
+				...(db.internal_env ? { "x-d1-internal-env": db.internal_env } : {}),
+				"content-type": "application/json",
+			},
 			body: JSON.stringify({
 				outputFormat: "polling",
 				dumpOptions,

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -171,8 +171,8 @@ async function exportRemotely(
 
 	logger.log(`🌀 Executing on remote database ${name} (${db.uuid}):`);
 	const dumpOptions = {
-		noSchema,
-		noData,
+		no_schema: noSchema,
+		no_data: noData,
 		tables,
 	};
 
@@ -189,14 +189,14 @@ async function exportRemotely(
 
 	logger.log(
 		chalk.gray(
-			`You can also download your export from the following URL manually. This link will be valid for one hour: ${finalResponse.result.signedUrl}`
+			`You can also download your export from the following URL manually. This link will be valid for one hour: ${finalResponse.result.signed_url}`
 		)
 	);
 
 	await spinnerWhile({
 		startMessage: `Downloading SQL to ${output}`,
 		async promise() {
-			const contents = await fetch(finalResponse.result.signedUrl);
+			const contents = await fetch(finalResponse.result.signed_url);
 			await fs.writeFile(output, contents.body || "");
 		},
 	});
@@ -209,8 +209,8 @@ async function pollExport(
 	db: Database,
 	dumpOptions: {
 		tables: string[];
-		noSchema?: boolean;
-		noData?: boolean;
+		no_schema?: boolean;
+		no_data?: boolean;
 	},
 	currentBookmark: string | undefined,
 	num_parts_uploaded = 0
@@ -224,9 +224,9 @@ async function pollExport(
 				"content-type": "application/json",
 			},
 			body: JSON.stringify({
-				outputFormat: "polling",
-				dumpOptions,
-				currentBookmark,
+				output_format: "polling",
+				dump_options: dumpOptions,
+				current_bookmark: currentBookmark,
 			}),
 		}
 	);
@@ -249,7 +249,7 @@ async function pollExport(
 		return response;
 	} else if (response.status === "error") {
 		throw new APIError({
-			text: response.errors.join("\n"),
+			text: response.error,
 			notes: response.messages.map((text) => ({ text })),
 		});
 	} else {

--- a/packages/wrangler/src/d1/types.ts
+++ b/packages/wrangler/src/d1/types.ts
@@ -106,9 +106,8 @@ export interface D1QueriesGraphQLResponse {
 }
 
 export type ImportInitResponse = {
-	success: true;
 	filename: string;
-	uploadUrl: string;
+	upload_url: string;
 };
 export type ImportPollingResponse = {
 	success: true;
@@ -123,9 +122,8 @@ export type ImportPollingResponse = {
 	| {
 			status: "complete";
 			result: {
-				success: boolean;
-				finalBookmark: string;
-				numQueries: number;
+				final_bookmark: string;
+				num_queries: number;
 				meta: {
 					served_by: string;
 					duration: number;
@@ -145,14 +143,14 @@ export type ExportPollingResponse = {
 	type: "export";
 	at_bookmark: string;
 	messages: string[];
-	errors: string[];
+	error: string;
 } & (
 	| {
 			status: "active" | "error";
 	  }
 	| {
 			status: "complete";
-			result: { filename: string; signedUrl: string };
+			result: { filename: string; signed_url: string };
 	  }
 );
 


### PR DESCRIPTION
## What this PR solves / how to test

Internal API change for D1 import/export. 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: behaviour unchanged
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: behaviour unchanged
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: covered by D1 OpenAPI description
