### PR TITLE
fix: allow `getPlatformProxy` to handle RPC calls returning objects

### DIFF
--- a/.changeset/polite-dodos-happen.md
+++ b/.changeset/polite-dodos-happen.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+fix: Allow the magic proxy to proxy objects containing functions indexed by symbols
+
+In https://github.com/cloudflare/workers-sdk/pull/5670 we introduced the possibility
+of the magic proxy to handle object containing functions, the implementation didn't
+account for functions being indexed by symbols, address such issue

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
@@ -188,8 +188,14 @@ describe("getPlatformProxy - env", () => {
 			rpc = env.MY_RPC as unknown as EntrypointService;
 			return dispose;
 		});
-		it("can call RPC methods directly", async () => {
+		it("can call RPC methods returning a string", async () => {
 			expect(await rpc.sum([1, 2, 3])).toMatchInlineSnapshot(`6`);
+		});
+		it("can call RPC methods returning an object", async () => {
+			expect(await rpc.sumObj([1, 2, 3, 5])).toEqual({
+				isObject: true,
+				value: 11,
+			});
 		});
 		it("can call RPC methods returning a Response", async () => {
 			const resp = await rpc.asJsonResponse([1, 2, 3]);

--- a/fixtures/get-platform-proxy/workers/rpc-worker/index.ts
+++ b/fixtures/get-platform-proxy/workers/rpc-worker/index.ts
@@ -12,6 +12,14 @@ export class NamedEntrypoint extends WorkerEntrypoint {
 	sum(args: number[]): number {
 		return args.reduce((a, b) => a + b);
 	}
+
+	sumObj(args: number[]): { isObject: true; value: number } {
+		return {
+			isObject: true,
+			value: args.reduce((a, b) => a + b),
+		};
+	}
+
 	asJsonResponse(args: unknown): {
 		status: number;
 		text: () => Promise<string>;

--- a/packages/miniflare/src/workers/core/proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/proxy.worker.ts
@@ -69,7 +69,15 @@ function isPlainObject(value: unknown) {
 	);
 }
 function objectContainsFunctions(obj: Record<string, unknown>): boolean {
-	for (const [, entry] of Object.entries(obj)) {
+	const propertyNames = Object.getOwnPropertyNames(obj);
+	const propertySymbols = Object.getOwnPropertySymbols(obj);
+	const properties = [...propertyNames, ...propertySymbols];
+
+	for (const property of properties) {
+		// @ts-ignore - ignoring the following line since TypeScript seems to
+		//              incorrectly error if `property` is a symbol
+		//              (see: https://github.com/Microsoft/TypeScript/issues/24587)
+		const entry = obj[property];
 		if (typeof entry === "function") {
 			return true;
 		}

--- a/packages/miniflare/src/workers/core/proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/proxy.worker.ts
@@ -68,15 +68,12 @@ function isPlainObject(value: unknown) {
 		Object.getOwnPropertyNames(proto).sort().join("\0") === objectProtoNames
 	);
 }
-function objectContainsFunctions(obj: Record<string, unknown>): boolean {
+function objectContainsFunctions(obj: Record<string | symbol, unknown>): boolean {
 	const propertyNames = Object.getOwnPropertyNames(obj);
 	const propertySymbols = Object.getOwnPropertySymbols(obj);
 	const properties = [...propertyNames, ...propertySymbols];
 
 	for (const property of properties) {
-		// @ts-ignore - ignoring the following line since TypeScript seems to
-		//              incorrectly error if `property` is a symbol
-		//              (see: https://github.com/Microsoft/TypeScript/issues/24587)
 		const entry = obj[property];
 		if (typeof entry === "function") {
 			return true;

--- a/packages/miniflare/src/workers/core/proxy.worker.ts
+++ b/packages/miniflare/src/workers/core/proxy.worker.ts
@@ -68,7 +68,9 @@ function isPlainObject(value: unknown) {
 		Object.getOwnPropertyNames(proto).sort().join("\0") === objectProtoNames
 	);
 }
-function objectContainsFunctions(obj: Record<string | symbol, unknown>): boolean {
+function objectContainsFunctions(
+	obj: Record<string | symbol, unknown>
+): boolean {
 	const propertyNames = Object.getOwnPropertyNames(obj);
 	const propertySymbols = Object.getOwnPropertySymbols(obj);
 	const properties = [...propertyNames, ...propertySymbols];


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6285

Fixes the first point of #6235

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bugfix

___

As part of https://github.com/cloudflare/workers-sdk/pull/5922 I've removed the code that we had (implemented by @penalosa) that dropped the problematic `dispose` and `asyncDispose` properties from `RpcProperty`s (see [here](https://github.com/cloudflare/workers-sdk/blob/c9f081ab72142060a3cf2e9a7ef4546b8014b210/packages/miniflare/src/workers/core/proxy.worker.ts#L271)), as I thought that such operations were no longer necessary (and there were no tests showing that removing them was breaking something) but it turns out that they are 😓, so I am reinstating the old code back and adding tests to make sure we don't re-regress on this 🙂 