### PR TITLE
VS-197: Enable wrangler to interact with Vectorize V2 indexes

### DIFF
--- a/.changeset/thick-hairs-notice.md
+++ b/.changeset/thick-hairs-notice.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Enable Wrangler to operate on Vectorize V2 indexes

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { validateQueryFilter } from "../../vectorize/query";
 import { endEventLoop } from "../helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -7,6 +8,7 @@ import { useMockIsTTY } from "../helpers/mock-istty";
 import { createFetchResult, msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
+import type { VectorizeQueryOptions } from "../../vectorize/types";
 
 describe("vectorize help", () => {
 	const std = mockConsoleMethods();
@@ -17,31 +19,40 @@ describe("vectorize help", () => {
 		await endEventLoop();
 
 		expect(std.out).toMatchInlineSnapshot(`
-			"wrangler vectorize
+				"wrangler vectorize
 
-			🧮 Manage Vectorize indexes [open beta]
+				🧮 Manage Vectorize indexes [open beta]
 
-			COMMANDS
-			  wrangler vectorize create <name>  Create a Vectorize index
-			  wrangler vectorize delete <name>  Delete a Vectorize index
-			  wrangler vectorize get <name>     Get a Vectorize index by name
-			  wrangler vectorize list           List your Vectorize indexes
-			  wrangler vectorize insert <name>  Insert vectors into a Vectorize index
+				COMMANDS
+				  wrangler vectorize create <name>                 Create a Vectorize index
+				  wrangler vectorize delete <name>                 Delete a Vectorize index
+				  wrangler vectorize get <name>                    Get a Vectorize index by name
+				  wrangler vectorize list                          List your Vectorize indexes
+				  wrangler vectorize query <name>                  Query a Vectorize index
+				  wrangler vectorize insert <name>                 Insert vectors into a Vectorize index
+				  wrangler vectorize upsert <name>                 Upsert vectors into a Vectorize index
+				  wrangler vectorize get-vectors <name>            Get vectors from a Vectorize index
+				  wrangler vectorize delete-vectors <name>         Delete vectors in a Vectorize index
+				  wrangler vectorize info <name>                   Get additional details about the index
+				  wrangler vectorize create-metadata-index <name>  Enable metadata filtering on the specified property
+				  wrangler vectorize list-metadata-index <name>    List metadata properties on which metadata filtering is enabled
+				  wrangler vectorize delete-metadata-index <name>  Delete metadata indexes
 
-			GLOBAL FLAGS
-			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
-			  -c, --config                    Path to .toml configuration file  [string]
-			  -e, --env                       Environment to use for operations and .env files  [string]
-			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]
+				GLOBAL FLAGS
+				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+				  -c, --config                    Path to .toml configuration file  [string]
+				  -e, --env                       Environment to use for operations and .env files  [string]
+				  -h, --help                      Show help  [boolean]
+				  -v, --version                   Show version number  [boolean]
 
-			--------------------
-			📣 Vectorize is currently in open beta
-			📣 See the Vectorize docs for how to get started and known issues: https://developers.cloudflare.com/vectorize
-			📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-			📣 To give feedback, visit https://discord.cloudflare.com/
-			--------------------"
-		`);
+				--------------------
+				📣 Vectorize is currently in open beta
+				📣 Please use the '--deprecated-v1' flag to create, get, list, delete and insert vectors into legacy Vectorize indexes
+				📣 See the Vectorize docs for how to get started and known issues: https://developers.cloudflare.com/vectorize
+				📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
+				📣 To give feedback, visit https://discord.cloudflare.com/
+				--------------------"
+			`);
 	});
 
 	it("should show help when an invalid argument is passed", async () => {
@@ -50,37 +61,46 @@ describe("vectorize help", () => {
 		);
 
 		expect(std.err).toMatchInlineSnapshot(`
-		"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: foobarfofum[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: foobarfofum[0m
 
-		"
-	`);
-		expect(std.out).toMatchInlineSnapshot(`
 			"
-			wrangler vectorize
-
-			🧮 Manage Vectorize indexes [open beta]
-
-			COMMANDS
-			  wrangler vectorize create <name>  Create a Vectorize index
-			  wrangler vectorize delete <name>  Delete a Vectorize index
-			  wrangler vectorize get <name>     Get a Vectorize index by name
-			  wrangler vectorize list           List your Vectorize indexes
-			  wrangler vectorize insert <name>  Insert vectors into a Vectorize index
-
-			GLOBAL FLAGS
-			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
-			  -c, --config                    Path to .toml configuration file  [string]
-			  -e, --env                       Environment to use for operations and .env files  [string]
-			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]
-
-			--------------------
-			📣 Vectorize is currently in open beta
-			📣 See the Vectorize docs for how to get started and known issues: https://developers.cloudflare.com/vectorize
-			📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-			📣 To give feedback, visit https://discord.cloudflare.com/
-			--------------------"
 		`);
+		expect(std.out).toMatchInlineSnapshot(`
+				"
+				wrangler vectorize
+
+				🧮 Manage Vectorize indexes [open beta]
+
+				COMMANDS
+				  wrangler vectorize create <name>                 Create a Vectorize index
+				  wrangler vectorize delete <name>                 Delete a Vectorize index
+				  wrangler vectorize get <name>                    Get a Vectorize index by name
+				  wrangler vectorize list                          List your Vectorize indexes
+				  wrangler vectorize query <name>                  Query a Vectorize index
+				  wrangler vectorize insert <name>                 Insert vectors into a Vectorize index
+				  wrangler vectorize upsert <name>                 Upsert vectors into a Vectorize index
+				  wrangler vectorize get-vectors <name>            Get vectors from a Vectorize index
+				  wrangler vectorize delete-vectors <name>         Delete vectors in a Vectorize index
+				  wrangler vectorize info <name>                   Get additional details about the index
+				  wrangler vectorize create-metadata-index <name>  Enable metadata filtering on the specified property
+				  wrangler vectorize list-metadata-index <name>    List metadata properties on which metadata filtering is enabled
+				  wrangler vectorize delete-metadata-index <name>  Delete metadata indexes
+
+				GLOBAL FLAGS
+				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+				  -c, --config                    Path to .toml configuration file  [string]
+				  -e, --env                       Environment to use for operations and .env files  [string]
+				  -h, --help                      Show help  [boolean]
+				  -v, --version                   Show version number  [boolean]
+
+				--------------------
+				📣 Vectorize is currently in open beta
+				📣 Please use the '--deprecated-v1' flag to create, get, list, delete and insert vectors into legacy Vectorize indexes
+				📣 See the Vectorize docs for how to get started and known issues: https://developers.cloudflare.com/vectorize
+				📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
+				📣 To give feedback, visit https://discord.cloudflare.com/
+				--------------------"
+			`);
 	});
 
 	it("should show help when the get command is passed without an index", async () => {
@@ -89,36 +109,38 @@ describe("vectorize help", () => {
 		);
 
 		expect(std.err).toMatchInlineSnapshot(`
-		"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
 
-		"
-	`);
-		expect(std.out).toMatchInlineSnapshot(`
 			"
-			wrangler vectorize get <name>
-
-			Get a Vectorize index by name
-
-			POSITIONALS
-			  name  The name of the Vectorize index.  [string] [required]
-
-			GLOBAL FLAGS
-			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
-			  -c, --config                    Path to .toml configuration file  [string]
-			  -e, --env                       Environment to use for operations and .env files  [string]
-			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]
-
-			OPTIONS
-			      --json  return output as clean JSON  [boolean] [default: false]
-
-			--------------------
-			📣 Vectorize is currently in open beta
-			📣 See the Vectorize docs for how to get started and known issues: https://developers.cloudflare.com/vectorize
-			📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
-			📣 To give feedback, visit https://discord.cloudflare.com/
-			--------------------"
 		`);
+		expect(std.out).toMatchInlineSnapshot(`
+				"
+				wrangler vectorize get <name>
+
+				Get a Vectorize index by name
+
+				POSITIONALS
+				  name  The name of the Vectorize index.  [string] [required]
+
+				GLOBAL FLAGS
+				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+				  -c, --config                    Path to .toml configuration file  [string]
+				  -e, --env                       Environment to use for operations and .env files  [string]
+				  -h, --help                      Show help  [boolean]
+				  -v, --version                   Show version number  [boolean]
+
+				OPTIONS
+				      --json           return output as clean JSON  [boolean] [default: false]
+				      --deprecated-v1  Fetch a deprecated V1 Vectorize index. This must be enabled if the index was created with V1 option.  [boolean] [default: false]
+
+				--------------------
+				📣 Vectorize is currently in open beta
+				📣 Please use the '--deprecated-v1' flag to create, get, list, delete and insert vectors into legacy Vectorize indexes
+				📣 See the Vectorize docs for how to get started and known issues: https://developers.cloudflare.com/vectorize
+				📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
+				📣 To give feedback, visit https://discord.cloudflare.com/
+				--------------------"
+			`);
 	});
 });
 
@@ -142,52 +164,205 @@ describe("vectorize commands", () => {
 		clearDialogs();
 	});
 
-	it("should handle creating a vectorize index", async () => {
+	it("should handle creating a vectorize V1 index", async () => {
 		mockVectorizeRequest();
 		await runWrangler(
-			"vectorize create some-index --dimensions=768 --metric=cosine"
+			"vectorize create some-index --dimensions=768 --metric=cosine --deprecated-v1=true"
 		);
 		expect(std.out).toMatchInlineSnapshot(`
-			"🚧 Creating index: 'some-index'
-			✅ Successfully created a new Vectorize index: 'test-index'
-			📋 To start querying from a Worker, add the following binding configuration into 'wrangler.toml':
+				"🚧 Creating index: 'some-index'
+				✅ Successfully created a new Vectorize index: 'test-index'
+				📋 To start querying from a Worker, add the following binding configuration into 'wrangler.toml':
 
-			[[vectorize]]
-			binding = \\"VECTORIZE_INDEX\\"
-			index_name = \\"test-index\\"
-			"
+				[[vectorize]]
+				binding = \\"VECTORIZE_INDEX\\"
+				index_name = \\"test-index\\"
+				"
+			`);
+	});
+
+	it("should handle creating a vectorize index", async () => {
+		mockVectorizeV2Request();
+		await runWrangler(
+			"vectorize create test-index --dimensions=1536 --metric=euclidean"
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+				"🚧 Creating index: 'test-index'
+				✅ Successfully created a new Vectorize index: 'test-index'
+				📋 To start querying from a Worker, add the following binding configuration into 'wrangler.toml':
+
+				[[vectorize]]
+				binding = \\"VECTORIZE\\"
+				index_name = \\"test-index\\"
+				"
+			`);
+	});
+
+	it("should handle creating a vectorize index with preset", async () => {
+		mockVectorizeV2Request();
+		await runWrangler(
+			"vectorize create test-index --preset=openai/text-embedding-ada-002"
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+				"Configuring index based for the embedding model openai/text-embedding-ada-002.
+				🚧 Creating index: 'test-index'
+				✅ Successfully created a new Vectorize index: 'test-index'
+				📋 To start querying from a Worker, add the following binding configuration into 'wrangler.toml':
+
+				[[vectorize]]
+				binding = \\"VECTORIZE\\"
+				index_name = \\"test-index\\"
+				"
+			`);
+	});
+
+	it("should fail index creation with invalid metric", async () => {
+		mockVectorizeV2Request();
+
+		await expect(() =>
+			runWrangler(
+				"vectorize create test-index --dimensions=1536 --metric=pythagorian"
+			)
+		).rejects.toThrow(
+			`Invalid values:
+  Argument: metric, Given: "pythagorian", Choices: "euclidean", "cosine", "dot-product"`
+		);
+
+		expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mInvalid values:[0m
+
+				    Argument: metric, Given: \\"pythagorian\\", Choices: \\"euclidean\\", \\"cosine\\", \\"dot-product\\"
+
+				"
+			`);
+	});
+
+	it("should fail index creation with invalid preset", async () => {
+		mockVectorizeV2Request();
+
+		await expect(() =>
+			runWrangler(
+				"vectorize create test-index --preset=openai/gpt-400-pro-max-ultra"
+			)
+		).rejects.toThrow(
+			`Invalid values:
+  Argument: preset, Given: "openai/gpt-400-pro-max-ultra", Choices: "@cf/baai/bge-small-en-v1.5", "@cf/baai/bge-base-en-v1.5", "@cf/baai/bge-large-en-v1.5", "openai/text-embedding-ada-002", "cohere/embed-multilingual-v2.0"`
+		);
+
+		expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mInvalid values:[0m
+
+    Argument: preset, Given: \\"openai/gpt-400-pro-max-ultra\\", Choices: \\"@cf/baai/bge-small-en-v1.5\\",
+  \\"@cf/baai/bge-base-en-v1.5\\", \\"@cf/baai/bge-large-en-v1.5\\", \\"openai/text-embedding-ada-002\\",
+  \\"cohere/embed-multilingual-v2.0\\"
+
+"
+			`);
+	});
+
+	it("should fail index creation with invalid config", async () => {
+		mockVectorizeV2Request();
+
+		await expect(
+			runWrangler("vectorize create test-index --dimensions=1536")
+		).resolves.toBeUndefined();
+
+		expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou must provide both dimensions and a metric, or a known model preset when creating an index.[0m
+
+"
+			`);
+	});
+
+	it("should handle listing vectorize V1 indexes", async () => {
+		mockVectorizeRequest();
+		await runWrangler("vectorize list --deprecated-v1=true");
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Listing Vectorize indexes...
+			┌───────────────┬────────────┬───────────┬─────────────┬────────────────────────────┬────────────────────────────┐
+			│ name          │ dimensions │ metric    │ description │ created                    │ modified                   │
+			├───────────────┼────────────┼───────────┼─────────────┼────────────────────────────┼────────────────────────────┤
+			│ test-index    │ 768        │ cosine    │             │ 2023-09-25T13:02:18.00268Z │ 2023-09-25T13:02:18.00268Z │
+			├───────────────┼────────────┼───────────┼─────────────┼────────────────────────────┼────────────────────────────┤
+			│ another-index │ 3          │ euclidean │             │ 2023-09-25T13:02:18.00268Z │ 2023-09-25T13:02:18.00268Z │
+			└───────────────┴────────────┴───────────┴─────────────┴────────────────────────────┴────────────────────────────┘"
 		`);
 	});
 
 	it("should handle listing vectorize indexes", async () => {
-		mockVectorizeRequest();
+		mockVectorizeV2Request();
 		await runWrangler("vectorize list");
 		expect(std.out).toMatchInlineSnapshot(`
-		"📋 Listing Vectorize indexes...
-		┌───────────────┬────────────┬───────────┬─────────────┬────────────────────────────┬────────────────────────────┐
-		│ name          │ dimensions │ metric    │ description │ created                    │ modified                   │
-		├───────────────┼────────────┼───────────┼─────────────┼────────────────────────────┼────────────────────────────┤
-		│ test-index    │ 768        │ cosine    │             │ 2023-09-25T13:02:18.00268Z │ 2023-09-25T13:02:18.00268Z │
-		├───────────────┼────────────┼───────────┼─────────────┼────────────────────────────┼────────────────────────────┤
-		│ another-index │ 3          │ euclidean │             │ 2023-09-25T13:02:18.00268Z │ 2023-09-25T13:02:18.00268Z │
-		└───────────────┴────────────┴───────────┴─────────────┴────────────────────────────┴────────────────────────────┘"
-	`);
+			"📋 Listing Vectorize indexes...
+			┌───────────────┬────────────┬─────────────┬──────────────┬────────────────────────────┬────────────────────────────┐
+			│ name          │ dimensions │ metric      │ description  │ created                    │ modified                   │
+			├───────────────┼────────────┼─────────────┼──────────────┼────────────────────────────┼────────────────────────────┤
+			│ test-index    │ 1536       │ euclidean   │ test-desc    │ 2024-07-11T13:02:18.00268Z │ 2024-07-11T13:02:18.00268Z │
+			├───────────────┼────────────┼─────────────┼──────────────┼────────────────────────────┼────────────────────────────┤
+			│ another-index │ 32         │ dot-product │ another-desc │ 2024-07-11T13:02:18.00268Z │ 2024-07-11T13:02:18.00268Z │
+			└───────────────┴────────────┴─────────────┴──────────────┴────────────────────────────┴────────────────────────────┘"
+		`);
+	});
+
+	it("should warn when there are no vectorize indexes", async () => {
+		mockVectorizeV2RequestError();
+		await runWrangler("vectorize list");
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Listing Vectorize indexes..."
+		`);
+
+		expect(std.warn).toMatchInlineSnapshot(`
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m[0m
+
+  You haven't created any indexes on this account.
+
+  Use 'wrangler vectorize create <name>' to create one, or visit
+  [4mhttps://developers.cloudflare.com/vectorize/[0m to get started.
+
+
+"
+		`);
+	});
+
+	it("should handle a get on a vectorize V1 index", async () => {
+		mockVectorizeRequest();
+		await runWrangler("vectorize get test-index --deprecated-v1=true");
+		expect(std.out).toMatchInlineSnapshot(`
+			"┌────────────┬────────────┬────────┬─────────────┬────────────────────────────┬────────────────────────────┐
+			│ name       │ dimensions │ metric │ description │ created                    │ modified                   │
+			├────────────┼────────────┼────────┼─────────────┼────────────────────────────┼────────────────────────────┤
+			│ test-index │ 768        │ cosine │             │ 2023-09-25T13:02:18.00268Z │ 2023-09-25T13:02:18.00268Z │
+			└────────────┴────────────┴────────┴─────────────┴────────────────────────────┴────────────────────────────┘"
+		`);
 	});
 
 	it("should handle a get on a vectorize index", async () => {
-		mockVectorizeRequest();
+		mockVectorizeV2Request();
 		await runWrangler("vectorize get test-index");
 		expect(std.out).toMatchInlineSnapshot(`
-		"┌────────────┬────────────┬────────┬─────────────┬────────────────────────────┬────────────────────────────┐
-		│ name       │ dimensions │ metric │ description │ created                    │ modified                   │
-		├────────────┼────────────┼────────┼─────────────┼────────────────────────────┼────────────────────────────┤
-		│ test-index │ 768        │ cosine │             │ 2023-09-25T13:02:18.00268Z │ 2023-09-25T13:02:18.00268Z │
-		└────────────┴────────────┴────────┴─────────────┴────────────────────────────┴────────────────────────────┘"
+			"┌────────────┬────────────┬───────────┬─────────────┬────────────────────────────┬────────────────────────────┐
+			│ name       │ dimensions │ metric    │ description │ created                    │ modified                   │
+			├────────────┼────────────┼───────────┼─────────────┼────────────────────────────┼────────────────────────────┤
+			│ test-index │ 1536       │ euclidean │ test-desc   │ 2024-07-11T13:02:18.00268Z │ 2024-07-11T13:02:18.00268Z │
+			└────────────┴────────────┴───────────┴─────────────┴────────────────────────────┴────────────────────────────┘"
+		`);
+	});
+
+	it("should handle a delete on a vectorize V1 index", async () => {
+		mockVectorizeRequest();
+		mockConfirm({
+			text: "OK to delete the index 'test-index'?",
+			result: true,
+		});
+		await runWrangler("vectorize delete test-index --deprecated-v1=true");
+		expect(std.out).toMatchInlineSnapshot(`
+		"Deleting Vectorize index test-index
+		✅ Deleted index test-index"
 	`);
 	});
 
 	it("should handle a delete on a vectorize index", async () => {
-		mockVectorizeRequest();
+		mockVectorizeV2Request();
 		mockConfirm({
 			text: "OK to delete the index 'test-index'?",
 			result: true,
@@ -196,7 +371,437 @@ describe("vectorize commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 		"Deleting Vectorize index test-index
 		✅ Deleted index test-index"
-	`);
+		`);
+	});
+
+	it("should handle a getByIds on a vectorize index", async () => {
+		mockVectorizeV2Request();
+		await runWrangler("vectorize get-vectors test-index --ids a 'b'");
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Fetching vectors...
+[
+  {
+    \\"id\\": \\"a\\",
+    \\"values\\": [
+      1,
+      2,
+      3,
+      4
+    ],
+    \\"namespace\\": \\"abcd\\",
+    \\"metadata\\": {
+      \\"a\\": true,
+      \\"b\\": 123
+    }
+  },
+  {
+    \\"id\\": \\"b\\",
+    \\"values\\": [
+      5,
+      6,
+      7,
+      8
+    ],
+    \\"metadata\\": {
+      \\"c\\": false,
+      \\"b\\": \\"123\\"
+    }
+  }
+]"
+		`);
+	});
+
+	it("should warn when there are no vectors matching the getByIds identifiers", async () => {
+		mockVectorizeV2RequestError();
+		await runWrangler("vectorize get-vectors test-index --ids a 'b'");
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Fetching vectors..."
+		`);
+
+		expect(std.warn).toMatchInlineSnapshot(`
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe index does not contain vectors corresponding to the provided identifiers[0m
+
+"
+		`);
+	});
+
+	it("should log error when getByIds does not receive ids", async () => {
+		mockVectorizeV2Request();
+		await runWrangler("vectorize get-vectors test-index --ids");
+
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Please provide valid vector identifiers.[0m
+
+"
+		`);
+	});
+
+	it("should handle a deleteByIds on a vectorize index", async () => {
+		mockVectorizeV2Request();
+		await runWrangler("vectorize delete-vectors test-index --ids a 'b'");
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Deleting vectors...
+			✅ Successfully enqueued 2 vectors into index 'test-index' for deletion. Mutation changeset identifier: xxxxxx-xxxx-xxxx-xxxx-xxxxxx."
+		`);
+	});
+
+	it("should log error when deleteByIds does not receive ids", async () => {
+		mockVectorizeV2Request();
+		await runWrangler("vectorize delete-vectors test-index --ids");
+
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Please provide valid vector identifiers for deletion.[0m
+
+"
+		`);
+	});
+
+	it("should handle a query on a vectorize index", async () => {
+		mockVectorizeV2Request();
+		// Parses the vector as [1, 2, 3, 4, 1.5, 2.6, 7, 8]
+		await runWrangler(
+			"vectorize query test-index --vector 1 2 3 '4' 1.5 '2.6' a 'b' null 7 abc 8 undefined"
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Searching for relevant vectors...
+{
+  \\"count\\": 2,
+  \\"matches\\": [
+    {
+      \\"id\\": \\"a\\",
+      \\"score\\": 0.5,
+      \\"values\\": [
+        1,
+        2,
+        3,
+        4
+      ],
+      \\"namespace\\": \\"abcd\\",
+      \\"metadata\\": {
+        \\"a\\": true,
+        \\"b\\": 123
+      }
+    },
+    {
+      \\"id\\": \\"b\\",
+      \\"score\\": 0.75,
+      \\"values\\": [
+        5,
+        6,
+        7,
+        8
+      ],
+      \\"metadata\\": {
+        \\"c\\": false,
+        \\"b\\": \\"123\\"
+      }
+    }
+  ]
+}"
+		`);
+	});
+
+	it("should handle a query on a vectorize index with all options", async () => {
+		mockVectorizeV2Request();
+		await runWrangler(
+			`vectorize query test-index --vector 1 2 3 '4' --top-k=2 --return-values=true --return-metadata=indexed --namespace=abc --filter '{ "p1": "abc", "p2": { "$ne": true }, "p3": 10, "p4": false, "nested.p5": "abcd" }'`
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Searching for relevant vectors...
+{
+  \\"count\\": 2,
+  \\"matches\\": [
+    {
+      \\"id\\": \\"a\\",
+      \\"score\\": 0.5,
+      \\"values\\": [
+        1,
+        2,
+        3,
+        4
+      ],
+      \\"namespace\\": \\"abcd\\",
+      \\"metadata\\": {
+        \\"a\\": true,
+        \\"b\\": 123
+      }
+    },
+    {
+      \\"id\\": \\"b\\",
+      \\"score\\": 0.75,
+      \\"values\\": [
+        5,
+        6,
+        7,
+        8
+      ],
+      \\"metadata\\": {
+        \\"c\\": false,
+        \\"b\\": \\"123\\"
+      }
+    }
+  ]
+}"
+		`);
+
+		// No warning > Valid filter
+		expect(std.warn).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should proceed with querying and log warning if the filter is invalid", async () => {
+		mockVectorizeV2Request();
+		await runWrangler(
+			"vectorize query test-index --vector 1 2 3 '4' --filter='{ 'p1': [1,2,3] }'"
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Searching for relevant vectors...
+{
+  \\"count\\": 2,
+  \\"matches\\": [
+    {
+      \\"id\\": \\"a\\",
+      \\"score\\": 0.5,
+      \\"values\\": [
+        1,
+        2,
+        3,
+        4
+      ],
+      \\"namespace\\": \\"abcd\\",
+      \\"metadata\\": {
+        \\"a\\": true,
+        \\"b\\": 123
+      }
+    },
+    {
+      \\"id\\": \\"b\\",
+      \\"score\\": 0.75,
+      \\"values\\": [
+        5,
+        6,
+        7,
+        8
+      ],
+      \\"metadata\\": {
+        \\"c\\": false,
+        \\"b\\": \\"123\\"
+      }
+    }
+  ]
+}"
+		`);
+
+		expect(std.warn).toMatchInlineSnapshot(`
+		"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m🚨 Invalid query filter. Please use the recommended format.[0m
+
+"
+		`);
+	});
+
+	it("should warn when query returns no vectors", async () => {
+		mockVectorizeV2RequestError();
+		await runWrangler("vectorize query test-index --vector 1 2 3 '4'");
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Searching for relevant vectors..."
+		`);
+
+		expect(std.warn).toMatchInlineSnapshot(`
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mCould not find any relevant vectors[0m
+
+"
+		`);
+	});
+
+	it("should fail query with invalid return-metadata flag", async () => {
+		mockVectorizeV2Request();
+
+		await expect(() =>
+			runWrangler(
+				"vectorize query test-index --vector 1 2 3 '4' --return-metadata=truncated"
+			)
+		).rejects.toThrow(
+			`Invalid values:
+  Argument: return-metadata, Given: "truncated", Choices: "all", "indexed", "none"`
+		);
+
+		expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mInvalid values:[0m
+
+				    Argument: return-metadata, Given: \\"truncated\\", Choices: \\"all\\", \\"indexed\\", \\"none\\"
+
+				"
+			`);
+	});
+
+	it("should handle info on a vectorize index", async () => {
+		mockVectorizeV2Request();
+		await runWrangler("vectorize info test-index");
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Fetching index info...
+┌────────────┬─────────────┬──────────────────────────────────────┬──────────────────────────┐
+│ dimensions │ vectorCount │ processedUpToMutation                │ processedUpToDatetime    │
+├────────────┼─────────────┼──────────────────────────────────────┼──────────────────────────┤
+│ 1024       │ 1000        │ 7f11d6e5-d126-4f76-936e-fbfec079e0be │ 2024-07-19T13:11:44.064Z │
+└────────────┴─────────────┴──────────────────────────────────────┴──────────────────────────┘"
+		`);
+	});
+
+	it("should handle create metadata index", async () => {
+		mockVectorizeV2Request();
+		await runWrangler(
+			`vectorize create-metadata-index test-index --property-name='some-prop' --type='string'`
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Creating metadata index...
+			✅ Successfully enqueued metadata index creation request. Mutation changeset identifier: xxxxxx-xxxx-xxxx-xxxx-xxxxxx."
+		`);
+	});
+
+	it("should error if create metadata index type is invalid", async () => {
+		mockVectorizeV2Request();
+		await expect(() =>
+			runWrangler(
+				`vectorize create-metadata-index test-index --property-name='some-prop' --type='array'`
+			)
+		).rejects.toThrow(`Invalid values:
+  Argument: type, Given: "array", Choices: "string", "number", "boolean"`);
+
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mInvalid values:[0m
+
+			    Argument: type, Given: \\"array\\", Choices: \\"string\\", \\"number\\", \\"boolean\\"
+
+			"
+		`);
+	});
+
+	it("should handle list metadata index", async () => {
+		mockVectorizeV2Request();
+		await runWrangler(`vectorize list-metadata-index test-index`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Fetching metadata indexes...
+┌──────────────┬─────────┐
+│ propertyName │ type    │
+├──────────────┼─────────┤
+│ string-prop  │ string  │
+├──────────────┼─────────┤
+│ num-prop     │ number  │
+├──────────────┼─────────┤
+│ bool-prop    │ boolean │
+└──────────────┴─────────┘"
+		`);
+	});
+
+	it("should warn when list metadata indexes returns empty", async () => {
+		mockVectorizeV2RequestError();
+		await runWrangler("vectorize list-metadata-index test-index");
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Fetching metadata indexes..."
+		`);
+
+		expect(std.warn).toMatchInlineSnapshot(`
+			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m[0m
+
+  You haven't created any metadata indexes on this account.
+
+  Use 'wrangler vectorize create-metadata-index <name>' to create one, or visit
+  [4mhttps://developers.cloudflare.com/vectorize/[0m to get started.
+
+
+"
+		`);
+	});
+
+	it("should handle delete metadata index", async () => {
+		mockVectorizeV2Request();
+		await runWrangler(
+			`vectorize delete-metadata-index test-index --property-name='some-prop'`
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+			"📋 Deleting metadata index...
+			✅ Successfully enqueued metadata index deletion request. Mutation changeset identifier: xxxxxx-xxxx-xxxx-xxxx-xxxxxx."
+		`);
+	});
+});
+
+describe("vectorize query filter", () => {
+	it("should parse correctly", async () => {
+		let jsonString =
+			'{ "p1": "abc", "p2": { "$ne": true }, "p3": 10, "p4": false, "nested.p5": "abcd" }'; // Successful parse
+		expect(
+			JSON.stringify(validateQueryFilter(JSON.parse(jsonString)))
+		).toMatchInlineSnapshot(
+			`"{\\"p1\\":\\"abc\\",\\"p2\\":{\\"$ne\\":true},\\"p3\\":10,\\"p4\\":false,\\"nested.p5\\":\\"abcd\\"}"`
+		);
+
+		jsonString =
+			'{ "streaming_platform": "netflix", "has_viewed": { "$ne": true }, "prop_2": [1,2] }'; // Successful parse, with skipped prop
+		expect(
+			JSON.stringify(validateQueryFilter(JSON.parse(jsonString)))
+		).toMatchInlineSnapshot(
+			`"{\\"streaming_platform\\":\\"netflix\\",\\"has_viewed\\":{\\"$ne\\":true}}"`
+		);
+
+		jsonString = '{ "prop_5": "" }'; // Successful parse
+		expect(
+			JSON.stringify(validateQueryFilter(JSON.parse(jsonString)))
+		).toMatchInlineSnapshot(`"{\\"prop_5\\":\\"\\"}"`);
+
+		const jsonStrings = new Map<number, string>([
+			[0, ""], // Does not get parsed as JSON Object
+			[1, '{ "abc" }'], // Does not get parsed as JSON Object
+			[2, '{ "abc": }'], // Does not get parsed as JSON Object
+			[3, "abc"], // Does not get parsed as JSON Object
+			[4, "100"], // Invalid json
+			[5, "true"], // Invalid json
+			[6, "null"], // Invalid json
+			[7, '["abc","def"]'], // Invalid json
+			[8, "{}"], // Empty result
+			[9, '{ "prop_1": ["a", "b"] }'], // Skip field with array
+			[10, '{ "prop_2": {} }'], // Skipping because inner is empty
+			[11, '{ "prop_3": { "abc" } }'], // Does not get parsed as JSON Object
+			[12, '{ "prop_4": { "abc": } }'], // Does not get parsed as JSON Object
+			[13, '{ "prop_5": { ["abc","d"] } }'], // Does not get parsed as JSON Object
+			[14, '{ "prop_6": { "abc": "def" } }'], // Invalid operator
+			[15, '{ "prop_7": { "$ne": ["a", "b"] } }'], // Skipping because inner is array
+			[16, '{ "prop_8": { "$ne" } }'], // Does not get parsed as JSON Object
+			[17, '{ "prop_9": { "" } }'], // Does not get parsed as JSON Object
+			[18, '{ "prop_10": { 100 } }'], // Does not get parsed as JSON Object
+			[19, '{ "prop_11": { true } }'], // Does not get parsed as JSON Object
+			[20, '{ "prop_12": { {} } }'], // Does not get parsed as JSON Object
+			[21, '{ "prop_13": { "$ne": {} } }'], // Skipping operation because empty
+			[22, '{"prop_14": {"address": {"$eq": "123 Main St"}}}'], // Invalid operator
+		]);
+
+		const parseFailureCases = new Set<number>();
+		const validationFailureCases = new Set<number>();
+		for (const [i, js] of [...jsonStrings]) {
+			let jsObj: VectorizeQueryOptions["filter"];
+			try {
+				// This mimics the coerce behavior in the query options.
+				jsObj = JSON.parse(js);
+			} catch (_) {
+				parseFailureCases.add(i);
+				continue;
+			}
+			// parse func should return null
+			if (jsObj) {
+				expect(validateQueryFilter(jsObj)).toBe(null);
+			}
+			validationFailureCases.add(i);
+		}
+
+		const expectedParseFailures = new Set<number>([
+			0, 1, 2, 3, 11, 12, 13, 16, 17, 18, 19, 20,
+		]);
+		expect([...parseFailureCases]).toEqual([...expectedParseFailures]);
+
+		const expectedvalidationFailures = new Set<number>([
+			4, 5, 6, 7, 8, 9, 10, 14, 15, 21, 22,
+		]);
+		expect([...validationFailureCases]).toEqual([
+			...expectedvalidationFailures,
+		]);
 	});
 });
 
@@ -279,6 +884,293 @@ function mockVectorizeRequest() {
 								},
 							},
 						],
+						true
+					)
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+/** Create a mock handler for the Vectorize V2 API */
+function mockVectorizeV2Request() {
+	msw.use(
+		http.get(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							created_on: "2024-07-11T13:02:18.00268Z",
+							modified_on: "2024-07-11T13:02:18.00268Z",
+							name: "test-index",
+							description: "test-desc",
+							config: {
+								dimensions: 1536,
+								metric: "euclidean",
+							},
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							created_on: "2024-07-11T13:02:18.00268Z",
+							modified_on: "2024-07-11T13:02:18.00268Z",
+							name: "test-index",
+							description: "test-desc",
+							config: {
+								dimensions: 1536,
+								metric: "euclidean",
+							},
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.delete(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index",
+			() => {
+				return HttpResponse.json(createFetchResult(null, true));
+			},
+			{ once: true }
+		),
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/query",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							count: 2,
+							matches: [
+								{
+									id: "a",
+									score: 0.5,
+									values: [1, 2, 3, 4],
+									namespace: "abcd",
+									metadata: {
+										a: true,
+										b: 123,
+									},
+								},
+								{
+									id: "b",
+									score: 0.75,
+									values: [5, 6, 7, 8],
+									metadata: {
+										c: false,
+										b: "123",
+									},
+								},
+							],
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/get_by_ids",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						[
+							{
+								id: "a",
+								values: [1, 2, 3, 4],
+								namespace: "abcd",
+								metadata: {
+									a: true,
+									b: 123,
+								},
+							},
+							{
+								id: "b",
+								values: [5, 6, 7, 8],
+								metadata: {
+									c: false,
+									b: "123",
+								},
+							},
+						],
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/delete_by_ids",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							mutationId: "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.get(
+			"*/accounts/:accountId/vectorize/v2/indexes",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						[
+							{
+								created_on: "2024-07-11T13:02:18.00268Z",
+								modified_on: "2024-07-11T13:02:18.00268Z",
+								name: "test-index",
+								description: "test-desc",
+								config: {
+									dimensions: 1536,
+									metric: "euclidean",
+								},
+							},
+							{
+								created_on: "2024-07-11T13:02:18.00268Z",
+								modified_on: "2024-07-11T13:02:18.00268Z",
+								name: "another-index",
+								description: "another-desc",
+								config: {
+									dimensions: 32,
+									metric: "dot-product",
+								},
+							},
+						],
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.get(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/info",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							vectorCount: 1000,
+							dimensions: 1024,
+							processedUpToDatetime: "2024-07-19T13:11:44.064Z",
+							processedUpToMutation: "7f11d6e5-d126-4f76-936e-fbfec079e0be",
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/metadata_index/create",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							mutationId: "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/metadata_index/list",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							metadataIndexes: [
+								{
+									propertyName: "string-prop",
+									indexType: "string",
+								},
+								{
+									propertyName: "num-prop",
+									indexType: "number",
+								},
+								{
+									propertyName: "bool-prop",
+									indexType: "boolean",
+								},
+							],
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/metadata_index/delete",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							mutationId: "xxxxxx-xxxx-xxxx-xxxx-xxxxxx",
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockVectorizeV2RequestError() {
+	msw.use(
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/query",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							count: 0,
+							matches: [],
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		),
+		http.get(
+			"*/accounts/:accountId/vectorize/v2/indexes",
+			() => {
+				return HttpResponse.json(createFetchResult([], true));
+			},
+			{ once: true }
+		),
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/get_by_ids",
+			() => {
+				return HttpResponse.json(createFetchResult([], true));
+			},
+			{ once: true }
+		),
+		http.post(
+			"*/accounts/:accountId/vectorize/v2/indexes/test-index/metadata_index/list",
+			() => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							metadataIndexes: [],
+						},
 						true
 					)
 				);

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -6,7 +7,7 @@ import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { toString } from "../helpers/serialize-form-data-entry";
-import type { VectorizeVector } from "@cloudflare/workers-types";
+import type { VectorizeVector } from "../../vectorize/types";
 
 describe("dataset upsert", () => {
 	const std = mockConsoleMethods();
@@ -41,11 +42,16 @@ describe("dataset upsert", () => {
 		{
 			id: "15cc795d-93d3-416d-9a2a-36fa6fac73da",
 			values: [0.6323, 0.1111, 0.5136, 0.7512, 0.6632, 0.5254],
-			metadata: { text: "Which witch is which?" },
+			metadata: {
+				text: "Which witch is which?",
+				boo: false,
+				num: 100,
+				nested: { t: "abcd" },
+			},
 		},
 	];
 
-	it("should batch uploads in ndjson format", async () => {
+	it("should batch uploads in ndjson format for Vectorize v1", async () => {
 		writeFileSync(
 			"vectors.ndjson",
 			testVectors.map((v) => JSON.stringify(v)).join(`\n`)
@@ -71,7 +77,7 @@ describe("dataset upsert", () => {
 					} else {
 						expect(vectors).toMatchInlineSnapshot(`
 "{\\"id\\":\\"15cc795d-93d3-416d-9a2a-36fa6fac73da\\",\\"values\\":[0.8525,0.7751,0.6326,0.1512,0.9655,0.6626],\\"metadata\\":{\\"text\\":\\"He threw three free throws\\"}}
-{\\"id\\":\\"15cc795d-93d3-416d-9a2a-36fa6fac73da\\",\\"values\\":[0.6323,0.1111,0.5136,0.7512,0.6632,0.5254],\\"metadata\\":{\\"text\\":\\"Which witch is which?\\"}}"
+{\\"id\\":\\"15cc795d-93d3-416d-9a2a-36fa6fac73da\\",\\"values\\":[0.6323,0.1111,0.5136,0.7512,0.6632,0.5254],\\"metadata\\":{\\"text\\":\\"Which witch is which?\\",\\"boo\\":false,\\"num\\":100,\\"nested\\":{\\"t\\":\\"abcd\\"}}}"
 `);
 					}
 					insertRequestCount++;
@@ -90,7 +96,7 @@ describe("dataset upsert", () => {
 		);
 
 		await runWrangler(
-			`vectorize insert my-index --file vectors.ndjson --batch-size ${batchSize}`
+			`vectorize insert my-index --file vectors.ndjson --batch-size ${batchSize} --deprecated-v1=true`
 		);
 
 		expect(insertRequestCount).toBe(2);
@@ -98,6 +104,122 @@ describe("dataset upsert", () => {
 		"✨ Uploading vector batch (3 vectors)
 		✨ Uploading vector batch (2 vectors)
 		✅ Successfully inserted 5 vectors into index 'my-index'"
+	`);
+	});
+
+	it("should batch uploads in ndjson format for Vectorize", async () => {
+		writeFileSync(
+			"vectors.ndjson",
+			testVectors.map((v) => JSON.stringify(v)).join(`\n`)
+		);
+
+		const mutationId = crypto.randomUUID();
+
+		const batchSize = 3;
+		let insertRequestCount = 0;
+		msw.use(
+			http.post(
+				"*/vectorize/v2/indexes/:indexName/insert",
+				async ({ request, params }) => {
+					expect(params.indexName).toEqual("my-index");
+
+					const formData = await request.formData();
+					const vectors = await toString(formData.get("vectors"));
+
+					if (insertRequestCount === 0) {
+						expect(vectors).toMatchInlineSnapshot(`
+"{\\"id\\":\\"b0daca4a-ffd8-4865-926b-e24800af2a2d\\",\\"values\\":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121],\\"metadata\\":{\\"text\\":\\"She sells seashells by the seashore\\"}}
+{\\"id\\":\\"a44706aa-a366-48bc-8cc1-3feffd87d548\\",\\"values\\":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512],\\"metadata\\":{\\"text\\":\\"Peter Piper picked a peck of pickled peppers\\"}}
+{\\"id\\":\\"43cfcb31-07e2-411f-8bf9-f82a95ba8b96\\",\\"values\\":[0.0515,0.7512,0.8612,0.2153,0.1521,0.6812],\\"metadata\\":{\\"text\\":\\"You know New York, you need New York, you know you need unique New York\\"}}"
+`);
+					} else {
+						expect(vectors).toMatchInlineSnapshot(`
+"{\\"id\\":\\"15cc795d-93d3-416d-9a2a-36fa6fac73da\\",\\"values\\":[0.8525,0.7751,0.6326,0.1512,0.9655,0.6626],\\"metadata\\":{\\"text\\":\\"He threw three free throws\\"}}
+{\\"id\\":\\"15cc795d-93d3-416d-9a2a-36fa6fac73da\\",\\"values\\":[0.6323,0.1111,0.5136,0.7512,0.6632,0.5254],\\"metadata\\":{\\"text\\":\\"Which witch is which?\\",\\"boo\\":false,\\"num\\":100,\\"nested\\":{\\"t\\":\\"abcd\\"}}}"
+`);
+					}
+					insertRequestCount++;
+
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							messages: [],
+							result: { mutationId: mutationId },
+						},
+						{ status: 200 }
+					);
+				}
+			)
+		);
+
+		await runWrangler(
+			`vectorize insert my-index --file vectors.ndjson --batch-size ${batchSize}`
+		);
+
+		expect(insertRequestCount).toBe(2);
+		expect(std.out).toMatchInlineSnapshot(`
+		"✨ Enqueued 3 vectors into index 'my-index' for insertion. Mutation changeset identifier: ${mutationId}
+		✨ Enqueued 2 vectors into index 'my-index' for insertion. Mutation changeset identifier: ${mutationId}
+		✅ Successfully enqueued 5 vectors into index 'my-index' for insertion."
+	`);
+	});
+
+	it("should batch uploads for upsert in ndjson format for Vectorize", async () => {
+		writeFileSync(
+			"vectors.ndjson",
+			testVectors.map((v) => JSON.stringify(v)).join(`\n`)
+		);
+
+		const mutationId = crypto.randomUUID();
+
+		const batchSize = 3;
+		let insertRequestCount = 0;
+		msw.use(
+			http.post(
+				"*/vectorize/v2/indexes/:indexName/upsert",
+				async ({ request, params }) => {
+					expect(params.indexName).toEqual("my-index");
+
+					const formData = await request.formData();
+					const vectors = await toString(formData.get("vectors"));
+
+					if (insertRequestCount === 0) {
+						expect(vectors).toMatchInlineSnapshot(`
+"{\\"id\\":\\"b0daca4a-ffd8-4865-926b-e24800af2a2d\\",\\"values\\":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121],\\"metadata\\":{\\"text\\":\\"She sells seashells by the seashore\\"}}
+{\\"id\\":\\"a44706aa-a366-48bc-8cc1-3feffd87d548\\",\\"values\\":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512],\\"metadata\\":{\\"text\\":\\"Peter Piper picked a peck of pickled peppers\\"}}
+{\\"id\\":\\"43cfcb31-07e2-411f-8bf9-f82a95ba8b96\\",\\"values\\":[0.0515,0.7512,0.8612,0.2153,0.1521,0.6812],\\"metadata\\":{\\"text\\":\\"You know New York, you need New York, you know you need unique New York\\"}}"
+`);
+					} else {
+						expect(vectors).toMatchInlineSnapshot(`
+"{\\"id\\":\\"15cc795d-93d3-416d-9a2a-36fa6fac73da\\",\\"values\\":[0.8525,0.7751,0.6326,0.1512,0.9655,0.6626],\\"metadata\\":{\\"text\\":\\"He threw three free throws\\"}}
+{\\"id\\":\\"15cc795d-93d3-416d-9a2a-36fa6fac73da\\",\\"values\\":[0.6323,0.1111,0.5136,0.7512,0.6632,0.5254],\\"metadata\\":{\\"text\\":\\"Which witch is which?\\",\\"boo\\":false,\\"num\\":100,\\"nested\\":{\\"t\\":\\"abcd\\"}}}"
+`);
+					}
+					insertRequestCount++;
+
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							messages: [],
+							result: { mutationId: mutationId },
+						},
+						{ status: 200 }
+					);
+				}
+			)
+		);
+
+		await runWrangler(
+			`vectorize upsert my-index --file vectors.ndjson --batch-size ${batchSize}`
+		);
+
+		expect(insertRequestCount).toBe(2);
+		expect(std.out).toMatchInlineSnapshot(`
+		"✨ Enqueued 3 vectors into index 'my-index' for upsertion. Mutation changeset identifier: ${mutationId}
+		✨ Enqueued 2 vectors into index 'my-index' for upsertion. Mutation changeset identifier: ${mutationId}
+		✅ Successfully enqueued 5 vectors into index 'my-index' for upsertion."
 	`);
 	});
 });

