### PR TITLE
fix(C3): make sure to always warn developers trying to use git when their git instance is not properly configured

### DIFF
--- a/.changeset/slimy-mangos-punch.md
+++ b/.changeset/slimy-mangos-punch.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: make sure to always warn developers trying to use git when their git instance is not properly configured

--- a/packages/create-cloudflare/src/__tests__/git.test.ts
+++ b/packages/create-cloudflare/src/__tests__/git.test.ts
@@ -149,8 +149,8 @@ describe("git helpers", () => {
 		test("happy path", async () => {
 			const ctx = createTestContext();
 			mockGitInstalled(true);
-			mockGitConfig();
 			mockInsideGitRepo(false);
+			mockGitConfig();
 			mockDefaultBranchName();
 
 			// Mock user selecting true

--- a/packages/create-cloudflare/src/git.ts
+++ b/packages/create-cloudflare/src/git.ts
@@ -26,21 +26,6 @@ export const offerGit = async (ctx: C3Context) => {
 		return; // bail early
 	}
 
-	const gitConfigured = await isGitConfigured();
-	if (!gitConfigured) {
-		// haven't prompted yet, if provided as --git arg
-		if (ctx.args.git) {
-			updateStatus(
-				"Must configure `user.name` and user.email` to use git. Continuing without git.",
-			);
-		}
-
-		// override true (--git flag) and undefined (not prompted yet) to false (don't use git)
-		ctx.args.git = false;
-
-		return; // bail early
-	}
-
 	const insideGitRepo = await isInsideGitRepo(ctx.project.path);
 
 	if (insideGitRepo) {
@@ -55,9 +40,22 @@ export const offerGit = async (ctx: C3Context) => {
 		defaultValue: C3_DEFAULTS.git,
 	});
 
-	if (ctx.args.git) {
-		await initializeGit(ctx.project.path);
+	if (!ctx.args.git) {
+		return;
 	}
+
+	const gitConfigured = await isGitConfigured();
+	if (!gitConfigured) {
+		updateStatus(
+			"Must configure `user.name` and user.email` to use git. Continuing without git.",
+		);
+
+		// override ctx.args.git to false (don't use git)
+		ctx.args.git = false;
+		return;
+	}
+
+	await initializeGit(ctx.project.path);
 };
 
 export const gitCommit = async (ctx: C3Context) => {


### PR DESCRIPTION
## What this PR solves / how to test

Currently in C3 if someone has git installed but not properly configured, C3 will simply skip
the git initialization, a more clear workflow would be to actually still offer git but warn (and skip it)
in case they don't have it properly configured, that's what this PR is introducing:
![Screenshot 2024-07-30 at 16 42 43](https://github.com/user-attachments/assets/af539168-1529-4581-947d-9f4563dc937c)

> [!NOTE]
> This is quite an edge case for people not too accustomed with git, and it unlikely to effect most C3 users


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because: we don't currently test the git integration in C3
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: not something that needs documentation
