### PR TITLE
fix(wrangler): Add extra `experimental_assets` validation

### DIFF
--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -1799,7 +1799,7 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasWarnings()).toBeFalsy();
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - Expected \\"experimental_assets.directory\\" cannot be an empty string."
+					  - Expected \\"experimental_assets.directory\\" to be a non-empty string."
 				`);
 			});
 		});

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -1781,6 +1781,27 @@ describe("normalizeAndValidateConfig()", () => {
 					  - Expected \\"experimental_assets.binding\\" to be of type string but got 2."
 				`);
 			});
+
+			it("should error if `directory` is an empty string", () => {
+				const expectedConfig = {
+					experimental_assets: {
+						directory: "",
+					},
+				};
+
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					expectedConfig as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(config).toEqual(expect.objectContaining(expectedConfig));
+				expect(diagnostics.hasWarnings()).toBeFalsy();
+				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Expected \\"experimental_assets.directory\\" cannot be an empty string."
+				`);
+			});
 		});
 
 		describe("[browser]", () => {

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -232,6 +232,27 @@ export const isString: ValidatorFn = (diagnostics, field, value) => {
 };
 
 /**
+ * Validate that the field is a non-empty string.
+ */
+export const isNonEmptyString: ValidatorFn = (diagnostics, field, value) => {
+	if (value !== undefined && typeof value !== "string") {
+		diagnostics.errors.push(
+			`Expected "${field}" to be of type string but got ${JSON.stringify(
+				value
+			)}.`
+		);
+		return false;
+	}
+
+	if (value?.trim() === "") {
+		diagnostics.errors.push(`Expected "${field}" cannot be an empty string.`);
+		return false;
+	}
+
+	return true;
+};
+
+/**
  * Validate that the `name` field is compliant with EWC constraints.
  */
 export const isValidName: ValidatorFn = (diagnostics, field, value) => {

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -234,18 +234,18 @@ export const isString: ValidatorFn = (diagnostics, field, value) => {
 /**
  * Validate that the field is a non-empty string.
  */
-export const isNonEmptyString: ValidatorFn = (diagnostics, field, value) => {
-	if (value !== undefined && typeof value !== "string") {
-		diagnostics.errors.push(
-			`Expected "${field}" to be of type string but got ${JSON.stringify(
-				value
-			)}.`
-		);
+export const isNonEmptyString: ValidatorFn = (
+	diagnostics,
+	field,
+	value,
+	topLevelEnv
+) => {
+	if (!isString(diagnostics, field, value, topLevelEnv)) {
 		return false;
 	}
 
-	if (value?.trim() === "") {
-		diagnostics.errors.push(`Expected "${field}" cannot be an empty string.`);
+	if ((value as string)?.trim() === "") {
+		diagnostics.errors.push(`Expected "${field}" to be a non-empty string.`);
 		return false;
 	}
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -14,6 +14,7 @@ import {
 	inheritableInLegacyEnvironments,
 	isBoolean,
 	isMutuallyExclusiveWith,
+	isNonEmptyString,
 	isObjectWith,
 	isOneOf,
 	isOptionalProperty,
@@ -2060,6 +2061,14 @@ const validateAssetsConfig: ValidatorFn = (diagnostics, field, value) => {
 			"directory",
 			(value as ExperimentalAssets).directory,
 			"string"
+		) && isValid;
+
+	isValid =
+		isNonEmptyString(
+			diagnostics,
+			`${field}.directory`,
+			(value as ExperimentalAssets).directory,
+			undefined
 		) && isValid;
 
 	isValid =

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -7,9 +7,9 @@ import type { Config } from "./config";
  */
 export function getExperimentalAssetsBasePath(
 	config: Config,
-	experimentalAssetsDirectory: string | undefined
+	experimentalAssetsCommandLineArg: string | undefined
 ): string {
-	return experimentalAssetsDirectory
+	return experimentalAssetsCommandLineArg
 		? process.cwd()
 		: path.resolve(path.dirname(config.configPath ?? "wrangler.toml"));
 }


### PR DESCRIPTION
## What this PR solves / how to test

This commit adds an extra validation rule for the `experimental_assets` config key, that should prevent `directory` brom being an empty string.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: config validation change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: config validation change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: config validation change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
