### PR TITLE
chore: Add wrangler team to C3 CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@
 /packages/wrangler/src/cloudchamber/ @cloudflare/cloudchamber @cloudflare/wrangler
 
 # C3 ownership
-/packages/create-cloudflare/ @cloudflare/c3
+/packages/create-cloudflare/ @cloudflare/c3 @cloudflare/wrangler
 
 # kv-asset-handler ownership
 /packages/kv-asset-handler/ @cloudflare/wrangler


### PR DESCRIPTION
## What this PR solves / how to test

https://github.com/cloudflare/workers-sdk/pull/4176 removed the wrangler team from the C3 CODEOWNERS. The [reasoning](https://github.com/cloudflare/workers-sdk/pull/4176#pullrequestreview-1677317060) back then was that:
 
```
Requiring wrangler approvals for C3 changes is unnecessary at this point because the two projects are independent, 
so this requirement is unnecessarily coupling teams and slowing us down. I'm happy to discuss if anyone has a concern
about this change.
```

As per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners however

<img width="740" alt="Screenshot 2024-08-19 at 11 46 22" src="https://github.com/user-attachments/assets/9fd021e8-e36b-4d88-8d56-42bab033e428">

so having both `@cloudflare/c3` and  `@cloudflare/wrangler` should not affect C3 team's ability to merge PRs without wrangler approval, but it will unblock the wrangler team to merge C3-related PR when needed (we needed this last week)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: codeowners change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:codeowners change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: codeowners change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because: codeowners change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
