### PR TITLE
Add RayID to `wrangler login` debug message

### DIFF
--- a/.changeset/olive-walls-shake.md
+++ b/.changeset/olive-walls-shake.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: Add RayID to `wrangler login` error message displayed when a user hits a bot challenge page

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1285,7 +1285,7 @@ async function getJSONFromResponse(response: Response) {
 			);
 			if (text.match(/challenge-platform/)) {
 				logger.error(
-					"It looks like you might have hit a bot challenge page. This may be transient but if not, please contact Cloudflare to find out what can be done."
+					`It looks like you might have hit a bot challenge page. This may be transient but if not, please contact Cloudflare to find out what can be done. When you contact Cloudflare, please provide your Ray ID: ${response.headers.get("cf-ray")}`
 				);
 			}
 		}


### PR DESCRIPTION
## What this PR solves / how to test

Further debgging for https://github.com/cloudflare/workers-sdk/issues/3672. This PR adds the Ray ID to the error message printed by Wrangler, which can help when diagnosing these kinds of issues.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: change in messaging
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no e2e tests cover this code path
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: change in error messaging

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
