### PR TITLE
Fix wrangler version secrets with Assets

### DIFF
--- a/.changeset/lovely-pigs-bow.md
+++ b/.changeset/lovely-pigs-bow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Persist Workers Assets when doing `wrangler versions secrets put/bulk`

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -56,6 +56,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 		});
 
 		await runWrangler(
@@ -96,6 +97,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 		});
 
 		await runWrangler(`versions secret bulk --name script-name --x-versions`);
@@ -146,6 +148,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 		});
 
 		await runWrangler(`versions secret bulk --name script-name --x-versions`);

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -40,6 +40,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 		});
 		await runWrangler(
 			"versions secret put NEW_SECRET --name script-name --x-versions"
@@ -67,6 +68,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 		});
 
 		mockStdIn.send(
@@ -107,6 +109,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 		});
 		await runWrangler("versions secret put NEW_SECRET --x-versions");
 
@@ -136,6 +139,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 
 			expect(metadata.annotations).not.toBeUndefined();
 			expect(
@@ -172,6 +176,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 
 			expect(metadata.annotations).not.toBeUndefined();
 			expect(
@@ -211,6 +216,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 
 			expect(metadata.annotations).not.toBeUndefined();
 			expect(
@@ -286,6 +292,7 @@ describe("versions secret put", () => {
 				"secret_key",
 				"secret_text",
 			]);
+			expect(metadata.keep_assets).toBeTruthy();
 
 			expect(metadata.annotations).not.toBeUndefined();
 			expect(

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -179,6 +179,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		tail_consumers,
 		limits,
 		annotations,
+		keep_assets,
 		experimental_assets,
 		observability,
 	} = worker;
@@ -585,6 +586,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		...(tail_consumers && { tail_consumers }),
 		...(limits && { limits }),
 		...(annotations && { annotations }),
+		...(keep_assets !== undefined && { keep_assets }),
 		...(experimental_assets && {
 			assets: {
 				jwt: experimental_assets.jwt,

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -355,6 +355,7 @@ export interface CfWorkerInit {
 	tail_consumers: CfTailConsumer[] | undefined;
 	limits: CfUserLimits | undefined;
 	annotations?: Record<string, string | undefined>;
+	keep_assets?: boolean | undefined;
 	experimental_assets: CfExperimentalAssets | undefined;
 	observability: Observability | undefined;
 }

--- a/packages/wrangler/src/versions/secrets/index.ts
+++ b/packages/wrangler/src/versions/secrets/index.ts
@@ -209,6 +209,7 @@ export async function copyWorkerVersionWithNewSecrets({
 			"workers/message": versionMessage,
 			"workers/tag": versionTag,
 		},
+		keep_assets: true,
 		experimental_assets: undefined,
 		observability: scriptSettings.observability,
 	};


### PR DESCRIPTION
## What this PR solves / how to test

Persists Workers Assets across `wrangler versions secrets put/bulk`.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no coverage
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: unreleased

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
