### PR TITLE
refactor: prevent bundling entire `package.json` in built code

### DIFF
--- a/.changeset/eight-emus-compete.md
+++ b/.changeset/eight-emus-compete.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+refactor: prevent bundling entire `package.json` in built code

--- a/packages/wrangler/src/update-check.ts
+++ b/packages/wrangler/src/update-check.ts
@@ -1,7 +1,10 @@
 import chalk from "chalk";
 import supportsColor from "supports-color";
 import checkForUpdate from "update-check";
-import pkg, { version as wranglerVersion } from "../package.json";
+import {
+	name as wranglerName,
+	version as wranglerVersion,
+} from "../package.json";
 import { logger } from "./logger";
 import type { Result } from "update-check";
 
@@ -42,6 +45,9 @@ After installation, run Wrangler with \`npx wrangler\`.`
 
 async function doUpdateCheck(): Promise<string | undefined> {
 	let update: Result | null = null;
+	// `check-update` only requires the name and version to check. This way we
+	// don't have to bundle the entire `package.json` in the final build.
+	const pkg = { name: wranglerName, version: wranglerVersion };
 	try {
 		// default cache for update check is 1 day
 		update = await checkForUpdate(pkg, {


### PR DESCRIPTION
## What this PR solves / how to test

Fixes N/A

I noticed that the `package.json` was bundled in `wrangler/wrangler-dist/cli.js`. I found that we can simplify the `package.json` import to prevent that from happening.

The `package.json` is used by the `check-update` dependency, but it only requires the `name` and `version` to detect updates: https://github.com/vercel/update-check/blob/4338e215c9d089f46c6edff45ba41941c070d39f/index.js#L169-L201. So we only need to import the name and version to satisfy it.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: refactors
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: refactors
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactor

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
