### PR TITLE
Push workflows branch to npm

### DIFF
--- a/.github/workflows/prerelease-workflows.yml
+++ b/.github/workflows/prerelease-workflows.yml
@@ -1,0 +1,38 @@
+name: Workflows
+on:
+  push:
+    branches:
+      - workflows
+
+jobs:
+  release:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Check for errors
+        run: pnpm run check
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
+
+      - name: Modify package.json version
+        run: node .github/version-script.js
+
+      - name: Publish to NPM
+        run: pnpm publish --tag workflows
+        env:
+          NODE_ENV: "production"
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        working-directory: packages/wrangler

--- a/.github/workflows/prerelease-workflows.yml
+++ b/.github/workflows/prerelease-workflows.yml
@@ -1,4 +1,4 @@
-name: Workflows
+name: Prerelease Workflows
 on:
   push:
     branches:


### PR DESCRIPTION
This adds a GitHub Action to deploy the (experimental and work in progress) https://github.com/cloudflare/workers-sdk/pull/6372 PR to a named npm release tagged `workflows`