### PR TITLE
fix assets + custom build = infinite loop

### DIFF
--- a/.changeset/happy-balloons-work.md
+++ b/.changeset/happy-balloons-work.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: custom builds outputting files in assets watched directory no longer cause the custom build to run again in an infinite loop

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -927,10 +927,15 @@ describe("custom builds", () => {
 		await helper.seed({
 			"public/index.html": "world",
 		});
-		await setTimeout(300);
 
-		const res2 = await fetch(url);
-		await expect(res2.text()).resolves.toBe("world");
+		const resText = await retry(
+			(text) => text === "hello\n",
+			async () => {
+				const res2 = await fetch(url);
+				return res2.text();
+			}
+		);
+		await expect(resText).toBe("world");
 	});
 });
 

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -911,6 +911,21 @@ describe("custom builds", () => {
 		await expect(
 			worker.readUntil(/Running custom build:/, 5_000)
 		).rejects.toThrowError();
+
+		// now check assets are still fetchable, even after updates
+
+		const { url } = await worker.waitForReady();
+
+		const res = await fetch(url);
+		await expect(res.text()).resolves.toBe("hello\n");
+
+		await helper.seed({
+			"public/index.html": "world",
+		});
+		await setTimeout(300);
+
+		const res2 = await fetch(url);
+		await expect(res2.text()).resolves.toBe("world");
 	});
 });
 

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -263,7 +263,6 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 	#assetsWatcher?: ReturnType<typeof watch>;
 	async #ensureWatchingAssets(config: StartDevWorkerOptions) {
 		await this.#assetsWatcher?.close();
-		console.log(config.assets?.directory);
 
 		if (config.assets?.directory) {
 			this.#assetsWatcher = watch(config.assets.directory, {


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6876

Previously, if a `build.custom` command output files into the `assets.directory`, it caused the command to run again in an infinite loop.

This was caused by the assets watcher in the ConfigController to trigger a configUpdate event – with the intention of triggering a runtime reload – which caused the BundleController to trigger a full build.

The assets watcher has now been moved to the BundleController and triggers a bundleCompleted event instead – with the intention of triggering a runtime reload where Miniflare itself reads the new assets from the filesystem.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
