### PR TITLE
Fix incorrect type of change in changesets

### DIFF
--- a/.changeset/angry-steaks-wait.md
+++ b/.changeset/angry-steaks-wait.md
@@ -1,8 +1,8 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
-fix: rename `--count` to `--limit` in `wrangler d1 insights`
+feat: rename `--count` to `--limit` in `wrangler d1 insights`
 
 This PR renames `wrangler d1 insight`'s `--count` flag to `--limit` to improve clarity and conform to naming conventions.
 

--- a/.changeset/honest-deers-work.md
+++ b/.changeset/honest-deers-work.md
@@ -1,5 +1,5 @@
 ---
-"create-cloudflare": patch
+"create-cloudflare": minor
 ---
 
 feat: guiding user template selection with description for each options

--- a/.changeset/long-buttons-help.md
+++ b/.changeset/long-buttons-help.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
 feat: `whoami` shows membership information when available

--- a/.changeset/shaggy-insects-jam.md
+++ b/.changeset/shaggy-insects-jam.md
@@ -1,5 +1,5 @@
 ---
-"create-cloudflare": patch
+"create-cloudflare": minor
 ---
 
 feat: update welcome and summary message


### PR DESCRIPTION
## What this PR solves / how to test

Fix incorrect type of change in changesets, from `patch` to `minor`

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: changesets change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: changesets change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: changesets change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: changesets change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
