### PR TITLE
fix: remove experimental: prefix requirement for nodejs_compat_v2

### DIFF
--- a/.changeset/green-lies-crash.md
+++ b/.changeset/green-lies-crash.md
@@ -4,4 +4,4 @@
 
 fix: remove `experimental:` prefix requirement for nodejs_compat_v2
 
-See https://jira.cfdata.org/bro
+See https://jira.cfdata.org/browse/DEVDASH-218

--- a/.changeset/green-lies-crash.md
+++ b/.changeset/green-lies-crash.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: remove `experimental:` prefix requirement for nodejs_compat_v2
+
+See https://jira.cfdata.org/bro

--- a/fixtures/nodejs-hybrid-app/wrangler.toml
+++ b/fixtures/nodejs-hybrid-app/wrangler.toml
@@ -1,7 +1,7 @@
 name = "nodejs-hybrid-app"
 main = "src/index.ts"
 compatibility_date = "2024-06-03"
-compatibility_flags = ["experimental:nodejs_compat_v2"]
+compatibility_flags = ["nodejs_compat_v2"]
 
 [vars]
 # These DB connection values are to a public database containing information about

--- a/fixtures/pages-nodejs-v2-compat/wrangler.toml
+++ b/fixtures/pages-nodejs-v2-compat/wrangler.toml
@@ -1,3 +1,3 @@
 name = "pages-nodejs-compat"
 compatibility_date = "2024-08-20"
-compatibility_flags = ["experimental:nodejs_compat_v2"]
+compatibility_flags = ["nodejs_compat_v2"]

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -9930,10 +9930,10 @@ export default{
 				"deploy index.js --no-bundle --node-compat --dry-run --outdir dist"
 			);
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling Wrangler compile-time Node.js compatibility polyfill mode for builtins and globals. This is experimental and has serious tradeoffs.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--node-compat\` and \`--no-bundle\` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process.[0m
 
 
-				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--node-compat\` and \`--no-bundle\` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process.[0m
+				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling Wrangler compile-time Node.js compatibility polyfill mode for builtins and globals. This is experimental and has serious tradeoffs.[0m
 
 				"
 			`);
@@ -9950,10 +9950,10 @@ export default{
 			fs.writeFileSync("index.js", scriptContent);
 			await runWrangler("deploy index.js --dry-run --outdir dist");
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling Wrangler compile-time Node.js compatibility polyfill mode for builtins and globals. This is experimental and has serious tradeoffs.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--node-compat\` and \`--no-bundle\` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process.[0m
 
 
-				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--node-compat\` and \`--no-bundle\` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process.[0m
+				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mEnabling Wrangler compile-time Node.js compatibility polyfill mode for builtins and globals. This is experimental and has serious tradeoffs.[0m
 
 				"
 			`);

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -174,12 +174,11 @@ export async function deploy({
 		}
 	}
 
