### PR TITLE
fix(vitest-pool-workers): add node lib timers implementation

### DIFF
--- a/packages/vitest-pool-workers/src/worker/lib/node/timers.ts
+++ b/packages/vitest-pool-workers/src/worker/lib/node/timers.ts
@@ -1,1 +1,9 @@
-export default {};
+// partial implementation of node:timers
+// missing functions are setImmediate, active, enroll, unenroll,
+// and the timers.promises object
+export const setTimeout = globalThis.setTimeout.bind(globalThis);
+export const clearTimeout = globalThis.clearTimeout.bind(globalThis);
+export const setInterval = globalThis.setInterval.bind(globalThis);
+export const clearInterval = globalThis.clearInterval.bind(globalThis);
+const _default = { setTimeout, clearTimeout, setInterval, clearInterval };
+export default _default;


### PR DESCRIPTION
## What this PR solves / how to test

Adds node lib timers implementation, so that the following code works:

```
require('node:timers').setTimeout
```

`setImmediate`, `active`, `unroll`, and `promises` are not implemented.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: they weren't there before, but I'm willing to add some
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not necessary because: not relevant for this type of fix
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: wasn't there before

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
