### PR TITLE
chore(create-cloudflare): provide SPARROW_SOURCE_KEY on pre-release and publish build 

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,7 +34,8 @@ jobs:
         env:
           CI_OS: ${{ runner.os }}
           # This is the "production" key for sparrow analytics.
-          # This is needed for create-cloudflare
+          # This is needed for create-cloudflare only as wrangler will be rebuilt in the next step
+          # FIXME: We should removes the need to setup the env in multiple steps
           SPARROW_SOURCE_KEY: "50598e014ed44c739ec8074fdc16057c"
 
       - name: Create Version PR or Publish to NPM

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -33,6 +33,9 @@ jobs:
         run: pnpm run build
         env:
           CI_OS: ${{ runner.os }}
+          # This is the "production" key for sparrow analytics.
+          # This is needed for create-cloudflare
+          SPARROW_SOURCE_KEY: "50598e014ed44c739ec8074fdc16057c"
 
       - name: Create Version PR or Publish to NPM
         id: changesets

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -41,7 +41,8 @@ jobs:
           NODE_ENV: "production"
           CI_OS: ${{ runner.os }}
           # this is the "test/staging" key for sparrow analytics
-          # This is needed for create-cloudflare
+          # This is needed for create-cloudflare only as wrangler will be rebuilt in the next step
+          # FIXME: We should removes the need to setup the env in multiple steps
           SPARROW_SOURCE_KEY: "5adf183f94b3436ba78d67f506965998"
 
       - name: Check for errors

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -40,6 +40,9 @@ jobs:
         env:
           NODE_ENV: "production"
           CI_OS: ${{ runner.os }}
+          # this is the "test/staging" key for sparrow analytics
+          # This is needed for create-cloudflare
+          SPARROW_SOURCE_KEY: "5adf183f94b3436ba78d67f506965998"
 
       - name: Check for errors
         run: pnpm run check


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6484.

We merged #6484 today and thought that the current build setup should be sufficient as both `wrangler` and `create-cloudflare` rely on the same env `SPARROW_SOURCE_KEY`. Unfortunately, wrangler does an additional re-build before publish and the current setup inject the env only on the publish step instead of during the build.

This is a quick fix to enable telemetry in c3. We should removes the need to set the env on both steps in the future.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no feature change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no feature change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: Already covered in #6484 which is merged today
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No feature change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