-	const nodejsCompatMode = validateNodeCompat({
-		legacyNodeCompat: false,
-		compatibilityFlags:
-			config?.compatibility_flags ?? deploymentConfig.compatibility_flags ?? [],
-		noBundle: config?.no_bundle ?? false,
-	});
+	const nodejsCompatMode = validateNodeCompat(
+		config?.compatibility_flags ?? deploymentConfig.compatibility_flags ?? [],
+		/* node_compat */ false,
+		config?.no_bundle
+	);
 	const defineNavigatorUserAgent = isNavigatorDefined(
 		config?.compatibility_date ?? deploymentConfig.compatibility_date,
 		config?.compatibility_flags ?? deploymentConfig.compatibility_flags

--- a/packages/wrangler/src/api/pages/deploy.tsx
+++ b/packages/wrangler/src/api/pages/deploy.tsx
@@ -6,7 +6,7 @@ import { cwd } from "node:process";
 import { File, FormData } from "undici";
 import { fetchResult } from "../../cfetch";
 import { readConfig } from "../../config";
-import { validateNodeCompat } from "../../deployment-bundle/node-compat";
+import { getNodeCompatMode } from "../../deployment-bundle/node-compat";
 import { FatalError } from "../../errors";
 import { logger } from "../../logger";
 import { isNavigatorDefined } from "../../navigator-user-agent";
@@ -174,10 +174,12 @@ export async function deploy({
 		}
 	}
 
-	const nodejsCompatMode = validateNodeCompat(
+	const nodejsCompatMode = getNodeCompatMode(
 		config?.compatibility_flags ?? deploymentConfig.compatibility_flags ?? [],
-		/* node_compat */ false,
-		config?.no_bundle
+		{
+			nodeCompat: false,
+			noBundle: config?.no_bundle,
+		}
 	);
 	const defineNavigatorUserAgent = isNavigatorDefined(
 		config?.compatibility_date ?? deploymentConfig.compatibility_date,

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -21,7 +21,7 @@ import {
 	createModuleCollector,
 	getWrangler1xLegacyModuleReferences,
 } from "../deployment-bundle/module-collection";
-import { validateNodeCompat } from "../deployment-bundle/node-compat";
+import { getNodeCompatMode } from "../deployment-bundle/node-compat";
 import { loadSourceMaps } from "../deployment-bundle/source-maps";
 import { addHyphens } from "../deployments";
 import { confirm } from "../dialogs";
@@ -399,11 +399,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	const compatibilityFlags =
 		props.compatibilityFlags ?? config.compatibility_flags;
-	const nodejsCompatMode = validateNodeCompat(
-		compatibilityFlags,
-		props.nodeCompat ?? config.node_compat,
-		props.noBundle ?? config.no_bundle
-	);
+	const nodejsCompatMode = getNodeCompatMode(compatibilityFlags, {
+		nodeCompat: props.nodeCompat ?? config.node_compat,
+		noBundle: props.noBundle ?? config.no_bundle,
+	});
 
 	// Warn if user tries minify with no-bundle
 	if (props.noBundle && minify) {

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -399,11 +399,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	const compatibilityFlags =
 		props.compatibilityFlags ?? config.compatibility_flags;
-	const nodejsCompatMode = validateNodeCompat({
-		legacyNodeCompat: props.nodeCompat ?? config.node_compat ?? false,
+	const nodejsCompatMode = validateNodeCompat(
 		compatibilityFlags,
-		noBundle: props.noBundle ?? config.no_bundle ?? false,
-	});
+		props.nodeCompat ?? config.node_compat,
+		props.noBundle ?? config.no_bundle
+	);
 
 	// Warn if user tries minify with no-bundle
 	if (props.noBundle && minify) {

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -3,7 +3,6 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { File, FormData } from "undici";
 import { handleUnsafeCapnp } from "./capnp";
-import { stripExperimentalPrefixes } from "./node-compat";
 import type {
 	CfDurableObjectMigrations,
 	CfModuleType,
@@ -547,7 +546,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		bindings: metadataBindings,
 		...(compatibility_date && { compatibility_date }),
 		...(compatibility_flags && {
-			compatibility_flags: stripExperimentalPrefixes(compatibility_flags),
+			compatibility_flags,
 		}),
 		...(migrations && { migrations }),
 		capnp_schema: capnpSchemaOutputFile,

--- a/packages/wrangler/src/deployment-bundle/node-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/node-compat.ts
@@ -17,10 +17,10 @@ export type NodeJSCompatMode = "legacy" | "v1" | "v2" | null;
  * Returns one of:
  *  - "legacy": build-time polyfills, from `node_compat` flag
  *  - "v1": nodejs_compat compatibility flag
- *  - "v2": experimental nodejs_compat_v2 flag
+ *  - "v2": nodejs_compat_v2 compatibility flag
  *  - null: no Node.js compatibility
  *
- * Currently we require that the v2 mode is configured via `nodejs_compat_v2` compat flag.
+ * Currently v2 mode is configured via `nodejs_compat_v2` compat flag.
  * At a future compatibility date, the use of `nodejs_compat` flag will imply `nodejs_compat_v2`.
  *
  * We assert that only one of these modes can be specified at a time.

--- a/packages/wrangler/src/deployment-bundle/node-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/node-compat.ts
@@ -1,6 +1,5 @@
 import { UserError } from "../errors";
 import { logger } from "../logger";
-import type { Config } from "../config";
 
 /**
  * Wrangler can provide Node.js compatibility in a number of different modes:
@@ -28,7 +27,9 @@ export type NodeJSCompatMode = "legacy" | "v1" | "v2" | null;
  * We warn if using legacy or v2 mode.
  */
 export function validateNodeCompat(
-	config: Pick<Config, "compatibility_flags" | "node_compat" | "no_bundle">
+	compatibilityFlags: string[],
+	nodeCompat: boolean | undefined,
+	noBundle: boolean | undefined
 ): NodeJSCompatMode {
 	const {
 		mode,
@@ -36,7 +37,7 @@ export function validateNodeCompat(
 		nodejsCompatV2,
 		experimentalNodejsCompatV2,
 		legacy,
-	} = getNodeCompatMode(config);
+	} = getNodeCompatMode(compatibilityFlags, nodeCompat);
 
 	if (experimentalNodejsCompatV2) {
 		throw new UserError(
@@ -56,13 +57,13 @@ export function validateNodeCompat(
 		);
 	}
 
-	if (config.no_bundle && legacy) {
+	if (noBundle && legacy) {
 		logger.warn(
 			"`--node-compat` and `--no-bundle` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process."
 		);
 	}
 
-	if (config.no_bundle && nodejsCompatV2) {
+	if (noBundle && nodejsCompatV2) {
 		logger.warn(
 			"`nodejs_compat_v2` compatibility flag and `--no-bundle` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process."
 		);
@@ -77,14 +78,14 @@ export function validateNodeCompat(
 	return mode;
 }
 
-export function getNodeCompatMode({
-	compatibility_flags,
-	node_compat,
-}: Pick<Config, "compatibility_flags" | "node_compat">) {
-	const legacy = node_compat === true;
-	const nodejsCompat = compatibility_flags.includes("nodejs_compat");
-	const nodejsCompatV2 = compatibility_flags.includes("nodejs_compat_v2");
-	const experimentalNodejsCompatV2 = compatibility_flags.includes(
+export function getNodeCompatMode(
+	compatibilityFlags: string[],
+	nodeCompat: boolean | undefined
+) {
+	const legacy = nodeCompat === true;
+	const nodejsCompat = compatibilityFlags.includes("nodejs_compat");
+	const nodejsCompatV2 = compatibilityFlags.includes("nodejs_compat_v2");
+	const experimentalNodejsCompatV2 = compatibilityFlags.includes(
 		"experimental:nodejs_compat_v2"
 	);
 

--- a/packages/wrangler/src/deployment-bundle/node-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/node-compat.ts
@@ -78,6 +78,7 @@ export function getNodeCompatMode({
 	compatibility_flags,
 	node_compat,
 }: Pick<Config, "compatibility_flags" | "node_compat">) {
+	const legacy = node_compat === true;
 	const nodejsCompat = compatibility_flags.includes("nodejs_compat");
 	const nodejsCompatV2 = compatibility_flags.includes("nodejs_compat_v2");
 
@@ -86,14 +87,14 @@ export function getNodeCompatMode({
 		mode = "v2";
 	} else if (nodejsCompat) {
 		mode = "v1";
-	} else if (node_compat) {
+	} else if (legacy) {
 		mode = "legacy";
 	} else {
 		mode = null;
 	}
 
 	return {
-		legacy: node_compat === true,
+		legacy,
 		mode,
 		nodejsCompat,
 		nodejsCompatV2,

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -12,7 +12,7 @@ import {
 } from "./api/startDevWorker/utils";
 import { findWranglerToml, printBindings, readConfig } from "./config";
 import { getEntry } from "./deployment-bundle/entry";
-import { validateNodeCompat } from "./deployment-bundle/node-compat";
+import { getNodeCompatMode } from "./deployment-bundle/node-compat";
 import { getBoundRegisteredWorkers } from "./dev-registry";
 import Dev, { devRegistry } from "./dev/dev";
 import { getVarsForDev } from "./dev/dev-vars";
@@ -680,10 +680,12 @@ export async function startDev(args: StartDevOptions) {
 					moduleRoot: args.moduleRoot,
 					moduleRules: args.rules,
 					nodejsCompatMode: (parsedConfig: Config) =>
-						validateNodeCompat(
+						getNodeCompatMode(
 							args.compatibilityFlags ?? parsedConfig.compatibility_flags ?? [],
-							args.nodeCompat ?? parsedConfig.node_compat,
-							args.noBundle ?? parsedConfig.no_bundle
+							{
+								nodeCompat: args.nodeCompat ?? parsedConfig.node_compat,
+								noBundle: args.noBundle ?? parsedConfig.no_bundle,
+							}
 						),
 				},
 				bindings: {
@@ -829,10 +831,12 @@ export async function startDev(args: StartDevOptions) {
 			additionalModules,
 		} = await validateDevServerSettings(args, config);
 
-		const nodejsCompatMode = validateNodeCompat(
+		const nodejsCompatMode = getNodeCompatMode(
 			args.compatibilityFlags ?? config.compatibility_flags ?? [],
-			args.nodeCompat ?? config.node_compat,
-			args.noBundle ?? config.no_bundle
+			{
+				nodeCompat: args.nodeCompat ?? config.node_compat,
+				noBundle: args.noBundle ?? config.no_bundle,
+			}
 		);
 
 		void metrics.sendMetricsEvent(
@@ -968,10 +972,12 @@ export async function startApiDev(args: StartDevOptions) {
 		additionalModules,
 	} = await validateDevServerSettings(args, config);
 
-	const nodejsCompatMode = validateNodeCompat(
+	const nodejsCompatMode = getNodeCompatMode(
 		args.compatibilityFlags ?? config.compatibility_flags,
-		args.nodeCompat ?? config.node_compat,
-		args.noBundle ?? config.no_bundle
+		{
+			nodeCompat: args.nodeCompat ?? config.node_compat,
+			noBundle: args.noBundle ?? config.no_bundle,
+		}
 	);
 
 	await metrics.sendMetricsEvent(

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -680,15 +680,11 @@ export async function startDev(args: StartDevOptions) {
 					moduleRoot: args.moduleRoot,
 					moduleRules: args.rules,
 					nodejsCompatMode: (parsedConfig: Config) =>
-						validateNodeCompat({
-							legacyNodeCompat:
-								args.nodeCompat ?? parsedConfig.node_compat ?? false,
-							compatibilityFlags:
-								args.compatibilityFlags ??
-								parsedConfig.compatibility_flags ??
-								[],
-							noBundle: args.noBundle ?? parsedConfig.no_bundle ?? false,
-						}),
+						validateNodeCompat(
+							args.compatibilityFlags ?? parsedConfig.compatibility_flags ?? [],
+							args.nodeCompat ?? parsedConfig.node_compat,
+							args.noBundle ?? parsedConfig.no_bundle
+						),
 				},
 				bindings: {
 					...(await getPagesAssetsFetcher(
@@ -833,12 +829,11 @@ export async function startDev(args: StartDevOptions) {
 			additionalModules,
 		} = await validateDevServerSettings(args, config);
 
-		const nodejsCompatMode = validateNodeCompat({
-			legacyNodeCompat: args.nodeCompat ?? config.node_compat ?? false,
-			compatibilityFlags:
-				args.compatibilityFlags ?? config.compatibility_flags ?? [],
-			noBundle: args.noBundle ?? config.no_bundle ?? false,
-		});
+		const nodejsCompatMode = validateNodeCompat(
+			args.compatibilityFlags ?? config.compatibility_flags ?? [],
+			args.nodeCompat ?? config.node_compat,
+			args.noBundle ?? config.no_bundle
+		);
 
 		void metrics.sendMetricsEvent(
 			"run dev",
@@ -973,11 +968,11 @@ export async function startApiDev(args: StartDevOptions) {
 		additionalModules,
 	} = await validateDevServerSettings(args, config);
 
-	const nodejsCompatMode = validateNodeCompat({
-		legacyNodeCompat: args.nodeCompat ?? config.node_compat ?? false,
-		compatibilityFlags: args.compatibilityFlags ?? config.compatibility_flags,
-		noBundle: args.noBundle ?? config.no_bundle ?? false,
-	});
+	const nodejsCompatMode = validateNodeCompat(
+		args.compatibilityFlags ?? config.compatibility_flags,
+		args.nodeCompat ?? config.node_compat,
+		args.noBundle ?? config.no_bundle
+	);
 
 	await metrics.sendMetricsEvent(
 		"run dev (api)",

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -18,7 +18,6 @@ import {
 } from "../ai/fetcher";
 import { readConfig } from "../config";
 import { ModuleTypeToRuleType } from "../deployment-bundle/module-collection";
-import { stripExperimentalPrefixes } from "../deployment-bundle/node-compat";
 import { withSourceURLs } from "../deployment-bundle/source-url";
 import { UserError } from "../errors";
 import { logger } from "../logger";
@@ -892,9 +891,7 @@ export async function buildMiniflareOptions(
 			{
 				name: getName(config),
 				compatibilityDate: config.compatibilityDate,
-				compatibilityFlags: stripExperimentalPrefixes(
-					config.compatibilityFlags
-				),
+				compatibilityFlags: config.compatibilityFlags,
 
 				...sourceOptions,
 				...bindingOptions,

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -7,7 +7,6 @@ import { useErrorHandler } from "react-error-boundary";
 import { helpIfErrorIsSizeOrScriptStartup } from "../deploy/deploy";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
 import { getBundleType } from "../deployment-bundle/bundle-type";
-import { stripExperimentalPrefixes } from "../deployment-bundle/node-compat";
 import { withSourceURLs } from "../deployment-bundle/source-url";
 import { getInferredHost } from "../dev";
 import { UserError } from "../errors";
@@ -669,7 +668,7 @@ export async function createRemoteWorkerInit(props: {
 		},
 		migrations: undefined, // no migrations in dev
 		compatibility_date: props.compatibilityDate,
-		compatibility_flags: stripExperimentalPrefixes(props.compatibilityFlags),
+		compatibility_flags: props.compatibilityFlags,
 		keepVars: true,
 		keepSecrets: true,
 		logpush: false,

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -10,7 +10,7 @@ import path, {
 import { createUploadWorkerBundleContents } from "../api/pages/create-worker-bundle-contents";
 import { readConfig } from "../config";
 import { writeAdditionalModules } from "../deployment-bundle/find-additional-modules";
-import { validateNodeCompat } from "../deployment-bundle/node-compat";
+import { getNodeCompatMode } from "../deployment-bundle/node-compat";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
@@ -438,11 +438,10 @@ const validateArgs = async (args: PagesBuildArgs): Promise<ValidatedArgs> => {
 	}
 
 	const { nodeCompat: node_compat, ...argsExceptNodeCompat } = args;
-	const nodejsCompatMode = validateNodeCompat(
-		args.compatibilityFlags ?? [],
-		node_compat,
-		config?.no_bundle
-	);
+	const nodejsCompatMode = getNodeCompatMode(args.compatibilityFlags ?? [], {
+		nodeCompat: node_compat,
+		noBundle: config?.no_bundle,
+	});
 
 	const defineNavigatorUserAgent = isNavigatorDefined(
 		args.compatibilityDate,

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -437,12 +437,12 @@ const validateArgs = async (args: PagesBuildArgs): Promise<ValidatedArgs> => {
 		args.outfile = resolvePath(args.outfile);
 	}
 
-	const { nodeCompat: legacyNodeCompat, ...argsExceptNodeCompat } = args;
-	const nodejsCompatMode = validateNodeCompat({
-		legacyNodeCompat: legacyNodeCompat,
-		compatibilityFlags: args.compatibilityFlags ?? [],
-		noBundle: config?.no_bundle ?? false,
-	});
+	const { nodeCompat: node_compat, ...argsExceptNodeCompat } = args;
+	const nodejsCompatMode = validateNodeCompat(
+		args.compatibilityFlags ?? [],
+		node_compat,
+		config?.no_bundle
+	);
 
 	const defineNavigatorUserAgent = isNavigatorDefined(
 		args.compatibilityDate,

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -360,12 +360,11 @@ export const Handler = async (args: PagesDevArguments) => {
 
 	let scriptPath = "";
 
-	const nodejsCompatMode = validateNodeCompat({
-		legacyNodeCompat: args.nodeCompat,
-		compatibilityFlags:
-			args.compatibilityFlags ?? config.compatibility_flags ?? [],
-		noBundle: args.noBundle ?? config.no_bundle ?? false,
-	});
+	const nodejsCompatMode = validateNodeCompat(
+		args.compatibilityFlags ?? config.compatibility_flags ?? [],
+		args.nodeCompat,
+		args.noBundle ?? config.no_bundle
+	);
 
 	const defineNavigatorUserAgent = isNavigatorDefined(
 		compatibilityDate,

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -7,7 +7,7 @@ import { unstable_dev } from "../api";
 import { readConfig } from "../config";
 import { isBuildFailure } from "../deployment-bundle/build-failures";
 import { esbuildAliasExternalPlugin } from "../deployment-bundle/esbuild-plugins/alias-external";
-import { validateNodeCompat } from "../deployment-bundle/node-compat";
+import { getNodeCompatMode } from "../deployment-bundle/node-compat";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
@@ -360,10 +360,12 @@ export const Handler = async (args: PagesDevArguments) => {
 
 	let scriptPath = "";
 
-	const nodejsCompatMode = validateNodeCompat(
+	const nodejsCompatMode = getNodeCompatMode(
 		args.compatibilityFlags ?? config.compatibility_flags ?? [],
-		args.nodeCompat,
-		args.noBundle ?? config.no_bundle
+		{
+			nodeCompat: args.nodeCompat,
+			noBundle: args.noBundle ?? config.no_bundle,
+		}
 	);
 
 	const defineNavigatorUserAgent = isNavigatorDefined(

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -92,10 +92,10 @@ export async function typesHandler(
 		const tsconfigPath =
 			config.tsconfig ?? join(dirname(configPath), "tsconfig.json");
 		const tsconfigTypes = readTsconfigTypes(tsconfigPath);
-		const { mode } = getNodeCompatMode(
-			config.compatibility_flags,
-			config.node_compat
-		);
+		const mode = getNodeCompatMode(config.compatibility_flags, {
+			validateConfig: false,
+			nodeCompat: config.node_compat,
+		});
 
 		logRuntimeTypesMessage(outFile, tsconfigTypes, mode !== null);
 	}

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -92,7 +92,10 @@ export async function typesHandler(
 		const tsconfigPath =
 			config.tsconfig ?? join(dirname(configPath), "tsconfig.json");
 		const tsconfigTypes = readTsconfigTypes(tsconfigPath);
-		const { mode } = getNodeCompatMode(config);
+		const { mode } = getNodeCompatMode(
+			config.compatibility_flags,
+			config.node_compat
+		);
 
 		logRuntimeTypesMessage(outFile, tsconfigTypes, mode !== null);
 	}

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -184,11 +184,11 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	const minify = props.minify ?? config.minify;
 
-	const nodejsCompatMode = validateNodeCompat({
-		legacyNodeCompat: props.nodeCompat ?? config.node_compat ?? false,
-		compatibilityFlags: props.compatibilityFlags ?? config.compatibility_flags,
-		noBundle: props.noBundle ?? config.no_bundle ?? false,
-	});
+	const nodejsCompatMode = validateNodeCompat(
+		props.compatibilityFlags ?? config.compatibility_flags,
+		props.nodeCompat ?? config.node_compat,
+		props.noBundle ?? config.no_bundle
+	);
 
 	const compatibilityFlags =
 		props.compatibilityFlags ?? config.compatibility_flags;

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -19,7 +19,7 @@ import {
 	createModuleCollector,
 	getWrangler1xLegacyModuleReferences,
 } from "../deployment-bundle/module-collection";
-import { validateNodeCompat } from "../deployment-bundle/node-compat";
+import { getNodeCompatMode } from "../deployment-bundle/node-compat";
 import { loadSourceMaps } from "../deployment-bundle/source-maps";
 import { confirm } from "../dialogs";
 import { getMigrationsToUpload } from "../durable";
@@ -184,10 +184,12 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	const minify = props.minify ?? config.minify;
 
-	const nodejsCompatMode = validateNodeCompat(
+	const nodejsCompatMode = getNodeCompatMode(
 		props.compatibilityFlags ?? config.compatibility_flags,
-		props.nodeCompat ?? config.node_compat,
-		props.noBundle ?? config.no_bundle
+		{
+			nodeCompat: props.nodeCompat ?? config.node_compat,
+			noBundle: props.noBundle ?? config.no_bundle,
+		}
 	);
 
 	const compatibilityFlags =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11201,7 +11201,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.5.4)
       '@typescript-eslint/utils': 6.10.0(eslint@8.49.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@9.2.2)
+      debug: 4.3.5
       eslint: 8.49.0
       ts-api-utils: 1.0.3(typescript@5.5.4)
     optionalDependencies:


### PR DESCRIPTION
## What this PR solves / how to test

This PR builds on top and supersedes https://github.com/cloudflare/workers-sdk/pull/6545

Changes in this PR are in the[ last commit](https://github.com/cloudflare/workers-sdk/commit/510898e452cc4c68c6ac2369b62d27914e103e34) - the functionality stays the same but the code is re-organized.

```
Rename validateNodeCompat to getNodeCompatMode which is what the function does

Convert the parameters to optional options for better readability.

Added a `validateConfig` to be able to skip validation (used once in the code base).

The former getNodeCompatMode is now parseNodeCompatibilityFlags and is only responsible to return the compat flags and no more exported.

Improve the documentation
```
