### PR TITLE
fix deploy for dispatch namespace workers

### DIFF
--- a/.changeset/small-kiwis-mix.md
+++ b/.changeset/small-kiwis-mix.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix - fixes a bug where deploying a worker to a dispacth namespace would fail due to fetching invalid migrations

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -580,6 +580,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					config,
 					legacyEnv: props.legacyEnv,
 					env: props.env,
+					dispatchNamespace: props.dispatchNamespace,
 				})
 			: undefined;
 


### PR DESCRIPTION
## What this PR solves / how to test

This PR addresses an issue where deploying a worker to dispatch namespaces would fail due to the way Wrangler retrieves migrations from the script. Although this PR is not fully complete, it aims to provide a headstart for the team. Please feel free to modify or replace this as needed.

hope you have a nice day :)
## Author has addressed the following

- Tests
  - [x] TODO (before merge - i will let a team member take care of this)
  - [ ] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: this fixes a bug without any breaking changes to end users

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
