### PR TITLE
chore: Drop the "Fixes" check in CI

### DIFF
--- a/tools/deployments/__tests__/validate-pr-description.test.ts
+++ b/tools/deployments/__tests__/validate-pr-description.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { validateDescription } from "../validate-pr-description";
 
-
 describe("validateDescription()", () => {
 	it("should skip validation with the `skip-pr-description-validation` label", () => {
 		expect(

--- a/tools/deployments/__tests__/validate-pr-description.test.ts
+++ b/tools/deployments/__tests__/validate-pr-description.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { validateDescription } from "../validate-pr-description";
 
+
 describe("validateDescription()", () => {
 	it("should skip validation with the `skip-pr-description-validation` label", () => {
 		expect(
@@ -38,7 +39,6 @@ Fixes #[insert GH or internal issue number(s)].
 			)
 		).toMatchInlineSnapshot(`
 			[
-			  "Your PR description must include an issue reference in the format \`Fixes #000\` (for GitHub issues), \`Fixes [AA-000](https://jira.cfdata.org/browse/AA-000)\` (for internal Jira ticket references), or \`Fixes N/A\` if there's no associated issue (and it doesn't make sense to create one)",
 			  "All TODO checkboxes in your PR description must be unchecked before merging",
 			  "Your PR must include tests, or provide justification for why no tests are required",
 			  "Your PR must run E2E tests, or provide justification for why running them is not required",
@@ -46,101 +46,6 @@ Fixes #[insert GH or internal issue number(s)].
 			  "Your PR must include documentation (in the form of a link to a Cloudflare Docs issue or PR), or provide justification for why no documentation is required",
 			]
 		`);
-	});
-	it("should accept GitHub issue reference", () => {
-		expect(
-			validateDescription(
-				"",
-				`## What this PR solves / how to test
-
-Fixes #1234.
-
-## Author has addressed the following
-
-- Tests
-  - [ ] TODO (before merge)
-  - [ ] Tests included
-  - [x] Tests not necessary because: test
-- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
-  - [ ] I don't know
-  - [ ] Required
-  - [x] Not required because: test
-- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
-  - [ ] TODO (before merge)
-  - [ ] Changeset included
-  - [x] Changeset not necessary because: test
-- Public documentation
-  - [ ] TODO (before merge)
-  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
-  - [x] Documentation not necessary because: test
-`,
-				"[]"
-			)
-		).toMatchInlineSnapshot(`[]`);
-	});
-
-	it("should accept JIRA issue reference", () => {
-		expect(
-			validateDescription(
-				"",
-				`## What this PR solves / how to test
-
-Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
-
-## Author has addressed the following
-
-- Tests
-  - [ ] TODO (before merge)
-  - [ ] Tests included
-  - [x] Tests not necessary because: test
-- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
-  - [ ] I don't know
-  - [ ] Required
-  - [x] Not required because: test
-- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
-  - [ ] TODO (before merge)
-  - [ ] Changeset included
-  - [x] Changeset not necessary because: test
-- Public documentation
-  - [ ] TODO (before merge)
-  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
-  - [x] Documentation not necessary because: test
-`,
-				"[]"
-			)
-		).toMatchInlineSnapshot(`[]`);
-	});
-
-	it("should accept N/A issue reference", () => {
-		expect(
-			validateDescription(
-				"",
-				`## What this PR solves / how to test
-
-Fixes N/A.
-
-## Author has addressed the following
-
-- Tests
-  - [ ] TODO (before merge)
-  - [ ] Tests included
-  - [x] Tests not necessary because: test
-- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
-  - [ ] I don't know
-  - [ ] Required
-  - [x] Not required because: test
-- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
-  - [ ] TODO (before merge)
-  - [ ] Changeset included
-  - [x] Changeset not necessary because: test
-- Public documentation
-  - [ ] TODO (before merge)
-  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
-  - [x] Documentation not necessary because: test
-`,
-				"[]"
-			)
-		).toMatchInlineSnapshot(`[]`);
 	});
 
 	it("should accept everything included", () => {

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -31,16 +31,6 @@ export function validateDescription(
 		return [];
 	}
 
-	if (
-		!/^Fixes (#\d+|N\/A|\[[A-Z]+-\d+\]\(https:\/\/jira\.cfdata\.org\/browse\/[A-Z]+-\d+\))/m.test(
-			body
-		)
-	) {
-		errors.push(
-			"Your PR description must include an issue reference in the format `Fixes #000` (for GitHub issues), `Fixes [AA-000](https://jira.cfdata.org/browse/AA-000)` (for internal Jira ticket references), or `Fixes N/A` if there's no associated issue (and it doesn't make sense to create one)"
-		);
-	}
-
 	if (/- \[x\] TODO \(before merge\)/.test(body)) {
 		errors.push(
 			"All TODO checkboxes in your PR description must be unchecked before merging"


### PR DESCRIPTION
## What this PR solves / how to test

I had the PR description check failed because I typed "Fixes n/a" instead of "Fixes N/A"
It should be ok to make this check case insensitive.


Fixes N/A

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because: trivial change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: CI change
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [X] Changeset not necessary because: CI minor tweak
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: CI 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
