### PR TITLE
Implement TODO: support symbolic links

### DIFF
--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -233,10 +233,6 @@ const walk = async (
 			const relativeFilepath = path.relative(startingDir, filepath);
 			const filestat = await stat(filepath);
 
-			if (filestat.isSymbolicLink()) {
-				return;
-			}
-
 			if (filestat.isDirectory()) {
 				manifest = await walk(filepath, manifest, startingDir);
 			} else {

--- a/packages/wrangler/src/miniflare-cli/assets.ts
+++ b/packages/wrangler/src/miniflare-cli/assets.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import { existsSync, lstatSync, readFileSync } from "node:fs";
+import { existsSync, statSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { createMetadataObject } from "@cloudflare/pages-shared/metadata-generator/createMetadataObject";
 import { parseHeaders } from "@cloudflare/pages-shared/metadata-generator/parseHeaders";
@@ -216,7 +216,7 @@ async function generateAssetsFetch(
 
 				if (
 					existsSync(filepath) &&
-					lstatSync(filepath).isFile() &&
+					statSync(filepath).isFile() &&
 					!ignoredFiles.includes(filepath)
 				) {
 					const hash = hashFile(filepath);

--- a/packages/wrangler/src/pages/validate.tsx
+++ b/packages/wrangler/src/pages/validate.tsx
@@ -81,10 +81,6 @@ export const validate = async (args: {
 					}
 				}
 
-				if (filestat.isSymbolicLink()) {
-					return;
-				}
-
 				if (filestat.isDirectory()) {
 					fileMap = await walk(filepath, fileMap, startingDir);
 				} else {

--- a/packages/wrangler/src/sites.ts
+++ b/packages/wrangler/src/sites.ts
@@ -38,8 +38,7 @@ async function* getFilesInFolder(dirPath: string): AsyncIterable<string> {
 		if (file.name.startsWith(".") && !HIDDEN_FILES_TO_INCLUDE.has(file.name)) {
 			continue;
 		}
-		// TODO: follow symlinks??
-		if (file.isDirectory()) {
+		if (file.isDirectory() || (file.isSymbolicLink() && (await stat(path.join(dirPath, file.name))).isDirectory())) {
 			yield* await getFilesInFolder(path.join(dirPath, file.name));
 		} else {
 			yield path.join(dirPath, file.name);


### PR DESCRIPTION
## Support symbolic links for static assets

Fixes #3094 (auto-closed but not resolved)

Supports symbolic links for static Pages assets in local dev server mode and in deploy.

## Author has addressed the following

- Tests
  - [X] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [X] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [X] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [X] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
