### PR TITLE
Bump path-to-regexp to 6.3.0

### DIFF
--- a/.changeset/gorgeous-eagles-matter.md
+++ b/.changeset/gorgeous-eagles-matter.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Bump path-to-regexp dependency version

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -79,7 +79,7 @@
 		"esbuild": "0.17.19",
 		"miniflare": "workspace:*",
 		"nanoid": "^3.3.3",
-		"path-to-regexp": "^6.2.0",
+		"path-to-regexp": "^6.3.0",
 		"resolve": "^1.22.8",
 		"resolve.exports": "^2.0.2",
 		"selfsigned": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1675,8 +1675,8 @@ importers:
         specifier: ^3.3.3
         version: 3.3.6
       path-to-regexp:
-        specifier: ^6.2.0
-        version: 6.2.0
+        specifier: ^6.3.0
+        version: 6.3.0
       resolve:
         specifier: ^1.22.8
         version: 1.22.8
@@ -7121,8 +7121,8 @@ packages:
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
 
-  path-to-regexp@6.2.0:
-    resolution: {integrity: sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==}
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -14370,7 +14370,7 @@ snapshots:
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.2
-      path-to-regexp: 6.2.0
+      path-to-regexp: 6.3.0
       strict-event-emitter: 0.5.1
       type-fest: 4.18.2
       yargs: 17.7.2
@@ -14808,7 +14808,7 @@ snapshots:
 
   path-to-regexp@0.1.7: {}
 
-  path-to-regexp@6.2.0: {}
+  path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 
@@ -16052,7 +16052,7 @@ snapshots:
       '@protobuf-ts/plugin-framework': 2.9.3
       camel-case: 4.1.2
       dot-object: 2.1.4
-      path-to-regexp: 6.2.0
+      path-to-regexp: 6.3.0
       ts-poet: 4.15.0
       yaml: 1.10.2
     optionalDependencies:


### PR DESCRIPTION
## What this PR solves / how to test

Yesterday, a backport for the fix of a redos in path-to-regexp was published.
PR of path-to-regexp fix: https://github.com/pillarjs/path-to-regexp/pull/324 - the advisory database wasn't updated yet, so it might take a while before warnings go away.

Alternatively, path-to-regexp could be updated to `^8.1.0`, but there are a fair amount of changes between v6 and (v7 and) v8.

Fixes #6720 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: no code changes
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: don't think it's needed for this
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: no new features

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
