### PR TITLE
Fail wrangler dev when there are unexpected fields in migrations

### DIFF
--- a/.changeset/cold-planets-type.md
+++ b/.changeset/cold-planets-type.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Add config validation to ensure durable object bindings have migrations

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -1722,6 +1722,7 @@ describe("normalizeAndValidateConfig()", () => {
 								},
 							],
 							deleted_classes: [666, 777],
+							bad_key: null
 						},
 					],
 				};
@@ -1735,56 +1736,17 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(config).toEqual(expect.objectContaining(expectedConfig));
 				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - Expected \\"migrations[0].tag\\" to be of type string but got 111.
-			            - Expected \\"migrations[0].new_classes.[0]\\" to be of type string but got 222.
-			            - Expected \\"migrations[0].new_classes.[1]\\" to be of type string but got 333.
-			            - Expected \\"migrations[0].new_sqlite_classes.[0]\\" to be of type string but got 222.
-			            - Expected \\"migrations[0].new_sqlite_classes.[1]\\" to be of type string but got 333.
-			            - Expected \\"migrations[0].renamed_classes\\" to be an array of \\"{from: string, to: string}\\" objects but got [{\\"from\\":444,\\"to\\":555}].
-			            - Expected \\"migrations[0].deleted_classes.[0]\\" to be of type string but got 666.
-			            - Expected \\"migrations[0].deleted_classes.[1]\\" to be of type string but got 777."
-		        `);
-			});
-
-			it("should warn/error on unexpected fields on `migrations`", async () => {
-				const expectedConfig = {
-					migrations: [
-						{
-							tag: "TAG",
-							new_classes: ["CLASS_1", "CLASS_2"],
-							renamed_classes: [
-								{
-									from: "FROM_CLASS",
-									to: "TO_CLASS",
-								},
-								{
-									a: "something",
-									b: "someone",
-								},
-							],
-							deleted_classes: ["CLASS_3", "CLASS_4"],
-							unrecognized_field: "FOO",
-						},
-					],
-				};
-
-				const { config, diagnostics } = normalizeAndValidateConfig(
-					expectedConfig as unknown as RawConfig,
-					undefined,
-					{ env: undefined }
-				);
-
-				expect(config).toEqual(expect.objectContaining(expectedConfig));
-				expect(diagnostics.hasErrors()).toBe(true);
-				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - Unexpected fields found in migrations field: \\"unrecognized_field\\""
-		        `);
-				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - Expected \\"migrations[0].renamed_classes\\" to be an array of \\"{from: string, to: string}\\" objects but got [{\\"from\\":\\"FROM_CLASS\\",\\"to\\":\\"TO_CLASS\\"},{\\"a\\":\\"something\\",\\"b\\":\\"someone\\"}]."
-		        `);
+					"Processing wrangler configuration:
+					  - Unexpected fields found in migrations field: \\"bad_key\\"
+					  - Expected \\"migrations[0].tag\\" to be of type string but got 111.
+					  - Expected \\"migrations[0].new_classes.[0]\\" to be of type string but got 222.
+					  - Expected \\"migrations[0].new_classes.[1]\\" to be of type string but got 333.
+					  - Expected \\"migrations[0].new_sqlite_classes.[0]\\" to be of type string but got 222.
+					  - Expected \\"migrations[0].new_sqlite_classes.[1]\\" to be of type string but got 333.
+					  - Expected \\"migrations[0].renamed_classes\\" to be an array of \\"{from: string, to: string}\\" objects but got [{\\"from\\":444,\\"to\\":555}].
+					  - Expected \\"migrations[0].deleted_classes.[0]\\" to be of type string but got 666.
+					  - Expected \\"migrations[0].deleted_classes.[1]\\" to be of type string but got 777."
+				`);
 			});
 		});
 
