### PR TITLE
Fix dev-env logging

### DIFF
--- a/.changeset/gentle-apricots-kiss.md
+++ b/.changeset/gentle-apricots-kiss.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Various fixes for logging in `--x-dev-env`, primarily to ensure the hotkeys don't wipe useful output and are cleaned up correctly

--- a/.prettierignore
+++ b/.prettierignore
@@ -36,3 +36,6 @@ templates/*/build
 templates/*/dist
 
 .github/pull_request_template.md
+
+# This file intentionally has a syntax error
+fixtures/interactive-dev-tests/src/startup-error.ts

--- a/fixtures/interactive-dev-tests/src/startup-error.ts
+++ b/fixtures/interactive-dev-tests/src/startup-error.ts
@@ -1,0 +1,5 @@
+export default {
+	async fetch(): Promise<Response {
+		return new Response("body");
+	},
+};

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -230,23 +230,26 @@ describe.each(devScripts)("wrangler $args", ({ args, expectedBody }) => {
 	});
 });
 
-it.only("hotkeys should be unregistered when the initial build fails", async () => {
-	const wrangler = await startWranglerDev(
-		["dev", "--x-dev-env", "src/startup-error.ts"],
-		true
-	);
+it.runIf(RUN_IF && nodePtySupported)(
+	"hotkeys should be unregistered when the initial build fails",
+	async () => {
+		const wrangler = await startWranglerDev(
+			["dev", "--x-dev-env", "src/startup-error.ts"],
+			true
+		);
 
-	expect(await wrangler.exitPromise).toBe(1);
+		expect(await wrangler.exitPromise).toBe(1);
 
-	const hotkeysRenderCount = [
-		...wrangler.stdout.matchAll(/\[b\] open a browser/g),
-	];
+		const hotkeysRenderCount = [
+			...wrangler.stdout.matchAll(/\[b\] open a browser/g),
+		];
 
-	const clearHotkeysCount = [
-		// This is the control sequence for moving the cursor up and then clearing from the cursor to the end
-		...wrangler.stdout.matchAll(/\[\dA\[0J/g),
-	];
+		const clearHotkeysCount = [
+			// This is the control sequence for moving the cursor up and then clearing from the cursor to the end
+			...wrangler.stdout.matchAll(/\[\dA\[0J/g),
+		];
 
-	// The hotkeys should be rendered the same number of times as the control sequence for clearing them from the screen
-	expect(hotkeysRenderCount.length).toBe(clearHotkeysCount.length);
-});
+		// The hotkeys should be rendered the same number of times as the control sequence for clearing them from the screen
+		expect(hotkeysRenderCount.length).toBe(clearHotkeysCount.length);
+	}
+);

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -230,23 +230,26 @@ describe.each(devScripts)("wrangler $args", ({ args, expectedBody }) => {
 	});
 });
 
-it("hotkeys should be unregistered when the initial build fails", async () => {
-	const wrangler = await startWranglerDev(
-		["dev", "src/startup-error.ts"],
-		true
-	);
+it.runIf(RUN_IF && nodePtySupported)(
+	"hotkeys should be unregistered when the initial build fails",
+	async () => {
+		const wrangler = await startWranglerDev(
+			["dev", "src/startup-error.ts"],
+			true
+		);
 
-	expect(await wrangler.exitPromise).toBe(1);
+		expect(await wrangler.exitPromise).toBe(1);
 
-	const hotkeysRenderCount = [
-		...wrangler.stdout.matchAll(/\[b\] open a browser/g),
-	];
+		const hotkeysRenderCount = [
+			...wrangler.stdout.matchAll(/\[b\] open a browser/g),
+		];
 
-	const clearHotkeysCount = [
-		// This is the control sequence for moving the cursor up and then clearing from the cursor to the end
-		...wrangler.stdout.matchAll(/\[\dA\[0J/g),
-	];
+		const clearHotkeysCount = [
+			// This is the control sequence for moving the cursor up and then clearing from the cursor to the end
+			...wrangler.stdout.matchAll(/\[\dA\[0J/g),
+		];
 
-	// The hotkeys should be rendered the same number of times as the control sequence for clearing them from the screen
-	expect(hotkeysRenderCount.length).toBe(clearHotkeysCount.length);
-});
+		// The hotkeys should be rendered the same number of times as the control sequence for clearing them from the screen
+		expect(hotkeysRenderCount.length).toBe(clearHotkeysCount.length);
+	}
+);

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -230,7 +230,7 @@ describe.each(devScripts)("wrangler $args", ({ args, expectedBody }) => {
 	});
 });
 
-it.only("hotkeys should be unregistered when the initial build fails", async () => {
+it("hotkeys should be unregistered when the initial build fails", async () => {
 	const wrangler = await startWranglerDev(
 		["dev", "src/startup-error.ts"],
 		true

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -247,7 +247,7 @@ export async function fetchWorker(
 	});
 
 	if (!response.ok || !response.body) {
-		console.error(response.ok, response.body);
+		logger.error(response.ok, response.body);
 		throw new Error(
 			`Failed to fetch ${resource} - ${response.status}: ${response.statusText});`
 		);

--- a/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
+++ b/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
@@ -4,6 +4,7 @@ import { UserError } from "../errors";
 import { logger } from "../logger";
 import { COMMON_ESBUILD_OPTIONS } from "./bundle";
 import { getEntryPointFromMetafile } from "./entry-point-from-metafile";
+import { logBuildOutput } from "./esbuild-plugins/log-build-output";
 import type { CfScriptFormat } from "./worker";
 
 /**
@@ -39,6 +40,12 @@ export default async function guessWorkerFormat(
 		bundle: false,
 		write: false,
 		...(tsconfig && { tsconfig }),
+		logLevel: "silent",
+		plugins: [
+			logBuildOutput(
+				/* bundle: false means the NodeJS compat mode is irrelevant in the context of this build */ undefined
+			),
+		],
 	});
 
 	// result.metafile is defined because of the `metafile: true` option above.

--- a/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
+++ b/packages/wrangler/src/deployment-bundle/guess-worker-format.ts
@@ -4,7 +4,6 @@ import { UserError } from "../errors";
 import { logger } from "../logger";
 import { COMMON_ESBUILD_OPTIONS } from "./bundle";
 import { getEntryPointFromMetafile } from "./entry-point-from-metafile";
-import { logBuildOutput } from "./esbuild-plugins/log-build-output";
 import type { CfScriptFormat } from "./worker";
 
 /**
@@ -41,11 +40,6 @@ export default async function guessWorkerFormat(
 		write: false,
 		...(tsconfig && { tsconfig }),
 		logLevel: "silent",
-		plugins: [
-			logBuildOutput(
-				/* bundle: false means the NodeJS compat mode is irrelevant in the context of this build */ undefined
-			),
-		],
 	});
 
 	// result.metafile is defined because of the `metafile: true` option above.

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -604,7 +604,9 @@ export async function startDev(args: StartDevOptions) {
 				}
 			});
 
