### PR TITLE
feat(miniflare): Implement KV/Assets plugin and Workers Assets simulator

### DIFF
--- a/.changeset/eight-terms-beg.md
+++ b/.changeset/eight-terms-beg.md
@@ -1,0 +1,8 @@
+---
+"miniflare": minor
+"@cloudflare/workers-shared": minor
+---
+
+feat: Extend KV plugin behaviour to support Workers assets
+
+This commit extends Miniflare's KV plugin's behaviour to support Workers assets, and therefore enables the emulation of Workers with assets in local development.

--- a/fixtures/workers-with-assets/public/about/index.html
+++ b/fixtures/workers-with-assets/public/about/index.html
@@ -1,0 +1,1 @@
+<p>Learn more about Workers with Assets soon!</p>

--- a/fixtures/workers-with-assets/public/index.html
+++ b/fixtures/workers-with-assets/public/index.html
@@ -1,1 +1,1 @@
-<h1>Hello Workers + Assets World!</h1>
+<h1>Hello Workers + Assets World 🚀!</h1>

--- a/fixtures/workers-with-assets/tests/index.test.ts
+++ b/fixtures/workers-with-assets/tests/index.test.ts
@@ -17,10 +17,22 @@ describe("[Workers + Assets] `wrangler dev`", () => {
 		await stop?.();
 	});
 
-	it("renders ", async ({ expect }) => {
-		const response = await fetch(`http://${ip}:${port}/`);
-		const text = await response.text();
+	it("should respond with static asset content", async ({ expect }) => {
+		let response = await fetch(`http://${ip}:${port}/index.html`);
+		let text = await response.text();
 		expect(response.status).toBe(200);
-		expect(text).toContain(`Hello from Asset Server Worker 🚀`);
+		expect(text).toContain(`<h1>Hello Workers + Assets World 🚀!</h1>`);
+
+		response = await fetch(`http://${ip}:${port}/about/index.html`);
+		text = await response.text();
+		expect(response.status).toBe(200);
+		expect(text).toContain(`<p>Learn more about Workers with Assets soon!</p>`);
+	});
+
+	it("should not resolve '/' to '/index.html' ", async ({ expect }) => {
+		let response = await fetch(`http://${ip}:${port}/`);
+		let text = await response.text();
+		expect(response.status).toBe(404);
+		expect(text).toContain("Not Found");
 	});
 });

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -528,6 +528,16 @@ parameter in module format Workers.
   If set, only files with paths _not_ matching these glob patterns will be
   served.
 
+  - `assetsPath?: string`
+
+  Path to serve Workers assets from.
+
+  - `assetsKVBindingName?: string`
+    Name of the binding to the KV namespace that the assets are in. If `assetsPath` is set, this binding will be injected into this Worker.
+
+  - `assetsManifestBindingName?: string`
+    Name of the binding to an `ArrayBuffer` containing the binary-encoded assets manifest. If `assetsPath` is set, this binding will be injected into this Worker.
+
 #### R2
 
 - `r2Buckets?: Record<string, string> | string[]`

