### PR TITLE
Show kv help when run without params

### DIFF
--- a/.changeset/cyan-cycles-occur.md
+++ b/.changeset/cyan-cycles-occur.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: show help when kv commands are run without parameters

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -13,6 +13,7 @@ import type {
 	KVNamespaceInfo,
 	NamespaceKeyInfo,
 } from "../kv/helpers";
+import { endEventLoop } from "./helpers/end-event-loop";
 
 describe("wrangler", () => {
 	mockAccountId();
@@ -55,15 +56,53 @@ describe("wrangler", () => {
 
     it("should show help when no argument is passed", async () => {
 		await runWrangler("kv");
-		expect(std.out).toMatchInlineSnapshot();
+        await endEventLoop();
+		expect(std.out).toMatchInlineSnapshot(`
+			"wrangler kv
+
+			🗂️  Manage Workers KV Namespaces
+
+			COMMANDS
+			  wrangler kv namespace  Interact with your Workers KV Namespaces
+			  wrangler kv key        Individually manage Workers KV key-value pairs
+			  wrangler kv bulk       Interact with multiple Workers KV key-value pairs at once
+
+			GLOBAL FLAGS
+			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+			  -c, --config                    Path to .toml configuration file  [string]
+			  -e, --env                       Environment to use for operations and .env files  [string]
+			  -h, --help                      Show help  [boolean]
+			  -v, --version                   Show version number  [boolean]"
+		`);
 	});
 
 	it("should show help when an invalid argument is passed", async () => {
 		await expect(() => runWrangler("kv asdf")).rejects.toThrow(
 			"Unknown argument: asdf"
 		);
-		expect(std.err).toMatchInlineSnapshot();
-		expect(std.out).toMatchInlineSnapshot();
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: asdf[0m
+
+			"
+		`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			wrangler kv
+
+			🗂️  Manage Workers KV Namespaces
+
+			COMMANDS
+			  wrangler kv namespace  Interact with your Workers KV Namespaces
+			  wrangler kv key        Individually manage Workers KV key-value pairs
+			  wrangler kv bulk       Interact with multiple Workers KV key-value pairs at once
+
+			GLOBAL FLAGS
+			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
+			  -c, --config                    Path to .toml configuration file  [string]
+			  -e, --env                       Environment to use for operations and .env files  [string]
+			  -h, --help                      Show help  [boolean]
+			  -v, --version                   Show version number  [boolean]"
+		`);
 	});
 
 

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -53,6 +53,20 @@ describe("wrangler", () => {
 		`);
 	});
 
+    it("should show help when no argument is passed", async () => {
+		await runWrangler("kv");
+		expect(std.out).toMatchInlineSnapshot();
+	});
+
+	it("should show help when an invalid argument is passed", async () => {
+		await expect(() => runWrangler("kv asdf")).rejects.toThrow(
+			"Unknown argument: asdf"
+		);
+		expect(std.err).toMatchInlineSnapshot();
+		expect(std.out).toMatchInlineSnapshot();
+	});
+
+
 	describe("kv namespace", () => {
 		describe("create", () => {
 			function mockCreateRequest(expectedTitle: string) {

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { http, HttpResponse } from "msw";
+import { endEventLoop } from "./helpers/end-event-loop";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockConfirm } from "./helpers/mock-dialogs";
@@ -13,7 +14,6 @@ import type {
 	KVNamespaceInfo,
 	NamespaceKeyInfo,
 } from "../kv/helpers";
-import { endEventLoop } from "./helpers/end-event-loop";
 
 describe("wrangler", () => {
 	mockAccountId();
@@ -54,9 +54,9 @@ describe("wrangler", () => {
 		`);
 	});
 
-    it("should show help when no argument is passed", async () => {
+	it("should show help when no argument is passed", async () => {
 		await runWrangler("kv");
-        await endEventLoop();
+		await endEventLoop();
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler kv
 
@@ -104,7 +104,6 @@ describe("wrangler", () => {
 			  -v, --version                   Show version number  [boolean]"
 		`);
 	});
-
 
 	describe("kv namespace", () => {
 		describe("create", () => {

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -38,7 +38,7 @@ export function registerKvSubcommands(
 	subHelp: SubHelp
 ) {
 	return kvYargs
-        .command(subHelp)
+		.command(subHelp)
 		.command(
 			"namespace",
 			`Interact with your Workers KV Namespaces`,
@@ -64,7 +64,7 @@ export function registerKvSubcommands(
 
 export function kvNamespace(kvYargs: CommonYargsArgv) {
 	return kvYargs
-        .demandCommand()
+		.demandCommand()
 		.command(
 			"create <namespace>",
 			"Create a new namespace",
@@ -203,7 +203,7 @@ export function kvNamespace(kvYargs: CommonYargsArgv) {
 
 export const kvKey = (kvYargs: CommonYargsArgv) => {
 	return kvYargs
-        .demandCommand()
+		.demandCommand()
 		.command(
 			"put <key> [value]",
 			"Write a single key/value pair to the given namespace",
@@ -545,7 +545,7 @@ export const kvKey = (kvYargs: CommonYargsArgv) => {
 
 export const kvBulk = (kvYargs: CommonYargsArgv) => {
 	return kvYargs
-        .demandCommand()
+		.demandCommand()
 		.command(
 			"put <filename>",
 			"Upload multiple key-value pairs to a namespace",

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -38,6 +38,7 @@ export function registerKvSubcommands(
 	subHelp: SubHelp
 ) {
 	return kvYargs
+        .command(subHelp)
 		.command(
 			"namespace",
 			`Interact with your Workers KV Namespaces`,
@@ -63,6 +64,7 @@ export function registerKvSubcommands(
 
 export function kvNamespace(kvYargs: CommonYargsArgv) {
 	return kvYargs
+        .demandCommand()
 		.command(
 			"create <namespace>",
 			"Create a new namespace",
@@ -201,6 +203,7 @@ export function kvNamespace(kvYargs: CommonYargsArgv) {
 
 export const kvKey = (kvYargs: CommonYargsArgv) => {
 	return kvYargs
+        .demandCommand()
 		.command(
 			"put <key> [value]",
 			"Write a single key/value pair to the given namespace",
@@ -542,6 +545,7 @@ export const kvKey = (kvYargs: CommonYargsArgv) => {
 
 export const kvBulk = (kvYargs: CommonYargsArgv) => {
 	return kvYargs
+        .demandCommand()
 		.command(
 			"put <filename>",
 			"Upload multiple key-value pairs to a namespace",


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6143 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: just updating when to show command help output
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just updating when to show command help output

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
