### PR TITLE
Fix bugs when warning users using SQLite in Durable Objects in remote…

### DIFF
--- a/.changeset/fifty-students-prove.md
+++ b/.changeset/fifty-students-prove.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Bugs when warning users using SQLite in Durable Objects in remote dev

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -19,6 +19,7 @@ import {
 	maskVars,
 } from "../../dev";
 import { getLocalPersistencePath } from "../../dev/get-local-persistence-path";
+import { getClassNamesWhichUseSQLite } from "../../dev/validate-dev-props";
 import { UserError } from "../../errors";
 import { processExperimentalAssetsArg } from "../../experimental-assets";
 import { logger } from "../../logger";
@@ -319,17 +320,17 @@ async function resolveConfig(
 		);
 	}
 
+	// TODO(do) support remote wrangler dev
+	const classNamesWhichUseSQLite = getClassNamesWhichUseSQLite(
+		resolved.migrations
+	);
 	if (
-		resolved.migrations?.some(
-			(m) =>
-				Array.isArray(m.new_sqlite_classes) && m.new_sqlite_classes.length > 0
-		) &&
-		resolved.dev?.remote
+		resolved.dev.remote &&
+		Array.from(classNamesWhichUseSQLite.values()).some((v) => v)
 	) {
-		throw new UserError(
-			"SQLite in Durable Objects is only supported in local mode."
-		);
+		logger.warn("SQLite in Durable Objects is only supported in local mode.");
 	}
+
 	return resolved;
 }
 export class ConfigController extends Controller<ConfigControllerEventMap> {

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -618,18 +618,6 @@ export async function startDev(args: StartDevOptions) {
 			);
 		}
 
-		if (
-			args.remote &&
-			config.migrations?.some(
-				(m) =>
-					Array.isArray(m.new_sqlite_classes) && m.new_sqlite_classes.length > 0
-			)
-		) {
-			throw new UserError(
-				"SQLite in Durable Objects is only supported in local mode."
-			);
-		}
-
 		const projectRoot = configPath && path.dirname(configPath);
 
 		const devEnv = new DevEnv();

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -32,7 +32,10 @@ import { openInspector } from "./inspect";
 import { Local, maybeRegisterLocalWorker } from "./local";
 import { Remote } from "./remote";
 import { useEsbuild } from "./use-esbuild";
-import { validateDevProps } from "./validate-dev-props";
+import {
+	getClassNamesWhichUseSQLite,
+	validateDevProps,
+} from "./validate-dev-props";
 import type {
 	DevEnv,
 	ProxyData,
@@ -632,6 +635,17 @@ function DevSession(props: DevSessionProps) {
 		logger.warn(
 			"Queues are currently in Beta and are not supported in wrangler dev remote mode."
 		);
+	}
+
+	// TODO(do) support remote wrangler dev
+	const classNamesWhichUseSQLite = getClassNamesWhichUseSQLite(
+		props.migrations
+	);
+	if (
+		!props.local &&
+		Array.from(classNamesWhichUseSQLite.values()).some((v) => v)
+	) {
+		logger.warn("SQLite in Durable Objects is only supported in local mode.");
 	}
 
 	// this won't be called with props.experimentalDevEnv because useWorker is guarded with the same flag

--- a/packages/wrangler/src/dev/validate-dev-props.ts
+++ b/packages/wrangler/src/dev/validate-dev-props.ts
@@ -1,4 +1,5 @@
 import { UserError } from "../errors";
+import type { Config } from "../config";
 import type { DevProps } from "./dev";
 
 export function validateDevProps(props: Omit<DevProps, "host">) {
@@ -29,4 +30,53 @@ export function validateDevProps(props: Omit<DevProps, "host">) {
 			"You cannot configure [data_blobs] with an ES module worker. Instead, import the file directly in your code, and optionally configure `[rules]` in your wrangler.toml"
 		);
 	}
+}
+
+export function getClassNamesWhichUseSQLite(
+	migrations: Config["migrations"] | undefined
+) {
+	const classNamesWhichUseSQLite = new Map<string, boolean>();
+	(migrations || []).forEach((migration) => {
+		migration.deleted_classes?.forEach((deleted_class) => {
+			if (!classNamesWhichUseSQLite.delete(deleted_class)) {
+				throw new UserError(
+					`Cannot apply deleted_classes migration to non-existent class ${deleted_class}`
+				);
+			}
+		});
+
+		migration.renamed_classes?.forEach(({ from, to }) => {
+			const useSQLite = classNamesWhichUseSQLite.get(from);
+			if (useSQLite === undefined) {
+				throw new UserError(
+					`Cannot apply renamed_classes migration to non-existent class ${from}`
+				);
+			} else {
+				classNamesWhichUseSQLite.delete(from);
+				classNamesWhichUseSQLite.set(to, useSQLite);
+			}
+		});
+
+		migration.new_classes?.forEach((new_class) => {
+			if (classNamesWhichUseSQLite.has(new_class)) {
+				throw new UserError(
+					`Cannot apply new_classes migration to existing class ${new_class}`
+				);
+			} else {
+				classNamesWhichUseSQLite.set(new_class, false);
+			}
+		});
+
+		migration.new_sqlite_classes?.forEach((new_class) => {
+			if (classNamesWhichUseSQLite.has(new_class)) {
+				throw new UserError(
+					`Cannot apply new_sqlite_classes migration to existing class ${new_class}`
+				);
+			} else {
+				classNamesWhichUseSQLite.set(new_class, true);
+			}
+		});
+	});
+
+	return classNamesWhichUseSQLite;
 }


