### PR TITLE
Add versions secret:bulk

### DIFF
--- a/.changeset/short-news-decide.md
+++ b/.changeset/short-news-decide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feature: add an additional `wrangler versions secret:bulk` to be align with the current `wrangler secret:bulk` command.

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -69,6 +69,7 @@ describe("versions --help", () => {
 			  wrangler versions upload                    Uploads your Worker code and config as a new Version [beta]
 			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [beta]
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
+			  wrangler versions secret:bulk [json]        Create or update a secret variable for a Worker
 
 			GLOBAL FLAGS
 			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
@@ -108,6 +109,7 @@ describe("versions subhelp", () => {
 			  wrangler versions upload                    Uploads your Worker code and config as a new Version [beta]
 			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [beta]
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
+			  wrangler versions secret:bulk [json]        Create or update a secret variable for a Worker
 
 			GLOBAL FLAGS
 			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
@@ -135,6 +137,7 @@ describe("versions subhelp", () => {
 			  wrangler versions upload                    Uploads your Worker code and config as a new Version [beta]
 			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [beta]
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
+			  wrangler versions secret:bulk [json]        Create or update a secret variable for a Worker
 
 			GLOBAL FLAGS
 			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
@@ -162,6 +165,7 @@ describe("versions subhelp", () => {
 			  wrangler versions upload                    Uploads your Worker code and config as a new Version [beta]
 			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [beta]
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
+			  wrangler versions secret:bulk [json]        Create or update a secret variable for a Worker
 
 			GLOBAL FLAGS
 			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -14,6 +14,10 @@ import { collectKeyValues } from "../utils/collectKeyValues";
 import { versionsDeployHandler, versionsDeployOptions } from "./deploy";
 import { versionsListHandler, versionsListOptions } from "./list";
 import { registerVersionsSecretsSubcommands } from "./secrets";
+import {
+	versionsSecretPutBulkHandler,
+	versionsSecretsPutBulkOptions,
+} from "./secrets/bulk";
 import versionsUpload from "./upload";
 import { versionsViewHandler, versionsViewOptions } from "./view";
 import type { Config } from "../config";
@@ -272,5 +276,11 @@ export default function registerVersionsSubcommands(
 			(yargs) => {
 				return registerVersionsSecretsSubcommands(yargs.command(subHelp));
 			}
+		)
+		.command(
+			"secret:bulk [json]",
+			"Create or update a secret variable for a Worker",
+			versionsSecretsPutBulkOptions,
+			versionsSecretPutBulkHandler
 		);
 }


### PR DESCRIPTION
## What this PR solves / how to test

Adds an additional `versions secret:bulk` command to be align with existing `secret:bulk`

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because: covered by existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no e2e test changes
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/15516
  - [ ] Not necessary because:

