### PR TITLE
Update Workers Sites/Legacy Assets error message in versions commands

### DIFF
--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -546,7 +546,7 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 		);
 
 		expect(normalize(upload.output)).toMatchInlineSnapshot(`
-			"X [ERROR] Legacy Assets are not supported in Gradual Deployments.
+			"X [ERROR] Legacy Assets does not support uploading versions through \`wrangler versions upload\`. You must use \`wrangler deploy\` instead.
 			🪵  Logs were written to "<LOG>""
 		`);
 	});
@@ -580,7 +580,7 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 		const upload = await helper.run(`wrangler versions upload  --x-versions`);
 
 		expect(normalize(upload.output)).toMatchInlineSnapshot(`
-			"X [ERROR] Workers Sites are not supported in Gradual Deployments.
+			"X [ERROR] Workers Sites does not support uploading versions through \`wrangler versions upload\`. You must use \`wrangler deploy\` instead.
 			🪵  Logs were written to "<LOG>""
 		`);
 	});

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -219,12 +219,12 @@ export async function versionsUploadHandler(
 
 	if (args.site || config.site) {
 		throw new UserError(
-			"Workers Sites are not supported in Gradual Deployments."
+			"Workers Sites does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead."
 		);
 	}
 	if (args.legacyAssets || config.legacy_assets) {
 		throw new UserError(
-			"Legacy Assets are not supported in Gradual Deployments."
+			"Legacy Assets does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead."
 		);
 	}
 

--- a/packages/wrangler/src/versions/secrets/index.ts
+++ b/packages/wrangler/src/versions/secrets/index.ts
@@ -254,7 +254,7 @@ async function parseModules(
 		// Workers Sites is not supported
 		if (formData.get("__STATIC_CONTENT_MANIFEST") !== null) {
 			throw new UserError(
-				"Workers Sites is not supported for `versions secret put` today."
+				"Workers Sites and Legacy Assets do not support updating secrets through `wrangler versions secret put`. You must use `wrangler secret put` instead."
 			);
 		}
 


### PR DESCRIPTION
## What this PR solves / how to test

Updating the copy merged in https://github.com/cloudflare/workers-sdk/pull/6379 which has not been released yet so no ned for a changeset

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
