### PR TITLE
fix(wrangler): Validate additional config properties for `[observability]`

### DIFF
--- a/.changeset/gentle-goats-greet.md
+++ b/.changeset/gentle-goats-greet.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Validate additional config properties for `[observability]`

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -211,9 +211,9 @@ describe("normalizeAndValidateConfig()", () => {
 			expect("unexpected" in config).toBe(false);
 			expect(diagnostics.hasErrors()).toBe(false);
 			expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			        "Processing wrangler configuration:
-			          - Unexpected fields found in top-level field: \\"unexpected\\""
-		      `);
+				"Processing wrangler configuration:
+				  - Unexpected fields found in top-level field: \\"unexpected\\""
+			`);
 		});
 
 		it("should report a deprecation warning if `miniflare` appears at the top level", () => {
@@ -702,9 +702,9 @@ describe("normalizeAndValidateConfig()", () => {
 
 			expect(normalizePath(diagnostics.renderWarnings()))
 				.toMatchInlineSnapshot(`
-			        "Processing project/wrangler.toml configuration:
-			          - Unexpected fields found in triggers field: \\"someOtherfield\\""
-		      `);
+					"Processing project/wrangler.toml configuration:
+					  - Unexpected fields found in triggers field: \\"someOtherfield\\""
+				`);
 		});
 
 		it("should error on invalid `wasm_modules` paths", () => {
@@ -1778,9 +1778,9 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(config).toEqual(expect.objectContaining(expectedConfig));
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - Unexpected fields found in migrations field: \\"unrecognized_field\\""
-		        `);
+					"Processing wrangler configuration:
+					  - Unexpected fields found in migrations field: \\"unrecognized_field\\""
+				`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			          "Processing wrangler configuration:
 			            - Expected \\"migrations[0].renamed_classes\\" to be an array of \\"{from: string, to: string}\\" objects but got [{\\"from\\":\\"FROM_CLASS\\",\\"to\\":\\"TO_CLASS\\"},{\\"a\\":\\"something\\",\\"b\\":\\"someone\\"}]."
@@ -1902,6 +1902,29 @@ describe("normalizeAndValidateConfig()", () => {
 					"Processing wrangler configuration:
 					  - Expected \\"experimental_assets.directory\\" to be a non-empty string."
 				`);
+			});
+
+			it("should error on invalid additional fields", () => {
+				const expectedConfig = {
+					experimental_assets: {
+						directory: "./public",
+						invalid_field_1: "this is invalid",
+						invalid_field_2: "this is invalid too",
+					},
+				};
+
+				const { config, diagnostics } = normalizeAndValidateConfig(
+					expectedConfig as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(config).toEqual(expect.objectContaining(expectedConfig));
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in experimental_assets field: \\"invalid_field_1\\",\\"invalid_field_2\\""
+				`);
+				expect(diagnostics.hasErrors()).toBeFalsy();
 			});
 		});
 
@@ -2452,11 +2475,11 @@ describe("normalizeAndValidateConfig()", () => {
 					{ env: undefined }
 				);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - Unexpected fields found in d1_databases[2] field: \\"id\\"
-			  - Unexpected fields found in d1_databases[3] field: \\"id\\",\\"preview_id\\"
-			  - Unexpected fields found in d1_databases[4] field: \\"id\\""
-		`);
+					"Processing wrangler configuration:
+					  - Unexpected fields found in d1_databases[2] field: \\"id\\"
+					  - Unexpected fields found in d1_databases[3] field: \\"id\\",\\"preview_id\\"
+					  - Unexpected fields found in d1_databases[4] field: \\"id\\""
+				`);
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			"Processing wrangler configuration:
@@ -2555,9 +2578,9 @@ describe("normalizeAndValidateConfig()", () => {
 					{ env: undefined }
 				);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - Unexpected fields found in hyperdrive[2] field: \\"project\\""
-		`);
+					"Processing wrangler configuration:
+					  - Unexpected fields found in hyperdrive[2] field: \\"project\\""
+				`);
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			"Processing wrangler configuration:
@@ -2657,10 +2680,10 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - Unexpected fields found in queues field: \\"invalidField\\"
-			  - Unexpected fields found in queues.consumers[2] field: \\"invalidField\\""
-		`);
+					"Processing wrangler configuration:
+					  - Unexpected fields found in queues field: \\"invalidField\\"
+					  - Unexpected fields found in queues.consumers[2] field: \\"invalidField\\""
+				`);
 
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			"Processing wrangler configuration:
@@ -3218,11 +3241,11 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - Unexpected fields found in mtls_certificates[3] field: \\"namespace\\"
-			  - Unexpected fields found in mtls_certificates[4] field: \\"id\\"
-			  - Unexpected fields found in mtls_certificates[7] field: \\"service\\""
-		`);
+					"Processing wrangler configuration:
+					  - Unexpected fields found in mtls_certificates[3] field: \\"namespace\\"
+					  - Unexpected fields found in mtls_certificates[4] field: \\"id\\"
+					  - Unexpected fields found in mtls_certificates[7] field: \\"service\\""
+				`);
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
@@ -3334,9 +3357,9 @@ describe("normalizeAndValidateConfig()", () => {
 					{ env: undefined }
 				);
 				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
-			"Processing wrangler configuration:
-			  - Unexpected fields found in pipelines[2] field: \\"project\\""
-		`);
+					"Processing wrangler configuration:
+					  - Unexpected fields found in pipelines[2] field: \\"project\\""
+				`);
 				expect(diagnostics.hasWarnings()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
@@ -5497,7 +5520,12 @@ describe("normalizeAndValidateConfig()", () => {
 					{ env: undefined }
 				);
 
-				expect(diagnostics.hasWarnings()).toBe(false);
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in observability field: \\"notEnabled\\""
+				`);
+
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
@@ -5522,7 +5550,28 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(diagnostics.hasErrors()).toBe(true);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - \`observability.head_sampling_rate\` must be a value between 0 and 1."
+					  - \\"observability.head_sampling_rate\\" must be a value between 0 and 1."
+				`);
+			});
+
+			it("should error on invalid additional fields", () => {
+				const { diagnostics } = normalizeAndValidateConfig(
+					{
+						observability: {
+							enabled: true,
+							invalid_key_1: "hello world",
+							invalid_key_2: "hey there",
+						},
+					} as unknown as RawConfig,
+					undefined,
+					{ env: undefined }
+				);
+
+				expect(diagnostics.hasWarnings()).toBe(true);
+				expect(diagnostics.hasErrors()).toBe(false);
+				expect(diagnostics.renderWarnings()).toMatchInlineSnapshot(`
+					"Processing wrangler configuration:
+					  - Unexpected fields found in observability field: \\"invalid_key_1\\",\\"invalid_key_2\\""
 				`);
 			});
 		});

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -3347,11 +3347,17 @@ const validateObservability: ValidatorFn = (diagnostics, field, value) => {
 			"number"
 		) && isValid;
 
