### PR TITLE
fix: `pages project delete` should error if project name not specified

### DIFF
--- a/packages/wrangler/src/__tests__/pages/project-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-delete.test.ts
@@ -63,6 +63,14 @@ describe("pages project delete", () => {
 	`);
 	});
 
+	it("should error if no project name is specified", async () => {
+		await expect(
+			runWrangler("pages project delete")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Missing required argument: project-name]`
+		);
+	});
+
 	it("should not delete a project if confirmation refused", async () => {
 		mockConfirm({
 			text: `Are you sure you want to delete "some-project-name-2"? This action cannot be undone.`,

--- a/packages/wrangler/src/pages/projects.tsx
+++ b/packages/wrangler/src/pages/projects.tsx
@@ -188,7 +188,6 @@ export function DeleteOptions(yargs: CommonYargsArgv) {
 	return yargs
 		.positional("project-name", {
 			type: "string",
-			demandOption: true,
 			description: "The name of your Pages project",
 		})
 		.options({
@@ -197,7 +196,8 @@ export function DeleteOptions(yargs: CommonYargsArgv) {
 				type: "boolean",
 				description: 'Answer "yes" to confirm project deletion',
 			},
-		});
+		})
+		.demandOption("project-name");
 }
 
 export async function DeleteHandler(


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #5559 
To be quite honest, I have no idea why this appeases yargs and the previous state did not.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: adequately covered by unit tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: trivial
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: trivial

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
