### PR TITLE
Fix asset watching in x-dev-env

### DIFF
--- a/.changeset/big-waves-hammer.md
+++ b/.changeset/big-waves-hammer.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: debounce restarting worker on assets dir file changes when `--x-dev-env` is enabled.

--- a/packages/wrangler/e2e/helpers/wrangler.ts
+++ b/packages/wrangler/e2e/helpers/wrangler.ts
@@ -39,9 +39,10 @@ export class WranglerLongLivedCommand extends LongLivedCommand {
 		return match.groups as { url: string };
 	}
 
-	async waitForReload(): Promise<void> {
+	async waitForReload(readTimeout?: number): Promise<void> {
 		await this.readUntil(
-			/Detected changes, restarted server|Reloading local server\.\.\./
+			/Detected changes, restarted server|Reloading local server\.\.\./,
+			readTimeout
 		);
 	}
 }

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -14,6 +14,7 @@ import { getAssetChangeMessage } from "../../dev";
 import { runBuild } from "../../dev/use-esbuild";
 import { logger } from "../../logger";
 import { isNavigatorDefined } from "../../navigator-user-agent";
+import { debounce } from "../../pages/utils";
 import { getWranglerTmpDir } from "../../paths";
 import { Controller } from "./BaseController";
 import { castErrorCause } from "./events";
@@ -264,16 +265,23 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 	async #ensureWatchingAssets(config: StartDevWorkerOptions) {
 		await this.#assetsWatcher?.close();
 
+		const debouncedRefreshBundle = debounce(() => {
+			if (this.#currentBundle) {
+				this.emitBundleCompleteEvent(config, this.#currentBundle);
+			}
+		});
+
 		if (config.assets?.directory) {
 			this.#assetsWatcher = watch(config.assets.directory, {
 				persistent: true,
 				ignoreInitial: true,
 			}).on("all", async (eventName, filePath) => {
 				const message = getAssetChangeMessage(eventName, filePath);
-				logger.debug(`🌀 ${message}...`);
-				if (this.#currentBundle) {
-					this.emitBundleCompleteEvent(config, this.#currentBundle);
-				}
+				logger.log(`🌀 ${message}...`);
+				debouncedRefreshBundle();
+				// if (this.#currentBundle) {
+				// 	this.emitBundleCompleteEvent(config, this.#currentBundle);
+				// }
 			});
 		}
 	}


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6876

This applies https://github.com/cloudflare/workers-sdk/pull/6866 for the `--x-dev-env` flow

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
