### PR TITLE
Making explicit that if a body is sent to delete event notification config rules it is sent with an array of ruleIds

### DIFF
--- a/.changeset/blue-bags-walk.md
+++ b/.changeset/blue-bags-walk.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+fix: making explicit to only send a body if there are rule ids specified in the config delete

--- a/.changeset/blue-bags-walk.md
+++ b/.changeset/blue-bags-walk.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
 fix: making explicit to only send a body if there are rule ids specified in the config delete

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -1021,10 +1021,10 @@ describe("r2", () => {
 						  -v, --version                   Show version number  [boolean]
 
 						OPTIONS
-						      --event-types, --event-type  Specify the kinds of object events to emit notifications for. ex. '--event-types object-create object-delete'  [array] [required] [choices: \\"object-create\\", \\"object-delete\\"]
-						      --prefix                     only actions on objects with this prefix will emit notifications  [string]
-						      --suffix                     only actions on objects with this suffix will emit notifications  [string]
-						      --queue                      The name of the queue to which event notifications will be sent. ex '--queue my-queue'  [string] [required]"
+						      --event-types, --event-type  The type of event(s) that will emit event notifications  [array] [required] [choices: \\"object-create\\", \\"object-delete\\"]
+						      --prefix                     The prefix that an object must match to emit event notifications (note: regular expressions not supported)  [string]
+						      --suffix                     The suffix that an object must match to emit event notifications (note: regular expressions not supported)  [string]
+						      --queue                      The name of the queue that will receive event notification messages  [string] [required]"
 					`);
 				});
 			});
@@ -1178,8 +1178,8 @@ describe("r2", () => {
 						  -v, --version                   Show version number  [boolean]
 
 						OPTIONS
-						      --queue  The name of the queue that is configured to receive notifications. ex '--queue my-queue'  [string] [required]
-						      --rule   The id of the rule to delete. If no rule is specified, all rules for the bucket/queue configuration will be deleted.  [string]"
+						      --queue  The name of the queue that will receive event notification messages  [string] [required]
+						      --rule   The id of the rule to delete. If no rule is specified, all rules for the bucket/queue configuration will be deleted  [string]"
 					`);
 				});
 			});

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -1039,6 +1039,7 @@ describe("r2", () => {
 							async ({ request, params }) => {
 								const { accountId } = params;
 								expect(accountId).toEqual("some-account-id");
+								expect(request.body).toBeNull();
 								expect(request.headers.get("authorization")).toEqual(
 									"Bearer some-api-token"
 								);
@@ -1100,6 +1101,9 @@ describe("r2", () => {
 							async ({ request, params }) => {
 								const { accountId } = params;
 								expect(accountId).toEqual("some-account-id");
+								expect(request.body).not.toBeNull();
+								const requestBody = await request.text();
+								expect(requestBody).toContain(`"ruleIds":["${ruleId}"]`);
 								expect(request.headers.get("authorization")).toEqual(
 									"Bearer some-api-token"
 								);

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -584,18 +584,24 @@ export async function deleteEventNotificationConfig(
 	logger.log(
 		`Disabling event notifications for "${bucketName}" to queue ${queueName}...`
 	);
+	if (ruleId !== undefined) {
+		const body: DeleteNotificationRequestBody =
+			ruleId !== undefined
+				? {
+						ruleIds: [ruleId],
+					}
+				: {};
 
-	const body: DeleteNotificationRequestBody =
-		ruleId !== undefined
-			? {
-					ruleIds: [ruleId],
-				}
-			: {};
-
-	return await fetchResult<null>(
-		`/accounts/${accountId}/event_notifications/r2/${bucketName}/configuration/queues/${queue.queue_id}`,
-		{ method: "DELETE", body: JSON.stringify(body), headers }
-	);
+		return await fetchResult<null>(
+			`/accounts/${accountId}/event_notifications/r2/${bucketName}/configuration/queues/${queue.queue_id}`,
+			{ method: "DELETE", body: JSON.stringify(body), headers }
+		);
+	} else {
+		return await fetchResult<null>(
+			`/accounts/${accountId}/event_notifications/r2/${bucketName}/configuration/queues/${queue.queue_id}`,
+			{ method: "DELETE", headers }
+		);
+	}
 }
 
 /**

--- a/packages/wrangler/src/r2/notification.ts
+++ b/packages/wrangler/src/r2/notification.ts
@@ -49,8 +49,7 @@ export function CreateOptions(yargs: CommonYargsArgv) {
 			demandOption: true,
 		})
 		.option("event-types", {
-			describe:
-				"Specify the kinds of object events to emit notifications for. ex. '--event-types object-create object-delete'",
+			describe: "The type of event(s) that will emit event notifications",
 			alias: "event-type",
 			choices: Object.keys(actionsForEventCategories),
 			demandOption: true,
@@ -59,18 +58,18 @@ export function CreateOptions(yargs: CommonYargsArgv) {
 		})
 		.option("prefix", {
 			describe:
-				"only actions on objects with this prefix will emit notifications",
+				"The prefix that an object must match to emit event notifications (note: regular expressions not supported)",
 			requiresArg: false,
 			type: "string",
 		})
 		.option("suffix", {
 			describe:
-				"only actions on objects with this suffix will emit notifications",
+				"The suffix that an object must match to emit event notifications (note: regular expressions not supported)",
 			type: "string",
 		})
 		.option("queue", {
 			describe:
-				"The name of the queue to which event notifications will be sent. ex '--queue my-queue'",
+				"The name of the queue that will receive event notification messages",
 			demandOption: true,
 			requiresArg: true,
 			type: "string",
@@ -108,14 +107,14 @@ export function DeleteOptions(yargs: CommonYargsArgv) {
 		})
 		.option("queue", {
 			describe:
-				"The name of the queue that is configured to receive notifications. ex '--queue my-queue'",
+				"The name of the queue that will receive event notification messages",
 			demandOption: true,
 			requiresArg: true,
 			type: "string",
 		})
 		.option("rule", {
 			describe:
-				"The id of the rule to delete. If no rule is specified, all rules for the bucket/queue configuration will be deleted.",
+				"The id of the rule to delete. If no rule is specified, all rules for the bucket/queue configuration will be deleted",
 			requiresArg: false,
 			type: "string",
 		});


### PR DESCRIPTION
## What this PR solves / how to test

Updating body for [R2-2457](https://jira.cfdata.org/browse/R2-2457)

Fixes N/A

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: test changes covered by unit tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [] TODO (before merge):
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/16873
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
