### PR TITLE
Update Svelte display name to SvelteKit

### DIFF
--- a/.changeset/giant-pens-explain.md
+++ b/.changeset/giant-pens-explain.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: Rename Svelte to SvelteKit

--- a/packages/create-cloudflare/templates/svelte/c3.ts
+++ b/packages/create-cloudflare/templates/svelte/c3.ts
@@ -97,7 +97,7 @@ const updateTypeDefinitions = (ctx: C3Context) => {
 const config: TemplateConfig = {
 	configVersion: 1,
 	id: "svelte",
-	displayName: "Svelte",
+	displayName: "SvelteKit",
 	platform: "pages",
 	copyFiles: {
 		variants: {


### PR DESCRIPTION
## What this PR solves / how to test

Per https://github.com/cloudflare/workers-sdk/issues/3263#issuecomment-1888034131, this is what the Svelte team recommends. The Svelte framework template runs `create-svelte` which scaffolds a SvelteKit project, so this should make it clearer to users what type of project they're actually going to get. 

Fixes #3263

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: this doesn;t have any tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: e2e doesn't apply to c3
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: The Svelte guide skips this step with a CLI arg: https://developers.cloudflare.com/pages/framework-guides/deploy-a-svelte-site/

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
