### PR TITLE
chore: fix test that fails locally

### DIFF
--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -674,8 +674,8 @@ describe("wrangler secret", () => {
 
 			await expect(
 				runWrangler("secret bulk ./secret.json --name script-name")
-			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: The contents of "./secret.json" is not valid JSON: "ParseError: Unexpected token b"]`
+			).rejects.toThrowError(
+				`The contents of "./secret.json" is not valid JSON`
 			);
 		});
 


### PR DESCRIPTION
## What this PR solves / how to test

There is a difference in the Error message between different Node versions - this PR just tests the part of the error that we control to make it more robust.

Node v18.20.3:

```
[Error: The contents of "./secret.json" is not valid JSON: "ParseError: Unexpected token b"]
```

Node v:

```
[Error: The contents of "./secret.json" is not valid JSON: "SyntaxError: Unexpected token 'b', "bad file content" is not valid JSON"]
```

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: QoL improvement
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: QoL improvement
