### PR TITLE
chore: add missing changeset to deploy quick-edit

### DIFF
--- a/.changeset/six-buses-matter.md
+++ b/.changeset/six-buses-matter.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/quick-edit": patch
+---
+
+fix: set readOnly property when writing files


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6731.

We need a changeset for quick-edit to deploy the changes made on the quick edit extension.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Only changeset update
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Only changeset update
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: Only changeset update
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Only changeset update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
