### PR TITLE
Show a clearer user error when trying to use a python worker without the `python_workers` compatibility flag specified

### DIFF
--- a/.changeset/lucky-points-remain.md
+++ b/.changeset/lucky-points-remain.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Show a clearer user error when trying to use a python worker without the `python_workers` compatibility flag specified

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -1,12 +1,49 @@
 import path from "node:path";
+import { readConfig } from "../config";
 import { normalizeAndValidateConfig } from "../config/validation";
 import { normalizeSlashes } from "./helpers/mock-console";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { writeWranglerToml } from "./helpers/write-wrangler-toml";
 import type {
 	ConfigFields,
 	RawConfig,
 	RawDevConfig,
 	RawEnvironment,
 } from "../config";
+
+describe.only("readConfig()", () => {
+	runInTempDir();
+	it("should not error if a python entrypoint is used with the right compatibility_flag", () => {
+		writeWranglerToml({
+			main: "index.py",
+			compatibility_flags: ["python_workers"],
+		});
+		const config = readConfig("wrangler.toml", {});
+		expect(config.rules).toMatchInlineSnapshot(`
+			Array [
+			  Object {
+			    "globs": Array [
+			      "**/*.py",
+			    ],
+			    "type": "PythonModule",
+			  },
+			]
+		`);
+	});
+	it("should error if a python entrypoint is used without the right compatibility_flag", () => {
+		writeWranglerToml({
+			main: "index.py",
+		});
+		try {
+			readConfig("wrangler.toml", {});
+			expect.fail();
+		} catch (e) {
+			expect(e).toMatchInlineSnapshot(
+				`[Error: The \`python_workers\` compatibility flag is required to use Python.]`
+			);
+		}
+	});
+});
 
 describe("normalizeAndValidateConfig()", () => {
 	it("should use defaults for empty configuration", () => {

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -11,7 +11,7 @@ import type {
 	RawEnvironment,
 } from "../config";
 
-describe.only("readConfig()", () => {
+describe("readConfig()", () => {
 	runInTempDir();
 	it("should not error if a python entrypoint is used with the right compatibility_flag", () => {
 		writeWranglerToml({

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -10797,6 +10797,7 @@ export default{
 		it("should upload python module defined in wrangler.toml", async () => {
 			writeWranglerToml({
 				main: "index.py",
+				compatibility_flags: ["python_workers"],
 			});
 			await fs.promises.writeFile(
 				"index.py",
@@ -10835,7 +10836,9 @@ export default{
 		});
 
 		it("should upload python module specified in CLI args", async () => {
-			writeWranglerToml();
+			writeWranglerToml({
+				compatibility_flags: ["python_workers"],
+			});
 			await fs.promises.writeFile(
 				"index.py",
 				"from js import Response;\ndef fetch(request):\n return Response.new('hello')"

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -156,6 +156,11 @@ export function readConfig(
 		if (!config.rules.some((rule) => rule.type === "PythonModule")) {
 			config.rules.push({ type: "PythonModule", globs: ["**/*.py"] });
 		}
+		if (!config.compatibility_flags.includes("python_workers")) {
+			throw new UserError(
+				"The `python_workers` compatibility flag is required to use Python."
+			);
+		}
 	}
 
 	return config;

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -147,6 +147,15 @@ export function readConfig(
 		}
 	}
 
+	applyPythonConfig(config, args);
+
+	return config;
+}
+
+/**
+ * Modifies the provided config to support python workers, if the entrypoint is a .py file
+ */
+function applyPythonConfig(config: Config, args: ReadConfigCommandArgs) {
 	const mainModule = "script" in args ? args.script : config.main;
 	if (typeof mainModule === "string" && mainModule.endsWith(".py")) {
 		// Workers with a python entrypoint should have bundling turned off, since all of Wrangler's bundling is JS/TS specific
@@ -162,8 +171,6 @@ export function readConfig(
 			);
 		}
 	}
-
-	return config;
 }
 
 /**


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #5479

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: not covered by e2e tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: messsaging improvement

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
