### PR TITLE
Handle more module declaration cases

### DIFF
--- a/.changeset/popular-horses-hide.md
+++ b/.changeset/popular-horses-hide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Handle more module declaration cases

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as TOML from "@iarna/toml";
 import {
+	constructTSModuleGlob,
 	constructType,
 	constructTypeKey,
 	generateImportSpecifier,
@@ -45,6 +46,22 @@ describe("constructTypeKey", () => {
 		expect(constructTypeKey("123invalid")).toBe('"123invalid"');
 		expect(constructTypeKey("invalid-123")).toBe('"invalid-123"');
 		expect(constructTypeKey("invalid 123")).toBe('"invalid 123"');
+	});
+});
+
+describe.only("constructTSModuleGlob() should return a valid TS glob ", () => {
+	it.each([
+		["**/*.wasm", "*.wasm"],
+		["**/*.txt", "*.txt"],
+		["**/foo", "*/foo"],
+		["**/*foo", "*foo"],
+		["file.foo", "file.foo"],
+		["folder/file.foo", "folder/file.foo"],
+		["folder/*", "folder/*"],
+		["folder/**", "folder/*"],
+		["folder/**/*", "folder/*"],
+	])("$1 -> $2", (from, to) => {
+		expect(constructTSModuleGlob(from)).toBe(to);
 	});
 });
 

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -49,7 +49,7 @@ describe("constructTypeKey", () => {
 	});
 });
 
-describe.only("constructTSModuleGlob() should return a valid TS glob ", () => {
+describe("constructTSModuleGlob() should return a valid TS glob ", () => {
 	it.each([
 		["**/*.wasm", "*.wasm"],
 		["**/*.txt", "*.txt"],

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -165,6 +165,19 @@ export function constructTypeKey(key: string) {
 	return `"${key}"`;
 }
 
+export function constructTSModuleGlob(glob: string) {
+	// Exact module reference, don't transform
+	if (!glob.includes("*")) {
+		return glob;
+		// Usually something like **/*.wasm. Turn into *.wasm
+	} else if (glob.includes(".")) {
+		return `*.${glob.split(".").at(-1)}`;
+	} else {
+		// Replace common patterns
+		return glob.replace("**/*", "*").replace("**/", "*/").replace("/**", "/*");
+	}
+}
+
 /**
  * Generate a import specifier from one module to another
  */
@@ -426,9 +439,7 @@ async function generateTypes(
 				moduleTypeMap[ruleObject.type as keyof typeof moduleTypeMap];
 			if (typeScriptType !== undefined) {
 				ruleObject.globs.forEach((glob) => {
-					modulesTypeStructure.push(`declare module "*.${glob
-						.split(".")
-						.at(-1)}" {
+					modulesTypeStructure.push(`declare module "${constructTSModuleGlob(glob)}" {
 	const value: ${typeScriptType};
 	export default value;
 }`);


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6730

Handle more rule glob cases when generating `declare module "..." { }` types

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no e2e coverage
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
