### PR TITLE
fix: only warn about miniflare feature support (ai, vectorize, cron) once

### DIFF
--- a/.changeset/lemon-items-type.md
+++ b/.changeset/lemon-items-type.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: only warn about miniflare feature support (ai, vectorize, cron) once
+
+We have some warnings in local mode dev when trying to use ai bindings / vectorize / cron, but they are printed every time the worker is started. This PR changes the warning to only be printed once per worker start.

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -798,6 +798,10 @@ export function handleRuntimeStdio(stdout: Readable, stderr: Readable) {
 	});
 }
 
+let didWarnMiniflareCronSupport = false;
+let didWarnMiniflareVectorizeSupport = false;
+let didWarnAiAccountUsage = false;
+
 export async function buildMiniflareOptions(
 	log: Log,
 	config: Omit<ConfigBundle, "rules">,
@@ -808,20 +812,29 @@ export async function buildMiniflareOptions(
 	entrypointNames: string[];
 }> {
 	if (config.crons.length > 0) {
-		logger.warn("Miniflare 3 does not support CRON triggers yet, ignoring...");
+		if (!didWarnMiniflareCronSupport) {
+			didWarnMiniflareCronSupport = true;
+			log.warn("Miniflare 3 does not support CRON triggers yet, ignoring...");
+		}
 	}
 
 	if (config.bindings.ai) {
-		logger.warn(
-			"Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development."
-		);
+		if (!didWarnAiAccountUsage) {
+			didWarnAiAccountUsage = true;
+			logger.warn(
+				"Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development."
+			);
+		}
 	}
 
 	if (config.bindings.vectorize?.length) {
-		// TODO: add local support for Vectorize bindings (https://github.com/cloudflare/workers-sdk/issues/4360)
-		logger.warn(
-			"Vectorize bindings are not currently supported in local mode. Please use --remote if you are working with them."
-		);
+		if (!didWarnMiniflareVectorizeSupport) {
+			didWarnMiniflareVectorizeSupport = true;
+			// TODO: add local support for Vectorize bindings (https://github.com/cloudflare/workers-sdk/issues/4360)
+			logger.warn(
+				"Vectorize bindings are not currently supported in local mode. Please use --remote if you are working with them."
+			);
+		}
 	}
 
 	const upstream =


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/82cf3084-abac-4c0d-bfc7-793d45ff2fb4)


We have some warnings in local mode dev when trying to use ai bindings / vectorize / cron, but they are printed every time the worker is started. This PR changes the warning to only be printed once per worker start.


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: a simple dx tweak
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no functional change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: no functional changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
