### PR TITLE
fix: respect CLOUDLFARE_ACCOUNT_ID with `wrangler pages project`

### DIFF
--- a/.changeset/cuddly-waves-pump.md
+++ b/.changeset/cuddly-waves-pump.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: respect `CLOUDLFARE_ACCOUNT_ID` with `wrangler pages project` commands
+
+Fixes [#4947](https://github.com/cloudflare/workers-sdk/issues/4947)

--- a/.changeset/warm-games-brush.md
+++ b/.changeset/warm-games-brush.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: respect CLOUDFLARE_ACCOUNT_ID with `wrangler pages project`
+
+Fixes [#4947](https://github.com/cloudflare/workers-sdk/issues/4947)

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -155,7 +155,6 @@ describe("pages project create", () => {
 				"*/accounts/:accountId/pages/projects",
 				async ({ request, params }) => {
 					const body = (await request.json()) as Record<string, unknown>;
-					console.dir(request.url);
 					expect(params.accountId).toEqual("new-account-id");
 					return HttpResponse.json(
 						{

--- a/packages/wrangler/src/__tests__/pages/project-create.test.ts
+++ b/packages/wrangler/src/__tests__/pages/project-create.test.ts
@@ -148,4 +148,40 @@ describe("pages project create", () => {
             To deploy a folder of assets, run 'wrangler pages deploy [directory]'."
         `);
 	});
+
+	it("should override cached accountId with CLOUDFLARE_ACCOUNT_ID environmental variable if provided", async () => {
+		msw.use(
+			http.post(
+				"*/accounts/:accountId/pages/projects",
+				async ({ request, params }) => {
+					const body = (await request.json()) as Record<string, unknown>;
+					console.dir(request.url);
+					expect(params.accountId).toEqual("new-account-id");
+					return HttpResponse.json(
+						{
+							success: true,
+							errors: [],
+							messages: [],
+							result: {
+								...body,
+								subdomain: "an-existing-project.pages.dev",
+							},
+						},
+						{ status: 200 }
+					);
+				},
+				{ once: true }
+			)
+		);
+		vi.mock("getConfigCache", () => {
+			return {
+				account_id: "original-account-id",
+				project_name: "an-existing-project",
+			};
+		});
+		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "new-account-id");
+		await runWrangler(
+			"pages project create an-existing-project --production-branch=main --compatibility-date 2022-03-08"
+		);
+	});
 });

--- a/packages/wrangler/src/pages/projects.tsx
+++ b/packages/wrangler/src/pages/projects.tsx
@@ -8,6 +8,7 @@ import { FatalError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
+import { getCloudflareAccountIdFromEnv } from "../user/auth-variables";
 import { renderToString } from "../utils/render";
 import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
 import type {
@@ -23,7 +24,8 @@ export function ListOptions(yargs: CommonYargsArgv) {
 export async function ListHandler() {
 	const config = getConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME);
 
-	const accountId = await requireAuth(config);
+	const accountId =
+		getCloudflareAccountIdFromEnv() ?? (await requireAuth(config));
 
 	const projects: Array<Project> = await listProjects({ accountId });
 
@@ -106,7 +108,8 @@ export async function CreateHandler({
 	projectName,
 }: StrictYargsOptionsToInterface<typeof CreateOptions>) {
 	const config = getConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME);
-	const accountId = await requireAuth(config);
+	const accountId =
+		getCloudflareAccountIdFromEnv() ?? (await requireAuth(config));
 
 	const isInteractive = process.stdin.isTTY;
 	if (!projectName && isInteractive) {
@@ -204,7 +207,8 @@ export async function DeleteHandler(
 	args: StrictYargsOptionsToInterface<typeof DeleteOptions>
 ) {
 	const config = getConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME);
-	const accountId = await requireAuth(config);
+	const accountId =
+		getCloudflareAccountIdFromEnv() ?? (await requireAuth(config));
 
 	const confirmed =
 		args.yes ||


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #4947 
Previously `pages project` commands were always using cached accound id values, regardless of what was passed in as an env variable.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: unit tests should be adequate 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because: 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
