### PR TITLE
fix: Update copy for assets/legacy-assets flag and config key

### DIFF
--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -584,7 +584,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
 					  - [1mBehavior change[0m: \\"assets\\":
-					    The \`assets\` feature is experimental. We are going to be changing its behavior on August 15th.
+					    The \`assets\` feature is experimental. We are going to be changing its behavior after August 15th.
 					    Releases of wrangler after this date will no longer support current functionality.
 					    Please shift to \`legacy_assets\` to preserve the current functionality. "
 				`);

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -2260,7 +2260,7 @@ addEventListener('fetch', event => {});`
 
 
 				Note: Deployment ID has been renamed to Version ID. Deployment ID is present to maintain compatibility with the previous behavior of this command. This output will change in a future version of Wrangler. To learn more visit: https://developers.cloudflare.com/workers/configuration/versions-and-deployments",
-				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental. We are going to be changing the behavior of this experimental command on August 15th.[0m
+				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental. We are going to be changing the behavior of this experimental command after August 15th.[0m
 
 				  Releases of wrangler after this date will no longer support current functionality.
 				  Please shift to the --legacy-assets command to preserve the current functionality.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1329,7 +1329,7 @@ describe("wrangler dev", () => {
 				  "err": "",
 				  "info": "",
 				  "out": "",
-				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental. We are going to be changing the behavior of this experimental command on August 15th.[0m
+				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental. We are going to be changing the behavior of this experimental command after August 15th.[0m
 
 				  Releases of wrangler after this date will no longer support current functionality.
 				  Please shift to the --legacy-assets command to preserve the current functionality.

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -247,7 +247,7 @@ export function normalizeAndValidateConfig(
 		diagnostics,
 		rawConfig,
 		"assets",
-		`The \`assets\` feature is experimental. We are going to be changing its behavior on August 15th.\n` +
+		`The \`assets\` feature is experimental. We are going to be changing its behavior after August 15th.\n` +
 			`Releases of wrangler after this date will no longer support current functionality.\n` +
 			`Please shift to \`legacy_assets\` to preserve the current functionality. `,
 		false,

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -234,7 +234,7 @@ export async function deployHandler(
 
 	if (args.assets) {
 		logger.warn(
-			`The --assets argument is experimental. We are going to be changing the behavior of this experimental command on August 15th.\n` +
+			`The --assets argument is experimental. We are going to be changing the behavior of this experimental command after August 15th.\n` +
 				`Releases of wrangler after this date will no longer support current functionality.\n` +
 				`Please shift to the --legacy-assets command to preserve the current functionality.`
 		);

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -369,7 +369,7 @@ This is currently not supported 😭, but we think that we'll get it to work soo
 
 	if (args.assets) {
 		logger.warn(
-			`The --assets argument is experimental. We are going to be changing the behavior of this experimental command on August 15th.\n` +
+			`The --assets argument is experimental. We are going to be changing the behavior of this experimental command after August 15th.\n` +
 				`Releases of wrangler after this date will no longer support current functionality.\n` +
 				`Please shift to the --legacy-assets command to preserve the current functionality.`
 		);


### PR DESCRIPTION
## What this PR solves / how to test

This PR changes the copy for `assets` and `legacy-assets` flags & config keys from `We are going to be changing its behavior on August 15th.` to `We are going to be changing its behavior after August 15th.`

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: copy change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because: copy change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: copy change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