--- a/packages/wrangler/src/vectorize/common.ts
+++ b/packages/wrangler/src/vectorize/common.ts
@@ -1,7 +1,48 @@
+import { logger } from "../logger";
+import type { Interface as RLInterface } from "node:readline";
+
 export const vectorizeBetaWarning = `--------------------
 📣 Vectorize is currently in open beta
+📣 Please use the '--deprecated-v1' flag to create, get, list, delete and insert vectors into legacy Vectorize indexes
 📣 See the Vectorize docs for how to get started and known issues: https://developers.cloudflare.com/vectorize
 📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
 📣 To give feedback, visit https://discord.cloudflare.com/
 --------------------
 `;
+
+export const deprecatedV1DefaultFlag = false;
+
+export const VECTORIZE_V1_MAX_BATCH_SIZE = 1_000;
+export const VECTORIZE_MAX_BATCH_SIZE = 5_000;
+export const VECTORIZE_UPSERT_BATCH_SIZE = VECTORIZE_V1_MAX_BATCH_SIZE;
+export const VECTORIZE_MAX_UPSERT_VECTOR_RECORDS = 100_000;
+
+// helper method that reads an ndjson file line by line in batches. not this doesn't
+// actually do any parsing - that will be handled on the backend
+// https://nodejs.org/docs/latest-v16.x/api/readline.html#rlsymbolasynciterator
+export async function* getBatchFromFile(
+	rl: RLInterface,
+	batchSize = VECTORIZE_MAX_BATCH_SIZE
+): AsyncGenerator<string[]> {
+	const batch: string[] = [];
+
+	try {
+		for await (const line of rl) {
+			batch.push(line);
+
+			if (batch.length >= batchSize) {
+				yield batch.splice(0, batchSize);
+			}
+		}
+
+		// Yield any lines remaining in the last batch
+		if (batch.length > 0) {
+			yield batch;
+		}
+	} catch (error) {
+		logger.error(
+			`🚨 Encountered an error while reading batches from the file.`
+		);
+		return;
+	}
+}

