### PR TITLE
feat(wrangler): Add support for examples in `--help`

### DIFF
--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -142,6 +142,58 @@ describe("vectorize help", () => {
 				--------------------"
 			`);
 	});
+
+	it("should show help when the query command is passed without an argument", async () => {
+		await expect(() => runWrangler("vectorize query")).rejects.toThrow(
+			"Not enough non-option arguments: got 0, need at least 1"
+		);
+
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mNot enough non-option arguments: got 0, need at least 1[0m
+
+			"
+		`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			wrangler vectorize query <name>
+
+			Query a Vectorize index
+
+			POSITIONALS
+			  name  The name of the Vectorize index  [string] [required]
+
+			GLOBAL FLAGS
+			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+			  -c, --config                    Path to .toml configuration file  [string]
+			  -e, --env                       Environment to use for operations and .env files  [string]
+			  -h, --help                      Show help  [boolean]
+			  -v, --version                   Show version number  [boolean]
+
+			OPTIONS
+			      --vector           Vector to query the Vectorize Index  [array] [required]
+			      --top-k            The number of results (nearest neighbors) to return  [number] [default: 5]
+			      --return-values    Specify if the vector values should be included in the results  [boolean] [default: false]
+			      --return-metadata  Specify if the vector metadata should be included in the results  [string] [choices: \\"all\\", \\"indexed\\", \\"none\\"] [default: \\"none\\"]
+			      --namespace        Filter the query results based on this namespace  [string]
+			      --filter           Filter the query results based on this metadata filter.  [string]
+
+			EXAMPLES
+			  ❯❯ wrangler vectorize query --vector 1 2 3 0.5 1.25 6
+			     Query the Vectorize Index by vector. To read from a json file that contains data in the format [1, 2, 3], you could use a command like
+			     \`wrangler vectorize query --vector $(jq -r '.[]' data.json | xargs)\`
+
+			  ❯❯ wrangler vectorize query --filter '{ 'p1': 'abc', 'p2': { '$ne': true }, 'p3': 10, 'p4': false, 'nested.p5': 'abcd' }'
+			     Filter the query results.
+
+			--------------------
+			📣 Vectorize is currently in open beta
+			📣 Please use the '--deprecated-v1' flag to create, get, list, delete and insert vectors into legacy Vectorize indexes
+			📣 See the Vectorize docs for how to get started and known issues: https://developers.cloudflare.com/vectorize
+			📣 Please report any bugs to https://github.com/cloudflare/workers-sdk/issues/new/choose
+			📣 To give feedback, visit https://discord.cloudflare.com/
+			--------------------"
+		`);
+	});
 });
 
 describe("vectorize commands", () => {

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -277,6 +277,7 @@ export function createCLIParser(argv: string[]) {
 		"Commands:": `${chalk.bold("COMMANDS")}`,
 		"Options:": `${chalk.bold("OPTIONS")}`,
 		"Positionals:": `${chalk.bold("POSITIONALS")}`,
+		"Examples:": `${chalk.bold("EXAMPLES")}`,
 	});
 	wrangler.group(
 		["experimental-json-config", "config", "env", "help", "version"],

--- a/packages/wrangler/src/vectorize/query.ts
+++ b/packages/wrangler/src/vectorize/query.ts
@@ -21,14 +21,13 @@ export function options(yargs: CommonYargsArgv) {
 		.positional("name", {
 			type: "string",
 			demandOption: true,
-			description: "The name of the Vectorize index.",
+			description: "The name of the Vectorize index",
 		})
 		.options({
 			vector: {
 				type: "array",
 				demandOption: true,
-				describe:
-					"Vector to query the Vectorize Index. Example: `--vector 1 2 3 0.5 1.25 6`. To read from a json file that contains data in the format [1, 2, 3], you could use a command like `--vector $(jq -r '.[]' data.json | xargs)`",
+				describe: "Vector to query the Vectorize Index",
 				coerce: (arg: unknown[]) =>
 					arg
 						.map((value) =>
@@ -42,20 +41,20 @@ export function options(yargs: CommonYargsArgv) {
 			"top-k": {
 				type: "number",
 				default: 5,
-				describe: "The number of results (nearest neighbors) to return.",
+				describe: "The number of results (nearest neighbors) to return",
 			},
 			"return-values": {
 				type: "boolean",
 				default: false,
 				describe:
-					"Specify if the vector values should be included in the results.",
+					"Specify if the vector values should be included in the results",
 			},
 			"return-metadata": {
 				type: "string",
 				choices: ["all", "indexed", "none"],
 				default: "none",
 				describe:
-					"Specify if the vector metadata should be included in the results. Should be either 'all', 'indexed' or 'none'",
+					"Specify if the vector metadata should be included in the results",
 			},
 			namespace: {
 				type: "string",
@@ -63,8 +62,7 @@ export function options(yargs: CommonYargsArgv) {
 			},
 			filter: {
 				type: "string",
-				describe:
-					"Filter the query results based on this metadata filter. Example: `--filter '{ 'p1': 'abc', 'p2': { '$ne': true }, 'p3': 10, 'p4': false, 'nested.p5': 'abcd' }'`",
+				describe: "Filter the query results based on this metadata filter.",
 				coerce: (jsonStr: string): VectorizeQueryOptions["filter"] => {
 					try {
 						return JSON.parse(jsonStr);
@@ -76,6 +74,17 @@ export function options(yargs: CommonYargsArgv) {
 				},
 			},
 		})
+		.example([
+			[
+				`❯❯ wrangler vectorize query --vector 1 2 3 0.5 1.25 6\n` +
+					"   Query the Vectorize Index by vector. To read from a json file that contains data in the format [1, 2, 3], you could use a command like\n" +
+					"   `wrangler vectorize query --vector $(jq -r '.[]' data.json | xargs)`\n",
+			],
+			[
+				"❯❯ wrangler vectorize query --filter '{ 'p1': 'abc', 'p2': { '$ne': true }, 'p3': 10, 'p4': false, 'nested.p5': 'abcd' }'\n" +
+					"   Filter the query results.",
+			],
+		])
 		.epilogue(vectorizeBetaWarning);
 }
 


### PR DESCRIPTION
## What this PR solves / how to test

This commit enables yargs `example` support in wrangler (see https://yargs.js.org/docs/#api-reference-examplecmd1-desc1-cmd2-desc2), and adds one for `vectorize query`.

See https://github.com/cloudflare/workers-sdk/pull/6502#discussion_r1719416481 for context

<img width="1291" alt="Screenshot 2024-08-16 at 19 45 23" src="https://github.com/user-attachments/assets/b892a172-652a-4436-8b6f-e34f0f902b09">

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: stdout change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: internal change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
