### PR TITLE
Bump `pnpm` 9.1.3 -> 9.10.0 to support catalogs

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9.1.3
+        version: 9.10.0
 
     - name: Install Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4

--- a/.github/workflows/c3-e2e-dependabot.yml
+++ b/.github/workflows/c3-e2e-dependabot.yml
@@ -47,14 +47,14 @@ jobs:
         pm:
           [
             { name: npm, version: "0.0.0" },
-            { name: pnpm, version: "9.1.3" },
+            { name: pnpm, version: "9.10.0" },
             { name: bun, version: "1.0.3" },
             { name: yarn, version: "1.0.0" },
           ]
         # include a single windows test with pnpm
         include:
           - os: windows-latest
-            pm: { name: pnpm, version: "9.1.3" }
+            pm: { name: pnpm, version: "9.10.0" }
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/c3-e2e-quarantine.yml
+++ b/.github/workflows/c3-e2e-quarantine.yml
@@ -22,7 +22,7 @@ jobs:
         pm:
           [
             { name: npm, version: "0.0.0" },
-            { name: pnpm, version: "9.1.3" },
+            { name: pnpm, version: "9.10.0" },
             { name: bun, version: "1.0.3" },
           ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -28,14 +28,14 @@ jobs:
         pm:
           [
             { name: npm, version: "0.0.0" },
-            { name: pnpm, version: "9.1.3" },
+            { name: pnpm, version: "9.10.0" },
             { name: bun, version: "1.0.3" },
             { name: yarn, version: "1.0.0" },
           ]
         # include a single windows test with pnpm
         include:
           - os: windows-latest
-            pm: { name: pnpm, version: "9.1.3" }
+            pm: { name: pnpm, version: "9.10.0" }
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
 		"vite": "^5.0.12",
 		"vitest": "catalog:default"
 	},
-	"packageManager": "pnpm@9.1.3",
+	"packageManager": "pnpm@9.10.0",
 	"engines": {
 		"node": ">=18.20.0",
-		"pnpm": "^9.1.3"
+		"pnpm": "^9.10.0"
 	},
 	"volta": {
 		"node": "18.20.2"


### PR DESCRIPTION
## What this PR solves / how to test

Fixes N/A

We added [pnpm catalogs](https://pnpm.io/catalogs) recently, which are only supported in `pnpm@^9.5`. This caused changesets to fail when running `pnpm i --frozen-lockfile`: https://github.com/cloudflare/workers-sdk/actions/runs/10853200996/job/30120963322

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: dependency bump
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: e2e doesn't cover this
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: tooling change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: dependency bump

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
