### PR TITLE
c3: default "do you want to deploy" to no

### DIFF
--- a/packages/create-cloudflare/src/helpers/cli.ts
+++ b/packages/create-cloudflare/src/helpers/cli.ts
@@ -51,7 +51,7 @@ export const C3_DEFAULTS: C3Args = {
 	type: "hello-world",
 	framework: "analog",
 	autoUpdate: true,
-	deploy: true,
+	deploy: false,
 	git: true,
 	open: true,
 	lang: "ts",


### PR DESCRIPTION
This PR flips the default to "Do you want to deploy your application" to "No".

Most of our own docs guide users to say "no"

```
➜  rg 'you want to deploy your application'
src/content/partials/workers/c3-post-run-steps.mdx
14:* For *Do you want to deploy your application?*, choose `No` (we will be making some changes before deploying).
```

This partial is referenced 34 times across our docs:

```
➜  rg -c 'c3-post-run-steps'
src/content/docs/r2/api/workers/workers-api-usage.mdx:1
src/content/docs/r2/examples/upload-logs-event-notifications.mdx:1
src/content/docs/vectorize/get-started/embeddings.mdx:1
src/content/docs/vectorize/get-started/intro.mdx:1
src/content/docs/kv/get-started.mdx:1
src/content/docs/ai-gateway/tutorials/deploy-aig-worker.mdx:1
src/content/docs/d1/tutorials/build-a-comments-api/index.mdx:1
src/content/docs/workers-ai/get-started/workers-wrangler.mdx:1
src/content/docs/d1/get-started.mdx:1
src/content/docs/workers-ai/tutorials/build-a-retrieval-augmented-generation-ai.mdx:1
src/content/docs/developer-spotlight/tutorials/custom-access-control-for-files.mdx:1
src/content/docs/durable-objects/get-started.mdx:1
src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale/index.mdx:1
src/content/docs/browser-rendering/get-started/reuse-sessions.mdx:1
src/content/docs/browser-rendering/get-started/screenshots.mdx:1
src/content/docs/hyperdrive/get-started.mdx:1
src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/developing-with-wrangler.mdx:3
src/content/docs/cloudflare-for-platforms/workers-for-platforms/get-started/configuration.mdx:1
src/content/docs/radar/investigate/bgp-anomalies.mdx:1
src/content/docs/learning-paths/workers/get-started/first-worker.mdx:1
src/content/docs/workers/get-started/guide.mdx:1
src/content/docs/cloudflare-one/identity/authorization-cookie/cors.mdx:1
src/content/docs/workers/tutorials/upload-assets-with-r2/index.mdx:1
src/content/docs/workers/tutorials/postgres/index.mdx:1
src/content/docs/workers/tutorials/openai-function-calls-workers/index.mdx:1
src/content/docs/workers/tutorials/build-a-qr-code-generator/index.mdx:1
src/content/docs/workers/tutorials/generate-youtube-thumbnails-with-workers-and-images/index.mdx:1
src/content/docs/workers/tutorials/build-a-jamstack-app/index.mdx:1
src/content/docs/workers/tutorials/connect-to-turso-using-workers/index.mdx:1
src/content/docs/workers/tutorials/github-sms-notifications-using-twilio/index.mdx:1
src/content/docs/workers/tutorials/handle-form-submissions-with-airtable/index.mdx:1
src/content/docs/workers/tutorials/create-finetuned-chatgpt-ai-models-with-r2/index.mdx:1
src/content/docs/queues/tutorials/web-crawler-with-browser-rendering/index.mdx:1
src/content/docs/queues/get-started.mdx:1
```

<img width="473" alt="image" src="https://github.com/user-attachments/assets/699ab8f9-071d-49e1-97ab-dac91606bdad">