-			let teardownRegistryPromise: Promise<(name?: string) => Promise<void>>;
+			let teardownRegistryPromise:
+				| Promise<(name?: string) => Promise<void>>
+				| undefined;
 			if (!args.disableDevRegistry) {
 				teardownRegistryPromise = devRegistry((registry) =>
 					updateDevEnvRegistry(devEnv, registry)
@@ -629,15 +631,17 @@ export async function startDev(args: StartDevOptions) {
 				});
 			}
 
-			let unregisterHotKeys: () => void;
+			let unregisterHotKeys: (() => void) | undefined;
 			if (isInteractive() && args.showInteractiveDevSession !== false) {
 				unregisterHotKeys = registerDevHotKeys(devEnv, args);
 			}
 
 			devEnv.once("teardown", async () => {
-				const teardownRegistry = await teardownRegistryPromise;
-				await teardownRegistry(devEnv.config.latestConfig?.name);
-				unregisterHotKeys();
+				if (teardownRegistryPromise) {
+					const teardownRegistry = await teardownRegistryPromise;
+					await teardownRegistry(devEnv.config.latestConfig?.name);
+				}
+				unregisterHotKeys?.();
 			});
 
 			await devEnv.config.set(

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -55,7 +55,6 @@ export default function registerDevHotKeys(
 			keys: ["x", "q", "ctrl+c"],
 			label: "to exit",
 			handler: async () => {
-				unregisterHotKeys();
 				await devEnv.teardown();
 			},
 		},

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -181,7 +181,7 @@ export const logger = new Logger();
 export function logBuildWarnings(warnings: Message[]) {
 	const logs = formatMessagesSync(warnings, { kind: "warning", color: true });
 	for (const log of logs) {
-		console.warn(log);
+		logger.console("warn", log);
 	}
 }
 
@@ -192,7 +192,7 @@ export function logBuildWarnings(warnings: Message[]) {
 export function logBuildFailure(errors: Message[], warnings: Message[]) {
 	const logs = formatMessagesSync(errors, { kind: "error", color: true });
 	for (const log of logs) {
-		console.error(log);
+		logger.console("error", log);
 	}
 	logBuildWarnings(warnings);
 }

--- a/packages/wrangler/src/utils/log-file.ts
+++ b/packages/wrangler/src/utils/log-file.ts
@@ -63,8 +63,11 @@ ${message}
 			// TODO(consider): recommend opening an issue with the contents of this file?
 			if (hasSeenErrorMessage) {
 				// use console.*warn* here so not to pollute stdout -- some commands print json to stdout
-				// use *console*.warn here so not to have include the *very* visible bright-yellow [WARNING] indicator
-				console.warn(`🪵  Logs were written to "${debugLogFilepath}"`);
+				// use logger.*console*("warn", ...) here so not to have include the *very* visible bright-yellow [WARNING] indicator
+				logger.console(
+					"warn",
+					`🪵  Logs were written to "${debugLogFilepath}"`
+				);
 			}
 		});
 	}


### PR DESCRIPTION
## What this PR solves / how to test

Fixes N/A

Various fixes for logging in `--x-dev-env`, primarily to ensure the hotkeys don't wipe useful output:
- Ensure all direct console logging is through `logger.console()` so that the hotkeys are correctly rendered
- Ensure esbuild doesn't log directly to the console when guessing the format of a worker
- Ensure hotkeys are unregistered when `DevEnv` is torndown
- Ensure `devEnv.teardown()` is called when `startDev()` encounters a thrown error

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bufix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
