### PR TITLE
use --prod flag in e2e pnpm deploy step

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Deploy a local version of Wrangler
         run: |
-          pnpm --filter wrangler deploy ${{ github.workspace}}/temp/wrangler
+          pnpm --filter wrangler --prod deploy ${{ github.workspace}}/temp/wrangler
           rm ${{ github.workspace}}/temp/wrangler/templates/tsconfig.json
         env:
           NODE_ENV: "production"


### PR DESCRIPTION
## What this PR solves / how to test

The "Deploy a local version of Wrangler" step of the e2e workflow has been flaking on Windows. eg https://github.com/cloudflare/workers-sdk/actions/runs/11051135464/job/30701705503?pr=6819#step:5:29

All it does it is run `pnpm deploy` so I'm not sure why.

It seems to be failing to create files in the node_modules/.../bin directories so it may be something to do with executable files (permissions/chmod issue)

The intention is to create a wrangler package for the e2e tests which doesn't need the dev dependencies so we can and should use the [`–prod` flag](https://pnpm.io/cli/deploy#:~:text=deployed%20project%20name%3E-,%2D%2Dprod%20deploy,-%3Ctarget%20directory%3E) for pnpm deploy which may avoid having any (or as many) executable files

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: workflow change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: workflow change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: workflow change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
