### PR TITLE
fix(#6516)/VS-269: Add content-type header to Vectorize POST operations

### DIFF
--- a/.changeset/rare-cooks-marry.md
+++ b/.changeset/rare-cooks-marry.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix(6516): Add content-type header to Vectorize POST operations

--- a/packages/wrangler/src/vectorize/client.ts
+++ b/packages/wrangler/src/vectorize/client.ts
@@ -141,7 +141,9 @@ export async function queryIndex(
 		`/accounts/${accountId}/vectorize/v2/indexes/${indexName}/query`,
 		{
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: {
+				"content-type": jsonContentType,
+			},
 			body: JSON.stringify({
 				...options,
 				vector: Array.isArray(vector) ? vector : Array.from(vector),
@@ -161,6 +163,9 @@ export async function getByIds(
 		`/accounts/${accountId}/vectorize/v2/indexes/${indexName}/get_by_ids`,
 		{
 			method: "POST",
+			headers: {
+				"content-type": jsonContentType,
+			},
 			body: JSON.stringify(ids),
 		}
 	);
@@ -177,6 +182,9 @@ export async function deleteByIds(
 		`/accounts/${accountId}/vectorize/v2/indexes/${indexName}/delete_by_ids`,
 		{
 			method: "POST",
+			headers: {
+				"content-type": jsonContentType,
+			},
 			body: JSON.stringify(ids),
 		}
 	);
@@ -207,6 +215,9 @@ export async function createMetadataIndex(
 		`/accounts/${accountId}/vectorize/v2/indexes/${indexName}/metadata_index/create`,
 		{
 			method: "POST",
+			headers: {
+				"content-type": jsonContentType,
+			},
 			body: JSON.stringify(payload),
 		}
 	);
@@ -237,6 +248,9 @@ export async function deleteMetadataIndex(
 		`/accounts/${accountId}/vectorize/v2/indexes/${indexName}/metadata_index/delete`,
 		{
 			method: "POST",
+			headers: {
+				"content-type": jsonContentType,
+			},
 			body: JSON.stringify(payload),
 		}
 	);


### PR DESCRIPTION
## What this PR solves / how to test

Add content-type header to Vectorize POST operations

Fixes #6516/VS-269.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Tests with mocked responses exist. Only adding a header to Vectorize requests.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: Only adding a header to Vectorize requests.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: No change in public facing operations.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
