### PR TITLE
chore(quick-edit): run setup and custom-build script before deploy

### DIFF
--- a/.changeset/bright-radios-fail.md
+++ b/.changeset/bright-radios-fail.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/quick-edit": patch
+---
+
+fix: quick editor deploy script setup

--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -58,11 +58,7 @@ jobs:
         if: contains(github.event.*.labels.*.name, 'preview:quick-edit')
         # Quick Edit requires yarn and VS Code build deps, so needs fairly specific logic
         run: |
-          sudo apt-get install -y libkrb5-dev
-          yarn global add node-gyp
           cd packages/quick-edit
-          yarn setup
-          yarn custom:build
           pnpm run deploy
         env:
           DEBIAN_FRONTEND: noninteractive

--- a/packages/quick-edit-extension/scripts/bundle.ts
+++ b/packages/quick-edit-extension/scripts/bundle.ts
@@ -7,7 +7,6 @@ type BuildFlags = {
 
 async function buildMain(flags: BuildFlags = {}) {
 	const options: esbuild.BuildOptions = {
-		watch: flags.watch,
 		entryPoints: ["./src/extension.ts"],
 		bundle: true,
 		outfile: "./dist/extension.js",
@@ -41,15 +40,18 @@ async function buildMain(flags: BuildFlags = {}) {
 		],
 	};
 
-	await esbuild.build(options);
+	if (flags.watch) {
+		const ctx = await esbuild.context(options);
+
+		// Start watching for changes...
+		await ctx.watch();
+	} else {
+		await esbuild.build(options);
+	}
 }
 
 async function run() {
-	await buildMain();
-	if (process.argv.includes("--watch")) {
-		console.log("Built. Watching for changes...");
-		await Promise.all([buildMain({ watch: true })]);
-	}
+	await buildMain({ watch: process.argv.includes("--watch") });
 }
 
 run().catch((e) => {

--- a/packages/quick-edit/README.md
+++ b/packages/quick-edit/README.md
@@ -6,12 +6,12 @@ This package contains Cloudflare's fork VSCode for Web, to support web editing o
 
 1. You must switch your NodeJS version to NodeJS 18 (using a tool like nvm). VSCode's build process requires this. For instance, if you use `nvm`, running `nvm use` would be enough to switch to the correct NodeJS version.
 2. Run `pnpm install`
-3. Run `yarn setup`, which will install dependencies, clone VSCode (currently v1.85.2), apply the patches specified in `./patches`, and symlink the top level packages within `workers-sdk`.
+3. Run `pnpm run setup`, which will install dependencies, clone VSCode (currently v1.85.2), apply the patches specified in `./patches`, and symlink the top level packages within `workers-sdk`.
 4. Run `pnpm run dev`. This will start various dev servers for VSCode and `quick-edit-extension`. Note, this takes a _long_ time to start up. Expect up to 3 minutes, although reloads will be much faster. You can access the VSCode dev server at `http://localhost:8788`
 
 ## Building
 
-Follow steps (1), (2) and (3) from above, and then run `yarn custom:build`
+Follow steps (1), (2) and (3) from above, and then run `pnpm run custom:build`
 
 ## Deployment
 
@@ -26,7 +26,7 @@ Deployments are managed by Github Actions:
 
 ## Patching VSCode
 
-If you need to add additional patches to VSCode, ensure you've run `yarn setup`. Then:
+If you need to add additional patches to VSCode, ensure you've run `pnpm run setup`. Then:
 
 1. Make your changes in the checked out VSCode in `vendor/vscode`.
 2. Commit your changes with `git commit -m "YOUR MESSAGE" --no-verify` (run this in the `vendor/vscode` directory).

--- a/packages/quick-edit/build.sh
+++ b/packages/quick-edit/build.sh
@@ -1,5 +1,11 @@
 set -eu
 
+# The preinstall script in vscode will fail if npm_execpath is not set by yarn
+# This make sure the env is unset so yarn can set it accordingly
+unset npm_execpath
+# We cannot run yarn without disabling the corepack check as the packageManager field is set to pnpm
+SKIP_YARN_COREPACK_CHECK=0
+
 # Cleanup development symlink to vscode
 rm -f web/assets
 

--- a/packages/quick-edit/package.json
+++ b/packages/quick-edit/package.json
@@ -13,7 +13,7 @@
 		"check:lint": "eslint functions --max-warnings=0",
 		"check:type": "tsc",
 		"custom:build": "./build.sh",
-		"deploy": "CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 pnpm exec wrangler pages deploy --project-name quick-edit ./web",
+		"deploy": "pnpm run setup && pnpm run custom:build && CLOUDFLARE_ACCOUNT_ID=e35fd947284363a46fd7061634477114 pnpm exec wrangler pages deploy --project-name quick-edit ./web",
 		"dev": "concurrently 'pnpm exec wrangler pages dev ./web' 'npm --prefix web/quick-edit-extension run watch-web' 'yarn --cwd ../../vendor/vscode watch' 'yarn --cwd ../../vendor/vscode watch-web'",
 		"setup": "rm -rf web/assets web/quick-edit-extension && ./setup.sh"
 	},

--- a/packages/quick-edit/setup.sh
+++ b/packages/quick-edit/setup.sh
@@ -1,6 +1,18 @@
 set -eu
+# The preinstall script in vscode will fail if npm_execpath is not set by yarn
+# This make sure the env is unset so yarn can set it accordingly
+unset npm_execpath
+
 # The upstream VSCode version (tag) to build from
 VERSION="1.85.2"
+# We cannot run yarn without disabling the corepack check as the packageManager field is set to pnpm
+SKIP_YARN_COREPACK_CHECK=0
+
+# Setup for the CI environment
+if [ -n "${CI:-}" ]; then
+    sudo apt-get install -y libkrb5-dev
+    yarn global add node-gyp
+fi
 
 rm -rf web
 rm -rf ../../vendor/vscode
@@ -22,7 +34,7 @@ git config user.email "workers-devprod@cloudflare.com"
 git config user.name "Workers DevProd"
 
 git am ../../packages/quick-edit/patches/*.patch
-pnpm exec yarn
+yarn install
 cd ../../packages/quick-edit
 pnpm exec tsx bundle-dts.ts
 ln -s $PWD/../../vendor/vscode $PWD/web/assets


### PR DESCRIPTION
## What this PR solves / how to test

Fixes [DEVX-1404](https://jira.cfdata.org/browse/DEVX-1404)

Our quick editor depends on Vscode with a restriction on installation with yarn only. However, this conflict with our packageManager settings which points to pnpm. This updates both the setup and build script to make sure vscode is happy when we run `pnpm run deploy`.

The `Deploy Pages Previews` job proves that `pnpm run deploy` works now. So it should be safe to say that our deploy script that runs `pnpm run deploy` will work too. 👍🏼 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no feature update
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no feature update
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included: To bump the version so the deploy script will re-run
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: no feature update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