--- a/packages/wrangler/src/vectorize/createMetadataIndex.ts
+++ b/packages/wrangler/src/vectorize/createMetadataIndex.ts
@@ -1,0 +1,52 @@
+import { readConfig } from "../config";
+import { logger } from "../logger";
+import { createMetadataIndex } from "./client";
+import { vectorizeBetaWarning } from "./common";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+import type {
+	VectorizeMetadataIndexProperty,
+	VectorizeVectorMetadataValueString,
+} from "./types";
+
+export function options(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			type: "string",
+			demandOption: true,
+			description: "The name of the Vectorize index.",
+		})
+		.positional("property-name", {
+			type: "string",
+			demandOption: true,
+			description: "The name of the metadata property to index.",
+		})
+		.positional("type", {
+			type: "string",
+			demandOption: true,
+			choices: ["string", "number", "boolean"],
+			description:
+				"The type of metadata property to index. Valid types are 'string', 'number' and 'boolean'.",
+		})
+		.epilogue(vectorizeBetaWarning);
+}
+
+export async function handler(
+	args: StrictYargsOptionsToInterface<typeof options>
+) {
+	const config = readConfig(args.config, args);
+
+	const reqOptions: VectorizeMetadataIndexProperty = {
+		propertyName: args.propertyName,
+		indexType: args.type as VectorizeVectorMetadataValueString,
+	};
+
+	logger.log(`📋 Creating metadata index...`);
+	const mutation = await createMetadataIndex(config, args.name, reqOptions);
+
+	logger.log(
+		`✅ Successfully enqueued metadata index creation request. Mutation changeset identifier: ${mutation.mutationId}.`
+	);
+}

