### PR TITLE
Update e2e tests to use startWorker directly

### DIFF
--- a/packages/wrangler/e2e/dev-env.test.ts
+++ b/packages/wrangler/e2e/dev-env.test.ts
@@ -27,72 +27,72 @@ describe("switching runtimes", () => {
 			`,
 			"index.mjs": dedent/*javascript*/ `
 				import { setTimeout } from "timers/promises";
-				import { unstable_DevEnv as DevEnv } from "${WRANGLER_IMPORT}";
+				import { unstable_startWorker as startWorker } from "${WRANGLER_IMPORT}";
 
 				const firstRemote = process.argv[2] === "remote";
 
-				const devEnv = new DevEnv();
+                let worker;
+                try {
+                    worker = await startWorker({
+                        name: "worker",
+                        entrypoint: "index.ts",
+                        compatibilityFlags: ["nodejs_compat"],
+                        compatibilityDate: "2023-10-01",
+                        bindings: {
+                            REMOTE: {
+                                type: "json",
+                                value: firstRemote,
+                            },
+                            ORDER: {
+                                type: "plain_text",
+                                value: "1",
+                            },
+                        },
+                        dev: {
+                            remote: firstRemote,
+                            auth: {
+                                accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+                                apiToken: process.env.CLOUDFLARE_API_TOKEN,
+                            },
+                        },
+                    });
 
-				let config = {
-					name: "worker",
-					entrypoint: "index.ts",
-					compatibilityFlags: ["nodejs_compat"],
-					compatibilityDate: "2023-10-01",
-					bindings: {
-						REMOTE: {
-							type: "json",
-							value: firstRemote,
-						},
-						ORDER: {
-							type: "plain_text",
-							value: "1",
-						},
-					},
-					dev: {
-						remote: firstRemote,
-						auth: {
-							accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
-							apiToken: process.env.CLOUDFLARE_API_TOKEN,
-						},
-					},
-				};
-				void devEnv.config.set(config);
+                    const url = await worker.url;
+                    console.log(await fetch(url).then((r) => r.text()));
 
-				const { url } = await devEnv.proxy.ready.promise;
-				console.log(await fetch(url).then((r) => r.text()));
+                    await worker.patchConfig({
+                        bindings: {
+                            REMOTE: {
+                                type: "json",
+                                value: !firstRemote,
+                            },
+                            ORDER: {
+                                type: "plain_text",
+                                value: "2",
+                            },
+                        },
+                        dev: {
+                            ...worker.config.dev,
+                            remote: !firstRemote,
+                        },
+                    });
 
-				void devEnv.config.patch({
-					bindings: {
-						REMOTE: {
-							type: "json",
-							value: !firstRemote,
-						},
-						ORDER: {
-							type: "plain_text",
-							value: "2",
-						},
-					},
-					dev: {
-						...config.dev,
-						remote: !firstRemote,
-					},
-				});
+                    // Give the config some time to propagate
+                    await setTimeout(500);
 
-				// Give the config some time to propagate
-				await setTimeout(500);
-
-				console.log(await fetch(url).then((r) => r.text()));
-
-				await devEnv.teardown();
-				process.exit(0);
-					`,
+                    console.log(await fetch(url).then((r) => r.text()));
+                } finally {
+                    await worker?.dispose();
+                    process.exit(0);
+                }
+            `,
 			"package.json": dedent`
-					{
-						"name": "ai-app",
-						"version": "0.0.0",
-						"private": true
-					}
-					`,
+                {
+                    "name": "ai-app",
+                    "version": "0.0.0",
+                    "private": true
+                }
+            `,
 		});
 	});
 	it("can switch from local to remote", async () => {

--- a/packages/wrangler/e2e/startWorker.test.ts
+++ b/packages/wrangler/e2e/startWorker.test.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
 import events from "events";
-import { afterEach } from "node:test";
 import path from "path";
 import { setTimeout } from "timers/promises";
 import getPort from "get-port";
@@ -36,9 +35,7 @@ describe.each(OPTIONS)("DevEnv", ({ remote }) => {
 		helper = new WranglerE2ETestHelper();
 		wrangler = await helper.importWrangler();
 		startWorker = wrangler.unstable_startWorker;
-		startWorker = wrangler.unstable_startWorker;
 	});
-	afterEach(async () => {});
 
 	it("ProxyWorker buffers requests while runtime reloads", async (t) => {
 		t.onTestFinished(() => worker?.dispose());


### PR DESCRIPTION
## What this PR solves / how to test

Update e2e tests to use startWorker directly instead of DevEnv.startWorker

startWorker is the public interface whereas DevEnv provides access to internals (controllers) for advanced use-cases with APIs that we will iterate on and do not want to commit to yet.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: test change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
