### PR TITLE
test: do not run the C3 e2e CLI tests concurrently

### DIFF
--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -15,9 +15,9 @@ const frameworkToTest = getFrameworkToTest({ experimental: false });
 
 // Note: skipIf(frameworkToTest) makes it so that all the basic C3 functionality
 //       tests are skipped in case we are testing a specific framework
-describe
-	.skipIf(experimental || frameworkToTest || isQuarantineMode())
-	.concurrent("E2E: Basic C3 functionality ", () => {
+describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
+	"E2E: Basic C3 functionality ",
+	() => {
 		beforeAll((ctx) => {
 			recreateLogFolder({ experimental }, ctx as Suite);
 		});
@@ -337,4 +337,5 @@ describe
 				expect(output).toContain(`lang JavaScript`);
 			},
 		);
-	});
+	},
+);


### PR DESCRIPTION
## What this PR solves / how to test

The CLI C3 e2e tests appear to be flaky on Bun - the keep timing out, specifically the ones that simulate interaction with the user. This change is to see if the problem can be fixed by not running these interactive tests in parallel concurrently.

Fixes #0000

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: C3 tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: test change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
