### PR TITLE
Add `Fixes N/A` as an option to Pr description validation

### DIFF
--- a/tools/deployments/__tests__/validate-pr-description.test.ts
+++ b/tools/deployments/__tests__/validate-pr-description.test.ts
@@ -38,7 +38,7 @@ Fixes #[insert GH or internal issue number(s)].
 			)
 		).toMatchInlineSnapshot(`
 			[
-			  "Your PR description must include an issue reference in the format \`Fixes #000\` (for GitHub issues) or \`Fixes [AA-000](https://jira.cfdata.org/browse/AA-000)\` (for internal Jira ticket references)",
+			  "Your PR description must include an issue reference in the format \`Fixes #000\` (for GitHub issues), \`Fixes [AA-000](https://jira.cfdata.org/browse/AA-000)\` (for internal Jira ticket references), or \`Fixes N/A\` if there's no associated issue (and it doesn't make sense to create one)",
 			  "All TODO checkboxes in your PR description must be unchecked before merging",
 			  "Your PR must include tests, or provide justification for why no tests are required",
 			  "Your PR must run E2E tests, or provide justification for why running them is not required",

--- a/tools/deployments/__tests__/validate-pr-description.test.ts
+++ b/tools/deployments/__tests__/validate-pr-description.test.ts
@@ -111,6 +111,38 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
 		).toMatchInlineSnapshot(`[]`);
 	});
 
+	it("should accept N/A issue reference", () => {
+		expect(
+			validateDescription(
+				"",
+				`## What this PR solves / how to test
+
+Fixes N/A.
+
+## Author has addressed the following
+
+- Tests
+  - [ ] TODO (before merge)
+  - [ ] Tests included
+  - [x] Tests not necessary because: test
+- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
+  - [ ] I don't know
+  - [ ] Required
+  - [x] Not required because: test
+- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
+  - [ ] TODO (before merge)
+  - [ ] Changeset included
+  - [x] Changeset not necessary because: test
+- Public documentation
+  - [ ] TODO (before merge)
+  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
+  - [x] Documentation not necessary because: test
+`,
+				"[]"
+			)
+		).toMatchInlineSnapshot(`[]`);
+	});
+
 	it("should accept everything included", () => {
 		expect(
 			validateDescription(

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -32,12 +32,12 @@ export function validateDescription(
 	}
 
 	if (
-		!/^Fixes (#\d+|\[[A-Z]+-\d+\]\(https:\/\/jira\.cfdata\.org\/browse\/[A-Z]+-\d+\))/m.test(
+		!/^Fixes (#\d+|N\\A|\[[A-Z]+-\d+\]\(https:\/\/jira\.cfdata\.org\/browse\/[A-Z]+-\d+\))/m.test(
 			body
 		)
 	) {
 		errors.push(
-			"Your PR description must include an issue reference in the format `Fixes #000` (for GitHub issues) or `Fixes [AA-000](https://jira.cfdata.org/browse/AA-000)` (for internal Jira ticket references)"
+			"Your PR description must include an issue reference in the format `Fixes #000` (for GitHub issues), `Fixes [AA-000](https://jira.cfdata.org/browse/AA-000)` (for internal Jira ticket references), or `Fixes N/A` if there's no associated issue (and it doesn't make sense to create one)"
 		);
 	}
 

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -94,7 +94,7 @@ export function validateDescription(
 
 	if (
 		!(
-			/- \[x\] Cloudflare docs PR\(s\): https:\/\/github\.com\/cloudflare\/cloudflare-docs\/(pull|issue)\/\d+/.test(
+			/- \[x\] Cloudflare docs PR\(s\): https:\/\/github\.com\/cloudflare\/cloudflare-docs\/(pull|issues)\/\d+/.test(
 				body
 			) || /- \[x\] Documentation not necessary because: .+/.test(body)
 		)

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -32,7 +32,7 @@ export function validateDescription(
 	}
 
 	if (
-		!/^Fixes (#\d+|N\\A|\[[A-Z]+-\d+\]\(https:\/\/jira\.cfdata\.org\/browse\/[A-Z]+-\d+\))/m.test(
+		!/^Fixes (#\d+|N\/A|\[[A-Z]+-\d+\]\(https:\/\/jira\.cfdata\.org\/browse\/[A-Z]+-\d+\))/m.test(
 			body
 		)
 	) {


### PR DESCRIPTION
## What this PR solves / how to test

Fixes N/A

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: e2e doesn't cover this tool
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: internal tool
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal tool

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
