### PR TITLE
Add missing config params to router-worker and asset-worker

### DIFF
--- a/.changeset/stupid-dogs-hear.md
+++ b/.changeset/stupid-dogs-hear.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+fix: Add missing config params to asset-worker and router-worker

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
 		"pnpm": "^9.10.0"
 	},
 	"volta": {
-		"node": "18.20.2"
+		"node": "18.20.2",
+		"pnpm": "9.10.0"
 	},
 	"pnpm": {
 		"peerDependencyRules": {

--- a/packages/workers-shared/asset-worker/wrangler.toml
+++ b/packages/workers-shared/asset-worker/wrangler.toml
@@ -15,6 +15,11 @@ compatibility_date = "2024-07-31"
 compatibility_flags = ["nodejs_compat"]
 
 [[unsafe.bindings]]
+name = "CONFIG"
+type = "param"
+param = "assetConfig"
+
+[[unsafe.bindings]]
 name = "ASSETS_MANIFEST"
 type = "param"
 param = "assetManifest"

--- a/packages/workers-shared/router-worker/wrangler.toml
+++ b/packages/workers-shared/router-worker/wrangler.toml
@@ -14,6 +14,11 @@ main = "src/index.ts"
 compatibility_date = "2024-07-31"
 
 [[unsafe.bindings]]
+name = "CONFIG"
+type = "param"
+param = "routerConfig"
+
+[[unsafe.bindings]]
 name = "ASSET_WORKER"
 type = "internal_assets"
 fetcherApi = "fetcher"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.0.5
+      version: 2.0.5
+    '@vitest/snapshot':
+      specifier: ~2.0.5
+      version: 2.0.5
     vitest:
       specifier: ~2.0.5
       version: 2.0.5


### PR DESCRIPTION
## What this PR solves / how to test

Fixes router-worker and asset-worker in prod (they expect these config bindings)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: prod infra
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unreleased

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
