### PR TITLE
Allow CI deploying non-private packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 	"author": "wrangler@cloudflare.com",
 	"scripts": {
 		"build": "dotenv -- turbo build",
-		"check": "pnpm check:fixtures && node lint-turbo.mjs && dotenv -- turbo check:lint check:type check:format type:tests",
+		"check": "pnpm check:fixtures && pnpm check:deployments && node lint-turbo.mjs && dotenv -- turbo check:lint check:type check:format type:tests",
+		"check:deployments": "node -r esbuild-register tools/deployments/deploy-non-npm-packages.ts check",
 		"check:fixtures": "node -r esbuild-register tools/deployments/ensure-fixtures-are-not-deployable.ts",
 		"check:format": "prettier . --check --ignore-unknown",
 		"check:lint": "dotenv -- turbo check:lint",

--- a/packages/devprod-status-bot/package.json
+++ b/packages/devprod-status-bot/package.json
@@ -14,5 +14,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/packages/edge-preview-authenticated-proxy/package.json
+++ b/packages/edge-preview-authenticated-proxy/package.json
@@ -21,5 +21,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/packages/format-errors/package.json
+++ b/packages/format-errors/package.json
@@ -21,5 +21,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/packages/playground-preview-worker/package.json
+++ b/packages/playground-preview-worker/package.json
@@ -30,5 +30,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/packages/prerelease-registry/package.json
+++ b/packages/prerelease-registry/package.json
@@ -23,5 +23,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/packages/quick-edit/package.json
+++ b/packages/quick-edit/package.json
@@ -31,5 +31,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/packages/turbo-r2-archive/package.json
+++ b/packages/turbo-r2-archive/package.json
@@ -28,5 +28,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/packages/workers-playground/package.json
+++ b/packages/workers-playground/package.json
@@ -59,5 +59,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -63,6 +63,7 @@
 		"extends": "../../package.json"
 	},
 	"workers-sdk": {
-		"prerelease": true
+		"prerelease": true,
+		"deploy": true
 	}
 }

--- a/packages/workers.new/package.json
+++ b/packages/workers.new/package.json
@@ -20,5 +20,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/packages/wrangler-devtools/package.json
+++ b/packages/wrangler-devtools/package.json
@@ -18,5 +18,8 @@
 	},
 	"volta": {
 		"extends": "../../package.json"
+	},
+	"workers-sdk": {
+		"deploy": true
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11188,7 +11188,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.5.4)
       '@typescript-eslint/utils': 6.10.0(eslint@8.49.0)(typescript@5.5.4)
-      debug: 4.3.6(supports-color@9.2.2)
+      debug: 4.3.5
       eslint: 8.49.0
       ts-api-utils: 1.0.3(typescript@5.5.4)
     optionalDependencies:

--- a/tools/deployments/__tests__/deploy-non-npm-packages.test.ts
+++ b/tools/deployments/__tests__/deploy-non-npm-packages.test.ts
@@ -105,6 +105,7 @@ describe("findDeployablePackageNames()", () => {
 			  "@cloudflare/quick-edit",
 			  "turbo-r2-archive",
 			  "workers-playground",
+			  "@cloudflare/workers-shared",
 			  "workers.new",
 			  "@cloudflare/wrangler-devtools",
 			}

--- a/tools/deployments/deploy-non-npm-packages.ts
+++ b/tools/deployments/deploy-non-npm-packages.ts
@@ -89,7 +89,7 @@ export function findDeployablePackageNames(): Set<string> {
 	}
 	const deployablePackages = new Set<string>();
 	for (const pkg of allPackages) {
-		if (pkg.private && pkg.scripts?.deploy !== undefined) {
+		if (pkg.scripts?.deploy !== undefined) {
 			deployablePackages.add(pkg.name);
 		}
 	}


### PR DESCRIPTION
## What this PR solves / how to test

workers-shared is the only non-private and deployable package. And it was skipped in the last release because of this check.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because: 
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required / Maybe required
  - [x] Not required because: no coverage
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: internal tooling change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: internal tooling change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
