### PR TITLE
fix: Throw error when attempting to configure Workers with assets and tail consumers

### DIFF
--- a/.changeset/fresh-ravens-pull.md
+++ b/.changeset/fresh-ravens-pull.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Throw error when attempting to configure Workers with assets and tail consumers
+
+Tail Workers are currently not supported for Workers with assets. This commit ensures we throw a corresponding error if users are attempting to configure `tail_consumers` via their configuration file, for a Worker with assets. This validation is applied for all `wrangler dev`, `wrangler deploy`, `wrangler versions upload`.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -2453,27 +2453,28 @@ addEventListener('fetch', event => {});`
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 			await runWrangler("deploy --legacy-assets assets");
 
-			expect(std).toMatchInlineSnapshot(`
-				Object {
-				  "debug": "",
-				  "err": "",
-				  "info": "Fetching list of already uploaded assets...
-				Building list of assets to upload...
-				 + file-1.2ca234f380.txt (uploading new version of file-1.txt)
-				 + file-2.5938485188.txt (uploading new version of file-2.txt)
-				Uploading 2 new assets...
-				Uploaded 100% [2 out of 2]",
-				  "out": "↗️  Done syncing assets
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --legacy-assets argument is experimental and may change or break at any time.[0m
+
+				"
+			`);
+			expect(std.out).toMatchInlineSnapshot(`
+				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
-				Current Version ID: Galaxy-Class",
-				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --legacy-assets argument is experimental and may change or break at any time.[0m
+				Current Version ID: Galaxy-Class"
+			`);
 
-				",
-				}
+			expect(std.info).toMatchInlineSnapshot(`
+				"Fetching list of already uploaded assets...
+				Building list of assets to upload...
+				 + file-1.2ca234f380.txt (uploading new version of file-1.txt)
+				 + file-2.5938485188.txt (uploading new version of file-2.txt)
+				Uploading 2 new assets...
+				Uploaded 100% [2 out of 2]"
 			`);
 		});
 
@@ -2500,33 +2501,32 @@ addEventListener('fetch', event => {});`
 			mockUploadAssetsToKVRequest(kvNamespace.id, assets);
 			await runWrangler("deploy --assets assets");
 
-			expect(std).toMatchInlineSnapshot(`
-				Object {
-				  "debug": "",
-				  "err": "",
-				  "info": "Fetching list of already uploaded assets...
-				Building list of assets to upload...
-				 + file-1.2ca234f380.txt (uploading new version of file-1.txt)
-				 + file-2.5938485188.txt (uploading new version of file-2.txt)
-				Uploading 2 new assets...
-				Uploaded 100% [2 out of 2]",
-				  "out": "↗️  Done syncing assets
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental. We are going to be changing the behavior of this experimental command after August 15th.[0m
+
+				  Releases of wrangler after this date will no longer support current functionality.
+				  Please shift to the --legacy-assets command to preserve the current functionality.
+
+				"
+			`);
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
-				Current Version ID: Galaxy-Class",
-				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental. We are going to be changing the behavior of this experimental command after August 15th.[0m
+				Current Version ID: Galaxy-Class"
+			`);
 
-				  Releases of wrangler after this date will no longer support current functionality.
-				  Please shift to the --legacy-assets command to preserve the current functionality.
-
-
-				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --assets argument is experimental and may change or break at any time[0m
-
-				",
-				}
+			expect(std.info).toMatchInlineSnapshot(`
+				"Fetching list of already uploaded assets...
+				Building list of assets to upload...
+				 + file-1.2ca234f380.txt (uploading new version of file-1.txt)
+				 + file-2.5938485188.txt (uploading new version of file-2.txt)
+				Uploading 2 new assets...
+				Uploaded 100% [2 out of 2]"
 			`);
 		});
 
@@ -2564,13 +2564,13 @@ addEventListener('fetch', event => {});`
 			await expect(
 				runWrangler("deploy --legacy-assets abc --site xyz")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+				`[Error: Cannot use Legacy Assets and Workers Sites in the same Worker.]`
 			);
 
 			expect(std).toMatchInlineSnapshot(`
 				Object {
 				  "debug": "",
-				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Assets and Workers Sites in the same Worker.[0m
+				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Legacy Assets and Workers Sites in the same Worker.[0m
 
 				",
 				  "info": "",
@@ -2593,13 +2593,13 @@ addEventListener('fetch', event => {});`
 			await expect(
 				runWrangler("deploy --legacy-assets abc")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+				`[Error: Cannot use Legacy Assets and Workers Sites in the same Worker.]`
 			);
 
 			expect(std).toMatchInlineSnapshot(`
 				Object {
 				  "debug": "",
-				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Assets and Workers Sites in the same Worker.[0m
+				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Legacy Assets and Workers Sites in the same Worker.[0m
 
 				",
 				  "info": "",
@@ -2620,13 +2620,13 @@ addEventListener('fetch', event => {});`
 			await expect(
 				runWrangler("deploy --site xyz")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+				`[Error: Cannot use Legacy Assets and Workers Sites in the same Worker.]`
 			);
 
 			expect(std).toMatchInlineSnapshot(`
 				Object {
 				  "debug": "",
-				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Assets and Workers Sites in the same Worker.[0m
+				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Legacy Assets and Workers Sites in the same Worker.[0m
 
 				",
 				  "info": "",
@@ -2652,13 +2652,13 @@ addEventListener('fetch', event => {});`
 			await expect(
 				runWrangler("deploy")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+				`[Error: Cannot use Legacy Assets and Workers Sites in the same Worker.]`
 			);
 
 			expect(std).toMatchInlineSnapshot(`
 				Object {
 				  "debug": "",
-				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Assets and Workers Sites in the same Worker.[0m
+				  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot use Legacy Assets and Workers Sites in the same Worker.[0m
 
 				",
 				  "info": "",
@@ -4342,7 +4342,7 @@ addEventListener('fetch', event => {});`
 			await expect(
 				runWrangler("deploy")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+				`[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.]`
 			);
 		});
 
@@ -4357,7 +4357,7 @@ addEventListener('fetch', event => {});`
 			await expect(
 				runWrangler("deploy --experimental-assets abc")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Assets and Workers Sites in the same Worker.]`
+				`[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.]`
 			);
 		});
 

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1563,7 +1563,7 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Legacy Assets and Experimental Assets in the same Worker.]`
+				`[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.]`
 			);
 		});
 
@@ -1573,7 +1573,7 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --experimental-assets assets --legacy-assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Legacy Assets and Experimental Assets in the same Worker.]`
+				`[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.]`
 			);
 		});
 
