### PR TITLE
Configure GitHub Actions to deploy Asset Worker

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -64,6 +64,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           WORKERS_NEW_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.WORKERS_NEW_CLOUDFLARE_ACCOUNT_ID }}
           WORKERS_NEW_CLOUDFLARE_API_TOKEN: ${{ secrets.WORKERS_NEW_CLOUDFLARE_API_TOKEN }}
+          WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN: ${{ secrets.WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN }}
 
       - name: Create C3 Diffs PR
         if: contains(steps.changesets.outputs.publishedPackages, '"create-cloudflare"')

--- a/packages/workers-shared/asset-worker/README.md
+++ b/packages/workers-shared/asset-worker/README.md
@@ -1,3 +1,3 @@
 # `asset-worker`
 
-The Asset Worker is a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that is responsible of serving assets for Workers deployed on the edge, that contain static assets as well.
+The Asset Worker is a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that is responsible of serving static assets. It is deployed in production and is also used in local `wrangler dev`.

--- a/packages/workers-shared/asset-worker/wrangler.toml
+++ b/packages/workers-shared/asset-worker/wrangler.toml
@@ -8,5 +8,7 @@
 # (see packages/wrangler/src/dev/miniflare.ts -> buildMiniflareOptions())
 ##
 name = "asset-worker"
+account_id = "0f1b8aa119a907021f659042f95ea9ba"
+workers_dev = false
 main = "src/index.ts"
 compatibility_date = "2024-07-31"

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -31,6 +31,8 @@
 		"check:type": "pnpm run check:type:tests && tsc",
 		"check:type:tests": "tsc -p ./asset-worker/tests/tsconfig.json",
 		"clean": "rimraf dist",
+		"deploy": "pnpm run deploy:asset-worker",
+		"deploy:asset-worker": "CLOUDFLARE_API_TOKEN=$WORKERS_NEW_CLOUDFLARE_API_TOKEN wrangler versions upload --experimental-versions -c asset-worker/wrangler.toml",
 		"dev": "pnpm run clean && concurrently -n bundle:asset-worker,bundle:router-worker -c blue,magenta \"pnpm run bundle:asset-worker --watch\" \"pnpm run bundle:router-worker --watch\"",
 		"test": "vitest",
 		"test:ci": "pnpm run test run"


### PR DESCRIPTION
## What this PR solves / how to test

Configure GitHub Actions to deploy Asset Worker

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: GH action change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: GH action change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: internal facing change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: internal facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
