### PR TITLE
fix(wrangler): Support switching between static and dynamic Workers

### DIFF
--- a/.changeset/bright-guests-destroy.md
+++ b/.changeset/bright-guests-destroy.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Support switching between static and dynamic Workers
+
+This commit fixes the current behaviour of watch mode for Workers with assets, and adds support for switching between static and dynamic Workers within a single `wrangler dev` session.

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -1105,13 +1105,14 @@ describe("watch mode", () => {
 				const { url } = await worker.waitForReady();
 
 				// verify response from Asset Worker
-				let { response } = await fetchWithETag(`${url}/index.html`, {});
+				let response = await fetch(`${url}/index.html`);
+				expect(response.status).toBe(200);
 				expect(await response.text()).toBe("<h1>Hello Workers + Assets</h1>");
 
 				// verify no response from route that will be handled by the
 				// User Worker in the future
-				({ response } = await fetchWithETag(`${url}/hey`, {}));
-				expect(await response.status).toBe(404);
+				response = await fetch(`${url}/hey`);
+				expect(response.status).toBe(404);
 
 				await helper.seed({
 					"wrangler.toml": dedent`
@@ -1132,10 +1133,14 @@ describe("watch mode", () => {
 
 				await worker.waitForReload();
 
-				({ response } = await fetchWithETag(`${url}/index.html`, {}));
+				// verify we still get the correct response for the Asset Worker
+				response = await fetch(`${url}/index.html`);
+				expect(response.status).toBe(200);
 				expect(await response.text()).toBe("<h1>Hello Workers + Assets</h1>");
 
-				({ response } = await fetchWithETag(`${url}/hey`, {}));
+				// verify response from User Worker
+				response = await fetch(`${url}/hey`);
+				expect(response.status).toBe(200);
 				expect(await response.text()).toBe("Hello from user Worker!");
 			});
 
@@ -1164,11 +1169,13 @@ describe("watch mode", () => {
 				const { url } = await worker.waitForReady();
 
 				// verify response from Asset Worker
-				let { response } = await fetchWithETag(`${url}/index.html`, {});
+				let response = await fetch(`${url}/index.html`);
+				expect(response.status).toBe(200);
 				expect(await response.text()).toBe("<h1>Hello Workers + Assets</h1>");
 
 				// verify response from User Worker
-				({ response } = await fetchWithETag(`${url}/hey`, {}));
+				response = await fetch(`${url}/hey`);
+				expect(response.status).toBe(200);
 				expect(await response.text()).toBe("Hello from user Worker!");
 
 				await helper.seed({
@@ -1184,12 +1191,13 @@ describe("watch mode", () => {
 				await worker.waitForReload();
 
 				// verify we still get the correct response from Asset Worker
-				({ response } = await fetchWithETag(`${url}/index.html`, {}));
+				response = await fetch(`${url}/index.html`);
+				expect(response.status).toBe(200);
 				expect(await response.text()).toBe("<h1>Hello Workers + Assets</h1>");
 
 				// verify we no longer get a response from the User Worker
-				({ response } = await fetchWithETag(`${url}/hey`, {}));
-				expect(await response.status).toBe(404);
+				response = await fetch(`${url}/hey`);
+				expect(response.status).toBe(404);
 			});
 		}
 	);
@@ -1301,14 +1309,14 @@ describe("watch mode", () => {
 			const { url } = await worker.waitForReady();
 
 			// verify response from Asset Worker
-			let { response } = await fetchWithETag(`${url}/index.html`, {});
+			let response = await fetch(`${url}/index.html`);
+			expect(response.status).toBe(200);
 			expect(await response.text()).toBe("<h1>Hello Workers + Assets</h1>");
-			expect(await response.status).toBe(200);
 
 			// verify no response from route that will be handled by the
 			// User Worker in the future
-			({ response } = await fetchWithETag(`${url}/hey`, {}));
-			expect(await response.status).toBe(404);
+			response = await fetch(`${url}/hey`);
+			expect(response.status).toBe(404);
 
 			await helper.seed({
 				"wrangler.toml": dedent`
@@ -1320,13 +1328,15 @@ describe("watch mode", () => {
 
 			await worker.waitForReload();
 
-			({ response } = await fetchWithETag(`${url}/index.html`, {}));
+			// verify response from Asset Worker
+			response = await fetch(`${url}/index.html`);
+			expect(response.status).toBe(200);
 			expect(await response.text()).toBe("<h1>Hello Workers + Assets</h1>");
-			expect(await response.status).toBe(200);
 
-			({ response } = await fetchWithETag(`${url}/hey`, {}));
+			// verify response from User Worker
+			response = await fetch(`${url}/hey`);
+			expect(response.status).toBe(200);
 			expect(await response.text()).toBe("Hello from user Worker!");
-			expect(await response.status).toBe(200);
 		});
 
 		it(`supports switching from Workers with assets to assets-only Workers during the current dev session`, async () => {
@@ -1350,14 +1360,14 @@ describe("watch mode", () => {
 			const { url } = await worker.waitForReady();
 
 			// verify response from Asset Worker
-			let { response } = await fetchWithETag(`${url}/index.html`, {});
+			let response = await fetch(`${url}/index.html`);
+			expect(response.status).toBe(200);
 			expect(await response.text()).toBe("<h1>Hello Workers + Assets</h1>");
-			expect(await response.status).toBe(200);
 
 			// verify response from User Worker
-			({ response } = await fetchWithETag(`${url}/hey`, {}));
+			response = await fetch(`${url}/hey`);
+			expect(response.status).toBe(200);
 			expect(await response.text()).toBe("Hello from user Worker!");
-			expect(await response.status).toBe(200);
 
 			await helper.seed({
 				"wrangler.toml": dedent`
@@ -1368,14 +1378,14 @@ describe("watch mode", () => {
 
 			await worker.waitForReload();
 
-			({ response } = await fetchWithETag(`${url}/index.html`, {}));
+			response = await fetch(`${url}/index.html`);
 			// verify response from Asset
+			expect(response.status).toBe(200);
 			expect(await response.text()).toBe("<h1>Hello Workers + Assets</h1>");
-			expect(await response.status).toBe(200);
 
 			// verify no response from User Worker
-			({ response } = await fetchWithETag(`${url}/hey`, {}));
-			expect(await response.status).toBe(404);
+			response = await fetch(`${url}/hey`);
+			expect(response.status).toBe(404);
 		});
 	});
 });

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -845,32 +845,22 @@ export async function startDev(args: StartDevOptions) {
 
 					logger.log(`${path.basename(config.configPath)} changed...`);
 
-					/*
-					 * If this is a Worker with assets, we want to enable switching
-					 * from assets only Worker to Worker with assets and vice versa
-					 * during local development. For that, we need to watch for changes
-					 * in the `wrangler.toml` file, specifically the `main` configuration
-					 * key, and re-asses the entry point every time.
-					 */
-					if (experimentalAssetsOptions?.directory) {
-						entry = await getEntry(
-							{
-								legacyAssets: args.legacyAssets,
-								script: args.script,
-								moduleRoot: args.moduleRoot,
-								experimentalAssets: args.experimentalAssets,
-							},
-							config,
-							"dev"
-						);
+					// ensure we reflect config changes in the `main` entry point
+					entry = await getEntry(
+						{
+							legacyAssets: args.legacyAssets,
+							script: args.script,
+							moduleRoot: args.moduleRoot,
+							experimentalAssets: args.experimentalAssets,
+						},
+						config,
+						"dev"
+					);
 
-						// this gets passed into the Dev React element, so ensure we don't
-						// block scope this var
-						experimentalAssetsOptions = processExperimentalAssetsArg(
-							args,
-							config
-						);
-					}
+					experimentalAssetsOptions = processExperimentalAssetsArg(
+						args,
+						config
+					);
 
 					/*
 					 * Handle experimental assets watching on config file changes

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -328,45 +328,46 @@ export function processExperimentalAssetsArg(
 	const experimentalAssets = args.experimentalAssets
 		? { directory: args.experimentalAssets }
 		: config.experimental_assets;
-	let experimentalAssetsOptions: ExperimentalAssetsOptions | undefined;
-	if (experimentalAssets) {
-		const experimentalAssetsBasePath = getExperimentalAssetsBasePath(
-			config,
-			args.experimentalAssets
-		);
-		const resolvedExperimentalAssetsPath = path.resolve(
-			experimentalAssetsBasePath,
-			experimentalAssets.directory
-		);
 
-		if (!existsSync(resolvedExperimentalAssetsPath)) {
-			const sourceOfTruthMessage = args.experimentalAssets
-				? '"--experimental-assets" command line argument'
-				: '"experimental_assets.directory" field in your configuration file';
-
-			throw new UserError(
-				`The directory specified by the ${sourceOfTruthMessage} does not exist:\n` +
-					`${resolvedExperimentalAssetsPath}`
-			);
-		}
-
-		experimentalAssets.directory = resolvedExperimentalAssetsPath;
-		const routingConfig = {
-			has_user_worker: Boolean(args.script || config.main),
-		};
-		// defaults are set in asset worker
-		const assetConfig = {
-			html_handling: config.experimental_assets?.html_handling,
-			not_found_handling: config.experimental_assets?.not_found_handling,
-		};
-		experimentalAssetsOptions = {
-			...experimentalAssets,
-			routingConfig,
-			assetConfig,
-		};
+	if (!experimentalAssets) {
+		return;
 	}
 
-	return experimentalAssetsOptions;
+	const experimentalAssetsBasePath = getExperimentalAssetsBasePath(
+		config,
+		args.experimentalAssets
+	);
+	const resolvedExperimentalAssetsPath = path.resolve(
+		experimentalAssetsBasePath,
+		experimentalAssets.directory
+	);
+
+	if (!existsSync(resolvedExperimentalAssetsPath)) {
+		const sourceOfTruthMessage = args.experimentalAssets
+			? '"--experimental-assets" command line argument'
+			: '"experimental_assets.directory" field in your configuration file';
+
+		throw new UserError(
+			`The directory specified by the ${sourceOfTruthMessage} does not exist:\n` +
+				`${resolvedExperimentalAssetsPath}`
+		);
+	}
+
+	experimentalAssets.directory = resolvedExperimentalAssetsPath;
+	const routingConfig = {
+		has_user_worker: Boolean(args.script || config.main),
+	};
+	// defaults are set in asset worker
+	const assetConfig = {
+		html_handling: config.experimental_assets?.html_handling,
+		not_found_handling: config.experimental_assets?.not_found_handling,
+	};
+
+	return {
+		...experimentalAssets,
+		routingConfig,
+		assetConfig,
+	};
 }
 
 /**


### PR DESCRIPTION
## What this PR solves / how to test

This commit fixes the current behaviour of watch mode for Workers with assets, and adds support for switching between static and dynamic Workers within a single `wrangler dev` session.

Fixes [WC-2721](https://jira.cfdata.org/browse/WC-2721)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