--- a/packages/wrangler/src/vectorize/delete.ts
+++ b/packages/wrangler/src/vectorize/delete.ts
@@ -2,7 +2,7 @@ import { readConfig } from "../config";
 import { confirm } from "../dialogs";
 import { logger } from "../logger";
 import { deleteIndex } from "./client";
-import { vectorizeBetaWarning } from "./common";
+import { deprecatedV1DefaultFlag, vectorizeBetaWarning } from "./common";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -20,6 +20,11 @@ export function options(yargs: CommonYargsArgv) {
 			type: "boolean",
 			alias: "y",
 			default: false,
+		})
+		.option("deprecated-v1", {
+			type: "boolean",
+			default: deprecatedV1DefaultFlag,
+			describe: "Delete a deprecated Vectorize V1 index.",
 		})
 		.epilogue(vectorizeBetaWarning);
 }
@@ -40,6 +45,6 @@ export async function handler(
 		}
 	}
 
-	await deleteIndex(config, args.name);
+	await deleteIndex(config, args.name, args.deprecatedV1);
 	logger.log(`✅ Deleted index ${args.name}`);
 }

--- a/packages/wrangler/src/vectorize/deleteByIds.ts
+++ b/packages/wrangler/src/vectorize/deleteByIds.ts
@@ -1,0 +1,45 @@
+import { readConfig } from "../config";
+import { logger } from "../logger";
+import { deleteByIds } from "./client";
+import { vectorizeBetaWarning } from "./common";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+export function options(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			type: "string",
+			demandOption: true,
+			description: "The name of the Vectorize index.",
+		})
+		.options({
+			ids: {
+				type: "array",
+				demandOption: true,
+				describe:
+					"Vector identifiers to be deleted from the Vectorize Index.  Example: `--ids a 'b' 1 '2'`",
+				coerce: (arg: unknown[]) => arg.map((a) => a?.toString() ?? ""),
+			},
+		})
+		.epilogue(vectorizeBetaWarning);
+}
+
+export async function handler(
+	args: StrictYargsOptionsToInterface<typeof options>
+) {
+	const config = readConfig(args.config, args);
+
+	if (args.ids.length === 0) {
+		logger.error("🚨 Please provide valid vector identifiers for deletion.");
+		return;
+	}
+
+	logger.log(`📋 Deleting vectors...`);
+	const mutation = await deleteByIds(config, args.name, args.ids);
+
+	logger.log(
+		`✅ Successfully enqueued ${args.ids.length} vectors into index '${args.name}' for deletion. Mutation changeset identifier: ${mutation.mutationId}.`
+	);
+}

