### PR TITLE
[wrangler] log version preview url when previews exist

### DIFF
--- a/.changeset/funny-comics-lick.md
+++ b/.changeset/funny-comics-lick.md
@@ -1,0 +1,13 @@
+---
+"wrangler": minor
+---
+
+feature: log version preview url when previews exist
+
+The version upload API returns a field indicating whether
+a preview exists for that version. If a preview exists and
+workers.dev is enabled, wrangler will now log the full
+URL on version upload.
+
+This does not impact wrangler deploy, which only prints the
+workers.dev route of the latest deployment.

--- a/.changeset/modern-scissors-relax.md
+++ b/.changeset/modern-scissors-relax.md
@@ -1,0 +1,18 @@
+---
+"wrangler": patch
+---
+
+chore: fix version upload log order
+
+Previously deploy prints:
+upload timings
+deploy timings
+current version id
+
+while version upload prints:
+worker version id
+upload timings
+
+This change makes version upload more similar to deploy by printing
+version id after upload, which also makes more sense, as version ID can
+only be known after upload has finished.

--- a/packages/wrangler/e2e/README.md
+++ b/packages/wrangler/e2e/README.md
@@ -77,8 +77,8 @@ describe("uploading Worker versions", () => {
 		// Check the output looks correct
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
-			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
+			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy --experimental-versions
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -61,8 +61,8 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: (TIMINGS)
-			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
+			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			To deploy this version to production traffic use the command wrangler versions deploy
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
@@ -176,8 +176,8 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: (TIMINGS)
-			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
+			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			To deploy this version to production traffic use the command wrangler versions deploy
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -98,8 +98,8 @@ describe("versions upload", () => {
 			 \\"abc\\": \\"def\\",
 			 \\"bool\\": true
 			}
-			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993
-			Uploaded test-worker (TIMINGS)"
+			Uploaded test-worker (TIMINGS)
+			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993"
 		`);
 	});
 });

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -122,6 +122,7 @@ interface EnvironmentInheritable {
 	 * test and deploy your Worker.
 	 *
 	 * // Carmen according to our tests the default is undefined
+	 * // warning: you must force "workers_dev: true" in tests to match expected behavior
 	 * @default `true` (This is a breaking change from Wrangler v1)
 	 * @breaking
 	 * @inheritable

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -1,6 +1,5 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { URLSearchParams } from "node:url";
 import { blue, gray } from "@cloudflare/cli/colors";
 import { fetchResult } from "../cfetch";
 import { printBindings } from "../config";
@@ -458,18 +457,12 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			await ensureQueuesExistByConfig(config);
 			let bindingsPrinted = false;
 
-			// Upload the script so it has time to propagate.
-			// We can also now tell whether available_on_subdomain is set
+			// Upload the version.
 			try {
 				const body = createWorkerUploadForm(worker);
 
 				const result = await fetchResult<{
-					available_on_subdomain: boolean;
-					id: string | null;
-					etag: string | null;
-					pipeline_hash: string | null;
-					mutable_pipeline_id: string | null;
-					deployment_id: string | null;
+					id: string;
 					startup_time_ms: number;
 				}>(
 					workerUrl,
@@ -478,12 +471,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						body,
 						headers: await getMetricsUsageHeaders(config.send_metrics),
 					},
-					new URLSearchParams({
-						include_subdomain_availability: "true",
-						// pass excludeScript so the whole body of the
-						// script doesn't get included in the response
-						excludeScript: "true",
-					})
 				);
 
 				logger.log("Worker Startup Time:", result.startup_time_ms, "ms");

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -476,7 +476,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				logger.log("Worker Startup Time:", result.startup_time_ms, "ms");
 				bindingsPrinted = true;
 				printBindings({ ...withoutStaticAssets, vars: maskedVars });
-				logger.log("Worker Version ID:", result.id);
 				versionId = result.id;
 			} catch (err) {
 				if (!bindingsPrinted) {
@@ -540,6 +539,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	const uploadMs = Date.now() - start;
 
 	logger.log("Uploaded", workerName, formatTime(uploadMs));
+	logger.log("Worker Version ID:", versionId);
 
 	const cmdVersionsDeploy = blue("wrangler versions deploy");
 	const cmdTriggersDeploy = blue("wrangler triggers deploy");


### PR DESCRIPTION
## What this PR solves / how to test

New feature - log version preview url when previews exist. This feature is currently restricted, but I'm adding wrangler support now to enable internal testing.

## Author has addressed the following

- Tests
  - [x] Included
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] Not required because: e2e account will not have previews yet, so current upload tests are correct in not printing previews.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Included
- Public documentation
  - [x] Not necessary because: Docs will be added when feature is released externally.