### PR TITLE
fix(wrangler) - remove e2e for `versions upload --experimental-assets`

### DIFF
--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -587,23 +587,24 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 		`);
 	});
 
-	it("currently fails to upload if using experimental assets", async () => {
+	// TODO: revisit once AUS stabilises/works
+	it.skip("currently fails to upload if using experimental assets", async () => {
 		await helper.seed({
 			"wrangler.toml": dedent`
-                name = "${workerName}"
-                compatibility_date = "2023-01-01"
+	            name = "${workerName}"
+	            compatibility_date = "2023-01-01"
 
-                [experimental_assets]
-                directory = "./public"
-            `,
+	            [experimental_assets]
+	            directory = "./public"
+	        `,
 			"public/asset.txt": `beep boop`,
 			"package.json": dedent`
-                {
-                    "name": "${workerName}",
-                    "version": "0.0.0",
-                    "private": true
-                }
-            `,
+	            {
+	                "name": "${workerName}",
+	                "version": "0.0.0",
+	                "private": true
+	            }
+	        `,
 		});
 
 		const upload = await helper.run(`wrangler versions upload  --x-versions`);


### PR DESCRIPTION
## What this PR solves / how to test

This e2e will be unstable while AUS is still being developed. To prevent this from blocking other work, it's been commented out until AUS is complete/stable.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: is a test
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: e2e change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: not related to public features

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
