### PR TITLE
Trigger C3 re-release

### DIFF
--- a/.changeset/empty-pots-fetch.md
+++ b/.changeset/empty-pots-fetch.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+chore: trigger re-release


### PR DESCRIPTION
## What this PR solves / how to test

Trigger a C3 re-release. The last release timed out (https://github.com/cloudflare/workers-sdk/actions/runs/10893160210/job/30227511447) and failed to publish C3 (while successfully publishing everything else)

Fixes N/A

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: re-release of https://github.com/cloudflare/workers-sdk/pull/6727
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: re-release
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: re-release

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