--- a/packages/wrangler/src/vectorize/deleteMetadataIndex.ts
+++ b/packages/wrangler/src/vectorize/deleteMetadataIndex.ts
@@ -1,0 +1,41 @@
+import { readConfig } from "../config";
+import { logger } from "../logger";
+import { deleteMetadataIndex } from "./client";
+import { vectorizeBetaWarning } from "./common";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+import type { VectorizeMetadataIndexPropertyName } from "./types";
+
+export function options(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			type: "string",
+			demandOption: true,
+			description: "The name of the Vectorize index.",
+		})
+		.positional("property-name", {
+			type: "string",
+			demandOption: true,
+			description: "The name of the metadata property to index.",
+		})
+		.epilogue(vectorizeBetaWarning);
+}
+
+export async function handler(
+	args: StrictYargsOptionsToInterface<typeof options>
+) {
+	const config = readConfig(args.config, args);
+
+	const reqOptions: VectorizeMetadataIndexPropertyName = {
+		propertyName: args.propertyName,
+	};
+
+	logger.log(`📋 Deleting metadata index...`);
+	const mutation = await deleteMetadataIndex(config, args.name, reqOptions);
+
+	logger.log(
+		`✅ Successfully enqueued metadata index deletion request. Mutation changeset identifier: ${mutation.mutationId}.`
+	);
+}

