### PR TITLE
Create manually triggered Github Action for running CI on behalf of forks

### DIFF
--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -1,0 +1,25 @@
+# This workflow cleans up any leftover projects created by e2e runs.
+
+name: Run CI on behalf of External Forks
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "The PR number to run CI on behalf of"
+        required: true
+      reviewed:
+        description: "Confirm that the PR has been reviewed for use/leakage of secrets"
+        type: boolean
+        required: true
+jobs:
+  create-draft-pr:
+    if: ${{ inputs.reviewed == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout PR"
+        run: gh pr checkout ${{ inputs.pr-number }}
+      - name: "Create Draft PR"
+        run: git checkout -b run-ci-on-hehalf-of-${{ inputs.pr-number }}
+          gh pr create --draft --title "Run CI on behalf of \#${{ inputs.pr-number }}" --body "This PR is created to run CI on behalf of \#${{ inputs.pr-number }}. It can be closed after the CI run is complete."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -16,10 +16,24 @@ jobs:
     if: ${{ inputs.reviewed == true }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check user for team affiliation
+        uses: tspascoal/get-user-teams-membership@v2
+        id: teamAffiliation
+        with:
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          username: ${{ github.actor }}
+          team: wrangler
+      - name: Stop workflow if user is no member
+        if: ${{ steps.teamAffiliation.outputs.isTeamMember == false }}
+        run: |
+          echo "You have must be on the "wrangler" team to trigger this job."
+          exit 1
+
       - name: "Checkout PR"
         run: gh pr checkout ${{ inputs.pr-number }}
+
       - name: "Create Draft PR"
         run: git checkout -b run-ci-on-hehalf-of-${{ inputs.pr-number }}
-          gh pr create --draft --title "Run CI on behalf of \#${{ inputs.pr-number }}" --body "This PR is created to run CI on behalf of \#${{ inputs.pr-number }}. It can be closed after the CI run is complete."
+          gh pr create --draft --label "e2e" --title "Run CI on behalf of \#${{ inputs.pr-number }}" --body "This PR is created to run CI on behalf of \#${{ inputs.pr-number }}. It can be closed after the CI run is complete."
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR introduces a GIthub Action which can be triggered manually to clone a fork to a new branch and open a draft PR with the "e2e" label which will (hopefully) run the e2e jobs.

Inputs:
- PR number `type: string` (the PR to clone from) 
- Reviewed `type: boolean` (to confirm the user has reviewed the PR for usage/leakage of secrets)

Also:
- The user triggering the action is enforced to be on the `wrangler` team