### PR TITLE
Configure GitHub Actions to deploy Router Worker

### DIFF
--- a/packages/workers-shared/asset-worker/wrangler.toml
+++ b/packages/workers-shared/asset-worker/wrangler.toml
@@ -12,3 +12,18 @@ account_id = "0f1b8aa119a907021f659042f95ea9ba"
 workers_dev = false
 main = "src/index.ts"
 compatibility_date = "2024-07-31"
+compatibility_flags = ["nodejs_compat"]
+
+[[unsafe.bindings]]
+name = "ASSETS_MANIFEST"
+type = "param"
+param = "assetManifest"
+data_ref = true
+
+[[unsafe.bindings]]
+name = "ASSETS_KV_NAMESPACE"
+type = "internal_assets"
+
+[unsafe.metadata.build_options]
+stable_id = "cloudflare/cf_asset_worker"
+networks = ["cf","jdc"]

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -31,8 +31,9 @@
 		"check:type": "pnpm run check:type:tests && tsc",
 		"check:type:tests": "tsc -p ./asset-worker/tests/tsconfig.json",
 		"clean": "rimraf dist",
-		"deploy": "pnpm run deploy:asset-worker",
+		"deploy": "pnpm run deploy:router-worker && pnpm run deploy:asset-worker",
 		"deploy:asset-worker": "CLOUDFLARE_API_TOKEN=$WORKERS_NEW_CLOUDFLARE_API_TOKEN wrangler versions upload --experimental-versions -c asset-worker/wrangler.toml",
+		"deploy:router-worker": "CLOUDFLARE_API_TOKEN=$WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN wrangler versions upload --experimental-versions -c router-worker/wrangler.toml",
 		"dev": "pnpm run clean && concurrently -n bundle:asset-worker,bundle:router-worker -c blue,magenta \"pnpm run bundle:asset-worker --watch\" \"pnpm run bundle:router-worker --watch\"",
 		"test": "vitest",
 		"test:ci": "pnpm run test run"

--- a/packages/workers-shared/router-worker/README.md
+++ b/packages/workers-shared/router-worker/README.md
@@ -1,3 +1,3 @@
 # `router-worker`
 
-The Router Worker is a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that is responsible for routing between a user worker and static assets in a Workers + Assets project.
+The Router Worker is a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that is responsible for routing between a user Worker and static assets in a Workers + Assets project.

--- a/packages/workers-shared/router-worker/wrangler.toml
+++ b/packages/workers-shared/router-worker/wrangler.toml
@@ -8,5 +8,7 @@
 # (see packages/wrangler/src/dev/miniflare.ts -> buildMiniflareOptions())
 ##
 name = "router-worker"
+account_id = "0f1b8aa119a907021f659042f95ea9ba"
+workers_dev = false
 main = "src/index.ts"
 compatibility_date = "2024-07-31"

--- a/packages/workers-shared/router-worker/wrangler.toml
+++ b/packages/workers-shared/router-worker/wrangler.toml
@@ -12,3 +12,16 @@ account_id = "0f1b8aa119a907021f659042f95ea9ba"
 workers_dev = false
 main = "src/index.ts"
 compatibility_date = "2024-07-31"
+
+[[unsafe.bindings]]
+name = "ASSET_WORKER"
+type = "internal_assets"
+fetcherApi = "fetcher"
+
+[[unsafe.bindings]]
+name = "USER_WORKER"
+type = "origin"
+
+[unsafe.metadata.build_options]
+stable_id = "cloudflare/cf_router_worker"
+networks = ["cf","jdc"]


### PR DESCRIPTION
Will conflict at `packages/workers-shared/package.json#scripts.deploy` with https://github.com/cloudflare/workers-sdk/pull/6542

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: GH actions change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: GH actions change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: internal facing change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: internal facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