--- a/packages/wrangler/src/vectorize/getByIds.ts
+++ b/packages/wrangler/src/vectorize/getByIds.ts
@@ -1,0 +1,50 @@
+import { readConfig } from "../config";
+import { logger } from "../logger";
+import { getByIds } from "./client";
+import { vectorizeBetaWarning } from "./common";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+export function options(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			type: "string",
+			demandOption: true,
+			description: "The name of the Vectorize index.",
+		})
+		.options({
+			ids: {
+				type: "array",
+				demandOption: true,
+				describe:
+					"Vector identifiers to be fetched from the Vectorize Index. Example: `--ids a 'b' 1 '2'`",
+				coerce: (arg: unknown[]) => arg.map((a) => a?.toString() ?? ""),
+			},
+		})
+		.epilogue(vectorizeBetaWarning);
+}
+
+export async function handler(
+	args: StrictYargsOptionsToInterface<typeof options>
+) {
+	const config = readConfig(args.config, args);
+
+	if (args.ids.length === 0) {
+		logger.error("🚨 Please provide valid vector identifiers.");
+		return;
+	}
+
+	logger.log(`📋 Fetching vectors...`);
+	const vectors = await getByIds(config, args.name, args.ids);
+
+	if (vectors.length === 0) {
+		logger.warn(
+			`The index does not contain vectors corresponding to the provided identifiers`
+		);
+		return;
+	}
+
+	logger.log(JSON.stringify(vectors, null, 2));
+}

--- a/packages/wrangler/src/vectorize/index.ts
+++ b/packages/wrangler/src/vectorize/index.ts
@@ -1,46 +1,108 @@
 import { vectorizeBetaWarning } from "./common";
 import { handler as createHandler, options as createOptions } from "./create";
+import {
+	handler as createMetadataIndexHandler,
+	options as createMetadataIndexOptions,
+} from "./createMetadataIndex";
 import { handler as deleteHandler, options as deleteOptions } from "./delete";
+import {
+	handler as deleteByIdsHandler,
+	options as deleteByIdsOptions,
+} from "./deleteByIds";
+import {
+	handler as deleteMetadataIndexHandler,
+	options as deleteMetadataIndexOptions,
+} from "./deleteMetadataIndex";
 import { handler as getHandler, options as getOptions } from "./get";
+import {
+	handler as getByIdsHandler,
+	options as getByIdsOptions,
+} from "./getByIds";
+import { handler as infoHandler, options as infoOptions } from "./info";
 import { handler as insertHandler, options as insertOptions } from "./insert";
 import { handler as listHandler, options as listOptions } from "./list";
+import {
+	handler as listMetadataIndexHandler,
+	options as listMetadataIndexOptions,
+} from "./listMetadataIndex";
+import { handler as queryHandler, options as queryOptions } from "./query";
+import { handler as upsertHandler, options as upsertOptions } from "./upsert";
 import type { CommonYargsArgv } from "../yargs-types";
 
 export function vectorize(yargs: CommonYargsArgv) {
-	return (
-		yargs
-			.command(
-				"create <name>",
-				"Create a Vectorize index",
-				createOptions,
-				createHandler
-			)
-			.command(
-				"delete <name>",
-				"Delete a Vectorize index",
-				deleteOptions,
-				deleteHandler
-			)
-			.command(
-				"get <name>",
-				"Get a Vectorize index by name",
-				getOptions,
-				getHandler
-			)
-			.command("list", "List your Vectorize indexes", listOptions, listHandler)
-			// TODO: coming during open beta
-			// .command(
-			// 	"query <name>",
-			// 	"Query a Vectorize index",
-			// 	queryOptions,
-			// 	queryHandler
-			// )
-			.command(
-				"insert <name>",
-				"Insert vectors into a Vectorize index",
-				insertOptions,
-				insertHandler
-			)
-			.epilogue(vectorizeBetaWarning)
-	);
+	return yargs
+		.command(
+			"create <name>",
+			"Create a Vectorize index",
+			createOptions,
+			createHandler
+		)
+		.command(
+			"delete <name>",
+			"Delete a Vectorize index",
+			deleteOptions,
+			deleteHandler
+		)
+		.command(
+			"get <name>",
+			"Get a Vectorize index by name",
+			getOptions,
+			getHandler
+		)
+		.command("list", "List your Vectorize indexes", listOptions, listHandler)
+		.command(
+			"query <name>",
+			"Query a Vectorize index",
+			queryOptions,
+			queryHandler
+		)
+		.command(
+			"insert <name>",
+			"Insert vectors into a Vectorize index",
+			insertOptions,
+			insertHandler
+		)
+		.command(
+			"upsert <name>",
+			"Upsert vectors into a Vectorize index",
+			upsertOptions,
+			upsertHandler
+		)
+		.command(
+			"get-vectors <name>",
+			"Get vectors from a Vectorize index",
+			getByIdsOptions,
+			getByIdsHandler
+		)
+		.command(
+			"delete-vectors <name>",
+			"Delete vectors in a Vectorize index",
+			deleteByIdsOptions,
+			deleteByIdsHandler
+		)
+		.command(
+			"info <name>",
+			"Get additional details about the index",
+			infoOptions,
+			infoHandler
+		)
+		.command(
+			"create-metadata-index <name>",
+			"Enable metadata filtering on the specified property",
+			createMetadataIndexOptions,
+			createMetadataIndexHandler
+		)
+		.command(
+			"list-metadata-index <name>",
+			"List metadata properties on which metadata filtering is enabled",
+			listMetadataIndexOptions,
+			listMetadataIndexHandler
+		)
+		.command(
+			"delete-metadata-index <name>",
+			"Delete metadata indexes",
+			deleteMetadataIndexOptions,
+			deleteMetadataIndexHandler
+		)
+		.epilogue(vectorizeBetaWarning);
 }

--- a/packages/wrangler/src/vectorize/info.ts
+++ b/packages/wrangler/src/vectorize/info.ts
@@ -1,7 +1,7 @@
 import { readConfig } from "../config";
 import { logger } from "../logger";
