### PR TITLE
chore(create-cloudflare): enable observability for Workers templates

### DIFF
--- a/.changeset/chilled-clocks-add.md
+++ b/.changeset/chilled-clocks-add.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": minor
+---
+
+chore: enable observability by default for Workers templates
+
+Workers created with `create-cloudflare` will now have [Workers Observability](https://developers.cloudflare.com/workers/observability/logs/workers-logs) enabled by default.

--- a/packages/create-cloudflare/templates-experimental/angular/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/angular/templates/wrangler.toml
@@ -3,3 +3,9 @@ name = "<TBD>"
 compatibility_date = "<TBD>"
 main = "./dist/server/server.mjs"
 assets = { directory = "./dist/browser", binding = "ASSETS" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/astro/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/astro/templates/wrangler.toml
@@ -4,3 +4,9 @@ compatibility_date = "<TBD>"
 compatibility_flags = ["nodejs_compat_v2"]
 main = "./dist/_worker.js"
 assets = { directory = "./dist", binding = "ASSETS" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/docusaurus/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/docusaurus/templates/wrangler.toml
@@ -2,3 +2,9 @@
 name = "<TBD>"
 compatibility_date = "<TBD>"
 assets = { directory = "./build" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/gatsby/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/gatsby/templates/wrangler.toml
@@ -2,3 +2,9 @@
 name = "<TBD>"
 compatibility_date = "<TBD>"
 assets = { directory = "./public" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/hello-world-assets-only/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/hello-world-assets-only/templates/wrangler.toml
@@ -2,3 +2,9 @@
 name = "<TBD>"
 compatibility_date = "<TBD>"
 assets = { directory = "./public" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/hello-world-durable-object-with-assets/js/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/hello-world-durable-object-with-assets/js/wrangler.toml
@@ -17,3 +17,8 @@ class_name = "MyDurableObject"
 tag = "v1"
 new_classes = ["MyDurableObject"]
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/hello-world-durable-object-with-assets/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/hello-world-durable-object-with-assets/ts/wrangler.toml
@@ -17,3 +17,8 @@ class_name = "MyDurableObject"
 tag = "v1"
 new_classes = ["MyDurableObject"]
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/wrangler.toml
@@ -4,3 +4,9 @@ main = "src/index.js"
 compatibility_date = "<TBD>"
 compatibility_flags = ["nodejs_compat"]
 assets = { directory = "./public", binding = "ASSETS" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/py/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/py/wrangler.toml
@@ -4,3 +4,9 @@ main = "src/entry.py"
 compatibility_flags = ["python_workers"]
 compatibility_date = "<TBD>"
 assets = { directory = "./public", binding = "ASSETS" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/wrangler.toml
@@ -4,3 +4,9 @@ main = "src/index.ts"
 compatibility_date = "<TBD>"
 compatibility_flags = ["nodejs_compat"]
 assets = { directory = "./public", binding = "ASSETS" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/nuxt/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/nuxt/templates/wrangler.toml
@@ -3,3 +3,9 @@ name = "<TBD>"
 compatibility_date = "<TBD>"
 main = "./dist/worker/index.js"
 assets = { directory = "./dist/public", binding = "ASSETS" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/qwik/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/qwik/templates/wrangler.toml
@@ -4,3 +4,9 @@ compatibility_date = "<TBD>"
 compatibility_flags = ["nodejs_compat"]
 main = "./dist/_worker.js"
 assets = { directory = "./dist", binding = "ASSET" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/remix/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/remix/templates/wrangler.toml
@@ -3,3 +3,9 @@ name = "<TBD>"
 compatibility_date = "<TBD>"
 main = "./build/worker/index.js"
 assets = { directory = "./build/client" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/solid/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/solid/templates/wrangler.toml
@@ -4,3 +4,9 @@ compatibility_date = "<TBD>"
 compatibility_flags = ["nodejs_compat"]
 main = "./dist/worker/index.js"
 assets = { directory = "./dist/public", binding = "ASSETS" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/svelte/js/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/svelte/js/wrangler.toml
@@ -3,3 +3,9 @@ name = "<TBD>"
 compatibility_date = "<TBD>"
 main = ".svelte-kit/cloudflare/_worker.js"
 assets = { directory = ".svelte-kit/cloudflare", binding = "ASSETS" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates-experimental/svelte/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/svelte/ts/wrangler.toml
@@ -3,3 +3,9 @@ name = "<TBD>"
 compatibility_date = "<TBD>"
 main = ".svelte-kit/cloudflare/_worker.js"
 assets = { directory = ".svelte-kit/cloudflare", binding = "ASSETS" }
+
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true

--- a/packages/create-cloudflare/templates/common/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/common/js/wrangler.toml
@@ -3,6 +3,12 @@ name = "<TBD>"
 main = "src/index.js"
 compatibility_date = "<TBD>"
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/common/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/common/ts/wrangler.toml
@@ -3,6 +3,12 @@ name = "<TBD>"
 main = "src/index.ts"
 compatibility_date = "<TBD>"
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/hello-world-durable-object/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/js/wrangler.toml
@@ -3,6 +3,12 @@ name = "<TBD>"
 main = "src/index.js"
 compatibility_date = "<TBD>"
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/hello-world-durable-object/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/ts/wrangler.toml
@@ -3,6 +3,12 @@ name = "<TBD>"
 main = "src/index.ts"
 compatibility_date = "<TBD>"
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/hello-world/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world/js/wrangler.toml
@@ -4,6 +4,12 @@ main = "src/index.js"
 compatibility_date = "<TBD>"
 compatibility_flags = ["nodejs_compat"]
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/hello-world/py/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world/py/wrangler.toml
@@ -4,6 +4,12 @@ main = "src/entry.py"
 compatibility_flags = ["python_workers"]
 compatibility_date = "<TBD>"
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/hello-world/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world/ts/wrangler.toml
@@ -4,6 +4,12 @@ main = "src/index.ts"
 compatibility_date = "<TBD>"
 compatibility_flags = ["nodejs_compat"]
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/hono/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates/hono/templates/wrangler.toml
@@ -3,6 +3,12 @@ name = "<TBD>"
 main = "src/index.ts"
 compatibility_date = "<TBD>"
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/openapi/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/openapi/ts/wrangler.toml
@@ -3,6 +3,12 @@ name = "<TBD>"
 main = "src/index.ts"
 compatibility_date = "<TBD>"
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/queues/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/queues/js/wrangler.toml
@@ -3,6 +3,12 @@ name = "<TBD>"
 main = "src/index.js"
 compatibility_date = "<TBD>"
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/queues/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/queues/ts/wrangler.toml
@@ -3,6 +3,12 @@ name = "<TBD>"
 main = "src/index.ts"
 compatibility_date = "<TBD>"
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/scheduled/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/scheduled/js/wrangler.toml
@@ -9,6 +9,12 @@ compatibility_date = "<TBD>"
 [triggers]
 crons = ["* * * * *"] # * * * * * = run every minute
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.

--- a/packages/create-cloudflare/templates/scheduled/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/scheduled/ts/wrangler.toml
@@ -9,6 +9,12 @@ compatibility_date = "<TBD>"
 [triggers]
 crons = ["* * * * *"] # * * * * * = run every minute
 
+# Workers Logs
+# Docs: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/
+# Configuration: https://rohin-observability-docs.cloudflare-docs-7ou.pages.dev/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true
+
 # Automatically place your workloads in an optimal location to minimize latency.
 # If you are running back-end logic in a Worker, running it closer to your back-end infrastructure
 # rather than the end user may result in better performance.


### PR DESCRIPTION
## What this PR solves / how to test

Adds Workers Observability to newly generated `create-cloudflare` projects.

Fixes [WO-198](https://jira.cfdata.org/browse/WO-186)

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Only adds an already tested setting to template configs
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Only adds an already tested setting to template configs
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/17028
  - [ ] Documentation not necessary because:
