### PR TITLE
feat: experimental workers assets can be ignored by adding a .assetsignore file

### DIFF
--- a/.changeset/nasty-hats-rhyme.md
+++ b/.changeset/nasty-hats-rhyme.md
@@ -2,4 +2,9 @@
 "wrangler": minor
 ---
 
-feat: experimental workers assets can be ignored by adding a .cfassetsignore file
+feat: experimental workers assets can be ignored by adding a .assetsignore file
+
+This file can be added to the root of the assets directory that is to be uploaded alongside the Worker
+when using `experimental_assets`.
+
+The file follows the `.gitignore` syntax, and any matching paths will not be included in the upload.

--- a/.changeset/nasty-hats-rhyme.md
+++ b/.changeset/nasty-hats-rhyme.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: experimental workers assets can be ignored by adding a .cfassetsignore file

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"cSpell.words": [
 		"Abortable",
+		"cfassetsignore",
 		"cfetch",
 		"chatgpt",
 		"clipboardy",
@@ -11,6 +12,7 @@
 		"esbuild",
 		"eslintcache",
 		"execa",
+		"filestat",
 		"haikunate",
 		"haikunator",
 		"httplogs",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"cSpell.words": [
 		"Abortable",
-		"cfassetsignore",
+		"assetsignore",
 		"cfetch",
 		"chatgpt",
 		"clipboardy",

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4371,9 +4371,9 @@ addEventListener('fetch', event => {});`
 			});
 		});
 
-		it("should ignore assets that match patterns in an .cfassetsignore file in the root of the assets directory", async () => {
+		it("should ignore assets that match patterns in an .assetsignore file in the root of the assets directory", async () => {
 			const assets = [
-				{ filePath: ".cfassetsignore", content: "*.bak\nsub-dir" },
+				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
 				{ filePath: "file-1.txt", content: "Content of file-1" },
 				{ filePath: "file-2.bak", content: "Content of file-2" },
 				{ filePath: "file-3.txt", content: "Content of file-3" },

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -388,7 +388,7 @@ const decodeFilepath = (filePath: string) => {
  * and returns true if the asset should not be ignored.
  */
 async function createAssetIgnoreFunction(dir: string) {
-	const CF_ASSETS_IGNORE_FILENAME = ".cfassetsignore";
+	const CF_ASSETS_IGNORE_FILENAME = ".assetsignore";
 
 	const cfAssetIgnorePath = path.resolve(dir, CF_ASSETS_IGNORE_FILENAME);
 
@@ -400,7 +400,7 @@ async function createAssetIgnoreFunction(dir: string) {
 		await readFile(cfAssetIgnorePath, { encoding: "utf8" })
 	).split("\n");
 
-	// Always ignore the `.cfassetsignore` file.
+	// Always ignore the `.assetsignore` file.
 	ignorePatterns.push(CF_ASSETS_IGNORE_FILENAME);
 
 	return createPatternMatcher(ignorePatterns, true);

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -13,6 +13,7 @@ import { logger, LOGGER_LEVELS } from "./logger";
 import { hashFile } from "./pages/hash";
 import { isJwtExpired } from "./pages/upload";
 import { APIError } from "./parse";
+import { createPatternMatcher } from "./utils/filesystem";
 import type { Config } from "./config";
 import type { ExperimentalAssets } from "./config/environment";
 
@@ -228,10 +229,20 @@ export const buildAssetsManifest = async (dir: string) => {
 	const files = await readdir(dir, { recursive: true });
 	const manifest: AssetManifest = {};
 	let counter = 0;
+
+	const ignoreFn = await createAssetIgnoreFunction(dir);
+
 	await Promise.all(
 		files.map(async (file) => {
 			const filepath = path.join(dir, file);
 			const relativeFilepath = path.relative(dir, filepath);
+
+			if (ignoreFn?.(relativeFilepath)) {
+				logger.debug("Ignoring asset:", relativeFilepath);
+				// This file should not be included in the manifest.
+				return;
+			}
+
 			const filestat = await stat(filepath);
 
 			if (filestat.isSymbolicLink() || filestat.isDirectory()) {
@@ -369,3 +380,28 @@ const decodeFilepath = (filePath: string) => {
 		.map((segment) => decodeURIComponent(segment))
 		.join(path.sep);
 };
+
+/**
+ * Create a function for filtering out ignored assets.
+ *
+ * The generated function takes an asset path, relative to the asset directory,
+ * and returns true if the asset should not be ignored.
+ */
+async function createAssetIgnoreFunction(dir: string) {
+	const CF_ASSETS_IGNORE_FILENAME = ".cfassetsignore";
+
+	const cfAssetIgnorePath = path.resolve(dir, CF_ASSETS_IGNORE_FILENAME);
+
+	if (!existsSync(cfAssetIgnorePath)) {
+		return null;
+	}
+
+	const ignorePatterns = (
+		await readFile(cfAssetIgnorePath, { encoding: "utf8" })
+	).split("\n");
+
+	// Always ignore the `.cfassetsignore` file.
+	ignorePatterns.push(CF_ASSETS_IGNORE_FILENAME);
+
+	return createPatternMatcher(ignorePatterns, true);
+}

--- a/packages/wrangler/src/sites.ts
+++ b/packages/wrangler/src/sites.ts
@@ -2,7 +2,6 @@ import assert from "node:assert";
 import { readdir, readFile, stat } from "node:fs/promises";
 import * as path from "node:path";
 import chalk from "chalk";
-import ignore from "ignore";
 import xxhash from "xxhash-wasm";
 import { UserError } from "./errors";
 import {
@@ -17,6 +16,7 @@ import {
 	putKVKeyValue,
 } from "./kv/helpers";
 import { logger, LOGGER_LEVELS } from "./logger";
+import { createPatternMatcher } from "./utils/filesystem";
 import type { Config } from "./config";
 import type { KeyValue } from "./kv/helpers";
 import type { XXHashAPI } from "xxhash-wasm";
@@ -389,18 +389,6 @@ export async function syncLegacyAssets(
 	logger.log("↗️  Done syncing assets");
 
 	return { manifest, namespace };
-}
-
-function createPatternMatcher(
-	patterns: string[],
-	exclude: boolean
-): (filePath: string) => boolean {
-	if (patterns.length === 0) {
-		return (_filePath) => !exclude;
-	} else {
-		const ignorer = ignore().add(patterns);
-		return (filePath) => ignorer.test(filePath).ignored;
-	}
 }
 
 /**

--- a/packages/wrangler/src/utils/filesystem.ts
+++ b/packages/wrangler/src/utils/filesystem.ts
@@ -1,6 +1,7 @@
 import { mkdirSync } from "fs";
 import { mkdir } from "fs/promises";
 import path from "path";
+import ignore from "ignore";
 
 export async function ensureDirectoryExists(filepath: string) {
 	const dirpath = path.dirname(filepath);
@@ -12,4 +13,19 @@ export function ensureDirectoryExistsSync(filepath: string) {
 	const dirpath = path.dirname(filepath);
 
 	mkdirSync(dirpath, { recursive: true });
+}
+
+/**
+ * Generate a function that can match relative filepaths against a list of gitignore formatted patterns.
+ */
+export function createPatternMatcher(
+	patterns: string[],
+	exclude: boolean
+): (filePath: string) => boolean {
+	if (patterns.length === 0) {
+		return (_filePath) => !exclude;
+	} else {
+		const ignorer = ignore().add(patterns);
+		return (filePath) => ignorer.test(filePath).ignored;
+	}
 }


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: experimental feature, not yet documented. This feature will be included in those docs when they are created. 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
