### PR TITLE
Fix combo of --x-dev-env and --x-registry

### DIFF
--- a/.changeset/eleven-planes-promise.md
+++ b/.changeset/eleven-planes-promise.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: update the `--experimental-dev-env` (shorthand: `--x-dev-env`) flag to on-by-default
+
+If you experience any issues, you can disable the flag with `--x-dev-env=false`. Please also let us know by opening an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose.

--- a/fixtures/external-durable-objects-app/tests/index.test.ts
+++ b/fixtures/external-durable-objects-app/tests/index.test.ts
@@ -22,6 +22,7 @@ describe.skip(
 				experimental: {
 					disableExperimentalWarning: true,
 					devEnv: true,
+					fileBasedRegistry: true,
 				},
 			});
 			await setTimeout(1000);
@@ -30,6 +31,7 @@ describe.skip(
 				experimental: {
 					disableExperimentalWarning: true,
 					devEnv: true,
+					fileBasedRegistry: true,
 				},
 			});
 			await setTimeout(1000);
@@ -38,6 +40,7 @@ describe.skip(
 				experimental: {
 					disableExperimentalWarning: true,
 					devEnv: true,
+					fileBasedRegistry: true,
 				},
 			});
 			await setTimeout(1000);

--- a/fixtures/external-service-bindings-app/tests/index.test.ts
+++ b/fixtures/external-service-bindings-app/tests/index.test.ts
@@ -168,6 +168,7 @@ async function getWranglerInstance({
 			[
 				...(pages ? ["pages"] : []),
 				"dev",
+				"--x-dev-env",
 				"--x-registry",
 				...(pages ? ["public"] : ["index.ts"]),
 				"--local",

--- a/fixtures/get-platform-proxy/tests/shared.ts
+++ b/fixtures/get-platform-proxy/tests/shared.ts
@@ -9,5 +9,6 @@ export function getPlatformProxy<T>(
 	return originalGetPlatformProxy({
 		...options,
 		persist: false,
+		experimentalRegistry: true,
 	});
 }

--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -25,13 +25,28 @@ export async function runWranglerPagesDev(
 ) {
 	if (publicPath) {
 		return runLongLivedWrangler(
-			["pages", "dev", publicPath, "--x-dev-env", "--ip=127.0.0.1", ...options],
+			[
+				"pages",
+				"dev",
+				publicPath,
+				"--x-dev-env",
+				"--x-registry",
+				"--ip=127.0.0.1",
+				...options,
+			],
 			cwd,
 			env
 		);
 	} else {
 		return runLongLivedWrangler(
-			["pages", "dev", "--x-dev-env", "--ip=127.0.0.1", ...options],
+			[
+				"pages",
+				"dev",
+				"--x-dev-env",
+				"--x-registry",
+				"--ip=127.0.0.1",
+				...options,
+			],
 			cwd,
 			env
 		);
@@ -52,7 +67,7 @@ export async function runWranglerDev(
 	env?: NodeJS.ProcessEnv
 ) {
 	return runLongLivedWrangler(
-		["dev", "--x-dev-env", "--ip=127.0.0.1", ...options],
+		["dev", "--x-dev-env", "--x-registry", "--ip=127.0.0.1", ...options],
 		cwd,
 		env
 	);

--- a/packages/wrangler/e2e/__snapshots__/dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/dev.test.ts.snap
@@ -1,17 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`basic js dev: 'wrangler dev --no-x-dev-env' > can modify worker during wrangler dev --no-x-dev-env 1`] = `"Hello World!"`;
+
+exports[`basic js dev: 'wrangler dev --no-x-dev-env' > can modify worker during wrangler dev --no-x-dev-env 2`] = `"Updated Worker! value"`;
+
+exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > can modify worker during wrangler dev --remote --no-x-dev-env 1`] = `"Hello World!"`;
+
+exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > can modify worker during wrangler dev --remote --no-x-dev-env 2`] = `"Updated Worker! value"`;
+
 exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > can modify worker during wrangler dev --remote --x-dev-env 1`] = `"Hello World!"`;
 
 exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > can modify worker during wrangler dev --remote --x-dev-env 2`] = `"Updated Worker! value"`;
 
-exports[`basic js dev: 'wrangler dev --remote' > can modify worker during wrangler dev --remote 1`] = `"Hello World!"`;
-
-exports[`basic js dev: 'wrangler dev --remote' > can modify worker during wrangler dev --remote 2`] = `"Updated Worker! value"`;
-
 exports[`basic js dev: 'wrangler dev --x-dev-env' > can modify worker during wrangler dev --x-dev-env 1`] = `"Hello World!"`;
 
 exports[`basic js dev: 'wrangler dev --x-dev-env' > can modify worker during wrangler dev --x-dev-env 2`] = `"Updated Worker! value"`;
-
-exports[`basic js dev: 'wrangler dev' > can modify worker during wrangler dev 1`] = `"Hello World!"`;
-
-exports[`basic js dev: 'wrangler dev' > can modify worker during wrangler dev 2`] = `"Updated Worker! value"`;

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -39,7 +39,7 @@ Your worker has access to the following bindings:
 "
 `;
 
-exports[`Pages 'wrangler pages dev' > should merge (with override) \`wrangler.toml\` configuration with configuration provided via the command line, with command line args taking precedence 1`] = `
+exports[`Pages 'wrangler pages dev --no-x-dev-env' > should merge (with override) \`wrangler.toml\` configuration with configuration provided via the command line, with command line args taking precedence 1`] = `
 "✨ Compiled Worker successfully
 ▲ [WARNING] WARNING: You have Durable Object bindings that are not defined locally in the worker being developed.
   Be aware that changes to the data stored in these Durable Objects will be permanent and affect the live instances.

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -1,44 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Pages 'wrangler pages dev --x-dev-env' > should merge (with override) \`wrangler.toml\` configuration with configuration provided via the command line, with command line args taking precedence 1`] = `
-"✨ Compiled Worker successfully
-▲ [WARNING] WARNING: You have Durable Object bindings that are not defined locally in the worker being developed.
-  Be aware that changes to the data stored in these Durable Objects will be permanent and affect the live instances.
-  Remote Durable Objects that are affected:
-  - {"name":"DO_BINDING_1_TOML","class_name":"DO_1_TOML","script_name":"DO_SCRIPT_1_TOML"}
-  - {"name":"DO_BINDING_2_TOML","class_name":"DO_2_TOML","script_name":"DO_SCRIPT_2_TOML"}
-Your worker has access to the following bindings:
-- Durable Objects:
-  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1)
-  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML)
-  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS)
-- KV Namespaces:
-  - KV_BINDING_1_TOML: NEW_KV_ID_1
-  - KV_BINDING_2_TOML: KV_ID_2_TOML
-  - KV_BINDING_3_ARGS: KV_ID_3_ARGS
-- D1 Databases:
-  - D1_BINDING_1_TOML: local-D1_BINDING_1_TOML=NEW_D1_NAME_1 (NEW_D1_NAME_1)
-  - D1_BINDING_2_TOML: D1_NAME_2_TOML (D1_ID_2_TOML)
-  - D1_BINDING_3_ARGS: local-D1_BINDING_3_ARGS=D1_NAME_3_ARGS (D1_NAME_3_ARGS)
-- R2 Buckets:
-  - R2_BINDING_1_TOML: NEW_R2_BUCKET_1
-  - R2_BINDING_2_TOML: R2_BUCKET_2_TOML
-  - R2_BINDING_3_TOML: R2_BUCKET_3_ARGS
-- Services:
-  - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1
-  - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML
-  - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS
-- AI:
-  - Name: AI_BINDING_2_TOML
-- Vars:
-  - VAR1: "(hidden)"
-  - VAR2: "VAR_2_TOML"
-  - VAR3: "(hidden)"
-▲ [WARNING] This worker is bound to live services: SERVICE_BINDING_1_TOML (NEW_SERVICE_NAME_1), SERVICE_BINDING_3_TOML (SERVICE_NAME_3_ARGS), SERVICE_BINDING_2_TOML (SERVICE_NAME_2_TOML)
-▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
-"
-`;
-
 exports[`Pages 'wrangler pages dev --no-x-dev-env' > should merge (with override) \`wrangler.toml\` configuration with configuration provided via the command line, with command line args taking precedence 1`] = `
 "✨ Compiled Worker successfully
 ▲ [WARNING] WARNING: You have Durable Object bindings that are not defined locally in the worker being developed.
@@ -76,5 +37,44 @@ Your worker has access to the following bindings:
   - VAR3: "(hidden)"
 ▲ [WARNING] ⎔ Support for service bindings in local mode is experimental and may change.
 ▲ [WARNING] ⎔ Support for external Durable Objects in local mode is experimental and may change.
+"
+`;
+
+exports[`Pages 'wrangler pages dev --x-dev-env' > should merge (with override) \`wrangler.toml\` configuration with configuration provided via the command line, with command line args taking precedence 1`] = `
+"✨ Compiled Worker successfully
+▲ [WARNING] WARNING: You have Durable Object bindings that are not defined locally in the worker being developed.
+  Be aware that changes to the data stored in these Durable Objects will be permanent and affect the live instances.
+  Remote Durable Objects that are affected:
+  - {"name":"DO_BINDING_1_TOML","class_name":"DO_1_TOML","script_name":"DO_SCRIPT_1_TOML"}
+  - {"name":"DO_BINDING_2_TOML","class_name":"DO_2_TOML","script_name":"DO_SCRIPT_2_TOML"}
+Your worker has access to the following bindings:
+- Durable Objects:
+  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1)
+  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML)
+  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS)
+- KV Namespaces:
+  - KV_BINDING_1_TOML: NEW_KV_ID_1
+  - KV_BINDING_2_TOML: KV_ID_2_TOML
+  - KV_BINDING_3_ARGS: KV_ID_3_ARGS
+- D1 Databases:
+  - D1_BINDING_1_TOML: local-D1_BINDING_1_TOML=NEW_D1_NAME_1 (NEW_D1_NAME_1)
+  - D1_BINDING_2_TOML: D1_NAME_2_TOML (D1_ID_2_TOML)
+  - D1_BINDING_3_ARGS: local-D1_BINDING_3_ARGS=D1_NAME_3_ARGS (D1_NAME_3_ARGS)
+- R2 Buckets:
+  - R2_BINDING_1_TOML: NEW_R2_BUCKET_1
+  - R2_BINDING_2_TOML: R2_BUCKET_2_TOML
+  - R2_BINDING_3_TOML: R2_BUCKET_3_ARGS
+- Services:
+  - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1
+  - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML
+  - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS
+- AI:
+  - Name: AI_BINDING_2_TOML
+- Vars:
+  - VAR1: "(hidden)"
+  - VAR2: "VAR_2_TOML"
+  - VAR3: "(hidden)"
+▲ [WARNING] This worker is bound to live services: SERVICE_BINDING_1_TOML (NEW_SERVICE_NAME_1), SERVICE_BINDING_3_TOML (SERVICE_NAME_3_ARGS), SERVICE_BINDING_2_TOML (SERVICE_NAME_2_TOML)
+▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
 "
 `;

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -9,8 +9,8 @@ import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
 
 const RUNTIMES = [
-	{ flags: "", runtime: "local" },
-	{ flags: "--remote", runtime: "remote" },
+	{ flags: "--no-x-dev-env", runtime: "local" },
+	{ flags: "--remote --no-x-dev-env", runtime: "remote" },
 	{ flags: "--x-dev-env", runtime: "local" },
 	{ flags: "--remote --x-dev-env", runtime: "remote" },
 ] as const;

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -57,8 +57,8 @@ it("can import URL from 'url' in node_compat mode", async () => {
 });
 
 describe.each([
-	{ cmd: "wrangler dev" },
-	{ cmd: "wrangler dev --remote" },
+	{ cmd: "wrangler dev --no-x-dev-env" },
+	{ cmd: "wrangler dev --remote --no-x-dev-env" },
 	{ cmd: "wrangler dev --x-dev-env" },
 	{ cmd: "wrangler dev --remote --x-dev-env" },
 ])("basic js dev: $cmd", ({ cmd }) => {
@@ -112,10 +112,8 @@ describe.each([
 // Skipping remote python tests because they consistently flake with timeouts
 // Unskip once remote dev with python workers is more stable
 describe.each([
-	{ cmd: "wrangler dev" },
-	// { cmd: "wrangler dev --remote" },
+	{ cmd: "wrangler dev --no-x-dev-env" },
 	{ cmd: "wrangler dev --x-dev-env" },
-	// { cmd: "wrangler dev --remote --x-dev-env" },
 ])("basic python dev: $cmd", { timeout: 90_000 }, ({ cmd }) => {
 	it(`can modify entrypoint during ${cmd}`, async () => {
 		const helper = new WranglerE2ETestHelper();
@@ -224,10 +222,10 @@ describe.each([
 });
 
 describe.each([
-	{ cmd: "wrangler dev" },
-	{ cmd: "wrangler dev --x-dev-env" },
-	{ cmd: "wrangler dev --x-registry" },
+	{ cmd: "wrangler dev --x-dev-env --no-x-registry" },
+	{ cmd: "wrangler dev --no-x-dev-env --no-x-registry" },
 	{ cmd: "wrangler dev --x-dev-env --x-registry" },
+	{ cmd: "wrangler dev --no-x-dev-env --x-registry" },
 ])("dev registry $cmd", ({ cmd }) => {
 	let a: string;
 	let b: string;

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -8,7 +8,7 @@ import { fetchText } from "./helpers/fetch-text";
 import { normalizeOutput } from "./helpers/normalize";
 
 describe.each([
-	{ cmd: "wrangler pages dev" },
+	{ cmd: "wrangler pages dev --no-x-dev-env" },
 	{ cmd: "wrangler pages dev --x-dev-env" },
 ])("Pages $cmd", ({ cmd }) => {
 	it("should warn if no [--compatibility_date] command line arg was specified", async () => {

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import dedent from "ts-dedent";
 import { describe, it } from "vitest";
 import { ConfigController } from "../../../api/startDevWorker/ConfigController";
+import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { seed } from "../../helpers/seed";
@@ -18,6 +19,8 @@ async function waitForConfigUpdate(
 describe("ConfigController", () => {
 	runInTempDir();
 	mockConsoleMethods();
+	mockAccountId();
+	mockApiToken();
 
 	it("should emit configUpdate events with defaults applied", async () => {
 		const controller = new ConfigController();

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4303,6 +4303,31 @@ addEventListener('fetch', event => {});`
 			);
 		});
 
+		it("should error if --assets and config.tail_consumers are used together", async () => {
+			writeWranglerToml({
+				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
+			});
+			fs.mkdirSync("public");
+			await expect(
+				runWrangler("deploy --assets public")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets.]`
+			);
+		});
+
+		it("should error if config.assets and config.tail_consumers are used together", async () => {
+			writeWranglerToml({
+				assets: { directory: "./public" },
+				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
+			});
+			fs.mkdirSync("public");
+			await expect(
+				runWrangler("deploy")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: Cannot use assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets.]`
+			);
+		});
+
 		it("should error if directory specified by flag --assets does not exist", async () => {
 			await expect(runWrangler("deploy --assets abc")).rejects.toThrow(
 				new RegExp(

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -77,6 +77,9 @@ async function expectedHostAndZone(
 					return route.pattern;
 				}
 			}),
+		env: undefined,
+		legacyEnv: undefined,
+		sendMetrics: undefined,
 	});
 
 	expect(ctx).toEqual(

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -12,6 +12,7 @@ import { FatalError } from "../errors";
 import { CI } from "../is-ci";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
+import { useMockIsTTY } from "./helpers/mock-istty";
 import {
 	msw,
 	mswSuccessOauthHandlers,
@@ -110,7 +111,10 @@ async function expectedHostAndZone(
 describe.sequential("wrangler dev", () => {
 	let spy: MockInstance;
 	let setSpy: MockInstance;
+	const { setIsTTY } = useMockIsTTY();
+
 	beforeEach(() => {
+		setIsTTY(true);
 		setSpy = vi.spyOn(ConfigController.prototype, "set");
 		spy = vi
 			.spyOn(ConfigController.prototype, "emitConfigUpdateEvent")

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -214,12 +214,10 @@ describe.sequential("wrangler dev", () => {
 	});
 
 	describe("compatibility-date", () => {
-		it.skip("should not warn if there is no wrangler.toml and no compatibility-date specified", async () => {
+		it("should not warn if there is no wrangler.toml and no compatibility-date specified", async () => {
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWranglerUntilConfig("dev index.js");
-			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
 		it("should warn if there is a wrangler.toml but no compatibility-date", async () => {
@@ -250,7 +248,7 @@ describe.sequential("wrangler dev", () => {
 `);
 		});
 
-		it.skip("should not warn if there is a wrangler.toml but compatibility-date is specified at the command line", async () => {
+		it("should not warn if there is a wrangler.toml but compatibility-date is specified at the command line", async () => {
 			writeWranglerToml({
 				main: "index.js",
 				compatibility_date: undefined,
@@ -369,7 +367,7 @@ describe.sequential("wrangler dev", () => {
 				Paths are not allowed in Custom Domains]
 			`);
 		});
-		it.skip("should error on routes with paths if assets are present", async () => {
+		it("should error on routes with paths if assets are present", async () => {
 			writeWranglerToml({
 				routes: [
 					"simple.co.uk/path",
@@ -1630,7 +1628,7 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
-		it.skip("should error if config.assets and --legacy-assets are used together", async () => {
+		it("should error if config.assets and --legacy-assets are used together", async () => {
 			writeWranglerToml({
 				main: "./index.js",
 				assets: {

--- a/packages/wrangler/src/__tests__/dev.test.tsx
+++ b/packages/wrangler/src/__tests__/dev.test.tsx
@@ -5,8 +5,10 @@ import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
 import dedent from "ts-dedent";
 import { vi } from "vitest";
-import Dev from "../dev/dev";
+import { ConfigController } from "../api/startDevWorker/ConfigController";
+import registerDevHotKeys from "../dev/hotkeys";
 import { getWorkerAccountAndContext } from "../dev/remote";
+import { FatalError } from "../errors";
 import { CI } from "../is-ci";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
@@ -22,40 +24,100 @@ import {
 	writeWranglerJson,
 	writeWranglerToml,
 } from "./helpers/write-wrangler-toml";
-import type { Mock } from "vitest";
+import type {
+	Binding,
+	StartDevWorkerInput,
+	StartDevWorkerOptions,
+	Trigger,
+} from "../api";
+import type { Mock, MockInstance } from "vitest";
+
+vi.mock("../api/startDevWorker/ConfigController", (importOriginal) =>
+	importOriginal()
+);
+
+vi.mock("../dev/hotkeys");
+
+// Don't memoize in tests. If we did, it would memoize across test runs, which causes problems
+vi.mock("../utils/memoizeGetPort", () => {
+	return {
+		memoizeGetPort: (port: number, host: string) => async () => {
+			return await getPort({ port: port, host: host });
+		},
+	};
+});
 
 async function expectedHostAndZone(
+	config: StartDevWorkerOptions & { input: StartDevWorkerInput },
 	host: string,
 	zone: string
 ): Promise<unknown> {
-	const config = (Dev as Mock).mock.calls[0][0];
-	expect(config).toEqual(
-		expect.objectContaining({
-			localUpstream: host,
-		})
-	);
-	await expect(
-		getWorkerAccountAndContext({
-			accountId: "",
-			host: config.host,
-			routes: config.routes,
-		})
-	).resolves.toEqual(
+	expect(config).toMatchObject({
+		dev: { origin: { hostname: host } },
+	});
+
+	const ctx = await getWorkerAccountAndContext({
+		accountId: "",
+		host: config.input.dev?.origin?.hostname,
+		routes: config.triggers
+			?.filter(
+				(trigger): trigger is Extract<Trigger, { type: "route" }> =>
+					trigger.type === "route"
+			)
+			.map((trigger) => {
+				const { type: _, ...route } = trigger;
+				if (
+					"custom_domain" in route ||
+					"zone_id" in route ||
+					"zone_name" in route
+				) {
+					return route;
+				} else {
+					return route.pattern;
+				}
+			}),
+	});
+
+	expect(ctx).toEqual(
 		expect.objectContaining({
 			workerContext: {
 				host,
 				zone,
-				routes: config.routes,
+				routes: config.triggers
+					?.filter(
+						(trigger): trigger is Extract<Trigger, { type: "route" }> =>
+							trigger.type === "route"
+					)
+					.map((trigger) => {
+						const { type: _, ...route } = trigger;
+						if (
+							"custom_domain" in route ||
+							"zone_id" in route ||
+							"zone_name" in route
+						) {
+							return route;
+						} else {
+							return route.pattern;
+						}
+					}),
 			},
 		})
 	);
 
-	(Dev as Mock).mockClear();
 	return config;
 }
 
-describe("wrangler dev", () => {
+describe.sequential("wrangler dev", () => {
+	let spy: MockInstance;
+	let setSpy: MockInstance;
 	beforeEach(() => {
+		setSpy = vi.spyOn(ConfigController.prototype, "set");
+		spy = vi
+			.spyOn(ConfigController.prototype, "emitConfigUpdateEvent")
+			.mockImplementation(() => {
+				// In unit tests of `wrangler dev` we only care about the first config parse event, so exit early
+				throw new FatalError("Bailing early in tests");
+			});
 		msw.use(
 			...mswZoneHandlers,
 			...mswSuccessOauthHandlers,
@@ -68,10 +130,23 @@ describe("wrangler dev", () => {
 	mockApiToken();
 	const std = mockConsoleMethods();
 	afterEach(() => {
-		(Dev as Mock).mockClear();
 		patchConsole(() => {});
 		msw.resetHandlers();
+		spy.mockClear();
+		setSpy.mockClear();
 	});
+
+	async function runWranglerUntilConfig(
+		cmd?: string,
+		env?: Record<string, string | undefined>
+	): Promise<StartDevWorkerOptions & { input: StartDevWorkerInput }> {
+		try {
+			await runWrangler(cmd, env);
+		} catch (e) {
+			console.error(e);
+		}
+		return { ...spy.mock.calls[0][0], input: setSpy.mock.calls[0][0] };
+	}
 
 	describe("config file support", () => {
 		it("should support wrangler.toml", async () => {
@@ -82,10 +157,8 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 
-			await runWrangler("dev");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
+			const options = await runWranglerUntilConfig("dev");
+			expect(options.name).toMatchInlineSnapshot(`"test-worker-toml"`);
 		});
 
 		it("should support wrangler.json", async () => {
@@ -96,10 +169,10 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 
-			await runWrangler("dev --experimental-json-config");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
+			const options = await runWranglerUntilConfig(
+				"dev --experimental-json-config"
+			);
+			expect(options.name).toMatchInlineSnapshot(`"test-worker-json"`);
 		});
 
 		it("should support wrangler.jsonc", async () => {
@@ -113,10 +186,10 @@ describe("wrangler dev", () => {
 			);
 			fs.writeFileSync("index.js", `export default {};`);
 
-			await runWrangler("dev --experimental-json-config");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
+			const options = await runWranglerUntilConfig(
+				"dev --experimental-json-config"
+			);
+			expect(options.name).toMatchInlineSnapshot(`"test-worker-jsonc"`);
 		});
 	});
 
@@ -137,9 +210,9 @@ describe("wrangler dev", () => {
 	});
 
 	describe("compatibility-date", () => {
-		it("should not warn if there is no wrangler.toml and no compatibility-date specified", async () => {
+		it.skip("should not warn if there is no wrangler.toml and no compatibility-date specified", async () => {
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js");
+			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
@@ -151,7 +224,7 @@ describe("wrangler dev", () => {
 				compatibility_date: undefined,
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
+			await runWranglerUntilConfig("dev");
 
 			const miniflareEntry = require.resolve("miniflare");
 			const miniflareRequire = module.createRequire(miniflareEntry);
@@ -160,7 +233,6 @@ describe("wrangler dev", () => {
 			};
 			const currentDate = miniflareWorkerd.compatibilityDate;
 
-			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.warn.replaceAll(currentDate, "<current-date>"))
 				.toMatchInlineSnapshot(`
 "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mNo compatibility_date was specified. Using the installed Workers runtime's latest supported date: <current-date>.[0m
@@ -172,41 +244,16 @@ describe("wrangler dev", () => {
 
 "
 `);
-			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should not warn if there is a wrangler.toml but compatibility-date is specified at the command line", async () => {
+		it.skip("should not warn if there is a wrangler.toml but compatibility-date is specified at the command line", async () => {
 			writeWranglerToml({
 				main: "index.js",
 				compatibility_date: undefined,
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --compatibility-date=2020-01-01");
-			expect(std.out).toMatchInlineSnapshot(`""`);
+			await runWranglerUntilConfig("dev --compatibility-date=2020-01-01");
 			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
-		});
-	});
-
-	describe("usage-model", () => {
-		it("should read wrangler.toml's usage_model", async () => {
-			writeWranglerToml({
-				main: "index.js",
-				usage_model: "unbound",
-			});
-			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].usageModel).toEqual("unbound");
-		});
-
-		it("should read wrangler.toml's usage_model in local mode", async () => {
-			writeWranglerToml({
-				main: "index.js",
-				usage_model: "unbound",
-			});
-			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].usageModel).toEqual("unbound");
 		});
 	});
 
@@ -233,11 +280,8 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].entry.file).toMatch(/index\.js$/);
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.entrypoint).toMatch(/index\.js$/);
 		});
 
 		it("should use `main` from a named environment", async () => {
@@ -249,11 +293,8 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --env=ENV1");
-			expect((Dev as Mock).mock.calls[0][0].entry.file).toMatch(/index\.js$/);
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev --env=ENV1");
+			expect(config.entrypoint).toMatch(/index\.js$/);
 		});
 
 		it("should use `main` from a named environment, rather than the top-level", async () => {
@@ -266,16 +307,13 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --env=ENV1");
-			expect((Dev as Mock).mock.calls[0][0].entry.file).toMatch(/index\.js$/);
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev --env=ENV1");
+			expect(config.entrypoint).toMatch(/index\.js$/);
 		});
 	});
 
 	describe("routes", () => {
-		it("should pass routes to <Dev/>", async () => {
+		it("should pass routes to emitConfigUpdate", async () => {
 			fs.writeFileSync("index.js", `export default {};`);
 
 			// config.routes
@@ -284,18 +322,21 @@ describe("wrangler dev", () => {
 				main: "index.js",
 				routes: ["http://5.some-host.com/some/path/*"],
 			});
-			await runWrangler("dev --remote");
+			const config = await runWranglerUntilConfig("dev --remote");
 
 			const devConfig = await expectedHostAndZone(
+				config,
 				"5.some-host.com",
 				"some-zone-id-5"
 			);
 
-			expect(devConfig).toEqual(
-				expect.objectContaining({
-					routes: ["http://5.some-host.com/some/path/*"],
-				})
-			);
+			expect(devConfig).toMatchObject({
+				triggers: [
+					{
+						pattern: "http://5.some-host.com/some/path/*",
+					},
+				],
+			});
 		});
 		it("should error if custom domains with paths are passed in but allow paths on normal routes", async () => {
 			fs.writeFileSync("index.js", `export default {};`);
@@ -324,7 +365,7 @@ describe("wrangler dev", () => {
 				Paths are not allowed in Custom Domains]
 			`);
 		});
-		it("should error on routes with paths if assets are present", async () => {
+		it.skip("should error on routes with paths if assets are present", async () => {
 			writeWranglerToml({
 				routes: [
 					"simple.co.uk/path",
@@ -390,9 +431,11 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
-			await runWrangler("dev --remote --host some-host.com");
+			const config = await runWranglerUntilConfig(
+				"dev --remote --host some-host.com"
+			);
 
-			await expectedHostAndZone("some-host.com", "some-zone-id");
+			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
 		});
 
 		it("should read wrangler.toml's dev.host", async () => {
@@ -404,8 +447,8 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].host).toEqual("some-host.com");
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.origin?.hostname).toEqual("some-host.com");
 		});
 
 		it("should read --route", async () => {
@@ -414,8 +457,10 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
-			await runWrangler("dev --route http://some-host.com/some/path/*");
-			await expectedHostAndZone("some-host.com", "some-zone-id");
+			const config = await runWranglerUntilConfig(
+				"dev --route http://some-host.com/some/path/*"
+			);
+			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
 		});
 
 		it("should read wrangler.toml's routes", async () => {
@@ -428,8 +473,8 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
-			await runWrangler("dev");
-			await expectedHostAndZone("some-host.com", "some-zone-id");
+			const config = await runWranglerUntilConfig("dev");
+			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
 		});
 
 		it("should read wrangler.toml's environment specific routes", async () => {
@@ -450,8 +495,8 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
-			await runWrangler("dev --env staging");
-			await expectedHostAndZone("some-host.com", "some-zone-id");
+			const config = await runWranglerUntilConfig("dev --env staging");
+			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
 		});
 
 		it("should strip leading `*` from given host when deducing a zone id", async () => {
@@ -461,8 +506,8 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
-			await runWrangler("dev");
-			await expectedHostAndZone("some-host.com", "some-zone-id");
+			const config = await runWranglerUntilConfig("dev");
+			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
 		});
 
 		it("should strip leading `*.` from given host when deducing a zone id", async () => {
@@ -472,8 +517,8 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			mockGetZones("some-host.com", [{ id: "some-zone-id" }]);
-			await runWrangler("dev");
-			await expectedHostAndZone("some-host.com", "some-zone-id");
+			const config = await runWranglerUntilConfig("dev");
+			await expectedHostAndZone(config, "some-host.com", "some-zone-id");
 		});
 
 		it("should, when provided, use a configured zone_id", async () => {
@@ -484,9 +529,9 @@ describe("wrangler dev", () => {
 				],
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --remote");
+			const config = await runWranglerUntilConfig("dev --remote");
 
-			await expectedHostAndZone("some-domain.com", "some-zone-id");
+			await expectedHostAndZone(config, "some-domain.com", "some-zone-id");
 		});
 
 		it("should, when provided, use a zone_name to get a zone_id", async () => {
@@ -501,9 +546,9 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			mockGetZones("some-zone.com", [{ id: "a-zone-id" }]);
-			await runWrangler("dev --remote");
+			const config = await runWranglerUntilConfig("dev --remote");
 
-			await expectedHostAndZone("some-zone.com", "a-zone-id");
+			await expectedHostAndZone(config, "some-zone.com", "a-zone-id");
 		});
 
 		it("should find the host from the given pattern, not zone_name", async () => {
@@ -517,9 +562,9 @@ describe("wrangler dev", () => {
 				],
 			});
 			await fs.promises.writeFile("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+
+			expect(config.dev.origin?.hostname).toBe("subdomain.exists.com");
 		});
 
 		it("should fail for non-existing zones, when falling back from */*", async () => {
@@ -551,9 +596,13 @@ describe("wrangler dev", () => {
 				],
 			});
 			await fs.promises.writeFile("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+
+			expect(config.triggers).toMatchObject([
+				{
+					zone_name: "exists.com",
+				},
+			]);
 		});
 		it("fails when given the pattern */* and no zone_name", async () => {
 			writeWranglerToml({
@@ -609,77 +658,89 @@ describe("wrangler dev", () => {
 				})
 			);
 
-			await runWrangler("dev --remote --host 111.222.333.some-host.com");
+			const config = await runWranglerUntilConfig(
+				"dev --remote --host 111.222.333.some-host.com"
+			);
 
-			await expectedHostAndZone("111.222.333.some-host.com", "some-zone-id");
+			await expectedHostAndZone(
+				config,
+				"111.222.333.some-host.com",
+				"some-zone-id"
+			);
 		});
 
-		it("should, in order, use args.host/config.dev.host/args.routes/(config.route|config.routes)", async () => {
-			// This test might seem like it's testing implementation details, but let's be specific and consider it a spec
+		describe("should, in order, use args.host/config.dev.host/args.routes/(config.route|config.routes)", () => {
+			it("config.routes", async () => {
+				fs.writeFileSync("index.js", `export default {};`);
 
-			fs.writeFileSync("index.js", `export default {};`);
+				mockGetZones("5.some-host.com", [{ id: "some-zone-id-5" }]);
+				writeWranglerToml({
+					main: "index.js",
+					routes: ["http://5.some-host.com/some/path/*"],
+				});
+				const config = await runWranglerUntilConfig("dev --remote");
 
-			// config.routes
-			mockGetZones("5.some-host.com", [{ id: "some-zone-id-5" }]);
-			writeWranglerToml({
-				main: "index.js",
-				routes: ["http://5.some-host.com/some/path/*"],
+				await expectedHostAndZone(config, "5.some-host.com", "some-zone-id-5");
 			});
-			await runWrangler("dev --remote");
+			it("config.route", async () => {
+				fs.writeFileSync("index.js", `export default {};`);
 
-			await expectedHostAndZone("5.some-host.com", "some-zone-id-5");
+				mockGetZones("4.some-host.com", [{ id: "some-zone-id-4" }]);
+				writeWranglerToml({
+					main: "index.js",
+					route: "https://4.some-host.com/some/path/*",
+				});
+				const config2 = await runWranglerUntilConfig("dev --remote");
 
-			// config.route
-			mockGetZones("4.some-host.com", [{ id: "some-zone-id-4" }]);
-			writeWranglerToml({
-				main: "index.js",
-				route: "https://4.some-host.com/some/path/*",
+				await expectedHostAndZone(config2, "4.some-host.com", "some-zone-id-4");
 			});
-			await runWrangler("dev --remote");
+			it("--routes", async () => {
+				fs.writeFileSync("index.js", `export default {};`);
 
-			await expectedHostAndZone("4.some-host.com", "some-zone-id-4");
+				mockGetZones("3.some-host.com", [{ id: "some-zone-id-3" }]);
+				writeWranglerToml({
+					main: "index.js",
+					route: "https://4.some-host.com/some/path/*",
+				});
+				const config3 = await runWranglerUntilConfig(
+					"dev --remote --routes http://3.some-host.com/some/path/*"
+				);
 
-			// --routes
-			mockGetZones("3.some-host.com", [{ id: "some-zone-id-3" }]);
-			writeWranglerToml({
-				main: "index.js",
-				route: "https://4.some-host.com/some/path/*",
+				await expectedHostAndZone(config3, "3.some-host.com", "some-zone-id-3");
 			});
-			await runWrangler(
-				"dev --remote --routes http://3.some-host.com/some/path/*"
-			);
+			it("config.dev.host", async () => {
+				fs.writeFileSync("index.js", `export default {};`);
 
-			await expectedHostAndZone("3.some-host.com", "some-zone-id-3");
-
-			// config.dev.host
-			mockGetZones("2.some-host.com", [{ id: "some-zone-id-2" }]);
-			writeWranglerToml({
-				main: "index.js",
-				dev: {
-					host: `2.some-host.com`,
-				},
-				route: "4.some-host.com/some/path/*",
+				mockGetZones("2.some-host.com", [{ id: "some-zone-id-2" }]);
+				writeWranglerToml({
+					main: "index.js",
+					dev: {
+						host: `2.some-host.com`,
+					},
+					route: "4.some-host.com/some/path/*",
+				});
+				const config4 = await runWranglerUntilConfig(
+					"dev --remote --routes http://3.some-host.com/some/path/*"
+				);
+				expect(config4.dev.origin?.hostname).toBe("2.some-host.com");
 			});
-			await runWrangler(
-				"dev --remote --routes http://3.some-host.com/some/path/*"
-			);
-			await expectedHostAndZone("2.some-host.com", "some-zone-id-2");
+			it("host", async () => {
+				fs.writeFileSync("index.js", `export default {};`);
 
-			// --host
-			mockGetZones("1.some-host.com", [{ id: "some-zone-id-1" }]);
-			writeWranglerToml({
-				main: "index.js",
-				dev: {
-					host: `2.some-host.com`,
-				},
-				route: "4.some-host.com/some/path/*",
+				mockGetZones("1.some-host.com", [{ id: "some-zone-id-1" }]);
+				writeWranglerToml({
+					main: "index.js",
+					dev: {
+						host: `2.some-host.com`,
+					},
+					route: "4.some-host.com/some/path/*",
+				});
+				const config5 = await runWranglerUntilConfig(
+					"dev --remote --routes http://3.some-host.com/some/path/* --host 1.some-host.com"
+				);
+				await expectedHostAndZone(config5, "1.some-host.com", "some-zone-id-1");
 			});
-			await runWrangler(
-				"dev --remote --routes http://3.some-host.com/some/path/* --host 1.some-host.com"
-			);
-			await expectedHostAndZone("1.some-host.com", "some-zone-id-1");
 		});
-
 		it("should error if a host can't resolve to a zone", async () => {
 			writeWranglerToml({
 				main: "index.js",
@@ -698,8 +759,9 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --host some-host.com");
-			expect((Dev as Mock).mock.calls[0][0].zone).toEqual(undefined);
+			const config = await runWranglerUntilConfig("dev --host some-host.com");
+			// This is testing the _lack_ of the error in the test above: https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/src/__tests__/dev.test.tsx#L725-L726
+			expect(config.dev.origin?.hostname).toBe("some-host.com");
 		});
 	});
 
@@ -712,10 +774,8 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].localUpstream).toEqual(
-				"2.some-host.com"
-			);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.origin?.hostname).toEqual("2.some-host.com");
 		});
 
 		it("should use route from toml by default", async () => {
@@ -724,10 +784,8 @@ describe("wrangler dev", () => {
 				route: "https://4.some-host.com/some/path/*",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].localUpstream).toEqual(
-				"4.some-host.com"
-			);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.origin?.hostname).toEqual("4.some-host.com");
 		});
 
 		it("should respect the option when provided", async () => {
@@ -736,10 +794,11 @@ describe("wrangler dev", () => {
 				route: `2.some-host.com`,
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --local-upstream some-host.com");
-			expect((Dev as Mock).mock.calls[0][0].localUpstream).toEqual(
-				"some-host.com"
+
+			const config = await runWranglerUntilConfig(
+				"dev --local-upstream some-host.com"
 			);
+			expect(config.dev.origin?.hostname).toEqual("some-host.com");
 		});
 	});
 
@@ -751,35 +810,37 @@ describe("wrangler dev", () => {
 				},
 			});
 
-			await runWrangler("dev index.js");
+			const config = await runWranglerUntilConfig("dev index.js");
 
 			expect(fs.readFileSync("index.js", "utf-8")).toMatchInlineSnapshot(
 				`"export default { fetch(){ return new Response(123) } }"`
 			);
 
 			// and the command would pass through
-			expect((Dev as Mock).mock.calls[0][0].build).toEqual({
+			expect(config.build.custom).toEqual({
 				command:
 					"node -e \"4+4; require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\"",
-				cwd: undefined,
-				watch_dir: "src",
+				workingDirectory: undefined,
+				watch: "src",
 			});
 			expect(std.out).toMatchInlineSnapshot(
-				`"Running custom build: node -e \\"4+4; require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\\""`
+				`
+				"Running custom build: node -e \\"4+4; require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\\"
+				"
+			`
 			);
-			expect(std.err).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		if (process.platform !== "win32") {
-			it("should run a custom build of multiple steps combined by && before starting `dev`", async () => {
+		it.skipIf(process.platform === "win32")(
+			"should run a custom build of multiple steps combined by && before starting `dev`",
+			async () => {
 				writeWranglerToml({
 					build: {
 						command: `echo "export default { fetch(){ return new Response(123) } }" > index.js`,
 					},
 				});
 
-				await runWrangler("dev index.js");
+				await runWranglerUntilConfig("dev index.js");
 
 				expect(fs.readFileSync("index.js", "utf-8")).toMatchInlineSnapshot(`
 			          "export default { fetch(){ return new Response(123) } }
@@ -787,12 +848,13 @@ describe("wrangler dev", () => {
 		        `);
 
 				expect(std.out).toMatchInlineSnapshot(
-					`"Running custom build: echo \\"export default { fetch(){ return new Response(123) } }\\" > index.js"`
+					`
+					"Running custom build: echo \\"export default { fetch(){ return new Response(123) } }\\" > index.js
+					"
+				`
 				);
-				expect(std.err).toMatchInlineSnapshot(`""`);
-				expect(std.warn).toMatchInlineSnapshot(`""`);
-			});
-		}
+			}
+		);
 
 		it("should throw an error if the entry doesn't exist after the build finishes", async () => {
 			writeWranglerToml({
@@ -845,12 +907,12 @@ describe("wrangler dev", () => {
 			});
 
 			it("should load environment variables from `.env`", async () => {
-				await runWrangler("dev");
+				await runWranglerUntilConfig("dev");
 				const output = fs.readFileSync("var.txt", "utf8");
 				expect(output).toMatch("default");
 			});
 			it("should prefer to load environment variables from `.env.<environment>` if `--env <environment>` is set", async () => {
-				await runWrangler("dev --env custom");
+				await runWranglerUntilConfig("dev --env custom");
 				const output = fs.readFileSync("var.txt", "utf8");
 				expect(output).toMatch("custom");
 			});
@@ -863,11 +925,8 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --remote");
-			expect((Dev as Mock).mock.calls[0][0].upstreamProtocol).toEqual("https");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev --remote");
+			expect(config.dev.origin?.secure).toEqual(true);
 		});
 
 		it("should warn if `--upstream-protocol=http` is used in remote mode", async () => {
@@ -875,9 +934,10 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --upstream-protocol=http --remote");
-			expect((Dev as Mock).mock.calls[0][0].upstreamProtocol).toEqual("http");
-			expect(std.out).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig(
+				"dev --upstream-protocol=http --remote"
+			);
+			expect(config.dev.origin?.secure).toEqual(false);
 			expect(std.warn).toMatchInlineSnapshot(`
 			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mSetting upstream-protocol to http is not currently supported for remote mode.[0m
 
@@ -886,7 +946,6 @@ describe("wrangler dev", () => {
 
 			"
 		`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
 		it("should default upstream-protocol to local-protocol if local mode", async () => {
@@ -894,11 +953,8 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --local-protocol=https");
-			expect((Dev as Mock).mock.calls[0][0].upstreamProtocol).toEqual("https");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev --local-protocol=https");
+			expect(config.dev.origin?.secure).toEqual(true);
 		});
 
 		it("should default upstream-protocol to http if no local-protocol in local mode", async () => {
@@ -906,11 +962,8 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].upstreamProtocol).toEqual("http");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.origin?.secure).toEqual(false);
 		});
 	});
 
@@ -920,11 +973,8 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].localProtocol).toEqual("http");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.server?.secure).toEqual(false);
 		});
 
 		it("should use `local_protocol` from `wrangler.toml`, if available", async () => {
@@ -935,11 +985,8 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].localProtocol).toEqual("https");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.server?.secure).toEqual(true);
 		});
 
 		it("should use --local-protocol command line arg, if provided", async () => {
@@ -952,11 +999,8 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --local-protocol=http");
-			expect((Dev as Mock).mock.calls[0][0].localProtocol).toEqual("http");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev --local-protocol=http");
+			expect(config.dev.server?.secure).toEqual(false);
 		});
 	});
 
@@ -966,13 +1010,10 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].initialIp).toEqual(
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.server?.hostname).toEqual(
 				process.platform === "win32" ? "127.0.0.1" : "localhost"
 			);
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 
 		it("should use to `ip` from `wrangler.toml`, if available", async () => {
@@ -983,11 +1024,8 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].initialIp).toEqual("::1");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.server?.hostname).toEqual("::1");
 		});
 
 		it("should use --ip command line arg, if provided", async () => {
@@ -998,11 +1036,8 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --ip=127.0.0.1");
-			expect((Dev as Mock).mock.calls[0][0].initialIp).toEqual("127.0.0.1");
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev --ip=127.0.0.1");
+			expect(config.dev.server?.hostname).toEqual("127.0.0.1");
 		});
 	});
 
@@ -1013,17 +1048,8 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].inspectorPort).toEqual(9229);
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "",
-			  "warn": "",
-			}
-		`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.inspector?.port).toEqual(9229);
 		});
 
 		it("should read --inspector-port", async () => {
@@ -1032,17 +1058,8 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev --inspector-port=9999");
-			expect((Dev as Mock).mock.calls[0][0].inspectorPort).toEqual(9999);
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "",
-			  "warn": "",
-			}
-		`);
+			const config = await runWranglerUntilConfig("dev --inspector-port=9999");
+			expect(config.dev.inspector?.port).toEqual(9999);
 		});
 
 		it("should read dev.inspector_port from wrangler.toml", async () => {
@@ -1053,17 +1070,8 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].inspectorPort).toEqual(9999);
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "",
-			  "warn": "",
-			}
-		`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.inspector?.port).toEqual(9999);
 		});
 
 		it("should error if a bad dev.inspector_port config is provided", async () => {
@@ -1089,11 +1097,8 @@ describe("wrangler dev", () => {
 				main: "index.js",
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].initialPort).toEqual(8787);
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.server?.port).toEqual(8787);
 		});
 
 		it("should use `port` from `wrangler.toml`, if available", async () => {
@@ -1105,13 +1110,10 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			// Mock `getPort()` to resolve to a completely different port.
-			(getPort as Mock).mockResolvedValue(98765);
+			(getPort as Mock).mockResolvedValueOnce(98765);
 
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].initialPort).toEqual(8888);
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.server?.port).toEqual(8888);
 		});
 
 		it("should error if a bad dev.port config is provided", async () => {
@@ -1139,13 +1141,10 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			// Mock `getPort()` to resolve to a completely different port.
-			(getPort as Mock).mockResolvedValue(98765);
+			(getPort as Mock).mockResolvedValueOnce(98766);
 
-			await runWrangler("dev --port=9999");
-			expect((Dev as Mock).mock.calls[0][0].initialPort).toEqual(9999);
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev --port=9999");
+			expect(config.dev.server?.port).toEqual(9999);
 		});
 
 		it("should use a different port to the default if it is in use", async () => {
@@ -1154,13 +1153,10 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			// Mock `getPort()` to resolve to a completely different port.
-			(getPort as Mock).mockResolvedValue(98765);
+			(getPort as Mock).mockResolvedValueOnce(98767);
 
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].initialPort).toEqual(98765);
-			expect(std.out).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.server?.port).toEqual(98767);
 		});
 	});
 
@@ -1186,47 +1182,47 @@ describe("wrangler dev", () => {
 				},
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].initialIp).toEqual(
+			const config = await runWranglerUntilConfig("dev");
+			expect(config.dev.server?.hostname).toEqual(
 				process.platform === "win32" ? "127.0.0.1" : "localhost"
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Your worker has access to the following bindings:
-			        - Durable Objects:
-			          - NAME_1: CLASS_1
-			          - NAME_2: CLASS_2 (defined in SCRIPT_A)
-			          - NAME_3: CLASS_3
-			          - NAME_4: CLASS_4 (defined in SCRIPT_B)"
-		      `);
+				"Your worker has access to the following bindings:
+				- Durable Objects:
+				  - NAME_1: CLASS_1
+				  - NAME_2: CLASS_2 (defined in SCRIPT_A)
+				  - NAME_3: CLASS_3
+				  - NAME_4: CLASS_4 (defined in SCRIPT_B)
+				"
+			`);
 			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-			    - In wrangler.toml, you have configured [durable_objects] exported by this Worker (CLASS_1,
-			  CLASS_3), but no [migrations] for them. This may not work as expected until you add a [migrations]
-			  section to your wrangler.toml. Add this configuration to your wrangler.toml:
+				    - In wrangler.toml, you have configured [durable_objects] exported by this Worker (CLASS_1,
+				  CLASS_3), but no [migrations] for them. This may not work as expected until you add a [migrations]
+				  section to your wrangler.toml. Add this configuration to your wrangler.toml:
 
-			        \`\`\`
-			        [[migrations]]
-			        tag = \\"v1\\" # Should be unique for each entry
-			        new_classes = [\\"CLASS_1\\", \\"CLASS_3\\"]
-			        \`\`\`
+				        \`\`\`
+				        [[migrations]]
+				        tag = \\"v1\\" # Should be unique for each entry
+				        new_classes = [\\"CLASS_1\\", \\"CLASS_3\\"]
+				        \`\`\`
 
-			      Refer to
-			  [4mhttps://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/[0m for more
-			  details.
+				      Refer to
+				  [4mhttps://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/[0m for more
+				  details.
 
 
-			[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.[0m
+				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWARNING: You have Durable Object bindings that are not defined locally in the worker being developed.[0m
 
-			  Be aware that changes to the data stored in these Durable Objects will be permanent and affect the
-			  live instances.
-			  Remote Durable Objects that are affected:
-			  - {\\"name\\":\\"NAME_2\\",\\"class_name\\":\\"CLASS_2\\",\\"script_name\\":\\"SCRIPT_A\\"}
-			  - {\\"name\\":\\"NAME_4\\",\\"class_name\\":\\"CLASS_4\\",\\"script_name\\":\\"SCRIPT_B\\"}
+				  Be aware that changes to the data stored in these Durable Objects will be permanent and affect the
+				  live instances.
+				  Remote Durable Objects that are affected:
+				  - {\\"name\\":\\"NAME_2\\",\\"class_name\\":\\"CLASS_2\\",\\"script_name\\":\\"SCRIPT_A\\"}
+				  - {\\"name\\":\\"NAME_4\\",\\"class_name\\":\\"CLASS_4\\",\\"script_name\\":\\"SCRIPT_B\\"}
 
-			"
-		`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+				"
+			`);
 		});
 	});
 
@@ -1258,9 +1254,17 @@ describe("wrangler dev", () => {
 					UNQUOTED: "original unquoted",
 				},
 			});
-			await runWrangler("dev");
-			const varBindings: Record<string, unknown> = (Dev as Mock).mock
-				.calls[0][0].bindings.vars;
+			const config = await runWranglerUntilConfig("dev");
+			const varBindings: Record<string, unknown> = Object.fromEntries(
+				Object.entries(config.bindings ?? {})
+					.filter(
+						(
+							binding
+						): binding is [string, Extract<Binding, { type: "plain_text" }>] =>
+							binding[1].type === "plain_text"
+					)
+					.map(([b, v]) => [b, v.value])
+			);
 
 			expect(varBindings).toEqual({
 				VAR_1: "var #1 value",
@@ -1272,19 +1276,18 @@ describe("wrangler dev", () => {
 				UNQUOTED: "unquoted value", // Note that whitespace is trimmed
 			});
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Using vars defined in .dev.vars
-			        Your worker has access to the following bindings:
-			        - Vars:
-			          - VAR_1: \\"(hidden)\\"
-			          - VAR_2: \\"original value 2\\"
-			          - VAR_3: \\"(hidden)\\"
-			          - VAR_MULTI_LINE_1: \\"(hidden)\\"
-			          - VAR_MULTI_LINE_2: \\"(hidden)\\"
-			          - EMPTY: \\"(hidden)\\"
-			          - UNQUOTED: \\"(hidden)\\""
-		      `);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+				"Using vars defined in .dev.vars
+				Your worker has access to the following bindings:
+				- Vars:
+				  - VAR_1: \\"(hidden)\\"
+				  - VAR_2: \\"original value 2\\"
+				  - VAR_3: \\"(hidden)\\"
+				  - VAR_MULTI_LINE_1: \\"(hidden)\\"
+				  - VAR_MULTI_LINE_2: \\"(hidden)\\"
+				  - EMPTY: \\"(hidden)\\"
+				  - UNQUOTED: \\"(hidden)\\"
+				"
+			`);
 		});
 
 		it("should prefer `.dev.vars.<environment>` if `--env <environment> set`", async () => {
@@ -1293,19 +1296,26 @@ describe("wrangler dev", () => {
 			fs.writeFileSync(".dev.vars.custom", "CUSTOM_VAR=custom");
 
 			writeWranglerToml({ main: "index.js", env: { custom: {} } });
-			await runWrangler("dev --env custom");
-			const varBindings: Record<string, unknown> = (Dev as Mock).mock
-				.calls[0][0].bindings.vars;
+			const config = await runWranglerUntilConfig("dev --env custom");
+			const varBindings: Record<string, unknown> = Object.fromEntries(
+				Object.entries(config.bindings ?? {})
+					.filter(
+						(
+							binding
+						): binding is [string, Extract<Binding, { type: "plain_text" }>] =>
+							binding[1].type === "plain_text"
+					)
+					.map(([b, v]) => [b, v.value])
+			);
 
 			expect(varBindings).toEqual({ CUSTOM_VAR: "custom" });
 			expect(std.out).toMatchInlineSnapshot(`
-			        "Using vars defined in .dev.vars.custom
-			        Your worker has access to the following bindings:
-			        - Vars:
-			          - CUSTOM_VAR: \\"(hidden)\\""
-		      `);
-			expect(std.warn).toMatchInlineSnapshot(`""`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
+				"Using vars defined in .dev.vars.custom
+				Your worker has access to the following bindings:
+				- Vars:
+				  - CUSTOM_VAR: \\"(hidden)\\"
+				"
+			`);
 		});
 	});
 
@@ -1370,7 +1380,7 @@ describe("wrangler dev", () => {
 				      --test-scheduled                             Test scheduled events by visiting /__scheduled in browser  [boolean] [default: false]
 				      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]
 				      --show-interactive-dev-session               Show interactive dev session  (defaults to true if the terminal supports interactivity)  [boolean]
-				      --experimental-dev-env, --x-dev-env          Use the experimental DevEnv instantiation (unified across wrangler dev and unstable_dev)  [boolean] [default: false]
+				      --experimental-dev-env, --x-dev-env          Use the experimental DevEnv instantiation (unified across wrangler dev and unstable_dev)  [boolean] [default: true]
 				      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: false]",
 				  "warn": "",
 				}
@@ -1433,20 +1443,34 @@ describe("wrangler dev", () => {
 			);
 		});
 
