### PR TITLE
Combined small bugfixes

### DIFF
--- a/.changeset/giant-pens-explain.md
+++ b/.changeset/giant-pens-explain.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: Rename Svelte to SvelteKit

--- a/.changeset/tough-ligers-grab.md
+++ b/.changeset/tough-ligers-grab.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Ensure esbuild warnings are logged when running wrangler deploy

--- a/packages/create-cloudflare/templates/svelte/c3.ts
+++ b/packages/create-cloudflare/templates/svelte/c3.ts
@@ -97,7 +97,7 @@ const updateTypeDefinitions = (ctx: C3Context) => {
 const config: TemplateConfig = {
 	configVersion: 1,
 	id: "svelte",
-	displayName: "Svelte",
+	displayName: "SvelteKit",
 	platform: "pages",
 	copyFiles: {
 		variants: {

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -625,6 +625,34 @@ describe("deploy", () => {
 			"
 		`);
 		});
+
+		it("should log esbuild warnings", async () => {
+			writeWranglerToml();
+			fs.writeFileSync(
+				"index.js",
+				dedent/* javascript */ `
+					export default {
+						fetch() {
+							return
+							new Response(dep);
+						}
+					}
+				`
+			);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+			await runWrangler("deploy ./index");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe following expression is not returned because of an automatically-inserted semicolon[0m [semicolon-after-return]
+
+				    index.js:3:8:
+				[37m      3 │     return[32m[37m
+				        ╵           [32m^[0m
+
+				"
+			`);
+		});
 	});
 
 	describe("environments", () => {

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -12,6 +12,7 @@ import {
 } from "../deployment-bundle/bundle-reporter";
 import { getBundleType } from "../deployment-bundle/bundle-type";
 import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
+import { logBuildOutput } from "../deployment-bundle/esbuild-plugins/log-build-output";
 import {
 	findAdditionalModules,
 	writeAdditionalModules,
@@ -554,21 +555,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 							props.compatibilityDate ?? config.compatibility_date,
 							props.compatibilityFlags ?? config.compatibility_flags
 						),
+						plugins: [logBuildOutput(nodejsCompatMode)],
 					}
 				);
-
-		// Add modules to dependencies for size warning
-		for (const module of modules) {
-			const modulePath =
-				module.filePath === undefined
-					? module.name
-					: path.relative("", module.filePath);
-			const bytesInOutput =
-				typeof module.content === "string"
-					? Buffer.byteLength(module.content)
-					: module.content.byteLength;
-			dependencies[modulePath] = { bytesInOutput };
-		}
 
 		// Add modules to dependencies for size warning
 		for (const module of modules) {

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/log-build-output.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/log-build-output.ts
@@ -1,0 +1,46 @@
+import { logBuildFailure, logBuildWarnings } from "../../logger";
+import { rewriteNodeCompatBuildFailure } from "../build-failures";
+import type { NodeJSCompatMode } from "../node-compat";
+import type { Plugin } from "esbuild";
+
+/**
+ * Log esbuild warnings and errors
+ */
+export function logBuildOutput(
+	nodejsCompatMode: NodeJSCompatMode | undefined,
+	onStart?: () => void,
+	updateBundle?: () => void
+): Plugin {
+	let bundled = false;
+
+	return {
+		name: "log-build-output",
+		setup(b) {
+			b.onStart(() => {
+				onStart?.();
+			});
+			b.onEnd(async (result) => {
+				const errors = result.errors;
+				const warnings = result.warnings;
+				if (errors.length > 0) {
+					if (nodejsCompatMode !== "legacy") {
+						rewriteNodeCompatBuildFailure(result.errors);
+					}
+					logBuildFailure(errors, warnings);
+					return;
+				}
+
+				if (warnings.length > 0) {
+					logBuildWarnings(warnings);
+				}
+
+				if (!bundled) {
+					// First bundle, no need to update bundle
+					bundled = true;
+				} else {
+					await updateBundle?.();
+				}
+			});
+		},
+	};
+}


### PR DESCRIPTION
## What this PR solves / how to test
- c71a539ec2d7259d9dba18ac0070e74737c00ee1 Update Svelte display name to SvelteKit. Per https://github.com/cloudflare/workers-sdk/issues/3263#issuecomment-1888034131, this is what the Svelte team recommends. The Svelte framework template runs `create-svelte` which scaffolds a SvelteKit project, so this should make it clearer to users what type of project they're actually going to get. Fixes #3263
- https://github.com/cloudflare/workers-sdk/pull/6559/commits/2bb28296e3fcdcbbd5a06df956b06f64bed06248 Make sure esbuild warnings are logged when running `wrangler deploy`. Fixes #4923

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
