### PR TITLE
chore: update actions/upload-artifact to v4

### DIFF
--- a/.github/actions/run-c3-e2e/action.yml
+++ b/.github/actions/run-c3-e2e/action.yml
@@ -61,7 +61,7 @@ runs:
         CI_OS: ${{ runner.os }}
 
     - name: Upload Logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: e2e-logs-${{matrix.os}}
@@ -69,7 +69,7 @@ runs:
 
     - name: Upload Framework Diffs
       if: ${{ steps.run-e2e.outcome == 'success' && inputs.saveDiffs == 'true' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: e2e-framework-diffs
         path: packages/create-cloudflare/.e2e-diffs

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -31,7 +31,7 @@ jobs:
         run: node .github/extract-runtime-versions.mjs # extract versions before modifying version to include commit hash
 
       - name: Upload runtime versions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: runtime-versions.md
           path: runtime-versions.md

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,21 +64,21 @@ jobs:
 
       - name: Upload debug logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-debug-logs-${{ matrix.os }}-${{ matrix.node }}
           path: ${{ runner.temp }}/wrangler-debug-logs/
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-report-${{ matrix.os }}-${{ matrix.node }}
           path: ${{ runner.temp }}/test-report/
 
       - name: Upload turbo logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: turbo-runs-${{ matrix.os }}-${{ matrix.node }}
           path: .turbo/runs

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -131,14 +131,14 @@ jobs:
 
       - name: Upload debug logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-debug-logs-${{ matrix.os }}-${{ matrix.node }}
           path: ${{ runner.temp }}/wrangler-debug-logs/
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-report-${{ matrix.os }}-${{ matrix.node }}
           path: ${{ runner.temp }}/test-report/


### PR DESCRIPTION
## What this PR solves / how to test

Warning in the CI:

<img width="1342" alt="image" src="https://github.com/user-attachments/assets/b4ceb563-dcc6-4689-8626-0945a1bed76c">

https://github.com/actions/upload-artifact says:

> [!WARNING]
> actions/upload-artifact@v3 is scheduled for deprecation on **November 30, 2024**. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
> Similarly, v1/v2 are scheduled for deprecation on **June 30, 2024**.
> Please update your workflow to use v4 of the artifact actions.
> This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.

Fixes N/A

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: CI update
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: CI dep update
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: CI dep update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