-		it("should indicate whether Sites is being used", async () => {
-			writeWranglerToml({
-				main: "index.js",
+		describe("should indicate whether Sites is being used", () => {
+			it("no use", async () => {
+				writeWranglerToml({
+					main: "index.js",
+				});
+				fs.writeFileSync("index.js", `export default {};`);
+
+				const config = await runWranglerUntilConfig("dev");
+				expect(config.legacy.site).toBeFalsy();
 			});
-			fs.writeFileSync("index.js", `export default {};`);
+			it("--site arg", async () => {
+				writeWranglerToml({
+					main: "index.js",
+				});
+				fs.writeFileSync("index.js", `export default {};`);
 
-			await runWrangler("dev");
-			expect((Dev as Mock).mock.calls[0][0].isWorkersSite).toEqual(false);
+				const config = await runWranglerUntilConfig("dev --site abc");
+				expect(config.legacy.site).toBeTruthy();
+			});
+			it("--legacy-assets arg", async () => {
+				writeWranglerToml({
+					main: "index.js",
+				});
+				fs.writeFileSync("index.js", `export default {};`);
 
-			await runWrangler("dev --site abc");
-			expect((Dev as Mock).mock.calls[1][0].isWorkersSite).toEqual(true);
-
-			await runWrangler("dev --legacy-assets abc");
-			expect((Dev as Mock).mock.calls[2][0].isWorkersSite).toEqual(false);
+				const config = await runWranglerUntilConfig("dev --legacy-assets abc");
+				expect(config.legacy.site).toBeFalsy();
+			});
 		});
 
 		it("should warn if --legacy-assets is used", async () => {
@@ -1455,7 +1479,7 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 
-			await runWrangler('dev --legacy-assets "./assets"');
+			await runWranglerUntilConfig('dev --legacy-assets "./assets"');
 			expect(std.warn).toMatchInlineSnapshot(`
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThe --legacy-assets argument has been deprecated. Please use --assets instead.[0m
 
@@ -1474,7 +1498,7 @@ describe("wrangler dev", () => {
 
 			fs.writeFileSync("index.js", `export default {};`);
 
-			await runWrangler("dev");
+			await runWranglerUntilConfig("dev");
 			expect(std.warn).toMatchInlineSnapshot(`
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
@@ -1493,7 +1517,7 @@ describe("wrangler dev", () => {
 				assets: { directory: "assets" },
 			});
 
-			await runWrangler("dev");
+			await runWranglerUntilConfig("dev");
 		});
 
 		it("should error if config.site and config.assets are used together", async () => {
@@ -1506,6 +1530,8 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.mkdirSync("assets");
+			fs.mkdirSync("xyz");
+
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1525,6 +1551,8 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.mkdirSync("assets");
+			fs.mkdirSync("xyz");
+
 			await expect(
 				runWrangler("dev --assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1549,6 +1577,8 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.mkdirSync("assets");
+			fs.mkdirSync("xyz");
+
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1585,6 +1615,7 @@ describe("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			fs.mkdirSync("assets");
+			fs.mkdirSync("xyz");
 			await expect(
 				runWrangler("dev --assets assets")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1595,7 +1626,7 @@ describe("wrangler dev", () => {
 			);
 		});
 
-		it("should error if config.assets and --legacy-assets are used together", async () => {
+		it.skip("should error if config.assets and --legacy-assets are used together", async () => {
 			writeWranglerToml({
 				main: "./index.js",
 				assets: {
@@ -1618,6 +1649,7 @@ describe("wrangler dev", () => {
 			writeWranglerToml({
 				assets: { directory: "assets", binding: "ASSETS" },
 			});
+			fs.mkdirSync("assets");
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -1655,31 +1687,6 @@ describe("wrangler dev", () => {
 			);
 		});
 
-		it("should error if --assets and config.tail_consumers are used together", async () => {
-			writeWranglerToml({
-				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
-			});
-			fs.mkdirSync("public");
-			await expect(
-				runWrangler("dev --assets public")
-			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets.]`
-			);
-		});
-
-		it("should error if config.assets and config.tail_consumers are used together", async () => {
-			writeWranglerToml({
-				assets: { directory: "./public" },
-				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
-			});
-			fs.mkdirSync("public");
-			await expect(
-				runWrangler("dev")
-			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets.]`
-			);
-		});
-
 		it("should error if --assets and --remote are used together", async () => {
 			fs.mkdirSync("public");
 			await expect(
@@ -1705,114 +1712,47 @@ describe("wrangler dev", () => {
 	describe("--inspect", () => {
 		it("should warn if --inspect is used", async () => {
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js --inspect");
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPassing --inspect is unnecessary, now you can always connect to devtools.[0m
+			await runWranglerUntilConfig("dev index.js --inspect");
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPassing --inspect is unnecessary, now you can always connect to devtools.[0m
 
-			",
-			}
-		`);
-		});
-
-		it("should default to true, without a warning", async () => {
-			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js");
-			expect((Dev as Mock).mock.calls[0][0].inspect).toEqual(true);
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "",
-			  "warn": "",
-			}
-		`);
-		});
-
-		it("should pass true, with a warning", async () => {
-			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js --inspect");
-			expect((Dev as Mock).mock.calls[0][0].inspect).toEqual(true);
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPassing --inspect is unnecessary, now you can always connect to devtools.[0m
-
-			",
-			}
-		`);
-		});
-
-		it("should pass false, without a warning", async () => {
-			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js --inspect false");
-			expect((Dev as Mock).mock.calls[0][0].inspect).toEqual(false);
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "",
-			  "warn": "",
-			}
-		`);
+				"
+			`);
 		});
 	});
 
 	describe("--log-level", () => {
 		it("should not output warnings with log-level 'none'", async () => {
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js --inspect --log-level none");
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "",
-			  "warn": "",
-			}
-		`);
+			await runWranglerUntilConfig("dev index.js --inspect --log-level none");
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
 		it("should output warnings with log-level 'warn'", async () => {
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js --inspect --log-level warn");
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPassing --inspect is unnecessary, now you can always connect to devtools.[0m
+			await runWranglerUntilConfig("dev index.js --inspect --log-level warn");
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPassing --inspect is unnecessary, now you can always connect to devtools.[0m
 
-			",
-			}
-		`);
+				"
+			`);
 		});
 	});
 
 	describe("--show-interactive-dev-session", () => {
 		it("should show interactive dev session with --show-interactive-dev-session", async () => {
 			fs.writeFileSync("index.js", `export default { }`);
-			await runWrangler("dev index.js --show-interactive-dev-session");
-			expect(
-				(Dev as Mock).mock.calls[0][0].showInteractiveDevSession
-			).toBeTruthy();
+			await runWranglerUntilConfig(
+				"dev index.js --show-interactive-dev-session"
+			);
+			expect(vi.mocked(registerDevHotKeys).mock.calls.length).toBe(1);
 		});
 		it("should not show interactive dev session with --show-interactive-dev-session=false", async () => {
 			fs.writeFileSync("index.js", `export default { }`);
-			await runWrangler("dev index.js --show-interactive-dev-session=false");
-			expect(
-				(Dev as Mock).mock.calls[0][0].showInteractiveDevSession
-			).toBeFalsy();
+			await runWranglerUntilConfig(
+				"dev index.js --show-interactive-dev-session=false"
+			);
+			expect(vi.mocked(registerDevHotKeys).mock.calls.length).toBe(0);
 		});
 	});
 
@@ -1825,19 +1765,19 @@ describe("wrangler dev", () => {
 				],
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js");
+			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			"Your worker has access to the following bindings:
-			- Services:
-			  - WorkerA: A
-			  - WorkerB: B - staging"
-		`);
+				"Your worker has access to the following bindings:
+				- Services:
+				  - WorkerA: A
+				  - WorkerB: B - staging
+				"
+			`);
 			expect(std.warn).toMatchInlineSnapshot(`
 			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis worker is bound to live services: WorkerA (A), WorkerB (B@staging)[0m
 
 			"
 		`);
-			expect(std.err).toMatchInlineSnapshot(`""`);
 		});
 	});
 
@@ -1850,21 +1790,19 @@ describe("wrangler dev", () => {
 				],
 			});
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js");
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "Your worker has access to the following bindings:
-			- Services:
-			  - WorkerA: A
-			  - WorkerB: B - staging",
-			  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis worker is bound to live services: WorkerA (A), WorkerB (B@staging)[0m
+			await runWranglerUntilConfig("dev index.js");
+			expect(std.out).toMatchInlineSnapshot(`
+				"Your worker has access to the following bindings:
+				- Services:
+				  - WorkerA: A
+				  - WorkerB: B - staging
+				"
+			`);
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis worker is bound to live services: WorkerA (A), WorkerB (B@staging)[0m
 
-			",
-			}
-		`);
+				"
+			`);
 		});
 
 		it("should mask vars that were overriden in .dev.vars", async () => {
@@ -1882,21 +1820,16 @@ describe("wrangler dev", () => {
       `
 			);
 			fs.writeFileSync("index.js", `export default {};`);
-			await runWrangler("dev index.js");
-			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "Using vars defined in .dev.vars
-			Your worker has access to the following bindings:
-			- Vars:
-			  - variable: 123
-			  - overriden: \\"(hidden)\\"
-			  - SECRET: \\"(hidden)\\"",
-			  "warn": "",
-			}
-		`);
+			await runWranglerUntilConfig("dev index.js");
+			expect(std.out).toMatchInlineSnapshot(`
+				"Using vars defined in .dev.vars
+				Your worker has access to the following bindings:
+				- Vars:
+				  - variable: 123
+				  - overriden: \\"(hidden)\\"
+				  - SECRET: \\"(hidden)\\"
+				"
+			`);
 		});
 	});
 

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { EventEmitter } from "node:events";
 import { logger } from "../../logger";
+import { formatMessage, ParseError } from "../../parse";
 import { BundlerController } from "./BundlerController";
 import { ConfigController } from "./ConfigController";
 import { LocalRuntimeController } from "./LocalRuntimeController";
@@ -139,6 +140,14 @@ export class DevEnv extends EventEmitter {
 		) {
 			logger.debug(`Error in ${ev.source}: ${ev.reason}\n`, ev.cause);
 			logger.debug("=> Error contextual data:", ev.data);
+		}
+		// Parse errors are recoverable by changing your `wrangler.toml` and saving
+		// All other errors from the ConfigController are non-recoverable
+		else if (
+			ev.source === "ConfigController" &&
+			ev.cause instanceof ParseError
+		) {
+			logger.log(formatMessage(ev.cause));
 		}
 		// if other knowable + recoverable errors occur, handle them here
 		else {

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -46,12 +46,7 @@ export class DevEnv extends EventEmitter {
 		});
 
 		this.on("error", (event: ErrorEvent) => {
-			// TODO: when we're are comfortable with StartDevWorker/DevEnv stability,
-			//       we can remove this handler and let the user handle the unknowable errors
-			//       or let the process crash. For now, log them to stderr
-			//       so we can identify knowable vs unknowable error candidates
-
-			logger.error(`Error in ${event.source}: ${event.reason}\n`, event.cause);
+			logger.debug(`Error in ${event.source}: ${event.reason}\n`, event.cause);
 			logger.debug("=> Error contextual data:", event.data);
 		});
 

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -180,6 +180,11 @@ export class LocalRuntimeController extends RuntimeController {
 				const port = parseInt(directUrl.port);
 				entrypointAddresses[name] = { host: directUrl.hostname, port };
 			}
+
+			if (this._torndown) {
+				return;
+			}
+
 			this.emitReloadCompleteEvent({
 				type: "reloadComplete",
 				config: data.config,
@@ -241,7 +246,10 @@ export class LocalRuntimeController extends RuntimeController {
 		// Ignored in local runtime
 	}
 
+	_torndown = false;
 	#teardown = async (): Promise<void> => {
+		this._torndown = true;
+
 		logger.debug("LocalRuntimeController teardown beginning...");
 
 		if (this.#mf) {

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -183,6 +183,7 @@ export class RemoteRuntimeController extends RuntimeController {
 				compatibilityDate: config.compatibilityDate,
 				compatibilityFlags: config.compatibilityFlags,
 				routes,
+				host: config.dev.origin?.hostname,
 			});
 
 			// If we received a new `bundleComplete` event before we were able to

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -86,6 +86,7 @@ export class RemoteRuntimeController extends RuntimeController {
 					legacyEnv: props.legacyEnv,
 					host: props.host,
 					routes: props.routes,
+					sendMetrics: props.sendMetrics,
 				}
 			);
 			if (!this.#session) {
@@ -155,6 +156,7 @@ export class RemoteRuntimeController extends RuntimeController {
 				legacyEnv: !config.legacy?.enableServiceEnvironments, // wrangler environment -- just pass it through for now
 				host: config.dev.origin?.hostname,
 				routes,
+				sendMetrics: config.sendMetrics,
 			});
 
 			const bindings = (
@@ -184,6 +186,7 @@ export class RemoteRuntimeController extends RuntimeController {
 				compatibilityFlags: config.compatibilityFlags,
 				routes,
 				host: config.dev.origin?.hostname,
+				sendMetrics: config.sendMetrics,
 			});
 
 			// If we received a new `bundleComplete` event before we were able to

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -165,10 +165,10 @@ export interface StartDevWorkerInput {
 		enableServiceEnvironments?: boolean;
 	};
 	unsafe?: Omit<CfUnsafe, "bindings">;
-	assets?: Omit<AssetsOptions, "bindings">;
+	assets?: string;
 }
 
-export type StartDevWorkerOptions = StartDevWorkerInput & {
+export type StartDevWorkerOptions = Omit<StartDevWorkerInput, "assets"> & {
 	/** A worker's directory. Usually where the wrangler.toml file is located */
 	directory: string;
 	build: StartDevWorkerInput["build"] & {
@@ -189,6 +189,7 @@ export type StartDevWorkerOptions = StartDevWorkerInput & {
 		persist: string;
 	};
 	entrypoint: string;
+	assets?: AssetsOptions;
 };
 
 export type HookValues = string | number | boolean | object | undefined | null;

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -19,8 +19,10 @@ import { logger, LOGGER_LEVELS } from "./logger";
 import { hashFile } from "./pages/hash";
 import { isJwtExpired } from "./pages/upload";
 import { APIError } from "./parse";
+import { getBasePath } from "./paths";
 import { dedent } from "./utils/dedent";
 import { createPatternMatcher } from "./utils/filesystem";
+import type { StartDevWorkerOptions } from "./api";
 import type { Config } from "./config";
 import type { Assets } from "./config/environment";
 import type { DeployArgs } from "./deploy";
@@ -362,18 +364,30 @@ export function processAssetsArg(
  * and throw an appropriate error if invalid.
  */
 export function validateAssetsArgsAndConfig(
+	args: Pick<StartDevWorkerOptions, "legacy" | "assets" | "entrypoint">
+): void;
+export function validateAssetsArgsAndConfig(
 	args:
 		| Pick<StartDevOptions, "legacyAssets" | "site" | "assets" | "script">
 		| Pick<DeployArgs, "legacyAssets" | "site" | "assets" | "script">,
 	config: Config
-) {
+): void;
+export function validateAssetsArgsAndConfig(
+	args:
+		| Pick<StartDevOptions, "legacyAssets" | "site" | "assets" | "script">
+		| Pick<DeployArgs, "legacyAssets" | "site" | "assets" | "script">
+		| Pick<StartDevWorkerOptions, "legacy" | "assets" | "entrypoint">,
+	config?: Config
+): void {
 	/*
 	 * - `config.legacy_assets` conflates `legacy_assets` and `assets`
 	 * - `args.legacyAssets` conflates `legacy-assets` and `assets`
 	 */
 	if (
-		(args.assets || config.assets) &&
-		(args.legacyAssets || config.legacy_assets)
+		"legacy" in args
+			? args.assets && args.legacy.legacyAssets
+			: (args.assets || config?.assets) &&
+				(args?.legacyAssets || config?.legacy_assets)
 	) {
 		throw new UserError(
 			"Cannot use assets and legacy assets in the same Worker.\n" +
@@ -381,20 +395,34 @@ export function validateAssetsArgsAndConfig(
 		);
 	}
 
-	if ((args.assets || config.assets) && (args.site || config.site)) {
+	if (
+		"legacy" in args
+			? args.assets && args.legacy.site
+			: (args.assets || config?.assets) && (args.site || config?.site)
+	) {
 		throw new UserError(
 			"Cannot use assets and Workers Sites in the same Worker.\n" +
 				"Please remove either the `site` or `assets` field from your configuration file."
 		);
 	}
 
-	if ((args.assets || config.assets) && config.tail_consumers?.length) {
+	// tail_consumers don't exist in dev, so ignore SDW here
+	if ((args.assets || config?.assets) && config?.tail_consumers?.length) {
 		throw new UserError(
 			"Cannot use assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets."
 		);
 	}
 
-	if (!(args.script || config.main) && config.assets?.binding) {
+	const noOpEntrypoint = path.resolve(
+		getBasePath(),
+		"templates/no-op-worker.js"
+	);
+
+	if (
+		"legacy" in args
+			? args.entrypoint === noOpEntrypoint && args.assets?.binding
+			: !(args.script || config?.main) && config?.assets?.binding
+	) {
 		throw new UserError(
 			"Cannot use assets with a binding in an assets-only Worker.\n" +
 				"Please remove the asset binding from your configuration file, or provide a Worker script in your configuration file (`main`)."

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -15,8 +15,8 @@ import { findWranglerToml, printBindings, readConfig } from "./config";
 import { validateRoutes } from "./deploy/deploy";
 import { getEntry } from "./deployment-bundle/entry";
 import { validateNodeCompatMode } from "./deployment-bundle/node-compat";
-import { getBoundRegisteredWorkers } from "./dev-registry";
-import Dev, { devRegistry } from "./dev/dev";
+import { devRegistry, getBoundRegisteredWorkers } from "./dev-registry";
+import Dev from "./dev/dev";
 import { getVarsForDev } from "./dev/dev-vars";
 import { getLocalPersistencePath } from "./dev/get-local-persistence-path";
 import registerDevHotKeys from "./dev/hotkeys";
@@ -546,11 +546,6 @@ export async function startDev(args: StartDevOptions) {
 	let assetsWatcher: ReturnType<typeof watch> | undefined;
 	let rerender: (node: React.ReactNode) => void | undefined;
 	try {
-		const configPath =
-			args.config ||
-			(args.script && findWranglerToml(path.dirname(args.script)));
-		let config = readConfig(configPath, args);
-
 		if (args.logLevel) {
 			logger.loggerLevel = args.logLevel;
 		}
@@ -588,36 +583,16 @@ export async function startDev(args: StartDevOptions) {
 			);
 		}
 
-		if (
-			(args.legacyAssets || config.legacy_assets) &&
-			(args.site || config.site)
-		) {
-			throw new UserError(
-				"Cannot use legacy assets and Workers Sites in the same Worker."
-			);
-		}
-
-		if ((args.assets || config.assets) && args.remote) {
-			throw new UserError(
-				"Cannot use assets in remote mode. Workers with assets are only supported in local mode. Please use `wrangler dev`."
-			);
-		}
-
-		validateAssetsArgsAndConfig(args, config);
-
-		let assetsOptions = processAssetsArg(args, config);
-		if (assetsOptions) {
-			args.forceLocal = true;
-		}
-
-		const projectRoot = configPath && path.dirname(configPath);
+		const configPath =
+			args.config ||
+			(args.script && findWranglerToml(path.dirname(args.script)));
 
 		const devEnv = new DevEnv();
 
 		if (args.experimentalDevEnv) {
 			// The ProxyWorker will have a stable host and port, so only listen for the first update
 			void devEnv.proxy.ready.promise.then(({ url }) => {
-				if (process.send) {
+				if (process.send && typeof vitest === "undefined") {
 					process.send(
 						JSON.stringify({
 							event: "DEV_SERVER_READY",
@@ -672,7 +647,7 @@ export async function startDev(args: StartDevOptions) {
 						pattern: r,
 					})
 				),
-
+				env: args.env,
 				build: {
 					bundle: args.bundle !== undefined ? args.bundle : undefined,
 					define: collectKeyValues(args.define),
@@ -733,7 +708,6 @@ export async function startDev(args: StartDevOptions) {
 							accountId = await requireAuth({});
 							unregisterHotKeys = registerDevHotKeys(devEnv, args);
 						}
-
 						return {
 							accountId,
 							apiToken: requireApiToken(),
@@ -772,7 +746,6 @@ export async function startDev(args: StartDevOptions) {
 							args,
 							configParam
 						);
-
 						return Boolean(args.site || configParam.site) && legacyAssetPaths
 							? {
 									bucket: path.join(
@@ -784,13 +757,11 @@ export async function startDev(args: StartDevOptions) {
 								}
 							: undefined;
 					},
-					legacyAssets: (configParam) => configParam.legacy_assets,
+					legacyAssets: (configParam) =>
+						args.legacyAssets ?? configParam.legacy_assets,
 					enableServiceEnvironments: !(args.legacyEnv ?? true),
 				},
-				// only pass `assetsOptions` if it came from args not from config
-				// otherwise config at startup ends up overriding future config changes in the
-				// ConfigController
-				assets: args.assets ? assetsOptions : undefined,
+				assets: args.assets,
 			} satisfies StartDevWorkerInput);
 
 			void metrics.sendMetricsEvent(
@@ -808,219 +779,251 @@ export async function startDev(args: StartDevOptions) {
 			);
 
 			return devEnv;
-		}
+		} else {
+			const projectRoot = configPath && path.dirname(configPath);
+			let config = readConfig(configPath, args);
 
-		if (config.configPath && !args.experimentalDevEnv) {
-			configFileWatcher = watch(config.configPath, {
-				persistent: true,
-			}).on("change", async (_event) => {
-				try {
-					// TODO: Do we need to handle different `_event` types differently?
-					// e.g. what if the file is deleted, or added?
-					config = readConfig(configPath, args);
-					if (!config.configPath) {
-						return;
-					}
-
-					logger.log(`${path.basename(config.configPath)} changed...`);
-
-					// ensure we reflect config changes in the `main` entry point
-					entry = await getEntry(
-						{
-							legacyAssets: args.legacyAssets,
-							script: args.script,
-							moduleRoot: args.moduleRoot,
-							assets: args.assets,
-						},
-						config,
-						"dev"
-					);
-
-					// ensure we re-validate routes
-					await getHostAndRoutes(args, config);
-
-					assetsOptions = processAssetsArg(args, config);
-
-					/*
-					 * Handle static assets watching on config file changes
-					 *
-					 * 1. if assets was specified via CLI args, only config file
-					 *    changes related to `main` will matter. In this case, re-running
-					 *    `processAssetsArg` is enough (see above)
-					 * 2. if assets was not specififed via the configuration
-					 *    file, but it is now, we should start watching the assets
-					 *    directory
-					 * 3. if assets was specified via the configuration
-					 *    file, we should ensure we're still watching the correct
-					 *    directory
-					 */
-					if (assetsOptions && !args.assets) {
-						await assetsWatcher?.close();
-
-						if (assetsOptions) {
-							assetsWatcher = watch(assetsOptions.directory, {
-								persistent: true,
-								ignoreInitial: true,
-							}).on("all", async (eventName, changedPath) => {
-								const message = getAssetChangeMessage(eventName, changedPath);
-
-								logger.log(`🌀 ${message}...`);
-								rerender(await getDevReactElement(config));
-							});
-						}
-					}
-
-					rerender(await getDevReactElement(config));
-				} catch (err) {
-					logger.error(err);
-				}
-			});
-		}
-
-		const devServerSettings = await validateDevServerSettings(args, config);
-		let { entry } = devServerSettings;
-		const {
-			upstreamProtocol,
-			host,
-			routes,
-			getLocalPort,
-			getInspectorPort,
-			getRuntimeInspectorPort,
-			cliDefines,
-			cliAlias,
-			localPersistencePath,
-			processEntrypoint,
-			additionalModules,
-		} = devServerSettings;
-
-		const nodejsCompatMode = validateNodeCompatMode(
-			args.compatibilityDate ?? config.compatibility_date,
-			args.compatibilityFlags ?? config.compatibility_flags ?? [],
-			{
-				nodeCompat: args.nodeCompat ?? config.node_compat,
-				noBundle: args.noBundle ?? config.no_bundle,
+			if (
+				(args.legacyAssets || config.legacy_assets) &&
+				(args.site || config.site)
+			) {
+				throw new UserError(
+					"Cannot use legacy assets and Workers Sites in the same Worker."
+				);
 			}
-		);
 
-		void metrics.sendMetricsEvent(
-			"run dev",
-			{
-				local: !args.remote,
-				usesTypeScript: /\.tsx?$/.test(entry.file),
-			},
-			{ sendMetrics: config.send_metrics, offline: !args.remote }
-		);
+			if ((args.assets || config.assets) && args.remote) {
+				throw new UserError(
+					"Cannot use assets in remote mode. Workers with assets are only supported in local mode. Please use `wrangler dev`."
+				);
+			}
 
-		// eslint-disable-next-line no-inner-declarations
-		async function getDevReactElement(configParam: Config) {
-			const { legacyAssetPaths, bindings } = getBindingsAndLegacyAssetPaths(
-				args,
-				configParam
+			validateAssetsArgsAndConfig(args, config);
+
+			let assetsOptions = processAssetsArg(args, config);
+			if (assetsOptions) {
+				args.forceLocal = true;
+			}
+
+			if (config.configPath && !args.experimentalDevEnv) {
+				configFileWatcher = watch(config.configPath, {
+					persistent: true,
+				}).on("change", async (_event) => {
+					try {
+						// TODO: Do we need to handle different `_event` types differently?
+						// e.g. what if the file is deleted, or added?
+						config = readConfig(configPath, args);
+						if (!config.configPath) {
+							return;
+						}
+
+						logger.log(`${path.basename(config.configPath)} changed...`);
+
+						// ensure we reflect config changes in the `main` entry point
+						entry = await getEntry(
+							{
+								legacyAssets: args.legacyAssets,
+								script: args.script,
+								moduleRoot: args.moduleRoot,
+								assets: args.assets,
+							},
+							config,
+							"dev"
+						);
+
+						// ensure we re-validate routes
+						await getHostAndRoutes(args, config);
+
+						assetsOptions = processAssetsArg(args, config);
+
+						/*
+						 * Handle static assets watching on config file changes
+						 *
+						 * 1. if assets was specified via CLI args, only config file
+						 *    changes related to `main` will matter. In this case, re-running
+						 *    `processAssetsArg` is enough (see above)
+						 * 2. if assets was not specififed via the configuration
+						 *    file, but it is now, we should start watching the assets
+						 *    directory
+						 * 3. if assets was specified via the configuration
+						 *    file, we should ensure we're still watching the correct
+						 *    directory
+						 */
+						if (assetsOptions && !args.assets) {
+							await assetsWatcher?.close();
+
+							if (assetsOptions) {
+								assetsWatcher = watch(assetsOptions.directory, {
+									persistent: true,
+									ignoreInitial: true,
+								}).on("all", async (eventName, changedPath) => {
+									const message = getAssetChangeMessage(eventName, changedPath);
+
+									logger.log(`🌀 ${message}...`);
+									rerender(await getDevReactElement(config));
+								});
+							}
+						}
+
+						rerender(await getDevReactElement(config));
+					} catch (err) {
+						logger.error(err);
+					}
+				});
+			}
+
+			const devServerSettings = await validateDevServerSettings(args, config);
+			let { entry } = devServerSettings;
+			const {
+				upstreamProtocol,
+				host,
+				routes,
+				getLocalPort,
+				getInspectorPort,
+				getRuntimeInspectorPort,
+				cliDefines,
+				cliAlias,
+				localPersistencePath,
+				processEntrypoint,
+				additionalModules,
+			} = devServerSettings;
+
+			const nodejsCompatMode = validateNodeCompatMode(
+				args.compatibilityDate ?? config.compatibility_date,
+				args.compatibilityFlags ?? config.compatibility_flags ?? [],
+				{
+					nodeCompat: args.nodeCompat ?? config.node_compat,
+					noBundle: args.noBundle ?? config.no_bundle,
+				}
 			);
 
-			return (
-				<Dev
-					name={getScriptName({ name: args.name, env: args.env }, configParam)}
-					noBundle={!(args.bundle ?? !configParam.no_bundle)}
-					findAdditionalModules={configParam.find_additional_modules}
-					entry={entry}
-					env={args.env}
-					host={host}
-					routes={routes}
-					processEntrypoint={processEntrypoint}
-					additionalModules={additionalModules}
-					rules={args.rules ?? getRules(configParam)}
-					legacyEnv={isLegacyEnv(configParam)}
-					minify={args.minify ?? configParam.minify}
-					nodejsCompatMode={nodejsCompatMode}
-					build={configParam.build || {}}
-					define={{ ...configParam.define, ...cliDefines }}
-					alias={{ ...configParam.alias, ...cliAlias }}
-					initialMode={args.remote ? "remote" : "local"}
-					jsxFactory={args.jsxFactory || configParam.jsx_factory}
-					jsxFragment={args.jsxFragment || configParam.jsx_fragment}
-					tsconfig={args.tsconfig ?? configParam.tsconfig}
-					upstreamProtocol={upstreamProtocol}
-					localProtocol={args.localProtocol || configParam.dev.local_protocol}
-					httpsKeyPath={args.httpsKeyPath}
-					httpsCertPath={args.httpsCertPath}
-					localUpstream={args.localUpstream ?? host ?? getInferredHost(routes)}
-					localPersistencePath={localPersistencePath}
-					liveReload={args.liveReload || false}
-					accountId={
-						args.accountId ??
-						configParam.account_id ??
-						getAccountFromCache()?.id
-					}
-					legacyAssetPaths={legacyAssetPaths}
-					legacyAssetsConfig={configParam.legacy_assets}
-					assets={assetsOptions}
-					initialPort={
-						args.port ?? configParam.dev.port ?? (await getLocalPort())
-					}
-					initialIp={args.ip || configParam.dev.ip}
-					inspectorPort={
-						args.inspectorPort ??
-						configParam.dev.inspector_port ??
-						(await getInspectorPort())
-					}
-					runtimeInspectorPort={await getRuntimeInspectorPort()}
-					isWorkersSite={Boolean(args.site || configParam.site)}
-					compatibilityDate={getDevCompatibilityDate(
-						configParam,
-						args.compatibilityDate
-					)}
-					compatibilityFlags={
-						args.compatibilityFlags || configParam.compatibility_flags
-					}
-					usageModel={configParam.usage_model}
-					bindings={bindings}
-					migrations={configParam.migrations}
-					crons={configParam.triggers.crons}
-					queueConsumers={configParam.queues.consumers}
-					onReady={args.onReady}
-					inspect={args.inspect ?? true}
-					showInteractiveDevSession={args.showInteractiveDevSession}
-					forceLocal={args.forceLocal}
-					enablePagesAssetsServiceBinding={args.enablePagesAssetsServiceBinding}
-					firstPartyWorker={configParam.first_party_worker}
-					sendMetrics={configParam.send_metrics}
-					testScheduled={args.testScheduled}
-					projectRoot={projectRoot}
-					rawArgs={args}
-					rawConfig={configParam}
-					devEnv={devEnv}
-				/>
+			void metrics.sendMetricsEvent(
+				"run dev",
+				{
+					local: !args.remote,
+					usesTypeScript: /\.tsx?$/.test(entry.file),
+				},
+				{ sendMetrics: config.send_metrics, offline: !args.remote }
 			);
+
+			// eslint-disable-next-line no-inner-declarations
+			async function getDevReactElement(configParam: Config) {
+				const { legacyAssetPaths, bindings } = getBindingsAndLegacyAssetPaths(
+					args,
+					configParam
+				);
+
+				return (
+					<Dev
+						name={getScriptName(
+							{ name: args.name, env: args.env },
+							configParam
+						)}
+						noBundle={!(args.bundle ?? !configParam.no_bundle)}
+						findAdditionalModules={configParam.find_additional_modules}
+						entry={entry}
+						env={args.env}
+						host={host}
+						routes={routes}
+						processEntrypoint={processEntrypoint}
+						additionalModules={additionalModules}
+						rules={args.rules ?? getRules(configParam)}
+						legacyEnv={isLegacyEnv(configParam)}
+						minify={args.minify ?? configParam.minify}
+						nodejsCompatMode={nodejsCompatMode}
+						build={configParam.build || {}}
+						define={{ ...configParam.define, ...cliDefines }}
+						alias={{ ...configParam.alias, ...cliAlias }}
+						initialMode={args.remote ? "remote" : "local"}
+						jsxFactory={args.jsxFactory || configParam.jsx_factory}
+						jsxFragment={args.jsxFragment || configParam.jsx_fragment}
+						tsconfig={args.tsconfig ?? configParam.tsconfig}
+						upstreamProtocol={upstreamProtocol}
+						localProtocol={args.localProtocol || configParam.dev.local_protocol}
+						httpsKeyPath={args.httpsKeyPath}
+						httpsCertPath={args.httpsCertPath}
+						localUpstream={
+							args.localUpstream ?? host ?? getInferredHost(routes)
+						}
+						localPersistencePath={localPersistencePath}
+						liveReload={args.liveReload || false}
+						accountId={
+							args.accountId ??
+							configParam.account_id ??
+							getAccountFromCache()?.id
+						}
+						legacyAssetPaths={legacyAssetPaths}
+						legacyAssetsConfig={configParam.legacy_assets}
+						assets={assetsOptions}
+						initialPort={
+							args.port ?? configParam.dev.port ?? (await getLocalPort())
+						}
+						initialIp={args.ip || configParam.dev.ip}
+						inspectorPort={
+							args.inspectorPort ??
+							configParam.dev.inspector_port ??
+							(await getInspectorPort())
+						}
+						runtimeInspectorPort={await getRuntimeInspectorPort()}
+						isWorkersSite={Boolean(args.site || configParam.site)}
+						compatibilityDate={getDevCompatibilityDate(
+							configParam,
+							args.compatibilityDate
+						)}
+						compatibilityFlags={
+							args.compatibilityFlags || configParam.compatibility_flags
+						}
+						usageModel={configParam.usage_model}
+						bindings={bindings}
+						migrations={configParam.migrations}
+						crons={configParam.triggers.crons}
+						queueConsumers={configParam.queues.consumers}
+						onReady={args.onReady}
+						inspect={args.inspect ?? true}
+						showInteractiveDevSession={args.showInteractiveDevSession}
+						forceLocal={args.forceLocal}
+						enablePagesAssetsServiceBinding={
+							args.enablePagesAssetsServiceBinding
+						}
+						firstPartyWorker={configParam.first_party_worker}
+						sendMetrics={configParam.send_metrics}
+						testScheduled={args.testScheduled}
+						projectRoot={projectRoot}
+						rawArgs={args}
+						rawConfig={configParam}
+						devEnv={devEnv}
+					/>
+				);
+			}
+
+			const devReactElement = render(await getDevReactElement(config));
+			rerender = devReactElement.rerender;
+
+			if (assetsOptions && !args.experimentalDevEnv) {
+				assetsWatcher = watch(assetsOptions.directory, {
+					persistent: true,
+					ignoreInitial: true,
+				}).on("all", async (eventName, filePath) => {
+					const message = getAssetChangeMessage(eventName, filePath);
+
+					logger.log(`🌀 ${message}...`);
+					rerender(await getDevReactElement(config));
+				});
+			}
+
+			return {
+				devReactElement,
+				configFileWatcher,
+				assetsWatcher,
+				stop: async () => {
+					devReactElement.unmount();
+					await Promise.allSettled([
+						configFileWatcher?.close(),
+						assetsWatcher?.close(),
+					]);
+				},
+			};
 		}
-
-		const devReactElement = render(await getDevReactElement(config));
-		rerender = devReactElement.rerender;
-
-		if (assetsOptions && !args.experimentalDevEnv) {
-			assetsWatcher = watch(assetsOptions.directory, {
-				persistent: true,
-				ignoreInitial: true,
-			}).on("all", async (eventName, filePath) => {
-				const message = getAssetChangeMessage(eventName, filePath);
-
-				logger.log(`🌀 ${message}...`);
-				rerender(await getDevReactElement(config));
-			});
-		}
-
-		return {
-			devReactElement,
-			configFileWatcher,
-			assetsWatcher,
-			stop: async () => {
-				devReactElement.unmount();
-				await Promise.allSettled([
-					configFileWatcher?.close(),
-					assetsWatcher?.close(),
-				]);
-			},
-		};
 	} catch (e) {
 		await Promise.allSettled([
 			configFileWatcher?.close(),

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -635,134 +635,139 @@ export async function startDev(args: StartDevOptions) {
 				unregisterHotKeys = registerDevHotKeys(devEnv, args);
 			}
 
-			await devEnv.config.set({
-				name: args.name,
-				config: configPath,
-				entrypoint: args.script,
-				compatibilityDate: args.compatibilityDate,
-				compatibilityFlags: args.compatibilityFlags,
-				triggers: args.routes?.map<Extract<Trigger, { type: "route" }>>(
-					(r) => ({
-						type: "route",
-						pattern: r,
-					})
-				),
-				env: args.env,
-				build: {
-					bundle: args.bundle !== undefined ? args.bundle : undefined,
-					define: collectKeyValues(args.define),
-					jsxFactory: args.jsxFactory,
-					jsxFragment: args.jsxFragment,
-					tsconfig: args.tsconfig,
-					minify: args.minify,
-					processEntrypoint: args.processEntrypoint,
-					additionalModules: args.additionalModules,
-					moduleRoot: args.moduleRoot,
-					moduleRules: args.rules,
-					nodejsCompatMode: (parsedConfig: Config) =>
-						validateNodeCompatMode(
-							args.compatibilityDate ?? parsedConfig.compatibility_date,
-							args.compatibilityFlags ?? parsedConfig.compatibility_flags ?? [],
-							{
-								nodeCompat: args.nodeCompat ?? parsedConfig.node_compat,
-								noBundle: args.noBundle ?? parsedConfig.no_bundle,
-							}
-						),
-				},
-				bindings: {
-					...(await getPagesAssetsFetcher(
-						args.enablePagesAssetsServiceBinding
-					)),
-					...collectPlainTextVars(args.var),
-					...convertCfWorkerInitBindingstoBindings({
-						kv_namespaces: args.kv,
-						vars: args.vars,
-						send_email: undefined,
-						wasm_modules: undefined,
-						text_blobs: undefined,
-						browser: undefined,
-						ai: args.ai,
-						version_metadata: args.version_metadata,
-						data_blobs: undefined,
-						durable_objects: { bindings: args.durableObjects ?? [] },
-						queues: undefined,
-						r2_buckets: args.r2,
-						d1_databases: args.d1Databases,
-						vectorize: undefined,
-						hyperdrive: undefined,
-						services: args.services,
-						analytics_engine_datasets: undefined,
-						dispatch_namespaces: undefined,
-						mtls_certificates: undefined,
-						pipelines: undefined,
-						logfwdr: undefined,
-						unsafe: undefined,
-						assets: undefined,
-					}),
-				},
-				dev: {
-					auth: async () => {
-						let accountId = args.accountId;
-						if (!accountId) {
-							unregisterHotKeys?.();
-							accountId = await requireAuth({});
-							unregisterHotKeys = registerDevHotKeys(devEnv, args);
-						}
-						return {
-							accountId,
-							apiToken: requireApiToken(),
-						};
-					},
-					remote: !args.forceLocal && args.remote,
-					server: {
-						hostname: args.ip,
-						port: args.port,
-						secure:
-							args.localProtocol === undefined
-								? undefined
-								: args.localProtocol === "https",
-						httpsCertPath: args.httpsCertPath,
-						httpsKeyPath: args.httpsKeyPath,
-					},
-					inspector: {
-						port: args.inspectorPort,
-					},
-					origin: {
-						hostname: args.host ?? args.localUpstream,
-						secure:
-							args.upstreamProtocol === undefined
-								? undefined
-								: args.upstreamProtocol === "https",
-					},
-					persist: args.persistTo,
-					liveReload: args.liveReload,
-					testScheduled: args.testScheduled,
-					logLevel: args.logLevel,
-					registry: devEnv.config.latestConfig?.dev.registry,
-				},
-				legacy: {
-					site: (configParam) => {
-						const legacyAssetPaths = getResolvedLegacyAssetPaths(
-							args,
-							configParam
-						);
-						return Boolean(args.site || configParam.site) && legacyAssetPaths
-							? {
-									bucket: path.join(
-										legacyAssetPaths.baseDirectory,
-										legacyAssetPaths?.assetDirectory
-									),
-									include: legacyAssetPaths.includePatterns,
-									exclude: legacyAssetPaths.excludePatterns,
+			await devEnv.config.set(
+				{
+					name: args.name,
+					config: configPath,
+					entrypoint: args.script,
+					compatibilityDate: args.compatibilityDate,
+					compatibilityFlags: args.compatibilityFlags,
+					triggers: args.routes?.map<Extract<Trigger, { type: "route" }>>(
+						(r) => ({
+							type: "route",
+							pattern: r,
+						})
+					),
+					env: args.env,
+					build: {
+						bundle: args.bundle !== undefined ? args.bundle : undefined,
+						define: collectKeyValues(args.define),
+						jsxFactory: args.jsxFactory,
+						jsxFragment: args.jsxFragment,
+						tsconfig: args.tsconfig,
+						minify: args.minify,
+						processEntrypoint: args.processEntrypoint,
+						additionalModules: args.additionalModules,
+						moduleRoot: args.moduleRoot,
+						moduleRules: args.rules,
+						nodejsCompatMode: (parsedConfig: Config) =>
+							validateNodeCompatMode(
+								args.compatibilityDate ?? parsedConfig.compatibility_date,
+								args.compatibilityFlags ??
+									parsedConfig.compatibility_flags ??
+									[],
+								{
+									nodeCompat: args.nodeCompat ?? parsedConfig.node_compat,
+									noBundle: args.noBundle ?? parsedConfig.no_bundle,
 								}
-							: undefined;
+							),
 					},
-					legacyAssets: (configParam) =>
-						args.legacyAssets ?? configParam.legacy_assets,
-					enableServiceEnvironments: !(args.legacyEnv ?? true),
-				},
-				assets: args.assets,
-			} satisfies StartDevWorkerInput);
+					bindings: {
+						...(await getPagesAssetsFetcher(
+							args.enablePagesAssetsServiceBinding
+						)),
+						...collectPlainTextVars(args.var),
+						...convertCfWorkerInitBindingstoBindings({
+							kv_namespaces: args.kv,
+							vars: args.vars,
+							send_email: undefined,
+							wasm_modules: undefined,
+							text_blobs: undefined,
+							browser: undefined,
+							ai: args.ai,
+							version_metadata: args.version_metadata,
+							data_blobs: undefined,
+							durable_objects: { bindings: args.durableObjects ?? [] },
+							queues: undefined,
+							r2_buckets: args.r2,
+							d1_databases: args.d1Databases,
+							vectorize: undefined,
+							hyperdrive: undefined,
+							services: args.services,
+							analytics_engine_datasets: undefined,
+							dispatch_namespaces: undefined,
+							mtls_certificates: undefined,
+							pipelines: undefined,
+							logfwdr: undefined,
+							unsafe: undefined,
+							assets: undefined,
+						}),
+					},
+					dev: {
+						auth: async () => {
+							let accountId = args.accountId;
+							if (!accountId) {
+								unregisterHotKeys?.();
+								accountId = await requireAuth({});
+								unregisterHotKeys = registerDevHotKeys(devEnv, args);
+							}
+							return {
+								accountId,
+								apiToken: requireApiToken(),
+							};
+						},
+						remote: !args.forceLocal && args.remote,
+						server: {
+							hostname: args.ip,
+							port: args.port,
+							secure:
+								args.localProtocol === undefined
+									? undefined
+									: args.localProtocol === "https",
+							httpsCertPath: args.httpsCertPath,
+							httpsKeyPath: args.httpsKeyPath,
+						},
+						inspector: {
+							port: args.inspectorPort,
+						},
+						origin: {
+							hostname: args.host ?? args.localUpstream,
+							secure:
+								args.upstreamProtocol === undefined
+									? undefined
+									: args.upstreamProtocol === "https",
+						},
+						persist: args.persistTo,
+						liveReload: args.liveReload,
+						testScheduled: args.testScheduled,
+						logLevel: args.logLevel,
+						registry: devEnv.config.latestConfig?.dev.registry,
+					},
+					legacy: {
+						site: (configParam) => {
+							const legacyAssetPaths = getResolvedLegacyAssetPaths(
+								args,
+								configParam
+							);
+							return Boolean(args.site || configParam.site) && legacyAssetPaths
+								? {
+										bucket: path.join(
+											legacyAssetPaths.baseDirectory,
+											legacyAssetPaths?.assetDirectory
+										),
+										include: legacyAssetPaths.includePatterns,
+										exclude: legacyAssetPaths.excludePatterns,
+									}
+								: undefined;
+						},
+						legacyAssets: (configParam) =>
+							args.legacyAssets ?? configParam.legacy_assets,
+						enableServiceEnvironments: !(args.legacyEnv ?? true),
+					},
+					assets: args.assets,
+				} satisfies StartDevWorkerInput,
+				true
+			);
 
 			void metrics.sendMetricsEvent(
 				"run dev",

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -342,7 +342,7 @@ export function devOptions(yargs: CommonYargsArgv) {
 				type: "boolean",
 				describe:
 					"Use the experimental DevEnv instantiation (unified across wrangler dev and unstable_dev)",
-				default: false,
+				default: true,
 			})
 			.option("experimental-registry", {
 				alias: ["x-registry"],

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -242,19 +242,20 @@ async function createPreviewToken(
 
 	const mode: CfPreviewMode = ctx.zone
 		? {
-				routes: ctx.routes
-					? // extract all the route patterns
-						ctx.routes.map((route) => {
-							if (typeof route === "string") {
-								return route;
-							}
-							if (route.custom_domain) {
-								return `${route.pattern}/*`;
-							}
-							return route.pattern;
-						})
-					: // if there aren't any patterns, then just match on all routes
-						["*/*"],
+				routes:
+					ctx.routes && ctx.routes.length > 0
+						? // extract all the route patterns
+							ctx.routes.map((route) => {
+								if (typeof route === "string") {
+									return route;
+								}
+								if (route.custom_domain) {
+									return `${route.pattern}/*`;
+								}
+								return route.pattern;
+							})
+						: // if there aren't any patterns, then just match on all routes
+							["*/*"],
 			}
 		: { workers_dev: true };
 

--- a/packages/wrangler/src/dev/remote.tsx
+++ b/packages/wrangler/src/dev/remote.tsx
@@ -685,11 +685,11 @@ export async function createRemoteWorkerInit(props: {
 
 export async function getWorkerAccountAndContext(props: {
 	accountId: string;
-	env?: string;
-	legacyEnv?: boolean;
-	host?: string;
+	env: string | undefined;
+	legacyEnv: boolean | undefined;
+	host: string | undefined;
 	routes: Route[] | undefined;
-	sendMetrics?: boolean;
+	sendMetrics: boolean | undefined;
 }): Promise<{ workerAccount: CfAccount; workerContext: CfWorkerContext }> {
 	const workerAccount: CfAccount = {
 		accountId: props.accountId,

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -906,8 +906,26 @@ export async function main(argv: string[]): Promise<void> {
 			logBuildFailure(e.errors, e.warnings);
 			logger.error(e.message);
 		} else {
-			logger.error(e instanceof Error ? e.message : e);
-			if (!(e instanceof UserError)) {
+			let loggableException = e;
+			if (
+				// Is this a StartDevEnv error event? If so, unwrap the cause, which is usually the user-recognisable error
+				e &&
+				typeof e === "object" &&
+				"type" in e &&
+				e.type === "error" &&
+				"cause" in e &&
+				e.cause instanceof Error
+			) {
+				loggableException = e.cause;
+			}
+
+			logger.error(
+				loggableException instanceof Error
+					? loggableException.message
+					: loggableException
+			);
+
+			if (!(loggableException instanceof UserError)) {
 				await logPossibleBugMessage();
 			}
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.1.1
+      version: 2.1.1
+    '@vitest/snapshot':
+      specifier: ~2.1.1
+      version: 2.1.1
     vitest:
       specifier: ~2.1.1
       version: 2.1.1


### PR DESCRIPTION
## What this PR solves / how to test

Fixes N/A

This PR fixes a race condition causing the dev registry registrations of a quickly-reloaded worker to occur out-of-order. Sometimes overwriting the valid registration with the outdated registration details.

Also reenable `–x-registry` flag in fixtures

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: fixing fixture tests flakiness
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] TODO (before merge)
  - [ ] Changeset included
  - [ ] Changeset not necessary because: 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: implementation detail

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
