### PR TITLE
fix(create-cloudflare):  support GitHub URL with subdirectory

### DIFF
--- a/.changeset/thick-moons-call.md
+++ b/.changeset/thick-moons-call.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix(create-cloudflare): support GitHub URL with subdirectory

--- a/.changeset/thick-moons-call.md
+++ b/.changeset/thick-moons-call.md
@@ -3,3 +3,5 @@
 ---
 
 fix: support GitHub URL with subdirectory
+
+You can now copy+paste the URL directly from your address bar when you find a template within a (mono)repo on github.com.

--- a/.changeset/thick-moons-call.md
+++ b/.changeset/thick-moons-call.md
@@ -2,4 +2,4 @@
 "create-cloudflare": patch
 ---
 
-fix(create-cloudflare): support GitHub URL with subdirectory
+fix: support GitHub URL with subdirectory

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -166,5 +166,29 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 				expect(output).toContain(`no deploy`);
 			},
 		);
+
+		test.skipIf(process.platform === "win32")(
+			"Cloning remote template with full GitHub URL",
+			async () => {
+				const { output } = await runC3(
+					[
+						projectPath,
+						"--template=https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-router",
+						"--no-deploy",
+						"--git=false",
+					],
+					[],
+					logStream,
+				);
+
+				expect(output).toContain(
+					`repository https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-router`,
+				);
+				expect(output).toContain(
+					`Cloning template from: github:cloudflare/workers-sdk/templates/worker-router`,
+				);
+				expect(output).toContain(`template cloned and validated`);
+			},
+		);
 	},
 );

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -326,8 +326,9 @@ export const processRemoteTemplate = async (args: Partial<C3Args>) => {
 	let src = templateUrl;
 
 	// GitHub URL with subdirectory is not supported by degit and has to be transformed.
-	// This only address templates on the main branch as a branch name
-	// might includes slashes that span multiple segments in the URL.
+	// This only addresses input template URLs on the main branch as a branch name
+	// might includes slashes that span multiple segments in the URL and cannot be
+	// reliably differentiated from the subdirectory path.
 	if (src.startsWith("https://github.com/") && src.includes("/tree/main/")) {
 		src = src
 			.replace("https://github.com/", "github:")

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -323,7 +323,18 @@ export const processRemoteTemplate = async (args: Partial<C3Args>) => {
 		defaultValue: C3_DEFAULTS.template,
 	});
 
-	const path = await downloadRemoteTemplate(templateUrl);
+	let src = templateUrl;
+
+	// GitHub URL with subdirectory is not supported by degit and has to be transformed.
+	// This only address templates on the main branch as a branch name
+	// might includes slashes that span multiple segments in the URL.
+	if (src.startsWith("https://github.com/") && src.includes("/tree/main/")) {
+		src = src
+			.replace("https://github.com/", "github:")
+			.replace("/tree/main/", "/");
+	}
+
+	const path = await downloadRemoteTemplate(src);
 	const config = inferTemplateConfig(path);
 	validateTemplate(path, config);
 


### PR DESCRIPTION
## What this PR solves / how to test

At the moment, users are not able to create an application with a GitHub URL if it is inside a subdirectory, e.g. https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-router

This PR fixes it by transforming the URL to the shorthand format. Note: This only address templates on the main branch as a branch name might includes slashes that span multiple segments in the URL.  

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
