### PR TITLE
Clarify what C3 is in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -15,7 +15,7 @@ body:
       label: Which Cloudflare product(s) does this pertain to?
       multiple: true
       options:
-        - C3
+        - C3 (npm create cloudflare)
         - D1
         - KV
         - Pages
@@ -25,7 +25,7 @@ body:
         - Workers for Platforms
         - Constellation
         - Workers Runtime
-        - Wrangler core
+        - Wrangler
         - Miniflare
         - KV Asset Handler
         - Workers Vitest Integration

--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -23,7 +23,7 @@ body:
         - Queues
         - R2
         - Workers for Platforms
-        - Constellation
+        - Workers AI
         - Workers Runtime
         - Wrangler
         - Miniflare


### PR DESCRIPTION
More clearly spell out `npm create cloudflare` — the command people typed — rather than just referring to this as "C3"