### PR TITLE
[D1] Rename --count to --limit in wrangler insights

### DIFF
--- a/.changeset/angry-steaks-wait.md
+++ b/.changeset/angry-steaks-wait.md
@@ -1,7 +1,9 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
-feat: rename `--count` to `--limit` in `wrangler d1 insights`
+fix: rename `--count` to `--limit` in `wrangler d1 insights`
 
-BREAKING CHANGE: This PR renames `wrangler d1 insight`'s `--count` flag to `--limit` to improve clarity and conform to naming conventions.
+This PR renames `wrangler d1 insight`'s `--count` flag to `--limit` to improve clarity and conform to naming conventions.
+
+To avoid a breaking change, we have kept `--count` as an alias to `--limit`.

--- a/.changeset/angry-steaks-wait.md
+++ b/.changeset/angry-steaks-wait.md
@@ -1,0 +1,7 @@
+---
+"wrangler": major
+---
+
+feat: rename `--count` to `--limit` in wrangler insights
+
+This is a breaking change and was made to align with traditional naming conventions and improve clarity.

--- a/.changeset/angry-steaks-wait.md
+++ b/.changeset/angry-steaks-wait.md
@@ -2,6 +2,6 @@
 "wrangler": minor
 ---
 
-feat: rename `--count` to `--limit` in wrangler insights
+feat: rename `--count` to `--limit` in `wrangler d1 insights`
 
 BREAKING CHANGE: This PR renames `wrangler d1 insight`'s `--count` flag to `--limit` to improve clarity and conform to naming conventions.

--- a/.changeset/angry-steaks-wait.md
+++ b/.changeset/angry-steaks-wait.md
@@ -1,7 +1,7 @@
 ---
-"wrangler": major
+"wrangler": minor
 ---
 
 feat: rename `--count` to `--limit` in wrangler insights
 
-This is a breaking change and was made to align with traditional naming conventions and improve clarity.
+BREAKING CHANGE: This PR renames `wrangler d1 insight`'s `--count` flag to `--limit` to improve clarity and conform to naming conventions.

--- a/packages/wrangler/src/d1/insights.ts
+++ b/packages/wrangler/src/d1/insights.ts
@@ -36,7 +36,7 @@ export function Options(d1ListYargs: CommonYargsArgv) {
 			describe: "Choose a sort direction",
 			default: "DESC" as const,
 		})
-		.option("count", {
+		.option("limit", {
 			describe: "fetch insights about the first X queries",
 			type: "number",
 			default: 5,
@@ -100,7 +100,7 @@ export const Handler = withConfig<HandlerOptions>(
 		name,
 		config,
 		json,
-		count,
+		limit,
 		timePeriod,
 		sortType,
 		sortBy,
@@ -131,7 +131,7 @@ export const Handler = withConfig<HandlerOptions>(
 						query: `query getD1QueriesOverviewQuery($accountTag: string, $filter: ZoneWorkersRequestsFilter_InputObject) {
 								viewer {
 									accounts(filter: {accountTag: $accountTag}) {
-										d1QueriesAdaptiveGroups(limit: ${count}, filter: $filter, orderBy: [${orderByClause}]) {
+										d1QueriesAdaptiveGroups(limit: ${limit}, filter: $filter, orderBy: [${orderByClause}]) {
 											sum {
 												queryDurationMs
 												rowsRead

--- a/packages/wrangler/src/d1/insights.ts
+++ b/packages/wrangler/src/d1/insights.ts
@@ -41,6 +41,7 @@ export function Options(d1ListYargs: CommonYargsArgv) {
 			type: "number",
 			default: 5,
 		})
+		.alias("count", "limit") //--limit used to be --count, we renamed the flags for clarity
 		.option("json", {
 			describe: "return output as clean JSON",
 			type: "boolean",


### PR DESCRIPTION
## What this PR solves / how to test
BREAKING CHANGE: This PR renames --count to --limit in the `d1 insights` command to improve clarity and conform to naming conventions.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: `insights` is an experimental command with no documentation.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