--- a/packages/miniflare/src/plugins/kv/assets.ts
+++ b/packages/miniflare/src/plugins/kv/assets.ts
@@ -1,0 +1,99 @@
+import { KVOptionsSchema } from "miniflare";
+import SCRIPT_KV_ASSETS from "worker:kv/assets";
+import { z } from "zod";
+import { Service, Worker_Binding } from "../../runtime";
+import { getAssetsBindingsNames, SharedBindings } from "../../workers";
+import { kProxyNodeBinding } from "../shared";
+import { KV_PLUGIN_NAME } from "./constants";
+
+export interface AssetsOptions {
+	assetsPath: string;
+	assetsKVBindingName?: string;
+	assetsManifestBindingName?: string;
+}
+
+export function isWorkersWithAssets(
+	options: z.infer<typeof KVOptionsSchema>
+): options is AssetsOptions {
+	return options.assetsPath !== undefined;
+}
+
+const SERVICE_NAMESPACE_ASSET = `${KV_PLUGIN_NAME}:asset`;
+
+export function buildAssetsManifest(): Uint8Array {
+	const buffer = new ArrayBuffer(20);
+	const assetManifest = new Uint8Array(buffer); // [0, 0, 0, ..., 0, 0]
+	// this will signal to Asset Server Worker that its running in a
+	// local dev "context"
+	assetManifest.set([1], 0); // [1, 0, 0, ..., 0, 0]
+
+	return assetManifest;
+}
+
+export async function getAssetsBindings(
+	options: AssetsOptions
+): Promise<Worker_Binding[]> {
+	const assetsBindings = getAssetsBindingsNames(
+		options?.assetsKVBindingName,
+		options?.assetsManifestBindingName
+	);
+
+	const assetsManifest = buildAssetsManifest();
+
+	return [
+		{
+			// this is the binding to the KV namespace that the assets are in.
+			name: assetsBindings.ASSETS_KV_NAMESPACE,
+			kvNamespace: { name: SERVICE_NAMESPACE_ASSET },
+		},
+		{
+			// this is the binding to an ArrayBuffer containing the binary-encoded
+			// assets manifest.
+			name: assetsBindings.ASSETS_MANIFEST,
+			data: assetsManifest,
+		},
+	];
+}
+
+export async function getAssetsNodeBindings(
+	options: AssetsOptions
+): Promise<Record<string, unknown>> {
+	const assetsManifest = buildAssetsManifest();
+	const assetsBindings = getAssetsBindingsNames(
+		options?.assetsKVBindingName,
+		options?.assetsManifestBindingName
+	);
+
+	return {
+		[assetsBindings.ASSETS_KV_NAMESPACE]: kProxyNodeBinding,
+		[assetsBindings.ASSETS_MANIFEST]: assetsManifest,
+	};
+}
+
+export function getAssetsServices(options: AssetsOptions): Service[] {
+	const storageServiceName = `${SERVICE_NAMESPACE_ASSET}:storage`;
+	const storageService: Service = {
+		name: storageServiceName,
+		disk: { path: options.assetsPath, writable: true },
+	};
+	const namespaceService: Service = {
+		name: SERVICE_NAMESPACE_ASSET,
+		worker: {
+			compatibilityDate: "2023-07-24",
+			compatibilityFlags: ["nodejs_compat"],
+			modules: [
+				{
+					name: "assets.worker.js",
+					esModule: SCRIPT_KV_ASSETS(),
+				},
+			],
+			bindings: [
+				{
+					name: SharedBindings.MAYBE_SERVICE_BLOBS,
+					service: { name: storageServiceName },
+				},
+			],
+		},
+	};
+	return [storageService, namespaceService];
+}

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -20,6 +20,12 @@ import {
 	Plugin,
 	SERVICE_LOOPBACK,
 } from "../shared";
