### PR TITLE
Tiny typo fix in create-cloudflare remix CLI

### DIFF
--- a/packages/create-cloudflare/templates-experimental/remix/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/remix/c3.ts
@@ -24,7 +24,7 @@ const configure = async () => {
 	await installPackages(["wrangler@latest"], {
 		dev: true,
 		startText: "Updating the Wrangler version",
-		doneText: `${brandColor(`updateed`)} ${dim("wrangler@latest")}`,
+		doneText: `${brandColor(`updated`)} ${dim("wrangler@latest")}`,
 	});
 
 	const typeDefsPath = "load-context.ts";


### PR DESCRIPTION
## What this PR solves / how to test

fixes a trivial typo in the create-cloudflare CLI: `updateed wrangler@latest` → `updated wrangler@latest`

## Author has addressed the following

- Tests
  - [x] Tests not necessary because: it is a trivial CLI output typo fix
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] Not required because: it is a trivial CLI output typo fix
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [x] Changeset not necessary because: it is a trivial CLI output typo fix
- Public documentation
  - [x] Documentation not necessary because: it is a trivial CLI output typo fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
