### PR TITLE
fix: ensure that `alias` config gets passed through to the bundler when using new `--x-dev-env`

### DIFF
--- a/.changeset/grumpy-apples-juggle.md
+++ b/.changeset/grumpy-apples-juggle.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: ensure that `alias` config gets passed through to the bundler when using new `--x-dev-env`
+
+Fixes #6898

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -123,14 +123,20 @@ describe("ConfigController", () => {
 			dev: {
 				origin: { hostname: "myexample.com" },
 			},
+			build: {
+				alias: { foo: "bar" },
+			},
 		});
-		// expect `dev` field to be overwritten and all other config to remain intact
+		// expect `dev` and `build.alias` fields to be overwritten and all other config to remain intact
 		await expect(event3).resolves.toMatchObject({
 			type: "configUpdate",
 			config: {
 				entrypoint: path.join(process.cwd(), "src/index.ts"),
 				directory: process.cwd(),
 				build: {
+					alias: {
+						foo: "bar",
+					},
 					additionalModules: [],
 					define: {},
 					format: "modules",

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -257,6 +257,7 @@ async function resolveConfig(
 		triggers: await resolveTriggers(config, input),
 		env: input.env,
 		build: {
+			alias: input.build?.alias ?? config.alias,
 			additionalModules: input.build?.additionalModules ?? [],
 			processEntrypoint: Boolean(input.build?.processEntrypoint),
 			bundle: input.build?.bundle ?? !config.no_bundle,


### PR DESCRIPTION
## What this PR solves / how to test

While this does fix the problem (it's a one-liner) and I added a test to prevent a regression,
we have a systemic problem here because the types are too loose within the `ConfigController`.

One approach to fixing this is: rather than defining the `StartDevWorkerInput`, where all the props are optional, and then inferring the `StartDevWorkerOptions`, we should flip it round. Make the `StartDevWorkerOptions` tight (i.e. nothing can be optional, but explicitly can be `undefined` if needed). And then infer the `StartDevWorkerInput` from there by "picking" the desired properties and marking the type as `Partial<>`.

This would have created a typings error when the `alias` property was added to the config, and therefore indicate to the developer that it needs to be addressed here.

There may be a better solution, perhaps using `zod` or similar. So I didn't do any refactoring in this PR to keep the fix simple to review and land.

Alternatively, we could avoid manually copying over properties and rely upon a more automatic merging helper function that would mean the developer has to do nothing here when adding to the config.

(I believe that there was some discussion about how this config copying was awkward at the time, and I think the plan was to clean it up once the "other" way of doing dev was removed, which is not far off now. So perhaps this can all be done in one go?)

Moreover the test coverage of this code is pretty thin, so whether (or how) we fix the typings we should make the ConfigController tests much more comprehensive.

Fixes #6898

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
