### PR TITLE
fix: error when asset binding is provided without user worker

### DIFF
--- a/.changeset/silly-birds-shout.md
+++ b/.changeset/silly-birds-shout.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: error if an asset binding is provided without a Worker script

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4385,6 +4385,20 @@ addEventListener('fetch', event => {});`
 			);
 		});
 
+		it("should error if an ASSET binding is provided without a user Worker", async () => {
+			writeWranglerToml({
+				experimental_assets: {
+					directory: "xyz",
+					binding: "ASSET",
+				},
+			});
+			await expect(
+				runWrangler("deploy")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Experimental Assets with a binding in a assets-only Worker.]`
+			);
+		});
+
 		it("should be able to upload files with special characters in filepaths", async () => {
 			// NB windows will disallow these characters in file paths anyway < > : " / \ | ? *
 			const assets = [

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4345,7 +4345,8 @@ addEventListener('fetch', event => {});`
 			await expect(
 				runWrangler("deploy")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.]`
+				dedent`[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.
+				Please remove either the \`site\` or \`experimental_assets\` field from your configuration file.]`
 			);
 		});
 
@@ -4360,7 +4361,8 @@ addEventListener('fetch', event => {});`
 			await expect(
 				runWrangler("deploy --experimental-assets abc")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.]`
+				dedent`[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.
+				Please remove either the \`site\` or \`experimental_assets\` field from your configuration file.]`
 			);
 		});
 
@@ -4392,11 +4394,11 @@ addEventListener('fetch', event => {});`
 					binding: "ASSET",
 				},
 			});
-			await expect(
-				runWrangler("deploy")
-			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets with a binding in a assets-only Worker.]`
-			);
+			await expect(runWrangler("deploy")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Cannot use Experimental Assets with a binding in an assets-only Worker.
+				Please remove the asset binding from your configuration file, or provide a Worker script in your configuration file (\`main\`).]
+			`);
 		});
 
 		it("should be able to upload files with special characters in filepaths", async () => {

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1613,6 +1613,17 @@ describe("wrangler dev", () => {
 			);
 		});
 
+		it("should error if an ASSET binding is provided without a user Worker", async () => {
+			writeWranglerToml({
+				experimental_assets: { directory: "assets", binding: "ASSETS" },
+			});
+			await expect(
+				runWrangler("dev")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use Experimental Assets with a binding in a assets-only Worker.]`
+			);
+		});
+
 		it("should error if directory specified by '--experimental-assets' command line argument does not exist", async () => {
 			writeWranglerToml({
 				main: "./index.js",

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -1526,7 +1526,10 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.]`
+				`
+				[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.
+				Please remove either the \`site\` or \`experimental_assets\` field from your configuration file.]
+			`
 			);
 		});
 
@@ -1542,7 +1545,10 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --experimental-assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.]`
+				`
+				[Error: Cannot use Experimental Assets and Workers Sites in the same Worker.
+				Please remove either the \`site\` or \`experimental_assets\` field from your configuration file.]
+			`
 			);
 		});
 
@@ -1563,7 +1569,10 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.]`
+				`
+				[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.
+				Please remove either the \`site\` or \`experimental_assets\` field from your configuration file.]
+			`
 			);
 		});
 
@@ -1573,7 +1582,10 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --experimental-assets assets --legacy-assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.]`
+				`
+				[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.
+				Please remove either the \`site\` or \`experimental_assets\` field from your configuration file.]
+			`
 			);
 		});
 
@@ -1593,7 +1605,10 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --experimental-assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.]`
+				`
+				[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.
+				Please remove either the \`site\` or \`experimental_assets\` field from your configuration file.]
+			`
 			);
 		});
 
@@ -1609,7 +1624,10 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev --legacy-assets xyz")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.]`
+				`
+				[Error: Cannot use Experimental Assets and Legacy Assets in the same Worker.
+				Please remove either the \`site\` or \`experimental_assets\` field from your configuration file.]
+			`
 			);
 		});
 
@@ -1620,7 +1638,10 @@ describe("wrangler dev", () => {
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use Experimental Assets with a binding in a assets-only Worker.]`
+				`
+				[Error: Cannot use Experimental Assets with a binding in an assets-only Worker.
+				Please remove the asset binding from your configuration file, or provide a Worker script in your configuration file (\`main\`).]
+			`
 			);
 		});
 

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -5,7 +5,7 @@ import { getEntry } from "../deployment-bundle/entry";
 import { UserError } from "../errors";
 import {
 	processExperimentalAssetsArg,
-	verifyMutuallyExclusiveAssetsArgsOrConfig,
+	validateAssetsArgsAndConfig,
 } from "../experimental-assets";
 import {
 	getRules,
@@ -292,7 +292,7 @@ export async function deployHandler(args: DeployArgs) {
 		);
 	}
 
-	verifyMutuallyExclusiveAssetsArgsOrConfig(args, config);
+	validateAssetsArgsAndConfig(args, config);
 
 	const experimentalAssetsOptions = processExperimentalAssetsArg(args, config);
 

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -24,7 +24,7 @@ import { startDevServer } from "./dev/start-server";
 import { UserError } from "./errors";
 import {
 	processExperimentalAssetsArg,
-	verifyMutuallyExclusiveAssetsArgsOrConfig,
+	validateAssetsArgsAndConfig,
 } from "./experimental-assets";
 import { run } from "./experimental-flags";
 import isInteractive from "./is-interactive";
@@ -621,7 +621,7 @@ export async function startDev(args: StartDevOptions) {
 			);
 		}
 
