### PR TITLE
Remove beta tag from r2 event notification wrangler commands

### DIFF
--- a/.changeset/many-years-nail.md
+++ b/.changeset/many-years-nail.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Remove Beta tag from r2 event notification wrangler command descriptions

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -96,7 +96,7 @@ describe("r2", () => {
 				  wrangler r2 bucket list           List R2 buckets
 				  wrangler r2 bucket delete <name>  Delete an R2 bucket
 				  wrangler r2 bucket sippy          Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket notification   Manage event notification rules for an R2 bucket [open beta]
+				  wrangler r2 bucket notification   Manage event notification rules for an R2 bucket
 
 				GLOBAL FLAGS
 				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
@@ -130,7 +130,7 @@ describe("r2", () => {
 				  wrangler r2 bucket list           List R2 buckets
 				  wrangler r2 bucket delete <name>  Delete an R2 bucket
 				  wrangler r2 bucket sippy          Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket notification   Manage event notification rules for an R2 bucket [open beta]
+				  wrangler r2 bucket notification   Manage event notification rules for an R2 bucket
 
 				GLOBAL FLAGS
 				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
@@ -902,7 +902,7 @@ describe("r2", () => {
 						"
 						wrangler r2 bucket notification list <bucket>
 
-						List event notification rules for a bucket [open beta]
+						List event notification rules for a bucket
 
 						POSITIONALS
 						  bucket  The name of the R2 bucket to get event notification rules for  [string] [required]
@@ -1008,7 +1008,7 @@ describe("r2", () => {
 						"
 						wrangler r2 bucket notification create <bucket>
 
-						Create an event notification rule for an R2 bucket [open beta]
+						Create an event notification rule for an R2 bucket
 
 						POSITIONALS
 						  bucket  The name of the R2 bucket to create an event notification rule for  [string] [required]
@@ -1165,7 +1165,7 @@ describe("r2", () => {
 						"
 						wrangler r2 bucket notification delete <bucket>
 
-						Delete an event notification rule from an R2 bucket [open beta]
+						Delete an event notification rule from an R2 bucket
 
 						POSITIONALS
 						  bucket  The name of the R2 bucket to delete an event notification rule for  [string] [required]

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -3,15 +3,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as stream from "node:stream";
 import { ReadableStream } from "node:stream/web";
-import chalk from "chalk";
 import prettyBytes from "pretty-bytes";
 import { readConfig } from "../config";
 import { FatalError, UserError } from "../errors";
-import {
-	betaCmdColor,
-	CommandLineArgsError,
-	printWranglerBanner,
-} from "../index";
+import { CommandLineArgsError, printWranglerBanner } from "../index";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
@@ -648,24 +643,24 @@ export function r2(r2Yargs: CommonYargsArgv, subHelp: SubHelp) {
 
 			r2BucketYargs.command(
 				"notification",
-				`Manage event notification rules for an R2 bucket ${chalk.hex(betaCmdColor)("[open beta]")}`,
+				"Manage event notification rules for an R2 bucket",
 				(r2EvNotifyYargs) => {
 					return r2EvNotifyYargs
 						.command(
 							["list <bucket>", "get <bucket>"],
-							`List event notification rules for a bucket ${chalk.hex(betaCmdColor)("[open beta]")}`,
+							"List event notification rules for a bucket",
 							Notification.ListOptions,
 							Notification.ListHandler
 						)
 						.command(
 							"create <bucket>",
-							`Create an event notification rule for an R2 bucket ${chalk.hex(betaCmdColor)("[open beta]")}`,
+							"Create an event notification rule for an R2 bucket",
 							Notification.CreateOptions,
 							Notification.CreateHandler
 						)
 						.command(
 							"delete <bucket>",
-							`Delete an event notification rule from an R2 bucket ${chalk.hex(betaCmdColor)("[open beta]")}`,
+							"Delete an event notification rule from an R2 bucket",
 							Notification.DeleteOptions,
 							Notification.DeleteHandler
 						);


### PR DESCRIPTION
## What this PR solves / how to test

Removes beta tag from event notifications wrangler commands.

Fixes N/A

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: test changes covered by unit tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No functional change.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