### PR DESCRIPTION
## What this PR solves / how to test

Fixes 0a1224a135fe663a44fa066da58ad0529e0c5c6f

In the previous commit attempting to warn users that SQLite in Durable Objects does not work in remote development, there were three issues that I found after manual testing:
1. The error did not trigger when switching from local to remote development.
2. The error would persist if the user had new_sqlite_classes which had undergone a delete migration.
3. The error prevented customers from using remote development for code paths that didn't actually use SQLite in Durable Objects (warning seems more appropriate here). 

This PR reverts 0a1224a135fe663a44fa066da58ad0529e0c5c6f and instead implements the exact same logic as we do for queues. There is one downside to what is being done for queues (repeated log lines per warning):

```
npx wrangler dev

 ⛅️ wrangler 3.75.0 (update available 3.77.0)
-------------------------------------------------------

Your worker has access to the following bindings:
- Durable Objects:
  - SQLITE_DURABLE_OBJECT: SQLiteDurableObject
- Queues:
  - MY_QUEUE: my-queue
⎔ Starting local server...
[wrangler:inf] Ready on http://localhost:59290
▲ [WARNING] Queues are currently in Beta and are not supported in wrangler dev remote mode.


⎔ Shutting down local server...
▲ [WARNING] Queues are currently in Beta and are not supported in wrangler dev remote mode.


Total Upload: 5.80 KiB / gzip: 1.88 KiB
▲ [WARNING] worker failed to prewarm:  Service Temporarily Unavailable


╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ [b] open a browser, [d] open Devtools, [l] turn on local mode, [c] clear console, [x] to exit                │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
npx wrangler dev --remote

 ⛅️ wrangler 3.75.0 (update available 3.77.0)
-------------------------------------------------------

Your worker has access to the following bindings:
- Durable Objects:
  - SQLITE_DURABLE_OBJECT: SQLiteDurableObject
- Queues:
  - MY_QUEUE: my-queue
▲ [WARNING] Queues are currently in Beta and are not supported in wrangler dev remote mode.


▲ [WARNING] Queues are currently in Beta and are not supported in wrangler dev remote mode.


▲ [WARNING] Queues are currently in Beta and are not supported in wrangler dev remote mode.


Total Upload: 5.80 KiB / gzip: 1.88 KiB


╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ [b] open a browser, [d] open Devtools, [l] turn on local mode, [c] clear console, [x] to exit                │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
This PR does not address multiple log lines per warning, but it's at least consistent.
```
Script modified; context reset.
wrangler.toml changed...
Your worker has access to the following bindings:
- Durable Objects:
  - SQLITE_DURABLE_OBJECT: SQLiteDurableObject
- Queues:
  - MY_QUEUE: my-queue
▲ [WARNING] Queues are currently in Beta and are not supported in wrangler dev remote mode.


▲ [WARNING] SQLite in Durable Objects is only supported in local mode.


⎔ Detected changes, restarted server.
Total Upload: 5.83 KiB / gzip: 1.89 KiB
▲ [WARNING] Queues are currently in Beta and are not supported in wrangler dev remote mode.


▲ [WARNING] SQLite in Durable Objects is only supported in local mode.
```
I would suggest merging this as is, but I'd personally rather not see the duplicate warnings.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Included
  - [x] Not necessary because: Manually tested (not really sure that this can be tested)
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required / Maybe required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Included
  - [ ] Not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Not necessary because: Bug fix
