### PR TITLE
feat(create-cloudflare): allows user going back to the project name prompt

### DIFF
--- a/.changeset/early-kangaroos-guess.md
+++ b/.changeset/early-kangaroos-guess.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+feat: allow users going back to the project name prompt

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -244,7 +244,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 			"Going back and forth between the category, type, framework and lang prompts",
 			async ({ logStream, project }) => {
 				const { output } = await runC3(
-					[project.path, "--git=false", "--no-deploy"],
+					["/invalid-project-name", "--git=false", "--no-deploy"],
 					[
 						{
 							matcher: /What would you like to start with\?/,
@@ -256,7 +256,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 						{
 							matcher:
 								/In which directory do you want to create your application/,
-							input: [`${project.path}-test`, keys.enter],
+							input: [project.path, keys.enter],
 						},
 						{
 							matcher: /What would you like to start with\?/,
@@ -344,7 +344,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 					logStream,
 				);
 
-				expect(`${project.path}-test`).toExist();
+				expect(project.path).toExist();
 				expect(output).toContain(`type Hello World Worker`);
 				expect(output).toContain(`lang JavaScript`);
 			},

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -250,6 +250,18 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 							matcher: /What would you like to start with\?/,
 							input: {
 								type: "select",
+								target: "Go back",
+							},
+						},
+						{
+							matcher:
+								/In which directory do you want to create your application/,
+							input: [`${project.path}-test`, keys.enter],
+						},
+						{
+							matcher: /What would you like to start with\?/,
+							input: {
+								type: "select",
 								target: "Application Starter",
 							},
 						},
@@ -332,7 +344,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 					logStream,
 				);
 
-				expect(project.path).toExist();
+				expect(`${project.path}-test`).toExist();
 				expect(output).toContain(`type Hello World Worker`);
 				expect(output).toContain(`lang JavaScript`);
 			},

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -296,11 +296,15 @@ export const createContext = async (
 
 	// Allows the users to go back to the previous step
 	// By moving the cursor up to a certain line and clearing the screen
-	const goBack = async (from: "type" | "framework" | "lang") => {
+	const goBack = async (from: "category" | "type" | "framework" | "lang") => {
 		const currentArgs = { ...args };
 		let linesPrinted = 0;
 
 		switch (from) {
+			case "category":
+				linesPrinted = 6;
+				args.projectName = undefined;
+				break;
 			case "type":
 				linesPrinted = 9;
 				args.category = undefined;
@@ -341,7 +345,7 @@ export const createContext = async (
 		type: "text",
 		question: `In which directory do you want to create your application?`,
 		helpText: "also used as application name",
-		defaultValue: defaultName,
+		defaultValue: prevArgs?.projectName ?? defaultName,
 		label: "dir",
 		validate: (value) =>
 			validateProjectDirectory(String(value) || C3_DEFAULTS.projectName, args),
@@ -372,6 +376,7 @@ export const createContext = async (
 		},
 		// This is used only if the type is `pre-existing`
 		{ label: "Others", value: "others", hidden: true },
+		backOption,
 	];
 
 	const category = await processArgument(args, "category", {
@@ -381,6 +386,10 @@ export const createContext = async (
 		options: categoryOptions,
 		defaultValue: prevArgs?.category ?? C3_DEFAULTS.category,
 	});
+
+	if (category === BACK_VALUE) {
+		return goBack("category");
+	}
 
 	let template: TemplateConfig;
 


### PR DESCRIPTION
## What this PR solves / how to test

Fixes N/A

This PR adds the ability to go back to the project name prompt, mainly to give users an idea that they can always come back to the previous question when answering the prompt early on.

<img width="434" alt="Screenshot 2024-10-01 at 12 51 22" src="https://github.com/user-attachments/assets/da687e1a-4b2a-4b39-b31e-f26a7f44c4f6">

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no other impact
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ux improvement only

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
