### PR TITLE
Adding argument to specify rule to delete if don't want to delete every rule in config

### DIFF
--- a/.changeset/lazy-jeans-kick.md
+++ b/.changeset/lazy-jeans-kick.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: adding option to specify a rule within the config to delete (if no rules are specified, all rules get deleted)

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -974,7 +974,7 @@ describe("r2", () => {
 			});
 
 			describe("delete", () => {
-				it("follows happy path as expected", async () => {
+				it("follows happy path as expected without specified rules", async () => {
 					const bucketName = "my-bucket";
 					const queue = "my-queue";
 					msw.use(
@@ -1034,6 +1034,67 @@ describe("r2", () => {
 			`);
 				});
 
+				it("follows happy path as expected with specified rules", async () => {
+					const bucketName = "my-bucket";
+					const queue = "my-queue";
+					const ruleId = "rule123456789";
+					msw.use(
+						http.delete(
+							"*/accounts/:accountId/event_notifications/r2/:bucketName/configuration/queues/:queueUUID",
+							async ({ request, params }) => {
+								const { accountId } = params;
+								expect(accountId).toEqual("some-account-id");
+								expect(request.headers.get("authorization")).toEqual(
+									"Bearer some-api-token"
+								);
+								return HttpResponse.json(createFetchResult({}));
+							},
+							{ once: true }
+						),
+						http.get(
+							"*/accounts/:accountId/queues?*",
+							async ({ request, params }) => {
+								const url = new URL(request.url);
+								const { accountId } = params;
+								const nameParams = url.searchParams.getAll("name");
+
+								expect(accountId).toEqual("some-account-id");
+								expect(nameParams[0]).toEqual(queue);
+								expect(request.headers.get("authorization")).toEqual(
+									"Bearer some-api-token"
+								);
+								return HttpResponse.json({
+									success: true,
+									errors: [],
+									messages: [],
+									result: [
+										{
+											queue_id: "queue-id",
+											queue_name: queue,
+											created_on: "",
+											producers: [],
+											consumers: [],
+											producers_total_count: 1,
+											consumers_total_count: 0,
+											modified_on: "",
+										},
+									],
+								});
+							},
+							{ once: true }
+						)
+					);
+					await expect(
+						runWrangler(
+							`r2 bucket notification delete ${bucketName} --queue ${queue} --rule ${ruleId}`
+						)
+					).resolves.toBe(undefined);
+					expect(std.out).toMatchInlineSnapshot(`
+				"Disabling event notifications for \\"my-bucket\\" to queue my-queue...
+				Configuration deleted successfully!"
+			`);
+				});
+
 				it("errors if required options are not provided", async () => {
 					await expect(
 						runWrangler("r2 bucket notification delete notification-test-001")
@@ -1057,7 +1118,8 @@ describe("r2", () => {
 						  -v, --version                   Show version number  [boolean]
 
 						OPTIONS
-						      --queue  The name of the queue that is configured to receive notifications. ex '--queue my-queue'  [string] [required]"
+						      --queue  The name of the queue that is configured to receive notifications. ex '--queue my-queue'  [string] [required]
+						      --rule   The id of the rule to delete. If no rule is specified, all rules for the bucket/queue configuration will be deleted.  [string]"
 					`);
 				});
 			});

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -406,6 +406,11 @@ export type PutNotificationRequestBody = {
 	rules: NotificationRule[];
 };
 
+// This type captures the shape of the data expected by EWC API.
+export type DeleteNotificationRequestBody = {
+	ruleIds?: string[];
+};
+
 export function eventNotificationHeaders(
 	apiCredentials: ApiCredentials
 ): HeadersInit {
@@ -537,16 +542,25 @@ export async function deleteEventNotificationConfig(
 	apiCredentials: ApiCredentials,
 	accountId: string,
 	bucketName: string,
-	queueName: string
+	queueName: string,
+	ruleId: string | undefined
 ): Promise<null> {
 	const queue = await getQueue(config, queueName);
 	const headers = eventNotificationHeaders(apiCredentials);
 	logger.log(
 		`Disabling event notifications for "${bucketName}" to queue ${queueName}...`
 	);
+
+	const body: DeleteNotificationRequestBody =
+		ruleId !== undefined
+			? {
+					ruleIds: [ruleId],
+				}
+			: {};
+
 	return await fetchResult<null>(
 		`/accounts/${accountId}/event_notifications/r2/${bucketName}/configuration/queues/${queue.queue_id}`,
-		{ method: "DELETE", headers }
+		{ method: "DELETE", body: JSON.stringify(body), headers }
 	);
 }
 

--- a/packages/wrangler/src/r2/notification.ts
+++ b/packages/wrangler/src/r2/notification.ts
@@ -93,11 +93,11 @@ export async function CreateHandler(
 		config,
 		apiCreds,
 		accountId,
-		`${bucket}`,
-		`${queue}`,
+		bucket,
+		queue,
 		eventTypes as R2EventType[],
-		`${prefix}`,
-		`${suffix}`
+		prefix,
+		suffix
 	);
 	logger.log("Configuration created successfully!");
 }
@@ -116,6 +116,12 @@ export function DeleteOptions(yargs: CommonYargsArgv) {
 			demandOption: true,
 			requiresArg: true,
 			type: "string",
+		})
+		.option("rule", {
+			describe:
+				"The id of the rule to delete. If no rule is specified, all rules for the bucket/queue configuration will be deleted.",
+			requiresArg: false,
+			type: "string",
 		});
 }
 
@@ -126,13 +132,14 @@ export async function DeleteHandler(
 	const config = readConfig(args.config, args);
 	const accountId = await requireAuth(config);
 	const apiCreds = requireApiToken();
-	const { bucket, queue } = args;
+	const { bucket, queue, rule } = args;
 	await deleteEventNotificationConfig(
 		config,
 		apiCreds,
 		accountId,
-		`${bucket}`,
-		`${queue}`
+		bucket,
+		queue,
+		rule
 	);
 	logger.log("Configuration deleted successfully!");
 }


### PR DESCRIPTION
## What this PR solves / how to test

Updates the R2 Event Notification DELETE payload to the Cloudflare API to be able to specify rules within a config to delete.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge) 
  - [x] Cloudflare docs PR(s): https://jira.cfdata.org/browse/R2-2468 
  - [ ] Not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
