### PR TITLE
Bump Vitest in worker templates

### DIFF
--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/package.json
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/package.json
@@ -9,8 +9,8 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.5",
+		"@cloudflare/vitest-pool-workers": "^0.5",
 		"wrangler": "^3.60.3",
-		"vitest": "1.5.0"
+		"vitest": "2.0.5"
 	}
 }

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/package.json
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/package.json
@@ -10,9 +10,9 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.5",
+		"@cloudflare/vitest-pool-workers": "^0.5",
 		"typescript": "^5.5.2",
-		"vitest": "1.5.0",
+		"vitest": "2.0.5",
 		"wrangler": "^3.60.3"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -9,8 +9,8 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.5",
+		"@cloudflare/vitest-pool-workers": "^0.5",
 		"wrangler": "^3.60.3",
-		"vitest": "1.5.0"
+		"vitest": "2.0.5"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -10,9 +10,9 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.4.5",
+		"@cloudflare/vitest-pool-workers": "^0.5",
 		"typescript": "^5.5.2",
-		"vitest": "1.5.0",
+		"vitest": "2.0.5",
 		"wrangler": "^3.60.3"
 	}
 }


### PR DESCRIPTION
## What this PR solves / how to test

Bump Vitest to v2 in C3 templates, after the release of `@cloudflare/vitest-pool-workers@0.5`

Fixes #00

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: dependency bump to C3 templates
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because: dependency bump to C3 templates
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: dependency bump to C3 templates

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
