### PR TITLE
fix: let wrangler dev try to startup on stackblitz in remote mode

### DIFF
--- a/.changeset/dry-roses-rule.md
+++ b/.changeset/dry-roses-rule.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: let wrangler dev try to startup on stackblitz in remote mode
+
+Trying to get wrangler dev's remote mode working on stackblitz, but there's a hard exit whenever it detects that it's runnin in a webcontainer. This patch lets it run if it's running in remote mode.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -349,7 +349,7 @@ type DevArguments = StrictYargsOptionsToInterface<typeof devOptions>;
 export async function devHandler(args: DevArguments) {
 	await printWranglerBanner();
 
-	if (isWebContainer()) {
+	if (!args.remote && isWebContainer()) {
 		logger.error(
 			`Oh no! 😟 You tried to run \`wrangler dev\` in a StackBlitz WebContainer. 🤯
 This is currently not supported 😭, but we think that we'll get it to work soon... hang in there! 🥺`


### PR DESCRIPTION
Trying to get wrangler dev's remote mode working on stackblitz, but there's a hard exit whenever it detects that it's runnin in a webcontainer. This patch lets it run if it's running in remote mode.


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: maybe later after we get it actually working 
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no functional change in supported environments 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: no functional change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
