### PR TITLE
feat(wrangler): Add support for `wrangler.jsonc`

### DIFF
--- a/.changeset/rare-forks-fly.md
+++ b/.changeset/rare-forks-fly.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+feat: Add support for `wrangler.jsonc`
+
+This commit adds support for `wrangler.jsonc` config file for Workers. This feature is available behind the `--experimental-json-config` flag (just like `wrangler.json`).
+
+To use the new configuration file, add a `wrangler.jsonc` file to your Worker project and run `wrangler dev --experimental-json-config` or `wrangler deploy --experimental-json-config`.
+
+Please note that this work does NOT add `wrangler.json` or `wrangler.jsonc` support for Pages projects!

--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -4,7 +4,7 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 describe("execute", () => {
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -7,7 +7,7 @@ import { mockGetMemberships } from "../helpers/mock-oauth-flow";
 import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 describe("execute", () => {
 	mockAccountId({ accountId: null });

--- a/packages/wrangler/src/__tests__/d1/info.test.ts
+++ b/packages/wrangler/src/__tests__/d1/info.test.ts
@@ -6,7 +6,7 @@ import { mockGetMemberships } from "../helpers/mock-oauth-flow";
 import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 describe("info", () => {
 	mockAccountId({ accountId: null });

--- a/packages/wrangler/src/__tests__/d1/migrate.test.ts
+++ b/packages/wrangler/src/__tests__/d1/migrate.test.ts
@@ -10,7 +10,7 @@ import { mockSetTimeout } from "../helpers/mock-set-timeout";
 import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 describe("migrate", () => {
 	runInTempDir();

--- a/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
+++ b/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
@@ -7,7 +7,7 @@ import { mockGetMemberships } from "../helpers/mock-oauth-flow";
 import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 describe("time-travel", () => {
 	mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -6,7 +6,7 @@ import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
-import writeWranglerToml from "./helpers/write-wrangler-toml";
+import { writeWranglerToml } from "./helpers/write-wrangler-toml";
 import type { ServiceReferenceResponse, Tail } from "../delete";
 import type { KVNamespaceInfo } from "../kv/helpers";
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -47,7 +47,7 @@ import { mswListNewDeploymentsLatestFull } from "./helpers/msw/handlers/versions
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
-import writeWranglerToml from "./helpers/write-wrangler-toml";
+import { writeWranglerToml } from "./helpers/write-wrangler-toml";
 import type { Config } from "../config";
 import type { CustomDomain, CustomDomainChangeset } from "../deploy/deploy";
 import type { KVNamespaceInfo } from "../kv/helpers";
@@ -86,6 +86,190 @@ describe("deploy", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
 		clearDialogs();
+	});
+
+	it("should resolve wrangler.toml relative to the entrypoint", async () => {
+		fs.mkdirSync("./some-path/worker", { recursive: true });
+		fs.writeFileSync(
+			"./some-path/wrangler.toml",
+			TOML.stringify({
+				name: "test-name",
+				compatibility_date: "2022-01-12",
+				vars: { xyz: 123 },
+			}),
+			"utf-8"
+		);
+		writeWorkerSource({ basePath: "./some-path/worker" });
+		mockUploadWorkerRequest({
+			expectedBindings: [
+				{
+					json: 123,
+					name: "xyz",
+					type: "json",
+				},
+			],
+			expectedCompatibilityDate: "2022-01-12",
+		});
+		mockSubDomainRequest();
+		await runWrangler("deploy ./some-path/worker/index.js");
+		expect(std.out).toMatchInlineSnapshot(`
+		"Total Upload: xx KiB / gzip: xx KiB
+		Your worker has access to the following bindings:
+		- Vars:
+		  - xyz: 123
+		Uploaded test-name (TIMINGS)
+		Published test-name (TIMINGS)
+		  https://test-name.test-sub-domain.workers.dev
+		Current Deployment ID: Galaxy-Class
+		Current Version ID: Galaxy-Class
+
+
+		Note: Deployment ID has been renamed to Version ID. Deployment ID is present to maintain compatibility with the previous behavior of this command. This output will change in a future version of Wrangler. To learn more visit: https://developers.cloudflare.com/workers/configuration/versions-and-deployments"
+	`);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should support wrangler.json", async () => {
+		fs.mkdirSync("./my-worker", { recursive: true });
+		fs.writeFileSync(
+			"./wrangler.json",
+			JSON.stringify({
+				name: "test-worker",
+				compatibility_date: "2024-01-01",
+				vars: { xyz: 123 },
+			}),
+			"utf-8"
+		);
+		writeWorkerSource({ basePath: "./my-worker" });
+		mockUploadWorkerRequest({
+			expectedScriptName: "test-worker",
+			expectedBindings: [
+				{
+					json: 123,
+					name: "xyz",
+					type: "json",
+				},
+			],
+			expectedCompatibilityDate: "2024-01-01",
+		});
+		mockSubDomainRequest();
+
+		await runWrangler("deploy ./my-worker/index.js --experimental-json-config");
+		expect(std.out).toMatchInlineSnapshot(`
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Vars:
+			  - xyz: 123
+			Uploaded test-worker (TIMINGS)
+			Published test-worker (TIMINGS)
+			  https://test-worker.test-sub-domain.workers.dev
+			Current Deployment ID: Galaxy-Class
+			Current Version ID: Galaxy-Class
+
+
+			Note: Deployment ID has been renamed to Version ID. Deployment ID is present to maintain compatibility with the previous behavior of this command. This output will change in a future version of Wrangler. To learn more visit: https://developers.cloudflare.com/workers/configuration/versions-and-deployments"
+		`);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should support wrangler.jsonc", async () => {
+		fs.mkdirSync("./my-worker", { recursive: true });
+		fs.writeFileSync(
+			"./wrangler.jsonc",
+			JSON.stringify({
+				name: "test-worker-jsonc",
+				compatibility_date: "2024-01-01",
+				vars: { xyz: 123 },
+			}),
+			"utf-8"
+		);
+		writeWorkerSource({ basePath: "./my-worker" });
+		mockUploadWorkerRequest({
+			expectedScriptName: "test-worker-jsonc",
+			expectedBindings: [
+				{
+					json: 123,
+					name: "xyz",
+					type: "json",
+				},
+			],
+			expectedCompatibilityDate: "2024-01-01",
+		});
+		mockSubDomainRequest();
+
+		await runWrangler("deploy ./my-worker/index.js --experimental-json-config");
+		expect(std.out).toMatchInlineSnapshot(`
+			"Total Upload: xx KiB / gzip: xx KiB
+			Your worker has access to the following bindings:
+			- Vars:
+			  - xyz: 123
+			Uploaded test-worker-jsonc (TIMINGS)
+			Published test-worker-jsonc (TIMINGS)
+			  https://test-worker-jsonc.test-sub-domain.workers.dev
+			Current Deployment ID: Galaxy-Class
+			Current Version ID: Galaxy-Class
+
+
+			Note: Deployment ID has been renamed to Version ID. Deployment ID is present to maintain compatibility with the previous behavior of this command. This output will change in a future version of Wrangler. To learn more visit: https://developers.cloudflare.com/workers/configuration/versions-and-deployments"
+		`);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should not deploy if there's any other kind of error when checking deployment source", async () => {
+		writeWorkerSource();
+		writeWranglerToml();
+		mockSubDomainRequest();
+		mockUploadWorkerRequest();
+		msw.use(...mswSuccessOauthHandlers, ...mswSuccessUserHandlers);
+		msw.use(
+			http.get("*/accounts/:accountId/workers/services/:scriptName", () => {
+				return HttpResponse.json(
+					createFetchResult(null, false, [
+						{ code: 10000, message: "Authentication error" },
+					])
+				);
+			}),
+			http.get(
+				"*/accounts/:accountId/workers/deployments/by-script/:scriptTag",
+				() => {
+					return HttpResponse.json(
+						createFetchResult({
+							latest: { number: "2" },
+						})
+					);
+				}
+			)
+		);
+
+		await expect(
+			runWrangler("deploy index.js")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed.]`
+		);
+		expect(std.out).toMatchInlineSnapshot(`
+		"
+		[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed.[0m
+
+		  Authentication error [code: 10000]
+
+
+		📎 It looks like you are authenticating Wrangler via a custom API token set in an environment variable.
+		Please ensure it has the correct permissions for this operation.
+
+		Getting User settings...
+		👋 You are logged in with an API Token, associated with the email user@example.com!
+		ℹ️  The API Token is read from the CLOUDFLARE_API_TOKEN in your environment.
+		┌───────────────┬────────────┐
+		│ Account Name  │ Account ID │
+		├───────────────┼────────────┤
+		│ Account One   │ account-1  │
+		├───────────────┼────────────┤
+		│ Account Two   │ account-2  │
+		├───────────────┼────────────┤
+		│ Account Three │ account-3  │
+		└───────────────┴────────────┘
+		🔓 To see token permissions visit https://dash.cloudflare.com/profile/api-tokens"
+	`);
 	});
 
 	describe("output additional script information", () => {
@@ -670,47 +854,6 @@ describe("deploy", () => {
 		`);
 			});
 		});
-	});
-
-	it("should resolve wrangler.toml relative to the entrypoint", async () => {
-		fs.mkdirSync("./some-path/worker", { recursive: true });
-		fs.writeFileSync(
-			"./some-path/wrangler.toml",
-			TOML.stringify({
-				name: "test-name",
-				compatibility_date: "2022-01-12",
-				vars: { xyz: 123 },
-			}),
-			"utf-8"
-		);
-		writeWorkerSource({ basePath: "./some-path/worker" });
-		mockUploadWorkerRequest({
-			expectedBindings: [
-				{
-					json: 123,
-					name: "xyz",
-					type: "json",
-				},
-			],
-			expectedCompatibilityDate: "2022-01-12",
-		});
-		mockSubDomainRequest();
-		await runWrangler("deploy ./some-path/worker/index.js");
-		expect(std.out).toMatchInlineSnapshot(`
-		"Total Upload: xx KiB / gzip: xx KiB
-		Your worker has access to the following bindings:
-		- Vars:
-		  - xyz: 123
-		Uploaded test-name (TIMINGS)
-		Published test-name (TIMINGS)
-		  https://test-name.test-sub-domain.workers.dev
-		Current Deployment ID: Galaxy-Class
-		Current Version ID: Galaxy-Class
-
-
-		Note: Deployment ID has been renamed to Version ID. Deployment ID is present to maintain compatibility with the previous behavior of this command. This output will change in a future version of Wrangler. To learn more visit: https://developers.cloudflare.com/workers/configuration/versions-and-deployments"
-	`);
-		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
 	describe("routes", () => {
@@ -4947,6 +5090,7 @@ addEventListener('fetch', event => {});`
 			);
 		});
 	});
+
 	describe("custom builds", () => {
 		beforeEach(() => {
 			vi.unstubAllGlobals();
@@ -9128,63 +9272,6 @@ export default{
 				"
 			`);
 		});
-	});
-
-	it("should not deploy if there's any other kind of error when checking deployment source", async () => {
-		writeWorkerSource();
-		writeWranglerToml();
-		mockSubDomainRequest();
-		mockUploadWorkerRequest();
-		msw.use(...mswSuccessOauthHandlers, ...mswSuccessUserHandlers);
-		msw.use(
-			http.get("*/accounts/:accountId/workers/services/:scriptName", () => {
-				return HttpResponse.json(
-					createFetchResult(null, false, [
-						{ code: 10000, message: "Authentication error" },
-					])
-				);
-			}),
-			http.get(
-				"*/accounts/:accountId/workers/deployments/by-script/:scriptTag",
-				() => {
-					return HttpResponse.json(
-						createFetchResult({
-							latest: { number: "2" },
-						})
-					);
-				}
-			)
-		);
-
-		await expect(
-			runWrangler("deploy index.js")
-		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed.]`
-		);
-		expect(std.out).toMatchInlineSnapshot(`
-		"
-		[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/services/test-name) failed.[0m
-
-		  Authentication error [code: 10000]
-
-
-		📎 It looks like you are authenticating Wrangler via a custom API token set in an environment variable.
-		Please ensure it has the correct permissions for this operation.
-
-		Getting User settings...
-		👋 You are logged in with an API Token, associated with the email user@example.com!
-		ℹ️  The API Token is read from the CLOUDFLARE_API_TOKEN in your environment.
-		┌───────────────┬────────────┐
-		│ Account Name  │ Account ID │
-		├───────────────┼────────────┤
-		│ Account One   │ account-1  │
-		├───────────────┼────────────┤
-		│ Account Two   │ account-2  │
-		├───────────────┼────────────┤
-		│ Account Three │ account-3  │
-		└───────────────┴────────────┘
-		🔓 To see token permissions visit https://dash.cloudflare.com/profile/api-tokens"
-	`);
 	});
 
 	describe("queues", () => {

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
-import writeWranglerToml from "./helpers/write-wrangler-toml";
+import { writeWranglerToml } from "./helpers/write-wrangler-toml";
 
 function isFileNotFound(e: unknown) {
 	return (

--- a/packages/wrangler/src/__tests__/deprecated-usage-model.test.ts
+++ b/packages/wrangler/src/__tests__/deprecated-usage-model.test.ts
@@ -8,7 +8,7 @@ import { mswListNewDeploymentsLatestFull } from "./helpers/msw/handlers/versions
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
-import writeWranglerToml from "./helpers/write-wrangler-toml";
+import { writeWranglerToml } from "./helpers/write-wrangler-toml";
 
 describe("deprecated-usage-model", () => {
 	mockAccountId();

--- a/packages/wrangler/src/__tests__/helpers/write-wrangler-toml.ts
+++ b/packages/wrangler/src/__tests__/helpers/write-wrangler-toml.ts
@@ -3,7 +3,7 @@ import TOML from "@iarna/toml";
 import type { RawConfig } from "../../config";
 
 /** Write a mock wrangler.toml file to disk. */
-export default function writeWranglerToml(
+export function writeWranglerToml(
 	config: RawConfig = {},
 	path = "./wrangler.toml"
 ) {
@@ -13,6 +13,21 @@ export default function writeWranglerToml(
 			compatibility_date: "2022-01-12",
 			name: "test-name",
 			...(config as TOML.JsonMap),
+		}),
+		"utf-8"
+	);
+}
+
+export function writeWranglerJson(
+	config: RawConfig = {},
+	path = "./wrangler.json"
+) {
+	fs.writeFileSync(
+		path,
+		JSON.stringify({
+			compatibility_date: "2022-01-12",
+			name: "test-name",
+			...config,
 		}),
 
 		"utf-8"

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -7,7 +7,7 @@ import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
 import { writeWorkerSource } from "./helpers/write-worker-source";
-import writeWranglerToml from "./helpers/write-wrangler-toml";
+import { writeWranglerToml } from "./helpers/write-wrangler-toml";
 import type { PackageManager } from "../package-manager";
 import type { Mock } from "vitest";
 

--- a/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-build-env.test.ts
@@ -8,7 +8,7 @@ import {
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 describe("pages build env", () => {
 	const std = mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -10,7 +10,7 @@ import { useMockIsTTY } from "../helpers/mock-istty";
 import { msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 async function readNormalizedWranglerToml() {
 	return (await readFile("wrangler.toml", "utf8"))

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
@@ -5,7 +5,7 @@ import { mockConsoleMethods } from "../../helpers/mock-console";
 import { msw, mswGetVersion, mswListNewDeployments } from "../../helpers/msw";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
-import writeWranglerToml from "../../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../../helpers/write-wrangler-toml";
 
 describe("deployments list", () => {
 	mockAccountId();

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
@@ -5,7 +5,7 @@ import { mockConsoleMethods } from "../../helpers/mock-console";
 import { msw, mswGetVersion, mswListNewDeployments } from "../../helpers/msw";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
-import writeWranglerToml from "../../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../../helpers/write-wrangler-toml";
 
 describe("deployments list", () => {
 	mockAccountId();

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -5,7 +5,7 @@ import { clearDialogs, mockConfirm } from "../../helpers/mock-dialogs";
 import { useMockIsTTY } from "../../helpers/mock-istty";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
-import writeWranglerToml from "../../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../../helpers/write-wrangler-toml";
 import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
 
 describe("versions secret put", () => {

--- a/packages/wrangler/src/__tests__/versions/secrets/list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/list.test.ts
@@ -4,7 +4,7 @@ import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { createFetchResult, msw } from "../../helpers/msw";
 import { runWrangler } from "../../helpers/run-wrangler";
-import writeWranglerToml from "../../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../../helpers/write-wrangler-toml";
 import type { ApiDeployment, ApiVersion } from "../../../versions/types";
 
 describe("versions secret list", () => {

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -6,7 +6,7 @@ import { useMockIsTTY } from "../../helpers/mock-istty";
 import { useMockStdin } from "../../helpers/mock-stdin";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
-import writeWranglerToml from "../../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../../helpers/write-wrangler-toml";
 import { mockPostVersion, mockSetupApiCalls } from "./utils";
 
 describe("versions secret put", () => {

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -26,7 +26,7 @@ import { mswListNewDeploymentsLatestFiftyFifty } from "../helpers/msw/handlers/v
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 import type { VersionsDeployArgs } from "../../versions/deploy";
 
 describe("versions deploy", () => {

--- a/packages/wrangler/src/__tests__/versions/versions.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.list.test.ts
@@ -5,7 +5,7 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw, mswListVersions } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 describe("versions list", () => {
 	mockAccountId();

--- a/packages/wrangler/src/__tests__/versions/versions.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.view.test.ts
@@ -5,7 +5,7 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { msw, mswGetVersion } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
-import writeWranglerToml from "../helpers/write-wrangler-toml";
+import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 describe("versions view", () => {
 	mockAccountId();

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -35,7 +35,7 @@ export type GetPlatformProxyOptions = {
 	 */
 	configPath?: string;
 	/**
-	 * Flag to indicate the utility to read a json config file (`wrangler.json`)
+	 * Flag to indicate the utility to read a json config file (`wrangler.json`/`wrangler.jsonc`)
 	 * instead of the toml one (`wrangler.toml`)
 	 *
 	 * Note: this feature is experimental

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -65,7 +65,7 @@ export function readConfig(
 		// Load the configuration from disk if available
 		if (configPath?.endsWith("toml")) {
 			rawConfig = parseTOML(readFileSync(configPath), configPath);
-		} else if (configPath?.endsWith("json")) {
+		} else if (configPath?.endsWith("json") || configPath?.endsWith("jsonc")) {
 			rawConfig = parseJSONC(readFileSync(configPath), configPath);
 		}
 	} catch (e) {
@@ -90,7 +90,8 @@ export function readConfig(
 	 * configuration file belongs to a Workers or Pages project. This key
 	 * should always be set for Pages but never for Workers. Furthermore,
 	 * Pages projects currently have support for `wrangler.toml` only,
-	 * so we should error if `wrangler.json` is detected in a Pages project
+	 * so we should error if `wrangler.json` || `wrangler.jsonc` is detected
+	 * in a Pages project
 	 */
 	const isPagesConfigFile = isPagesConfig(rawConfig);
 	if (!isPagesConfigFile && requirePagesConfig) {
@@ -101,7 +102,9 @@ export function readConfig(
 	}
 	if (
 		isPagesConfigFile &&
-		(configPath?.endsWith("json") || isJsonConfigEnabled)
+		(configPath?.endsWith("json") ||
+			configPath?.endsWith("jsonc") ||
+			isJsonConfigEnabled)
 	) {
 		throw new UserError(
 			`Pages doesn't currently support JSON formatted config \`${
@@ -169,6 +172,7 @@ export function findWranglerToml(
 	if (preferJson) {
 		return (
 			findUpSync(`wrangler.json`, { cwd: referencePath }) ??
+			findUpSync(`wrangler.jsonc`, { cwd: referencePath }) ??
 			findUpSync(`wrangler.toml`, { cwd: referencePath })
 		);
 	}


### PR DESCRIPTION
## What this PR solves / how to test

This PR adds support for `wrangler.jsonc` config file, behind the same `--experimental-json-config` flag as `wrangler.json` support.

Fixes #5437

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
