### PR TITLE
chore(workers-shared): Project configuration and beta prereleases

### DIFF
--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           node .github/version-script.js wrangler
           node .github/version-script.js create-cloudflare
+          node .github/version-script.js workers-shared
 
       - name: Build
         run: pnpm run build
@@ -56,6 +57,10 @@ jobs:
 
       - name: Publish create-cloudflare@beta to NPM
         run: pnpm --filter create-cloudflare publish --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - name: Publish workers-shared@beta to NPM
+        run: pnpm --filter workers-shared publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 

--- a/packages/workers-shared/.eslintrc.js
+++ b/packages/workers-shared/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+	root: true,
+	extends: ["@cloudflare/eslint-config-worker"],
+	ignorePatterns: ["dist"],
+};

--- a/packages/workers-shared/asset-server-worker/src/index.ts
+++ b/packages/workers-shared/asset-server-worker/src/index.ts
@@ -1,5 +1,5 @@
 export default {
-	async fetch(request, env) {
+	async fetch() {
 		return new Response("Hello from Asset Server Worker 🚀");
 	},
 };

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20240725.0",
+		"@cloudflare/workers-types": "^4.20240806.0",
 		"concurrently": "^8.2.2",
 		"esbuild": "0.17.19",
 		"rimraf": "^6.0.1",

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -2,16 +2,50 @@
 	"name": "@cloudflare/workers-shared",
 	"version": "0.1.0",
 	"description": "Package that is used at Cloudflare to power some internal features of Cloudflare Workers.",
+	"keywords": [
+		"cloudflare",
+		"workers",
+		"cloudflare workers"
+	],
+	"homepage": "https://github.com/cloudflare/workers-sdk/tree/main/packages/workers-shared#readme",
+	"bugs": {
+		"url": "https://github.com/cloudflare/workers-sdk/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cloudflare/workers-sdk.git",
+		"directory": "packages/workers-shared"
+	},
+	"license": "MIT OR Apache-2.0",
+	"author": "wrangler@cloudflare.com",
+	"files": [
+		"dist"
+	],
 	"scripts": {
-		"build": "pnpm run clean && pnpm run bundle:asset-server",
+		"build": "pnpm run clean && pnpm run bundle:asset-server:prod",
 		"bundle:asset-server": "esbuild asset-server-worker/src/index.ts --format=esm --bundle --outfile=dist/asset-server-worker.mjs --sourcemap=external",
+		"bundle:asset-server:prod": "pnpm run bundle:asset-server --minify",
+		"check:lint": "eslint . --max-warnings=0",
+		"check:type": "tsc",
 		"clean": "rimraf dist",
 		"dev": "pnpm run clean && concurrently -n bundle:asset-server -c blue \"pnpm run bundle:asset-server --watch\""
 	},
 	"devDependencies": {
+		"@cloudflare/eslint-config-worker": "workspace:*",
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "^4.20240725.0",
 		"concurrently": "^8.2.2",
 		"esbuild": "0.17.19",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.5.4"
+	},
+	"engines": {
+		"node": ">=16.7.0"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"prerelease": true
 	}
 }

--- a/packages/workers-shared/tsconfig.json
+++ b/packages/workers-shared/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"sourceMap": true,
+		"forceConsistentCasingInFileNames": true,
+		"useUnknownInCatchVariables": false,
+		"types": ["@cloudflare/workers-types"]
+	},
+	"include": ["**/*.ts"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1472,8 +1472,8 @@ importers:
         specifier: workspace:*
         version: link:../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20240725.0
-        version: 4.20240725.0
+        specifier: ^4.20240806.0
+        version: 4.20240806.0
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1465,6 +1465,15 @@ importers:
 
   packages/workers-shared:
     devDependencies:
+      '@cloudflare/eslint-config-worker':
+        specifier: workspace:*
+        version: link:../eslint-config-worker
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20240725.0
+        version: 4.20240725.0
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2


### PR DESCRIPTION
## What this PR solves / how to test

This PR properly sets up the `workers-shared` project, by putting the necessary linting, TS compilation, and
`package.json` configuration in place. It also enables `@beta` prereleases for `workers-shared`

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: project config change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: project config change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: project config and not user facing
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
