### PR TITLE
feat: add support for vitest 2.1.x

### DIFF
--- a/.changeset/nervous-days-greet.md
+++ b/.changeset/nervous-days-greet.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+feat: add support for Vitest 2.1.x

--- a/fixtures/asset-config/vitest.config.ts
+++ b/fixtures/asset-config/vitest.config.ts
@@ -33,7 +33,7 @@ export default defineWorkersConfig({
 		server: {
 			deps: {
 				// Vitest automatically adds `/^(?!.*node_modules).*\.mjs$/` as an
-				// `inline` RegExp: https://github.com/vitest-dev/vitest/blob/v2.0.5/packages/vitest/src/constants.ts#L9
+				// `inline` RegExp: https://github.com/vitest-dev/vitest/blob/v2.1.1/packages/vitest/src/constants.ts#L9
 				// We'd like `packages/vitest-pool-workers/dist/pool/index.mjs` to be
 				// externalised though. Unfortunately, `inline`s are checked before
 				// `external`s, so there's no nice way we can override this. Instead,

--- a/fixtures/vitest-pool-workers-examples/vitest.workers.config.ts
+++ b/fixtures/vitest-pool-workers-examples/vitest.workers.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 		server: {
 			deps: {
 				// Vitest automatically adds `/^(?!.*node_modules).*\.mjs$/` as an
-				// `inline` RegExp: https://github.com/vitest-dev/vitest/blob/v2.0.5/packages/vitest/src/constants.ts#L9
+				// `inline` RegExp: https://github.com/vitest-dev/vitest/blob/v2.1.1/packages/vitest/src/constants.ts#L9
 				// We'd like `packages/vitest-pool-workers/dist/pool/index.mjs` to be
 				// externalised though. Unfortunately, `inline`s are checked before
 				// `external`s, so there's no nice way we can override this. Instead,

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/package.json
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/package.json
@@ -9,8 +9,8 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.5",
+		"@cloudflare/vitest-pool-workers": "^0.5.2",
 		"wrangler": "^3.60.3",
-		"vitest": "1.5.0"
+		"vitest": "2.1.1"
 	}
 }

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/package.json
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/package.json
@@ -10,9 +10,9 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.5",
+		"@cloudflare/vitest-pool-workers": "^0.5.2",
 		"typescript": "^5.5.2",
-		"vitest": "1.5.0",
+		"vitest": "2.1.1",
 		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -9,8 +9,8 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.5",
+		"@cloudflare/vitest-pool-workers": "^0.5.2",
 		"wrangler": "^3.60.3",
-		"vitest": "1.5.0"
+		"vitest": "2.1.1"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -10,9 +10,9 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.5",
+		"@cloudflare/vitest-pool-workers": "^0.5.2",
 		"typescript": "^5.5.2",
-		"vitest": "1.5.0",
+		"vitest": "2.1.1",
 		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -77,9 +77,9 @@
 		"vitest": "catalog:default"
 	},
 	"peerDependencies": {
-		"@vitest/runner": "2.0.x",
-		"@vitest/snapshot": "2.0.x",
-		"vitest": "2.0.x"
+		"@vitest/runner": "2.0.x - 2.1.x",
+		"@vitest/snapshot": "2.0.x - 2.1.x",
+		"vitest": "2.0.x - 2.1.x"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/vitest-pool-workers/src/config/index.ts
+++ b/packages/vitest-pool-workers/src/config/index.ts
@@ -123,7 +123,7 @@ function createConfigPlugin(): Plugin<WorkersConfigPluginAPI> {
 			},
 		},
 		// Run after `vitest:project` plugin:
-		// https://github.com/vitest-dev/vitest/blob/v2.0.5/packages/vitest/src/node/plugins/workspace.ts#L34
+		// https://github.com/vitest-dev/vitest/blob/v2.1.1/packages/vitest/src/node/plugins/workspace.ts#L34
 		config(config) {
 			config.resolve ??= {};
 			config.resolve.conditions ??= [];
@@ -140,7 +140,7 @@ function createConfigPlugin(): Plugin<WorkersConfigPluginAPI> {
 			ensureArrayIncludes(config.resolve.conditions, requiredConditions);
 
 			// Vitest sets this to an empty array if unset, so restore Vite defaults:
-			// https://github.com/vitest-dev/vitest/blob/v2.0.5/packages/vitest/src/node/plugins/index.ts#L93
+			// https://github.com/vitest-dev/vitest/blob/v2.1.1/packages/vitest/src/node/plugins/index.ts#L93
 			ensureArrayIncludes(config.resolve.mainFields, requiredMainFields);
 
 			// Apply `package.json` `browser` field remapping in SSR mode:

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -250,7 +250,7 @@ export async function parseProjectOptions(
 	let workersPoolOptions = poolOptions?.workers ?? {};
 	try {
 		if (typeof workersPoolOptions === "function") {
-			// https://github.com/vitest-dev/vitest/blob/v2.0.5/packages/vitest/src/integrations/inject.ts
+			// https://github.com/vitest-dev/vitest/blob/v2.1.1/packages/vitest/src/integrations/inject.ts
 			const inject = <K extends keyof ProvidedContext>(
 				key: K
 			): ProvidedContext[K] => {

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -72,7 +72,7 @@ interface SerializedOptions {
 	isolatedStorage?: boolean;
 }
 
-// https://github.com/vitest-dev/vitest/blob/v2.0.5/packages/vite-node/src/client.ts#L468
+// https://github.com/vitest-dev/vitest/blob/v2.1.1/packages/vite-node/src/client.ts#L468
 declare const __vite_ssr_import__: unknown;
 assert(
 	typeof __vite_ssr_import__ === "undefined",

--- a/packages/workers.new/tests/vitest.config.mts
+++ b/packages/workers.new/tests/vitest.config.mts
@@ -35,7 +35,7 @@ export default defineWorkersProject({
 		server: {
 			deps: {
 				// Vitest automatically adds `/^(?!.*node_modules).*\.mjs$/` as an
-				// `inline` RegExp: https://github.com/vitest-dev/vitest/blob/v2.0.5/packages/vitest/src/constants.ts#L9
+				// `inline` RegExp: https://github.com/vitest-dev/vitest/blob/v2.1.1/packages/vitest/src/constants.ts#L9
 				// We'd like `packages/vitest-pool-workers/dist/pool/index.mjs` to be
 				// externalised though. Unfortunately, `inline`s are checked before
 				// `external`s, so there's no nice way we can override this. Instead,

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -39,8 +39,8 @@ function mockDeploymentPost() {
 		http.post(
 			"*/deployments/v2",
 			async ({ request }) => {
-				expect(await request.text()).toMatchInlineSnapshot(
-					`"{\\"image\\":\\"hello:world\\",\\"location\\":\\"sfo06\\",\\"ssh_public_key_ids\\":[],\\"environment_variables\\":[{\\"name\\":\\"HELLO\\",\\"value\\":\\"WORLD\\"},{\\"name\\":\\"YOU\\",\\"value\\":\\"CONQUERED\\"}],\\"vcpu\\":3,\\"memory\\":\\"400GB\\",\\"network\\":{\\"assign_ipv4\\":\\"predefined\\"}}"`
+				expect(await request.text()).toBe(
+					`{"image":"hello:world","location":"sfo06","ssh_public_key_ids":[],"environment_variables":[{"name":"HELLO","value":"WORLD"},{"name":"YOU","value":"CONQUERED"}],"vcpu":3,"memory":"400GB","network":{"assign_ipv4":"predefined"}}`
 				);
 				return HttpResponse.json(MOCK_DEPLOYMENTS_COMPLEX[0]);
 			},

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -14,8 +14,8 @@ function mockDeployment() {
 		http.patch(
 			"*/deployments/1234/v2",
 			async ({ request }) => {
-				expect(await request.text()).toMatchInlineSnapshot(
-					`"{\\"image\\":\\"hello:modify\\",\\"location\\":\\"sfo06\\",\\"environment_variables\\":[{\\"name\\":\\"HELLO\\",\\"value\\":\\"WORLD\\"},{\\"name\\":\\"YOU\\",\\"value\\":\\"CONQUERED\\"}],\\"vcpu\\":3,\\"memory\\":\\"40MB\\"}"`
+				expect(await request.text()).toBe(
+					`{"image":"hello:modify","location":"sfo06","environment_variables":[{"name":"HELLO","value":"WORLD"},{"name":"YOU","value":"CONQUERED"}],"vcpu":3,"memory":"40MB"}`
 				);
 				return HttpResponse.json(MOCK_DEPLOYMENTS_COMPLEX[0]);
 			},

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -952,7 +952,7 @@ describe("wrangler", () => {
 							blankCursorValue
 						);
 						await runWrangler("kv key list --namespace-id some-namespace-id");
-						expect(std.err).toMatchInlineSnapshot(`""`);
+						expect(std.err).toEqual("");
 						expect(JSON.parse(std.out)).toEqual(keys);
 						expect(requests.count).toEqual(6);
 					});

--- a/packages/wrangler/src/__tests__/pages/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deploy.test.ts
@@ -493,7 +493,8 @@ describe("pages deploy", () => {
 				async ({ request, params }) => {
 					requests.push(request);
 					expect(params.accountId).toEqual("some-account-id");
-					expect(await request.formData()).toMatchInlineSnapshot(`
+					if (requests.length === 1) {
+						expect(await request.formData()).toMatchInlineSnapshot(`
 				      FormData {
 				        Symbol(state): Array [
 				          Object {
@@ -503,6 +504,7 @@ describe("pages deploy", () => {
 				        ],
 				      }
 			    `);
+					}
 
 					if (requests.length < 2) {
 						return HttpResponse.json(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,15 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.1.1
+      version: 2.1.1
+    '@vitest/snapshot':
+      specifier: ~2.1.1
+      version: 2.1.1
     vitest:
-      specifier: ~2.0.5
-      version: 2.0.5
+      specifier: ~2.1.1
+      version: 2.1.1
 
 overrides:
   '@types/react-dom@18>@types/react': ^18
@@ -107,7 +113,7 @@ importers:
         version: 5.0.12(@types/node@20.8.3)
       vitest:
         specifier: catalog:default
-        version: 2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+        version: 2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)
 
   fixtures/additional-modules:
     devDependencies:
@@ -155,7 +161,7 @@ importers:
         version: 5.28.4
       vitest:
         specifier: catalog:default
-        version: 2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+        version: 2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -695,7 +701,7 @@ importers:
         version: 5.5.2
       vitest:
         specifier: catalog:default
-        version: 2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+        version: 2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1380,10 +1386,10 @@ importers:
         version: 7.5.1
       '@vitest/runner':
         specifier: catalog:default
-        version: 2.0.5
+        version: 2.1.1
       '@vitest/snapshot':
         specifier: catalog:default
-        version: 2.0.5
+        version: 2.1.1
       capnp-ts:
         specifier: ^0.7.0
         version: 0.7.0(patch_hash=l4yimnxyvkiyj6alnps2ec3sii)
@@ -1401,7 +1407,7 @@ importers:
         version: 5.28.4
       vitest:
         specifier: catalog:default
-        version: 2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+        version: 2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)
 
   packages/workers-editor-shared:
     dependencies:
@@ -1614,7 +1620,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: catalog:default
-        version: 2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+        version: 2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)
 
   packages/workers-tsconfig: {}
 
@@ -1637,7 +1643,7 @@ importers:
         version: 5.5.2
       vitest:
         specifier: catalog:default
-        version: 2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+        version: 2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -1792,7 +1798,7 @@ importers:
         version: 17.0.24
       '@vitest/ui':
         specifier: ^1.6.0
-        version: 1.6.0(vitest@2.0.5)
+        version: 1.6.0(vitest@2.1.1)
       '@webcontainer/env':
         specifier: ^1.1.0
         version: 1.1.0
@@ -1945,10 +1951,10 @@ importers:
         version: 1.5.4
       vitest:
         specifier: catalog:default
-        version: 2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+        version: 2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)
       vitest-websocket-mock:
         specifier: ^0.3.0
-        version: 0.3.0(vitest@2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2))
+        version: 0.3.0(vitest@2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2))
       ws:
         specifier: ^8.17.1
         version: 8.17.1
@@ -2015,10 +2021,6 @@ packages:
 
   '@ampproject/remapping@2.2.0':
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
-    engines: {node: '>=6.0.0'}
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
   '@ava/typescript@4.1.0':
@@ -3950,23 +3952,32 @@ packages:
     peerDependencies:
       vite: ^4.2.0
 
-  '@vitest/expect@2.0.5':
-    resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
+  '@vitest/expect@2.1.1':
+    resolution: {integrity: sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==}
 
-  '@vitest/pretty-format@2.0.5':
-    resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
+  '@vitest/mocker@2.1.1':
+    resolution: {integrity: sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==}
+    peerDependencies:
+      '@vitest/spy': 2.1.1
+      msw: ^2.3.5
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
-  '@vitest/pretty-format@2.1.0':
-    resolution: {integrity: sha512-7sxf2F3DNYatgmzXXcTh6cq+/fxwB47RIQqZJFoSH883wnVAoccSRT6g+dTKemUBo8Q5N4OYYj1EBXLuRKvp3Q==}
+  '@vitest/pretty-format@2.1.1':
+    resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
 
-  '@vitest/runner@2.0.5':
-    resolution: {integrity: sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==}
+  '@vitest/runner@2.1.1':
+    resolution: {integrity: sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==}
 
-  '@vitest/snapshot@2.0.5':
-    resolution: {integrity: sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==}
+  '@vitest/snapshot@2.1.1':
+    resolution: {integrity: sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==}
 
-  '@vitest/spy@2.0.5':
-    resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+  '@vitest/spy@2.1.1':
+    resolution: {integrity: sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==}
 
   '@vitest/ui@1.6.0':
     resolution: {integrity: sha512-k3Lyo+ONLOgylctiGovRKy7V4+dIN2yxstX3eY5cWFXH6WP+ooVX79YSyi0GagdTQzLmT43BF27T0s6dOIPBXA==}
@@ -3976,8 +3987,8 @@ packages:
   '@vitest/utils@1.6.0':
     resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
 
-  '@vitest/utils@2.0.5':
-    resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
+  '@vitest/utils@2.1.1':
+    resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
 
   '@volar/language-core@2.3.4':
     resolution: {integrity: sha512-wXBhY11qG6pCDAqDnbBRFIDSIwbqkWI7no+lj5+L7IlA7HRIjRP7YQLGzT0LF4lS6eHkMSsclXqy9DwYJasZTQ==}
@@ -5367,10 +5378,6 @@ packages:
     resolution: {integrity: sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==}
     engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
@@ -5630,10 +5637,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
-
   get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
@@ -5855,10 +5858,6 @@ packages:
   human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
-
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
 
   hyphenate-style-name@1.0.4:
     resolution: {integrity: sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==}
@@ -8127,6 +8126,9 @@ packages:
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
+  tinyexec@0.3.0:
+    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+
   tinygradient@1.1.5:
     resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
 
@@ -8523,8 +8525,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite-node@2.0.5:
-    resolution: {integrity: sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==}
+  vite-node@2.1.1:
+    resolution: {integrity: sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -8586,15 +8588,15 @@ packages:
     peerDependencies:
       vitest: '>=1 <2'
 
-  vitest@2.0.5:
-    resolution: {integrity: sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==}
+  vitest@2.1.1:
+    resolution: {integrity: sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': 20.8.3
-      '@vitest/browser': 2.0.5
-      '@vitest/ui': 2.0.5
+      '@vitest/browser': 2.1.1
+      '@vitest/ui': 2.1.1
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -8885,11 +8887,6 @@ snapshots:
   '@ampproject/remapping@2.2.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.25
-
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
   '@ava/typescript@4.1.0':
@@ -9964,7 +9961,7 @@ snapshots:
   '@eslint/eslintrc@2.1.2':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5
+      debug: 4.3.6(supports-color@9.2.2)
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.3.1
@@ -10003,7 +10000,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.11':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.5
+      debug: 4.3.6(supports-color@9.2.2)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10105,7 +10102,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@manypkg/cli@0.21.4':
     dependencies:
@@ -11100,7 +11097,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.5.4)
       '@typescript-eslint/utils': 6.10.0(eslint@8.49.0)(typescript@5.5.4)
-      debug: 4.3.5
+      debug: 4.3.6(supports-color@9.2.2)
       eslint: 8.49.0
       ts-api-utils: 1.0.3(typescript@5.5.4)
     optionalDependencies:
@@ -11112,7 +11109,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.5.4)
       '@typescript-eslint/utils': 6.10.0(eslint@8.57.0)(typescript@5.5.4)
-      debug: 4.3.5
+      debug: 4.3.6(supports-color@9.2.2)
       eslint: 8.57.0
       ts-api-utils: 1.0.3(typescript@5.5.4)
     optionalDependencies:
@@ -11199,37 +11196,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.0.5':
+  '@vitest/expect@2.1.1':
     dependencies:
-      '@vitest/spy': 2.0.5
-      '@vitest/utils': 2.0.5
+      '@vitest/spy': 2.1.1
+      '@vitest/utils': 2.1.1
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/pretty-format@2.0.5':
+  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(msw@2.3.0(typescript@5.5.4))(vite@5.0.12(@types/node@20.8.3))':
+    dependencies:
+      '@vitest/spy': 2.1.1
+      estree-walker: 3.0.3
+      magic-string: 0.30.11
+    optionalDependencies:
+      msw: 2.3.0(typescript@5.5.4)
+      vite: 5.0.12(@types/node@20.8.3)
+
+  '@vitest/pretty-format@2.1.1':
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/pretty-format@2.1.0':
+  '@vitest/runner@2.1.1':
     dependencies:
-      tinyrainbow: 1.2.0
-
-  '@vitest/runner@2.0.5':
-    dependencies:
-      '@vitest/utils': 2.0.5
+      '@vitest/utils': 2.1.1
       pathe: 1.1.2
 
-  '@vitest/snapshot@2.0.5':
+  '@vitest/snapshot@2.1.1':
     dependencies:
-      '@vitest/pretty-format': 2.0.5
+      '@vitest/pretty-format': 2.1.1
       magic-string: 0.30.11
       pathe: 1.1.2
 
-  '@vitest/spy@2.0.5':
+  '@vitest/spy@2.1.1':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/ui@1.6.0(vitest@2.0.5)':
+  '@vitest/ui@1.6.0(vitest@2.1.1)':
     dependencies:
       '@vitest/utils': 1.6.0
       fast-glob: 3.3.2
@@ -11238,7 +11240,7 @@ snapshots:
       pathe: 1.1.1
       picocolors: 1.0.1
       sirv: 2.0.4
-      vitest: 2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+      vitest: 2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)
 
   '@vitest/utils@1.6.0':
     dependencies:
@@ -11247,10 +11249,9 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  '@vitest/utils@2.0.5':
+  '@vitest/utils@2.1.1':
     dependencies:
-      '@vitest/pretty-format': 2.0.5
-      estree-walker: 3.0.3
+      '@vitest/pretty-format': 2.1.1
       loupe: 3.1.1
       tinyrainbow: 1.2.0
 
@@ -11838,7 +11839,7 @@ snapshots:
 
   capnp-ts@0.5.1:
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.6(supports-color@9.2.2)
       format: 0.2.2
       tslib: 2.5.3
       utf8-encoding: 0.1.2
@@ -12938,18 +12939,6 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.3
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.1.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
   exit-hook@2.2.1: {}
 
   expand-template@2.0.3:
@@ -13291,8 +13280,6 @@ snapshots:
 
   get-stream@6.0.1: {}
 
-  get-stream@8.0.1: {}
-
   get-symbol-description@1.0.0:
     dependencies:
       call-bind: 1.0.2
@@ -13559,8 +13546,6 @@ snapshots:
   human-signals@3.0.1: {}
 
   human-signals@4.3.1: {}
-
-  human-signals@5.0.0: {}
 
   hyphenate-style-name@1.0.4: {}
 
@@ -14180,7 +14165,7 @@ snapshots:
 
   magic-string@0.30.3:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.5:
     dependencies:
@@ -15887,6 +15872,8 @@ snapshots:
 
   tinycolor2@1.6.0: {}
 
+  tinyexec@0.3.0: {}
+
   tinygradient@1.1.5:
     dependencies:
       '@types/tinycolor2': 1.4.4
@@ -16248,12 +16235,11 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.0.5(@types/node@20.8.3)(supports-color@9.2.2):
+  vite-node@2.1.1(@types/node@20.8.3)(supports-color@9.2.2):
     dependencies:
       cac: 6.7.14
       debug: 4.3.6(supports-color@9.2.2)
       pathe: 1.1.2
-      tinyrainbow: 1.2.0
       vite: 5.0.12(@types/node@20.8.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -16319,39 +16305,40 @@ snapshots:
       '@types/node': 20.8.3
       fsevents: 2.3.3
 
-  vitest-websocket-mock@0.3.0(vitest@2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)):
+  vitest-websocket-mock@0.3.0(vitest@2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)):
     dependencies:
       jest-diff: 29.7.0
       mock-socket: 9.3.1
-      vitest: 2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2)
+      vitest: 2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2)
 
-  vitest@2.0.5(@types/node@20.8.3)(@vitest/ui@1.6.0)(supports-color@9.2.2):
+  vitest@2.1.1(@types/node@20.8.3)(@vitest/ui@1.6.0)(msw@2.3.0(typescript@5.5.4))(supports-color@9.2.2):
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@vitest/expect': 2.0.5
-      '@vitest/pretty-format': 2.1.0
-      '@vitest/runner': 2.0.5
-      '@vitest/snapshot': 2.0.5
-      '@vitest/spy': 2.0.5
-      '@vitest/utils': 2.0.5
+      '@vitest/expect': 2.1.1
+      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(msw@2.3.0(typescript@5.5.4))(vite@5.0.12(@types/node@20.8.3))
+      '@vitest/pretty-format': 2.1.1
+      '@vitest/runner': 2.1.1
+      '@vitest/snapshot': 2.1.1
+      '@vitest/spy': 2.1.1
+      '@vitest/utils': 2.1.1
       chai: 5.1.1
       debug: 4.3.6(supports-color@9.2.2)
-      execa: 8.0.1
       magic-string: 0.30.11
       pathe: 1.1.2
       std-env: 3.7.0
       tinybench: 2.9.0
+      tinyexec: 0.3.0
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
       vite: 5.0.12(@types/node@20.8.3)
-      vite-node: 2.0.5(@types/node@20.8.3)(supports-color@9.2.2)
+      vite-node: 2.1.1(@types/node@20.8.3)(supports-color@9.2.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.8.3
-      '@vitest/ui': 1.6.0(vitest@2.0.5)
+      '@vitest/ui': 1.6.0(vitest@2.1.1)
     transitivePeerDependencies:
       - less
       - lightningcss
+      - msw
       - sass
       - stylus
       - sugarss

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,6 @@ packages:
   - "tools"
 
 catalog:
-  vitest: ~2.0.5
-  "@vitest/runner": ~2.0.5
-  "@vitest/snapshot": ~2.0.5
+  vitest: ~2.1.1
+  "@vitest/runner": ~2.1.1
+  "@vitest/snapshot": ~2.1.1


### PR DESCRIPTION
## What this PR solves / how to test

Adds support for Vitest 2.1.x, and bumps create-cloudflare templates to pull the new version. No code changes required my testing, so this is primarily just extending the supported version range.

I fixed up a few tests now that Vitest doesn't allow `toMatchInlineSnapshot` being called multiple times, but I'm not sure why the cloudchamber tests are failing.

Fixes #6717

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: No functional changes, just dep bumps
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No functional changes, just dep bumps
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No functional changes, just dep bumps
