### PR TITLE
fix: tweak the properties of the new Wrangler output file entries for…

### DIFF
--- a/.changeset/shaggy-lobsters-buy.md
+++ b/.changeset/shaggy-lobsters-buy.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: tweak the properties of the new Wrangler output file entries for better consistency

--- a/packages/wrangler/src/__tests__/output.test.ts
+++ b/packages/wrangler/src/__tests__/output.test.ts
@@ -100,11 +100,11 @@ describe("writeOutput()", () => {
 				log_file_path: "some/log/path.log",
 			});
 			writeOutput({
-				type: "deployment",
+				type: "deploy",
 				version: 1,
 				worker_name: "Worker",
 				worker_tag: "ABCDE12345",
-				deployment_id: "1234",
+				version_id: "1234",
 			});
 
 			const outputFile = readFileSync(WRANGLER_OUTPUT_FILE_PATH, "utf8");
@@ -117,11 +117,11 @@ describe("writeOutput()", () => {
 					log_file_path: "some/log/path.log",
 				},
 				{
-					type: "deployment",
+					type: "deploy",
 					version: 1,
 					worker_name: "Worker",
 					worker_tag: "ABCDE12345",
-					deployment_id: "1234",
+					version_id: "1234",
 				},
 			]);
 		} finally {
@@ -178,11 +178,11 @@ describe("writeOutput()", () => {
 				log_file_path: "some/log/path.log",
 			});
 			writeOutput({
-				type: "deployment",
+				type: "deploy",
 				version: 1,
 				worker_name: "Worker",
 				worker_tag: "ABCDE12345",
-				deployment_id: "1234",
+				version_id: "1234",
 			});
 
 			const outputFilePaths = readdirSync("output");
@@ -201,11 +201,11 @@ describe("writeOutput()", () => {
 					log_file_path: "some/log/path.log",
 				},
 				{
-					type: "deployment",
+					type: "deploy",
 					version: 1,
 					worker_name: "Worker",
 					worker_tag: "ABCDE12345",
-					deployment_id: "1234",
+					version_id: "1234",
 				},
 			]);
 		} finally {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -364,11 +364,12 @@ export async function deployHandler(
 	});
 
 	writeOutput({
-		type: "deployment",
+		type: "deploy",
 		version: 1,
 		worker_name: name ?? null,
 		worker_tag: workerTag,
-		deployment_id: deploymentId,
+		// Note that the `deploymentId` returned from a simple deployment is actually the versionId of the uploaded version.
+		version_id: deploymentId,
 	});
 
 	await metrics.sendMetricsEvent(

--- a/packages/wrangler/src/output.ts
+++ b/packages/wrangler/src/output.ts
@@ -76,30 +76,44 @@ export type StampedOutputEntry = { timestamp: string } & OutputEntry;
 export interface OutputEntrySession
 	extends OutputEntryBase<"wrangler-session"> {
 	version: 1;
+	/** The semver version string taken from Wrangler's package.json. */
 	wrangler_version: string;
+	/** The arguments passed to Wrangler. */
 	command_line_args: string[];
+	/** The absolute path to a file that contains debug logs for this Wrangler instance. */
 	log_file_path: string;
 }
 
-export interface OutputEntryDeployment extends OutputEntryBase<"deployment"> {
+export interface OutputEntryDeployment extends OutputEntryBase<"deploy"> {
 	version: 1;
+	/** The name of the Worker. */
 	worker_name: string | null;
+	/** The GUID that identifies the Worker. This never changes even if the name is changed. */
 	worker_tag: string | null;
-	deployment_id: string | null;
+	/** A GUID that identifies this deployed version of the Worker. This version is associated with an automatically created deployment, with this version set at 100%. */
+	version_id: string | null;
 }
 
 export interface OutputEntryVersionUpload
 	extends OutputEntryBase<"version-upload"> {
 	version: 1;
+	/** The name of the Worker. */
 	worker_name: string | null;
+	/** The GUID that identifies the Worker. This never changes even if the name is changed. */
 	worker_tag: string | null;
+	/** A GUID that identifies this uploaded, but not yet deployed, version of the Worker. This version will need to be "deployed" to receive traffic. */
 	version_id: string | null;
 }
 
 export interface OutputEntryVersionDeployment
 	extends OutputEntryBase<"version-deploy"> {
 	version: 1;
+	/** The name of the Worker. */
 	worker_name: string | null;
+	/** The GUID that identifies the Worker. This never changes even if the name is changed. */
 	worker_tag: string | null;
+	/** The ID of the gradual rollout deployment. */
+	deployment_id: string;
+	/** The percentage of traffic that goes to each version. */
 	version_traffic: Map<string, number>;
 }

--- a/packages/wrangler/src/versions/api.ts
+++ b/packages/wrangler/src/versions/api.ts
@@ -107,7 +107,7 @@ export async function createDeployment(
 	message: string | undefined,
 	force?: boolean
 ) {
-	return await fetchResult(
+	return await fetchResult<{ id: string }>(
 		`/accounts/${accountId}/workers/scripts/${workerName}/deployments${force ? "?force=true" : ""}`,
 		{
 			method: "POST",

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -177,10 +177,10 @@ export async function versionsDeployHandler(args: VersionsDeployArgs) {
 
 	const start = Date.now();
 
-	await spinnerWhile({
+	const { id: deploymentId } = await spinnerWhile({
 		startMessage: `Deploying ${confirmedVersionsToDeploy.length} version(s)`,
-		async promise() {
-			await createDeployment(
+		promise() {
+			return createDeployment(
 				accountId,
 				workerName,
 				confirmedVersionTraffic,
@@ -220,6 +220,8 @@ export async function versionsDeployHandler(args: VersionsDeployArgs) {
 		version: 1,
 		worker_name: workerName,
 		worker_tag: workerTag,
+		// NOTE this deploymentId is related to the gradual rollout of the versions given in the version_traffic.
+		deployment_id: deploymentId,
 		version_traffic: confirmedVersionTraffic,
 	});
 }


### PR DESCRIPTION
… better consistency

## What this PR solves / how to test

In consultation with the CI/CD team, this change is just a simple update to what fields are available on the output file entries.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: does not touch e2e tested code paths
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: internal experimental

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
