### PR TITLE
feat: add programmatic API for types

### DIFF
--- a/packages/wrangler/src/api/types/index.ts
+++ b/packages/wrangler/src/api/types/index.ts
@@ -1,0 +1,71 @@
+import { writeFile } from "fs/promises";
+import path from "path";
+import { readConfig } from "../../config";
+import type { Config } from "../../config";
+
+export async function generateProjectTypes(options: {
+	config?: Config;
+	configFile?: string;
+	outFile?: string;
+	persistToFilesystem?: boolean;
+}): Promise<string> {
+	return generateTypes(getProjectTypes, options);
+}
+
+export async function generateRuntimeTypes(options: {
+	config?: Config;
+	configFile?: string;
+	outFile?: string;
+	persistToFilesystem?: boolean;
+}): Promise<string> {
+	return generateTypes(
+		async (config) =>
+			getRuntimeTypes({
+				compatibilityDate: config.compatibility_date,
+				compatibilityFlags: config.compatibility_flags.filter(
+					(flag) => !flag.includes("nodejs_compat")
+				),
+			}),
+		options
+	);
+}
+
+async function generateTypes(
+	getTypesFunction: (config: Config) => Promise<string>,
+	{
+		config,
+		configFile,
+		outFile,
+		persistToFilesystem = false,
+	}: {
+		config?: Config;
+		configFile?: string;
+		outFile?: string;
+		persistToFilesystem?: boolean;
+	}
+): Promise<string> {
+	if (!config && !configFile) {
+		throw new Error("Either config or configFile must be provided");
+	}
+	if (config && configFile) {
+		throw new Error("Only one of config or configFile should be provided");
+	}
+	if (outFile && persistToFilesystem === undefined) {
+		throw new Error(
+			"persistToFilesystem must be specified when outFile is provided"
+		);
+	}
+
+	const resolvedConfig = config ?? readConfig(configFile, {});
+
+	const types = await getTypesFunction(resolvedConfig);
+
+	if (persistToFilesystem) {
+		const resolvedOutFile =
+			outFile ?? path.join(process.cwd(), "runtime-configuration.d.ts");
+
+		await writeFile(resolvedOutFile, types, "utf8");
+	}
+
+	return types;
+}

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -35,6 +35,7 @@ export { unstable_dev, unstable_pages, unstable_DevEnv, unstable_startWorker };
 export type { UnstableDevWorker, UnstableDevOptions };
 
 export * from "./api/integrations";
+export * from "./api/types";
 
 // Export internal APIs required by the Vitest integration as `unstable_`
 export { default as unstable_splitSqlQuery } from "./d1/splitter";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.1.1
+      version: 2.1.1
+    '@vitest/snapshot':
+      specifier: ~2.1.1
+      version: 2.1.1
     vitest:
       specifier: ~2.1.1
       version: 2.1.1


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #000.

Adds a programmatic API for type generation.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because: