### PR TITLE
VS-286 Support mixed-mode local bindings for Vectorize in Miniflare

### DIFF
--- a/.changeset/empty-lamps-turn.md
+++ b/.changeset/empty-lamps-turn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Local development now supports Vectorize bindings

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -513,7 +513,6 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 				index_name = "${name}"
 				`,
 			"samples.ndjson": dedent`
-				{"id":"b0daca4a-ffd8-4865-926b-e24800af2a2d","values":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"She sells seashells by the seashore"}}
 				{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"Peter Piper picked a peck of pickled peppers"}}
 			`,
 			"src/index.ts": dedent`
@@ -522,6 +521,14 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 				}
 				export default {
 					async fetch(request: Request, env: Env, ctx: any) {
+						let response = "";
+
+						response += JSON.stringify(await env.VECTORIZE.describe());
+						await env.VECTORIZE.insert([{"id":"b0daca4a-ffd8-4865-926b-e24800af2a2d","values":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"She sells seashells by the sea"}}]);
+						await env.VECTORIZE.upsert([{"id":"b0daca4a-ffd8-4865-926b-e24800af2a2d","values":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"She sells seashells by the seashore"}}]);
+						response += JSON.stringify(await env.VECTORIZE.getByIds(["a44706aa-a366-48bc-8cc1-3feffd87d548"]));
+						await env.VECTORIZE.deleteByIds(["b0daca4a-ffd8-4865-926b-e24800af2a2d"]);
+
 						const queryVector: Array<number> = [
 							0.13, 0.25, 0.44, 0.53, 0.62, 0.41, 0.59, 0.68, 0.29, 0.82, 0.37, 0.5,
 							0.74, 0.46, 0.57, 0.64, 0.28, 0.61, 0.73, 0.35, 0.78, 0.58, 0.42, 0.32,
@@ -532,7 +539,9 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 							returnValues: true,
 							returnMetadata: "all",
 						});
