### PR TITLE
fix: don't warn about `node:async_hooks` if `nodejs_als` is set

### DIFF
--- a/.changeset/silly-ways-brake.md
+++ b/.changeset/silly-ways-brake.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: don't warn about `node:async_hooks` if `nodejs_als` is set
+
+Fixes #6011

--- a/fixtures/nodejs-als-app/package.json
+++ b/fixtures/nodejs-als-app/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "nodejs-als-app",
+	"private": true,
+	"scripts": {
+		"build": "wrangler deploy --dry-run --outdir=./dist",
+		"dev": "wrangler dev --x-dev-env",
+		"test:ci": "vitest run",
+		"test:watch": "vitest"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "^4.20240821.1",
+		"undici": "^5.28.4",
+		"wrangler": "workspace:*"
+	}
+}

--- a/fixtures/nodejs-als-app/src/index.ts
+++ b/fixtures/nodejs-als-app/src/index.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const asyncLocalStorage = new AsyncLocalStorage<number>();
+
+export default {
+	async fetch(req: Request, env: unknown, ctx: ExecutionContext) {
+		if (new URL(req.url).pathname !== "/") {
+			return new Response("No Found", { status: 404 });
+		}
+
+		const results = await Promise.all([
+			asyncLocalStorage.run(1, async () => getValue()),
+			asyncLocalStorage.run(2, async () => getValue()),
+			asyncLocalStorage.run(3, async () => getValue()),
+		]);
+
+		return new Response(`Working ${JSON.stringify(results)}`);
+	},
+};
+
+async function getValue() {
+	await new Promise((resolve) => setTimeout(resolve, 1000));
+	return asyncLocalStorage.getStore();
+}

--- a/fixtures/nodejs-als-app/tests/index.test.ts
+++ b/fixtures/nodejs-als-app/tests/index.test.ts
@@ -1,0 +1,25 @@
+import { resolve } from "node:path";
+import { fetch } from "undici";
+import { describe, it } from "vitest";
+import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
+
+describe("nodejs als", () => {
+	it("should work with node:async_hooks without full nodejs compat", async ({
+		expect,
+	}) => {
+		const { ip, port, stop, getOutput } = await runWranglerDev(
+			resolve(__dirname, "../src"),
+			["--port=0", "--inspector-port=0"]
+		);
+		try {
+			// There should be no warning about async_hooks
+			expect(getOutput()).not.toContain("node:async_hooks");
+
+			const response = await fetch(`http://${ip}:${port}/`);
+			const body = await response.text();
+			expect(body).toMatchInlineSnapshot(`"Working [1,2,3]"`);
+		} finally {
+			await stop();
+		}
+	});
+});

--- a/fixtures/nodejs-als-app/tests/tsconfig.json
+++ b/fixtures/nodejs-als-app/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"types": ["node"]
+	},
+	"include": ["**/*.ts", "../../../node-types.d.ts"]
+}

--- a/fixtures/nodejs-als-app/tsconfig.json
+++ b/fixtures/nodejs-als-app/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"module": "esnext",
+		"target": "esnext",
+		"lib": ["esnext"],
+		"strict": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"types": ["@cloudflare/workers-types/experimental", "node"],
+		"allowJs": true,
+		"allowSyntheticDefaultImports": true
+	},
+	"include": ["src"]
+}

--- a/fixtures/nodejs-als-app/turbo.json
+++ b/fixtures/nodejs-als-app/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://turbo.build/schema.json",
+	"extends": ["//"],
+	"pipeline": {
+		"build": {
+			"outputs": ["dist/**"]
+		}
+	}
+}

--- a/fixtures/nodejs-als-app/vitest.config.mts
+++ b/fixtures/nodejs-als-app/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {},
+	})
+);

--- a/fixtures/nodejs-als-app/wrangler.toml
+++ b/fixtures/nodejs-als-app/wrangler.toml
@@ -1,0 +1,5 @@
+name = "nodejs-als-app"
+main = "src/index.ts"
+compatibility_date = "2024-08-03"
+compatibility_flags = ["nodejs_als"]
+

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -33,7 +33,7 @@
 		"clean": "rimraf dist",
 		"dev": "pnpm run clean && concurrently -n bundle:asset-worker,bundle:router-worker -c blue,magenta \"pnpm run bundle:asset-worker --watch\" \"pnpm run bundle:router-worker --watch\"",
 		"test": "vitest",
-		"test:ci": "pnpm run test"
+		"test:ci": "pnpm run test run"
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -12,6 +12,7 @@ import {
 } from "./build-failures";
 import { dedupeModulesByName } from "./dedupe-modules";
 import { getEntryPointFromMetafile } from "./entry-point-from-metafile";
+import { asyncLocalStoragePlugin } from "./esbuild-plugins/als-external";
 import { cloudflareInternalPlugin } from "./esbuild-plugins/cloudflare-internal";
 import { configProviderPlugin } from "./esbuild-plugins/config-provider";
 import { nodejsHybridPlugin } from "./esbuild-plugins/hybrid-nodejs-compat";
@@ -369,6 +370,7 @@ export async function bundleWorker(
 		plugins: [
 			aliasPlugin,
 			moduleCollector.plugin,
+			...(nodejsCompatMode === "als" ? [asyncLocalStoragePlugin] : []),
 			...(nodejsCompatMode === "legacy"
 				? [
 						NodeGlobalsPolyfills({ buffer: true }),

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/als-external.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/als-external.ts
@@ -1,0 +1,13 @@
+import type { Plugin } from "esbuild";
+
+/**
+ * An esbuild plugin that will mark `node:async_hooks` imports as external.
+ */
+export const asyncLocalStoragePlugin: Plugin = {
+	name: "Mark async local storage imports as external plugin",
+	setup(pluginBuild) {
+		pluginBuild.onResolve({ filter: /^node:async_hooks/ }, () => {
+			return { external: true };
+		});
+	},
+};

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/als-external.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/als-external.ts
@@ -6,7 +6,7 @@ import type { Plugin } from "esbuild";
 export const asyncLocalStoragePlugin: Plugin = {
 	name: "Mark async local storage imports as external plugin",
 	setup(pluginBuild) {
-		pluginBuild.onResolve({ filter: /^node:async_hooks/ }, () => {
+		pluginBuild.onResolve({ filter: /^node:async_hooks(\/|$)/ }, () => {
 			return { external: true };
 		});
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/nodejs-als-app:
+    devDependencies:
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20240821.1
+        version: 4.20240821.1
+      undici:
+        specifier: ^5.28.4
+        version: 5.28.4
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/nodejs-hybrid-app:
     devDependencies:
       '@cloudflare/workers-tsconfig':
@@ -11215,7 +11230,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.5.4)
       '@typescript-eslint/utils': 6.10.0(eslint@8.49.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@9.2.2)
+      debug: 4.3.5
       eslint: 8.49.0
       ts-api-utils: 1.0.3(typescript@5.5.4)
     optionalDependencies:


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6011

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
