### PR TITLE
fix bug with vitest + pages with wrangler.toml

### DIFF
--- a/.changeset/pretty-cherries-relate.md
+++ b/.changeset/pretty-cherries-relate.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: infer experimentalJsonConfig from file extension
+
+Fixes [#5768](https://github.com/cloudflare/workers-sdk/issues/5768) - issue with vitest and Pages projects with wrangler.toml

--- a/fixtures/vitest-pool-workers-examples/pages-with-config/README.md
+++ b/fixtures/vitest-pool-workers-examples/pages-with-config/README.md
@@ -1,0 +1,3 @@
+# pages-with-config
+
+Tests for regression of [#5768](https://github.com/cloudflare/workers-sdk/issues/5768)

--- a/fixtures/vitest-pool-workers-examples/pages-with-config/pages-config.test.ts
+++ b/fixtures/vitest-pool-workers-examples/pages-with-config/pages-config.test.ts
@@ -1,0 +1,5 @@
+import { expect, it } from "vitest";
+
+it("should run tests even if Pages project specifies wrangler.toml", () => {
+	expect(1).toBe(1);
+});

--- a/fixtures/vitest-pool-workers-examples/pages-with-config/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/pages-with-config/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.node.json",
+	"include": ["./*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/pages-with-config/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/pages-with-config/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineWorkersProject } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersProject({
+	test: {
+		poolOptions: {
+			workers: {
+				wrangler: { configPath: "./wrangler.toml" },
+			},
+		},
+	},
+});

--- a/fixtures/vitest-pool-workers-examples/pages-with-config/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/pages-with-config/wrangler.toml
@@ -1,0 +1,6 @@
+#:schema node_modules/wrangler/config-schema.json
+name = "pages-with-config"
+compatibility_date = "2024-09-19"
+compatibility_flags = ["nodejs_compat"]
+pages_build_output_dir = "public"
+

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -247,8 +247,15 @@ export function unstable_getMiniflareWorkerOptions(
 	define: Record<string, string>;
 	main?: string;
 } {
+	// experimental json is usually enabled via a cli arg,
+	// so it cannot be passed to the vitest integration.
+	// instead we infer it from the config path (instead of setting a default)
+	// because wrangler.json is not compatible with pages.
+	const isJsonConfigFile =
+		configPath.endsWith(".json") || configPath.endsWith(".jsonc");
+
 	const config = readConfig(configPath, {
-		experimentalJsonConfig: true,
+		experimentalJsonConfig: isJsonConfigFile,
 		env,
 	});
 


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #5768 

tl;dr: previously, `experimentalJsonConfig` was always set to `true` in `unstable_getMiniflareWorkerOptions`, which is used by the vitest integration to read config options. However `experimentalJsonConfig` is not supported by Pages, so any Pages + vitest setup that defined a wrangler.toml would trip up an error check for json + Pages.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by fixture
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

