### PR TITLE
enable hyperdrive bindings in `getPlatformProxy`

### DIFF
--- a/.changeset/gold-maps-itch.md
+++ b/.changeset/gold-maps-itch.md
@@ -1,0 +1,42 @@
+---
+"wrangler": patch
+---
+
+fix: Add hyperdrive binding support in `getPlatformProxy`
+
+example:
+
+```toml
+# wrangler.toml
+[[hyperdrive]]
+binding = "MY_HYPERDRIVE"
+id = "000000000000000000000000000000000"
+localConnectionString = "postgres://user:pass@127.0.0.1:1234/db"
+```
+
+```js
+// index.mjs
+
+import postgres from "postgres";
+import { getPlatformProxy } from "wrangler";
+
+const { env, dispose } = await getPlatformProxy();
+
+try {
+	const sql = postgres(
+		// Note: connectionString points to `postgres://user:pass@127.0.0.1:1234/db` not to the actual hyperdrive
+		//       connection string, for more details see the explanation below
+		env.MY_HYPERDRIVE.connectionString
+	);
+	const results = await sql`SELECT * FROM pg_tables`;
+	await sql.end();
+} catch (e) {
+	console.error(e);
+}
+
+await dispose();
+```
+
+Note: the returned binding values are no-op/passthrough that can be used inside node.js, meaning
+that besides direct connections via the `connect` methods, all the other values point to the
+same db connection specified in the user configuration

--- a/.changeset/slimy-waves-dance.md
+++ b/.changeset/slimy-waves-dance.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+fix: add hyperdrive bindings support in `getBindings`
+
+Note: the returned binding values are no-op/passthrough that can be used inside node.js, meaning
+that besides direct connections via the `connect` methods, all the other values point to the
+same db connection specified in the user configuration

--- a/fixtures/get-platform-proxy/wrangler.toml
+++ b/fixtures/get-platform-proxy/wrangler.toml
@@ -27,6 +27,11 @@ bindings = [
   { name = "MY_DO_B", script_name = "do-worker-b", class_name = "DurableObjectClass" }
 ]
 
+[[hyperdrive]]
+binding = "MY_HYPERDRIVE"
+id = "000000000000000000000000000000000"
+localConnectionString = "postgres://user:pass@127.0.0.1:1234/db"
+
 [[d1_databases]]
 binding = "MY_D1"
 database_name = "test-db"

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { Service } from "../../runtime";
 import { SharedBindings } from "../../workers";
 import { getUserServiceName } from "../core";
-import { kProxyNodeBinding, Plugin } from "../shared";
+import { Plugin, ProxyNodeBinding } from "../shared";
 import {
 	ASSETS_KV_SERVICE_NAME,
 	ASSETS_PLUGIN_NAME,
@@ -39,7 +39,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 			return {};
 		}
 		return {
-			[options.assets.bindingName]: kProxyNodeBinding,
+			[options.assets.bindingName]: new ProxyNodeBinding(),
 		};
 	},
 

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -36,10 +36,10 @@ import {
 import { getCacheServiceName } from "../cache";
 import { DURABLE_OBJECTS_STORAGE_SERVICE_NAME } from "../do";
 import {
-	kProxyNodeBinding,
 	kUnsafeEphemeralUniqueKey,
 	parseRoutes,
 	Plugin,
+	ProxyNodeBinding,
 	SERVICE_LOOPBACK,
 	WORKER_BINDING_SERVICE_LOOPBACK,
 } from "../shared";
@@ -473,7 +473,7 @@ export const CORE_PLUGIN: Plugin<
 			bindingEntries.push(
 				...Object.keys(options.serviceBindings).map((name) => [
 					name,
-					kProxyNodeBinding,
+					new ProxyNodeBinding(),
 				])
 			);
 		}
@@ -481,7 +481,7 @@ export const CORE_PLUGIN: Plugin<
 			bindingEntries.push(
 				...Object.keys(options.wrappedBindings).map((name) => [
 					name,
-					kProxyNodeBinding,
+					new ProxyNodeBinding(),
 				])
 			);
 		}

--- a/packages/miniflare/src/plugins/d1/index.ts
+++ b/packages/miniflare/src/plugins/d1/index.ts
@@ -10,13 +10,13 @@ import { SharedBindings } from "../../workers";
 import {
 	getMiniflareObjectBindings,
 	getPersistPath,
-	kProxyNodeBinding,
 	migrateDatabase,
 	namespaceEntries,
 	namespaceKeys,
 	objectEntryWorker,
 	PersistenceSchema,
 	Plugin,
+	ProxyNodeBinding,
 	SERVICE_LOOPBACK,
 } from "../shared";
 
@@ -69,7 +69,7 @@ export const D1_PLUGIN: Plugin<
 	getNodeBindings(options) {
 		const databases = namespaceKeys(options.d1Databases);
 		return Object.fromEntries(
-			databases.map((name) => [name, kProxyNodeBinding])
+			databases.map((name) => [name, new ProxyNodeBinding()])
 		);
 	},
 	async getServices({

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -4,10 +4,10 @@ import { Worker_Binding } from "../../runtime";
 import { getUserServiceName } from "../core";
 import {
 	getPersistPath,
-	kProxyNodeBinding,
 	kUnsafeEphemeralUniqueKey,
 	PersistenceSchema,
 	Plugin,
+	ProxyNodeBinding,
 	UnsafeUniqueKey,
 } from "../shared";
 
@@ -83,7 +83,9 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin<
 	},
 	getNodeBindings(options) {
 		const objects = Object.keys(options.durableObjects ?? {});
-		return Object.fromEntries(objects.map((name) => [name, kProxyNodeBinding]));
+		return Object.fromEntries(
+			objects.map((name) => [name, new ProxyNodeBinding()])
+		);
 	},
 	async getServices({
 		sharedOptions,

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -11,13 +11,13 @@ import { SharedBindings } from "../../workers";
 import {
 	getMiniflareObjectBindings,
 	getPersistPath,
-	kProxyNodeBinding,
 	migrateDatabase,
 	namespaceEntries,
 	namespaceKeys,
 	objectEntryWorker,
 	PersistenceSchema,
 	Plugin,
+	ProxyNodeBinding,
 	SERVICE_LOOPBACK,
 } from "../shared";
 import { KV_PLUGIN_NAME } from "./constants";
@@ -77,7 +77,7 @@ export const KV_PLUGIN: Plugin<
 	async getNodeBindings(options) {
 		const namespaces = namespaceKeys(options.kvNamespaces);
 		const bindings = Object.fromEntries(
-			namespaces.map((name) => [name, kProxyNodeBinding])
+			namespaces.map((name) => [name, new ProxyNodeBinding()])
 		);
 
 		if (isWorkersSitesEnabled(options)) {

--- a/packages/miniflare/src/plugins/kv/sites.ts
+++ b/packages/miniflare/src/plugins/kv/sites.ts
@@ -12,7 +12,7 @@ import {
 	SiteMatcherRegExps,
 	testSiteRegExps,
 } from "../../workers";
-import { kProxyNodeBinding } from "../shared";
+import { ProxyNodeBinding } from "../shared";
 import { KV_PLUGIN_NAME } from "./constants";
 
 async function* listKeysInDirectoryInner(
@@ -97,7 +97,7 @@ export async function getSitesNodeBindings(
 		siteRegExps
 	);
 	return {
-		[SiteBindings.KV_NAMESPACE_SITE]: kProxyNodeBinding,
+		[SiteBindings.KV_NAMESPACE_SITE]: new ProxyNodeBinding(),
 		[SiteBindings.JSON_SITE_MANIFEST]: __STATIC_CONTENT_MANIFEST,
 	};
 }

--- a/packages/miniflare/src/plugins/queues/index.ts
+++ b/packages/miniflare/src/plugins/queues/index.ts
@@ -15,9 +15,9 @@ import {
 import { getUserServiceName } from "../core";
 import {
 	getMiniflareObjectBindings,
-	kProxyNodeBinding,
 	objectEntryWorker,
 	Plugin,
+	ProxyNodeBinding,
 	SERVICE_LOOPBACK,
 } from "../shared";
 
@@ -53,7 +53,9 @@ export const QUEUES_PLUGIN: Plugin<typeof QueuesOptionsSchema> = {
 	},
 	getNodeBindings(options) {
 		const queues = bindingKeys(options.queueProducers);
-		return Object.fromEntries(queues.map((name) => [name, kProxyNodeBinding]));
+		return Object.fromEntries(
+			queues.map((name) => [name, new ProxyNodeBinding()])
+		);
 	},
 	async getServices({
 		options,

--- a/packages/miniflare/src/plugins/r2/index.ts
+++ b/packages/miniflare/src/plugins/r2/index.ts
@@ -10,13 +10,13 @@ import { SharedBindings } from "../../workers";
 import {
 	getMiniflareObjectBindings,
 	getPersistPath,
-	kProxyNodeBinding,
 	migrateDatabase,
 	namespaceEntries,
 	namespaceKeys,
 	objectEntryWorker,
 	PersistenceSchema,
 	Plugin,
+	ProxyNodeBinding,
 	SERVICE_LOOPBACK,
 } from "../shared";
 
@@ -51,7 +51,9 @@ export const R2_PLUGIN: Plugin<
 	},
 	getNodeBindings(options) {
 		const buckets = namespaceKeys(options.r2Buckets);
-		return Object.fromEntries(buckets.map((name) => [name, kProxyNodeBinding]));
+		return Object.fromEntries(
+			buckets.map((name) => [name, new ProxyNodeBinding()])
+		);
 	},
 	async getServices({
 		options,

--- a/packages/miniflare/src/plugins/ratelimit/index.ts
+++ b/packages/miniflare/src/plugins/ratelimit/index.ts
@@ -1,7 +1,7 @@
 import SCRIPT_RATELIMIT_OBJECT from "worker:ratelimit/ratelimit";
 import { z } from "zod";
 import { Worker_Binding } from "../../runtime";
-import { kProxyNodeBinding, Plugin } from "../shared";
+import { Plugin, ProxyNodeBinding } from "../shared";
 
 export enum PeriodType {
 	TENSECONDS = 10,
@@ -57,7 +57,10 @@ export const RATELIMIT_PLUGIN: Plugin<typeof RatelimitOptionsSchema> = {
 			return {};
 		}
 		return Object.fromEntries(
-			Object.keys(options.ratelimits).map((name) => [name, kProxyNodeBinding])
+			Object.keys(options.ratelimits).map((name) => [
+				name,
+				new ProxyNodeBinding(),
+			])
 		);
 	},
 	async getServices({ options }) {

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -116,9 +116,12 @@ export type Plugin<
 		? { sharedOptions?: undefined }
 		: { sharedOptions: SharedOptions });
 
-// When this is returned as the binding from `PluginBase#getNodeBindings()`,
-// Miniflare will replace it with a proxy to the binding in `workerd`
-export const kProxyNodeBinding = Symbol("kProxyNodeBinding");
+// When an instance of this class is returned as the binding from `PluginBase#getNodeBindings()`,
+// Miniflare will replace it with a proxy to the binding in `workerd`, alongside applying the
+// specified overrides (if there is any)
+export class ProxyNodeBinding {
+	constructor(public proxyOverrideHandler?: ProxyHandler<any>) {}
+}
 
 export function namespaceKeys(
 	namespaces?: Record<string, string> | string[]

--- a/packages/miniflare/test/plugins/hyperdrive/index.spec.ts
+++ b/packages/miniflare/test/plugins/hyperdrive/index.spec.ts
@@ -1,5 +1,6 @@
 import test from "ava";
 import { Miniflare, MiniflareOptions } from "miniflare";
+import type { Hyperdrive } from "@cloudflare/workers-types/experimental";
 
 test("fields match expected", async (t) => {
 	const connectionString = `postgresql://user:password@localhost:5432/database`;
@@ -32,6 +33,30 @@ test("fields match expected", async (t) => {
 	// Random host should not be the same as the original
 	t.not(hyperdrive.host, "localhost");
 	t.is(hyperdrive.port, 5432);
+});
+
+test("fields in binding proxy match expected", async (t) => {
+	const connectionString = "postgresql://user:password@localhost:5432/database";
+	const mf = new Miniflare({
+		modules: true,
+		script: "export default { fetch() {} }",
+		hyperdrives: {
+			HYPERDRIVE: connectionString,
+		},
+	});
+	t.teardown(() => mf.dispose());
+	const { HYPERDRIVE } = await mf.getBindings<{ HYPERDRIVE: Hyperdrive }>();
+	t.is(HYPERDRIVE.user, "user");
+	t.is(HYPERDRIVE.password, "password");
+	t.is(HYPERDRIVE.database, "database");
+	t.is(HYPERDRIVE.port, 5432);
+
+	// Important: the checks below differ from what the worker code would get inside workerd, this is necessary since getting the binding via `getBindings` implies that
+	//            the binding is going to be used inside node.js and not within workerd where the hyperdrive connection is actually set, so the values need need to remain
+	//            the exact same making the hyperdrive binding work as a simple no-op/passthrough (returning the workerd hyperdrive values wouldn't work as those would not
+	//            work/have any meaning in a node.js process)
+	t.is(HYPERDRIVE.connectionString, connectionString);
+	t.is(HYPERDRIVE.host, "localhost");
 });
 
 test("validates config", async (t) => {

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -1,57 +1,128 @@
 import { execSync } from "child_process";
+import * as nodeNet from "node:net";
 import dedent from "ts-dedent";
 import { beforeEach, describe, expect, it } from "vitest";
 import { CLOUDFLARE_ACCOUNT_ID } from "./helpers/account-id";
 import { makeRoot, seed } from "./helpers/setup";
 import { WRANGLER_IMPORT } from "./helpers/wrangler";
 
-// TODO(DEVX-1262): re-enable when we have set an API token with the proper AI permissions
-describe.skip("getPlatformProxy()", () => {
-	let root: string;
-	beforeEach(async () => {
-		root = await makeRoot();
+describe("getPlatformProxy()", () => {
+	// TODO(DEVX-1262): re-enable when we have set an API token with the proper AI permissions
+	describe.skip("Workers AI", () => {
+		let root: string;
+		beforeEach(async () => {
+			root = makeRoot();
 
-		await seed(root, {
-			"wrangler.toml": dedent`
-					name = "ai-app"
-					account_id = "${CLOUDFLARE_ACCOUNT_ID}"
-					compatibility_date = "2023-01-01"
-					compatibility_flags = ["nodejs_compat"]
+			await seed(root, {
+				"wrangler.toml": dedent`
+						name = "ai-app"
+						account_id = "${CLOUDFLARE_ACCOUNT_ID}"
+						compatibility_date = "2023-01-01"
+						compatibility_flags = ["nodejs_compat"]
 
-					[ai]
-					binding = "AI"
-			`,
-			"index.mjs": dedent/*javascript*/ `
-					import { getPlatformProxy } from "${WRANGLER_IMPORT}"
+						[ai]
+						binding = "AI"
+				`,
+				"index.mjs": dedent/*javascript*/ `
+						import { getPlatformProxy } from "${WRANGLER_IMPORT}"
 
-					const { env } = await getPlatformProxy();
-					const messages = [
+						const { env } = await getPlatformProxy();
+						const messages = [
+							{
+								role: "user",
+								// Doing snapshot testing against AI responses can be flaky, but this prompt generates the same output relatively reliably
+								content: "Respond with the exact text 'This is a response from Workers AI.'. Do not include any other text",
+							},
+						];
+
+						const content = await env.AI.run("@hf/thebloke/zephyr-7b-beta-awq", {
+							messages,
+						});
+
+						console.log(content.response);
+
+						process.exit(0);
+						`,
+				"package.json": dedent`
 						{
-							role: "user",
-							// Doing snapshot testing against AI responses can be flaky, but this prompt generates the same output relatively reliably
-							content: "Respond with the exact text 'This is a response from Workers AI.'. Do not include any other text",
-						},
-					];
-
-					const content = await env.AI.run("@hf/thebloke/zephyr-7b-beta-awq", {
-						messages,
-					});
-
-					console.log(content.response);
-
-					process.exit(0);
-					`,
-			"package.json": dedent`
-					{
-						"name": "ai-app",
-						"version": "0.0.0",
-						"private": true
-					}
-					`,
+							"name": "ai-app",
+							"version": "0.0.0",
+							"private": true
+						}
+						`,
+			});
+		});
+		it("can run ai inference", async () => {
+			const stdout = execSync(`node index.mjs`, {
+				cwd: root,
+				encoding: "utf-8",
+			});
+			expect(stdout).toContain("Workers AI");
 		});
 	});
-	it("can run ai inference", async () => {
-		const stdout = execSync(`node index.mjs`, { cwd: root, encoding: "utf-8" });
-		expect(stdout).toContain("Workers AI");
+
+	describe("Hyperdrive", () => {
+		let root: string;
+		let port = 5432;
+		let server: nodeNet.Server;
+
+		beforeEach(async () => {
+			server = nodeNet.createServer().listen();
+
+			if (server.address() && typeof server.address() !== "string") {
+				port = (server.address() as nodeNet.AddressInfo).port;
+			}
+
+			root = makeRoot();
+
+			await seed(root, {
+				"wrangler.toml": dedent`
+						name = "hyperdrive-app"
+						compatibility_date = "2024-08-20"
+						compatibility_flags = ["nodejs_compat"]
+
+						[[hyperdrive]]
+						binding = "HYPERDRIVE"
+						id = "hyperdrive_id"
+						localConnectionString = "postgresql://user:%21pass@127.0.0.1:${port}/some_db"
+				`,
+				"index.mjs": dedent/*javascript*/ `
+						import { getPlatformProxy } from "${WRANGLER_IMPORT}";
+
+						const { env, dispose } = await getPlatformProxy();
+
+						const conn = env.HYPERDRIVE.connect();
+						await conn.writable.getWriter().write(new TextEncoder().encode("test string sent using getPlatformProxy"));
+
+						await dispose();
+						`,
+				"package.json": dedent`
+						{
+							"name": "hyperdrive-app",
+							"version": "0.0.0",
+							"private": true
+						}
+						`,
+			});
+		});
+
+		it("can connect to a TCP socket via the hyperdrive connect method", async () => {
+			const socketDataMsgPromise = new Promise<string>((resolve, _) => {
+				server.on("connection", (sock) => {
+					sock.on("data", (data) => {
+						resolve(new TextDecoder().decode(data));
+						server.close();
+					});
+				});
+			});
+
+			execSync("node index.mjs", {
+				cwd: root,
+				encoding: "utf-8",
+			});
+			expect(await socketDataMsgPromise).toMatchInlineSnapshot(
+				`"test string sent using getPlatformProxy"`
+			);
+		});
 	});
 });

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -107,7 +107,7 @@ describe("getPlatformProxy()", () => {
 		});
 
 		it.skipIf(
-			// in c3 this test fails for windows because of ECONNRESET issues
+			// in CI this test fails for windows because of ECONNRESET issues
 			process.platform === "win32"
 		)(
 			"can connect to a TCP socket via the hyperdrive connect method",

--- a/packages/wrangler/e2e/get-platform-proxy.test.ts
+++ b/packages/wrangler/e2e/get-platform-proxy.test.ts
@@ -106,23 +106,29 @@ describe("getPlatformProxy()", () => {
 			});
 		});
 
-		it("can connect to a TCP socket via the hyperdrive connect method", async () => {
-			const socketDataMsgPromise = new Promise<string>((resolve, _) => {
-				server.on("connection", (sock) => {
-					sock.on("data", (data) => {
-						resolve(new TextDecoder().decode(data));
-						server.close();
+		it.skipIf(
+			// in c3 this test fails for windows because of ECONNRESET issues
+			process.platform === "win32"
+		)(
+			"can connect to a TCP socket via the hyperdrive connect method",
+			async () => {
+				const socketDataMsgPromise = new Promise<string>((resolve, _) => {
+					server.on("connection", (sock) => {
+						sock.on("data", (data) => {
+							resolve(new TextDecoder().decode(data));
+							server.close();
+						});
 					});
 				});
-			});
 
-			execSync("node index.mjs", {
-				cwd: root,
-				encoding: "utf-8",
-			});
-			expect(await socketDataMsgPromise).toMatchInlineSnapshot(
-				`"test string sent using getPlatformProxy"`
-			);
-		});
+				execSync("node index.mjs", {
+					cwd: root,
+					encoding: "utf-8",
+				});
+				expect(await socketDataMsgPromise).toMatchInlineSnapshot(
+					`"test string sent using getPlatformProxy"`
+				);
+			}
+		);
 	});
 });


### PR DESCRIPTION
## What this PR solves / how to test

This PR simply adds hyperdrive bindings support to Miniflare's `getBindings` and consequently to `getPlatformProxy`.

The hyperdrive proxies have overrides to make them usable within node.js, since the hyperdrive values can only work inside the workerd process itself.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/16706
  - [ ] Not necessary because

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
