### PR TITLE
ci: [C3] ensure that  is true on the pnpm ubuntu C3 e2e test run

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -60,4 +60,4 @@ jobs:
           accountId: ${{ secrets.C3_TEST_CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.C3_TEST_CLOUDFLARE_API_TOKEN }}
           # We only need to do this once per-framework per-run, so avoid re-running for each package manager and os
-          saveDiffs: ${{ github.head_ref == 'changeset-release/main' && matrix.pm == 'pnpm' && matrix.os == 'ubuntu-latest'}}
+          saveDiffs: ${{ github.head_ref == 'changeset-release/main' && matrix.pm.name == 'pnpm' && matrix.os == 'ubuntu-latest'}}


### PR DESCRIPTION
Our release job ("Handle Changesets") always fails on its last step because there are no C3 diffs artifacts to download.
We only want to create those artifacts in a single e2e test run (the pnpm + ubuntu one) so there is a check in that e2e CI job.
Unfortunately the check was wrong, since we converted the `pm` matrix value from a string (e.g. "pnpm") to an object (e.g. `{name: "pnpm", version: "9.1.3"}`).