### PR TITLE
PoC: multi-worker wrangler dev

### DIFF
--- a/fixtures/multi-worker/README.md
+++ b/fixtures/multi-worker/README.md
@@ -1,0 +1,11 @@
+# multi-worker
+
+The aim of this fixture is to use `wrangler dev` for multiple workers in the same project.
+
+## Usage
+
+```sh
+npx wrangler dev --x-dev-env \
+    -c packages/worker-a/wrangler.toml \
+    -c packages/worker-b/wrangler.toml
+```

--- a/fixtures/multi-worker/package.json
+++ b/fixtures/multi-worker/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "multi-worker",
+	"workspaces": [
+		"packages/*"
+	],
+	"devDependencies": {
+		"wrangler": "workspace:*"
+	}
+}

--- a/fixtures/multi-worker/packages/package.json
+++ b/fixtures/multi-worker/packages/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "multi-worker",
+	"workspaces": [
+		"worker-a",
+		"worker-b"
+	]
+}

--- a/fixtures/multi-worker/packages/package.json
+++ b/fixtures/multi-worker/packages/package.json
@@ -1,7 +1,0 @@
-{
-	"name": "multi-worker",
-	"workspaces": [
-		"worker-a",
-		"worker-b"
-	]
-}

--- a/fixtures/multi-worker/packages/worker-a/package.json
+++ b/fixtures/multi-worker/packages/worker-a/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "worker-a",
+	"private": true,
+	"scripts": {
+		"deploy": "wrangler deploy",
+		"start": "wrangler dev --x-dev-env"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20240909.0",
+		"wrangler": "workspace:*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/fixtures/multi-worker/packages/worker-a/src/index.ts
+++ b/fixtures/multi-worker/packages/worker-a/src/index.ts
@@ -1,0 +1,21 @@
+export default {
+	async fetch(
+		request: Request,
+		env: Env,
+		ctx: ExecutionContext
+	): Promise<Response> {
+		const result = await env.WORKER_B.hello();
+
+		return new Response(
+            `Worker A called Worker B: ${result}`
+        );
+	},
+};
+
+
+
+
+
+export interface Env {
+	WORKER_B: { hello(): Promise<string> };
+}

--- a/fixtures/multi-worker/packages/worker-a/tsconfig.json
+++ b/fixtures/multi-worker/packages/worker-a/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "es2021",
+		"lib": ["es2021"],
+		"module": "es2022",
+		"types": ["@cloudflare/workers-types/experimental"],
+		"noEmit": true,
+		"isolatedModules": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true
+	}
+}

--- a/fixtures/multi-worker/packages/worker-a/wrangler.toml
+++ b/fixtures/multi-worker/packages/worker-a/wrangler.toml
@@ -1,6 +1,6 @@
 name = "worker-a"
 main = "src/index.ts"
-compatibility_date = "2024-09-22"
+compatibility_date = "2024-09-09"
 
 services = [
   { binding = "WORKER_B", service = "worker-b", entrypoint = "default" }

--- a/fixtures/multi-worker/packages/worker-a/wrangler.toml
+++ b/fixtures/multi-worker/packages/worker-a/wrangler.toml
@@ -1,0 +1,7 @@
+name = "worker-a"
+main = "src/index.ts"
+compatibility_date = "2024-09-22"
+
+services = [
+  { binding = "WORKER_B", service = "worker-b", entrypoint = "default" }
+]

--- a/fixtures/multi-worker/packages/worker-b/package.json
+++ b/fixtures/multi-worker/packages/worker-b/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "worker-b",
+	"private": true,
+	"scripts": {
+		"deploy": "wrangler deploy",
+		"start": "wrangler dev --x-dev-env"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20240909.0",
+		"wrangler": "workspace:*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/fixtures/multi-worker/packages/worker-b/src/index.ts
+++ b/fixtures/multi-worker/packages/worker-b/src/index.ts
@@ -1,0 +1,7 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+export default class extends WorkerEntrypoint {
+	async hello() {
+		return "Hello World from Worker B!";
+	}
+}

--- a/fixtures/multi-worker/packages/worker-b/tsconfig.json
+++ b/fixtures/multi-worker/packages/worker-b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "es2021",
+		"lib": ["es2021"],
+		"module": "es2022",
+		"types": ["@cloudflare/workers-types/experimental"],
+		"noEmit": true,
+		"isolatedModules": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true
+	}
+}

