### PR TITLE
fix version preview url snapshot

### DIFF
--- a/packages/wrangler/e2e/helpers/normalize.ts
+++ b/packages/wrangler/e2e/helpers/normalize.ts
@@ -9,6 +9,7 @@ export function normalizeOutput(
 		removeStandardPricingWarning,
 		npmStripTimings,
 		removeWorkersDev,
+		removeWorkerPreviewUrl,
 		removeUUID,
 		normalizeErrorMarkers,
 		replaceByte,
@@ -43,6 +44,12 @@ function stripDevTimings(stdout: string): string {
 	return stdout.replace(/\(\dms\)/g, "(TIMINGS)");
 }
 
+function removeWorkerPreviewUrl(str: string) {
+	return str.replace(
+		/https:\/\/(?<sha>[a-f\d]+)-(?<workerName>.+)-(?<uuid>\w{8}-\w{4}-\w{4}-\w{4}-\w{12})\..+?\.workers\.dev/g,
+		"https://$2-PREVIEW-URL.SUBDOMAIN.workers.dev"
+	);
+}
 function removeWorkersDev(str: string) {
 	return str.replace(
 		/https:\/\/(.+?)\..+?\.workers\.dev/g,

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -63,6 +63,7 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Worker Startup Time: (TIMINGS)
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
+			Version Preview URL: https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev
 			To deploy this version to production traffic use the command wrangler versions deploy
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
@@ -178,6 +179,7 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Worker Startup Time: (TIMINGS)
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
+			Version Preview URL: https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev
 			To deploy this version to production traffic use the command wrangler versions deploy
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
@@ -623,6 +625,7 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			Worker Startup Time: (TIMINGS)
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
+			Version Preview URL: https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev
 			To deploy this version to production traffic use the command wrangler versions deploy
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"


### PR DESCRIPTION
## What this PR solves / how to test

Fixes mismatched snapshots

Version Preview URLs are now enabled. Wrangler already has code to print them to stdout if the property is on the api response. This PR simply updates our snapshots with their normalised form

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: snapshot update
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: snapshot update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
