### PR TITLE
Prefix headers sent by the playground with `cf-ew-raw-`

### DIFF
--- a/.changeset/nice-pants-wash.md
+++ b/.changeset/nice-pants-wash.md
@@ -1,0 +1,5 @@
+---
+"workers-playground": patch
+---
+
+Prefix HTTP headers sent by the playground with `cf-ew-raw-`

--- a/packages/workers-playground/src/QuickEditor/HTTPTab/fetchWorker.ts
+++ b/packages/workers-playground/src/QuickEditor/HTTPTab/fetchWorker.ts
@@ -11,7 +11,9 @@ export function fetchWorker(
 	return fetch(`${proxyUrl.origin}${init}`, {
 		...input,
 		headers: [
-			...(input?.headers ?? []).filter(([name]) => name),
+			...(input?.headers ?? [])
+				.filter(([name]) => name)
+				.map<[string, string]>(([n, v]) => [`cf-ew-raw-${n}`, v]),
 			["X-CF-Token", token],
 			["cf-raw-http", "true"],
 		],


### PR DESCRIPTION
## What this PR solves / how to test

Followup to https://github.com/cloudflare/workers-sdk/pull/6458, part of https://jira.cfdata.org/browse/DEVX-1312. See https://github.com/cloudflare/wrangler2/blob/penalosa/shared-editor/packages/workers-playground/README.md for instructions on running the Playground locally to test this—the `Cookie` header is a good one to test with.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Playground UI is manually tested
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: e2e doesn't apply to the playground
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
