### PR TITLE
fix: disable observability on deploy if not explicitly defined in config

### DIFF
--- a/.changeset/old-mugs-begin.md
+++ b/.changeset/old-mugs-begin.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: disable observability on deploy if not explicitly defined in config
+
+When deploying a Worker that has observability enabled in the deployed version but not specified in the `wrangler.toml` Wrangler will now set observability to disabled for the new version to match the `wrangler.toml` as the source of truth.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -10880,6 +10880,29 @@ export default{
 				Current Version ID: Galaxy-Class"
 			`);
 		});
+
+		it("should disable observability if not explicitly defined", async () => {
+			writeWranglerToml({});
+			await fs.promises.writeFile("index.js", `export default {};`);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedSettingsPatch: {
+					observability: {
+						enabled: false,
+					},
+				},
+			});
+
+			await runWrangler("publish index.js");
+			expect(std.out).toMatchInlineSnapshot(`
+				"Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
+		});
 	});
 });
 

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -829,11 +829,14 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 					versionMap.set(versionResult.id, 100);
 					await createDeployment(accountId, scriptName, versionMap, undefined);
 
-					// Update tail consumers and logpush settings
+					// Update tail consumers, logpush, and observability settings
 					await patchNonVersionedScriptSettings(accountId, scriptName, {
 						tail_consumers: worker.tail_consumers,
 						logpush: worker.logpush,
-						observability: worker.observability,
+						// If the user hasn't specified observability assume that they want it disabled if they have it on.
+						// This is a no-op in the event that they don't have observability enabled, but will remove observability
+						// if it has been removed from their wrangler.toml
+						observability: worker.observability ?? { enabled: false },
 					});
 
 					const { available_on_subdomain } = await fetchResult<{

--- a/packages/wrangler/src/versions/api.ts
+++ b/packages/wrangler/src/versions/api.ts
@@ -125,7 +125,7 @@ export async function createDeployment(
 	);
 }
 
-type NonVersionedScriptSettings = {
+export type NonVersionedScriptSettings = {
 	logpush: boolean;
 	tail_consumers: TailConsumer[];
 	observability: Observability;


### PR DESCRIPTION
## What this PR solves / how to test

Changes the deploy behavior deploys using the new versions API to disable observability if it isn't explicitly defined in the user's `wrangler.toml`. This behaves differently from how `logpush` and `tail_consumers` work, where they must be explicitly removed, but we decided that this PR's behavior matches user expectations better.

Fixes [WO-186](https://jira.cfdata.org/browse/WO-186)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: minor bug fix for unreleased feature
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because: minor bug fix for unreleased feature
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor bug fix for unreleased feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
