### PR TITLE
chore(create-cloudflare): remove unnecessary assertion in wrangler init test

### DIFF
--- a/packages/wrangler/e2e/c3-integration.test.ts
+++ b/packages/wrangler/e2e/c3-integration.test.ts
@@ -34,11 +34,9 @@ describe("c3 integration", () => {
 			GIT_COMMITTER_EMAIL: "test-user@cloudflare.com",
 		};
 
-		const init = await helper.run(`wrangler init ${workerName} --yes`, {
+		await helper.run(`wrangler init ${workerName} --yes`, {
 			env,
 		});
-
-		expect(init.output).toContain("APPLICATION CREATED");
 
 		expect(existsSync(path.join(helper.tmpPath, workerName))).toBe(true);
 	});

--- a/packages/wrangler/e2e/c3-integration.test.ts
+++ b/packages/wrangler/e2e/c3-integration.test.ts
@@ -38,7 +38,7 @@ describe("c3 integration", () => {
 			env,
 		});
 
-		expect(existsSync(path.join(helper.tmpPath, workerName))).toBe(true);
+		expect(existsSync(path.join(helper.tmpPath, workerName, "wrangler.toml"))).toBe(true);
 	});
 
 	it("can run `wrangler dev` on generated worker", async () => {

--- a/packages/wrangler/e2e/c3-integration.test.ts
+++ b/packages/wrangler/e2e/c3-integration.test.ts
@@ -38,7 +38,9 @@ describe("c3 integration", () => {
 			env,
 		});
 
-		expect(existsSync(path.join(helper.tmpPath, workerName, "wrangler.toml"))).toBe(true);
+		expect(
+			existsSync(path.join(helper.tmpPath, workerName, "wrangler.toml"))
+		).toBe(true);
 	});
 
 	it("can run `wrangler dev` on generated worker", async () => {


### PR DESCRIPTION
## What this PR solves / how to test

We updated the message on c3 in #6412 and break the wrangler init test due to an unnecessary assertion against the output message. 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
