### PR TITLE
Not including detail id in wrangler output from R2 event notifications

### DIFF
--- a/.changeset/smooth-bananas-obey.md
+++ b/.changeset/smooth-bananas-obey.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Update R2 Create Event Notification response

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -488,8 +488,7 @@ export async function getEventNotificationConfig(
 
 /** Construct & transmit notification configuration to EWC.
  *
- * On success, receive HTTP 200 response with a body like:
- * { event_notification_detail_id: string }
+ * On success, receive HTTP 200 response with no body
  *
  * Possible status codes on failure:
  * - 400 Bad Request - Either:
@@ -506,7 +505,7 @@ export async function putEventNotificationConfig(
 	eventTypes: R2EventType[],
 	prefix?: string,
 	suffix?: string
-): Promise<{ event_notification_detail_id: string }> {
+): Promise<void> {
 	const queue = await getQueue(config, queueName);
 	const headers = eventNotificationHeaders(apiCredentials);
 	let actions: R2EventableOperation[] = [];
@@ -526,7 +525,7 @@ export async function putEventNotificationConfig(
 			" and "
 		)} (${actions.join(",")})`
 	);
-	return await fetchResult<{ event_notification_detail_id: string }>(
+	return await fetchResult<void>(
 		`/accounts/${accountId}/event_notifications/r2/${bucketName}/configuration/queues/${queue.queue_id}`,
 		{ method: "PUT", body: JSON.stringify(body), headers }
 	);


### PR DESCRIPTION
## What this PR solves / how to test

Updates the fields parsed and displayed in wrangler from the R2 Event Notification PUT payload from the Cloudflare API.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: covered by existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: unlikely to affect e2e flows—no user-facing change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge) 
  - [x] Cloudflare docs PR(s): https://jira.cfdata.org/browse/R2-2468 
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