--- a/fixtures/multi-worker/packages/worker-b/wrangler.toml
+++ b/fixtures/multi-worker/packages/worker-b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "worker-b"
+main = "src/index.ts"
+compatibility_date = "2024-09-22"
+
+dev.port = 8788

--- a/fixtures/multi-worker/packages/worker-b/wrangler.toml
+++ b/fixtures/multi-worker/packages/worker-b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "worker-b"
 main = "src/index.ts"
-compatibility_date = "2024-09-22"
+compatibility_date = "2024-09-09"
 
 dev.port = 8788

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -176,7 +176,8 @@ export async function unstable_dev(
 		onReady: (address, port, proxyData) => {
 			readyResolve({ address, port, proxyData });
 		},
-		config: options?.config,
+		// @ts-expect-error who cares
+		config: options?.config === undefined ? undefined : [options.config],
 		env: options?.env,
 		processEntrypoint,
 		additionalModules,

--- a/packages/wrangler/src/api/startDevWorker/index.ts
+++ b/packages/wrangler/src/api/startDevWorker/index.ts
@@ -1,4 +1,8 @@
+import assert from "node:assert";
+import { updateDevEnvRegistry } from "../../dev";
+import { serializeWorkerRegistryDefinition } from "../../dev/local";
 import { DevEnv } from "./DevEnv";
+import type { WorkerDefinition } from "../../dev-registry";
 import type { StartDevWorkerInput, Worker } from "./types";
 
 export { DevEnv };
@@ -11,4 +15,82 @@ export async function startWorker(
 	const devEnv = new DevEnv();
 
 	return devEnv.startWorker(options);
+}
+
+export async function startMultiWorker(
+	optionsArray: StartDevWorkerInput[],
+	devEnv0: DevEnv
+): Promise<DevEnv[]> {
+	const workerRegistry = new Map<string, WorkerDefinition>();
+	let prevRegistry: Record<string, WorkerDefinition> = {};
+	async function updateWorkerRegistry(
+		name: string,
+		definition: WorkerDefinition
+	) {
+		workerRegistry.set(name, definition);
+
+		if (!devEnvs) {
+			return;
+		}
+
+		const nextRegistry = Object.fromEntries(workerRegistry);
+
+		if (JSON.stringify(prevRegistry) !== JSON.stringify(nextRegistry)) {
+			prevRegistry = nextRegistry;
+			await Promise.all(
+				devEnvs.map(async (devEnv) => {
+					await updateDevEnvRegistry(
+						devEnv,
+						Object.fromEntries(workerRegistry)
+					);
+				})
+			);
+		}
+	}
+
+	const devEnvs = await Promise.all(
+		optionsArray.map(async (options, workerIndex) => {
+			const devEnv = workerIndex === 0 ? devEnv0 : new DevEnv();
+
+			devEnv.runtimes.forEach((runtime) => {
+				runtime.on("reloadComplete", async (reloadEvent) => {
+					if (!reloadEvent.config.dev?.remote) {
+						const { url } = await devEnv.proxy.ready.promise;
+						const { name } = reloadEvent.config;
+						assert(name); // default value "multi-worker-n" is defined below
+
+						const definition = serializeWorkerRegistryDefinition(
+							url,
+							name,
+							reloadEvent.proxyData.internalDurableObjects,
+							reloadEvent.proxyData.entrypointAddresses
+						);
+
+						if (definition) {
+							await updateWorkerRegistry(name, definition);
+						}
+					}
+				});
+			});
+
+			await devEnv.config.set({
+				// name: `multi-worker-${workerIndex + 1}`,
+				...options,
+				dev: {
+					...options.dev,
+					remote: false,
+					inspector: { port: 0 },
+					server: {
+						...options.dev?.server,
+						// port: options.dev?.server?.port ?? 0,
+						// hostname: "localhost",
+					},
+				},
+			});
+
+			return devEnv;
+		})
+	);
+
+	return devEnvs;
 }

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -64,7 +64,6 @@ import type {
 } from "./config/environment";
 import type { CfModule, CfWorkerInit } from "./deployment-bundle/worker";
 import type { WorkerRegistry } from "./dev-registry";
-import type { ExperimentalAssetsOptions } from "./experimental-assets";
 import type { LoggerLevel } from "./logger";
 import type { EnablePagesAssetsServiceBindingOptions } from "./miniflare-cli/types";
 import type {
@@ -630,6 +629,10 @@ export async function startDev(args: StartDevOptions) {
 		const devEnv = new DevEnv();
 
 		if (args.experimentalDevEnv) {
+			assert(args.config);
+			args.disableDevRegistry = args.config.length > 1;
+			args.forceLocal ||= args.config.length > 1;
+
 			// The ProxyWorker will have a stable host and port, so only listen for the first update
 			void devEnv.proxy.ready.promise.then(({ url }) => {
 				if (process.send) {
@@ -801,7 +804,6 @@ export async function startDev(args: StartDevOptions) {
 				assets: args.assets ? assetsOptions : undefined,
 			};
 
-			assert(args.config);
 			logger.log(args.config);
 			const options = await Promise.all(
 				args.config.map((configPath1, workerIndex) =>
@@ -810,8 +812,6 @@ export async function startDev(args: StartDevOptions) {
 			);
 
 			const devEnvs = await startMultiWorker(options, devEnv);
-			args.disableDevRegistry = args.config.length === 1;
-			args.forceLocal ||= args.config.length > 1;
 
 			let unregisterHotKeys = () => {};
 			if (isInteractive() && args.showInteractiveDevSession !== false) {

--- a/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/ProxyWorker.ts
@@ -13,6 +13,7 @@ interface Env {
 	PROXY_CONTROLLER: Fetcher;
 	PROXY_CONTROLLER_AUTH_SECRET: string;
 	DURABLE_OBJECT: DurableObjectNamespace;
+	NAME: string;
 }
 
 // request.cf.hostMetadata is verbose to type using the workers-types Request -- this allows us to have Request correctly typed in this scope
@@ -35,7 +36,7 @@ export default {
 export class ProxyWorker implements DurableObject {
 	constructor(
 		readonly state: DurableObjectState,
-		readonly env: Env
+		public env: Env
 	) {}
 
 	proxyData?: ProxyData;
@@ -78,8 +79,8 @@ export class ProxyWorker implements DurableObject {
 		});
 	}
 
-	processProxyControllerRequest(request: Request) {
-		const event = request.cf?.hostMetadata;
+	async processProxyControllerRequest(request: Request) {
+		const event = await request.json<ProxyWorkerIncomingRequestBody>();
 		switch (event?.type) {
 			case "pause":
 				this.proxyData = undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/multi-worker:
+    devDependencies:
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/no-bundle-import:
     devDependencies:
       get-port:


### PR DESCRIPTION
## What this PR solves / how to test

This is a PoC for multi-worker wrangler dev.

The command now accepts multiple `-c`/`--config` args to point at multiple wrangler config file paths.

I have added a `multi-worker` fixture with a command in the README to run both workers in a single wrangler instance

Demo: https://www.loom.com/share/b80ac0825e3f4804ab519c2c6ca52d42?sid=75483f59-a391-4754-afc7-0732aeb9bdb7

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
