### PR TITLE
fix: ensure console methods are bound to instance

### DIFF
--- a/.changeset/real-cooks-argue.md
+++ b/.changeset/real-cooks-argue.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Ensures console methods are bound to their instance in Vitest Pool Worker tests

--- a/packages/vitest-pool-workers/src/worker/lib/node/console.ts
+++ b/packages/vitest-pool-workers/src/worker/lib/node/console.ts
@@ -33,6 +33,17 @@ export class Console {
 		const colors =
 			typeof opts.colorMode === "string" ? false : opts.colorMode ?? false;
 		this.#inspectOptions = opts.inspectOptions ?? { colors };
+
+		// Ensure methods are bound to the instance
+		return new Proxy(this, {
+			get(target, prop) {
+				const value = target[prop as keyof Console];
+				if (typeof value === "function") {
+					return value.bind(target);
+				}
+				return value;
+			},
+		});
 	}
 
 	// Vitest expects this function to be called `value`:

--- a/packages/vitest-pool-workers/test/console.test.ts
+++ b/packages/vitest-pool-workers/test/console.test.ts
@@ -53,6 +53,27 @@ test.skipIf(process.platform === "win32")(
 	}
 );
 
+test("handles detatched console methods", async ({
+	expect,
+	seed,
+	vitestDev,
+}) => {
+	await seed({
+		"vitest.config.mts": minimalVitestConfig,
+		"index.test.ts": dedent`
+			import { SELF } from "cloudflare:test";
+			import { expect, it } from "vitest";
+			it("no crash console", async () => {
+				const fn = console["debug"];
+				fn("Does not crash");
+				expect(true).toBe(true);
+			});
+	`,
+	});
+	const result = vitestDev();
+	expect(result.stderr).toMatch("");
+});
+
 test("console.logs() inside `export default`ed handlers with SELF", async ({
 	expect,
 	seed,

--- a/packages/vitest-pool-workers/test/console.test.ts
+++ b/packages/vitest-pool-workers/test/console.test.ts
@@ -63,7 +63,7 @@ test("handles detatched console methods", async ({
 		"index.test.ts": dedent`
 			import { SELF } from "cloudflare:test";
 			import { expect, it } from "vitest";
-			it("no crash console", async () => {
+			it("does not crash when using a detached console method", async () => {
 				const fn = console["debug"];
 				fn("Does not crash");
 				expect(true).toBe(true);


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #5591.

This solution proxies all methods to a bound version of the same method. Another way to solve this could have been to manually write out each binding.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because: 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: bug fix
