### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,4 +1,4 @@
-# Github Actions
+# GitHub Actions
 
 See below for a summary of this repo's Actions
 
@@ -14,7 +14,7 @@ See below for a summary of this repo's Actions
   - Builds all the packages.
   - Runs formatting, linting and type checks.
   - Runs fixture tests, Wrangler unit tests, C3 unit tests, Miniflare unit tests, and ESLint + Prettier checks.
-  - Adds the PR to a Github project
+  - Adds the PR to a GitHub project
 
 ### E2E tests (e2e.yml)
 
@@ -62,7 +62,7 @@ See below for a summary of this repo's Actions
 - Triggers
   - Updates to issues.
 - Actions
-  - Add the issue to a Github project.
+  - Add the issue to a GitHub project.
 
 ### Generate changesets for dependabot PRs (c3-dependabot-versioning-prs.yml and miniflare-dependabot-versioning-prs.yml)
 

--- a/ISSUE_TRIAGE.md
+++ b/ISSUE_TRIAGE.md
@@ -16,9 +16,9 @@ Follow these steps to triage an issue.
 
 ### Step 0: Is this a Pages or Wrangler issue?
 
-If the issue refers only to Pages commands then apply the `pages` label and add the issue to the [Pages](https://github.com/orgs/cloudflare/projects/2) Github project.
+If the issue refers only to Pages commands then apply the `pages` label and add the issue to the [Pages](https://github.com/orgs/cloudflare/projects/2) GitHub project.
 
-Otherwise, add the issue to the [Wrangler](https://github.com/orgs/cloudflare/projects/1) Github project, set its status to `Untriaged`, and continue to step 1.
+Otherwise, add the issue to the [Wrangler](https://github.com/orgs/cloudflare/projects/1) GitHub project, set its status to `Untriaged`, and continue to step 1.
 
 ### Step 1: Does the issue have enough information?
 

--- a/packages/create-cloudflare/README.md
+++ b/packages/create-cloudflare/README.md
@@ -7,4 +7,4 @@ For more details on how to use the create-cloudflare CLI (C3) please visit the [
 ### Community
 
 - Join us [on Discord](https://discord.cloudflare.com)
-- File an issue [on Github](https://github.com/cloudflare/workers-sdk/issues/new/choose)
+- File an issue [on GitHub](https://github.com/cloudflare/workers-sdk/issues/new/choose)

--- a/packages/quick-edit/README.md
+++ b/packages/quick-edit/README.md
@@ -15,7 +15,7 @@ Follow steps (1), (2) and (3) from above, and then run `pnpm run custom:build`
 
 ## Deployment
 
-Deployments are managed by Github Actions:
+Deployments are managed by GitHub Actions:
 
 - deploy-pages-previews.yml:
   - Runs on any PR that has the `preview:quick-edit` label.

--- a/packages/workers-playground/README.md
+++ b/packages/workers-playground/README.md
@@ -20,7 +20,7 @@ This generates the files into the `dist` directory that can then be deployed to 
 
 ## Deployment
 
-Deployments are managed by Github Actions:
+Deployments are managed by GitHub Actions:
 
 - deploy-pages-previews.yml:
   - Runs on any PR that has the `preview:workers-playground` label.

--- a/packages/wrangler-devtools/README.md
+++ b/packages/wrangler-devtools/README.md
@@ -4,7 +4,7 @@ This package contains a Workers specific version of Chrome Devtools that is used
 
 ## Deployment
 
-Deployments are managed by Github Actions:
+Deployments are managed by GitHub Actions:
 
 - deploy-pages-previews.yml:
   - Runs on any PR that has the `preview:wrangler-devtools` label.


### PR DESCRIPTION
## What this PR solves / how to test

Fixes N/A
Fixes instances of incorrect GitHub capitalization in markdown files.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: just capitalization fixes in markdown files
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: just capitalization fixes in markdown files
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: just capitalization fixes in markdown files
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just capitalization fixes in markdown files

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
