### PR TITLE
feat: add router worker to workers-shared

### DIFF
--- a/.changeset/empty-laws-prove.md
+++ b/.changeset/empty-laws-prove.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+feat: add basic Router Worker to workers-shared

--- a/packages/workers-shared/README.md
+++ b/packages/workers-shared/README.md
@@ -8,6 +8,12 @@ The Asset Server Worker.
 
 For more details please refer to the dedicated README file.
 
+## `router-worker`
+
+Router worker.
+
+For more details please refer to the dedicated README file.
+
 > [!NOTE]
 > Since code in this package is used by the Workers infrastructure, it is important that PRs are given careful review with regards to how they could cause a failure in production.
 > Ideally, there should be comprehensive tests for changes being made to give extra confidence about the behavior.

--- a/packages/workers-shared/README.md
+++ b/packages/workers-shared/README.md
@@ -10,7 +10,7 @@ For more details please refer to the dedicated README file.
 
 ## `router-worker`
 
-Router worker.
+Router Worker.
 
 For more details please refer to the dedicated README file.
 

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -22,13 +22,15 @@
 		"dist"
 	],
 	"scripts": {
-		"build": "pnpm run clean && pnpm run bundle:asset-server:prod",
+		"build": "pnpm run clean && pnpm run bundle:asset-server:prod && pnpm run bundle:router:prod",
 		"bundle:asset-server": "esbuild asset-server-worker/src/index.ts --format=esm --bundle --outfile=dist/asset-server-worker.mjs --sourcemap=external",
 		"bundle:asset-server:prod": "pnpm run bundle:asset-server --minify",
+		"bundle:router": "esbuild router-worker/src/index.ts --format=esm --bundle --outfile=dist/router-worker.mjs --sourcemap=external",
+		"bundle:router:prod": "pnpm run bundle:router --minify",
 		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
 		"clean": "rimraf dist",
-		"dev": "pnpm run clean && concurrently -n bundle:asset-server -c blue \"pnpm run bundle:asset-server --watch\""
+		"dev": "pnpm run clean && concurrently -n bundle:asset-server,bundle:router -c blue,magenta \"pnpm run bundle:asset-server --watch\" \"pnpm run bundle:router --watch\""
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",

--- a/packages/workers-shared/router-worker/README.md
+++ b/packages/workers-shared/router-worker/README.md
@@ -1,0 +1,3 @@
+# `router-worker`
+
+The Router worker is a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that is responsible for routing between a user worker and static assets in a Workers + Assets project.

--- a/packages/workers-shared/router-worker/README.md
+++ b/packages/workers-shared/router-worker/README.md
@@ -1,3 +1,3 @@
 # `router-worker`
 
-The Router worker is a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that is responsible for routing between a user worker and static assets in a Workers + Assets project.
+The Router Worker is a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that is responsible for routing between a user worker and static assets in a Workers + Assets project.

--- a/packages/workers-shared/router-worker/src/index.ts
+++ b/packages/workers-shared/router-worker/src/index.ts
@@ -1,0 +1,19 @@
+import type { Fetcher, Request } from "@cloudflare/workers-types";
+
+interface Env {
+	ASSET_SERVER: Fetcher;
+	USER_WORKER: Fetcher;
+}
+export default {
+	async fetch(request: Request, env: Env) {
+		const result = await env.ASSET_SERVER.fetch(request);
+		if (!result.ok) {
+			if (result.status === 404) {
+				await env.USER_WORKER.fetch(request);
+			}
+			return new Response(`Failed to fetch content: ${result.statusText}`, {
+				status: result.status,
+			});
+		}
+	},
+};

--- a/packages/workers-shared/router-worker/src/index.ts
+++ b/packages/workers-shared/router-worker/src/index.ts
@@ -9,11 +9,13 @@ export default {
 		const result = await env.ASSET_SERVER.fetch(request);
 		if (!result.ok) {
 			if (result.status === 404) {
-				await env.USER_WORKER.fetch(request);
+				return await env.USER_WORKER.fetch(request);
 			}
+			// return failed response on non-404 errors
 			return new Response(`Failed to fetch content: ${result.statusText}`, {
 				status: result.status,
 			});
 		}
+		return result;
 	},
 };

--- a/packages/workers-shared/router-worker/wrangler.toml
+++ b/packages/workers-shared/router-worker/wrangler.toml
@@ -7,6 +7,6 @@
 # to this file are persisted in wrangler as well, when necessary.
 # (see packages/wrangler/src/dev/miniflare.ts -> buildMiniflareOptions())
 ##
-name = "router"
+name = "router-worker"
 main = "src/index.ts"
 compatibility_date = "2024-07-31"

--- a/packages/workers-shared/router-worker/wrangler.toml
+++ b/packages/workers-shared/router-worker/wrangler.toml
@@ -1,0 +1,12 @@
+##
+# Configuration file for the Router Worker
+#
+# Please note that wrangler has a dependency on this file, and will
+# attempt to read it as part of setting up a new Miniflare instance
+# in developemnt mode. We should ensure that any configuration changes
+# to this file are persisted in wrangler as well, when necessary.
+# (see packages/wrangler/src/dev/miniflare.ts -> buildMiniflareOptions())
+##
+name = "router"
+main = "src/index.ts"
+compatibility_date = "2024-07-31"


### PR DESCRIPTION
## What this PR solves / how to test
[WC-2556](https://jira.cfdata.org/browse/WC-2556)
Adds in basic router worker, but does not wire it up to anything (e.g. miniflare)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: just scaffolding
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: new Worker
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: workers-shared is not documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
