### PR TITLE
try improve fixture flakiness due to unstable_dev

### DIFF
--- a/.changeset/flat-bears-scream.md
+++ b/.changeset/flat-bears-scream.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: implicitly cleanup (call `stop()`) in `unstable_dev` if the returned Promise rejected and the `stop()` function was not returned

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
@@ -374,6 +374,7 @@ async function startWorkers(): Promise<UnstableDevWorker[]> {
 				ip: "127.0.0.1",
 				experimental: {
 					devEnv: true,
+					fileBasedRegistry: true,
 				},
 			});
 		})

--- a/fixtures/local-mode-tests/tests/module.test.ts
+++ b/fixtures/local-mode-tests/tests/module.test.ts
@@ -20,6 +20,7 @@ describe("module worker", () => {
 				config: path.resolve(__dirname, "..", "wrangler.module.toml"),
 				vars: { VAR4: "https://google.com" },
 				ip: "127.0.0.1",
+				port: 0,
 				experimental: {
 					disableExperimentalWarning: true,
 					disableDevRegistry: true,
@@ -57,74 +58,72 @@ describe("module worker", () => {
 			}"
 		`);
 	});
-	describe("header parsing", () => {
-		it.concurrent("should return Hi by default", async () => {
-			const resp = await worker.fetch("/");
-			expect(resp).not.toBe(undefined);
-			const respJson = await resp.text();
-			expect(respJson).toBe(JSON.stringify({ greeting: "Hi!" }));
-		});
-		it.concurrent("should return Bonjour when French", async () => {
-			const resp = await worker.fetch("/", { headers: { lang: "fr-FR" } });
-			expect(resp).not.toBe(undefined);
-			if (resp) {
-				const respJson = await resp.text();
-				expect(respJson).toBe(JSON.stringify({ greeting: "Bonjour!" }));
-			}
-		});
 
-		it.concurrent("should return G'day when Australian", async () => {
-			const resp = await worker.fetch("/", { headers: { lang: "en-AU" } });
-			expect(resp).not.toBe(undefined);
-			if (resp) {
-				const respJson = await resp.text();
-				expect(respJson).toBe(JSON.stringify({ greeting: "G'day!" }));
-			}
-		});
-
-		it.concurrent("should return Good day when British", async () => {
-			const resp = await worker.fetch("/", { headers: { lang: "en-GB" } });
-			expect(resp).not.toBe(undefined);
-			if (resp) {
-				const respJson = await resp.text();
-				expect(respJson).toBe(JSON.stringify({ greeting: "Good day!" }));
-			}
-		});
-
-		it.concurrent("should return Howdy when Texan", async () => {
-			const resp = await worker.fetch("/", { headers: { lang: "en-TX" } });
-			expect(resp).not.toBe(undefined);
-			if (resp) {
-				const respJson = await resp.text();
-				expect(respJson).toBe(JSON.stringify({ greeting: "Howdy!" }));
-			}
-		});
-
-		it.concurrent("should return Hello when American", async () => {
-			const resp = await worker.fetch("/", { headers: { lang: "en-US" } });
-			expect(resp).not.toBe(undefined);
-			if (resp) {
-				const respJson = await resp.text();
-				expect(respJson).toBe(JSON.stringify({ greeting: "Hello!" }));
-			}
-		});
-
-		it.concurrent("should return Hola when Spanish", async () => {
-			const resp = await worker.fetch("/", { headers: { lang: "es-ES" } });
-			expect(resp).not.toBe(undefined);
-			if (resp) {
-				const respJson = await resp.text();
-				expect(respJson).toBe(JSON.stringify({ greeting: "Hola!" }));
-			}
-		});
+	it("should return Hi by default", async () => {
+		const resp = await worker.fetch("/");
+		expect(resp).not.toBe(undefined);
+		const respJson = await resp.text();
+		expect(respJson).toBe(JSON.stringify({ greeting: "Hi!" }));
 	});
-	describe("buffer import", () => {
-		it.concurrent("returns hex string", async () => {
-			const resp = await worker.fetch("/buffer");
-			expect(resp).not.toBe(undefined);
+	it("should return Bonjour when French", async () => {
+		const resp = await worker.fetch("/", { headers: { lang: "fr-FR" } });
+		expect(resp).not.toBe(undefined);
+		if (resp) {
+			const respJson = await resp.text();
+			expect(respJson).toBe(JSON.stringify({ greeting: "Bonjour!" }));
+		}
+	});
 
-			const text = await resp.text();
-			expect(text).toMatch("68656c6c6f");
-		});
+	it("should return G'day when Australian", async () => {
+		const resp = await worker.fetch("/", { headers: { lang: "en-AU" } });
+		expect(resp).not.toBe(undefined);
+		if (resp) {
+			const respJson = await resp.text();
+			expect(respJson).toBe(JSON.stringify({ greeting: "G'day!" }));
+		}
+	});
+
+	it("should return Good day when British", async () => {
+		const resp = await worker.fetch("/", { headers: { lang: "en-GB" } });
+		expect(resp).not.toBe(undefined);
+		if (resp) {
+			const respJson = await resp.text();
+			expect(respJson).toBe(JSON.stringify({ greeting: "Good day!" }));
+		}
+	});
+
+	it("should return Howdy when Texan", async () => {
+		const resp = await worker.fetch("/", { headers: { lang: "en-TX" } });
+		expect(resp).not.toBe(undefined);
+		if (resp) {
+			const respJson = await resp.text();
+			expect(respJson).toBe(JSON.stringify({ greeting: "Howdy!" }));
+		}
+	});
+
+	it("should return Hello when American", async () => {
+		const resp = await worker.fetch("/", { headers: { lang: "en-US" } });
+		expect(resp).not.toBe(undefined);
+		if (resp) {
+			const respJson = await resp.text();
+			expect(respJson).toBe(JSON.stringify({ greeting: "Hello!" }));
+		}
+	});
+
+	it("should return Hola when Spanish", async () => {
+		const resp = await worker.fetch("/", { headers: { lang: "es-ES" } });
+		expect(resp).not.toBe(undefined);
+		if (resp) {
+			const respJson = await resp.text();
+			expect(respJson).toBe(JSON.stringify({ greeting: "Hola!" }));
+		}
+	});
+
+	it("returns hex string", async () => {
+		const resp = await worker.fetch("/buffer");
+		expect(resp).not.toBe(undefined);
+
+		const text = await resp.text();
+		expect(text).toMatch("68656c6c6f");
 	});
 });


### PR DESCRIPTION
## What this PR solves / how to test

This PR includes changes to fixture tests (notoriously flakey fixtures: `get-platform-proxy`, `local-mode-tests`) to make them more stable, including:
- use `fileBasedRegistry: true` in `get-platform-proxy` (hypothesis: only flakey because of the dev registry)
- use `port: 0` in `local-mode-tests` module.test.ts
- ensure `unstable_dev` cleans up `local-mode-tests` logging.test.ts (which expects it to fail – this may have affected other tests running after)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: fixture tests exist for unstable_dev
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
