### PR TITLE
C3: bump qwik to `1.9.0`

### DIFF
--- a/.changeset/few-feet-appear.md
+++ b/.changeset/few-feet-appear.md
@@ -1,0 +1,9 @@
+---
+"create-cloudflare": patch
+---
+
+fix: add missing `nodejs_compat` flag to c3 qwik template
+
+The c3 qwik template doesn't include the `nodejs_compat` but qwik seems to be using
+AsyncLocalStorage, so newly created applications do display a warning regarding it
+missing, fix the above issue by adding the missing compat flag

--- a/.changeset/spotty-snails-design.md
+++ b/.changeset/spotty-snails-design.md
@@ -1,0 +1,11 @@
+---
+"create-cloudflare": patch
+---
+
+- chore: update dependencies of "create-cloudflare" package
+
+  The following dependency versions have been updated:
+
+  | Dependency  | From  | To    |
+  | ----------- | ----- | ----- |
+  | create-qwik | 1.5.7 | 1.9.0 |

--- a/packages/create-cloudflare/src/frameworks/package.json
+++ b/packages/create-cloudflare/src/frameworks/package.json
@@ -11,7 +11,7 @@
 		"create-docusaurus": "3.5.2",
 		"create-hono": "0.12.0",
 		"create-next-app": "14.2.5",
-		"create-qwik": "1.5.7",
+		"create-qwik": "1.9.0",
 		"create-vite": "5.2.3",
 		"create-remix": "2.11.1",
 		"create-solid": "0.5.12",

--- a/packages/create-cloudflare/templates-experimental/qwik/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/qwik/c3.ts
@@ -13,7 +13,7 @@ import type { C3Context } from "types";
 const { npm, npx } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
-	await runFrameworkGenerator(ctx, ["basic", ctx.project.name]);
+	await runFrameworkGenerator(ctx, ["playground", ctx.project.name]);
 };
 
 const configure = async (ctx: C3Context) => {

--- a/packages/create-cloudflare/templates/qwik/c3.ts
+++ b/packages/create-cloudflare/templates/qwik/c3.ts
@@ -13,7 +13,7 @@ import type { C3Context } from "types";
 const { npm, npx } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
-	await runFrameworkGenerator(ctx, ["basic", ctx.project.name]);
+	await runFrameworkGenerator(ctx, ["playground", ctx.project.name]);
 };
 
 const configure = async (ctx: C3Context) => {

--- a/packages/create-cloudflare/templates/qwik/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates/qwik/templates/wrangler.toml
@@ -2,6 +2,7 @@
 name = "<TBD>"
 compatibility_date = "<TBD>"
 pages_build_output_dir = "./dist"
+compatibility_flags = ["nodejs_compat"]
 
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Pages Function, running it closer to your back-end infrastructure


### PR DESCRIPTION
## What this PR solves / how to test

This PR bumps the create-qwik version to `1.9.0`

It also adds the missing `nodejs_compat` flag needed by the qwik starter template

Fixes N/A

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: the tests are already present
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not user facing changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
