### PR TITLE
fix: Add `workers-shared` override in vitest-pool-workers  global setup

### DIFF
--- a/packages/vitest-pool-workers/test/global-setup.ts
+++ b/packages/vitest-pool-workers/test/global-setup.ts
@@ -35,6 +35,10 @@ export default async function ({ provide }: GlobalSetupContext) {
 		packDestinationPath,
 		path.join(packagesRoot, "kv-asset-handler")
 	);
+	const workersSharedTarballPath = packPackage(
+		packDestinationPath,
+		path.join(packagesRoot, "workers-shared")
+	);
 	const miniflareTarballPath = packPackage(
 		packDestinationPath,
 		path.join(packagesRoot, "miniflare")
@@ -75,6 +79,7 @@ export default async function ({ provide }: GlobalSetupContext) {
 		pnpm: {
 			overrides: {
 				"@cloudflare/kv-asset-handler": kvAssetHandlerTarballPath,
+				"@cloudflare/workers-shared": workersSharedTarballPath,
 				miniflare: miniflareTarballPath,
 				wrangler: wranglerTarballPath,
 			},


### PR DESCRIPTION
## What this PR solves / how to test

`vitest-pool-workers` tests are failing on https://github.com/cloudflare/workers-sdk/pull/6490 due to 👇 

<img width="897" alt="Screenshot 2024-08-15 at 17 56 10" src="https://github.com/user-attachments/assets/6254350f-c55b-4a8a-b9b6-e36264911451">

This is caused by that fact in that PR, the `workers-shared` version was  bumped to `0.2.0`, and `vitest-pool-workers` is trying to pull that package version from the registry.

This PR fixes the above issue, by having `vitest-pool-workers` use a local tarball of `workers-shared`, just like it does for `miniflare`, `wrangler`, etc.
## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: existing tests should be sufficient
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: internal change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: internal change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
