### PR TITLE
feat(wrangler): watch mode for Workers + Assets

### DIFF
--- a/.changeset/hungry-candles-knock.md
+++ b/.changeset/hungry-candles-knock.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: add support for experimental assets in `wrangler dev` watch mode

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -889,7 +889,7 @@ describe("watch mode", () => {
 				text = await fetchText(`${url}/workers/index.html`);
 				expect(text).toBe("Cloudflare Workers!");
 
-				await helper.remove(["public/index.html"]);
+				await helper.removeFiles(["public/index.html"]);
 
 				await worker.waitForReload();
 
@@ -1010,7 +1010,7 @@ describe("watch mode", () => {
 			expect(text).toBe("<h1>Read more about Workers + Assets</h1>");
 
 			// remove
-			await helper.remove(["dist/about.html"]);
+			await helper.removeFiles(["dist/about.html"]);
 
 			await worker.waitForReload();
 

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -781,3 +781,249 @@ describe("custom builds", () => {
 		expect(text).toMatchInlineSnapshot(`"Hello, World!"`);
 	});
 });
+
+describe("watch mode", () => {
+	describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --x-dev-env" }])(
+		"Workers + Assets watch mode: $cmd",
+		({ cmd }) => {
+			it(`supports modifying existing assets during dev session`, async () => {
+				const helper = new WranglerE2ETestHelper();
+				await helper.seed({
+					"wrangler.toml": dedent`
+								name = "${workerName}"
+								compatibility_date = "2023-01-01"
+
+								[experimental_assets]
+								directory = "./public"
+						`,
+					"public/index.html": dedent`
+								<h1>Hello Workers + Assets</h1>`,
+				});
+
+				const worker = helper.runLongLived(cmd);
+				const { url } = await worker.waitForReady();
+
+				let text = await fetchText(`${url}/index.html`);
+				expect(text).toBe("<h1>Hello Workers + Assets</h1>");
+
+				await helper.seed({
+					"public/index.html": dedent`
+							<h1>Hello Updated Workers + Assets</h1>`,
+				});
+
+				await worker.waitForReload();
+
+				text = await fetchText(`${url}/index.html`);
+				expect(text).toBe("<h1>Hello Updated Workers + Assets</h1>");
+			});
+
+			it(`supports adding new assets during dev session`, async () => {
+				const helper = new WranglerE2ETestHelper();
+				await helper.seed({
+					"wrangler.toml": dedent`
+								name = "${workerName}"
+								compatibility_date = "2023-01-01"
+
+								[experimental_assets]
+								directory = "./public"
+						`,
+					"public/index.html": dedent`
+								<h1>Hello Workers + Assets</h1>`,
+				});
+
+				const worker = helper.runLongLived(cmd);
+				const { url } = await worker.waitForReady();
+				let text = await fetchText(`${url}/index.html`);
+				expect(text).toBe("<h1>Hello Workers + Assets</h1>");
+
+				await helper.seed({
+					"public/about.html": dedent`About Workers + Assets`,
+					"public/workers/index.html": dedent`Cloudflare Workers!`,
+				});
+
+				await worker.waitForReload();
+
+				// re-calculating the asset manifest / reverse assets map might not be
+				// done at this point, so retry until they are available
+				const response = await retry(
+					(s) => s.status !== 200,
+					async () => {
+						const r = await fetch(`${url}/about.html`);
+						return { text: await r.text(), status: r.status };
+					}
+				);
+				expect(response.text).toBe("About Workers + Assets");
+
+				text = await fetchText(`${url}/workers/index.html`);
+				expect(text).toBe("Cloudflare Workers!");
+
+				text = await fetchText(`${url}/index.html`);
+				expect(text).toBe("<h1>Hello Workers + Assets</h1>");
+			});
+
+			it(`supports removing existing assets during dev session`, async () => {
+				const helper = new WranglerE2ETestHelper();
+				await helper.seed({
+					"wrangler.toml": dedent`
+								name = "${workerName}"
+								compatibility_date = "2023-01-01"
+
+								[experimental_assets]
+								directory = "./public"
+						`,
+					"public/index.html": dedent`
+								<h1>Hello Workers + Assets</h1>`,
+					"public/about.html": dedent`About Workers + Assets`,
+					"public/workers/index.html": dedent`Cloudflare Workers!`,
+				});
+
+				const worker = helper.runLongLived(cmd);
+				const { url } = await worker.waitForReady();
+
+				let text = await fetchText(`${url}/index.html`);
+				expect(text).toBe("<h1>Hello Workers + Assets</h1>");
+
+				text = await fetchText(`${url}/about.html`);
+				expect(text).toBe("About Workers + Assets");
+
+				text = await fetchText(`${url}/workers/index.html`);
+				expect(text).toBe("Cloudflare Workers!");
+
+				await helper.remove(["public/index.html"]);
+
+				await worker.waitForReload();
+
+				// re-calculating the asset manifest / reverse assets map might not be
+				// done at this point, so retry until they are available
+				const response = await retry(
+					(s) => s.status !== 404,
+					async () => {
+						const r = await fetch(`${url}/index.html`);
+						return { text: await r.text(), status: r.status };
+					}
+				);
+				expect(response.status).toBe(404);
+			});
+
+			it(`supports modifying the assets directory in wrangler.toml during dev session`, async () => {
+				const helper = new WranglerE2ETestHelper();
+				await helper.seed({
+					"wrangler.toml": dedent`
+								name = "${workerName}"
+								compatibility_date = "2023-01-01"
+
+								[experimental_assets]
+								directory = "./public"
+						`,
+					"public/index.html": dedent`
+								<h1>Hello Workers + Assets</h1>`,
+					"public2/index.html": dedent`
+								<h1>Hola Workers + Assets</h1>`,
+					"public2/about/index.html": dedent`
+								<h1>Read more about Workers + Assets</h1>`,
+				});
+
+				const worker = helper.runLongLived(cmd);
+				const { url } = await worker.waitForReady();
+
+				let text = await fetchText(`${url}/index.html`);
+				expect(text).toBe("<h1>Hello Workers + Assets</h1>");
+
+				await helper.seed({
+					"wrangler.toml": dedent`
+							name = "${workerName}"
+							compatibility_date = "2023-01-01"
+
+							[experimental_assets]
+							directory = "./public2"
+					`,
+				});
+
+				await worker.waitForReload();
+
+				const response = await retry(
+					(s) => s.text !== "<h1>Hola Workers + Assets</h1>",
+					async () => {
+						const r = await fetch(`${url}/index.html`);
+						return { text: await r.text(), status: r.status };
+					}
+				);
+				expect(response.text).toBe("<h1>Hola Workers + Assets</h1>");
+
+				text = await fetchText(`${url}/about/index.html`);
+				expect(text).toBe("<h1>Read more about Workers + Assets</h1>");
+			});
+		}
+	);
+
+	describe.each([
+		{ cmd: "wrangler dev --x-assets=dist" },
+		{ cmd: "wrangler dev --x-dev-env --x-assets=dist" },
+	])("Workers + Assets watch mode: $cmd", ({ cmd }) => {
+		it(`supports modifying assets during dev session`, async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
+								name = "${workerName}"
+								compatibility_date = "2023-01-01"
+						`,
+				"dist/index.html": dedent`
+								<h1>Hello Workers + Assets</h1>`,
+				"dist/about.html": dedent`
+								<h1>Read more about Workers + Assets</h1>`,
+			});
+
+			const worker = helper.runLongLived(cmd);
+			const { url } = await worker.waitForReady();
+
+			let text = await fetchText(`${url}/index.html`);
+			expect(text).toBe("<h1>Hello Workers + Assets</h1>");
+
+			text = await fetchText(`${url}/about.html`);
+			expect(text).toBe("<h1>Read more about Workers + Assets</h1>");
+
+			// change + add
+			await helper.seed({
+				"dist/index.html": dedent`
+							<h1>Hello Updated Workers + Assets</h1>`,
+				"dist/hello.html": dedent`
+							<h1>Hya Workers!</h1>`,
+			});
+
+			await worker.waitForReload();
+
+			// re-calculating the asset manifest / reverse assets map might not be
+			// done at this point, so retry until they are available
+			let response = await retry(
+				(s) => s.status !== 200,
+				async () => {
+					const r = await fetch(`${url}/hello.html`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(response.text).toBe("<h1>Hya Workers!</h1>");
+
+			text = await fetchText(`${url}/index.html`);
+			expect(text).toBe("<h1>Hello Updated Workers + Assets</h1>");
+
+			text = await fetchText(`${url}/about.html`);
+			expect(text).toBe("<h1>Read more about Workers + Assets</h1>");
+
+			// remove
+			await helper.remove(["dist/about.html"]);
+
+			await worker.waitForReload();
+
+			// re-calculating the asset manifest / reverse assets map might not be
+			// done at this point, so retry until they are available
+			response = await retry(
+				(s) => s.status !== 404,
+				async () => {
+					const r = await fetch(`${url}/about.html`);
+					return { text: await r.text(), status: r.status };
+				}
+			);
+			expect(response.status).toBe(404);
+		});
+	});
+});

--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import crypto from "node:crypto";
 import { onTestFinished } from "vitest";
 import { generateResourceName } from "./generate-resource-name";
-import { makeRoot, seed } from "./setup";
+import { makeRoot, remove, seed } from "./setup";
 import {
 	runWrangler,
 	WRANGLER_IMPORT,
@@ -19,6 +19,10 @@ export class WranglerE2ETestHelper {
 
 	async seed(files: Record<string, string | Uint8Array>) {
 		await seed(this.tmpPath, files);
+	}
+
+	async remove(files: string[]) {
+		await remove(this.tmpPath, files);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports

--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import crypto from "node:crypto";
 import { onTestFinished } from "vitest";
 import { generateResourceName } from "./generate-resource-name";
-import { makeRoot, remove, seed } from "./setup";
+import { makeRoot, removeFiles, seed } from "./setup";
 import {
 	runWrangler,
 	WRANGLER_IMPORT,
@@ -21,8 +21,8 @@ export class WranglerE2ETestHelper {
 		await seed(this.tmpPath, files);
 	}
 
-	async remove(files: string[]) {
-		await remove(this.tmpPath, files);
+	async removeFiles(files: string[]) {
+		await removeFiles(this.tmpPath, files);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports

--- a/packages/wrangler/e2e/helpers/setup.ts
+++ b/packages/wrangler/e2e/helpers/setup.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -18,5 +18,15 @@ export async function seed(
 		const filePath = path.resolve(root, name);
 		await mkdir(path.dirname(filePath), { recursive: true });
 		await writeFile(filePath, contents);
+	}
+}
+
+// Removes the given files from the `root` directory on the file system.
+export async function remove(root: string, files: string[]) {
+	for (const name of files) {
+		const filePath = path.resolve(root, name);
+		if (filePath) {
+			await rm(filePath);
+		}
 	}
 }

--- a/packages/wrangler/e2e/helpers/setup.ts
+++ b/packages/wrangler/e2e/helpers/setup.ts
@@ -22,7 +22,7 @@ export async function seed(
 }
 
 // Removes the given files from the `root` directory on the file system.
-export async function remove(root: string, files: string[]) {
+export async function removeFiles(root: string, files: string[]) {
 	for (const name of files) {
 		const filePath = path.resolve(root, name);
 		if (filePath) {

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -263,7 +263,8 @@ export async function unstable_dev(
 			() => startDev(devOptions)
 		)) as {
 			devReactElement: Instance;
-			watcher: FSWatcher | undefined;
+			configFileWatcher: FSWatcher | undefined;
+			assetsWatcher: FSWatcher | undefined;
 			stop: () => Promise<void>;
 		};
 		const { port, address, proxyData } = await readyPromise;

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -322,6 +322,7 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 		if (configPath) {
 			this.#configWatcher = watch(configPath, {
 				persistent: true,
+				ignoreInitial: true,
 			}).on("change", async (_event) => {
 				logger.log(`${path.basename(configPath)} changed...`);
 				assert(
@@ -422,8 +423,10 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 
 	async teardown() {
 		logger.debug("ConfigController teardown beginning...");
-		await this.#configWatcher?.close();
-		await this.#assetsWatcher?.close();
+		await Promise.allSettled([
+			this.#configWatcher?.close(),
+			this.#assetsWatcher?.close(),
+		]);
 		logger.debug("ConfigController teardown complete");
 	}
 

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -12,6 +12,7 @@ import {
 import { printBindings, readConfig } from "../../config";
 import { getEntry } from "../../deployment-bundle/entry";
 import {
+	getAssetChangeMessage,
 	getBindings,
 	getHostAndRoutes,
 	getInferredHost,
@@ -19,6 +20,7 @@ import {
 } from "../../dev";
 import { getLocalPersistencePath } from "../../dev/get-local-persistence-path";
 import { UserError } from "../../errors";
+import { processExperimentalAssetsArg } from "../../experimental-assets";
 import { logger } from "../../logger";
 import { getAccountId, requireApiToken } from "../../user";
 import { memoizeGetPort } from "../../utils/memoizeGetPort";
@@ -262,7 +264,7 @@ async function resolveConfig(
 			metadata: input.unsafe?.metadata ?? unsafe?.metadata,
 		},
 		experimental: {
-			assets: input?.experimental?.assets,
+			assets: input?.experimental?.assets ?? config.experimental_assets,
 		},
 	} satisfies StartDevWorkerOptions;
 
@@ -312,6 +314,7 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 	latestConfig?: StartDevWorkerOptions;
 
 	#configWatcher?: ReturnType<typeof watch>;
+	#assetsWatcher?: ReturnType<typeof watch>;
 	#abortController?: AbortController;
 
 	async #ensureWatchingConfig(configPath: string | undefined) {
@@ -321,6 +324,25 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 				persistent: true,
 			}).on("change", async (_event) => {
 				logger.log(`${path.basename(configPath)} changed...`);
+				assert(
+					this.latestInput,
+					"Cannot be watching config without having first set an input"
+				);
+				void this.#updateConfig(this.latestInput);
+			});
+		}
+	}
+
+	async #ensureWatchingAssets(assetsPath: string | undefined) {
+		await this.#assetsWatcher?.close();
+
+		if (assetsPath) {
+			this.#assetsWatcher = watch(assetsPath, {
+				persistent: true,
+				ignoreInitial: true,
+			}).on("all", async (eventName, filePath) => {
+				const message = getAssetChangeMessage(eventName, filePath);
+				logger.log(`🌀 ${message}...`);
 				assert(
 					this.latestInput,
 					"Cannot be watching config without having first set an input"
@@ -352,33 +374,46 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 		const signal = this.#abortController.signal;
 		this.latestInput = input;
 
-		const fileConfig = readConfig(input.config, {
-			env: input.env,
-			"dispatch-namespace": undefined,
-			"legacy-env": !input.legacy?.enableServiceEnvironments ?? true,
-			remote: input.dev?.remote,
-			upstreamProtocol:
-				input.dev?.origin?.secure === undefined
-					? undefined
-					: input.dev?.origin?.secure
-						? "https"
-						: "http",
-			localProtocol:
-				input.dev?.server?.secure === undefined
-					? undefined
-					: input.dev?.server?.secure
-						? "https"
-						: "http",
-		});
-		void this.#ensureWatchingConfig(fileConfig.configPath);
+		try {
+			const fileConfig = readConfig(input.config, {
+				env: input.env,
+				"dispatch-namespace": undefined,
+				"legacy-env": !input.legacy?.enableServiceEnvironments ?? true,
+				remote: input.dev?.remote,
+				upstreamProtocol:
+					input.dev?.origin?.secure === undefined
+						? undefined
+						: input.dev?.origin?.secure
+							? "https"
+							: "http",
+				localProtocol:
+					input.dev?.server?.secure === undefined
+						? undefined
+						: input.dev?.server?.secure
+							? "https"
+							: "http",
+			});
 
-		const resolvedConfig = await resolveConfig(fileConfig, input);
-		if (signal.aborted) {
-			return;
+			void this.#ensureWatchingConfig(fileConfig.configPath);
+
+			const experimentalAssets = processExperimentalAssetsArg(
+				{ experimentalAssets: input.experimental?.assets?.directory },
+				fileConfig
+			);
+			if (experimentalAssets) {
+				void this.#ensureWatchingAssets(experimentalAssets.directory);
+			}
+
+			const resolvedConfig = await resolveConfig(fileConfig, input);
+			if (signal.aborted) {
+				return;
+			}
+			this.latestConfig = resolvedConfig;
+			this.emitConfigUpdateEvent(resolvedConfig);
+			return this.latestConfig;
+		} catch (err) {
+			logger.error(err);
 		}
-		this.latestConfig = resolvedConfig;
-		this.emitConfigUpdateEvent(resolvedConfig);
-		return this.latestConfig;
 	}
 
 	// ******************
@@ -388,6 +423,7 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 	async teardown() {
 		logger.debug("ConfigController teardown beginning...");
 		await this.#configWatcher?.close();
+		await this.#assetsWatcher?.close();
 		logger.debug("ConfigController teardown complete");
 	}
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -788,7 +788,7 @@ export async function startDev(args: StartDevOptions) {
 					enableServiceEnvironments: !(args.legacyEnv ?? true),
 				},
 				experimental: {
-					assets: experimentalAssets,
+					assets: args.experimentalAssets ? experimentalAssets : undefined,
 				},
 			} satisfies StartDevWorkerInput);
 
@@ -1583,4 +1583,27 @@ export function getBindings(
 	};
 
 	return bindings;
+}
+
+export function getAssetChangeMessage(
+	eventName: "add" | "addDir" | "change" | "unlink" | "unlinkDir",
+	assetPath: string
+): string {
+	let message = `${assetPath} changed`;
+	switch (eventName) {
+		case "add":
+			message = `File ${assetPath} was added`;
+			break;
+		case "addDir":
+			message = `Directory ${assetPath} was added`;
+			break;
+		case "unlink":
+			message = `File ${assetPath} was removed`;
+			break;
+		case "unlinkDir":
+			message = `Directory ${assetPath} was removed`;
+			break;
+	}
+
+	return message;
 }

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -421,8 +421,10 @@ This is currently not supported 😭, but we think that we'll get it to work soo
 			await waitUntilExit();
 		}
 	} finally {
-		await configFileWatcher?.close();
-		await assetsWatcher?.close();
+		await Promise.allSettled([
+			configFileWatcher?.close(),
+			assetsWatcher?.close(),
+		]);
 	}
 }
 
@@ -995,13 +997,17 @@ export async function startDev(args: StartDevOptions) {
 			assetsWatcher,
 			stop: async () => {
 				devReactElement.unmount();
-				await configFileWatcher?.close();
-				await assetsWatcher?.close();
+				await Promise.allSettled([
+					configFileWatcher?.close(),
+					assetsWatcher?.close(),
+				]);
 			},
 		};
 	} catch (e) {
-		await configFileWatcher?.close();
-		await assetsWatcher?.close();
+		await Promise.allSettled([
+			configFileWatcher?.close(),
+			assetsWatcher?.close(),
+		]);
 		throw e;
 	}
 }


### PR DESCRIPTION
## What this PR solves / how to test

This PR implements watch mode for Workers with assets, more specifically:
- it watches the static assets directory for changes (add/delete files or directories)
- it reacts to config file changes and ensures we're still watching for the relevant asset directory

Fixes WC-2554

Clean commit history is caring 🫶  so pls review per commit

## How this was tested

Beside e2e tests, these changes were also manually tested in the following scenarios:

**[`wrangler dev` | `wrangler dev --x-dev-env`]**
- add/remove files & directories in the assets directory
<img width="903" alt="Screenshot 2024-08-28 at 12 37 21" src="https://github.com/user-attachments/assets/155034ad-afb7-412b-bd2b-b48055c40a73">

- change the assets folder in `wrangler.toml` + file changes in new assets directory + file changes in old assets directory to ensure it is not watched anymore
<img width="838" alt="Screenshot 2024-08-28 at 12 38 12" src="https://github.com/user-attachments/assets/4443d2d2-505c-431f-bec7-a1f52fd17431">

**[`wrangler dev --x-assets="dist"` | `wrangler dev --x-dev-env --x-assets="dist"`]**
- add/remove files & directories in the assets directory
- change the assets folder in `wrangler.toml` + file changes in that assets directory to ensure we are still watching the assets dir specified by `--x-assets`
<img width="882" alt="Screenshot 2024-08-28 at 12 46 40" src="https://github.com/user-attachments/assets/124f3b7e-073d-46ca-a747-e0a8b7b304df">


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: Workers + Assets is not documented yet

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
