### PR TITLE
Add warning about deploying Python with requirements.txt

### DIFF
--- a/.changeset/happy-mirrors-worry.md
+++ b/.changeset/happy-mirrors-worry.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feature:Add warning about deploying Python with requirements.txt
+
+This expands on the warning shown for all Python Workers to include a message about deploying Python Workers with a requirements.txt not being supported.

--- a/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
+++ b/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
@@ -26,7 +26,7 @@ export default async function guessWorkerFormat(
 			`The entrypoint ${path.relative(
 				process.cwd(),
 				entryFile
-			)} defines a Python worker, support for Python workers is currently experimental.`
+			)} defines a Python worker, support for Python workers is currently experimental. Python workers with a requirements.txt file can only be run locally and cannot be deployed.`
 		);
 		return "modules";
 	}


### PR DESCRIPTION
## What this PR solves / how to test

Refs https://github.com/cloudflare/python-workers-examples/issues/11.

Added a sentence to the standard Python Workers warning, so that anyone using `wrangler dev` gets a warning about Python Workers with a requirements.txt not being deployable.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: simple change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: simple change

