### PR TITLE
chore(create-cloudflare): add support for new bun.lock

### DIFF
--- a/.changeset/four-mayflies-smash.md
+++ b/.changeset/four-mayflies-smash.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Adds support for new upcoming bun.lock lockfile

--- a/packages/create-cloudflare/src/helpers/packageManagers.ts
+++ b/packages/create-cloudflare/src/helpers/packageManagers.ts
@@ -131,6 +131,9 @@ const detectPmMismatch = (ctx: C3Context) => {
 		case "pnpm":
 			return !existsSync(path.join(projectPath, "pnpm-lock.yaml"));
 		case "bun":
-			return !existsSync(path.join(projectPath, "bun.lockb"));
+			return (
+				!existsSync(path.join(projectPath, "bun.lockb")) &&
+				!existsSync(path.join(projectPath, "bun.lock"))
+			);
 	}
 };

--- a/packages/create-cloudflare/src/helpers/packageManagers.ts
+++ b/packages/create-cloudflare/src/helpers/packageManagers.ts
@@ -119,7 +119,7 @@ export const rectifyPmMismatch = async (ctx: C3Context) => {
 	});
 };
 
-const detectPmMismatch = (ctx: C3Context) => {
+export const detectPmMismatch = (ctx: C3Context) => {
 	const { npm } = detectPackageManager();
 	const projectPath = ctx.project.path;
 


### PR DESCRIPTION
## What this PR solves / how to test

Adds support for upcoming `bun.lock` to  `detectPmMismatch ` method. 

https://x.com/jarredsumner/status/1839056611765268651

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor addition to internals

