### PR TITLE
fix: move the Windows C++ redistributable warning so it is only shown if there is an actual access violation

### DIFF
--- a/.changeset/tasty-mayflies-march.md
+++ b/.changeset/tasty-mayflies-march.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: move the Windows C++ redistributable warning so it is only shown if there is an actual access violation
+
+Replaces #6471, which was too verbose.
+
+Fixes #6170

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
 		"PKCE",
 		"Positionals",
 		"qwik",
+		"Redistributable",
 		"reinitialise",
 		"scandir",
 		"selfsigned",

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -5,6 +5,10 @@ import { logErrors } from "./log";
 
 console.log("startup log");
 
+console.error(
+	"*** Received structured exception #0xc0000005: access violation; stack: 7ffe71872f57 7ff7834b643b 7ff7834b643b"
+);
+
 /** @param {Uint8Array} array */
 function hexEncode(array) {
 	return Array.from(array)

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -44,6 +44,13 @@ describe("'wrangler dev' correctly renders pages", () => {
 		expect(output).toContain("startup log");
 		expect(output).toContain("request log");
 
+		if (process.platform === "win32") {
+			// Check that the Windows warning is shown for the fake access violation error
+			expect(output).toContain(
+				"On Windows, this may be caused by an outdated Microsoft Visual C++ Redistributable library."
+			);
+		}
+
 		// check host on request in the Worker is as expected
 		expect(output).toContain(`host' => 'prod.example.org`);
 

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -228,15 +228,6 @@ function useLocalWorker(props: LocalProps) {
 					"code" in error &&
 					(error as { code: string }).code === "ERR_RUNTIME_FAILURE"
 				) {
-					// In the past we have seen Access Violation errors on Windows, which may be caused by an outdated
-					// version of the Microsoft Visual C++ Redistributable.
-					// See https://github.com/cloudflare/workers-sdk/issues/6170#issuecomment-2245209918
-					if (process.platform === "win32") {
-						logger.error(
-							"Check that you have the latest Microsoft Visual C++ Redistributable library installed.\n" +
-								"See https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist."
-						);
-					}
 					// Don't log a full verbose stack-trace when Miniflare 3's workerd instance fails to start.
 					// workerd will log its own errors, and our stack trace won't have any useful information.
 					logger.error(String(error));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11157,7 +11157,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.5.4)
       '@typescript-eslint/utils': 6.10.0(eslint@8.49.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@9.2.2)
+      debug: 4.3.5
       eslint: 8.49.0
       ts-api-utils: 1.0.3(typescript@5.5.4)
     optionalDependencies:


### PR DESCRIPTION
## What this PR solves / how to test

Replaces #6471, which was too verbose.

Fixes #6170

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
