### PR TITLE
[D1] add queryEfficiency to d1 insights output

### DIFF
--- a/.changeset/serious-walls-laugh.md
+++ b/.changeset/serious-walls-laugh.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: add queryEfficiency to `wrangler d1 insights` output

--- a/packages/wrangler/src/d1/insights.ts
+++ b/packages/wrangler/src/d1/insights.ts
@@ -136,11 +136,13 @@ export const Handler = withConfig<HandlerOptions>(
 												queryDurationMs
 												rowsRead
 												rowsWritten
+												rowsReturned
 											}
 											avg {
 												queryDurationMs
 												rowsRead
 												rowsWritten
+												rowsReturned
 											}
 											count
 											dimensions {
@@ -183,6 +185,10 @@ export const Handler = withConfig<HandlerOptions>(
 						avgDurationMs: row?.avg?.queryDurationMs ?? 0,
 						totalDurationMs: row?.sum?.queryDurationMs ?? 0,
 						numberOfTimesRun: row?.count ?? 0,
+						queryEfficiency:
+							row?.avg?.rowsReturned && row?.avg?.rowsRead
+								? row?.avg?.rowsReturned / row?.avg?.rowsRead
+								: 0,
 					});
 				}
 			);

--- a/packages/wrangler/src/d1/types.ts
+++ b/packages/wrangler/src/d1/types.ts
@@ -78,11 +78,13 @@ export interface D1Queries {
 		queryDurationMs?: number;
 		rowsRead?: number;
 		rowsWritten?: number;
+		rowsReturned?: number;
 	};
 	sum?: {
 		queryDurationMs?: number;
 		rowsRead?: number;
 		rowsWritten?: number;
+		rowsReturned?: number;
 	};
 	count?: number;
 	dimensions: {


### PR DESCRIPTION
## What this PR solves / how to test
This PR adds query efficiency to the `d1 insights` output.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: only command output has changed
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: `insights` is an experimental command with no documentation.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
