### PR TITLE
fix(wrangler): Error if Workers + Assets are run in remote mode

### DIFF
--- a/.changeset/hot-poems-march.md
+++ b/.changeset/hot-poems-march.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Error if Workers + Assets are run in remote mode
+
+Workers + Assets are currently supported only in local mode. We should throw an error if users attempt to use Workers with assets in remote mode.

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1666,6 +1666,27 @@ describe("wrangler dev", () => {
 				`[Error: Cannot use Experimental Assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets.]`
 			);
 		});
+
+		it("should error if --experimental-assets and --remote are used together", async () => {
+			fs.openSync("public", "w");
+			await expect(
+				runWrangler("dev --experimental-assets public --remote")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Experimental Assets in remote mode. Workers with assets are only supported in local mode.]`
+			);
+		});
+
+		it("should error if config.experimental_assets and --remote are used together", async () => {
+			writeWranglerToml({
+				experimental_assets: { directory: "./public" },
+			});
+			fs.openSync("public", "w");
+			await expect(
+				runWrangler("dev --remote")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Experimental Assets in remote mode. Workers with assets are only supported in local mode.]`
+			);
+		});
 	});
 
 	describe("--inspect", () => {

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -345,7 +345,7 @@ describe("wrangler dev", () => {
 					directory: "assets",
 				},
 			});
-			fs.openSync("assets", "w");
+			fs.mkdirSync("assets");
 			await expect(runWrangler(`dev`)).rejects
 				.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Invalid Routes:
@@ -1505,7 +1505,7 @@ describe("wrangler dev", () => {
 
 	describe("--experimental-assets", () => {
 		it("should not require entry point if using --experimental-assets", async () => {
-			fs.openSync("assets", "w");
+			fs.mkdirSync("assets");
 			writeWranglerToml({
 				experimental_assets: { directory: "assets" },
 			});
@@ -1522,7 +1522,7 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			fs.openSync("assets", "w");
+			fs.mkdirSync("assets");
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1538,7 +1538,7 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			fs.openSync("assets", "w");
+			fs.mkdirSync("assets");
 			await expect(
 				runWrangler("dev --experimental-assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1559,7 +1559,7 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			fs.openSync("assets", "w");
+			fs.mkdirSync("assets");
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1569,7 +1569,7 @@ describe("wrangler dev", () => {
 
 		it("should error if --experimental-assets and --legacy-assets are used together", async () => {
 			fs.writeFileSync("index.js", `export default {};`);
-			fs.openSync("assets", "w");
+			fs.mkdirSync("assets");
 			await expect(
 				runWrangler("dev --experimental-assets assets --legacy-assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1589,7 +1589,7 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			fs.openSync("assets", "w");
+			fs.mkdirSync("assets");
 			await expect(
 				runWrangler("dev --experimental-assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1605,7 +1605,7 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			fs.openSync("xyz", "w");
+			fs.mkdirSync("xyz");
 			await expect(
 				runWrangler("dev --legacy-assets xyz")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1646,7 +1646,7 @@ describe("wrangler dev", () => {
 			writeWranglerToml({
 				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
 			});
-			fs.openSync("public", "w");
+			fs.mkdirSync("public");
 			await expect(
 				runWrangler("dev --experimental-assets public")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1659,7 +1659,7 @@ describe("wrangler dev", () => {
 				experimental_assets: { directory: "./public" },
 				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
 			});
-			fs.openSync("public", "w");
+			fs.mkdirSync("public");
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1668,11 +1668,11 @@ describe("wrangler dev", () => {
 		});
 
 		it("should error if --experimental-assets and --remote are used together", async () => {
-			fs.openSync("public", "w");
+			fs.mkdirSync("public");
 			await expect(
 				runWrangler("dev --experimental-assets public --remote")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets in remote mode. Workers with assets are only supported in local mode.]`
+				`[Error: Cannot use Experimental Assets in remote mode. Workers with assets are only supported in local mode. Please use \`wrangler dev\`.]`
 			);
 		});
 
@@ -1680,11 +1680,11 @@ describe("wrangler dev", () => {
 			writeWranglerToml({
 				experimental_assets: { directory: "./public" },
 			});
-			fs.openSync("public", "w");
+			fs.mkdirSync("public");
 			await expect(
 				runWrangler("dev --remote")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets in remote mode. Workers with assets are only supported in local mode.]`
+				`[Error: Cannot use Experimental Assets in remote mode. Workers with assets are only supported in local mode. Please use \`wrangler dev\`.]`
 			);
 		});
 	});

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -612,6 +612,15 @@ export async function startDev(args: StartDevOptions) {
 			);
 		}
 
+		if (
+			(args.experimentalAssets || config.experimental_assets) &&
+			args.remote
+		) {
+			throw new UserError(
+				"Cannot use Experimental Assets in remote mode. Workers with assets are only supported in local mode. Please use `wrangler dev`."
+			);
+		}
+
 		verifyMutuallyExclusiveAssetsArgsOrConfig(args, config);
 
 		let experimentalAssetsOptions = processExperimentalAssetsArg(args, config);

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -412,6 +412,15 @@ export function verifyMutuallyExclusiveAssetsArgsOrConfig(
 			"Cannot use Experimental Assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets."
 		);
 	}
+
+	if (
+		(args.experimentalAssets || config.experimental_assets) &&
+		(args as StartDevOptions).remote
+	) {
+		throw new UserError(
+			"Cannot use Experimental Assets in remote mode. Workers with assets are only supported in local mode. Please use `wrangler dev`."
+		);
+	}
 }
 
 const CF_ASSETS_IGNORE_FILENAME = ".assetsignore";

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -412,15 +412,6 @@ export function verifyMutuallyExclusiveAssetsArgsOrConfig(
 			"Cannot use Experimental Assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets."
 		);
 	}
-
-	if (
-		(args.experimentalAssets || config.experimental_assets) &&
-		(args as StartDevOptions).remote
-	) {
-		throw new UserError(
-			"Cannot use Experimental Assets in remote mode. Workers with assets are only supported in local mode. Please use `wrangler dev`."
-		);
-	}
 }
 
 const CF_ASSETS_IGNORE_FILENAME = ".assetsignore";


### PR DESCRIPTION
## What this PR solves / how to test

Workers + Assets are currently supported only in local mode. We should throw an error if users attempt to use Workers with assets in remote mode.

<img width="926" alt="Screenshot 2024-09-19 at 20 54 26" src="https://github.com/user-attachments/assets/3a5eab3f-faa8-48aa-b1db-4aa19ffaf372">

Fixes [WC-2743](https://jira.cfdata.org/browse/WC-2743)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
