### PR TITLE
Add cloudchamber scopes to existing scopes instead of replacing them

### DIFF
--- a/.changeset/gorgeous-readers-move.md
+++ b/.changeset/gorgeous-readers-move.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add cloudchamber scope to existing scopes instead of replacing them.
+
+When using any cloudchamber command the cloudchamber scope will now be added to the existing scopes instead of replacing them.

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -369,9 +369,9 @@ const AllScopes = {
  *
  * "offline_access" is automatically included.
  */
-type Scope = keyof typeof AllScopes;
+export type Scope = keyof typeof AllScopes;
 
-let DefaultScopeKeys = Object.keys(DefaultScopes) as Scope[];
+export let DefaultScopeKeys = Object.keys(DefaultScopes) as Scope[];
 
 export function setLoginScopeKeys(scopes: Scope[]) {
 	DefaultScopeKeys = scopes;


### PR DESCRIPTION
When using any cloudchamber command this adds the cloudchamber scope, if not present, in addition to the existing scopes instead of replacing them.

## What this PR solves / how to test

Before this PR users had to re-auth when switching between cloudchamber/non-cloudchamber commands. This PR makes it so cloudchamber users only have to auth one additional time to add cloudchamber the cloudchamber scopes instead of every time they switch between cloudchamber/non-cloudchamber commands.

If the user isn't logged in and they run a cloudchamber command this also adds the defaultScopes + the cloudchamber scope as part of  that login.


## Author has addressed the following

- Tests
  - [ ] TODO (before merge): 
  - [ ] Included
  - [x] Not necessary because: changes which scopes are present only.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because: 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: This should be mostly transparent to users except they will no longer need to re-authenticate as often because cloudchamber was replacing existing scopes.
  
  
 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