-import { getIndex } from "./client";
-import { deprecatedV1DefaultFlag, vectorizeBetaWarning } from "./common";
+import { indexInfo } from "./client";
+import { vectorizeBetaWarning } from "./common";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -19,12 +19,6 @@ export function options(yargs: CommonYargsArgv) {
 			type: "boolean",
 			default: false,
 		})
-		.option("deprecated-v1", {
-			type: "boolean",
-			default: deprecatedV1DefaultFlag,
-			describe:
-				"Fetch a deprecated V1 Vectorize index. This must be enabled if the index was created with V1 option.",
-		})
 		.epilogue(vectorizeBetaWarning);
 }
 
@@ -32,21 +26,21 @@ export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
 	const config = readConfig(args.config, args);
-	const index = await getIndex(config, args.name, args.deprecatedV1);
+
+	logger.log(`📋 Fetching index info...`);
+	const info = await indexInfo(config, args.name);
 
 	if (args.json) {
-		logger.log(JSON.stringify(index, null, 2));
+		logger.log(JSON.stringify(info, null, 2));
 		return;
 	}
 
 	logger.table([
 		{
-			name: index.name,
-			dimensions: index.config?.dimensions.toString(),
-			metric: index.config?.metric,
-			description: index.description || "",
-			created: index.created_on,
-			modified: index.modified_on,
+			dimensions: info.dimensions.toString(),
+			vectorCount: info.vectorCount.toString(),
+			processedUpToMutation: info.processedUpToMutation,
+			processedUpToDatetime: info.processedUpToDatetime,
 		},
 	]);
 }

--- a/packages/wrangler/src/vectorize/list.ts
+++ b/packages/wrangler/src/vectorize/list.ts
@@ -1,7 +1,7 @@
 import { readConfig } from "../config";
 import { logger } from "../logger";
 import { listIndexes } from "./client";
-import { vectorizeBetaWarning } from "./common";
+import { deprecatedV1DefaultFlag, vectorizeBetaWarning } from "./common";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -14,6 +14,11 @@ export function options(yargs: CommonYargsArgv) {
 			type: "boolean",
 			default: false,
 		})
+		.option("deprecated-v1", {
+			type: "boolean",
+			default: deprecatedV1DefaultFlag,
+			describe: "List deprecated Vectorize V1 indexes for your account.",
+		})
 		.epilogue(vectorizeBetaWarning);
 }
 