-						return Response.json({matches});
+						response += JSON.stringify(matches);
+
+						return new Response(response);
 					}
 				}
 				`,

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -519,17 +519,15 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 
 				async function waitForMutation(env: Env, mutationId: string) {
 					while((await env.VECTORIZE.describe()).processedUpToMutation != mutationId) {
-						await new Promise(resolve => setTimeout(resolve, 500));
+						await new Promise(resolve => setTimeout(resolve, 2000));
 					}
 				}
 
 				export default {
 					async fetch(request: Request, env: Env, ctx: any) {
-						await env.VECTORIZE.insert([{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"Peter Piper picked a peck of pickled peppers"}}]);
-						await env.VECTORIZE.insert([{"id":"b0daca4a-ffd8-4865-926b-e24800af2a2d","values":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"She sells seashells by the sea"}}]);
-						const {mutationId} = await env.VECTORIZE.upsert([{"id":"b0daca4a-ffd8-4865-926b-e24800af2a2d","values":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"She sells seashells by the seashore"}}]);
-
-						await waitForMutation(env, mutationId);
+						await waitForMutation(env, (await env.VECTORIZE.insert([{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"Peter Piper picked a peck of pickled peppers"}}])).mutationId);
+						await waitForMutation(env, (await env.VECTORIZE.insert([{"id":"b0daca4a-ffd8-4865-926b-e24800af2a2d","values":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"She sells seashells by the sea"}}])).mutationId);
+						await waitForMutation(env, (await env.VECTORIZE.upsert([{"id":"b0daca4a-ffd8-4865-926b-e24800af2a2d","values":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"She sells seashells by the seashore"}}])).mutationId);
 
 						let response = "";
 						response += JSON.stringify(await env.VECTORIZE.getByIds(["a44706aa-a366-48bc-8cc1-3feffd87d548"]));
@@ -544,7 +542,7 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 							returnValues: true,
 							returnMetadata: "all",
 						});
-						response += JSON.stringify(matches);
+						response += " " + matches.count;
 
 						return new Response(response);
 					}
@@ -559,7 +557,7 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 		const res = await fetch(url);
 
 		await expect(res.text()).resolves.toBe(
-			`[{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","namespace":null,"metadata":{"text":"Peter Piper picked a peck of pickled peppers"},"values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}]{"count":2,"matches":[{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","score":2.9689255,"values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"Peter Piper picked a peck of pickled peppers"}},{"id":"b0daca4a-ffd8-4865-926b-e24800af2a2d","score":3.06765,"values":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"She sells seashells by the seashore"}}]}`
+			`[{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","namespace":null,"metadata":{"text":"Peter Piper picked a peck of pickled peppers"},"values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}] 2`
 		);
 	});
 

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -549,7 +549,9 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 
 		await helper.run(`wrangler vectorize insert ${name} --file samples.ndjson`);
 
-		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const worker = helper.runLongLived(
+			`wrangler dev ${flags} --experimental-vectorize-bind-to-prod`
+		);
 		const { url } = await worker.waitForReady();
 		const res = await fetch(url);
 

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -513,24 +513,8 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 				index_name = "${name}"
 				`,
 			"samples.ndjson": dedent`
-				{
-					id: "1",
-					values: [
-					0.12, 0.45, 0.67, 0.89, 0.23, 0.56, 0.34, 0.78, 0.12, 0.9, 0.24, 0.67,
-					0.89, 0.35, 0.48, 0.7, 0.22, 0.58, 0.74, 0.33, 0.88, 0.66, 0.45, 0.27,
-					0.81, 0.54, 0.39, 0.76, 0.41, 0.29, 0.83, 0.55,
-					],
-					metadata: { url: "/products/sku/13913913" },
-				}
-				{
-					id: "2",
-					values: [
-					0.14, 0.23, 0.36, 0.51, 0.62, 0.47, 0.59, 0.74, 0.33, 0.89, 0.41, 0.53,
-					0.68, 0.29, 0.77, 0.45, 0.24, 0.66, 0.71, 0.34, 0.86, 0.57, 0.62, 0.48,
-					0.78, 0.52, 0.37, 0.61, 0.69, 0.28, 0.8, 0.53,
-					],
-					metadata: { url: "/products/sku/10148191" },
-				}
+				{"id":"b0daca4a-ffd8-4865-926b-e24800af2a2d","values":[0.2331,1.0125,0.6131,0.9421,0.9661,0.8121,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"She sells seashells by the seashore"}}
+				{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"metadata":{"text":"Peter Piper picked a peck of pickled peppers"}}
 			`,
 			"src/index.ts": dedent`
 				export interface Env {
@@ -560,7 +544,13 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 		const { url } = await worker.waitForReady();
 		const res = await fetch(url);
 
-		expect(await res.json()).toEqual({ todo: "" });
+		const text = await res.text();
+		console.log(text);
+		const obj = JSON.parse(text) as any;
+
+		const count = obj.matches.count;
+
+		expect(count).toBe(2);
 	});
 
 	it.skipIf(!isLocal)("exposes queue producer/consumer bindings", async () => {

--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -93,4 +93,17 @@ export class WranglerE2ETestHelper {
 
 		return { id, name };
 	}
+
+	async vectorize(dimensions: number, metric: string) {
+		// vectorize does not have a local dev mode yet, so we don't yet support the isLocal flag here
+		const name = generateResourceName("vectorize");
+		await this.run(
+			`wrangler vectorize create ${name} --dimensions ${dimensions} --metric ${metric}`
+		);
+		onTestFinished(async () => {
+			await this.run(`wrangler vectorize delete ${name}`);
+		});
+
+		return name;
+	}
 }

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1420,7 +1420,8 @@ describe.sequential("wrangler dev", () => {
 				      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]
 				      --show-interactive-dev-session               Show interactive dev session  (defaults to true if the terminal supports interactivity)  [boolean]
 				      --experimental-dev-env, --x-dev-env          Use the experimental DevEnv instantiation (unified across wrangler dev and unstable_dev)  [boolean] [default: true]
-				      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: false]",
+				      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: false]
+				      --experimental-vectorize-bind-to-prod        Bind to production Vectorize indexes in local development mode  [boolean] [default: false]",
 				  "warn": "",
 				}
 			`);

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -78,7 +78,8 @@ describe("pages", () => {
 			      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"]
 			      --show-interactive-dev-session               Show interactive dev session (defaults to true if the terminal supports interactivity)  [boolean]
 			      --experimental-dev-env, --x-dev-env          Use the experimental DevEnv instantiation (unified across wrangler dev and unstable_dev)  [boolean] [default: false]
-			      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: false]"
+			      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: false]
+			      --experimental-vectorize-bind-to-prod        Bind to production Vectorize indexes in local development mode  [boolean] [default: false]"
 		`);
 	});
 

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -83,6 +83,7 @@ export interface UnstableDevOptions {
 		watch?: boolean; // unstable_dev doesn't support watch-mode yet in testMode
 		devEnv?: boolean;
 		fileBasedRegistry?: boolean;
+		vectorizeBindToProd?: boolean;
 	};
 }
 
@@ -128,6 +129,7 @@ export async function unstable_dev(
 		testScheduled,
 		devEnv = false,
 		fileBasedRegistry = false,
+		vectorizeBindToProd,
 		// 2. options for alpha/beta products/libs
 		d1Databases,
 		enablePagesAssetsServiceBinding,
@@ -223,6 +225,7 @@ export async function unstable_dev(
 		experimentalVersions: undefined,
 		experimentalDevEnv: devEnv,
 		experimentalRegistry: fileBasedRegistry,
+		experimentalVectorizeBindToProd: vectorizeBindToProd ?? false,
 	};
 
 	//due to Pages adoption of unstable_dev, we can't *just* disable rebuilds and watching. instead, we'll have two versions of startDev, which will converge.

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -126,6 +126,7 @@ async function resolveDevConfig(
 		// absolute resolved path
 		persist: localPersistencePath,
 		registry: input.dev?.registry,
+		bindVectorizeToProd: input.dev?.bindVectorizeToProd ?? false,
 	} satisfies StartDevWorkerOptions["dev"];
 }
 

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -118,6 +118,7 @@ async function convertToConfigBundle(
 		inspect: true,
 		services: bindings.services,
 		serviceBindings: fetchers,
+		bindVectorizeToProd: event.config.dev?.bindVectorizeToProd ?? false,
 	};
 }
 

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -159,6 +159,9 @@ export interface StartDevWorkerInput {
 		registry?: WorkerRegistry;
 
 		testScheduled?: boolean;
+
+		/** Whether to use Vectorize mixed mode -- the worker is run locally but accesses to Vectorize are made remotely */
+		bindVectorizeToProd?: boolean;
 	};
 	legacy?: {
 		site?: Hook<Config["site"], [Config]>;

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -353,9 +353,9 @@ export function devOptions(yargs: CommonYargsArgv) {
 				default: false,
 			})
 			.option("experimental-vectorize-bind-to-prod", {
-				alias: ["x-vectorize-bind-to-prod"],
 				type: "boolean",
-				describe: "Bind to production Vectorize indexes in local development mode",
+				describe:
+					"Bind to production Vectorize indexes in local development mode",
 				default: false,
 			})
 	);

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -352,6 +352,12 @@ export function devOptions(yargs: CommonYargsArgv) {
 					"Use the experimental file based dev registry for multi-worker development",
 				default: false,
 			})
+			.option("experimental-vectorize-bind-to-prod", {
+				alias: ["x-vectorize-bind-to-prod"],
+				type: "boolean",
+				describe: "Bind to production Vectorize indexes in local development mode",
+				default: false,
+			})
 	);
 }
 
@@ -748,6 +754,7 @@ export async function startDev(args: StartDevOptions) {
 						testScheduled: args.testScheduled,
 						logLevel: args.logLevel,
 						registry: devEnv.config.latestConfig?.dev.registry,
+						bindVectorizeToProd: args.experimentalVectorizeBindToProd,
 					},
 					legacy: {
 						site: (configParam) => {
@@ -1007,6 +1014,7 @@ export async function startDev(args: StartDevOptions) {
 						rawArgs={args}
 						rawConfig={configParam}
 						devEnv={devEnv}
+						bindVectorizeToProd={args.experimentalVectorizeBindToProd}
 					/>
 				);
 			}
@@ -1206,6 +1214,7 @@ export async function startApiDev(args: StartDevOptions) {
 			rawArgs: args,
 			rawConfig: configParam,
 			devEnv,
+			bindVectorizeToProd: args.experimentalVectorizeBindToProd,
 		});
 	}
 

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -196,6 +196,7 @@ export type DevProps = {
 	rawConfig: Config;
 	rawArgs: StartDevOptions;
 	devEnv: DevEnv;
+	bindVectorizeToProd: boolean;
 };
 
 export function DevImplementation(props: DevProps): JSX.Element {
@@ -398,6 +399,7 @@ function DevSession(props: DevSessionProps) {
 				liveReload: props.liveReload,
 				testScheduled: props.testScheduled,
 				persist: "",
+				bindVectorizeToProd: props.bindVectorizeToProd,
 			},
 			legacy: {
 				site:
@@ -656,6 +658,7 @@ function DevSession(props: DevSessionProps) {
 			enablePagesAssetsServiceBinding={props.enablePagesAssetsServiceBinding}
 			sourceMapPath={bundle?.sourceMapPath}
 			services={props.bindings.services}
+			bindVectorizeToProd={props.bindVectorizeToProd}
 		/>
 	) : (
 		<Remote

--- a/packages/wrangler/src/dev/dev.tsx
+++ b/packages/wrangler/src/dev/dev.tsx
@@ -460,6 +460,7 @@ function DevSession(props: DevSessionProps) {
 		props.localUpstream,
 		props.liveReload,
 		props.testScheduled,
+		props.bindVectorizeToProd,
 		accountIdDeferred,
 	]);
 

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -56,6 +56,7 @@ export interface LocalProps {
 	testScheduled?: boolean;
 	sourceMapPath: string | undefined;
 	services: Config["services"] | undefined;
+	bindVectorizeToProd: boolean;
 }
 
 // TODO(soon): we should be able to remove this function when we fully migrate
@@ -110,6 +111,7 @@ export async function localPropsToConfigBundle(
 		inspect: props.inspect,
 		services: props.services,
 		serviceBindings,
+		bindVectorizeToProd: props.bindVectorizeToProd,
 	};
 }
 

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -282,12 +282,12 @@ async function buildSourceOptions(
 			? {
 					entrypointSource: config.bundle.entrypointSource,
 					modules: config.bundle.modules,
-			  }
+				}
 			: withSourceURLs(
 					scriptPath,
 					config.bundle.entrypointSource,
 					config.bundle.modules
-			  );
+				);
 
 		const entrypointNames = isPython
 			? []

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -924,7 +924,7 @@ export async function buildMiniflareOptions(
 		if (!didWarnMiniflareVectorizeSupport) {
 			didWarnMiniflareVectorizeSupport = true;
 			logger.warn(
-				"Using Vectorize always accesses your Cloudflare account in order to run queries. It will make changes and incur usage charges even in local development."
+				"Using Vectorize always accesses your Cloudflare account in order to run queries and may incur usage charges even in local development. Write operations are also not enabled in local development; use `--remote` if write operations are needed."
 			);
 		}
 	}

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -283,12 +283,12 @@ async function buildSourceOptions(
 			? {
 					entrypointSource: config.bundle.entrypointSource,
 					modules: config.bundle.modules,
-			  }
+				}
 			: withSourceURLs(
 					scriptPath,
 					config.bundle.entrypointSource,
 					config.bundle.modules
-			  );
+				);
 
 		const entrypointNames = isPython
 			? []
@@ -620,7 +620,7 @@ export function buildMiniflareBindingOptions(config: MiniflareBindingsConfig): {
 					},
 				],
 				serviceBindings: {
-					FETCHER: MakeVectorizeFetcher(indexName, indexVersion),
+					FETCHER: MakeVectorizeFetcher(indexName),
 				},
 				bindings: {
 					INDEX_ID: indexName,

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -282,12 +282,12 @@ async function buildSourceOptions(
 			? {
 					entrypointSource: config.bundle.entrypointSource,
 					modules: config.bundle.modules,
-				}
+			  }
 			: withSourceURLs(
 					scriptPath,
 					config.bundle.entrypointSource,
 					config.bundle.modules
-				);
+			  );
 
 		const entrypointNames = isPython
 			? []
@@ -607,7 +607,7 @@ export function buildMiniflareBindingOptions(config: MiniflareBindingsConfig): {
 		for (const vectorizeBinding of bindings.vectorize) {
 			const bindingName = vectorizeBinding.binding;
 			const indexName = vectorizeBinding.index_name;
-			const indexVersion = "v2"; // TODO: support v1?
+			const indexVersion = "v2";
 
 			externalWorkers.push({
 				name: EXTERNAL_VECTORIZE_WORKER_NAME + bindingName,
@@ -924,7 +924,7 @@ export async function buildMiniflareOptions(
 		if (!didWarnMiniflareVectorizeSupport) {
 			didWarnMiniflareVectorizeSupport = true;
 			logger.warn(
-				"Using Vectorize always accesses your Cloudflare account in order to run queries and may incur usage charges even in local development. Write operations are also not enabled in local development; use `--remote` if write operations are needed."
+				"Using Vectorize always accesses your Cloudflare account. It may incur usage charges and modify your databases even in local development. "
 			);
 		}
 	}

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -197,6 +197,7 @@ export interface ConfigBundle {
 	inspect: boolean;
 	services: Config["services"] | undefined;
 	serviceBindings: Record<string, ServiceFetch>;
+	bindVectorizeToProd: boolean;
 }
 
 export class WranglerLog extends Log {
@@ -918,6 +919,13 @@ export async function buildMiniflareOptions(
 				"Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development."
 			);
 		}
+	}
+
+	if (!config.bindVectorizeToProd && config.bindings.vectorize?.length) {
+		logger.warn(
+			"Vectorize local bindings are not supported yet. You may use the `--experimental-vectorize-bind-to-prod` flag to bind to your production index in local dev mode."
+		);
+		config.bindings.vectorize = [];
 	}
 
 	if (config.bindings.vectorize?.length) {

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -932,7 +932,7 @@ export async function buildMiniflareOptions(
 		if (!didWarnMiniflareVectorizeSupport) {
 			didWarnMiniflareVectorizeSupport = true;
 			logger.warn(
-				"Using Vectorize always accesses your Cloudflare account. It may incur usage charges and modify your databases even in local development. "
+				"You are using a mixed-mode binding for Vectorize (through `--experimental-vectorize-bind-to-prod`). It may incur usage charges and modify your databases even in local development. "
 			);
 		}
 	}

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -923,9 +923,8 @@ export async function buildMiniflareOptions(
 	if (config.bindings.vectorize?.length) {
 		if (!didWarnMiniflareVectorizeSupport) {
 			didWarnMiniflareVectorizeSupport = true;
-			// TODO: add local support for Vectorize bindings (https://github.com/cloudflare/workers-sdk/issues/4360)
 			logger.warn(
-				"Vectorize bindings are not currently supported in local mode. Please use --remote if you are working with them."
+				"Using Vectorize always accesses your Cloudflare account in order to run queries. It will make changes and incur usage charges even in local development."
 			);
 		}
 	}

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -150,6 +150,7 @@ export async function startDevServer(
 			persist: props.localPersistencePath ?? undefined,
 			testScheduled: props.testScheduled,
 			registry: workerDefinitions,
+			bindVectorizeToProd: props.bindVectorizeToProd,
 		},
 		build: {
 			bundle: !props.noBundle,
@@ -321,6 +322,7 @@ export async function startDevServer(
 			sourceMapPath: bundle?.sourceMapPath,
 			services: props.bindings.services,
 			experimentalDevEnv: props.experimentalDevEnv,
+			bindVectorizeToProd: props.bindVectorizeToProd,
 		});
 
 		return {

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -251,6 +251,11 @@ export function Options(yargs: CommonYargsArgv) {
 					"Use the experimental file based dev registry for multi-worker development",
 				default: false,
 			},
+			"experimental-vectorize-bind-to-prod": {
+				type: "boolean",
+				describe: "Bind to production Vectorize indexes in local development mode",
+				default: false,
+			}
 		});
 }
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -253,9 +253,10 @@ export function Options(yargs: CommonYargsArgv) {
 			},
 			"experimental-vectorize-bind-to-prod": {
 				type: "boolean",
-				describe: "Bind to production Vectorize indexes in local development mode",
+				describe:
+					"Bind to production Vectorize indexes in local development mode",
 				default: false,
-			}
+			},
 		});
 }
 

--- a/packages/wrangler/src/vectorize/fetcher.ts
+++ b/packages/wrangler/src/vectorize/fetcher.ts
@@ -33,11 +33,7 @@ const URL_SUBSTITUTIONS = new Map<string, string>([
 	["deleteByIds", "delete_by_ids"],
 ]);
 
-function toNdJson(arr: object[]): string {
-	return arr.reduce((acc, o) => acc + JSON.stringify(o) + "\n", "").trim();
-}
-
-export function MakeVectorizeFetcher(indexId: string, indexVersion: string) {
+export function MakeVectorizeFetcher(indexId: string) {
 	return async function (request: Request): Promise<Response> {
 		const accountId = await getAccountId();
 
@@ -68,7 +64,7 @@ export function MakeVectorizeFetcher(indexId: string, indexVersion: string) {
 			: {
 					error: apiResponse.errors[0].message,
 					code: apiResponse.errors[0].code,
-			  };
+				};
 
 		return new Response(JSON.stringify(newResponse), {
 			status: res.status,

--- a/packages/wrangler/src/vectorize/fetcher.ts
+++ b/packages/wrangler/src/vectorize/fetcher.ts
@@ -74,7 +74,7 @@ export function MakeVectorizeFetcher(indexId: string, indexVersion: string) {
 			: {
 					error: apiResponse.errors[0].message,
 					code: apiResponse.errors[0].code,
-			  };
+				};
 
 		return new Response(JSON.stringify(newResponse), {
 			status: res.status,

--- a/packages/wrangler/src/vectorize/fetcher.ts
+++ b/packages/wrangler/src/vectorize/fetcher.ts
@@ -1,0 +1,48 @@
+import { Headers, Response } from "miniflare";
+import { performApiFetch } from "../cfetch/internal";
+import { getAccountId } from "../user";
+import type { Request } from "miniflare";
+
+export const EXTERNAL_VECTORIZE_WORKER_NAME =
+	"__WRANGLER_EXTERNAL_VECTORIZE_WORKER";
+
+export const EXTERNAL_VECTORIZE_WORKER_SCRIPT = `
+import makeBinding from 'cloudflare-internal:vectorize-api'
+
+export default function (env) {
+    return makeBinding({
+        fetcher: env.FETCHER,
+        indexId: env.INDEX_ID,
+        indexVersion: env.INDEX_VERSION,
+    });
+}
+`;
+
+export function MakeVectorizeFetcher(indexId: string, indexVersion: string) {
+	return async function (request: Request): Promise<Response> {
+		const accountId = await getAccountId();
+
+		request.headers.delete("Host");
+		request.headers.delete("Content-Length");
+
+		const url = request.url.replace(
+			"http://vector-search/",
+			`/accounts/${accountId}/vectorize/${indexVersion}/indexes/${indexId}/`
+		);
+
+		// TODO: v1 endpoints have a different format
+
+		const res = await performApiFetch(url, {
+			method: "POST",
+			headers: Object.fromEntries(request.headers.entries()),
+			body: request.body,
+			duplex: "half",
+		});
+
+		const respHeaders = new Headers(res.headers);
+		respHeaders.delete("Host");
+		respHeaders.delete("Content-Length");
+
+		return new Response(res.body, { status: res.status, headers: respHeaders });
+	};
+}

--- a/packages/wrangler/src/vectorize/fetcher.ts
+++ b/packages/wrangler/src/vectorize/fetcher.ts
@@ -14,6 +14,7 @@ export default function (env) {
         fetcher: env.FETCHER,
         indexId: env.INDEX_ID,
         indexVersion: env.INDEX_VERSION,
+        useNdJson: true,
     });
 }
 `;


### PR DESCRIPTION
## What this PR solves / how to test

Fixes VS-286.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: I don't think this limitation is mentioned anywhere in docs and it's generally expected that bindings work in local dev mode. 
