### PR TITLE
ci: only try to download c3 diff artifacts, during the release job, if the C3 package was actually deployed

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -66,7 +66,7 @@ jobs:
           WORKERS_NEW_CLOUDFLARE_API_TOKEN: ${{ secrets.WORKERS_NEW_CLOUDFLARE_API_TOKEN }}
 
       - name: Create C3 Diffs PR
-        if: steps.changesets.outputs.published == 'true'
+        if: contains(steps.changesets.outputs.publishedPackages, '"create-cloudflare"')
         uses: ./.github/actions/create-c3-docs-pr
         with:
           token: ${{ secrets.C3_DIFF_TOOL_GH_TOKEN }}


### PR DESCRIPTION
## What this PR solves / how to test

Although we now do upload C3 diffs during e2e tests, those tests only run if there was a change to the c3 package.
So we also should avoid trying to download them if c3 is not being deployed in the release.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: ci change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not necessary because: ci change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: ci change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: ci change

