### PR TITLE
[wrangler] Add experimental assets config and flag

### DIFF
--- a/.changeset/dirty-bobcats-tickle.md
+++ b/.changeset/dirty-bobcats-tickle.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+feat: add CLI flag and config key for experimental Workers + Assets
+
+This change adds a new experimental CLI flag (`--experimental-assets`) and configuration key (`experimental_assets`) for the new Workers + Assets work.
+
+The new flag and configuration key are for the time being "inactive", in the sense that no behaviour is attached to them yet. This will follow up in future work.

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -1736,6 +1736,58 @@ describe("normalizeAndValidateConfig()", () => {
 			});
 		});
 
+		describe("[experimental_assets]", () => {
+			it("should override `experimental_assets` config defaults with provided values", () => {
+				const expectedConfig: RawConfig = {
+					experimental_assets: [
+						{
+							directory: "public/",
+							binding: "ASSETS",
+						},
+					],
+				};
+
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					expectedConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(config).toEqual(expect.objectContaining(expectedConfig));
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(false);
+			});
+
+			it("should error on invalid `experimental_assets` values", () => {
+				const expectedConfig = {
+					experimental_assets: [
+						{
+							binding: 2,
+							notAField: "boop",
+						},
+					],
+				};
+
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					expectedConfig as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(config).toEqual(expect.objectContaining(expectedConfig));
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in \\"experimental_assets[0]\\" field: \\"notAField\\""
+				`);
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - \\"experimental_assets[0]\\" should have a string \\"directory\\" field but got {\\"binding\\":2,\\"notAField\\":\\"boop\\"}.
+					  - \\"experimental_assets[0]\\" should, optionally, have a string \\"binding\\" field, but got {\\"binding\\":2,\\"notAField\\":\\"boop\\"}."
+				`);
+			});
+		});
+
 		describe("[browser]", () => {
 			it("should error if browser is an array", () => {
 				const { diagnostics } = normalizeAndValidateConfig(

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -1739,12 +1739,10 @@ describe("normalizeAndValidateConfig()", () => {
 		describe("[experimental_assets]", () => {
 			it("should override `experimental_assets` config defaults with provided values", () => {
 				const expectedConfig: RawConfig = {
-					experimental_assets: [
-						{
-							directory: "public/",
-							binding: "ASSETS",
-						},
-					],
+					experimental_assets: {
+						directory: "public/",
+						binding: "ASSETS",
+					},
 				};
 
 				const { config, diagnostics } = normalizeAndValidateConfig(
@@ -1760,12 +1758,10 @@ describe("normalizeAndValidateConfig()", () => {
 
 			it("should error on invalid `experimental_assets` values", () => {
 				const expectedConfig = {
-					experimental_assets: [
-						{
-							binding: 2,
-							notAField: "boop",
-						},
-					],
+					experimental_assets: {
+						binding: 2,
+						notAField: "boop",
+					},
 				};
 
 				const { config, diagnostics } = normalizeAndValidateConfig(
@@ -1778,12 +1774,12 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - Unexpected fields found in \\"experimental_assets[0]\\" field: \\"notAField\\""
+					  - Unexpected fields found in experimental_assets field: \\"notAField\\""
 				`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - \\"experimental_assets[0]\\" should have a string \\"directory\\" field but got {\\"binding\\":2,\\"notAField\\":\\"boop\\"}.
-					  - \\"experimental_assets[0]\\" should, optionally, have a string \\"binding\\" field, but got {\\"binding\\":2,\\"notAField\\":\\"boop\\"}."
+					  - \\"experimental_assets.directory\\" is a required field.
+					  - Expected \\"experimental_assets.binding\\" to be of type string but got 2."
 				`);
 			});
 		});

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4338,7 +4338,7 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			await expect(runWrangler("deploy")).rejects.toThrow(
 				new RegExp(
-					"^The directory specified by the `experimental_assets` field in your configuration file does not exist:[Ss]*"
+					'^The directory specified by "experimental_assets\\[0\\]" in your configuration file does not exist:[Ss]*'
 				)
 			);
 		});

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -2408,6 +2408,9 @@ addEventListener('fetch', event => {});`
 				  Releases of wrangler after this date will no longer support current functionality.
 				  Please shift to the --legacy-assets command to preserve the current functionality.
 
+
+				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
+
 				",
 				}
 			`);
@@ -4242,6 +4245,102 @@ addEventListener('fetch', event => {});`
 			Uploaded 100% [110 out of 110]"
 		`);
 			});
+		});
+	});
+
+	describe("--experimental-assets", () => {
+		it("should not require entry point if using --experimental-assets", async () => {
+			const assets = [
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "file-2.txt", content: "Content of file-2" },
+			];
+			writeAssets(assets);
+			writeWranglerToml({
+				experimental_assets: [{ directory: "assets" }],
+			});
+			writeWorkerSource();
+			mockUploadWorkerRequest({
+				expectedMainModule: "no-op-worker.js",
+			});
+			mockSubDomainRequest();
+			await runWrangler("deploy");
+		});
+		it("should error if config.site and config.experimental_assets are used together", async () => {
+			writeWranglerToml({
+				main: "./index.js",
+				experimental_assets: [{ directory: "abd" }],
+				site: {
+					bucket: "xyz",
+				},
+			});
+			writeWorkerSource();
+			await expect(
+				runWrangler("deploy")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+			);
+
+			expect(std).toMatchInlineSnapshot(`
+				Object {
+				  "debug": "",
+				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Assets and Workers Sites in the same Worker.[0m
+
+				",
+				  "info": "",
+				  "out": "",
+				  "warn": "",
+				}
+			`);
+		});
+
+		it("should error if --experimental-assets and config.site are used together", async () => {
+			writeWranglerToml({
+				main: "./index.js",
+				site: {
+					bucket: "xyz",
+				},
+			});
+			writeWorkerSource();
+			await expect(
+				runWrangler("deploy --experimental-assets abc")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+			);
+
+			expect(std).toMatchInlineSnapshot(`
+			Object {
+			  "debug": "",
+			  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Assets and Workers Sites in the same Worker.[0m
+
+			",
+			  "info": "",
+			  "out": "",
+			  "warn": "",
+			}
+		`);
+		});
+
+		it("should error if directory specified by flag --experimental-assets does not exist", async () => {
+			writeWorkerSource();
+			await expect(
+				runWrangler("deploy --experimental-assets abc")
+			).rejects.toThrow(
+				new RegExp(
+					'^The directory specified by the "--experimental-assets" command line argument does not exist:[Ss]*'
+				)
+			);
+		});
+
+		it("should error if directory specified by config experimental_assets does not exist", async () => {
+			writeWranglerToml({
+				experimental_assets: [{ directory: "abc" }],
+			});
+			writeWorkerSource();
+			await expect(runWrangler("deploy")).rejects.toThrow(
+				new RegExp(
+					"^The directory specified by the `experimental_assets` field in your configuration file does not exist:[Ss]*"
+				)
+			);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4256,7 +4256,7 @@ addEventListener('fetch', event => {});`
 			];
 			writeAssets(assets);
 			writeWranglerToml({
-				experimental_assets: [{ directory: "assets" }],
+				experimental_assets: { directory: "assets" },
 			});
 			writeWorkerSource();
 			mockUploadWorkerRequest({
@@ -4265,10 +4265,11 @@ addEventListener('fetch', event => {});`
 			mockSubDomainRequest();
 			await runWrangler("deploy");
 		});
+
 		it("should error if config.site and config.experimental_assets are used together", async () => {
 			writeWranglerToml({
 				main: "./index.js",
-				experimental_assets: [{ directory: "abd" }],
+				experimental_assets: { directory: "abd" },
 				site: {
 					bucket: "xyz",
 				},
@@ -4279,18 +4280,6 @@ addEventListener('fetch', event => {});`
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
 			);
-
-			expect(std).toMatchInlineSnapshot(`
-				Object {
-				  "debug": "",
-				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Assets and Workers Sites in the same Worker.[0m
-
-				",
-				  "info": "",
-				  "out": "",
-				  "warn": "",
-				}
-			`);
 		});
 
 		it("should error if --experimental-assets and config.site are used together", async () => {
@@ -4306,18 +4295,6 @@ addEventListener('fetch', event => {});`
 			).rejects.toThrowErrorMatchingInlineSnapshot(
 				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
 			);
-
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Assets and Workers Sites in the same Worker.[0m
-
-			",
-			  "info": "",
-			  "out": "",
-			  "warn": "",
-			}
-		`);
 		});
 
 		it("should error if directory specified by flag --experimental-assets does not exist", async () => {
@@ -4333,12 +4310,12 @@ addEventListener('fetch', event => {});`
 
 		it("should error if directory specified by config experimental_assets does not exist", async () => {
 			writeWranglerToml({
-				experimental_assets: [{ directory: "abc" }],
+				experimental_assets: { directory: "abc" },
 			});
 			writeWorkerSource();
 			await expect(runWrangler("deploy")).rejects.toThrow(
 				new RegExp(
-					'^The directory specified by "experimental_assets\\[0\\]" in your configuration file does not exist:[Ss]*'
+					'^The directory specified by the "experimental_assets.directory" field in your configuration file does not exist:[Ss]*'
 				)
 			);
 		});

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1422,15 +1422,16 @@ describe("wrangler dev", () => {
 		it("should not require entry point if using --experimental-assets", async () => {
 			fs.openSync("assets", "w");
 			writeWranglerToml({
-				experimental_assets: [{ directory: "assets" }],
+				experimental_assets: { directory: "assets" },
 			});
 
 			await runWrangler("dev");
 		});
+
 		it("should error if config.site and config.experimental_assets are used together", async () => {
 			writeWranglerToml({
 				main: "./index.js",
-				experimental_assets: [{ directory: "assets" }],
+				experimental_assets: { directory: "assets" },
 				site: {
 					bucket: "xyz",
 				},
@@ -1460,7 +1461,7 @@ describe("wrangler dev", () => {
 			);
 		});
 
-		it("should error if directory specified by flag --experimental-assets does not exist", async () => {
+		it("should error if directory specified by '--experimental-assets' command line argument does not exist", async () => {
 			writeWranglerToml({
 				main: "./index.js",
 			});
@@ -1474,19 +1475,17 @@ describe("wrangler dev", () => {
 			);
 		});
 
-		it("should error if directory specified by config experimental_assets does not exist", async () => {
+		it("should error if directory specified by 'experimental_assets' configuration key does not exist", async () => {
 			writeWranglerToml({
 				main: "./index.js",
-				experimental_assets: [
-					{
-						directory: "abc",
-					},
-				],
+				experimental_assets: {
+					directory: "abc",
+				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			await expect(runWrangler("dev")).rejects.toThrow(
 				new RegExp(
-					"^The directory specified by the `experimental_assets` field in your configuration file does not exist:[Ss]*"
+					'^The directory specified by the "experimental_assets.directory" field in your configuration file does not exist:[Ss]*'
 				)
 			);
 		});

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1418,6 +1418,80 @@ describe("wrangler dev", () => {
 		});
 	});
 
+	describe("--experimental-assets", () => {
+		it("should not require entry point if using --experimental-assets", async () => {
+			fs.openSync("assets", "w");
+			writeWranglerToml({
+				experimental_assets: [{ directory: "assets" }],
+			});
+
+			await runWrangler("dev");
+		});
+		it("should error if config.site and config.experimental_assets are used together", async () => {
+			writeWranglerToml({
+				main: "./index.js",
+				experimental_assets: [{ directory: "assets" }],
+				site: {
+					bucket: "xyz",
+				},
+			});
+			fs.writeFileSync("index.js", `export default {};`);
+			fs.openSync("assets", "w");
+			await expect(
+				runWrangler("dev")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+			);
+		});
+
+		it("should error if --experimental-assets and config.site are used together", async () => {
+			writeWranglerToml({
+				main: "./index.js",
+				site: {
+					bucket: "xyz",
+				},
+			});
+			fs.writeFileSync("index.js", `export default {};`);
+			fs.openSync("assets", "w");
+			await expect(
+				runWrangler("dev --experimental-assets assets")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+			);
+		});
+
+		it("should error if directory specified by flag --experimental-assets does not exist", async () => {
+			writeWranglerToml({
+				main: "./index.js",
+			});
+			fs.writeFileSync("index.js", `export default {};`);
+			await expect(
+				runWrangler("dev --experimental-assets abc")
+			).rejects.toThrow(
+				new RegExp(
+					'^The directory specified by the "--experimental-assets" command line argument does not exist:[Ss]*'
+				)
+			);
+		});
+
+		it("should error if directory specified by config experimental_assets does not exist", async () => {
+			writeWranglerToml({
+				main: "./index.js",
+				experimental_assets: [
+					{
+						directory: "abc",
+					},
+				],
+			});
+			fs.writeFileSync("index.js", `export default {};`);
+			await expect(runWrangler("dev")).rejects.toThrow(
+				new RegExp(
+					"^The directory specified by the `experimental_assets` field in your configuration file does not exist:[Ss]*"
+				)
+			);
+		});
+	});
+
 	describe("--inspect", () => {
 		it("should warn if --inspect is used", async () => {
 			fs.writeFileSync("index.js", `export default {};`);

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -23,6 +23,7 @@ export interface UnstableDevOptions {
 	localProtocol?: "http" | "https"; // Protocol to listen to requests on, defaults to http.
 	httpsKeyPath?: string;
 	httpsCertPath?: string;
+	experimentalAssets?: string; // Static assets to be served
 	legacyAssets?: string; // Static assets to be served
 	site?: string; // Root folder of static assets for Workers Sites
 	siteInclude?: string[]; // Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.
@@ -188,6 +189,7 @@ export async function unstable_dev(
 		localProtocol: options?.localProtocol,
 		httpsKeyPath: options?.httpsKeyPath,
 		httpsCertPath: options?.httpsCertPath,
+		experimentalAssets: options?.experimentalAssets,
 		legacyAssets: options?.legacyAssets,
 		site: options?.site, // Root folder of static assets for Workers Sites
 		siteInclude: options?.siteInclude, // Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -389,6 +389,7 @@ export const defaultWranglerConfig: Config = {
 	logfwdr: { bindings: [] },
 	logpush: undefined,
 	upload_source_maps: undefined,
+	experimental_assets: undefined,
 
 	/** NON-INHERITABLE ENVIRONMENT FIELDS **/
 	define: {},

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -332,6 +332,18 @@ interface EnvironmentInheritable {
 	 * @inheritable
 	 */
 	placement: { mode: "off" | "smart" } | undefined;
+
+	/**
+	 * Specify the directory of static assets to deploy/serve
+	 *
+	 * @inheritable
+	 */
+	experimental_assets:
+		| {
+				directory: string;
+				binding?: string;
+		  }[]
+		| undefined;
 }
 
 export type DurableObjectBindings = {

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -338,12 +338,7 @@ interface EnvironmentInheritable {
 	 *
 	 * @inheritable
 	 */
-	experimental_assets:
-		| {
-				directory: string;
-				binding?: string;
-		  }[]
-		| undefined;
+	experimental_assets: ExperimentalAssets | undefined;
 }
 
 export type DurableObjectBindings = {
@@ -891,3 +886,8 @@ export interface UserLimits {
 	/** Maximum allowed CPU time for a Worker's invocation in milliseconds */
 	cpu_ms: number;
 }
+
+export type ExperimentalAssets = {
+	directory: string;
+	binding?: string;
+};

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -76,6 +76,7 @@ type Props = {
 	compatibilityDate: string | undefined;
 	compatibilityFlags: string[] | undefined;
 	assetPaths: AssetPaths | undefined;
+	experimentalAssets: string | undefined;
 	vars: Record<string, string> | undefined;
 	defines: Record<string, string> | undefined;
 	alias: Record<string, string> | undefined;

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { findWranglerToml, readConfig } from "../config";
 import { getEntry } from "../deployment-bundle/entry";
 import { UserError } from "../errors";
+import { getExperimentalAssetsBasePath } from "../experimental-assets";
 import {
 	getRules,
 	getScriptName,
@@ -288,20 +289,31 @@ export async function deployHandler(
 		);
 	}
 
+	const experimentalAssetsBasePath = getExperimentalAssetsBasePath(
+		config,
+		args.experimentalAssets
+	);
+
 	if (
 		args.experimentalAssets &&
-		!existsSync(path.resolve(process.cwd(), args.experimentalAssets))
+		!existsSync(
+			path.resolve(experimentalAssetsBasePath, args.experimentalAssets)
+		)
 	) {
 		throw new UserError(
 			`The directory specified by the "--experimental-assets" command line argument does not exist:\n` +
-				`${path.resolve(process.cwd(), args.experimentalAssets)}`
+				`${path.resolve(experimentalAssetsBasePath, args.experimentalAssets)}`
 		);
 	} else {
-		config.experimental_assets?.forEach((x) => {
-			const assetDir = path.resolve(process.cwd(), x.directory);
+		config.experimental_assets?.forEach((assetConfig, index) => {
+			const assetDir = path.resolve(
+				experimentalAssetsBasePath,
+				assetConfig.directory
+			);
+
 			if (!existsSync(assetDir)) {
 				throw new UserError(
-					`The directory specified by the \`experimental_assets\` field in your configuration file does not exist:\n` +
+					`The directory specified by "experimental_assets[${index}]" in your configuration file does not exist:\n` +
 						`${assetDir}`
 				);
 			}

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -313,6 +313,8 @@ export async function deployHandler(
 					`${resolvedExperimentalAssetsPath}`
 			);
 		}
+
+		experimentalAssets.directory = resolvedExperimentalAssetsPath;
 	}
 
 	if (args.assets) {

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -38,6 +38,7 @@ export async function getEntry(
 		format?: CfScriptFormat | undefined;
 		legacyAssets?: string | undefined | boolean;
 		moduleRoot?: string;
+		experimentalAssets?: string;
 	},
 	config: Config,
 	command: "dev" | "deploy" | "types"
@@ -54,7 +55,12 @@ export async function getEntry(
 				? path.resolve(config.site?.["entry-point"])
 				: // site.entry-point could be a directory
 					path.resolve(config.site?.["entry-point"], "index.js");
-		} else if (args.legacyAssets || config.legacy_assets) {
+		} else if (
+			args.legacyAssets ||
+			config.legacy_assets ||
+			args.experimentalAssets ||
+			config.experimental_assets?.some((x) => x.directory)
+		) {
 			file = path.resolve(getBasePath(), "templates/no-op-worker.js");
 		} else {
 			throw new UserError(

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -59,7 +59,7 @@ export async function getEntry(
 			args.legacyAssets ||
 			config.legacy_assets ||
 			args.experimentalAssets ||
-			config.experimental_assets?.some((x) => x.directory)
+			config.experimental_assets?.directory
 		) {
 			file = path.resolve(getBasePath(), "templates/no-op-worker.js");
 		} else {

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -59,7 +59,7 @@ export async function getEntry(
 			args.legacyAssets ||
 			config.legacy_assets ||
 			args.experimentalAssets ||
-			config.experimental_assets?.directory
+			config.experimental_assets
 		) {
 			file = path.resolve(getBasePath(), "templates/no-op-worker.js");
 		} else {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -798,6 +798,7 @@ export async function startDev(args: StartDevOptions) {
 				);
 			}
 
+			experimentalAssets.directory = resolvedExperimentalAssetsPath;
 			args.forceLocal = true;
 		}
 

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import type { Config } from "./config";
+
+/**
+ * Returns the base path of the experimental assets to upload.
+ *
+ */
+export function getExperimentalAssetsBasePath(
+	config: Config,
+	experimentalAssetsDirectory: string | undefined
+): string {
+	return experimentalAssetsDirectory
+		? process.cwd()
+		: path.resolve(path.dirname(config.configPath ?? "wrangler.toml"));
+}


### PR DESCRIPTION
## What this PR solves / how to test

Add an experimental asset config key and flag.
Doesn't really do anything yet but should have appropriate validation.
See [WC-2389](https://jira.cfdata.org/browse/WC-2389)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: doesn't affect existing e2e tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: we don't want this on the docs yet

