### PR TITLE
fix: ensure that directory imports in commonjs modules get resolved to their index file

### DIFF
--- a/.changeset/dry-cobras-smash.md
+++ b/.changeset/dry-cobras-smash.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: ensure that directory imports in commonjs modules get resolved to their index file
+
+Fixes #6406

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/README.md
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/README.md
@@ -1,0 +1,5 @@
+# internal-module-resolution
+
+This simple fixture checks that the Vitest integration import resolution works correctly when a CommonJS packages has a require to a directory rather than a specific file.
+
+There is no Worker defined here but we still need a minimal wrangler.toml that we can pass to the vitest-pool-workers plugin to trigger that plugin to handle import resolution and file loading.

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/test/index.d.ts
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/test/index.d.ts
@@ -1,0 +1,4 @@
+declare module "ext-dep" {
+	var x: number;
+	export default x;
+}

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/test/index.spec.ts
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/test/index.spec.ts
@@ -1,0 +1,8 @@
+import dep from "ext-dep";
+import { assert, describe, test } from "vitest";
+
+describe("test", () => {
+	test("resolves commonjs directory dependencies correctly", async () => {
+		assert.equal(dep, 123);
+	});
+});

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/test/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.workerd-test.json",
+	"include": ["./**/*.ts", "../index.d.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.node.json",
+	"include": ["./*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep/index.js
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./subfolder");

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep/package.json
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "ext-dep",
+	"type": "commonjs",
+	"main": "index.js"
+}

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep/subfolder/index.js
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep/subfolder/index.js
@@ -1,0 +1,1 @@
+module.exports = 123;

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineWorkersProject } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersProject({
+	test: {
+		poolOptions: {
+			workers: {
+				wrangler: { configPath: "./wrangler.toml" },
+			},
+		},
+	},
+});

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/wrangler.toml
@@ -1,0 +1,3 @@
+name = "internal-module-resolution"
+compatibility_date = "2024-04-05"
+compatibility_flags = ["nodejs_compat"]

--- a/fixtures/vitest-pool-workers-examples/package.json
+++ b/fixtures/vitest-pool-workers-examples/package.json
@@ -11,6 +11,7 @@
 		"@cloudflare/vitest-pool-workers": "workspace:*",
 		"@cloudflare/workers-types": "^4.20240806.0",
 		"@types/node": "20.8.3",
+		"ext-dep": "file:./internal-module-resolution/vendor/ext-dep",
 		"jose": "^5.2.2",
 		"miniflare": "workspace:*",
 		"toucan-js": "^3.3.1",

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -75,6 +75,17 @@ function isFile(filePath: string): boolean {
 	}
 }
 
+function isDirectory(filePath: string): boolean {
+	try {
+		return fs.statSync(filePath).isDirectory();
+	} catch (e) {
+		if (isFileNotFoundError(e)) {
+			return false;
+		}
+		throw e;
+	}
+}
+
 function getParentPaths(filePath: string): string[] {
 	const parentPaths: string[] = [];
 	// eslint-disable-next-line no-constant-condition
@@ -225,6 +236,9 @@ function maybeGetTargetFilePath(target: string): string | undefined {
 	}
 	if (target.endsWith(disableCjsEsmShimSuffix)) {
 		return target;
+	}
+	if (isDirectory(target)) {
+		return maybeGetTargetFilePath(target + "/index");
 	}
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,9 @@ importers:
       '@types/node':
         specifier: 20.8.3
         version: 20.8.3
+      ext-dep:
+        specifier: file:./internal-module-resolution/vendor/ext-dep
+        version: file:fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep
       jose:
         specifier: ^5.2.2
         version: 5.2.2
@@ -5206,6 +5209,9 @@ packages:
   express@4.18.1:
     resolution: {integrity: sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==}
     engines: {node: '>= 0.10.0'}
+
+  ext-dep@file:fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep:
+    resolution: {directory: fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep, type: directory}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -12806,6 +12812,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  ext-dep@file:fixtures/vitest-pool-workers-examples/internal-module-resolution/vendor/ext-dep: {}
 
   extendable-error@0.1.7: {}
 


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6406

The build from this PR should fix the reproduction here: https://github.com/hansottowirtz/workers-sdk-index-js-require-repro.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bug fix

