### PR TITLE
Add missing bindings to `init --from-dash`

### DIFF
--- a/.changeset/pink-months-promise.md
+++ b/.changeset/pink-months-promise.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Add missing binding to `init --from-dash`

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -2566,6 +2566,46 @@ describe("init", () => {
 						name: "UNSAFE_BINDING_TWO",
 						data: 1337,
 					},
+					{
+						type: "inherit",
+						name: "INHERIT_BINDING",
+					},
+					{
+						type: "pipelines",
+						name: "PIPELINE_BINDING",
+						id: "some-id",
+					},
+					{
+						type: "mtls_certificate",
+						name: "MTLS_BINDING",
+						certificate_id: "some-id",
+					},
+					{
+						type: "hyperdrive",
+						name: "HYPER_BINDING",
+						id: "some-id",
+					},
+					{
+						type: "vectorize",
+						name: "VECTOR_BINDING",
+						index_name: "some-name",
+					},
+					{
+						type: "queue",
+						name: "queue_BINDING",
+						queue_name: "some-name",
+						delivery_delay: 1,
+					},
+					{
+						type: "send_email",
+						name: "EMAIL_BINDING",
+						destination_address: "some@address.com",
+						allowed_destination_addresses: ["some2@address.com"],
+					},
+					{
+						type: "version_metadata",
+						name: "Version_BINDING",
+					},
 				],
 				routes = [
 					{
@@ -2720,6 +2760,53 @@ describe("init", () => {
 							name: "UNSAFE_BINDING_TWO",
 							type: "another unsafe thing",
 							data: 1337,
+						},
+						{
+							name: "INHERIT_BINDING",
+							type: "inherit",
+						},
+					],
+				},
+				vectorize: [
+					{
+						binding: "VECTOR_BINDING",
+						index_name: "some-name",
+					},
+				],
+				send_email: [
+					{
+						allowed_destination_addresses: ["some2@address.com"],
+						destination_address: "some@address.com",
+						name: "EMAIL_BINDING",
+					},
+				],
+				version_metadata: {
+					binding: "Version_BINDING",
+				},
+				hyperdrive: [
+					{
+						binding: "HYPER_BINDING",
+						id: "some-id",
+					},
+				],
+				mtls_certificates: [
+					{
+						binding: "MTLS_BINDING",
+						certificate_id: "some-id",
+					},
+				],
+				pipelines: [
+					{
+						binding: "PIPELINE_BINDING",
+						pipeline: "some-id",
+					},
+				],
+				queues: {
+					producers: [
+						{
+							binding: "queue_BINDING",
+							delivery_delay: 1,
+							queue: "some-name",
 						},
 					],
 				},
@@ -3250,6 +3337,39 @@ describe("init", () => {
 					  type = \\"another unsafe thing\\"
 					  name = \\"UNSAFE_BINDING_TWO\\"
 					  data = 1_337
+
+					  [[unsafe.bindings]]
+					  type = \\"inherit\\"
+					  name = \\"INHERIT_BINDING\\"
+
+					[[pipelines]]
+					binding = \\"PIPELINE_BINDING\\"
+					pipeline = \\"some-id\\"
+
+					[[mtls_certificates]]
+					binding = \\"MTLS_BINDING\\"
+					certificate_id = \\"some-id\\"
+
+					[[hyperdrive]]
+					binding = \\"HYPER_BINDING\\"
+					id = \\"some-id\\"
+
+					[[vectorize]]
+					binding = \\"VECTOR_BINDING\\"
+					index_name = \\"some-name\\"
+
+					[[queues.producers]]
+					binding = \\"queue_BINDING\\"
+					queue = \\"some-name\\"
+					delivery_delay = 1
+
+					[[send_email]]
+					name = \\"EMAIL_BINDING\\"
+					destination_address = \\"some@address.com\\"
+					allowed_destination_addresses = [ \\"some2@address.com\\" ]
+
+					[version_metadata]
+					binding = \\"Version_BINDING\\"
 					"
 				`);
 				expect(std.out).toContain("cd isolinear-optical-chip");


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6735

Adds missing bindings to `init --from-dash`, as well as an `assertNever()` type check to ensure this list doesn't get out of sync in future

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Wrangler tests are sufficient
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
