### PR TITLE
fix: add a helpful message on Windows when Miniflare fails to start

### DIFF
--- a/.changeset/odd-steaks-change.md
+++ b/.changeset/odd-steaks-change.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: add a helpful message on Windows when Miniflare fails to start

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -228,6 +228,15 @@ function useLocalWorker(props: LocalProps) {
 					"code" in error &&
 					(error as { code: string }).code === "ERR_RUNTIME_FAILURE"
 				) {
+					// In the past we have seen Access Violation errors on Windows, which may be caused by an outdated
+					// version of the Microsoft Visual C++ Redistributable.
+					// See https://github.com/cloudflare/workers-sdk/issues/6170#issuecomment-2245209918
+					if (process.platform === "win32") {
+						logger.error(
+							"Check that you have the latest Microsoft Visual C++ Redistributable library installed.\n" +
+								"See https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist."
+						);
+					}
 					// Don't log a full verbose stack-trace when Miniflare 3's workerd instance fails to start.
 					// workerd will log its own errors, and our stack trace won't have any useful information.
 					logger.error(String(error));


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