@@ -23,7 +28,7 @@ export async function handler(
 	const config = readConfig(args.config, args);
 
 	logger.log(`📋 Listing Vectorize indexes...`);
-	const indexes = await listIndexes(config);
+	const indexes = await listIndexes(config, args.deprecatedV1);
 
 	if (indexes.length === 0) {
 		logger.warn(`

--- a/packages/wrangler/src/vectorize/listMetadataIndex.ts
+++ b/packages/wrangler/src/vectorize/listMetadataIndex.ts
@@ -1,0 +1,54 @@
+import { readConfig } from "../config";
+import { logger } from "../logger";
+import { listMetadataIndex } from "./client";
+import { vectorizeBetaWarning } from "./common";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+export function options(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			type: "string",
+			demandOption: true,
+			description: "The name of the Vectorize index.",
+		})
+		.option("json", {
+			describe: "return output as clean JSON",
+			type: "boolean",
+			default: false,
+		})
+		.epilogue(vectorizeBetaWarning);
+}
+
+export async function handler(
+	args: StrictYargsOptionsToInterface<typeof options>
+) {
+	const config = readConfig(args.config, args);
+
+	logger.log(`📋 Fetching metadata indexes...`);
+	const res = await listMetadataIndex(config, args.name);
+
+	if (res.metadataIndexes.length === 0) {
+		logger.warn(`
+You haven't created any metadata indexes on this account.
+
+Use 'wrangler vectorize create-metadata-index <name>' to create one, or visit
+https://developers.cloudflare.com/vectorize/ to get started.
+		`);
+		return;
+	}
+
+	if (args.json) {
+		logger.log(JSON.stringify(res.metadataIndexes, null, 2));
+		return;
+	}
+
+	logger.table(
+		res.metadataIndexes.map((index) => ({
+			propertyName: index.propertyName,
+			type: index.indexType,
+		}))
+	);
+}

--- a/packages/wrangler/src/vectorize/query.ts
+++ b/packages/wrangler/src/vectorize/query.ts
@@ -6,7 +6,15 @@ import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
-import type { VectorizeVector } from "@cloudflare/workers-types";
+import type {
+	VectorizeMetadataFilterInnerValue,
+	VectorizeMetadataFilterValue,
+	VectorizeMetadataRetrievalLevel,
+	VectorizeQueryOptions,
+	VectorizeVectorMetadataFilter,
+	VectorizeVectorMetadataFilterOp,
+	VectorizeVectorMetadataValue,
+} from "./types";
 
 export function options(yargs: CommonYargsArgv) {
 	return yargs
@@ -16,17 +24,56 @@ export function options(yargs: CommonYargsArgv) {
 			description: "The name of the Vectorize index.",
 		})
 		.options({
-			query: {
-				type: "string",
+			vector: {
+				type: "array",
 				demandOption: true,
-				describe: "The vector value to query for",
+				describe:
+					"Vector to query the Vectorize Index. Example: `--vector 1 2 3 0.5 1.25 6`",
+				coerce: (arg: unknown[]) =>
+					arg
+						.map((value) =>
+							typeof value === "string" ? parseFloat(value) : value
+						)
+						.filter(
+							(value): value is number =>
+								typeof value === "number" && !isNaN(value)
+						),
 			},
-		})
-		.options({
 			"top-k": {
 				type: "number",
-				default: 3,
+				default: 5,
 				describe: "The number of results (nearest neighbors) to return.",
+			},
+			"return-values": {
+				type: "boolean",
+				default: false,
+				describe:
+					"Specify if the vector values should be included in the results.",
+			},
+			"return-metadata": {
+				type: "string",
+				choices: ["all", "indexed", "none"],
+				default: "none",
+				describe:
+					"Specify if the vector metadata should be included in the results. Should be either 'all', 'indexed' or 'none'",
+			},
+			namespace: {
+				type: "string",
+				describe: "Filter the query results based on this namespace",
+			},
+			filter: {
+				type: "string",
+				describe:
+					"Filter the query results based on this metadata filter. Example: `--filter '{ 'p1': 'abc', 'p2': { '$ne': true }, 'p3': 10, 'p4': false, 'nested.p5': 'abcd' }'`",
+				coerce: (jsonStr: string): VectorizeQueryOptions["filter"] => {
+					try {
+						return JSON.parse(jsonStr);
+					} catch (_) {
+						logger.warn(
+							"🚨 Invalid query filter. Please use the recommended format."
+						);
+					}
+				},
 			},
 		})
 		.epilogue(vectorizeBetaWarning);
@@ -37,11 +84,126 @@ export async function handler(
 ) {
 	const config = readConfig(args.config, args);
 
-	const query: VectorizeVector = { id: "a", values: [13.5] };
-	if (args.query) {
-		// Parse vector into a Vector type
+	const queryOptions: VectorizeQueryOptions = {
+		topK: args.topK,
+		returnValues: args.returnValues,
+		returnMetadata: args.returnMetadata as VectorizeMetadataRetrievalLevel,
+	};
+
+	if (args.namespace) {
+		queryOptions.namespace = args.namespace;
 	}
 
-	const index = await queryIndex(config, args.name, query);
-	logger.log(JSON.stringify(index, null, 2));
+	if (args.filter) {
+		const parsedFilter = validateQueryFilter(args.filter);
+		if (!parsedFilter) {
+			logger.warn(
+				"🚨 Could not parse the provided query filter. Please use the recommended format."
+			);
+		} else {
+			queryOptions.filter = parsedFilter;
+		}
+	}
+
+	logger.log(`📋 Searching for relevant vectors...`);
+	const res = await queryIndex(config, args.name, args.vector, queryOptions);
+
+	if (res.count === 0) {
+		logger.warn(`Could not find any relevant vectors`);
+		return;
+	}
+
+	logger.log(JSON.stringify(res, null, 2));
+}
+
+export function validateQueryFilter(
+	input: object
+): VectorizeVectorMetadataFilter | null {
+	try {
+		const parsedObj = input;
+
+		// Check if the parsed result is an object, not null, and not an array
+		if (
+			typeof parsedObj !== "object" ||
+			parsedObj === null ||
+			Array.isArray(parsedObj)
+		) {
+			// Invalid json
+			return null;
+		}
+
+		const result: VectorizeVectorMetadataFilter = {};
+
+		for (const field in parsedObj) {
+			if (Object.prototype.hasOwnProperty.call(parsedObj, field)) {
+				const value = (
+					parsedObj as Record<string, VectorizeMetadataFilterValue>
+				)[field];
+
+				if (Array.isArray(value)) {
+					// Skip arrays
+					continue;
+				}
+
+				if (typeof value === "object" && value !== null) {
+					// Handle nested objects
+					const innerObj: Partial<{
+						[Op in VectorizeVectorMetadataFilterOp]?: Exclude<
+							VectorizeVectorMetadataValue,
+							string[]
+						> | null;
+					}> = {};
+					let validInnerObj = true;
+
+					for (const op in value) {
+						if (Object.prototype.hasOwnProperty.call(value, op)) {
+							if (!["$eq", "$ne"].includes(op)) {
+								// Skip objects with invalid operators
+								validInnerObj = false;
+								break;
+							}
+							const innerValue = (value as VectorizeMetadataFilterInnerValue)[
+								op as VectorizeVectorMetadataFilterOp
+							];
+							if (Array.isArray(innerValue)) {
+								// Skip arrays in nested objects
+								validInnerObj = false;
+								break;
+							}
+							if (
+								typeof innerValue === "object" &&
+								innerValue !== null &&
+								Object.keys(innerValue).length === 0
+							) {
+								// Skip empty objects in nested objects
+								validInnerObj = false;
+								break;
+							}
+							innerObj[op as VectorizeVectorMetadataFilterOp] = innerValue;
+						}
+					}
+
+					// Only add valid and non-empty innerObj to result
+					if (validInnerObj && Object.keys(innerObj).length > 0) {
+						result[field] = innerObj as VectorizeMetadataFilterValue;
+					} else if (validInnerObj) {
+						// Invalid innerObj
+					}
+				} else {
+					// Ensure value is of type Exclude<MdV, string[]> (i.e., string | number | boolean | null)
+					result[field] = value;
+				}
+			}
+		}
+
+		if (Object.keys(result).length > 0) {
+			return result;
+		} else {
+			// Empty result
+			return null;
+		}
+	} catch (error) {
+		// Error parsing
+		return null;
+	}
 }

--- a/packages/wrangler/src/vectorize/types.ts
+++ b/packages/wrangler/src/vectorize/types.ts
@@ -1,0 +1,174 @@
+/**
+ * Data types supported for holding vector metadata.
+ */
+export type VectorizeVectorMetadataValue = string | number | boolean | string[];
+
+// /**
+//  * Data types supported for holding vector metadata as strings.
+//  */
+export type VectorizeVectorMetadataValueString =
+	| "string"
+	| "number"
+	| "boolean";
+
+/**
+ * Additional information to associate with a vector.
+ */
+type VectorizeVectorMetadata =
+	| VectorizeVectorMetadataValue
+	| Record<string, VectorizeVectorMetadataValue>;
+
+export type VectorFloatArray = Float32Array | Float64Array;
+
+/**
+ * Comparison logic/operation to use for metadata filtering.
+ *
+ * This list is expected to grow as support for more operations are released.
+ */
+export type VectorizeVectorMetadataFilterOp = "$eq" | "$ne";
+
+export type VectorizeMetadataFilterInnerValue = Record<
+	VectorizeVectorMetadataFilterOp,
+	Exclude<VectorizeVectorMetadataValue, string[]>
+>;
+
+export type VectorizeMetadataFilterValue =
+	| Exclude<VectorizeVectorMetadataValue, string[]>
+	| null
+	| VectorizeMetadataFilterInnerValue;
+
+/**
+ * Filter criteria for vector metadata used to limit the retrieved query result set.
+ */
+export type VectorizeVectorMetadataFilter = {
+	[field: string]: VectorizeMetadataFilterValue;
+};
+
+/**
+ * Supported distance metrics for an index.
+ * Distance metrics determine how other "similar" vectors are determined.
+ */
+export type VectorizeDistanceMetric = "euclidean" | "cosine" | "dot-product";
+
+/**
+ * Metadata return levels for a Vectorize query.
+ *
+ * Default to "none".
+ *
+ * @property all      Full metadata for the vector return set, including all fields (including those un-indexed) without truncation. This is a more expensive retrieval, as it requires additional fetching & reading of un-indexed data.
+ * @property indexed  Return all metadata fields configured for indexing in the vector return set. This level of retrieval is "free" in that no additional overhead is incurred returning this data. However, note that indexed metadata is subject to truncation (especially for larger strings).
+ * @property none     No indexed metadata will be returned.
+ */
+export type VectorizeMetadataRetrievalLevel = "all" | "indexed" | "none";
+
+export interface VectorizeQueryOptions {
+	topK?: number;
+	namespace?: string;
+	returnValues?: boolean;
+	returnMetadata?: VectorizeMetadataRetrievalLevel;
+	filter?: VectorizeVectorMetadataFilter;
+}
+
+/**
+ * Information about the configuration of an index.
+ */
+type VectorizeIndexConfig = {
+	dimensions: number;
+	metric: VectorizeDistanceMetric;
+};
+
+/**
+ * Metadata about an existing index.
+ */
+export interface VectorizeIndex {
+	/** The name of the index. */
+	name: string;
+	/** (optional) A human readable description for the index. */
+	description?: string;
+	/** Specifies the timestamp the index was created as an ISO8601 string. */
+	readonly created_on: string;
+	/** Specifies the timestamp the index was modified as an ISO8601 string. */
+	readonly modified_on: string;
+	/** Configuration properties for the created index. */
+	readonly config: VectorizeIndexConfig;
+}
+
+/**
+ * Represents a single vector value set along with its associated metadata.
+ */
+export interface VectorizeVector {
+	/** The ID for the vector. This can be user-defined, and must be unique. It should uniquely identify the object, and is best set based on the ID of what the vector represents. */
+	id: string;
+	/** The vector values */
+	values: VectorFloatArray | number[];
+	/** The namespace this vector belongs to. */
+	namespace?: string;
+	/** Metadata associated with the vector. Includes the values of other fields and potentially additional details. */
+	metadata?: Record<string, VectorizeVectorMetadata>;
+}
+
+/**
+ * Represents a matched vector for a query along with its score and (if specified) the matching vector information.
+ */
+type VectorizeMatch = Pick<Partial<VectorizeVector>, "values"> &
+	Omit<VectorizeVector, "values"> & {
+		/** The score or rank for similarity, when returned as a result */
+		score: number;
+	};
+
+/**
+ * A set of matching {@link VectorizeMatch} for a particular query.
+ */
+export interface VectorizeMatches {
+	matches: VectorizeMatch[];
+	count: number;
+}
+
+/**
+ * Results of an operation that performed a mutation on a set of vectors.
+ * Here, `ids` is a list of vectors that were successfully processed.
+ *
+ * This type is exclusively for the Vectorize **beta** and will be deprecated once Vectorize RC is released.
+ * See {@link VectorizeAsyncMutation} for its post-beta equivalent.
+ */
+export interface VectorizeVectorMutation {
+	/* List of ids of vectors that were successfully processed. */
+	ids: string[];
+	/* Total count of the number of processed vectors. */
+	count: number;
+}
+
+/**
+ * Result type indicating a mutation on the Vectorize Index.
+ * Actual mutations are processed async where the `mutationId` is the unique identifier for the operation.
+ */
+export interface VectorizeAsyncMutation {
+	/** The unique identifier for the async mutation operation containing the changeset. */
+	mutationId: string;
+}
+
+export type VectorizeIndexDetails = {
+	/** Specifies the dimensions value for the index. */
+	dimensions: number;
+	/** Specifies the number of vectors in the index. */
+	vectorCount: number;
+	/** Specifies the timestamp the last mutation batch was processed. */
+	processedUpToDatetime: string;
+	/** Identifier for the last mutation batch processed. */
+	processedUpToMutation: string;
+};
+
+export interface VectorizeMetadataIndexProperty
+	extends VectorizeMetadataIndexPropertyName {
+	/** Specifies the type of metadata property to index. */
+	indexType: VectorizeVectorMetadataValueString;
+}
+
+export type VectorizeMetadataIndexList = {
+	metadataIndexes: VectorizeMetadataIndexProperty[];
+};
+
+export interface VectorizeMetadataIndexPropertyName {
+	/** Indexed metadata property. */
+	propertyName: string;
+}

--- a/packages/wrangler/src/vectorize/upsert.ts
+++ b/packages/wrangler/src/vectorize/upsert.ts
@@ -1,0 +1,97 @@
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+import { File, FormData } from "undici";
+import { readConfig } from "../config";
+import { logger } from "../logger";
+import { upsertIntoIndex } from "./client";
+import {
+	getBatchFromFile,
+	VECTORIZE_MAX_BATCH_SIZE,
+	VECTORIZE_MAX_UPSERT_VECTOR_RECORDS,
+	vectorizeBetaWarning,
+} from "./common";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+export function options(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			type: "string",
+			demandOption: true,
+			description: "The name of the Vectorize index.",
+		})
+		.options({
+			file: {
+				describe:
+					"A file containing line separated json (ndjson) vector objects.",
+				demandOption: true,
+				type: "string",
+			},
+			"batch-size": {
+				describe:
+					"Number of vector records to include in a single upsert batch when sending to the Cloudflare API.",
+				type: "number",
+				default: VECTORIZE_MAX_BATCH_SIZE,
+			},
+			json: {
+				describe: "return output as clean JSON",
+				type: "boolean",
+				default: false,
+			},
+		})
+		.epilogue(vectorizeBetaWarning);
+}
+
+export async function handler(
+	args: StrictYargsOptionsToInterface<typeof options>
+) {
+	const config = readConfig(args.config, args);
+	const rl = createInterface({ input: createReadStream(args.file) });
+
+	if (Number(args.batchSize) > VECTORIZE_MAX_BATCH_SIZE) {
+		logger.error(
+			`🚨 The global rate limit for the Cloudflare API is 1200 requests per five minutes. Vectorize indexes currently limit upload batches to ${VECTORIZE_MAX_BATCH_SIZE} records at a time to stay within the service limits`
+		);
+		return;
+	}
+
+	let vectorUpsertCount = 0;
+	for await (const batch of getBatchFromFile(rl, args.batchSize)) {
+		const formData = new FormData();
+		formData.append(
+			"vectors",
+			new File([batch.join(`\n`)], "vectors.ndjson", {
+				type: "application/x-ndjson",
+			})
+		);
+		{
+			const mutation = await upsertIntoIndex(config, args.name, formData);
+			vectorUpsertCount += batch.length;
+			logger.log(
+				`✨ Enqueued ${batch.length} vectors into index '${args.name}' for upsertion. Mutation changeset identifier: ${mutation.mutationId}`
+			);
+		}
+
+		if (vectorUpsertCount > VECTORIZE_MAX_UPSERT_VECTOR_RECORDS) {
+			logger.warn(
+				`🚧 While Vectorize is in beta, we've limited uploads to 100k vectors per run. You may run this again with another batch to upload further`
+			);
+			break;
+		}
+	}
+
+	if (args.json) {
+		logger.log(
+			JSON.stringify({ index: args.name, count: vectorUpsertCount }, null, 2)
+		);
+		return;
+	}
+
+	{
+		logger.log(
+			`✅ Successfully enqueued ${vectorUpsertCount} vectors into index '${args.name}' for upsertion.`
+		);
+	}
+}


### PR DESCRIPTION
## What this PR solves / how to test

Enables users to operate on Vectorize V2 operations via wrangler.

Fixes #[VS-197].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [] TODO (before merge)
  - [x ] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/15916
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
