### PR TITLE
Retry deployments

### DIFF
--- a/.changeset/chilled-trainers-switch.md
+++ b/.changeset/chilled-trainers-switch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: implement retries within `wrangler deploy` and `wrangler versions upload` to workaround spotty network connections and service flakes

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -37,11 +37,16 @@ describe("versions upload", () => {
 			)
 		);
 	}
-	function mockUploadVersion(has_preview: boolean) {
+	function mockUploadVersion(has_preview: boolean, flakeCount = 1) {
 		msw.use(
 			http.post(
 				`*/accounts/:accountId/workers/scripts/:scriptName/versions`,
 				({ params }) => {
+					if (flakeCount > 0) {
+						flakeCount--;
+						// return HttpResponse.error();
+					}
+
 					expect(params.scriptName).toEqual("test-worker");
 
 					return HttpResponse.json(
@@ -53,8 +58,7 @@ describe("versions upload", () => {
 							},
 						})
 					);
-				},
-				{ once: true }
+				}
 			)
 		);
 	}

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -44,7 +44,7 @@ describe("versions upload", () => {
 				({ params }) => {
 					if (flakeCount > 0) {
 						flakeCount--;
-						// return HttpResponse.error();
+						return HttpResponse.error();
 					}
 
 					expect(params.scriptName).toEqual("test-worker");

--- a/packages/wrangler/src/utils/retry.ts
+++ b/packages/wrangler/src/utils/retry.ts
@@ -1,0 +1,18 @@
+import { setTimeout } from "node:timers/promises";
+
+export async function retryOnError<T>(
+	action: () => T | Promise<T>,
+	backoff = 2_000,
+	attempts = 3
+): Promise<T> {
+	try {
+		return await action();
+	} catch (err) {
+		if (attempts <= 1) {
+			throw err;
+		}
+
+		await setTimeout(backoff);
+		return retryOnError(action, backoff, attempts - 1);
+	}
+}


### PR DESCRIPTION
## What this PR solves / how to test

This PR adds retries within `wrangler deploy` and `wrangler versions upload` to workaround spotty network connections and service flakes

We need to be careful about retrying the whole multi-step process because of some non-atomic steps.

Users have reported flakes at the upload step so we can safely add retries for that step to address those specific failures.

Fixes #0000

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by other tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: transparent change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
