### PR TITLE
Optionally strip cf-ew-raw prefix

### DIFF
--- a/.changeset/smart-tomatoes-sell.md
+++ b/.changeset/smart-tomatoes-sell.md
@@ -1,0 +1,6 @@
+---
+"edge-preview-authenticated-proxy": minor
+"playground-preview-worker": minor
+---
+
+feat: Optionally strip cf-ew-raw- prefix from headers before passing to the user worker

--- a/.changeset/smart-tomatoes-sell.md
+++ b/.changeset/smart-tomatoes-sell.md
@@ -3,4 +3,4 @@
 "playground-preview-worker": minor
 ---
 
-feat: Optionally strip cf-ew-raw- prefix from headers before passing to the user worker
+feat: Optionally strip `cf-ew-raw-` prefix from headers before passing to the user worker

--- a/packages/edge-preview-authenticated-proxy/src/index.ts
+++ b/packages/edge-preview-authenticated-proxy/src/index.ts
@@ -220,6 +220,15 @@ async function handleRawHttp(request: Request, url: URL) {
 	requestHeaders.delete("X-CF-Token");
 	requestHeaders.delete("X-CF-Remote");
 
+	const headerEntries = [...requestHeaders.entries()];
+
+	for (const header of headerEntries) {
+		if (header[0].startsWith("cf-ew-raw-")) {
+			requestHeaders.set(header[0].split("cf-ew-raw-")[1], header[1]);
+			requestHeaders.delete(header[0]);
+		}
+	}
+
 	const workerResponse = await fetch(
 		switchRemote(url, remote),
 		new Request(request, {

--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -65,6 +65,15 @@ async function handleRawHttp(request: Request, url: URL, env: Env) {
 	const headers = new Headers(request.headers);
 	headers.delete("X-CF-Token");
 
+	const headerEntries = [...headers.entries()];
+
+	for (const header of headerEntries) {
+		if (header[0].startsWith("cf-ew-raw-")) {
+			headers.set(header[0].split("cf-ew-raw-")[1], header[1]);
+			headers.delete(header[0]);
+		}
+	}
+
 	const workerResponse = await userObject.fetch(
 		url,
 		new Request(request, {


### PR DESCRIPTION
## What this PR solves / how to test

Part of https://jira.cfdata.org/browse/DEVX-1312

When sending raw HTTP requests to the playground & quick edit, we'd previously been passing along the headers that the user specified directly in the request to the proxy. This meant that some headers were instead being interpreted by the browser/proxy rather than being passed along to the user-worker (e.g. `Accept`). This change supports optionally prefixing headers with `cf-ew-raw-`, which will be stripped before being passed to the user worker. Followup PRs will add this prefixing to the playground & quick edit UI to take advantage.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: Doesn't touch Wrangler code
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: Not currently documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