+import {
+	getAssetsBindings,
+	getAssetsNodeBindings,
+	getAssetsServices,
+	isWorkersWithAssets,
+} from "./assets";
 import { KV_PLUGIN_NAME } from "./constants";
 import {
 	getSitesBindings,
@@ -30,6 +36,11 @@ import {
 
 export const KVOptionsSchema = z.object({
 	kvNamespaces: z.union([z.record(z.string()), z.string().array()]).optional(),
+
+	// Workers + Assets
+	assetsPath: PathSchema.optional(),
+	assetsKVBindingName: z.string().optional(),
+	assetsManifestBindingName: z.string().optional(),
 
 	// Workers Sites
 	sitePath: PathSchema.optional(),
@@ -71,18 +82,29 @@ export const KV_PLUGIN: Plugin<
 			bindings.push(...(await getSitesBindings(options)));
 		}
 
+		if (isWorkersWithAssets(options)) {
+			bindings.push(...(await getAssetsBindings(options)));
+		}
+
 		return bindings;
 	},
+
 	async getNodeBindings(options) {
 		const namespaces = namespaceKeys(options.kvNamespaces);
 		const bindings = Object.fromEntries(
 			namespaces.map((name) => [name, kProxyNodeBinding])
 		);
+
 		if (isWorkersSitesEnabled(options)) {
 			Object.assign(bindings, await getSitesNodeBindings(options));
 		}
+
+		if (isWorkersWithAssets(options)) {
+			Object.assign(bindings, await getAssetsNodeBindings(options));
+		}
 		return bindings;
 	},
+
 	async getServices({
 		options,
 		sharedOptions,
@@ -151,8 +173,13 @@ export const KV_PLUGIN: Plugin<
 			services.push(...getSitesServices(options));
 		}
 
+		if (isWorkersWithAssets(options)) {
+			services.push(...getAssetsServices(options));
+		}
+
 		return services;
 	},
+
 	getPersistPath({ kvPersist }, tmpPath) {
 		return getPersistPath(KV_PLUGIN_NAME, tmpPath, kvPersist);
 	},

--- a/packages/miniflare/src/workers/kv/assets.worker.ts
+++ b/packages/miniflare/src/workers/kv/assets.worker.ts
@@ -1,0 +1,33 @@
+import { SharedBindings } from "miniflare:shared";
+import { KVParams } from "./constants";
+
+interface Env {
+	[SharedBindings.MAYBE_SERVICE_BLOBS]: Fetcher;
+}
+
+export default <ExportedHandler<Env>>{
+	async fetch(request, env) {
+		// Only permit reads
+		if (request.method !== "GET") {
+			const message = `Cannot ${request.method.toLowerCase()}() with Workers Assets namespace`;
+			return new Response(message, { status: 405, statusText: message });
+		}
+
+		// Decode key
+		const url = new URL(request.url);
+		let key = url.pathname.substring(1); // Strip leading "/"
+
+		if (url.searchParams.get(KVParams.URL_ENCODED)?.toLowerCase() === "true") {
+			key = decodeURIComponent(key);
+		}
+
+		const blobsService = env[SharedBindings.MAYBE_SERVICE_BLOBS];
+		if (key === "" || key === "/") {
+			return new Response("Not Found", {
+				status: 404,
+			});
+		} else {
+			return blobsService.fetch(new URL(key, "http://placeholder"));
+		}
+	},
+};

--- a/packages/miniflare/src/workers/kv/constants.ts
+++ b/packages/miniflare/src/workers/kv/constants.ts
@@ -45,6 +45,7 @@ export function decodeSitesKey(key: string): string {
 		? decodeURIComponent(key.substring(SITES_NO_CACHE_PREFIX.length))
 		: key;
 }
+
 export function isSitesRequest(request: { url: string }) {
 	const url = new URL(request.url);
 	return url.pathname.startsWith(`/${SITES_NO_CACHE_PREFIX}`);
@@ -115,4 +116,18 @@ export function testSiteRegExps(
 	// Either exclude globs undefined, or name doesn't match them
 	if (regExps.exclude !== undefined) return !testRegExps(regExps.exclude, key);
 	return true;
+}
+
+export function getAssetsBindingsNames(
+	// __STATIC_CONTENT and __STATIC_CONTENT_MANIFEST binding names are
+	// reserved for Workers Sites. Since we want to allow both sites and
+	// assets to work side by side, we cannot use the same binding name
+	// for assets. Therefore deferring to a different default naming here.
+	assetsKVBindingName = "__STATIC_ASSETS_CONTENT",
+	assetsManifestBindingName = "__STATIC_ASSETS_CONTENT_MANIFEST"
+) {
+	return {
+		ASSETS_KV_NAMESPACE: assetsKVBindingName,
+		ASSETS_MANIFEST: assetsManifestBindingName,
+	} as const;
 }

--- a/packages/miniflare/test/fixtures/assets/worker-with-custom-assets-bindings.ts
+++ b/packages/miniflare/test/fixtures/assets/worker-with-custom-assets-bindings.ts
@@ -1,0 +1,14 @@
+interface Env {
+	//  custom kv binding name
+	CUSTOM_ASSETS_NAMESPACE: KVNamespace;
+}
+
+export default {
+	async fetch(request: Request, env: Env) {
+		const url = new URL(request.url);
+		const { pathname } = url;
+
+		const content = await env.CUSTOM_ASSETS_NAMESPACE.get(pathname);
+		return new Response(content);
+	},
+};

--- a/packages/miniflare/test/fixtures/assets/worker-with-default-assets-bindings.ts
+++ b/packages/miniflare/test/fixtures/assets/worker-with-default-assets-bindings.ts
@@ -1,0 +1,14 @@
+interface Env {
+	//  this is the default kv binding name
+	__STATIC_ASSETS_CONTENT: KVNamespace;
+}
+
+export default {
+	async fetch(request: Request, env: Env) {
+		const url = new URL(request.url);
+		const { pathname } = url;
+
+		const content = await env.__STATIC_ASSETS_CONTENT.get(pathname);
+		return new Response(content);
+	},
+};

--- a/packages/miniflare/test/plugins/kv/assets.spec.ts
+++ b/packages/miniflare/test/plugins/kv/assets.spec.ts
@@ -1,0 +1,192 @@
+import fs from "fs/promises";
+import path from "path";
+import anyTest, { Macro, TestFn } from "ava";
+import esbuild from "esbuild";
+import { Miniflare } from "miniflare";
+import { useTmp } from "../../test-shared";
+
+const FIXTURES_PATH = path.resolve(
+	__dirname,
+	"../../../../test/fixtures/assets"
+);
+const MODULES_ENTRY_PATH = path.join(
+	FIXTURES_PATH,
+	"worker-with-default-assets-bindings.ts"
+);
+
+interface Context {
+	modulesPath: string;
+}
+
+const test = anyTest as TestFn<Context>;
+
+test.before(async (t) => {
+	// Build fixtures
+	const tmp = await useTmp(t);
+	await esbuild.build({
+		entryPoints: [MODULES_ENTRY_PATH],
+		format: "esm",
+		bundle: true,
+		sourcemap: true,
+		outdir: tmp,
+	});
+	t.context.modulesPath = path.join(
+		tmp,
+		"worker-with-default-assets-bindings.js"
+	);
+});
+
+type Route = keyof typeof routeContents;
+const routeContents = {
+	"/index.html": "<p>Index</p>",
+	"/a.txt": "a",
+	"/b/b.txt": "b",
+};
+
+const getAssetMacro: Macro<[Set<Route>], Context> = {
+	async exec(t, expectedRoutes) {
+		const tmp = await useTmp(t);
+		for (const [route, contents] of Object.entries(routeContents)) {
+			const routePath = path.join(tmp, route);
+			await fs.mkdir(path.dirname(routePath), { recursive: true });
+			await fs.writeFile(routePath, contents, "utf8");
+		}
+
+		const mf = new Miniflare({
+			scriptPath: t.context.modulesPath,
+			modules: true,
+			assetsPath: tmp,
+		});
+		t.teardown(() => mf.dispose());
+
+		for (const [route, expectedContents] of Object.entries(routeContents)) {
+			const res = await mf.dispatchFetch(`http://localhost:8787${route}`);
+			const text = (await res.text()).trim();
+			const expected = expectedRoutes.has(route as Route);
+			t.is(res.status, expected ? 200 : 404, `${route}: ${text}`);
+			if (expected) t.is(text, expectedContents, route);
+		}
+	},
+};
+
+// Tests for checking different types of globs are matched correctly
+const matchMacro: Macro<[string], Context> = {
+	async exec(t) {
+		const tmp = await useTmp(t);
+		const dir = path.join(tmp, "a", "b", "c");
+		await fs.mkdir(dir, { recursive: true });
+		await fs.writeFile(path.join(dir, "test.txt"), "test", "utf8");
+		const mf = new Miniflare({
+			scriptPath: t.context.modulesPath,
+			modules: true,
+			assetsPath: tmp,
+		});
+		t.teardown(() => mf.dispose());
+
+		const res = await mf.dispatchFetch("http://localhost:8787/a/b/c/test.txt");
+		t.is(res.status, 200);
+		await res.arrayBuffer();
+	},
+};
+
+const customBindingsMacro: Macro<[Set<Route>], Context> = {
+	async exec(t, expectedRoutes) {
+		const ENTRY_PATH = path.join(
+			FIXTURES_PATH,
+			"worker-with-custom-assets-bindings.ts"
+		);
+		const tmp = await useTmp(t);
+
+		for (const [route, contents] of Object.entries(routeContents)) {
+			const routePath = path.join(tmp, route);
+			await fs.mkdir(path.dirname(routePath), { recursive: true });
+			await fs.writeFile(routePath, contents, "utf8");
+		}
+
+		await esbuild.build({
+			entryPoints: [ENTRY_PATH],
+			format: "esm",
+			bundle: true,
+			sourcemap: true,
+			outdir: tmp,
+		});
+		t.context.modulesPath = path.join(
+			tmp,
+			"worker-with-custom-assets-bindings.js"
+		);
+
+		const mf = new Miniflare({
+			scriptPath: t.context.modulesPath,
+			modules: true,
+			assetsPath: tmp,
+			assetsKVBindingName: "CUSTOM_ASSETS_NAMESPACE",
+		});
+		t.teardown(() => mf.dispose());
+
+		for (const [route, expectedContents] of Object.entries(routeContents)) {
+			const res = await mf.dispatchFetch(`http://localhost:8787${route}`);
+			const text = (await res.text()).trim();
+			const expected = expectedRoutes.has(route as Route);
+			t.is(res.status, expected ? 200 : 404, `${route}: ${text}`);
+			if (expected) t.is(text, expectedContents, route);
+		}
+	},
+};
+
+test(
+	"gets all assets",
+	getAssetMacro,
+	new Set<Route>(["/index.html", "/a.txt", "/b/b.txt"])
+);
+
+test("matches file name pattern", matchMacro, "test.txt");
+test("matches exact pattern", matchMacro, "a/b/c/test.txt");
+test("matches extension patterns", matchMacro, "*.txt");
+test("matches globstar patterns", matchMacro, "**/*.txt");
+test("matches wildcard directory patterns", matchMacro, "a/*/c/*.txt");
+
+test("gets assets with percent-encoded paths", async (t) => {
+	// https://github.com/cloudflare/miniflare/issues/326
+	const tmp = await useTmp(t);
+	const testPath = path.join(tmp, "ń.txt");
+	await fs.writeFile(testPath, "test", "utf8");
+	const mf = new Miniflare({
+		scriptPath: t.context.modulesPath,
+		modules: true,
+		assetsPath: tmp,
+	});
+	t.teardown(() => mf.dispose());
+	const res = await mf.dispatchFetch("http://localhost:8787/ń.txt");
+	t.is(await res.text(), "test");
+});
+
+// skipping until we put caching in place
+test.skip("doesn't cache assets", async (t) => {
+	const tmp = await useTmp(t);
+	const testPath = path.join(tmp, "test.txt");
+	await fs.writeFile(testPath, "1", "utf8");
+
+	const mf = new Miniflare({
+		scriptPath: t.context.modulesPath,
+		modules: true,
+		assetsPath: tmp,
+	});
+	t.teardown(() => mf.dispose());
+
+	const res1 = await mf.dispatchFetch("http://localhost:8787/test.txt");
+	const text1 = await res1.text();
+	t.is(res1.headers.get("CF-Cache-Status"), "MISS");
+	t.is(text1, "1");
+
+	await fs.writeFile(testPath, "2", "utf8");
+	const res2 = await mf.dispatchFetch("http://localhost:8787/test.txt");
+	const text2 = await res2.text();
+	t.is(res2.headers.get("CF-Cache-Status"), "MISS");
+	t.is(text2, "2");
+});
+
+test(
+	"supports binding to a custom assets KV namespace",
+	customBindingsMacro,
+	new Set<Route>(["/index.html", "/a.txt", "/b/b.txt"])
+);

--- a/packages/workers-shared/asset-server-worker/src/assets-manifest-no-op.ts
+++ b/packages/workers-shared/asset-server-worker/src/assets-manifest-no-op.ts
@@ -1,0 +1,13 @@
+/**
+ * This is the NOOP version of `AssetsManifest`, and is meant to be used
+ * in local development only.
+ *
+ * The `NoopAssetsManifest` assumes a file path to file path mapping in
+ * concept, which is why its `get` fn will always return the given pathname
+ * unchanged.
+ */
+export class NoopAssetsManifest {
+	async get(pathname: string) {
+		return Promise.resolve(pathname);
+	}
+}

--- a/packages/workers-shared/asset-server-worker/src/assets-manifest.ts
+++ b/packages/workers-shared/asset-server-worker/src/assets-manifest.ts
@@ -1,0 +1,11 @@
+export class AssetsManifest {
+	private data: ArrayBuffer;
+
+	constructor(data: ArrayBuffer) {
+		this.data = data;
+	}
+
+	async get(pathname: string) {
+		return Promise.resolve(pathname);
+	}
+}

--- a/packages/workers-shared/asset-server-worker/src/index.ts
+++ b/packages/workers-shared/asset-server-worker/src/index.ts
@@ -1,5 +1,38 @@
+import { AssetsManifest } from "./assets-manifest";
+import { NoopAssetsManifest } from "./assets-manifest-no-op";
+
+interface Env {
+	ASSETS_MANIFEST: ArrayBuffer;
+	ASSETS_KV_NAMESPACE: KVNamespace;
+}
+
 export default {
-	async fetch() {
-		return new Response("Hello from Asset Server Worker 🚀");
+	async fetch(request: Request, env: Env) {
+		const {
+			// ASSETS_MANIFEST is a pipeline binding to an ArrayBuffer containing the
+			// binary-encoded site manifest
+			ASSETS_MANIFEST = new ArrayBuffer(0),
+
+			// ASSETS_KV_NAMESPACE is a pipeline binding to the KV namespace that the
+			// assets are in.
+			ASSETS_KV_NAMESPACE,
+		} = env;
+
+		const url = new URL(request.url);
+		const { pathname } = url;
+
+		const isLocalDevContext = new Uint8Array(ASSETS_MANIFEST).at(0) === 1;
+		const assetsManifest = isLocalDevContext
+			? new NoopAssetsManifest()
+			: new AssetsManifest(ASSETS_MANIFEST);
+		const assetEntry = await assetsManifest.get(pathname);
+
+		const content = await ASSETS_KV_NAMESPACE.get(assetEntry);
+
+		if (!content) {
+			return new Response("Not Found", { status: 404 });
+		}
+
+		return new Response(content);
 	},
 };

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -931,6 +931,9 @@ function getAssetServerWorker(
 					port: 0,
 				},
 			],
+			assetsPath: config.experimentalAssets.directory,
+			assetsKVBindingName: "ASSETS_KV_NAMESPACE",
+			assetsManifestBindingName: "ASSETS_MANIFEST",
 		},
 	];
 }

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -15,6 +15,7 @@ import { isJwtExpired } from "./pages/upload";
 import { APIError } from "./parse";
 import { urlSafe } from "./sites";
 import type { Config } from "./config";
+import type { ExperimentalAssets } from "./config/environment";
 
 export type AssetManifest = { [path: string]: { hash: string; size: number } };
 
@@ -313,7 +314,7 @@ export function getExperimentalAssetsBasePath(
 export function processExperimentalAssetsArg(
 	args: { experimentalAssets: string | undefined },
 	config: Config
-) {
+): ExperimentalAssets | undefined {
 	const experimentalAssets = args.experimentalAssets
 		? { directory: args.experimentalAssets }
 		: config.experimental_assets;


### PR DESCRIPTION
## What this PR solves / how to test

This commit extends Miniflare's KV plugin's behaviour to support Workers assets, and therefore enables the emulation of Workers with assets in local development.

Fixes WC-2394

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
