### PR TITLE
Add Cloudflare Pipelines commands

### DIFF
--- a/.changeset/polite-tigers-end.md
+++ b/.changeset/polite-tigers-end.md
@@ -1,0 +1,20 @@
+---
+"wrangler": minor
+---
+
+feature: Integrate the Cloudflare Pipelines product into wrangler.
+
+Cloudflare Pipelines is a product that handles the ingest of event streams 
+into R2.  This feature integrates various forms of managing pipelines.
+
+Usage:
+  wrangler pipelines create <pipeline>  Create a new pipeline
+  wrangler pipelines list               List current pipelines
+  wrangler pipelines show <pipeline>    Show a pipeline configuration
+  wrangler pipelines update <pipeline>  Update a pipeline
+  wrangler pipelines delete <pipeline>  Delete a pipeline
+
+Examples:
+  wrangler pipelines create my-pipeline --r2 MY_BUCKET --access-key-id "my-key" --secret-access-key "my-secret"
+  wrangler pipelines show my-pipeline
+  wrangler pipelines delete my-pipline

--- a/packages/wrangler/src/__tests__/ai.test.ts
+++ b/packages/wrangler/src/__tests__/ai.test.ts
@@ -21,7 +21,6 @@ describe("ai help", () => {
 
 			🤖 Manage AI models
 
-
 			COMMANDS
 			  wrangler ai models    List catalog models
 			  wrangler ai finetune  Interact with finetune files
@@ -50,7 +49,6 @@ describe("ai help", () => {
 			wrangler ai
 
 			🤖 Manage AI models
-
 
 			COMMANDS
 			  wrangler ai models    List catalog models

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -383,7 +383,7 @@ describe("deploy", () => {
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
-				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in.
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
@@ -424,7 +424,7 @@ describe("deploy", () => {
 
 				expect(std.out).toMatchInlineSnapshot(`
 					"Attempting to login via OAuth...
-					Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+					Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 					Successfully logged in.
 					Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -61,6 +61,7 @@ describe("wrangler", () => {
 				  wrangler pubsub                 📮 Manage Pub/Sub brokers [private beta]
 				  wrangler dispatch-namespace     🏗️  Manage dispatch namespaces
 				  wrangler ai                     🤖 Manage AI models
+				  wrangler pipelines              🚰 Manage Worker Pipelines
 
 				  wrangler login                  🔓 Login to Cloudflare
 				  wrangler logout                 🚪 Logout from Cloudflare
@@ -118,6 +119,7 @@ describe("wrangler", () => {
 				  wrangler pubsub                 📮 Manage Pub/Sub brokers [private beta]
 				  wrangler dispatch-namespace     🏗️  Manage dispatch namespaces
 				  wrangler ai                     🤖 Manage AI models
+				  wrangler pipelines              🚰 Manage Worker Pipelines
 
 				  wrangler login                  🔓 Login to Cloudflare
 				  wrangler logout                 🚪 Logout from Cloudflare

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -1,0 +1,571 @@
+import { http, HttpResponse } from "msw";
+import { __testSkipDelays } from "../pipelines";
+import { endEventLoop } from "./helpers/end-event-loop";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { msw } from "./helpers/msw";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+import type { Pipeline, PipelineEntry } from "../pipelines/client";
+
+describe("pipelines", () => {
+	const std = mockConsoleMethods();
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+
+	const samplePipeline = {
+		currentVersion: 1,
+		id: "0001",
+		name: "my-pipeline",
+		metadata: {},
+		source: [
+			{
+				type: "binding",
+				format: "json",
+			},
+		],
+		transforms: [],
+		destination: {
+			type: "json",
+			batch: {},
+			compression: {
+				type: "none",
+			},
+			format: "json",
+			path: {
+				bucket: "bucket",
+			},
+		},
+		endpoint: "https://0001.pipelines.cloudflarestorage.com",
+	};
+
+	function mockCreateR2Token(bucket: string) {
+		const requests = { count: 0 };
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/r2/buckets/:bucket",
+				async ({ params }) => {
+					expect(params.accountId).toEqual("some-account-id");
+					expect(params.bucket).toEqual(bucket);
+					requests.count++;
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							messages: [],
+							result: null,
+						},
+						{ status: 200 }
+					);
+				},
+				{ once: true }
+			),
+			http.get(
+				"*/user/tokens/permission_groups",
+				async () => {
+					requests.count++;
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							messages: [],
+							result: [
+								{
+									id: "2efd5506f9c8494dacb1fa10a3e7d5b6",
+									name: "Workers R2 Storage Bucket Item Write",
+									description:
+										"Grants write access to Cloudflare R2 Bucket Scoped Storage",
+									scopes: ["com.cloudflare.edge.r2.bucket"],
+								},
+							],
+						},
+						{ status: 200 }
+					);
+				},
+				{ once: true }
+			),
+			http.post(
+				"*/user/tokens",
+				async () => {
+					requests.count++;
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								id: "service-token-id",
+								name: "my-service-token",
+								value: "my-secret-value",
+							},
+						},
+						{ status: 200 }
+					);
+				},
+				{ once: true }
+			)
+		);
+		return requests;
+	}
+
+	function mockCreeatR2TokenFailure(bucket: string) {
+		const requests = { count: 0 };
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/r2/buckets/:bucket",
+				async ({ params }) => {
+					expect(params.accountId).toEqual("some-account-id");
+					expect(params.bucket).toEqual(bucket);
+					requests.count++;
+					return HttpResponse.json(
+						{
+							success: false,
+							errors: [
+								{
+									code: 10006,
+									message: "The specified bucket does not exist.",
+								},
+							],
+							messages: [],
+							result: null,
+						},
+						{ status: 404 }
+					);
+				},
+				{ once: true }
+			)
+		);
+		return requests;
+	}
+
+	function mockCreateRequest(
+		name: string,
+		status: number = 200,
+		error?: object
+	) {
+		const requests = { count: 0 };
+		msw.use(
+			http.post(
+				"*/accounts/:accountId/pipelines",
+				async ({ request, params }) => {
+					expect(params.accountId).toEqual("some-account-id");
+					const config = (await request.json()) as Pipeline;
+					expect(config.name).toEqual(name);
+					requests.count++;
+					const pipeline: Pipeline = {
+						...config,
+						id: "0001",
+						name: name,
+						endpoint: "foo",
+					};
+					return HttpResponse.json(
+						{
+							success: !error,
+							errors: error ? [error] : [],
+							messages: [],
+							result: pipeline,
+						},
+						{ status: status }
+					);
+				},
+				{ once: true }
+			)
+		);
+		return requests;
+	}
+
+	function mockListRequest(entries: PipelineEntry[]) {
+		const requests = { count: 0 };
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/pipelines",
+				async ({ params }) => {
+					requests.count++;
+					expect(params.accountId).toEqual("some-account-id");
+
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							messages: [],
+							result: entries,
+						},
+						{ status: 200 }
+					);
+				},
+				{ once: true }
+			)
+		);
+		return requests;
+	}
+
+	function mockShowRequest(
+		name: string,
+		pipeline: Pipeline | null,
+		status: number = 200,
+		error?: object
+	) {
+		const requests = { count: 0 };
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/pipelines/:name",
+				async ({ params }) => {
+					requests.count++;
+					expect(params.accountId).toEqual("some-account-id");
+					expect(params.name).toEqual(name);
+
+					return HttpResponse.json(
+						{
+							success: !error,
+							errors: error ? [error] : [],
+							messages: [],
+							result: pipeline,
+						},
+						{ status }
+					);
+				},
+				{ once: true }
+			)
+		);
+		return requests;
+	}
+
+	function mockUpdateRequest(
+		name: string,
+		pipeline: Pipeline | null,
+		status: number = 200,
+		error?: object
+	) {
+		const requests: { count: number; body: Pipeline | null } = {
+			count: 0,
+			body: null,
+		};
+		msw.use(
+			http.put(
+				"*/accounts/:accountId/pipelines/:name",
+				async ({ params, request }) => {
+					requests.count++;
+					requests.body = (await request.json()) as Pipeline;
+					expect(params.accountId).toEqual("some-account-id");
+					expect(params.name).toEqual(name);
+
+					// update strips creds, so enforce this
+					if (pipeline?.destination) {
+						pipeline.destination.credentials = undefined;
+					}
+
+					return HttpResponse.json(
+						{
+							success: !error,
+							errors: error ? [error] : [],
+							messages: [],
+							result: pipeline,
+						},
+						{ status }
+					);
+				},
+				{ once: true }
+			)
+		);
+		return requests;
+	}
+
+	function mockDeleteRequest(
+		name: string,
+		status: number = 200,
+		error?: object
+	) {
+		const requests = { count: 0 };
+		msw.use(
+			http.delete(
+				"*/accounts/:accountId/pipelines/:name",
+				async ({ params }) => {
+					requests.count++;
+					expect(params.accountId).toEqual("some-account-id");
+					expect(params.name).toEqual(name);
+
+					return HttpResponse.json(
+						{
+							success: !error,
+							errors: error ? [error] : [],
+							messages: [],
+							result: null,
+						},
+						{ status }
+					);
+				},
+				{ once: true }
+			)
+		);
+		return requests;
+	}
+	beforeAll(() => {
+		__testSkipDelays();
+	});
+
+	it("shows usage details", async () => {
+		await runWrangler("pipelines");
+		await endEventLoop();
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+          "wrangler pipelines
+
+          🚰 Manage Worker Pipelines
+
+
+          COMMANDS
+            wrangler pipelines create <pipeline>  Create a new pipeline
+            wrangler pipelines list               List current pipelines
+            wrangler pipelines show <pipeline>    Show a pipeline configuration
+            wrangler pipelines update <pipeline>  Update a pipeline
+            wrangler pipelines delete <pipeline>  Delete a pipeline
+
+          GLOBAL FLAGS
+            -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+            -c, --config                    Path to .toml configuration file  [string]
+            -e, --env                       Environment to use for operations and .env files  [string]
+            -h, --help                      Show help  [boolean]
+            -v, --version                   Show version number  [boolean]"
+        `);
+	});
+
+	it("create - should create a pipeline", async () => {
+		const tokenReq = mockCreateR2Token("test-bucket");
+		const requests = mockCreateRequest("my-pipeline");
+		await runWrangler("pipelines create my-pipeline --r2 test-bucket");
+
+		expect(tokenReq.count).toEqual(3);
+		expect(requests.count).toEqual(1);
+	});
+
+	it("create - should create a pipeline with explicit credentials", async () => {
+		const requests = mockCreateRequest("my-pipeline");
+		await runWrangler(
+			"pipelines create my-pipeline --r2 test-bucket --access-key-id my-key --secret-access-key my-secret"
+		);
+		expect(requests.count).toEqual(1);
+	});
+
+	it("create - should fail a missing bucket", async () => {
+		const requests = mockCreeatR2TokenFailure("bad-bucket");
+		await expect(
+			runWrangler("pipelines create bad-pipeline --r2 bad-bucket")
+		).rejects.toThrowError();
+
+		await endEventLoop();
+
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThe R2 bucket [bad-bucket] doesn't exist[0m
+
+			"
+		`);
+		expect(std.out).toMatchInlineSnapshot(`""`);
+		expect(requests.count).toEqual(1);
+	});
+
+	it("list - should list pipelines", async () => {
+		const requests = mockListRequest([
+			{
+				name: "foo",
+				id: "0001",
+				endpoint: "https://0001.pipelines.cloudflarestorage.com",
+			},
+		]);
+		await runWrangler("pipelines list");
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"┌──────┬──────┬──────────────────────────────────────────────┐
+			│ name │ id   │ endpoint                                     │
+			├──────┼──────┼──────────────────────────────────────────────┤
+			│ foo  │ 0001 │ https://0001.pipelines.cloudflarestorage.com │
+			└──────┴──────┴──────────────────────────────────────────────┘"
+		`);
+		expect(requests.count).toEqual(1);
+	});
+
+	it("show - should show pipeline", async () => {
+		const requests = mockShowRequest("foo", samplePipeline);
+		await runWrangler("pipelines show foo");
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"Retrieving config for pipeline \\"foo\\".
+			{
+			  \\"currentVersion\\": 1,
+			  \\"id\\": \\"0001\\",
+			  \\"name\\": \\"my-pipeline\\",
+			  \\"metadata\\": {},
+			  \\"source\\": [
+			    {
+			      \\"type\\": \\"binding\\",
+			      \\"format\\": \\"json\\"
+			    }
+			  ],
+			  \\"transforms\\": [],
+			  \\"destination\\": {
+			    \\"type\\": \\"json\\",
+			    \\"batch\\": {},
+			    \\"compression\\": {
+			      \\"type\\": \\"none\\"
+			    },
+			    \\"format\\": \\"json\\",
+			    \\"path\\": {
+			      \\"bucket\\": \\"bucket\\"
+			    }
+			  },
+			  \\"endpoint\\": \\"https://0001.pipelines.cloudflarestorage.com\\"
+			}"
+		`);
+		expect(requests.count).toEqual(1);
+	});
+
+	it("show - should fail on missing pipeline", async () => {
+		const requests = mockShowRequest("bad-pipeline", null, 404, {
+			code: 1000,
+			message: "Pipeline does not exist",
+		});
+		await expect(
+			runWrangler("pipelines show bad-pipeline")
+		).rejects.toThrowError();
+
+		await endEventLoop();
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"Retrieving config for pipeline \\"bad-pipeline\\".
+
+			[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/pipelines/bad-pipeline) failed.[0m
+
+			  Pipeline does not exist [code: 1000]
+
+			  If you think this is a bug, please open an issue at:
+			  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
+
+			"
+		`);
+		expect(requests.count).toEqual(1);
+	});
+
+	it("update - should update a pipeline", async () => {
+		const pipeline: Pipeline = samplePipeline;
+		mockShowRequest(pipeline.name, pipeline);
+
+		const update = JSON.parse(JSON.stringify(pipeline));
+		update.destination.compression.type = "gzip";
+		const updateReq = mockUpdateRequest(update.name, update);
+
+		await runWrangler("pipelines update my-pipeline --compression gzip");
+		expect(updateReq.count).toEqual(1);
+	});
+
+	it("update - should update a pipeline with new bucket", async () => {
+		const pipeline: Pipeline = samplePipeline;
+		const tokenReq = mockCreateR2Token("new-bucket");
+		mockShowRequest(pipeline.name, pipeline);
+
+		const update = JSON.parse(JSON.stringify(pipeline));
+		update.destination.path.bucket = "new_bucket";
+		update.destination.credentials = {
+			endpoint: "https://some-account-id.r2.cloudflarestorage.com",
+			access_key_id: "service-token-id",
+			secret_access_key:
+				"be22cbae9c1585c7b61a92fdb75afd10babd535fb9b317f90ac9a9ca896d02d7",
+		};
+		const updateReq = mockUpdateRequest(update.name, update);
+
+		await runWrangler("pipelines update my-pipeline --r2 new-bucket");
+
+		expect(tokenReq.count).toEqual(3);
+		expect(updateReq.count).toEqual(1);
+	});
+
+	it("update - should update a pipeline with new credential", async () => {
+		const pipeline: Pipeline = samplePipeline;
+		mockShowRequest(pipeline.name, pipeline);
+
+		const update = JSON.parse(JSON.stringify(pipeline));
+		update.destination.path.bucket = "new-bucket";
+		update.destination.credentials = {
+			endpoint: "https://some-account-id.r2.cloudflarestorage.com",
+			access_key_id: "new-key",
+			secret_access_key: "new-secret",
+		};
+		const updateReq = mockUpdateRequest(update.name, update);
+
+		await runWrangler(
+			"pipelines update my-pipeline --r2 new-bucket --access-key-id new-key --secret-access-key new-secret"
+		);
+
+		expect(updateReq.count).toEqual(1);
+	});
+
+	it("update - should fail a missing pipeline", async () => {
+		const requests = mockShowRequest("bad-pipeline", null, 404, {
+			code: 1000,
+			message: "Pipeline does not exist",
+		});
+		await expect(
+			runWrangler(
+				"pipelines update bad-pipeline --r2 new-bucket --access-key-id new-key --secret-access-key new-secret"
+			)
+		).rejects.toThrowError();
+
+		await endEventLoop();
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/pipelines/bad-pipeline) failed.[0m
+
+			  Pipeline does not exist [code: 1000]
+
+			  If you think this is a bug, please open an issue at:
+			  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
+
+			"
+		`);
+		expect(requests.count).toEqual(1);
+	});
+
+	it("delete - should delete pipeline", async () => {
+		const requests = mockDeleteRequest("foo");
+		await runWrangler("pipelines delete foo");
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"Deleting pipeline foo.
+			Deleted pipeline foo."
+		`);
+		expect(requests.count).toEqual(1);
+	});
+
+	it("delete - should fail a missing pipeline", async () => {
+		const requests = mockDeleteRequest("bad-pipeline", 404, {
+			code: 1000,
+			message: "Pipeline does not exist",
+		});
+		await expect(
+			runWrangler("pipelines delete bad-pipeline")
+		).rejects.toThrowError();
+
+		await endEventLoop();
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"Deleting pipeline bad-pipeline.
+
+			[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/pipelines/bad-pipeline) failed.[0m
+
+			  Pipeline does not exist [code: 1000]
+
+			  If you think this is a bug, please open an issue at:
+			  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
+
+			"
+		`);
+		expect(requests.count).toEqual(1);
+	});
+});

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -65,10 +65,10 @@ describe("User", () => {
 
 			expect(counter).toBe(1);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Attempting to login via OAuth...
-			Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
-			Successfully logged in."
-		`);
+				"Attempting to login via OAuth...
+				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+				Successfully logged in."
+			`);
 			expect(readAuthConfigFile()).toEqual<UserAuthConfig>({
 				api_token: undefined,
 				oauth_token: "test-access-token",
@@ -105,7 +105,7 @@ describe("User", () => {
 			expect(counter).toBe(1);
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
-				Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=4b2ea6cc-9421-4761-874b-ce550e0e3def&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+				Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=4b2ea6cc-9421-4761-874b-ce550e0e3def&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in."
 			`);
 

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -37,6 +37,7 @@ describe("versions --help", () => {
 			  wrangler pubsub                    📮 Manage Pub/Sub brokers [private beta]
 			  wrangler dispatch-namespace        🏗️  Manage dispatch namespaces
 			  wrangler ai                        🤖 Manage AI models
+			  wrangler pipelines                 🚰 Manage Worker Pipelines
 
 			  wrangler login                     🔓 Login to Cloudflare
 			  wrangler logout                    🚪 Logout from Cloudflare

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -45,6 +45,7 @@ import { mTlsCertificateCommands } from "./mtls-certificate/cli";
 import { writeOutput } from "./output";
 import { pages } from "./pages";
 import { APIError, formatMessage, ParseError } from "./parse";
+import { pipelines } from "./pipelines"
 import { pubSubCommands } from "./pubsub/pubsub-commands";
 import { queues } from "./queues/cli/commands";
 import { r2 } from "./r2";
@@ -600,9 +601,18 @@ export function createCLIParser(argv: string[]) {
 	);
 
 	// ai
-	wrangler.command("ai", "🤖 Manage AI models\n", (aiYargs) => {
+	wrangler.command("ai", "🤖 Manage AI models", (aiYargs) => {
 		return ai(aiYargs.command(subHelp));
 	});
+
+	// pipelines
+	wrangler.command(
+		"pipelines",
+		`🚰 Manage Worker Pipelines\n`,
+		(pipelinesYargs) => {
+			return pipelines(pipelinesYargs.command(subHelp));
+		}
+	);
 
 	/******************** CMD GROUP ***********************/
 	// login

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -76,7 +76,12 @@ export type EventNames =
 	| "view latest versioned deployment"
 	| "list versioned deployments"
 	| "download pages config"
-	| "deploy worker triggers";
+	| "deploy worker triggers"
+	| "create pipeline"
+	| "list pipelines"
+	| "delete pipeline"
+	| "update pipeline"
+	| "show pipeline";
 
 /**
  * Send a metrics event, with no extra properties, to Cloudflare, if usage tracking is enabled.

--- a/packages/wrangler/src/pipelines/client.ts
+++ b/packages/wrangler/src/pipelines/client.ts
@@ -1,0 +1,202 @@
+import { createHash } from "node:crypto";
+import { fetchResult } from "../cfetch";
+import type { R2BucketInfo } from "../r2/helpers";
+
+// ensure this is in sync with:
+//   https://bitbucket.cfdata.org/projects/PIPE/repos/superpipe/browse/src/coordinator/types.ts#6
+export type RecursivePartial<T> = {
+	[P in keyof T]?: RecursivePartial<T[P]>;
+};
+export type PartialExcept<T, K extends keyof T> = RecursivePartial<T> &
+	Pick<T, K>;
+
+export type TransformConfig = {
+	script: string;
+	entrypoint: string;
+};
+export type PipelineUserConfig = {
+	name: string;
+	metadata: { [x: string]: string };
+	source: {
+		type: string;
+		format: string;
+		schema?: string;
+	}[];
+	transforms: TransformConfig[];
+	destination: {
+		type: string;
+		format: string;
+		compression: {
+			type: string;
+		};
+		batch: {
+			max_duration_s?: number;
+			max_mb?: number;
+			max_rows?: number;
+		};
+		path: {
+			bucket: string;
+			filepath?: string;
+			filename?: string;
+		};
+		credentials: {
+			endpoint: string;
+			secret_access_key: string;
+			access_key_id: string;
+		};
+	};
+};
+
+// Pipeline from v4 API
+export type Pipeline = Omit<PipelineUserConfig, "destination"> & {
+	id: string;
+	currentVersion: number;
+	endpoint: string;
+	destination: Omit<PipelineUserConfig["destination"], "credentials"> & {
+		credentials?: PipelineUserConfig["destination"]["credentials"];
+	};
+};
+
+// abbreviated Pipeline from Pipeline list call
+export type PipelineEntry = {
+	id: string;
+	name: string;
+	endpoint: string;
+};
+
+// Payload for Service Tokens
+export type ServiceToken = {
+	id: string;
+	name: string;
+	value: string;
+};
+
+// standard headers for update calls to v4 API
+const API_HEADERS = {
+	"Content-Type": "application/json",
+};
+
+export function sha256(s: string): string {
+	return createHash("sha256").update(s).digest("hex");
+}
+
+export type PermissionGroup = {
+	id: string;
+	name: string;
+	description: string;
+	scopes: string[];
+};
+
+// Generate a Service Token to write to R2 for a pipeline
+export async function generateR2ServiceToken(
+	label: string,
+	accountId: string,
+	bucket: string
+): Promise<ServiceToken> {
+	const res = await fetchResult<PermissionGroup[]>(
+		`/user/tokens/permission_groups`,
+		{
+			method: "GET",
+		}
+	);
+	const perm = res.find(
+		(g) => g.name == "Workers R2 Storage Bucket Item Write"
+	);
+	if (!perm) {
+		throw new Error("Missing R2 Permissions");
+	}
+
+	// generate specific bucket write token for pipeline
+	const body = JSON.stringify({
+		policies: [
+			{
+				effect: "allow",
+				permission_groups: [{ id: perm.id }],
+				resources: {
+					[`com.cloudflare.edge.r2.bucket.${accountId}_default_${bucket}`]: "*",
+				},
+			},
+		],
+		name: label,
+	});
+
+	return await fetchResult<ServiceToken>(`/user/tokens`, {
+		method: "POST",
+		headers: API_HEADERS,
+		body,
+	});
+}
+
+// Get R2 bucket information from v4 API
+export async function getR2Bucket(
+	accountId: string,
+	name: string
+): Promise<R2BucketInfo> {
+	return await fetchResult<R2BucketInfo>(
+		`/accounts/${accountId}/r2/buckets/${name}`
+	);
+}
+
+// v4 API to Create new Pipeline
+export async function createPipeline(
+	accountId: string,
+	config: PipelineUserConfig
+): Promise<Pipeline> {
+	return await fetchResult<Pipeline>(`/accounts/${accountId}/pipelines`, {
+		method: "POST",
+		headers: API_HEADERS,
+		body: JSON.stringify(config),
+	});
+}
+
+// v4 API to Get Pipeline Details
+export async function getPipeline(
+	accountId: string,
+	name: string
+): Promise<Pipeline> {
+	return await fetchResult<Pipeline>(
+		`/accounts/${accountId}/pipelines/${name}`,
+		{
+			method: "GET",
+		}
+	);
+}
+
+// v4 API to Update Pipeline Configuration
+export async function updatePipeline(
+	accountId: string,
+	name: string,
+	config: PartialExcept<PipelineUserConfig, "name">
+): Promise<Pipeline> {
+	return await fetchResult<Pipeline>(
+		`/accounts/${accountId}/pipelines/${name}`,
+		{
+			method: "PUT",
+			headers: API_HEADERS,
+			body: JSON.stringify(config),
+		}
+	);
+}
+
+// v4 API to List Available Pipelines
+export async function listPipelines(
+	accountId: string
+): Promise<PipelineEntry[]> {
+	return await fetchResult<PipelineEntry[]>(
+		`/accounts/${accountId}/pipelines`,
+		{
+			method: "GET",
+		}
+	);
+}
+
+// v4 API to Delete Pipeline
+export async function deletePipeline(
+	accountId: string,
+	name: string
+): Promise<void> {
+	return await fetchResult<void>(`/accounts/${accountId}/pipelines/${name}`, {
+		method: "DELETE",
+		headers: API_HEADERS,
+	});
+}

--- a/packages/wrangler/src/pipelines/index.ts
+++ b/packages/wrangler/src/pipelines/index.ts
@@ -1,0 +1,464 @@
+import { readConfig } from "../config";
+import { sleep } from "../deploy/deploy";
+import { FatalError } from "../errors";
+import { printWranglerBanner } from "../index";
+import { logger } from "../logger";
+import * as metrics from "../metrics";
+import { APIError } from "../parse";
+import { requireAuth } from "../user";
+import {
+	createPipeline,
+	deletePipeline,
+	generateR2ServiceToken,
+	getPipeline,
+	getR2Bucket,
+	listPipelines,
+	sha256,
+	updatePipeline,
+} from "./client";
+import type { CommonYargsArgv, CommonYargsOptions } from "../yargs-types";
+import type { PipelineUserConfig } from "./client";
+import type { Argv } from "yargs";
+
+// flag to skip delays for tests
+let __testSkipDelaysFlag = false;
+
+async function authorizeR2Bucket(
+	name: string,
+	accountId: string,
+	bucket: string
+) {
+	try {
+		await getR2Bucket(accountId, bucket);
+	} catch (err) {
+		if (err instanceof APIError) {
+			if (err.code == 10006) {
+				throw new FatalError(`The R2 bucket [${bucket}] doesn't exist`);
+			}
+		}
+		throw err;
+	}
+
+	logger.log(`🌀 Authorizing R2 bucket "${bucket}"`);
+
+	const serviceToken = await generateR2ServiceToken(
+		`Service token for Pipeline ${name}`,
+		accountId,
+		bucket
+	);
+	const access_key_id = serviceToken.id;
+	const secret_access_key = sha256(serviceToken.value);
+
+	// wait for token to settle/propagate
+	!__testSkipDelaysFlag && (await sleep(3000));
+
+	return {
+		secret_access_key,
+		access_key_id,
+	};
+}
+
+function getAccountR2Endpoint(accountId: string) {
+	return `https://${accountId}.r2.cloudflarestorage.com`;
+}
+
+function validateName(label: string, name: string) {
+	if (!name.match(/^[a-zA-Z0-9-]+$/)) {
+		throw new Error(`Must provide a valid ${label}`);
+	}
+}
+
+// Parse out a transform of the form: <script>[.<entrypoint>]
+function parseTransform(spec: string) {
+	const [script, entrypoint, ...rest] = spec.split(".");
+	if (!script || rest.length > 0) {
+		throw new Error(
+			"Invalid transform: required syntax <script>[.<entrypoint>]"
+		);
+	}
+	return {
+		script,
+		entrypoint: entrypoint || "Transform",
+	};
+}
+
+function addCreateAndUpdateOptions(yargs: Argv<CommonYargsOptions>) {
+	return yargs
+		.option("secret-access-key", {
+			describe: "The R2 service token Access Key to write data",
+			type: "string",
+			demandOption: false,
+		})
+		.option("access-key-id", {
+			describe: "The R2 service token Secret Key to write data",
+			type: "string",
+			demandOption: false,
+		})
+		.option("batch-max-mb", {
+			describe:
+				"The approximate maximum size of a batch before flush in megabytes \nDefault: 10",
+			type: "number",
+			demandOption: false,
+		})
+		.option("batch-max-rows", {
+			describe:
+				"The approximate maximum size of a batch before flush in rows \nDefault: 10000",
+			type: "number",
+			demandOption: false,
+		})
+		.option("batch-max-seconds", {
+			describe:
+				"The approximate maximum duration of a batch before flush in seconds \nDefault: 15",
+			type: "number",
+			demandOption: false,
+		})
+		.option("transform", {
+			describe:
+				'The worker and entrypoint of the PipelineTransform implementation in the format "worker.entrypoint" \nDefault: No transformation worker',
+			type: "string",
+			demandOption: false,
+		})
+		.option("compression", {
+			describe: "Sets the compression format of output files \nDefault: gzip",
+			type: "string",
+			choices: ["none", "gzip", "deflate"],
+			demandOption: false,
+		})
+		.option("filepath", {
+			describe:
+				"The path to store files in the destination bucket \nDefault: event_date=${date}/hr=${hr}",
+			type: "string",
+			demandOption: false,
+		})
+		.option("filename", {
+			describe:
+				'The name of the file in the bucket. Must contain "${slug}". File extension is optional \nDefault: ${slug}-${hr}.json',
+			type: "string",
+			demandOption: false,
+		})
+		.option("authentication", {
+			describe:
+				"Enabling authentication means that data can only be sent to the pipeline via the binding \nDefault: false",
+			type: "boolean",
+			demandOption: false,
+		});
+}
+
+export function pipelines(pipelineYargs: CommonYargsArgv) {
+	return pipelineYargs
+		.command(
+			"create <pipeline>",
+			"Create a new pipeline",
+			(yargs) => {
+				return addCreateAndUpdateOptions(yargs)
+					.positional("pipeline", {
+						describe: "The name of the new pipeline",
+						type: "string",
+						demandOption: true,
+					})
+					.option("r2", {
+						type: "string",
+						describe: "Destination R2 bucket name",
+						demandOption: true,
+					});
+			},
+			async (args) => {
+				await printWranglerBanner();
+
+				const config = readConfig(args.config, args);
+				const bucket = args.r2;
+				const name = args.pipeline;
+				const compression =
+					args.compression === undefined ? "gzip" : args.compression;
+
+				const batch = {
+					max_mb: args["batch-max-mb"],
+					max_duration_s: args["batch-max-seconds"],
+					max_rows: args["batch-max-rows"],
+				};
+
+				if (!bucket) {
+					throw new FatalError("Requires a r2 bucket");
+				}
+
+				const accountId = await requireAuth(config);
+
+				const pipelineConfig: PipelineUserConfig = {
+					name: name,
+					metadata: {},
+					source: [
+						{
+							type: "http",
+							format: "json",
+						},
+						{
+							type: "binding",
+							format: "json",
+						},
+					],
+					transforms: [],
+					destination: {
+						type: "r2",
+						format: "json",
+						compression: {
+							type: compression,
+						},
+						batch: batch,
+						path: {
+							bucket: bucket,
+						},
+						credentials: {
+							endpoint: getAccountR2Endpoint(accountId),
+							access_key_id: args["access-key-id"] || "",
+							secret_access_key: args["secret-access-key"] || "",
+						},
+					},
+				};
+				const destination = pipelineConfig.destination;
+				if (
+					!destination.credentials.access_key_id &&
+					!destination.credentials.secret_access_key
+				) {
+					// auto-generate a service token
+					const auth = await authorizeR2Bucket(
+						name,
+						accountId,
+						pipelineConfig.destination.path.bucket
+					);
+					destination.credentials.access_key_id = auth.access_key_id;
+					destination.credentials.secret_access_key = auth.secret_access_key;
+				}
+
+				if (!destination.credentials.access_key_id) {
+					throw new FatalError("Requires a r2 access key id");
+				}
+
+				if (!destination.credentials.secret_access_key) {
+					throw new FatalError("Requires a r2 secret access key");
+				}
+
+				if (args.authentication) {
+					pipelineConfig.source = [
+						{
+							type: "binding",
+							format: "json",
+						},
+					];
+				}
+
+				if (args.transform !== undefined) {
+					pipelineConfig.transforms.push(parseTransform(args.transform));
+				}
+
+				if (args.filepath) {
+					pipelineConfig.destination.path.filepath = args.filepath;
+				}
+				if (args.filename) {
+					pipelineConfig.destination.path.filename = args.filename;
+				}
+
+				logger.log(`🌀 Creating pipeline named "${name}"`);
+				const pipeline = await createPipeline(accountId, pipelineConfig);
+				await metrics.sendMetricsEvent("create pipeline", {
+					sendMetrics: config.send_metrics,
+				});
+
+				logger.log(
+					`✅ Successfully created pipeline "${pipeline.name}" with id ${pipeline.id}`
+				);
+				logger.log("🎉 You can now send data to your pipeline!");
+				logger.log(
+					`Example: curl "${pipeline.endpoint}" -d '[{"foo": "bar"}]'`
+				);
+			}
+		)
+		.command(
+			"list",
+			"List current pipelines",
+			(yargs) => yargs,
+			async (args) => {
+				const config = readConfig(args.config, args);
+				const accountId = await requireAuth(config);
+
+				// TODO: we should show bindings & transforms if they exist for given ids
+				const list = await listPipelines(accountId);
+				await metrics.sendMetricsEvent("list pipelines", {
+					sendMetrics: config.send_metrics,
+				});
+
+				logger.table(
+					list.map((pipeline) => ({
+						name: pipeline.name,
+						id: pipeline.id,
+						endpoint: pipeline.endpoint,
+					}))
+				);
+			}
+		)
+		.command(
+			"show <pipeline>",
+			"Show a pipeline configuration",
+			(yargs) => {
+				return yargs.positional("pipeline", {
+					type: "string",
+					describe: "The name of the pipeline to show",
+					demandOption: true,
+				});
+			},
+			async (args) => {
+				await printWranglerBanner();
+				const config = readConfig(args.config, args);
+				const accountId = await requireAuth(config);
+				const name = args.pipeline;
+
+				validateName("pipeline name", name);
+
+				logger.log(`Retrieving config for pipeline "${name}".`);
+				const pipeline = await getPipeline(accountId, name);
+				await metrics.sendMetricsEvent("show pipeline", {
+					sendMetrics: config.send_metrics,
+				});
+
+				logger.log(JSON.stringify(pipeline, null, 2));
+			}
+		)
+		.command(
+			"update <pipeline>",
+			"Update a pipeline",
+			(yargs) => {
+				return addCreateAndUpdateOptions(yargs)
+					.positional("pipeline", {
+						describe: "The name of the pipeline to update",
+						type: "string",
+						demandOption: true,
+					})
+					.option("r2", {
+						type: "string",
+						describe: "Destination R2 bucket name",
+						demandOption: false,
+					});
+			},
+			async (args) => {
+				await printWranglerBanner();
+
+				const name = args.pipeline;
+				// only the fields set will be updated - other fields will use the existing config
+				const config = readConfig(args.config, args);
+				const accountId = await requireAuth(config);
+
+				const pipelineConfig = await getPipeline(accountId, name);
+
+				if (args.compression) {
+					pipelineConfig.destination.compression.type = args.compression;
+				}
+				if (args["batch-max-mb"]) {
+					pipelineConfig.destination.batch.max_mb = args["batch-max-mb"];
+				}
+				if (args["batch-max-seconds"]) {
+					pipelineConfig.destination.batch.max_duration_s =
+						args["batch-max-seconds"];
+				}
+				if (args["batch-max-rows"]) {
+					pipelineConfig.destination.batch.max_rows = args["batch-max-rows"];
+				}
+
+				const bucket = args.r2;
+				const accessKeyId = args["access-key-id"];
+				const secretAccessKey = args["secret-access-key"];
+				if (bucket || accessKeyId || secretAccessKey) {
+					const destination = pipelineConfig.destination;
+					if (bucket) {
+						pipelineConfig.destination.path.bucket = bucket;
+					}
+					destination.credentials = {
+						endpoint: getAccountR2Endpoint(accountId),
+						access_key_id: accessKeyId || "",
+						secret_access_key: secretAccessKey || "",
+					};
+					if (!accessKeyId && !secretAccessKey) {
+						const auth = await authorizeR2Bucket(
+							name,
+							accountId,
+							destination.path.bucket
+						);
+						destination.credentials.access_key_id = auth.access_key_id;
+						destination.credentials.secret_access_key = auth.secret_access_key;
+					}
+					if (!destination.credentials.access_key_id) {
+						throw new FatalError("Requires a r2 access key id");
+					}
+
+					if (!destination.credentials.secret_access_key) {
+						throw new FatalError("Requires a r2 secret access key");
+					}
+				}
+
+				if (args.authentication !== undefined) {
+					// strip off existing http source
+					pipelineConfig.source = pipelineConfig.source.filter(
+						(s) => s.type == "http"
+					);
+
+					// add back only if unauthenticated
+					if (!args.authentication) {
+						pipelineConfig.source.push({
+							type: "http",
+							format: "json",
+						});
+					}
+				}
+
+				if (args.transform !== undefined) {
+					pipelineConfig.transforms.push(parseTransform(args.transform));
+				}
+
+				if (args.filepath) {
+					pipelineConfig.destination.path.filepath = args.filepath;
+				}
+				if (args.filename) {
+					pipelineConfig.destination.path.filename = args.filename;
+				}
+
+				logger.log(`🌀 Updating pipeline "${name}"`);
+				const pipeline = await updatePipeline(accountId, name, pipelineConfig);
+				await metrics.sendMetricsEvent("update pipeline", {
+					sendMetrics: config.send_metrics,
+				});
+
+				logger.log(
+					`✅ Successfully updated pipeline "${pipeline.name}" with ID ${pipeline.id}\n`
+				);
+			}
+		)
+		.command(
+			"delete <pipeline>",
+			"Delete a pipeline",
+			(yargs) => {
+				return yargs.positional("pipeline", {
+					type: "string",
+					describe: "The name of the pipeline to delete",
+					demandOption: true,
+				});
+			},
+			async (args) => {
+				await printWranglerBanner();
+				const config = readConfig(args.config, args);
+				const accountId = await requireAuth(config);
+				const name = args.pipeline;
+
+				validateName("pipeline name", name);
+
+				logger.log(`Deleting pipeline ${name}.`);
+				await deletePipeline(accountId, name);
+				logger.log(`Deleted pipeline ${name}.`);
+				await metrics.sendMetricsEvent("delete pipeline", {
+					sendMetrics: config.send_metrics,
+				});
+			}
+		);
+}
+
+// Test exception to remove delays
+export function __testSkipDelays() {
+	__testSkipDelaysFlag = true;
+}

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -352,6 +352,8 @@ const DefaultScopes = {
 	"ssl_certs:write": "See and manage mTLS certificates for your account",
 	"ai:write": "See and change Workers AI catalog and assets",
 	"queues:write": "See and change Cloudflare Queues settings and data",
+	"pipelines:write":
+		"See and change Cloudflare Pipelines configurations and data",
 } as const;
 
 const OptionalScopes = {


### PR DESCRIPTION
## What this PR solves / how to test

Adds new Cloudflare Pipelines commands: PIPE-27, PIPE-96, PIPE-110

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/16639
  - [ ] Not necessary because: PM writing docs separately, but needs working wrangler to test.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
