### PR TITLE
wrangler cloudchamber: fix --json flags when required fields for it to work are not passed

### DIFF
--- a/.changeset/nervous-eyes-fetch.md
+++ b/.changeset/nervous-eyes-fetch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: wrangler cloudchamber json errors are properly formatted

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -52,6 +52,26 @@ describe("cloudchamber create", () => {
 		`);
 	});
 
+	it("should fail with a nice message when parameters are missing", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		await expect(
+			runWrangler("cloudchamber create --image hello:world")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: location is required but it's not passed as an argument]`
+		);
+	});
+
+	it("should fail with a nice message when parameters are missing (json)", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		await runWrangler("cloudchamber create --image hello:world --json");
+		expect(std.out).toMatchInlineSnapshot(
+			`"{\\"error\\":\\"location is required but it's not passed as an argument\\"}"`
+		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
 	it("should create deployment (detects no interactivity)", async () => {
 		setIsTTY(false);
 		setWranglerConfig({});
@@ -86,26 +106,26 @@ describe("cloudchamber create", () => {
 		// so testing the actual UI will be harder than expected
 		// TODO: think better on how to test UI actions
 		expect(std.out).toMatchInlineSnapshot(`
-		"{
-		    \\"id\\": \\"1\\",
-		    \\"type\\": \\"default\\",
-		    \\"created_at\\": \\"123\\",
-		    \\"account_id\\": \\"123\\",
-		    \\"vcpu\\": 4,
-		    \\"memory\\": \\"400MB\\",
-		    \\"version\\": 1,
-		    \\"image\\": \\"hello\\",
-		    \\"location\\": {
-		        \\"name\\": \\"sfo06\\",
-		        \\"enabled\\": true
-		    },
-		    \\"network\\": {
-		        \\"ipv4\\": \\"1.1.1.1\\"
-		    },
-		    \\"placements_ref\\": \\"http://ref\\",
-		    \\"node_group\\": \\"metal\\"
-		}"
-	`);
+			"{
+			    \\"id\\": \\"1\\",
+			    \\"type\\": \\"default\\",
+			    \\"created_at\\": \\"123\\",
+			    \\"account_id\\": \\"123\\",
+			    \\"vcpu\\": 4,
+			    \\"memory\\": \\"400MB\\",
+			    \\"version\\": 1,
+			    \\"image\\": \\"hello\\",
+			    \\"location\\": {
+			        \\"name\\": \\"sfo06\\",
+			        \\"enabled\\": true
+			    },
+			    \\"network\\": {
+			        \\"ipv4\\": \\"1.1.1.1\\"
+			    },
+			    \\"placements_ref\\": \\"http://ref\\",
+			    \\"node_group\\": \\"metal\\"
+			}"
+		`);
 	});
 
 	it("should create deployment indicating ssh keys (detects no interactivity)", async () => {

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -79,9 +79,7 @@ export function handleFailure<
 			}
 
 			if (err instanceof Error) {
-				logger.log(
-					`${{ error: err.message, name: err.name, stack: err.stack }}`
-				);
+				logger.log(`${JSON.stringify({ error: err.message })}`);
 				return;
 			}
 


### PR DESCRIPTION
## What this PR solves / how to test
`wrangler.js cloudchamber create --image whatever.com --json`
spits
`[object Object]`

With this change it spits:
`{"error":"location is required but it's not passed as an argument"}`


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: client side change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: not relevant

