### PR TITLE
Remove some missed --x-versions and move deploy to existing util function

### DIFF
--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -63,9 +63,9 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Worker Startup Time: (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
-			To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
-			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy --experimental-versions
-			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"
+			To deploy this version to production traffic use the command wrangler versions deploy
+			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
+			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
 		`);
 	});
 
@@ -178,9 +178,9 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Worker Startup Time: (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
-			To deploy this version to production traffic use the command wrangler versions deploy --experimental-versions
-			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy --experimental-versions
-			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy --experimental-versions"
+			To deploy this version to production traffic use the command wrangler versions deploy
+			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
+			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
 		`);
 
 		const versionsList = await helper.run(

--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -156,7 +156,7 @@ describe("deployments", () => {
 				await expect(
 					runWrangler("deployments view 1701-E")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: \`wrangler deployments view <deployment-id>\` has been renamed \`wrangler versions view [version-id] --x-versions\`. Please use that command instead.]`
+					`[Error: \`wrangler deployments view <deployment-id>\` has been renamed \`wrangler versions view [version-id]\`. Please use that command instead.]`
 				);
 			});
 

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -348,7 +348,7 @@ describe("wrangler secret", () => {
 
 			await expect(runWrangler(`secret put secret-name --name ${scriptName}`))
 				.rejects.toThrowErrorMatchingInlineSnapshot(`
-				[Error: Secret edit failed. You attempted to modify a secret, but the latest version of your Worker isn't currently deployed. Please ensure that the latest version of your Worker is fully deployed (wrangler versions deploy --x-versions) before modifying secrets. Alternatively, you can use the Cloudflare dashboard to modify secrets and deploy the version.
+				[Error: Secret edit failed. You attempted to modify a secret, but the latest version of your Worker isn't currently deployed. Please ensure that the latest version of your Worker is fully deployed (wrangler versions deploy) before modifying secrets. Alternatively, you can use the Cloudflare dashboard to modify secrets and deploy the version.
 
 				Note: This limitation will be addressed in an upcoming release.]
 			`);

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.view.test.ts
@@ -9,7 +9,7 @@ describe("deployments view", () => {
 		const result = runWrangler("deployments view  --x-versions");
 
 		await expect(result).rejects.toMatchInlineSnapshot(
-			`[Error: \`wrangler deployments view\` has been renamed \`wrangler deployments status --x-versions\`. Please use that command instead.]`
+			`[Error: \`wrangler deployments view\` has been renamed \`wrangler deployments status\`. Please use that command instead.]`
 		);
 		await expect(result).rejects.toBeInstanceOf(UserError);
 	});
@@ -18,7 +18,7 @@ describe("deployments view", () => {
 		const result = runWrangler("deployments view dummy-id  --x-versions");
 
 		await expect(result).rejects.toMatchInlineSnapshot(
-			`[Error: \`wrangler deployments view <deployment-id>\` has been renamed \`wrangler versions view [version-id] --x-versions\`. Please use that command instead.]`
+			`[Error: \`wrangler deployments view <deployment-id>\` has been renamed \`wrangler versions view [version-id]\`. Please use that command instead.]`
 		);
 		await expect(result).rejects.toBeInstanceOf(UserError);
 	});

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -68,7 +68,7 @@ describe("versions secret put", () => {
 			✨ Successfully created secret for key: SECRET_2
 			✨ Successfully created secret for key: SECRET_3
 			✨ Success! Created version id with 3 secrets.
-			➡️  To deploy this version to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version to production traffic use the command \\"wrangler versions deploy\\"."
 		`
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
@@ -106,7 +106,7 @@ describe("versions secret put", () => {
 			✨ Successfully created secret for key: SECRET_2
 			✨ Successfully created secret for key: SECRET_3
 			✨ Success! Created version id with 3 secrets.
-			➡️  To deploy this version to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version to production traffic use the command \\"wrangler versions deploy\\"."
 		`
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -44,7 +44,7 @@ describe("versions secret put", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🌀 Deleting the secret SECRET on the Worker script-name
 			✨ Success! Created version id with deleted secret SECRET.
-			➡️  To deploy this version without the secret SECRET to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version without the secret SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
@@ -72,7 +72,7 @@ describe("versions secret put", () => {
 			🤖 Using fallback value in non-interactive context: yes
 			🌀 Deleting the secret SECRET on the Worker script-name
 			✨ Success! Created version id with deleted secret SECRET.
-			➡️  To deploy this version without the secret SECRET to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version without the secret SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
@@ -99,7 +99,7 @@ describe("versions secret put", () => {
 			🤖 Using fallback value in non-interactive context: yes
 			🌀 Deleting the secret SECRET on the Worker script-name
 			✨ Success! Created version id with deleted secret SECRET.
-			➡️  To deploy this version without the secret SECRET to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version without the secret SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -48,7 +48,7 @@ describe("versions secret put", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🌀 Creating the secret for the Worker \\"script-name\\"
 			✨ Success! Created version id with secret NEW_SECRET.
-			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
@@ -113,7 +113,7 @@ describe("versions secret put", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🌀 Creating the secret for the Worker \\"script-name\\"
 			✨ Success! Created version id with secret NEW_SECRET.
-			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
@@ -149,7 +149,7 @@ describe("versions secret put", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🌀 Creating the secret for the Worker \\"script-name\\"
 			✨ Success! Created version id with secret NEW_SECRET.
-			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
@@ -188,7 +188,7 @@ describe("versions secret put", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🌀 Creating the secret for the Worker \\"script-name\\"
 			✨ Success! Created version id with secret NEW_SECRET.
-			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
@@ -224,7 +224,7 @@ describe("versions secret put", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🌀 Creating the secret for the Worker \\"script-name\\"
 			✨ Success! Created version id with secret SECRET.
-			➡️  To deploy this version with secret SECRET to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version with secret SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
@@ -299,7 +299,7 @@ describe("versions secret put", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🌀 Creating the secret for the Worker \\"script-name\\"
 			✨ Success! Created version id with secret SECRET.
-			➡️  To deploy this version with secret SECRET to production traffic use the command \\"wrangler versions deploy --x-versions\\"."
+			➡️  To deploy this version with secret SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -189,7 +189,7 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 							throw new UserError(
 								"Secret edit failed. You attempted to modify a secret, but the latest version of your Worker isn't currently deployed. " +
 									"Please ensure that the latest version of your Worker is fully deployed " +
-									"(wrangler versions deploy --x-versions) before modifying secrets. " +
+									"(wrangler versions deploy) before modifying secrets. " +
 									"Alternatively, you can use the Cloudflare dashboard to modify secrets and deploy the version." +
 									"\n\nNote: This limitation will be addressed in an upcoming release."
 							);

--- a/packages/wrangler/src/versions/deployments/view.ts
+++ b/packages/wrangler/src/versions/deployments/view.ts
@@ -31,11 +31,11 @@ export async function versionsDeploymentsViewHandler(
 
 	if (args.deploymentId === undefined) {
 		throw new UserError(
-			"`wrangler deployments view` has been renamed `wrangler deployments status --x-versions`. Please use that command instead."
+			"`wrangler deployments view` has been renamed `wrangler deployments status`. Please use that command instead."
 		);
 	} else {
 		throw new UserError(
-			"`wrangler deployments view <deployment-id>` has been renamed `wrangler versions view [version-id] --x-versions`. Please use that command instead."
+			"`wrangler deployments view <deployment-id>` has been renamed `wrangler versions view [version-id]`. Please use that command instead."
 		);
 	}
 }

--- a/packages/wrangler/src/versions/secrets/bulk.ts
+++ b/packages/wrangler/src/versions/secrets/bulk.ts
@@ -124,6 +124,6 @@ export async function versionsSecretPutBulkHandler(
 	}
 	logger.log(
 		`✨ Success! Created version ${newVersion.id} with ${secrets.length} secrets.` +
-			`\n➡️  To deploy this version to production traffic use the command "wrangler versions deploy --x-versions".`
+			`\n➡️  To deploy this version to production traffic use the command "wrangler versions deploy".`
 	);
 }

--- a/packages/wrangler/src/versions/secrets/delete.ts
+++ b/packages/wrangler/src/versions/secrets/delete.ts
@@ -113,7 +113,7 @@ export async function versionsSecretDeleteHandler(
 
 		logger.log(
 			`✨ Success! Created version ${newVersion.id} with deleted secret ${args.key}.` +
-				`\n➡️  To deploy this version without the secret ${args.key} to production traffic use the command "wrangler versions deploy --x-versions".`
+				`\n➡️  To deploy this version without the secret ${args.key} to production traffic use the command "wrangler versions deploy".`
 		);
 	}
 }

--- a/packages/wrangler/src/versions/secrets/put.ts
+++ b/packages/wrangler/src/versions/secrets/put.ts
@@ -94,6 +94,6 @@ export async function versionsSecretPutHandler(
 
 	logger.log(
 		`✨ Success! Created version ${newVersion.id} with secret ${args.key}.` +
-			`\n➡️  To deploy this version with secret ${args.key} to production traffic use the command "wrangler versions deploy --x-versions".`
+			`\n➡️  To deploy this version with secret ${args.key} to production traffic use the command "wrangler versions deploy".`
 	);
 }

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -554,12 +554,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	logger.log("Uploaded", workerName, formatTime(uploadMs));
 
-	const cmdVersionsDeploy = blue(
-		"wrangler versions deploy --experimental-versions"
-	);
-	const cmdTriggersDeploy = blue(
-		"wrangler triggers deploy --experimental-versions"
-	);
+	const cmdVersionsDeploy = blue("wrangler versions deploy");
+	const cmdTriggersDeploy = blue("wrangler triggers deploy");
 	logger.info(
 		gray(`
 To deploy this version to production traffic use the command ${cmdVersionsDeploy}


### PR DESCRIPTION
## What this PR solves / how to test

Missed a few --x-versions and also moved the deployment creation in wrangler deploy over to the existing util function

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: only small changes in copy removing a flag which was previously mentioned in release notes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: nothing new here, existing doc updates stand

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
