### PR TITLE
fix(create-cloudflare): rename category

### DIFF
--- a/.changeset/three-months-work.md
+++ b/.changeset/three-months-work.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: renamed the "Demo Application" category to "Application Starter"

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -236,7 +236,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 							matcher: /What would you like to start with\?/,
 							input: {
 								type: "select",
-								target: "Demo application",
+								target: "Application Starter",
 								assertDescriptionText:
 									"Select from a range of starter applications using various Cloudflare products",
 							},
@@ -255,7 +255,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 				);
 
 				expect(projectPath).toExist();
-				expect(output).toContain(`category Demo application`);
+				expect(output).toContain(`category Application Starter`);
 				expect(output).toContain(`type API starter (OpenAPI compliant)`);
 			},
 		);
@@ -270,7 +270,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 							matcher: /What would you like to start with\?/,
 							input: {
 								type: "select",
-								target: "Demo application",
+								target: "Application Starter",
 							},
 						},
 						{
@@ -300,7 +300,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())(
 							input: {
 								type: "select",
 								target: "Framework Starter",
-								assertDefaultSelection: "Demo application",
+								assertDefaultSelection: "Application Starter",
 							},
 						},
 						{

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -53,7 +53,7 @@ const cliDefinition: ArgumentsDefinition = {
 			values: [
 				{ name: "hello-world", description: "Hello World example" },
 				{ name: "web-framework", description: "Framework Starter" },
-				{ name: "demo", description: "Demo application" },
+				{ name: "demo", description: "Application Starter" },
 				{ name: "remote-template", description: "Template from a Github repo" },
 			],
 		},

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -289,7 +289,7 @@ export const createContext = async (
 			description: "Select from the most popular full-stack web frameworks",
 		},
 		{
-			label: "Demo application",
+			label: "Application Starter",
 			value: "demo",
 			description:
 				"Select from a range of starter applications using various Cloudflare products",


### PR DESCRIPTION
## What this PR solves / how to test

Fixes [DEVX-1381](https://jira.cfdata.org/browse/DEVX-1381)

This PR renamed the "Demo Application" category to "Application Starter" on c3.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: Renaming
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/16383
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
