### PR TITLE
fix: render a helpful build error if a Service Worker mode Worker has imports

### DIFF
--- a/.changeset/perfect-experts-draw.md
+++ b/.changeset/perfect-experts-draw.md
@@ -1,0 +1,15 @@
+---
+"wrangler": patch
+---
+
+fix: render a helpful build error if a Service Worker mode Worker has imports
+
+A common mistake is to forget to export from the entry-point of a Worker, which causes
+Wrangler to infer that we are in "Service Worker" mode.
+
+In this mode, imports to external modules are not allowed.
+Currently this only fails at runtime, because our esbuild step converts these imports to an internal `__require()` call that throws an error.
+The error message is misleading and does not help the user identify the cause of the problem.
+This is particularly tricky where the external imports are added by a library or our own node.js polyfills.
+
+Fixes #6648

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8890,7 +8890,7 @@ addEventListener('fetch', event => {});`
 					)
 				)
 			).resolves.toContain(
-				`X [ERROR] Unexpected import "cloudflare:sockets" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker? [plugin Cloudflare internal imports plugin]`
+				`X [ERROR] Unexpected import "cloudflare:sockets" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker? [plugin Cloudflare internal imports plugin]`
 			);
 		});
 
@@ -8918,7 +8918,7 @@ addEventListener('fetch', event => {});`
 				)
 			).resolves.toContain(
 				dedent`
-					X [ERROR] Unexpected import "node:stream" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker?
+					X [ERROR] Unexpected import "node:stream" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker?
 					Imported from:
 					 - index.js
 					 [plugin nodejs_compat imports plugin]
@@ -8950,7 +8950,7 @@ addEventListener('fetch', event => {});`
 					)
 				)
 			).resolves.toContain(
-				`X [ERROR] Unexpected import "node:stream" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker? [plugin unenv-cloudflare]`
+				`X [ERROR] Unexpected import "node:stream" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker? [plugin unenv-cloudflare]`
 			);
 		});
 	});

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8851,6 +8851,110 @@ addEventListener('fetch', event => {});`
 		});
 	});
 
+	describe("service worker format", () => {
+		it("should error if trying to import a cloudflare prefixed external when in service worker format", async () => {
+			writeWranglerToml();
+			fs.writeFileSync(
+				"dep-1.js",
+				dedent`
+					import sockets from 'cloudflare:sockets';
+					export const external = sockets;
+				`
+			);
+			fs.writeFileSync(
+				"dep-2.js",
+				dedent`
+					export const internal = 100;
+				`
+			);
+			fs.writeFileSync(
+				"index.js",
+				dedent`
+					import {external} from "./dep-1"; // will the external import check be transitive?
+					import {internal} from "./dep-2"; // ensure that we can still have a non-external import
+					let x = [external, internal]; // to ensure that esbuild doesn't tree shake the imports
+					// no default export making this a service worker format
+					addEventListener('fetch', (event) => {
+						event.respondWith(new Response(''));
+					});
+			`
+			);
+
+			await expect(
+				runWrangler("deploy index.js --dry-run").catch((e) =>
+					normalizeString(
+						esbuild
+							.formatMessagesSync(e?.errors ?? [], { kind: "error" })
+							.join()
+							.trim()
+					)
+				)
+			).resolves.toContain(
+				`X [ERROR] Unexpected import "cloudflare:sockets" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker? [plugin Cloudflare internal imports plugin]`
+			);
+		});
+
+		it("should error if importing a node.js library when in service worker format", async () => {
+			writeWranglerToml();
+			fs.writeFileSync(
+				"index.js",
+				dedent`
+					import stream from "node:stream";
+					let temp = stream;
+					addEventListener('fetch', (event) => {
+						event.respondWith(new Response(''));
+					});
+			`
+			);
+
+			await expect(
+				runWrangler("deploy index.js --dry-run").catch((e) =>
+					normalizeString(
+						esbuild
+							.formatMessagesSync(e?.errors ?? [], { kind: "error" })
+							.join()
+							.trim()
+					)
+				)
+			).resolves.toContain(
+				dedent`
+					X [ERROR] Unexpected import "node:stream" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker?
+					Imported from:
+					 - index.js
+					 [plugin nodejs_compat imports plugin]
+				`
+			);
+		});
+
+		it("should error if nodejs_compat (v2) is turned on when in service worker format", async () => {
+			writeWranglerToml({
+				compatibility_date: "2024-09-23", // Sept 23 to turn on nodejs compat v2 mode
+				compatibility_flags: ["nodejs_compat"],
+			});
+			fs.writeFileSync(
+				"index.js",
+				dedent`
+					addEventListener('fetch', (event) => {
+						event.respondWith(new Response(''));
+					});
+			`
+			);
+
+			await expect(
+				runWrangler("deploy index.js --dry-run").catch((e) =>
+					normalizeString(
+						esbuild
+							.formatMessagesSync(e?.errors ?? [], { kind: "error" })
+							.join()
+							.trim()
+					)
+				)
+			).resolves.toContain(
+				`X [ERROR] Unexpected import "node:stream" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker? [plugin unenv-cloudflare]`
+			);
+		});
+	});
+
 	describe("legacy module specifiers", () => {
 		it("should work with legacy module specifiers, with a deprecation warning (1)", async () => {
 			writeWranglerToml({

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8881,17 +8881,23 @@ addEventListener('fetch', event => {});`
 			);
 
 			await expect(
-				runWrangler("deploy index.js --dry-run").catch((e) =>
-					normalizeString(
-						esbuild
-							.formatMessagesSync(e?.errors ?? [], { kind: "error" })
-							.join()
-							.trim()
-					)
+				runWrangler("deploy index.js --dry-run").catch(
+					(e) =>
+						normalizeString(
+							esbuild
+								.formatMessagesSync(e?.errors ?? [], { kind: "error" })
+								.join()
+								.trim()
+						).split("This error came from the")[0]
 				)
-			).resolves.toContain(
-				`X [ERROR] Unexpected import "cloudflare:sockets" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker? [plugin Cloudflare internal imports plugin]`
-			);
+			).resolves.toMatchInlineSnapshot(`
+				"X [ERROR] Unexpected external import of \\"cloudflare:sockets\\". Imports are not valid in a Service Worker format Worker.
+				Did you mean to create a Module Worker?
+				If so, try adding \`export default { ... }\` in your entry-point.
+				See https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/. [plugin Cloudflare internal imports plugin]
+
+				  "
+			`);
 		});
 
 		it("should error if importing a node.js library when in service worker format", async () => {
@@ -8908,22 +8914,25 @@ addEventListener('fetch', event => {});`
 			);
 
 			await expect(
-				runWrangler("deploy index.js --dry-run").catch((e) =>
-					normalizeString(
-						esbuild
-							.formatMessagesSync(e?.errors ?? [], { kind: "error" })
-							.join()
-							.trim()
-					)
+				runWrangler("deploy index.js --dry-run").catch(
+					(e) =>
+						normalizeString(
+							esbuild
+								.formatMessagesSync(e?.errors ?? [], { kind: "error" })
+								.join()
+								.trim()
+						).split("This error came from the")[0]
 				)
-			).resolves.toContain(
-				dedent`
-					X [ERROR] Unexpected import "node:stream" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker?
-					Imported from:
-					 - index.js
-					 [plugin nodejs_compat imports plugin]
-				`
-			);
+			).resolves.toMatchInlineSnapshot(`
+				"X [ERROR]
+										Unexpected external import of \\"node:stream\\". Imports are not valid in a Service Worker format Worker.
+										Did you mean to create a Module Worker?
+										If so, try adding \`export default { ... }\` in your entry-point.
+										See https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/.
+									 [plugin nodejs_compat imports plugin]
+
+				  "
+			`);
 		});
 
 		it("should error if nodejs_compat (v2) is turned on when in service worker format", async () => {
@@ -8941,17 +8950,23 @@ addEventListener('fetch', event => {});`
 			);
 
 			await expect(
-				runWrangler("deploy index.js --dry-run").catch((e) =>
-					normalizeString(
-						esbuild
-							.formatMessagesSync(e?.errors ?? [], { kind: "error" })
-							.join()
-							.trim()
-					)
+				runWrangler("deploy index.js --dry-run").catch(
+					(e) =>
+						normalizeString(
+							esbuild
+								.formatMessagesSync(e?.errors ?? [], { kind: "error" })
+								.join()
+								.trim()
+						).split("This error came from the")[0]
 				)
-			).resolves.toContain(
-				`X [ERROR] Unexpected import "node:stream" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker? [plugin unenv-cloudflare]`
-			);
+			).resolves.toMatchInlineSnapshot(`
+				"X [ERROR] Unexpected external import of \\"node:stream\\" and \\"node:timers/promises\\". Imports are not valid in a Service Worker format Worker.
+				Did you mean to create a Module Worker?
+				If so, try adding \`export default { ... }\` in your entry-point.
+				See https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/. [plugin unenv-cloudflare]
+
+				  "
+			`);
 		});
 	});
 

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/cloudflare-internal.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/cloudflare-internal.ts
@@ -1,3 +1,4 @@
+import { dedent } from "../../utils/dedent";
 import type { Plugin } from "esbuild";
 
 /**
@@ -6,18 +7,29 @@ import type { Plugin } from "esbuild";
 export const cloudflareInternalPlugin: Plugin = {
 	name: "Cloudflare internal imports plugin",
 	setup(pluginBuild) {
+		const paths = new Set();
+		pluginBuild.onStart(() => paths.clear());
 		pluginBuild.onResolve({ filter: /^cloudflare:.*/ }, (args) => {
-			if (pluginBuild.initialOptions.format === "iife") {
-				//  If we are bundling a "Service Worker" formatted Worker, imports of external modules,
-				//  which won't be inlined/bundled by esbuild, are invalid.
-				//
-				//  Throw an error if we identify `cloudflare:...` external imports.
-				//
+			paths.add(args.path);
+			return { external: true };
+		});
+		pluginBuild.onEnd(() => {
+			if (pluginBuild.initialOptions.format === "iife" && paths.size > 0) {
+				// If we are bundling in "Service Worker" mode,
+				// imports of external modules such as `cloudflare:...`,
+				// which won't be inlined/bundled by esbuild, are invalid.
+				const pathList = new Intl.ListFormat("en-US").format(
+					Array.from(paths.keys()).map((p) => `"${p}"`)
+				);
 				throw new Error(
-					`Unexpected import "${args.path}" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker?`
+					dedent`
+						Unexpected external import of ${pathList}. Imports are not valid in a Service Worker format Worker.
+						Did you mean to create a Module Worker?
+						If so, try adding \`export default { ... }\` in your entry-point.
+						See https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/.
+					`
 				);
 			}
-			return { external: true };
 		});
 	},
 };

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/cloudflare-internal.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/cloudflare-internal.ts
@@ -6,7 +6,17 @@ import type { Plugin } from "esbuild";
 export const cloudflareInternalPlugin: Plugin = {
 	name: "Cloudflare internal imports plugin",
 	setup(pluginBuild) {
-		pluginBuild.onResolve({ filter: /^cloudflare:.*/ }, () => {
+		pluginBuild.onResolve({ filter: /^cloudflare:.*/ }, (args) => {
+			if (pluginBuild.initialOptions.format === "iife") {
+				//  If we are bundling a "Service Worker" formatted Worker, imports of external modules,
+				//  which won't be inlined/bundled by esbuild, are invalid.
+				//
+				//  Throw an error if we identify `cloudflare:...` external imports.
+				//
+				throw new Error(
+					`Unexpected import "${args.path}" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker?`
+				);
+			}
 			return { external: true };
 		});
 	},

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/cloudflare-internal.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/cloudflare-internal.ts
@@ -14,7 +14,7 @@ export const cloudflareInternalPlugin: Plugin = {
 				//  Throw an error if we identify `cloudflare:...` external imports.
 				//
 				throw new Error(
-					`Unexpected import "${args.path}" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker?`
+					`Unexpected import "${args.path}" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker?`
 				);
 			}
 			return { external: true };

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -32,7 +32,7 @@ function errorOnServiceWorkerFormat(build: PluginBuild) {
 	build.onResolve({ filter: NODEJS_MODULES_RE }, (args) => {
 		if (build.initialOptions.format === "iife") {
 			throw new Error(
-				`Unexpected import "${args.path}" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker?`
+				`Unexpected import "${args.path}" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker?`
 			);
 		}
 		return null;

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -66,6 +66,15 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 				pluginBuild.initialOptions.format === "iife" &&
 				warnedPackaged.size > 0
 			) {
+				const paths = new Intl.ListFormat("en-US").format(
+					Array.from(warnedPackaged.keys()).map((p) => `"${p}"`)
+				);
+				throw new Error(`
+						Unexpected external import of ${paths}. Imports are not valid in a Service Worker format Worker.
+						Did you mean to create a Module Worker?
+						If so, try adding \`export default { ... }\` in your entry-point.
+						See https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/.
+					`);
 				const errors = Array.from(warnedPackaged.entries()).map(
 					([path, importers]) =>
 						`Unexpected import "${path}" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker?\n` +

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -1,6 +1,7 @@
 import { relative } from "path";
 import chalk from "chalk";
 import { logger } from "../../logger";
+import { dedent } from "../../utils/dedent";
 import type { Plugin } from "esbuild";
 
 /**
@@ -53,25 +54,48 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 				return result;
 			}
 		);
+
+		/**
+		 * If we are bundling a "Service Worker" formatted Worker, imports of external modules,
+		 * which won't be inlined/bundled by esbuild, are invalid.
+		 *
+		 * This `onEnd()` handler will error if it identifies node.js external imports.
+		 */
+		pluginBuild.onEnd(() => {
+			if (
+				pluginBuild.initialOptions.format === "iife" &&
+				warnedPackaged.size > 0
+			) {
+				const errors = Array.from(warnedPackaged.entries()).map(
+					([path, importers]) =>
+						`Unexpected import "${path}" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker?\n` +
+						"Imported from:\n" +
+						toList(importers, pluginBuild.initialOptions.absWorkingDir) +
+						"\n"
+				);
+				throw new Error(errors.join(""));
+			}
+		});
+
 		// Wait until the build finishes to log warnings, so that all files which import a package
 		// can be collated
 		pluginBuild.onEnd(() => {
 			if (!silenceWarnings) {
 				warnedPackaged.forEach((importers: string[], path: string) => {
 					logger.warn(
-						`The package "${path}" wasn't found on the file system but is built into node.
-Your Worker may throw errors at runtime unless you enable the "nodejs_compat" compatibility flag. Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details. Imported from:
-${importers
-	.map(
-		(i) =>
-			` - ${chalk.blue(
-				relative(pluginBuild.initialOptions.absWorkingDir ?? "/", i)
-			)}`
-	)
-	.join("\n")}`
+						dedent`
+						The package "${path}" wasn't found on the file system but is built into node.
+						Your Worker may throw errors at runtime unless you enable the "nodejs_compat" compatibility flag. Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details. Imported from:
+						${toList(importers, pluginBuild.initialOptions.absWorkingDir)}`
 					);
 				});
 			}
 		});
 	},
 });
+
+function toList(items: string[], absWorkingDir: string | undefined): string {
+	return items
+		.map((i) => ` - ${chalk.blue(relative(absWorkingDir ?? "/", i))}`)
+		.join("\n");
+}

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -68,7 +68,7 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 			) {
 				const errors = Array.from(warnedPackaged.entries()).map(
 					([path, importers]) =>
-						`Unexpected import "${path}" which is not valid in a Service Worker format Worker. Are you missing a default export from your Worker?\n` +
+						`Unexpected import "${path}" which is not valid in a Service Worker format Worker. Are you missing \`export default { ... }\` from your Worker?\n` +
 						"Imported from:\n" +
 						toList(importers, pluginBuild.initialOptions.absWorkingDir) +
 						"\n"


### PR DESCRIPTION
A common mistake is to forget to export from the entry-point of a Worker, which causes
Wrangler to infer that we are in "Service Worker" mode.

In this mode, imports to external modules are not allowed.
Currently this only fails at runtime, because our esbuild step converts these imports to an internal `__require()` call that throws an error.
The error message is misleading and does not help the user identify the cause of the problem.
This is particularly tricky where the external imports are added by a library or our own node.js polyfills.

Fixes #6648

## What this PR solves / how to test

Fixes #[insert GH or internal issue number(s)].

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
