### PR TITLE
remove outdated config options

### DIFF
--- a/fixtures/workers-with-assets-only/wrangler.toml
+++ b/fixtures/workers-with-assets-only/wrangler.toml
@@ -3,6 +3,3 @@ compatibility_date = "2024-01-01"
 
 [experimental_assets]
 directory = "./public"
-serve_exact_matches_only = false
-trailing_slashes = "remove"
-not_found_behavior = "404-page"


### PR DESCRIPTION
## What this PR solves / how to test

Super quick followup to https://github.com/cloudflare/workers-sdk/pull/6631 where I forgot to remove some outdated config options from the wrangler.toml in the assets-only fixture.
Fixes #000?

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no functionality change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no functionality change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: no functionality change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functionality change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
