### PR TITLE
test: run version upload tests in a temp directory, rather than the wrangler package directory

### DIFF
--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -5,11 +5,13 @@ import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
 import { msw } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWorkerSource } from "../helpers/write-worker-source";
 import { writeWranglerToml } from "../helpers/write-wrangler-toml";
 
 describe("versions upload", () => {
+	runInTempDir();
 	mockAccountId();
 	mockApiToken();
 	const { setIsTTY } = useMockIsTTY();


### PR DESCRIPTION
Prior to this, when you run the Wrangler tests you would find a directory (versions-upload-test-worker) and a couple of files (index.js and another.js) keep appearing.