### PR TITLE
fix not-deterministic log message

### DIFF
--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/cloudflare-internal.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/cloudflare-internal.ts
@@ -19,7 +19,9 @@ export const cloudflareInternalPlugin: Plugin = {
 				// imports of external modules such as `cloudflare:...`,
 				// which won't be inlined/bundled by esbuild, are invalid.
 				const pathList = new Intl.ListFormat("en-US").format(
-					Array.from(paths.keys()).map((p) => `"${p}"`)
+					Array.from(paths.keys())
+						.map((p) => `"${p}"`)
+						.sort()
 				);
 				throw new Error(
 					dedent`

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -38,7 +38,9 @@ function errorOnServiceWorkerFormat(build: PluginBuild) {
 	build.onEnd(() => {
 		if (build.initialOptions.format === "iife" && paths.size > 0) {
 			const pathList = new Intl.ListFormat("en-US").format(
-				Array.from(paths.keys()).map((p) => `"${p}"`)
+				Array.from(paths.keys())
+					.map((p) => `"${p}"`)
+					.sort()
 			);
 			throw new Error(
 				dedent`

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/nodejs-compat.ts
@@ -67,7 +67,9 @@ export const nodejsCompatPlugin: (silenceWarnings: boolean) => Plugin = (
 				warnedPackaged.size > 0
 			) {
 				const paths = new Intl.ListFormat("en-US").format(
-					Array.from(warnedPackaged.keys()).map((p) => `"${p}"`)
+					Array.from(warnedPackaged.keys())
+						.map((p) => `"${p}"`)
+						.sort()
 				);
 				throw new Error(`
 						Unexpected external import of ${paths}. Imports are not valid in a Service Worker format Worker.


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #0000

Sometimes caused a snapshot mismatch eg https://github.com/cloudflare/workers-sdk/actions/runs/11161082325/job/31022879309#step:5:1

Simple fix to ensure the order is deterministic

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: unit tested
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: not user facing – decreases test flakiness
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not user facing

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
