### PR TITLE
fix(workers-shared): Add asset-worker configuration file to `workers-shared` distribution

### DIFF
--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -24,7 +24,7 @@
 	"scripts": {
 		"build": "pnpm run clean && pnpm run bundle:asset-worker:prod && pnpm run bundle:router-worker:prod",
 		"bundle:asset-worker": "esbuild asset-worker/src/index.ts --format=esm --bundle --outfile=dist/asset-worker.mjs --sourcemap=external --external:cloudflare:*",
-		"bundle:asset-worker:prod": "pnpm run bundle:asset-worker --minify",
+		"bundle:asset-worker:prod": "pnpm run bundle:asset-worker --minify && node -r esbuild-register scripts/copy-config-file.ts",
 		"bundle:router-worker": "esbuild router-worker/src/index.ts --format=esm --bundle --outfile=dist/router-worker.mjs --sourcemap=external",
 		"bundle:router-worker:prod": "pnpm run bundle:router-worker --minify",
 		"check:lint": "eslint . --max-warnings=0",

--- a/packages/workers-shared/scripts/copy-config-file.ts
+++ b/packages/workers-shared/scripts/copy-config-file.ts
@@ -1,0 +1,16 @@
+/**
+ * This script is temporary and will be deleted in a next iteration
+ */
+import { copyFileSync, existsSync, mkdirSync } from "fs";
+import { join, resolve } from "path";
+
+const pkgRoot = resolve(__dirname, "..");
+const dstDirectory = join(pkgRoot, "dist");
+const configFileSrc = join(pkgRoot, "asset-worker", "wrangler.toml");
+const configFileDst = join(dstDirectory, "asset-worker.toml");
+
+if (!existsSync(dstDirectory)) {
+	mkdirSync(dstDirectory);
+}
+
+copyFileSync(configFileSrc, configFileDst);

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -925,7 +925,7 @@ function getAssetServerWorker(
 		"@cloudflare/workers-shared/dist/asset-worker.mjs"
 	);
 	const assetServerConfigPath = require.resolve(
-		"@cloudflare/workers-shared/asset-worker/wrangler.toml"
+		"@cloudflare/workers-shared/dist/asset-worker.toml"
 	);
 	let assetServerConfig: Config | undefined;
 


### PR DESCRIPTION
## What this PR solves / how to test

Wrangler has a dependency on `workers-shared`, specifically on the bundled Asset Worker [here](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/dev/miniflare.ts#L927), and the Asset Worker config file [here](https://github.com/cloudflare/workers-sdk/blob/main/packages/wrangler/src/dev/miniflare.ts#L930). Currently the `wrangler.toml` file is not included in the `workers-shared` distribution, which results in that import failing with `Error: Cannot find module '@cloudflare/workers-shared/asset-server-worker/wrangler.toml'`.

This PR copies the config file to the distribution folder `dist`, so that wrangler can properly import it, and folks can test experimental assets with `wrangler dev`.

Note:
- currently this is broken only for `wrangler dev` with experimental assets
- this is a temp fix to unblock folks for now. We can remove the script once https://github.com/cloudflare/workers-sdk/pull/6564 lands

Fixes WC-2623

## How this was tested

Tested with a demo Workers + Assets project (outside `workers-sdk`) + wrangler prerelease 
<img width="603" alt="Screenshot 2024-08-28 at 11 58 12" src="https://github.com/user-attachments/assets/131961f6-7af0-40eb-a5ec-ea6b11776d05">


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: build script changes
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: build script changes
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: build script changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: AW is not documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
