### PR TITLE
Add Wrangler CTA to the playground

### DIFF
--- a/.changeset/soft-turtles-exercise.md
+++ b/.changeset/soft-turtles-exercise.md
@@ -1,0 +1,5 @@
+---
+"workers-playground": patch
+---
+
+Add Wrangler CTA to the playground

--- a/packages/workers-playground/package.json
+++ b/packages/workers-playground/package.json
@@ -16,6 +16,7 @@
 	"dependencies": {
 		"@cloudflare/component-button": "^7.0.11",
 		"@cloudflare/component-code-block": "^4.1.2",
+		"@cloudflare/component-heading": "^4.0.6",
 		"@cloudflare/component-icon": "^11.5.1",
 		"@cloudflare/component-input": "^8.1.1",
 		"@cloudflare/component-listbox": "^1.10.6",

--- a/packages/workers-playground/src/QuickEditor/MigrateToWrangler/DocsLink.tsx
+++ b/packages/workers-playground/src/QuickEditor/MigrateToWrangler/DocsLink.tsx
@@ -1,0 +1,42 @@
+import { Icon } from "@cloudflare/component-icon";
+import { A, Span } from "@cloudflare/elements";
+import { isDarkMode } from "@cloudflare/style-const";
+import { createStyledComponent } from "@cloudflare/style-container";
+import React from "react";
+
+const Link = createStyledComponent(
+	({ theme }) => ({
+		display: "inline-flex",
+		alignItems: "center",
+		width: "fit-content",
+		fontSize: theme.fontSizes[1],
+		color: `${theme.colors.indigo[isDarkMode() ? 9 : 2]} !important`,
+		backgroundColor: theme.colors.indigo[isDarkMode() ? 4 : 9],
+		borderRadius: "100vw",
+		px: 2,
+		py: "1px",
+		textDecoration: "none",
+		lineHeight: 1.5,
+		verticalAlign: "bottom",
+		gap: 2,
+		"& svg": {
+			color: theme.colors.indigo[isDarkMode() ? 9 : 4],
+		},
+		"&:hover svg": {
+			color: theme.colors.indigo[isDarkMode() ? 9 : 2],
+		},
+	}),
+	A
+);
+
+type Props = React.ComponentProps<typeof Link>;
+
+export const DocsLink: React.FC<Props> = ({ children, ...props }) => (
+	<Link target="_blank" {...props} rel="noopener noreferrer">
+		<Span display="flex" flex="none" alignItems="center">
+			<Icon type="documentation" label="documentation" size={12} />
+		</Span>
+
+		{children}
+	</Link>
+);

--- a/packages/workers-playground/src/QuickEditor/MigrateToWrangler/DocsLink.tsx
+++ b/packages/workers-playground/src/QuickEditor/MigrateToWrangler/DocsLink.tsx
@@ -2,7 +2,7 @@ import { Icon } from "@cloudflare/component-icon";
 import { A, Span } from "@cloudflare/elements";
 import { isDarkMode } from "@cloudflare/style-const";
 import { createStyledComponent } from "@cloudflare/style-container";
-import React from "react";
+import type React from "react";
 
 const Link = createStyledComponent(
 	({ theme }) => ({

--- a/packages/workers-playground/src/QuickEditor/MigrateToWrangler/MigrateToWrangler.tsx
+++ b/packages/workers-playground/src/QuickEditor/MigrateToWrangler/MigrateToWrangler.tsx
@@ -47,8 +47,8 @@ export function MigrateToWranglerGuide() {
 							<Div ml={2} flex="1">
 								<Heading size={4}>Deploy your project </Heading>
 								<P>
-									You'll be asked to deploy via the create-cloudflare CLI.
-									Choose 'yes' and your project will deploy.
+									You&apos;ll be asked to deploy via the create-cloudflare CLI.
+									Choose &apos;yes&apos; and your project will deploy.
 								</P>
 							</Div>
 						</Li>
@@ -57,8 +57,8 @@ export function MigrateToWranglerGuide() {
 						<Heading size={4}>That’s it! 🎉 </Heading>
 						<P mt={3}>
 							You’ve now deployed your project via the CLI. To support you along
-							your journey developing with Cloudflare's CLI tool, Wrangler, here
-							are some resources:
+							your journey developing with Cloudflare&apos;s CLI tool, Wrangler,
+							here are some resources:
 						</P>
 						<Ul mt={3} pl={0} ml={0} listStyle="none">
 							<Li mb={2}>

--- a/packages/workers-playground/src/QuickEditor/MigrateToWrangler/MigrateToWrangler.tsx
+++ b/packages/workers-playground/src/QuickEditor/MigrateToWrangler/MigrateToWrangler.tsx
@@ -1,0 +1,82 @@
+import CodeBlock from "@cloudflare/component-code-block";
+import { Heading } from "@cloudflare/component-heading";
+import { A, Div, Li, Ol, P, Ul } from "@cloudflare/elements";
+import { DocsLink } from "./DocsLink";
+import { StepNumber } from "./StepNumber";
+
+export function MigrateToWranglerGuide() {
+	return (
+		<Div display="flex" flexDirection="column" mx="auto" width="90%" py={4}>
+			<>
+				<Div fontSize={4} fontWeight={700}>
+					Develop with Wrangler CLI
+				</Div>
+				<Div display="flex" flexDirection="column" maxWidth={700}>
+					<Div display="flex" alignItems="baseline" flexWrap="wrap" mt={3}>
+						<P>
+							Build, preview, and deploy your Workers from the Wrangler command
+							line interface (CLI). Once set up, you’ll be able to quickly
+							iterate on Worker code and configuration from your local
+							development environment.
+							<DocsLink
+								ml={2}
+								href="https://developers.cloudflare.com/workers/wrangler/"
+							>
+								Using Wrangler CLI
+							</DocsLink>
+						</P>
+					</Div>
+					<Ol ml={0} mt={4} listStyle="none" p={0}>
+						<Li my={3} display="flex">
+							<StepNumber number={1} active={true} />
+
+							<Div ml={2} flex="1">
+								<Heading size={4}>Initialise a new project</Heading>
+
+								<P>
+									<CodeBlock
+										code={`$ npx create-cloudflare@latest`}
+										language="sh"
+									/>
+								</P>
+							</Div>
+						</Li>
+						<Li my={2} display="flex">
+							<StepNumber number={2} active={true} />
+
+							<Div ml={2} flex="1">
+								<Heading size={4}>Deploy your project </Heading>
+								<P>
+									You'll be asked to deploy via the create-cloudflare CLI.
+									Choose 'yes' and your project will deploy.
+								</P>
+							</Div>
+						</Li>
+					</Ol>
+					<Div ml={3} mb={4}>
+						<Heading size={4}>That’s it! 🎉 </Heading>
+						<P mt={3}>
+							You’ve now deployed your project via the CLI. To support you along
+							your journey developing with Cloudflare's CLI tool, Wrangler, here
+							are some resources:
+						</P>
+						<Ul mt={3} pl={0} ml={0} listStyle="none">
+							<Li mb={2}>
+								<A href="https://developers.cloudflare.com/workers/wrangler/commands/">
+									Wrangler Commands
+								</A>
+							</Li>
+							<Li mb={2}>
+								<A href="https://developers.cloudflare.com/workers/cli-wrangler/configuration#keys">
+									wrangler.toml Config
+								</A>
+							</Li>
+						</Ul>
+					</Div>
+				</Div>
+			</>
+		</Div>
+	);
+}
+
+export default MigrateToWranglerGuide;

--- a/packages/workers-playground/src/QuickEditor/MigrateToWrangler/StepNumber.tsx
+++ b/packages/workers-playground/src/QuickEditor/MigrateToWrangler/StepNumber.tsx
@@ -1,0 +1,27 @@
+import { Div } from "@cloudflare/elements";
+import React from "react";
+
+export const StepNumber: React.FC<{
+	number: React.ReactNode;
+	active?: boolean;
+	complete?: boolean;
+}> = ({ number, active, complete }) => (
+	<Div
+		display="inline-flex"
+		justifyContent="center"
+		alignItems="center"
+		flex="none"
+		width={26}
+		height={26}
+		mr={2}
+		fontWeight="bold"
+		lineHeight={1}
+		border="1px solid"
+		borderRadius="50%"
+		borderColor={active || complete ? "blue.4" : "gray.7"}
+		color={active ? "#fff" : complete ? "blue.4" : "gray.4"}
+		backgroundColor={active ? "blue.4" : "transparent"}
+		userSelect="none"
+		children={number}
+	/>
+);

--- a/packages/workers-playground/src/QuickEditor/MigrateToWrangler/StepNumber.tsx
+++ b/packages/workers-playground/src/QuickEditor/MigrateToWrangler/StepNumber.tsx
@@ -1,5 +1,5 @@
 import { Div } from "@cloudflare/elements";
-import React from "react";
+import type React from "react";
 
 export const StepNumber: React.FC<{
 	number: React.ReactNode;
@@ -22,6 +22,7 @@ export const StepNumber: React.FC<{
 		color={active ? "#fff" : complete ? "blue.4" : "gray.4"}
 		backgroundColor={active ? "blue.4" : "transparent"}
 		userSelect="none"
-		children={number}
-	/>
+	>
+		{number}
+	</Div>
 );

--- a/packages/workers-playground/src/QuickEditor/TabBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/TabBar.tsx
@@ -11,6 +11,7 @@ import {
 	TabPanel as ReactTabPanel,
 	Tabs as ReactTabs,
 } from "react-tabs";
+import type { TabPanelProps as ReactTabPanelProps } from "react-tabs";
 import type { TabProps as ReactTabProps } from "react-tabs";
 
 const HIGHLIGHT_BLUE = variables.colors.blue[4];
@@ -137,12 +138,14 @@ export const Tabs = createComponent(
 	ReactTabs
 );
 
-export const TabPanel = createComponent(
-	({ selected }) => ({
+export const TabPanel = createComponent<
+	React.FC<ReactTabPanelProps & { scrollable?: boolean }>
+>(
+	({ selected, scrollable }) => ({
 		display: selected ? "flex" : "none",
 		flex: selected ? "auto" : "none",
 		position: "relative",
-		overflow: "hidden",
+		overflow: scrollable ? "auto" : "hidden",
 	}),
 	ReactTabPanel
 );

--- a/packages/workers-playground/src/QuickEditor/TabBar.tsx
+++ b/packages/workers-playground/src/QuickEditor/TabBar.tsx
@@ -11,8 +11,10 @@ import {
 	TabPanel as ReactTabPanel,
 	Tabs as ReactTabs,
 } from "react-tabs";
-import type { TabPanelProps as ReactTabPanelProps } from "react-tabs";
-import type { TabProps as ReactTabProps } from "react-tabs";
+import type {
+	TabPanelProps as ReactTabPanelProps,
+	TabProps as ReactTabProps,
+} from "react-tabs";
 
 const HIGHLIGHT_BLUE = variables.colors.blue[4];
 

--- a/packages/workers-playground/src/QuickEditor/ToolsPane.tsx
+++ b/packages/workers-playground/src/QuickEditor/ToolsPane.tsx
@@ -6,6 +6,7 @@ import { SplitPane } from "@cloudflare/workers-editor-shared";
 import { useState } from "react";
 import DevtoolsIframe from "./DevtoolsIframe";
 import { HTTPTab } from "./HTTPTab/HTTPTab";
+import MigrateToWrangler from "./MigrateToWrangler/MigrateToWrangler";
 import PreviewTab from "./PreviewTab/PreviewTab";
 import { Tab, TabBar, TabList, TabPanel, Tabs } from "./TabBar";
 
@@ -40,6 +41,9 @@ export default function ToolsPane() {
 								<Tab>
 									<Icon type="two-way" mr={2} />
 									HTTP
+								</Tab>
+								<Tab>
+									<Icon type="wrangler" />
 								</Tab>
 							</TabList>
 							<Div
@@ -89,6 +93,9 @@ export default function ToolsPane() {
 						)}
 						<TabPanel>
 							<HTTPTab />
+						</TabPanel>
+						<TabPanel scrollable>
+							<MigrateToWrangler />
 						</TabPanel>
 					</Tabs>
 				</Main>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1372,6 +1372,9 @@ importers:
       '@cloudflare/component-code-block':
         specifier: ^4.1.2
         version: 4.2.8(@cloudflare/component-icon@11.8.0(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(react@18.3.1))(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(@types/react-dom@18.2.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(regenerator-runtime@0.14.1)
+      '@cloudflare/component-heading':
+        specifier: ^4.0.6
+        version: 4.0.6(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@cloudflare/component-icon':
         specifier: ^11.5.1
         version: 11.8.0(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -2277,6 +2280,13 @@ packages:
       '@cloudflare/style-container': ^7.10.0
       react: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
       react-dom: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
+
+  '@cloudflare/component-heading@4.0.6':
+    resolution: {integrity: sha512-Rj4yClX7MsUZopiBrLEILCaLx5xl75Mn0Ad3As1Mlb7NcRpVHKR5giAt06M9a+bKg7fqKx8EV+jlf7RSwDeypQ==}
+    peerDependencies:
+      '@cloudflare/style-const': ^5.3.9
+      '@cloudflare/style-container': ^7.10.0
+      react: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
 
   '@cloudflare/component-icon@11.8.0':
     resolution: {integrity: sha512-H97P7IRQv1PwKbIgn0ZVukQNggGF4sZeBUze3B7li5qZIKWd1f04te6Ef5tOrdq7E+l0/6zpmg1uCtShxTuPkA==}
@@ -9472,6 +9482,13 @@ snapshots:
       - '@types/react-dom'
       - regenerator-runtime
 
+  '@cloudflare/component-heading@4.0.6(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@cloudflare/style-const': 5.7.3(react@18.3.1)
+      '@cloudflare/style-container': 7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1)
+      prop-types: 15.8.1
+      react: 18.3.1
+
   '@cloudflare/component-icon@11.8.0(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@cloudflare/style-const': 5.7.3(react@18.3.1)
@@ -11309,7 +11326,7 @@ snapshots:
       pathe: 1.1.1
       picocolors: 1.0.1
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.12.12)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+      vitest: 1.6.0(@types/node@20.8.3)(@vitest/ui@1.6.0)
 
   '@vitest/utils@1.5.0':
     dependencies:


### PR DESCRIPTION
## What this PR solves / how to test

Fixes https://jira.cfdata.org/browse/DEVX-1311

Adds a tab to the workers playground which calls out the C3 flow for creating a worker
<img width="692" alt="Screenshot 2024-08-20 at 10 29 07" src="https://github.com/user-attachments/assets/72951c69-f327-4b8a-a9f6-ad6a229ac7b3">

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: The playground frontend is manually tested
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: playground
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
