### PR TITLE
fix(miniflare): Fix regression introduced in #5570

### DIFF
--- a/.changeset/cool-beans-applaud.md
+++ b/.changeset/cool-beans-applaud.md
@@ -1,0 +1,9 @@
+---
+"miniflare": minor
+---
+
+fix: Fix Miniflare regression introduced in #5570
+
+PR #5570 introduced a regression in Miniflare, namely that declaring Queue Producers like `queueProducers: { "MY_QUEUE": "my-queue" }` no longer works. This commit fixes the issue.
+
+Fixes #5908

--- a/.changeset/cool-beans-applaud.md
+++ b/.changeset/cool-beans-applaud.md
@@ -1,5 +1,5 @@
 ---
-"miniflare": minor
+"miniflare": patch
 ---
 
 fix: Fix Miniflare regression introduced in #5570


### PR DESCRIPTION
## What this PR solves / how to test

PR #5570 introduced a regression in Miniflare, namely that declaring Queue Producers like 
```
queueProducers: { "MY_QUEUE": "my-queue" }
```
no longer works. This PR restores balance in the Miniflare + Queues Universe 🪐 

Possibly addresses  #5908


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: covered by unit tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: regression fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