@@ -4729,14 +4691,13 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-
-					  - \\"env.ENV1\\" environment configuration
-					    - Unexpected fields found in migrations field: \\"unrecognized_field\\""
+					"
 				`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
 
 					  - \\"env.ENV1\\" environment configuration
+					    - Unexpected fields found in migrations field: \\"unrecognized_field\\"
 					    - Expected \\"migrations[0].renamed_classes\\" to be an array of \\"{from: string, to: string}\\" objects but got [{\\"from\\":\\"FROM_CLASS\\",\\"to\\":\\"TO_CLASS\\"},{\\"a\\":\\"something\\",\\"b\\":\\"someone\\"}]."
 				`);
 			});

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -7777,12 +7777,17 @@ addEventListener('fetch', event => {});`
 				mockSubDomainRequest();
 
 				await expect(runWrangler("deploy index.js")).rejects
-					.toThrowErrorMatchingInlineSnapshot(`
-					[Error: You seem to be trying to use Durable Objects in a Worker written as a service-worker.
-					You can use Durable Objects defined in other Workers by specifying a \`script_name\` in your wrangler.toml, where \`script_name\` is the name of the Worker that implements that Durable Object. For example:
-					{ name = EXAMPLE_DO_BINDING, class_name = ExampleDurableObject } ==> { name = EXAMPLE_DO_BINDING, class_name = ExampleDurableObject, script_name = example-do-binding-worker }
-					Alternatively, migrate your worker to ES Module syntax to implement a Durable Object in this Worker:
-					https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/]
+					.toThrowErrorMatchingInlineSnapshot(dedent`
+					[Error: Processing wrangler.toml configuration:
+			    - In wrangler.toml, you have configured [durable_objects] exported by this Worker (ExampleDurableObject), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Add this configuration to your wrangler.toml:
+
+			        \`\`\`
+			        [[migrations]]
+			        tag = \"v1\" # Should be unique for each entry
+			        new_classes = [\"ExampleDurableObject\"]
+			        \`\`\`
+
+			      Refer to https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/ for more details.]
 				`);
 			});
 		});

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1186,47 +1186,22 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].initialIp).toEqual(
-				process.platform === "win32" ? "127.0.0.1" : "localhost"
-			);
-			expect(std.out).toMatchInlineSnapshot(`
-			        "Your worker has access to the following bindings:
-			        - Durable Objects:
-			          - NAME_1: CLASS_1
-			          - NAME_2: CLASS_2 (defined in SCRIPT_A)
-			          - NAME_3: CLASS_3
-			          - NAME_4: CLASS_4 (defined in SCRIPT_B)"
-		      `);
-			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+			await expect(
+				runWrangler("dev")
+			).rejects.toThrowErrorMatchingInlineSnapshot(dedent`
+				[Error: Processing wrangler.toml configuration:
+			   - In wrangler.toml, you have configured [durable_objects] exported by this Worker (CLASS_1, CLASS_3), but no [migrations] for them. This may not work as expected until you add a [migrations] section to your wrangler.toml. Add this configuration to your wrangler.toml:
 
-			    - In wrangler.toml, you have configured [durable_objects] exported by this Worker (CLASS_1,
-			  CLASS_3), but no [migrations] for them. This may not work as expected until you add a [migrations]
-			  section to your wrangler.toml. Add this configuration to your wrangler.toml:
+			       \`\`\`
+			       [[migrations]]
+			       tag = \"v1\" # Should be unique for each entry
+			       new_classes = [\"CLASS_1\", \"CLASS_3\"]
+			       \`\`\`
 
-			        \`\`\`
-			        [[migrations]]
-			        tag = \\"v1\\" # Should be unique for each entry
-			        new_classes = [\\"CLASS_1\\", \\"CLASS_3\\"]
-			        \`\`\`
-
-			      Refer to
-			  [4mhttps://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/[0m for more
-			  details.
-
-
-			[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.[0m
-
-			  Be aware that changes to the data stored in these Durable Objects will be permanent and affect the
-			  live instances.
-			  Remote Durable Objects that are affected:
-			  - {\\"name\\":\\"NAME_2\\",\\"class_name\\":\\"CLASS_2\\",\\"script_name\\":\\"SCRIPT_A\\"}
-			  - {\\"name\\":\\"NAME_4\\",\\"class_name\\":\\"CLASS_4\\",\\"script_name\\":\\"SCRIPT_B\\"}
-
-			"
-		`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			     Refer to https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/ for more details.]
+			`);
+			expect(std.out).toMatchInlineSnapshot(`""`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -147,6 +147,12 @@ const bindingsConfigMock: Omit<
 			},
 		],
 	},
+	migrations: [
+		{
+			tag: "v1",
+			new_classes: ["DurableDirect", "DurableReexport", "DurableNoexport"],
+		},
+	],
 	r2_buckets: [
 		{
 			binding: "R2_BUCKET_BINDING",

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -542,7 +542,8 @@ export const validateAdditionalProperties = (
 	diagnostics: Diagnostics,
 	fieldPath: string,
 	restProps: Iterable<string>,
-	knownProps: Iterable<string>
+	knownProps: Iterable<string>,
+	errorWithAdditionalProperties: boolean = false
 ): boolean => {
 	const restPropSet = new Set(restProps);
 	for (const knownProp of knownProps) {
@@ -550,9 +551,12 @@ export const validateAdditionalProperties = (
 	}
 	if (restPropSet.size > 0) {
 		const fields = Array.from(restPropSet.keys()).map((field) => `"${field}"`);
-		diagnostics.warnings.push(
-			`Unexpected fields found in ${fieldPath} field: ${fields}`
-		);
+		const message = `Unexpected fields found in ${fieldPath} field: ${fields}`;
+		if (errorWithAdditionalProperties) {
+			diagnostics.errors.push(message);
+		} else {
+			diagnostics.warnings.push(message);
+		}
 		return false;
 	}
 	return true;

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -3251,7 +3251,8 @@ const validateMigrations: ValidatorFn = (diagnostics, field, value) => {
 				diagnostics,
 				"migrations",
 				Object.keys(rest),
-				[]
+				[],
+				true
 			) && valid;
 
 		valid =


### PR DESCRIPTION
## What this PR solves / how to test

This matches the behavior of `wrangler deploy` more closely and will hopefully lead to customers catching bad configs in development before deploying. 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: This should reduce differences between wrangler deploy and dev behavior.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
