### PR TITLE
fix(wrangler): Make `wrangler generate` deprecation warning more user-friendly

### DIFF
--- a/packages/wrangler/src/generate/index.ts
+++ b/packages/wrangler/src/generate/index.ts
@@ -63,8 +63,9 @@ export async function generateHandler(args: GenerateArgs) {
 	await printWranglerBanner();
 
 	logger.warn(
-		`The \`generate\` command is no longer supported and will be removed in a future version.`
-		// TODO: recommend replacement commands
+		`Deprecation: \`wrangler generate\` has been deprecated and will be removed in a future version.\n` +
+			`Use \`npm create cloudflare@latest\` for new Workers and Pages projects.\n\n` +
+			`Please refer to https://developers.cloudflare.com/workers/wrangler/deprecations/#generate for more information."`
 	);
 
 	if (args.type) {


### PR DESCRIPTION
## What this PR solves / how to test

**Before**
<img width="813" alt="Screenshot 2024-07-16 at 18 26 53" src="https://github.com/user-attachments/assets/c455a570-812b-4afa-b13a-a51d7bd91fa2">


**After**
<img width="860" alt="Screenshot 2024-07-16 at 18 15 16" src="https://github.com/user-attachments/assets/83a7f1d5-5e81-40ed-84ae-1ad911f61929">

Fixes #6222

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: verbiage change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: verbiage change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: verbiage change
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
