### PR TITLE
Use the same workerName for all of the tests in e2e/dev-with-resources

### DIFF
--- a/packages/wrangler/e2e/c3-integration.test.ts
+++ b/packages/wrangler/e2e/c3-integration.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
@@ -14,7 +15,12 @@ describe("c3 integration", () => {
 	beforeAll(async () => {
 		const pathToC3 = path.resolve(__dirname, "../../create-cloudflare");
 		execSync("pnpm pack --pack-destination ./pack", { cwd: pathToC3 });
-		const version = execSync("ls pack", { encoding: "utf-8", cwd: pathToC3 });
+		const versions = execSync("ls -1 pack", {
+			encoding: "utf-8",
+			cwd: pathToC3,
+		});
+		const version = versions.trim().split("\n").at(-1); // get last version
+		assert(version);
 		c3Packed = path.join(pathToC3, "pack", version);
 	});
 
@@ -32,7 +38,7 @@ describe("c3 integration", () => {
 			env,
 		});
 
-		expect(init.stdout).toContain("APPLICATION CREATED");
+		expect(init.output).toContain("APPLICATION CREATED");
 
 		expect(existsSync(path.join(helper.tmpPath, workerName))).toBe(true);
 	});

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -7,14 +7,29 @@ import { fetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
+import { generateResourceName } from "./helpers/generate-resource-name";
 import { retry } from "./helpers/retry";
 import { seed as baseSeed, makeRoot } from "./helpers/setup";
+
+/**
+ * We use the same workerName for all of the tests in this suite in hopes of reducing flakes.
+ * When creating a new worker, a <workerName>.devprod-testing7928.workers.dev subdomain is created.
+ * The platform API locks a database table for the zone (devprod-testing7928.workers.dev) while doing this.
+ * Creating many workers in the same account/zone in quick succession can run up against the lock.
+ * This test suite runs sequentially so does not cause lock issues for itself, but we run into lock issues
+ * when multiple PRs have jobs running at the same time (or the same PR has the tests run across multiple OSes).
+ */
+const workerName = generateResourceName();
+/**
+ * Some tests require a 2nd worker to bind to. Let's create that here too.
+ */
+const workerName2 = generateResourceName();
 
 it("can import URL from 'url' in node_compat mode", async () => {
 	const helper = new WranglerE2ETestHelper();
 	await helper.seed({
 		"wrangler.toml": dedent`
-				name = "worker"
+				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				node_compat = true
@@ -50,7 +65,7 @@ describe.each([
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-							name = "worker"
+							name = "${workerName}"
 							main = "src/index.ts"
 							compatibility_date = "2023-01-01"
 							compatibility_flags = ["nodejs_compat"]
@@ -103,7 +118,7 @@ describe.each([
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-					name = "worker"
+					name = "${workerName}"
 					main = "index.py"
 					compatibility_date = "2023-01-01"
 					compatibility_flags = ["python_workers"]
@@ -156,7 +171,7 @@ describe.each([
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-					name = "worker"
+					name = "${workerName}"
 					main = "index.py"
 					compatibility_date = "2023-01-01"
 					compatibility_flags = ["python_workers"]
@@ -220,13 +235,13 @@ describe.each([
 		a = await makeRoot();
 		await baseSeed(a, {
 			"wrangler.toml": dedent`
-					name = "a"
+					name = "${workerName}"
 					main = "src/index.ts"
 					compatibility_date = "2023-01-01"
 
 					[[services]]
 					binding = "BEE"
-					service = 'b'
+					service = '${workerName2}'
 			`,
 			"src/index.ts": dedent/* javascript */ `
 				export default {
@@ -247,7 +262,7 @@ describe.each([
 		b = await makeRoot();
 		await baseSeed(b, {
 			"wrangler.toml": dedent`
-					name = "b"
+					name = "${workerName2}"
 					main = "src/index.ts"
 					compatibility_date = "2023-01-01"
 			`,
@@ -321,7 +336,7 @@ describe("hyperdrive dev tests", () => {
 		}
 		await helper.seed({
 			"wrangler.toml": dedent`
-					name = "worker"
+					name = "${workerName}"
 					main = "src/index.ts"
 					compatibility_date = "2023-10-25"
 
@@ -368,7 +383,7 @@ describe("hyperdrive dev tests", () => {
 		}
 		await helper.seed({
 			"wrangler.toml": dedent`
-					name = "worker"
+					name = "${workerName}"
 					main = "src/index.ts"
 					compatibility_date = "2023-10-25"
 
@@ -422,7 +437,7 @@ describe("hyperdrive dev tests", () => {
 		}
 		await helper.seed({
 			"wrangler.toml": dedent`
-					name = "worker"
+					name = "${workerName}"
 					main = "src/index.ts"
 					compatibility_date = "2023-10-25"
 
@@ -483,7 +498,7 @@ describe("queue dev tests", () => {
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-					name = "worker"
+					name = "${workerName}"
 					main = "src/index.ts"
 					compatibility_date = "2024-04-04"
 
@@ -520,7 +535,7 @@ describe("writes debug logs to hidden file", () => {
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-					name = "a"
+					name = "${workerName}"
 					main = "src/index.ts"
 					compatibility_date = "2023-01-01"
 				`,
@@ -557,7 +572,7 @@ describe("writes debug logs to hidden file", () => {
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-				name = "a"
+				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 			`,
@@ -590,7 +605,7 @@ describe("zone selection", () => {
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-				name = "worker"
+				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				compatibility_flags = ["nodejs_compat"]`,
@@ -621,7 +636,7 @@ describe("zone selection", () => {
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-				name = "worker"
+				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				compatibility_flags = ["nodejs_compat"]
@@ -657,7 +672,7 @@ describe("zone selection", () => {
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-				name = "worker"
+				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				compatibility_flags = ["nodejs_compat"]
@@ -695,7 +710,7 @@ describe("zone selection", () => {
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-				name = "worker"
+				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
 				compatibility_flags = ["nodejs_compat"]
@@ -731,7 +746,7 @@ describe("custom builds", () => {
 		const helper = new WranglerE2ETestHelper();
 		await helper.seed({
 			"wrangler.toml": dedent`
-						name = "worker"
+						name = "${workerName}"
 						compatibility_date = "2023-01-01"
 						main = "src/index.ts"
 						build.command = "echo 'hello'"

--- a/packages/wrangler/e2e/helpers/command.ts
+++ b/packages/wrangler/e2e/helpers/command.ts
@@ -32,7 +32,7 @@ export function runCommand(
 	{ cwd, env, timeout = DEFAULT_TIMEOUT }: CommandOptions = {}
 ) {
 	try {
-		const { status, stdout, stderr } = spawnSync(command, [], {
+		const { status, stdout, stderr, output } = spawnSync(command, [], {
 			shell: true,
 			cwd,
 			stdio: "pipe",
@@ -49,7 +49,12 @@ export function runCommand(
 				console.error(stderr);
 			}
 		}
-		return { status, stdout, stderr };
+		return {
+			status,
+			stdout,
+			stderr,
+			output: output.filter(Boolean).join("\n"),
+		};
 	} catch (e) {
 		if (isTimedOutError(e)) {
 			throw new Error(dedent`

--- a/packages/wrangler/e2e/helpers/command.ts
+++ b/packages/wrangler/e2e/helpers/command.ts
@@ -53,7 +53,7 @@ export function runCommand(
 			status,
 			stdout,
 			stderr,
-			output: output.filter(Boolean).join("\n"),
+			output: output.filter((line) => line !== null).join("\n"),
 		};
 	} catch (e) {
 		if (isTimedOutError(e)) {

--- a/packages/wrangler/e2e/helpers/read-until.ts
+++ b/packages/wrangler/e2e/helpers/read-until.ts
@@ -18,10 +18,14 @@ export async function readUntil(
 		while (true) {
 			const result = await Promise.race([reader.read(), timeoutPromise]);
 			if (result === TIMEOUT) {
-				throw new Error(`Timed out matching ${regExp}:\n${read()}`);
+				throw new Error(
+					`readUntil() timed out matching ${regExp} in output:\n${read()}`
+				);
 			}
 			if (result.done) {
-				throw new Error(`Exhausted matching ${regExp}:\n${read()}`);
+				throw new Error(
+					`readUntil() reached the end of the stream without matching ${regExp} in output:\n${read()}`
+				);
 			}
 			const match = result.value.match(regExp);
 			if (match !== null) {

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -1,11 +1,9 @@
 import dedent from "ts-dedent";
-import { chai, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
-
-chai.config.truncateThreshold = 1e6;
 
 function matchVersionId(stdout: string): string {
 	return stdout.match(/Version ID:\s+([a-f\d-]+)/)?.[1] as string;

--- a/packages/wrangler/e2e/vitest.config.mts
+++ b/packages/wrangler/e2e/vitest.config.mts
@@ -16,6 +16,9 @@ export default defineConfig({
 		reporters: ["verbose", "html"],
 		bail: 1,
 		chaiConfig: {
+			// this controls how much output is shown when expect(string).toContain(...) fails
+			// the default results in a very short, unhelpful string whereas we would like to
+			// see the full string to help figure out why the assertion failed
 			truncateThreshold: 1e6,
 		},
 	},

--- a/packages/wrangler/e2e/vitest.config.mts
+++ b/packages/wrangler/e2e/vitest.config.mts
@@ -15,5 +15,8 @@ export default defineConfig({
 		globalSetup: path.resolve(__dirname, "./validate-environment.ts"),
 		reporters: ["verbose", "html"],
 		bail: 1,
+		chaiConfig: {
+			truncateThreshold: 1e6,
+		},
 	},
 });


### PR DESCRIPTION
## What this PR solves / how to test

This PR changes e2e/dev-with-resources to use the same workerName for all of the tests in this suite in hopes of reducing flakes.

When creating a new worker, a `<workerName>.devprod-testing7928.workers.dev` subdomain is created. The platform API locks a database table for the zone (`devprod-testing7928.workers.dev`) while doing this.

Creating many workers in the same account/zone in quick succession can run up against the lock. This test suite runs sequentially so does not cause lock issues for itself, but we run into lock issues when multiple PRs have jobs running at the same time (or the same PR has the tests run across multiple OSes).

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: tests

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
