### PR TITLE
fix: use cli script-name arg when deploying a worker with queue consumers

### DIFF
--- a/.changeset/stupid-beans-joke.md
+++ b/.changeset/stupid-beans-joke.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: use cli script-name arg when deploying a worker with queue consumers

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -27,13 +27,15 @@ export function mockUploadWorkerRequest(
 		keepSecrets?: boolean;
 		tag?: string;
 		expectedDispatchNamespace?: string;
+		expectedScriptName?: string;
 	} = {}
 ) {
+	const expectedScriptName = (options.expectedScriptName ??= "test-name");
 	const handleUpload: HttpResponseResolver = async ({ params, request }) => {
 		const url = new URL(request.url);
 		expect(params.accountId).toEqual("some-account-id");
 		expect(params.scriptName).toEqual(
-			legacyEnv && env ? `test-name-${env}` : "test-name"
+			legacyEnv && env ? `${expectedScriptName}-${env}` : expectedScriptName
 		);
 		if (!legacyEnv) {
 			expect(params.envName).toEqual(env);
@@ -169,7 +171,7 @@ export function mockUploadWorkerRequest(
 			({ params }) => {
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual(
-					legacyEnv && env ? `test-name-${env}` : "test-name"
+					legacyEnv && env ? `${expectedScriptName}-${env}` : expectedScriptName
 				);
 				if (!legacyEnv) {
 					expect(params.envName).toEqual(env);

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -41,6 +41,7 @@ import type {
 import type { ValidatorFn } from "./validation-helpers";
 
 export type NormalizeAndValidateConfigArgs = {
+	name?: string;
 	env?: string;
 	"legacy-env"?: boolean;
 	// This is not relevant in dev. It's only purpose is loosening Worker name validation when deploying to a dispatch namespace

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -1054,6 +1054,7 @@ export async function updateQueueProducers(
 }
 
 export async function updateQueueConsumers(
+	scriptName: string | undefined,
 	config: Config
 ): Promise<Promise<string[]>[]> {
 	const consumers = config.queues.consumers || [];
@@ -1091,7 +1092,7 @@ export async function updateQueueConsumers(
 				])
 			);
 		} else {
-			if (config.name === undefined) {
+			if (scriptName === undefined) {
 				// TODO: how can we reliably get the current script name?
 				throw new UserError(
 					"Script name is required to update queue consumers"
@@ -1101,7 +1102,7 @@ export async function updateQueueConsumers(
 			const body: PostTypedConsumerBody = {
 				type: "worker",
 				dead_letter_queue: consumer.dead_letter_queue,
-				script_name: config.name,
+				script_name: scriptName,
 				settings: {
 					batch_size: consumer.max_batch_size,
 					max_retries: consumer.max_retries,
@@ -1117,12 +1118,12 @@ export async function updateQueueConsumers(
 			// Current script already assigned to queue?
 			const existingConsumer =
 				queue.consumers.filter(
-					(c) => c.script === config.name || c.service === config.name
+					(c) => c.script === scriptName || c.service === scriptName
 				).length > 0;
 			const envName = undefined; // TODO: script environment for wrangler deploy?
 			if (existingConsumer) {
 				updateConsumers.push(
-					putConsumer(config, consumer.queue, config.name, envName, body).then(
+					putConsumer(config, consumer.queue, scriptName, envName, body).then(
 						() => [`Consumer for ${consumer.queue}`]
 					)
 				);

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -239,7 +239,7 @@ export default async function triggersDeploy(props: Props): Promise<void> {
 	}
 
 	if (config.queues.consumers && config.queues.consumers.length) {
-		const updateConsumers = await updateQueueConsumers(config);
+		const updateConsumers = await updateQueueConsumers(scriptName, config);
 
 		deployments.push(...updateConsumers);
 	}


### PR DESCRIPTION
## What this PR solves / how to test

When deploying a Worker that has a queue consumer, we make a POST request to set it up that uses the Worker name.
Unfortunately we were not taking into account the command line script-name arg in this request, which causes a problem when there is a mismatch between the wrangler.toml name and command line arg name.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bug fix