+	isValid =
+		validateAdditionalProperties(diagnostics, field, Object.keys(val), [
+			"enabled",
+			"head_sampling_rate",
+		]) && isValid;
+
 	const samplingRate = val?.head_sampling_rate;
 
 	if (samplingRate && (samplingRate < 0 || samplingRate > 1)) {
 		diagnostics.errors.push(
-			`\`${field}.head_sampling_rate\` must be a value between 0 and 1.`
+			`"${field}.head_sampling_rate" must be a value between 0 and 1.`
 		);
 	}
 


### PR DESCRIPTION
## What this PR solves / how to test

Fixes N/A but please refer to https://github.com/cloudflare/workers-sdk/issues/2586 for the wider scope feat request

`wrangler dev`
<img width="744" alt="Screenshot 2024-09-24 at 08 49 43" src="https://github.com/user-attachments/assets/cb72cf44-7a90-4337-b14b-02263793a3c4">

`wrangler dev --env staging`
<img width="807" alt="Screenshot 2024-09-24 at 08 47 59" src="https://github.com/user-attachments/assets/2f7d4367-90cf-40ee-afcf-3f5bdbb56aff">

`wrangler dev --env production`
<img width="699" alt="Screenshot 2024-09-24 at 08 48 35" src="https://github.com/user-attachments/assets/45e859bb-2762-49f6-a2e0-f0a0eb0013b4">


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: captured by unit tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
