### PR TITLE
fix: Fix changesets with incorrect message format

### DIFF
--- a/.changeset/happy-mirrors-worry.md
+++ b/.changeset/happy-mirrors-worry.md
@@ -2,6 +2,6 @@
 "wrangler": patch
 ---
 
-feature:Add warning about deploying Python with requirements.txt
+feature: Add warning about deploying Python with requirements.txt
 
 This expands on the warning shown for all Python Workers to include a message about deploying Python Workers with a requirements.txt not being supported.

--- a/.changeset/honest-bulldogs-mix.md
+++ b/.changeset/honest-bulldogs-mix.md
@@ -2,7 +2,7 @@
 "wrangler": minor
 ---
 
-Add types to DurableObjectNamespace type generation. For example:
+chore: Add types to DurableObjectNamespace type generation. For example:
 
 ```ts
 interface Env {

--- a/.changeset/purple-ligers-own.md
+++ b/.changeset/purple-ligers-own.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Update config-schema.json for the wrangler.toml
+chore: Update config-schema.json for the wrangler.toml


### PR DESCRIPTION
## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: changesets change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: changesets change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: changesets change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: changesets change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
