### PR TITLE
Bradley/r2 event notification get

### DIFF
--- a/.changeset/nice-beds-raise.md
+++ b/.changeset/nice-beds-raise.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Update R2 Get Event Notification response, display, and actions

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -96,7 +96,7 @@ describe("r2", () => {
 				  wrangler r2 bucket list           List R2 buckets
 				  wrangler r2 bucket delete <name>  Delete an R2 bucket
 				  wrangler r2 bucket sippy          Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket notification   Manage event notifications for an R2 bucket
+				  wrangler r2 bucket notification   Manage event notifications for an R2 bucket [open beta]
 
 				GLOBAL FLAGS
 				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
@@ -130,7 +130,7 @@ describe("r2", () => {
 				  wrangler r2 bucket list           List R2 buckets
 				  wrangler r2 bucket delete <name>  Delete an R2 bucket
 				  wrangler r2 bucket sippy          Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket notification   Manage event notifications for an R2 bucket
+				  wrangler r2 bucket notification   Manage event notifications for an R2 bucket [open beta]
 
 				GLOBAL FLAGS
 				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
@@ -902,7 +902,7 @@ describe("r2", () => {
 						"
 						wrangler r2 bucket notification get <bucket>
 
-						Get event notification configuration for a bucket
+						Get event notification configuration for a bucket [open beta]
 
 						POSITIONALS
 						  bucket  The name of the bucket for which notifications will be emitted  [string] [required]
@@ -1008,7 +1008,7 @@ describe("r2", () => {
 						"
 						wrangler r2 bucket notification create <bucket>
 
-						Create new event notification configuration for an R2 bucket
+						Create new event notification configuration for an R2 bucket [open beta]
 
 						POSITIONALS
 						  bucket  The name of the bucket for which notifications will be emitted  [string] [required]
@@ -1100,7 +1100,7 @@ describe("r2", () => {
 						"
 						wrangler r2 bucket notification delete <bucket>
 
-						Delete event notification configuration for an R2 bucket and queue
+						Delete event notification configuration for an R2 bucket and queue [open beta]
 
 						POSITIONALS
 						  bucket  The name of the bucket for which notifications will be emitted  [string] [required]

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -786,6 +786,61 @@ describe("r2", () => {
 									"Bearer some-api-token"
 								);
 								const getResponse = {
+									bucketName,
+									queues: [
+										{
+											queueId: queueId,
+											queueName,
+											rules: [
+												{
+													ruleId: "8cdcce8a-89b3-474f-a087-3eb4fcacfa37",
+													createdAt: "2024-09-05T01:02:03.000Z",
+													prefix: "",
+													suffix: "",
+													actions: [
+														"PutObject",
+														"CompleteMultipartUpload",
+														"CopyObject",
+													],
+												},
+											],
+										},
+									],
+								};
+								return HttpResponse.json(createFetchResult(getResponse));
+							},
+							{ once: true }
+						)
+					);
+					await expect(
+						await runWrangler(`r2 bucket notification get ${bucketName}`)
+					).toBe(undefined);
+					expect(std.out).toMatchInlineSnapshot(`
+				"Fetching notification configuration for bucket my-bucket...
+				rule_id:     8cdcce8a-89b3-474f-a087-3eb4fcacfa37
+				created_at:  2024-09-05T01:02:03.000Z
+				queue_name:  my-queue
+				prefix:
+				suffix:
+				event_type:  PutObject,CompleteMultipartUpload,CopyObject"
+			`);
+				});
+
+				it("is backwards compatible with old API version", async () => {
+					const bucketName = "my-bucket";
+					const queueId = "471537e8-6e5a-4163-a4d4-9478087c32c3";
+					const queueName = "my-queue";
+					msw.use(
+						http.get(
+							"*/accounts/:accountId/event_notifications/r2/:bucketName/configuration",
+							async ({ request, params }) => {
+								const { accountId, bucketName: bucketParam } = params;
+								expect(accountId).toEqual("some-account-id");
+								expect(bucketName).toEqual(bucketParam);
+								expect(request.headers.get("authorization")).toEqual(
+									"Bearer some-api-token"
+								);
+								const getResponse = {
 									[bucketName]: {
 										"9d738cb7-be18-433a-957f-a9b88793de2c": {
 											queue: queueId,
@@ -828,11 +883,12 @@ describe("r2", () => {
 					).toBe(undefined);
 					expect(std.out).toMatchInlineSnapshot(`
 				"Fetching notification configuration for bucket my-bucket...
-				┌────────────┬────────┬────────┬───────────────┐
-				│ queue_name │ prefix │ suffix │ event_type    │
-				├────────────┼────────┼────────┼───────────────┤
-				│ my-queue   │        │        │ object-create │
-				└────────────┴────────┴────────┴───────────────┘"
+				rule_id:
+				created_at:
+				queue_name:  my-queue
+				prefix:
+				suffix:
+				event_type:  PutObject,CompleteMultipartUpload,CopyObject"
 			`);
 				});
 
@@ -937,7 +993,7 @@ describe("r2", () => {
 						)
 					).resolves.toBe(undefined);
 					expect(std.out).toMatchInlineSnapshot(`
-				"Creating event notification rule for object creation and deletion (PutObject,CompleteMultipartUpload,CopyObject,DeleteObject)
+				"Creating event notification rule for object creation and deletion (PutObject,CompleteMultipartUpload,CopyObject,DeleteObject,LifecycleDeletion)
 				Configuration created successfully!"
 			`);
 				});

--- a/packages/wrangler/src/__tests__/r2/helpers.test.ts
+++ b/packages/wrangler/src/__tests__/r2/helpers.test.ts
@@ -1,12 +1,10 @@
-import crypto from "crypto";
-import { vi } from "vitest";
 import { logger } from "../../logger";
 import {
 	eventNotificationHeaders,
 	tableFromNotificationGetResponse,
 } from "../../r2/helpers";
+import formatLabelledValues from "../../utils/render-labelled-values";
 import { mockConsoleMethods } from "../helpers/mock-console";
-import type { Config } from "../../config";
 import type { GetNotificationConfigResponse } from "../../r2/helpers";
 import type { ApiCredentials } from "../../user";
 
@@ -16,63 +14,67 @@ describe("event notifications", () => {
 	test("tableFromNotificationsGetResponse", async () => {
 		const bucketName = "my-bucket";
 		const config = { account_id: "my-account" };
-		const queueMap: Record<string, string> = {
-			"471537e8-6e5a-4163-a4d4-9478087c32c3": "my-queue-1",
-			"be6b6a37-ae49-4eea-9032-5e8d3ad1d29b": "my-queue-2",
-		};
 		const response: GetNotificationConfigResponse = {
-			[bucketName]: {
-				"9d738cb7-be18-433a-957f-a9b88793de2c": {
-					queue: "471537e8-6e5a-4163-a4d4-9478087c32c3",
+			bucketName,
+			queues: [
+				{
+					queueId: "471537e8-6e5a-4163-a4d4-9478087c32c3",
+					queueName: "my-queue-1",
 					rules: [
 						{
+							ruleId: "68746106-12f8-4bba-a57b-adaf37fe11ca",
 							prefix: "/p1",
 							suffix: "s1/",
-							actions: [
-								"PutObject",
-								"CompleteMultipartUpload",
-								"CopyObject",
-								"DeleteObject",
-							],
+							actions: ["PutObject", "CopyObject", "DeleteObject"],
 						},
 						{
+							ruleId: "5aa280bb-39d7-48ed-8c21-405fcd078192",
 							actions: ["DeleteObject"],
 						},
 					],
 				},
-				[crypto.randomUUID()]: {
-					queue: "be6b6a37-ae49-4eea-9032-5e8d3ad1d29b",
+				{
+					queueId: "be6b6a37-ae49-4eea-9032-5e8d3ad1d29b",
+					queueName: "my-queue-2",
 					rules: [
 						{
+							ruleId: "c4725929-3799-477a-a8d9-2d300f957e51",
+							createdAt: "2024-09-05T01:02:03.000Z",
 							prefix: "//1",
 							suffix: "2//",
-							actions: ["DeleteObject"],
+							actions: ["LifecycleDeletion"],
 						},
 					],
 				},
-			},
+			],
 		};
 		const tableOutput = await tableFromNotificationGetResponse(
 			config,
-			response[bucketName],
-			vi
-				.fn()
-				.mockImplementation((_: Pick<Config, "account_id">, queue: string) => ({
-					queue_name: queueMap[queue],
-				}))
+			response
 		);
-		logger.table(tableOutput);
+		logger.log(tableOutput.map((x) => formatLabelledValues(x)).join("\n\n"));
 
 		await expect(std.out).toMatchInlineSnapshot(`
-		"┌────────────┬────────┬────────┬─────────────────────────────┐
-		│ queue_name │ prefix │ suffix │ event_type                  │
-		├────────────┼────────┼────────┼─────────────────────────────┤
-		│ my-queue-1 │ /p1    │ s1/    │ object-create,object-delete │
-		├────────────┼────────┼────────┼─────────────────────────────┤
-		│ my-queue-1 │        │        │ object-delete               │
-		├────────────┼────────┼────────┼─────────────────────────────┤
-		│ my-queue-2 │ //1    │ 2//    │ object-delete               │
-		└────────────┴────────┴────────┴─────────────────────────────┘"
+		"rule_id:     68746106-12f8-4bba-a57b-adaf37fe11ca
+		created_at:
+		queue_name:  my-queue-1
+		prefix:      /p1
+		suffix:      s1/
+		event_type:  PutObject,CopyObject,DeleteObject
+
+		rule_id:     5aa280bb-39d7-48ed-8c21-405fcd078192
+		created_at:
+		queue_name:  my-queue-1
+		prefix:
+		suffix:
+		event_type:  DeleteObject
+
+		rule_id:     c4725929-3799-477a-a8d9-2d300f957e51
+		created_at:  2024-09-05T01:02:03.000Z
+		queue_name:  my-queue-2
+		prefix:      //1
+		suffix:      2//
+		event_type:  LifecycleDeletion"
 	`);
 	});
 	test("auth email eventNotificationHeaders", () => {

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -80,7 +80,7 @@ import type { Arguments } from "yargs";
 
 const resetColor = "\x1b[0m";
 const fgGreenColor = "\x1b[32m";
-const betaCmdColor = "#BD5B08";
+export const betaCmdColor = "#BD5B08";
 
 export const DEFAULT_LOCAL_PORT = 8787;
 export const DEFAULT_INSPECTOR_PORT = 9229;

--- a/packages/wrangler/src/queues/client.ts
+++ b/packages/wrangler/src/queues/client.ts
@@ -204,10 +204,9 @@ async function ensureQueuesExist(config: Config, queueNames: string[]) {
 }
 
 export async function getQueueById(
-	config: Pick<Config, "account_id">,
+	accountId: string,
 	queueId: string
 ): Promise<QueueResponse> {
-	const accountId = await requireAuth(config);
 	return fetchResult(queuesUrl(accountId, queueId), {});
 }
 

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -3,10 +3,15 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as stream from "node:stream";
 import { ReadableStream } from "node:stream/web";
+import chalk from "chalk";
 import prettyBytes from "pretty-bytes";
 import { readConfig } from "../config";
 import { FatalError, UserError } from "../errors";
-import { CommandLineArgsError, printWranglerBanner } from "../index";
+import {
+	betaCmdColor,
+	CommandLineArgsError,
+	printWranglerBanner,
+} from "../index";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
@@ -643,24 +648,24 @@ export function r2(r2Yargs: CommonYargsArgv, subHelp: SubHelp) {
 
 			r2BucketYargs.command(
 				"notification",
-				"Manage event notifications for an R2 bucket",
+				`Manage event notifications for an R2 bucket ${chalk.hex(betaCmdColor)("[open beta]")}`,
 				(r2EvNotifyYargs) => {
 					return r2EvNotifyYargs
 						.command(
 							"get <bucket>",
-							"Get event notification configuration for a bucket",
+							`Get event notification configuration for a bucket ${chalk.hex(betaCmdColor)("[open beta]")}`,
 							Notification.GetOptions,
 							Notification.GetHandler
 						)
 						.command(
 							"create <bucket>",
-							"Create new event notification configuration for an R2 bucket",
+							`Create new event notification configuration for an R2 bucket ${chalk.hex(betaCmdColor)("[open beta]")}`,
 							Notification.CreateOptions,
 							Notification.CreateHandler
 						)
 						.command(
 							"delete <bucket>",
-							"Delete event notification configuration for an R2 bucket and queue",
+							`Delete event notification configuration for an R2 bucket and queue ${chalk.hex(betaCmdColor)("[open beta]")}`,
 							Notification.DeleteOptions,
 							Notification.DeleteHandler
 						);

--- a/packages/wrangler/src/r2/notification.ts
+++ b/packages/wrangler/src/r2/notification.ts
@@ -1,8 +1,8 @@
 import { readConfig } from "../config";
 import { logger } from "../logger";
-import { getQueueById } from "../queues/client";
 import { printWranglerBanner } from "../update-check";
 import { requireApiToken, requireAuth } from "../user";
+import formatLabelledValues from "../utils/render-labelled-values";
 import {
 	actionsForEventCategories,
 	deleteEventNotificationConfig,
@@ -36,12 +36,8 @@ export async function GetHandler(
 		accountId,
 		`${args.bucket}`
 	);
-	const tableOutput = await tableFromNotificationGetResponse(
-		config,
-		resp[args.bucket],
-		getQueueById
-	);
-	logger.table(tableOutput);
+	const tableOutput = await tableFromNotificationGetResponse(config, resp);
+	logger.log(tableOutput.map((x) => formatLabelledValues(x)).join("\n\n"));
 }
 
 export function CreateOptions(yargs: CommonYargsArgv) {


### PR DESCRIPTION
## What this PR solves / how to test

- Updates the expected R2 Event Notification GET payload from the Cloudflare API.
- Updates the R2 action types that are included in the object-delete event type.
- Updates the format of the table of rules that is displayed after running `wrangler r2 bucket notification get`

Note: The change to the GET payload is not backwards compatible. Users will need to update to the latest version of wrangler to continue using Event Notifications after the GA launch. Backwards compatibility is added here for the case that we need to revert the API changes.

Fixes #[insert GH or internal issue number(s)].
Internal issues: R2-2379 and R2-2380

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