-		verifyMutuallyExclusiveAssetsArgsOrConfig(args, config);
+		validateAssetsArgsAndConfig(args, config);
 
 		let experimentalAssetsOptions = processExperimentalAssetsArg(args, config);
 		if (experimentalAssetsOptions) {

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -371,16 +371,23 @@ export function processExperimentalAssetsArg(
 }
 
 /**
+ * Validate assets configuration after CLI args and config have been combined.
+ *
  * Workers assets cannot be used in combination with a few other select
  * Workers features, such as: legacy assets, sites and tail consumers.
  *
- * This function ensures that if any of these mutually exclusive config
- * keys or command args are used together, an appropriate error is thrown.
+ * An asset binding cannot be used in a Worker that only has assets.
  */
-export function verifyMutuallyExclusiveAssetsArgsOrConfig(
+export function validateAssetsArgsAndConfig(
 	args:
-		| Pick<StartDevOptions, "legacyAssets" | "site" | "experimentalAssets">
-		| Pick<DeployArgs, "legacyAssets" | "site" | "experimentalAssets">,
+		| Pick<
+				StartDevOptions,
+				"legacyAssets" | "site" | "experimentalAssets" | "script"
+		  >
+		| Pick<
+				DeployArgs,
+				"legacyAssets" | "site" | "experimentalAssets" | "script"
+		  >,
 	config: Config
 ) {
 	/*
@@ -411,6 +418,12 @@ export function verifyMutuallyExclusiveAssetsArgsOrConfig(
 	) {
 		throw new UserError(
 			"Cannot use Experimental Assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets."
+		);
+	}
+
+	if (!(args.script || config.main) && config.experimental_assets?.binding) {
+		throw new UserError(
+			"Cannot use Experimental Assets with a binding in a assets-only Worker."
 		);
 	}
 }

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -371,12 +371,11 @@ export function processExperimentalAssetsArg(
 }
 
 /**
- * Validate assets configuration after CLI args and config have been combined.
- *
- * Workers assets cannot be used in combination with a few other select
- * Workers features, such as: legacy assets, sites and tail consumers.
- *
- * An asset binding cannot be used in a Worker that only has assets.
+ * Validate assets configuration against the following requirements:
+ *     - assets cannot be used in combination with a few other select
+ *        Workers features, such as: legacy assets, sites and tail consumers
+ *     - an asset binding cannot be used in a Worker that only has assets
+ * and throw an appropriate error if invalid.
  */
 export function validateAssetsArgsAndConfig(
 	args:
@@ -399,7 +398,8 @@ export function validateAssetsArgsAndConfig(
 		(args.legacyAssets || config.legacy_assets)
 	) {
 		throw new UserError(
-			"Cannot use Experimental Assets and Legacy Assets in the same Worker."
+			"Cannot use Experimental Assets and Legacy Assets in the same Worker.\n" +
+				"Please remove either the `site` or `experimental_assets` field from your configuration file."
 		);
 	}
 
@@ -408,7 +408,8 @@ export function validateAssetsArgsAndConfig(
 		(args.site || config.site)
 	) {
 		throw new UserError(
-			"Cannot use Experimental Assets and Workers Sites in the same Worker."
+			"Cannot use Experimental Assets and Workers Sites in the same Worker.\n" +
+				"Please remove either the `site` or `experimental_assets` field from your configuration file."
 		);
 	}
 
@@ -423,7 +424,8 @@ export function validateAssetsArgsAndConfig(
 
 	if (!(args.script || config.main) && config.experimental_assets?.binding) {
 		throw new UserError(
-			"Cannot use Experimental Assets with a binding in an assets-only Worker."
+			"Cannot use Experimental Assets with a binding in an assets-only Worker.\n" +
+				"Please remove the asset binding from your configuration file, or provide a Worker script in your configuration file (`main`)."
 		);
 	}
 }

--- a/packages/wrangler/src/experimental-assets.ts
+++ b/packages/wrangler/src/experimental-assets.ts
@@ -423,7 +423,7 @@ export function validateAssetsArgsAndConfig(
 
 	if (!(args.script || config.main) && config.experimental_assets?.binding) {
 		throw new UserError(
-			"Cannot use Experimental Assets with a binding in a assets-only Worker."
+			"Cannot use Experimental Assets with a binding in an assets-only Worker."
 		);
 	}
 }

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -5,7 +5,7 @@ import { getEntry } from "../deployment-bundle/entry";
 import { UserError } from "../errors";
 import {
 	processExperimentalAssetsArg,
-	verifyMutuallyExclusiveAssetsArgsOrConfig,
+	validateAssetsArgsAndConfig,
 } from "../experimental-assets";
 import {
 	getRules,
@@ -234,7 +234,7 @@ export async function versionsUploadHandler(
 		);
 	}
 
-	verifyMutuallyExclusiveAssetsArgsOrConfig(
+	validateAssetsArgsAndConfig(
 		{
 			// given that legacyAssets and sites are not supported by
 			// `wrangler versions upload` pass them as undefined to
@@ -242,6 +242,7 @@ export async function versionsUploadHandler(
 			legacyAssets: undefined,
 			site: undefined,
 			experimentalAssets: args.experimentalAssets,
+			script: args.script,
 		},
 		config
 	);


### PR DESCRIPTION
## What this PR solves / how to test

Fixes [WC-2744](https://jira.cfdata.org/browse/WC-2744)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no e2e's for this yet :(
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unreleased feat

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
