### PR TITLE
fix: remove invalid `ctx` import from hello-world experimental templates

### DIFF
--- a/.changeset/tasty-bears-behave.md
+++ b/.changeset/tasty-bears-behave.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: remove invalid `ctx` import from hello-world experimental templates

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/test/index.spec.js
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/test/index.spec.js
@@ -16,7 +16,7 @@ describe('Hello World user worker', () => {
 
 		it('responds with "Hello, World!" (integration style)', async () => {
 			const request = new Request('http://example.com/message');
-			const response = await SELF.fetch(request, env, ctx);
+			const response = await SELF.fetch(request);
 			expect(await response.text()).toMatchInlineSnapshot(`"Hello, World!"`);
 		});
 	});
@@ -34,7 +34,7 @@ describe('Hello World user worker', () => {
 
 		it('responds with a random UUID (integration style)', async () => {
 			const request = new Request('http://example.com/random');
-			const response = await SELF.fetch(request, env, ctx);
+			const response = await SELF.fetch(request);
 			expect(await response.text()).toMatch(/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/);
 		});
 	});

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/test/index.spec.js
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/test/index.spec.js
@@ -1,4 +1,4 @@
-import { env, ctx, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
+import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 import worker from '../src';
 

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/test/index.spec.ts
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { env, ctx, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
+import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 import worker from '../src';
 

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/test/index.spec.ts
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/test/index.spec.ts
@@ -16,7 +16,7 @@ describe('Hello World user worker', () => {
 
 		it('responds with "Hello, World!" (integration style)', async () => {
 			const request = new Request('http://example.com/message');
-			const response = await SELF.fetch(request, env);
+			const response = await SELF.fetch(request);
 			expect(await response.text()).toMatchInlineSnapshot(`"Hello, World!"`);
 		});
 	});

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/test/index.spec.ts
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/test/index.spec.ts
@@ -5,7 +5,7 @@ import worker from '../src';
 describe('Hello World user worker', () => {
 	describe('request for /message', () => {
 		it('/ responds with "Hello, World!" (unit style)', async () => {
-			const request = new Request('http://example.com/message');
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/message');
 			// Create an empty context to pass to `worker.fetch()`.
 			const ctx = createExecutionContext();
 			const response = await worker.fetch(request, env, ctx);
@@ -16,14 +16,14 @@ describe('Hello World user worker', () => {
 
 		it('responds with "Hello, World!" (integration style)', async () => {
 			const request = new Request('http://example.com/message');
-			const response = await SELF.fetch(request, env, ctx);
+			const response = await SELF.fetch(request, env);
 			expect(await response.text()).toMatchInlineSnapshot(`"Hello, World!"`);
 		});
 	});
 
 	describe('request for /random', () => {
 		it('/ responds with a random UUID (unit style)', async () => {
-			const request = new Request('http://example.com/random');
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/random');
 			// Create an empty context to pass to `worker.fetch()`.
 			const ctx = createExecutionContext();
 			const response = await worker.fetch(request, env, ctx);
@@ -34,7 +34,7 @@ describe('Hello World user worker', () => {
 
 		it('responds with a random UUID (integration style)', async () => {
 			const request = new Request('http://example.com/random');
-			const response = await SELF.fetch(request, env, ctx);
+			const response = await SELF.fetch(request);
 			expect(await response.text()).toMatch(/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/);
 		});
 	});


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #0000

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: test change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change

