### PR TITLE
chore: downgrade the action to v3 for reading artifacts

### DIFF
--- a/.github/actions/create-c3-docs-pr/action.yml
+++ b/.github/actions/create-c3-docs-pr/action.yml
@@ -61,7 +61,7 @@ runs:
         git checkout -b "c3-diffs-${{ github.sha }}"
 
     - name: Download Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: e2e-framework-diffs
         path: ./clone-dir/content/pages/_partials/framework-diffs/


### PR DESCRIPTION
Attempt two to fix the release script, which keeps breaking the C3 diff PR generation.
(Previously we tried to update the upload action to v4; now we update the download action to v3.