@@ -1593,7 +1593,7 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --experimental-assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Legacy Assets and Experimental Assets in the same Worker.]`
+				`[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.]`
 			);
 		});
 
@@ -1609,7 +1609,7 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --legacy-assets xyz")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Legacy Assets and Experimental Assets in the same Worker.]`
+				`[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.]`
 			);
 		});
 
@@ -1639,6 +1639,31 @@ describe("wrangler dev", () => {
 				new RegExp(
 					'^The directory specified by the "experimental_assets.directory" field in your configuration file does not exist:[Ss]*'
 				)
+			);
+		});
+
+		it("should error if --experimental-assets and config.tail_consumers are used together", async () => {
+			writeWranglerToml({
+				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
+			});
+			fs.openSync("public", "w");
+			await expect(
+				runWrangler("dev --experimental-assets public")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Experimental Assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets.]`
+			);
+		});
+
+		it("should error if config.experimental_assets and config.tail_consumers are used together", async () => {
+			writeWranglerToml({
+				experimental_assets: { directory: "./public" },
+				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
+			});
+			fs.openSync("public", "w");
+			await expect(
+				runWrangler("dev")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Experimental Assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets.]`
 			);
 		});
 	});

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { findWranglerToml, readConfig } from "../config";
 import { getEntry } from "../deployment-bundle/entry";
 import { UserError } from "../errors";
-import { processExperimentalAssetsArg } from "../experimental-assets";
+import {
+	processExperimentalAssetsArg,
+	verifyMutuallyExclusiveAssetsArgsOrConfig,
+} from "../experimental-assets";
 import {
 	getRules,
 	getScriptName,
@@ -230,6 +233,18 @@ export async function versionsUploadHandler(
 			"Legacy Assets does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead."
 		);
 	}
+
+	verifyMutuallyExclusiveAssetsArgsOrConfig(
+		{
+			// given that legacyAssets and sites are not supported by
+			// `wrangler versions upload` pass them as undefined to
+			// skip the corresponding mutual exclusivity validation
+			legacyAssets: undefined,
+			site: undefined,
+			experimentalAssets: args.experimentalAssets,
+		},
+		config
+	);
 
 	const experimentalAssetsOptions = processExperimentalAssetsArg(args, config);
 


### PR DESCRIPTION
Tail Workers are currently not supported for Workers with assets. This commit ensures we throw the corresponding error if users are attempting to configure `tail_consumers` via their configuration file, for a Worker with assets. This validation is applied for all `wrangler dev`, `wrangler deploy`, `wrangler versions upload`.

Fixes [WC-2711](https://jira.cfdata.org/browse/WC-2711)

<img width="850" alt="Screenshot 2024-09-18 at 13 33 57" src="https://github.com/user-attachments/assets/e5886fa4-0503-4e95-95aa-8a53deed8fbd">


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not docummented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
