### PR TITLE
refactor: simplify date calculation and remove date-fns dependency

### DIFF
--- a/.changeset/light-insects-drive.md
+++ b/.changeset/light-insects-drive.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+refactor: simplify date calculation and remove date-fns dependency

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -75,7 +75,6 @@
 		"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^3.5.3",
-		"date-fns": "^3.6.0",
 		"esbuild": "0.17.19",
 		"miniflare": "workspace:*",
 		"nanoid": "^3.3.3",

--- a/packages/wrangler/src/dev-registry.ts
+++ b/packages/wrangler/src/dev-registry.ts
@@ -13,7 +13,6 @@ import net from "node:net";
 import path from "node:path";
 import bodyParser from "body-parser";
 import { watch } from "chokidar";
-import { subMinutes } from "date-fns";
 import express from "express";
 import { createHttpTerminator } from "http-terminator";
 import { fetch } from "undici";
@@ -75,8 +74,8 @@ async function loadWorkerDefinitions(): Promise<WorkerRegistry> {
 				"utf8"
 			);
 			const stats = await stat(path.join(DEV_REGISTRY_PATH, workerName));
-			// Cleanup old workers
-			if (stats.mtime < subMinutes(new Date(), 10)) {
+			// Cleanup existing workers older than 10 minutes
+			if (stats.mtime.getTime() < Date.now() - 600000) {
 				await unregisterWorker(workerName);
 			} else {
 				globalWorkers[workerName] = JSON.parse(file);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1668,9 +1668,6 @@ importers:
       chokidar:
         specifier: ^3.5.3
         version: 3.5.3
-      date-fns:
-        specifier: ^3.6.0
-        version: 3.6.0
       esbuild:
         specifier: 0.17.19
         version: 0.17.19
@@ -4832,9 +4829,6 @@ packages:
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
-
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
   date-time@3.1.0:
     resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
@@ -12215,8 +12209,6 @@ snapshots:
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.22.5
-
-  date-fns@3.6.0: {}
 
   date-time@3.1.0:
     dependencies:


### PR DESCRIPTION
## What this PR solves / how to test

Removes the `date-fns` depedency and simplify the single place where it's used. It's currently used to subtract minutes, but we can do so manually directly and avoid bringing in a large dependency.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: refactors code
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: refactors code
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactor

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
