### PR TITLE
Run deploy interactively in C3

### DIFF
--- a/.changeset/smart-drinks-joke.md
+++ b/.changeset/smart-drinks-joke.md
@@ -1,6 +1,5 @@
 ---
 "create-cloudflare": patch
-"wrangler": patch
 ---
 
 Make sure `wrangler deploy` and `wrangler pages deploy` are run in an interactive context in C3, so that users are able to respond to interactive prompts

--- a/.changeset/smart-drinks-joke.md
+++ b/.changeset/smart-drinks-joke.md
@@ -1,0 +1,6 @@
+---
+"create-cloudflare": patch
+"wrangler": patch
+---
+
+Make sure `wrangler deploy` and `wrangler pages deploy` are run in an interactive context in C3, so that users are able to respond to interactive prompts

--- a/packages/create-cloudflare/src/__tests__/deploy.test.ts
+++ b/packages/create-cloudflare/src/__tests__/deploy.test.ts
@@ -130,8 +130,10 @@ describe("deploy helpers", async () => {
 			ctx.template.platform = "pages";
 			ctx.commitMessage = commitMsg;
 			mockInsideGitRepo(false);
-			vi.mocked(runCommand).mockResolvedValueOnce(deployedUrl);
-
+			vi.mocked(runCommand).mockResolvedValueOnce("");
+			vi.mocked(readFile).mockImplementationOnce(
+				() => `{"type":"deploy", "targets":["${deployedUrl}"]}`,
+			);
 			await runDeploy(ctx);
 			expect(runCommand).toHaveBeenCalledWith(
 				["npm", "run", "deploy", "--", "--commit-message", `"${commitMsg}"`],

--- a/packages/create-cloudflare/src/deploy.ts
+++ b/packages/create-cloudflare/src/deploy.ts
@@ -1,7 +1,7 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { crash, startSection, updateStatus } from "@cloudflare/cli";
+import { startSection, updateStatus } from "@cloudflare/cli";
 import { blue, brandColor, dim } from "@cloudflare/cli/colors";
 import TOML from "@iarna/toml";
 import { processArgument } from "helpers/args";
@@ -136,10 +136,10 @@ export const runDeploy = async (ctx: C3Context) => {
 		if (deployedUrlMatch) {
 			ctx.deployment.url = deployedUrlMatch[0];
 		} else {
-			crash("Failed to find deployment url.");
+			throw new Error("Failed to find deployment url.");
 		}
 	} catch {
-		crash("Failed to find deployment url.");
+		throw new Error("Failed to find deployment url.");
 	}
 
 	// if a pages url (<sha1>.<project>.pages.dev), remove the sha1

--- a/packages/create-cloudflare/src/deploy.ts
+++ b/packages/create-cloudflare/src/deploy.ts
@@ -108,7 +108,7 @@ export const runDeploy = async (ctx: C3Context) => {
 		"output.json",
 	);
 
-	const result = await runCommand(deployCmd, {
+	await runCommand(deployCmd, {
 		cwd: ctx.project.path,
 		env: {
 			CLOUDFLARE_ACCOUNT_ID: ctx.account.id,

--- a/packages/create-cloudflare/src/deploy.ts
+++ b/packages/create-cloudflare/src/deploy.ts
@@ -1,9 +1,13 @@
-import { startSection, updateStatus } from "@cloudflare/cli";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { crash, startSection, updateStatus } from "@cloudflare/cli";
 import { blue, brandColor, dim } from "@cloudflare/cli/colors";
 import TOML from "@iarna/toml";
 import { processArgument } from "helpers/args";
 import { C3_DEFAULTS, openInBrowser } from "helpers/cli";
 import { quoteShellArgs, runCommand } from "helpers/command";
+import { readFile } from "helpers/files";
 import { detectPackageManager } from "helpers/packageManagers";
 import { poll } from "helpers/poll";
 import { isInsideGitRepo } from "./git";
@@ -99,12 +103,17 @@ export const runDeploy = async (ctx: C3Context) => {
 			: []),
 	];
 
+	const outputFile = join(
+		await mkdtemp(join(tmpdir(), "c3-wrangler-deploy-")),
+		"output.json",
+	);
+
 	const result = await runCommand(deployCmd, {
-		silent: true,
 		cwd: ctx.project.path,
 		env: {
 			CLOUDFLARE_ACCOUNT_ID: ctx.account.id,
 			NODE_ENV: "production",
+			WRANGLER_OUTPUT_FILE_PATH: outputFile,
 		},
 		startText: "Deploying your application",
 		doneText: `${brandColor("deployed")} ${dim(
@@ -112,12 +121,25 @@ export const runDeploy = async (ctx: C3Context) => {
 		)}`,
 	});
 
-	const deployedUrlRegex = /https:\/\/.+\.(pages|workers)\.dev/;
-	const deployedUrlMatch = result.match(deployedUrlRegex);
-	if (deployedUrlMatch) {
-		ctx.deployment.url = deployedUrlMatch[0];
-	} else {
-		throw new Error("Failed to find deployment url.");
+	try {
+		const contents = readFile(outputFile);
+
+		const entries = contents
+			.split("\n")
+			.filter(Boolean)
+			.map((entry) => JSON.parse(entry));
+		const url: string | undefined =
+			entries.find((entry) => entry.type === "deploy")?.targets?.[0] ??
+			entries.find((entry) => entry.type === "pages-deploy")?.url;
+		const deployedUrlRegex = /https:\/\/.+\.(pages|workers)\.dev/;
+		const deployedUrlMatch = url?.match(deployedUrlRegex);
+		if (deployedUrlMatch) {
+			ctx.deployment.url = deployedUrlMatch[0];
+		} else {
+			crash("Failed to find deployment url.");
+		}
+	} catch {
+		crash("Failed to find deployment url.");
 	}
 
 	// if a pages url (<sha1>.<project>.pages.dev), remove the sha1


### PR DESCRIPTION
## What this PR solves / how to test

Previously, C3 ran `wrangler deploy` and `wrangler pages deploy` non-interactively. Since this is intended to be an interactive command, this led to various bugs. However, since C3 parsed the output of Wrangler's deploy command (and that's not possible with an interactive spawn), a change was also needed to how C3 figured out what Wrangler did during a deploy. This PR runs the deploy command interactively, after that change to Wrangler's output was made in https://github.com/cloudflare/workers-sdk/pull/6571

Fixes #4915, fixes #4263, fixes #6230

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
