### PR TITLE
Switch to multipart/form-data for Workers Assets upload

### DIFF
--- a/.changeset/stupid-weeks-cheat.md
+++ b/.changeset/stupid-weeks-cheat.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Switch to multipart/form-data upload format for Workers Assets
+
+This has proven to be much more reliable.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4315,33 +4315,41 @@ addEventListener('fetch', event => {});`
 					},
 				},
 			});
-			expect(uploadBodies.flatMap((b) => b)).toEqual(
-				expect.arrayContaining([
+			const flatBodies = Object.fromEntries(
+				uploadBodies.flatMap((b) => [...b.entries()])
+			);
+			await expect(
+				flatBodies["ff5016e92f039aa743a4ff7abb3180fa"]
+			).toBeAFileWhichMatches(
+				new File(
+					["Q29udGVudCBvZiBmaWxlLTM="],
+					"ff5016e92f039aa743a4ff7abb3180fa",
 					{
-						base64: true,
-						key: "ff5016e92f039aa743a4ff7abb3180fa",
-						metadata: {
-							contentType: "text/plain",
-						},
-						value: "Q29udGVudCBvZiBmaWxlLTM=",
-					},
+						type: "text/plain",
+					}
+				)
+			);
+			await expect(
+				flatBodies["7574a8cd3094a050388ac9663af1c1d6"]
+			).toBeAFileWhichMatches(
+				new File(
+					["Q29udGVudCBvZiBmaWxlLTI="],
+					"7574a8cd3094a050388ac9663af1c1d6",
 					{
-						base64: true,
-						key: "7574a8cd3094a050388ac9663af1c1d6",
-						metadata: {
-							contentType: "text/plain",
-						},
-						value: "Q29udGVudCBvZiBmaWxlLTI=",
-					},
+						type: "text/plain",
+					}
+				)
+			);
+			await expect(
+				flatBodies["0de3dd5df907418e9730fd2bd747bd5e"]
+			).toBeAFileWhichMatches(
+				new File(
+					["Q29udGVudCBvZiBmaWxlLTE="],
+					"0de3dd5df907418e9730fd2bd747bd5e",
 					{
-						base64: true,
-						key: "0de3dd5df907418e9730fd2bd747bd5e",
-						metadata: {
-							contentType: "text/plain",
-						},
-						value: "Q29udGVudCBvZiBmaWxlLTE=",
-					},
-				])
+						type: "text/plain",
+					}
+				)
 			);
 		});
 

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -132,7 +132,7 @@ export const syncExperimentalAssets = async (
 
 			try {
 				const res = await fetchResult<UploadResponse>(
-					`/accounts/${accountId}/workers/assets/upload`,
+					`/accounts/${accountId}/workers/assets/upload?base64=true`,
 					{
 						method: "POST",
 						headers: {


### PR DESCRIPTION
## What this PR solves / how to test

Uploads Workers Assets with multipart/form-data rather than JSON Lines. This is much easier for the asset upload service to deal with, and means we can now properly support large files/a large number of files.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no e2e test changes
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: unreleased

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
