### PR TITLE
Queues is now GA so don't say it's in beta in warning messages

### DIFF
--- a/.changeset/pretty-birds-scream.md
+++ b/.changeset/pretty-birds-scream.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: update warning in `wrangler dev --remote` when using Queues to not mention beta status

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -313,9 +313,7 @@ async function resolveConfig(
 		(queues?.length ||
 			resolved.triggers?.some((t) => t.type === "queue-consumer"))
 	) {
-		logger.warn(
-			"Queues are not yet supported in wrangler dev remote mode."
-		);
+		logger.warn("Queues are not yet supported in wrangler dev remote mode.");
 	}
 
 	// TODO(do) support remote wrangler dev

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -314,7 +314,7 @@ async function resolveConfig(
 			resolved.triggers?.some((t) => t.type === "queue-consumer"))
 	) {
 		logger.warn(
-			"Queues are currently in Beta and are not supported in wrangler dev remote mode."
+			"Queues are not yet supported in wrangler dev remote mode."
 		);
 	}
 

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -631,7 +631,7 @@ function DevSession(props: DevSessionProps) {
 		(props.bindings.queues?.length || props.queueConsumers?.length)
 	) {
 		logger.warn(
-			"Queues are currently in Beta and are not supported in wrangler dev remote mode."
+			"Queues are not yet supported in wrangler dev remote mode."
 		);
 	}
 

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -630,9 +630,7 @@ function DevSession(props: DevSessionProps) {
 		!props.local &&
 		(props.bindings.queues?.length || props.queueConsumers?.length)
 	) {
-		logger.warn(
-			"Queues are not yet supported in wrangler dev remote mode."
-		);
+		logger.warn("Queues are not yet supported in wrangler dev remote mode.");
 	}
 
 	// TODO(do) support remote wrangler dev


### PR DESCRIPTION
`wrangler dev --remote` still isn't supported (hopefully soon!), but Queues is not in beta anymore so we should remove that part of the message.

@jbw1991 @sdnts 