### PR TITLE
fix: c3, use latest types for `@cloudflare/workers-types`

### DIFF
--- a/.changeset/few-sheep-fail.md
+++ b/.changeset/few-sheep-fail.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+fix: c3, use latest types for `@cloudflare/workers-types`
+
+We have some code that looks for the latest compat date generated in a workers-types dist, but that's been frozen for 202307-01 forever. We have upcoming work that'll replace this with generated types based on compat date/flags, but till then let's generate new projects with the default types.

--- a/packages/create-cloudflare/src/helpers/__tests__/compatDate.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/compatDate.test.ts
@@ -62,7 +62,7 @@ describe("Compatibility Date Helpers", () => {
 
 			const date = await getWorkerdCompatibilityDate();
 
-			const fallbackDate = "2023-05-18";
+			const fallbackDate = "2024-10-04";
 			expect(date).toBe(fallbackDate);
 			expect(spinner.start).toHaveBeenCalled();
 			expect(spinner.stop).toHaveBeenCalledWith(
@@ -78,7 +78,7 @@ describe("Compatibility Date Helpers", () => {
 
 			const date = await getWorkerdCompatibilityDate();
 
-			const fallbackDate = "2023-05-18";
+			const fallbackDate = "2024-10-04";
 			expect(date).toBe(fallbackDate);
 			expect(spinner.start).toHaveBeenCalled();
 			expect(spinner.stop).toHaveBeenCalledWith(

--- a/packages/create-cloudflare/src/helpers/compatDate.ts
+++ b/packages/create-cloudflare/src/helpers/compatDate.ts
@@ -35,7 +35,7 @@ export async function getWorkerdCompatibilityDate() {
 		}
 	} catch {}
 
-	const fallbackDate = "2023-05-18";
+	const fallbackDate = "2024-10-04";
 
 	s.stop(
 		`${brandColor("compatibility date")} ${dim(

--- a/packages/create-cloudflare/templates-experimental/nuxt/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/nuxt/c3.ts
@@ -3,7 +3,6 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
 import { mergeObjectProperties, transformFile } from "helpers/codemod";
-import { getLatestTypesEntrypoint } from "helpers/compatDate";
 import { readFile, writeFile } from "helpers/files";
 import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
@@ -48,7 +47,7 @@ const configure = async (ctx: C3Context) => {
 	updateEnvTypes(ctx);
 };
 
-const updateEnvTypes = (ctx: C3Context) => {
+const updateEnvTypes = (_ctx: C3Context) => {
 	const filepath = "env.d.ts";
 
 	const s = spinner();
@@ -56,11 +55,7 @@ const updateEnvTypes = (ctx: C3Context) => {
 
 	let file = readFile(filepath);
 
-	let typesEntrypoint = `@cloudflare/workers-types`;
-	const latestEntrypoint = getLatestTypesEntrypoint(ctx);
-	if (latestEntrypoint) {
-		typesEntrypoint += `/${latestEntrypoint}`;
-	}
+	const typesEntrypoint = `@cloudflare/workers-types/experimental`;
 
 	// Replace placeholder with actual types entrypoint
 	file = file.replace("WORKERS_TYPES_ENTRYPOINT", typesEntrypoint);

--- a/packages/create-cloudflare/templates/analog/c3.ts
+++ b/packages/create-cloudflare/templates/analog/c3.ts
@@ -3,7 +3,6 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
 import { loadTemplateSnippets, transformFile } from "helpers/codemod";
-import { getLatestTypesEntrypoint } from "helpers/compatDate";
 import { readFile, writeFile } from "helpers/files";
 import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
@@ -43,7 +42,7 @@ const configure = async (ctx: C3Context) => {
 	updateEnvTypes(ctx);
 };
 
-const updateEnvTypes = (ctx: C3Context) => {
+const updateEnvTypes = (_ctx: C3Context) => {
 	const filepath = "env.d.ts";
 
 	const s = spinner();
@@ -51,11 +50,7 @@ const updateEnvTypes = (ctx: C3Context) => {
 
 	let file = readFile(filepath);
 
-	let typesEntrypoint = `@cloudflare/workers-types`;
-	const latestEntrypoint = getLatestTypesEntrypoint(ctx);
-	if (latestEntrypoint) {
-		typesEntrypoint += `/${latestEntrypoint}`;
-	}
+	const typesEntrypoint = `@cloudflare/workers-types/experimental`;
 
 	// Replace placeholder with actual types entrypoint
 	file = file.replace("WORKERS_TYPES_ENTRYPOINT", typesEntrypoint);

--- a/packages/create-cloudflare/templates/nuxt/c3.ts
+++ b/packages/create-cloudflare/templates/nuxt/c3.ts
@@ -3,7 +3,6 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
 import { mergeObjectProperties, transformFile } from "helpers/codemod";
-import { getLatestTypesEntrypoint } from "helpers/compatDate";
 import { readFile, writeFile } from "helpers/files";
 import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
@@ -48,7 +47,7 @@ const configure = async (ctx: C3Context) => {
 	updateEnvTypes(ctx);
 };
 
-const updateEnvTypes = (ctx: C3Context) => {
+const updateEnvTypes = (_ctx: C3Context) => {
 	const filepath = "env.d.ts";
 
 	const s = spinner();
@@ -56,11 +55,7 @@ const updateEnvTypes = (ctx: C3Context) => {
 
 	let file = readFile(filepath);
 
-	let typesEntrypoint = `@cloudflare/workers-types`;
-	const latestEntrypoint = getLatestTypesEntrypoint(ctx);
-	if (latestEntrypoint) {
-		typesEntrypoint += `/${latestEntrypoint}`;
-	}
+	const typesEntrypoint = `@cloudflare/workers-types/experimental`;
 
 	// Replace placeholder with actual types entrypoint
 	file = file.replace("WORKERS_TYPES_ENTRYPOINT", typesEntrypoint);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.1.1
+      version: 2.1.1
+    '@vitest/snapshot':
+      specifier: ~2.1.1
+      version: 2.1.1
     vitest:
       specifier: ~2.1.1
       version: 2.1.1


### PR DESCRIPTION
We have some code that looks for the latest compat date generated in a workers-types dist, but that's been frozen for 202307-01 forever. We have upcoming work that'll replace this with generated types based on compat date/flags, but till then let's generate new projects with the default types.

## What this PR solves / how to test

Fixes #000

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included 
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functional change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
