### PR TITLE
skip python remote e2e tests

### DIFF
--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -108,7 +108,7 @@ describe.each([
 	});
 });
 
-// Skipping remote python tests because the consistently flake with timeouts
+// Skipping remote python tests because they consistently flake with timeouts
 // Unskip once remote dev with python workers is more stable
 describe.skip.each([
 	{ cmd: "wrangler dev" },

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -110,7 +110,7 @@ describe.each([
 
 // Skipping remote python tests because they consistently flake with timeouts
 // Unskip once remote dev with python workers is more stable
-describe.skip.each([
+describe.each([
 	{ cmd: "wrangler dev" },
 	// { cmd: "wrangler dev --remote" },
 	{ cmd: "wrangler dev --x-dev-env" },

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -108,11 +108,13 @@ describe.each([
 	});
 });
 
-describe.each([
+// Skipping remote python tests because the consistently flake with timeouts
+// Unskip once remote dev with python workers is more stable
+describe.skip.each([
 	{ cmd: "wrangler dev" },
-	{ cmd: "wrangler dev --remote" },
+	// { cmd: "wrangler dev --remote" },
 	{ cmd: "wrangler dev --x-dev-env" },
-	{ cmd: "wrangler dev --remote --x-dev-env" },
+	// { cmd: "wrangler dev --remote --x-dev-env" },
 ])("basic python dev: $cmd", { timeout: 90_000 }, ({ cmd }) => {
 	it(`can modify entrypoint during ${cmd}`, async () => {
 		const helper = new WranglerE2ETestHelper();


### PR DESCRIPTION
## What this PR solves / how to test

The python remote dev tests consistently flakey due to timeouts. This PR removes those variations but keeps the local dev variations.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: tests only
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: tests only

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
