### PR TITLE
Support `.vsix` artifacts in pre-release registry

### DIFF
--- a/.changeset/cool-crews-happen.md
+++ b/.changeset/cool-crews-happen.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/prerelease-registry": minor
+---
+
+feat: Support `.vsix` artifacts in pre-release registry

--- a/packages/prerelease-registry/functions/utils/getArtifactForWorkflowRun.ts
+++ b/packages/prerelease-registry/functions/utils/getArtifactForWorkflowRun.ts
@@ -130,13 +130,15 @@ export const getArtifactForWorkflowRun = async ({
 
 		const files = zip.files;
 		const fileNames = Object.keys(files);
-		const tgzFileName = fileNames.find((fileName) => fileName.endsWith(".tgz"));
-		if (tgzFileName === undefined) {
+		const downloadableFileName = fileNames.find(
+			(fileName) => fileName.endsWith(".tgz") || fileName.endsWith(".vsix")
+		);
+		if (downloadableFileName === undefined) {
 			return Response.json({ fileNames }, { status: 404 });
 		}
 
-		const tgzBlob = await files[tgzFileName].async("blob");
-		const response = new Response(tgzBlob, {
+		const downloadableBlob = await files[downloadableFileName].async("blob");
+		const response = new Response(downloadableBlob, {
 			headers: { "Cache-Control": `public, s-maxage=${ONE_WEEK}` },
 		});
 


### PR DESCRIPTION
## What this PR solves / how to test

Support GH pre-release artifacts with just a `.vsix` file, as well as `.tgz` files

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: pre-release registry has no tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: pre-release registry has no e2e tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: internal detail

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
