### PR TITLE
WC-2695 Add better visibility for router-worker

### DIFF
--- a/.changeset/poor-shoes-tickle.md
+++ b/.changeset/poor-shoes-tickle.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+feat: Add observability to router-worker

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -1,0 +1,71 @@
+import type { Environment, ReadyAnalytics } from "./types";
+
+// This will allow us to make breaking changes to the analytic schema
+const VERSION = 1;
+
+export enum DISPATCH_TYPE {
+	ASSETS = "asset",
+	WORKER = "worker",
+}
+
+// When adding new columns please update the schema
+type Data = {
+	// -- Doubles --
+	// double1 - The time it takes for the whole request to complete in milliseconds
+	requestTime?: number;
+	// double2 - Colo ID
+	coloId?: number;
+	// double3 - Metal ID
+	metalId?: number;
+	// double4 - Colo tier (e.g. tier 1, tier 2, tier 3)
+	coloTier?: number;
+
+	// -- Blobs --
+	// blob1 - Hostname of the request
+	hostname?: string;
+	// blob2 - Dispatch type - what kind of thing did we dispatch
+	dispatchtype?: DISPATCH_TYPE;
+	// blob3 - Error message
+	error?: string;
+	// blob4 - The current version UUID of router-server
+	version?: string;
+	// blob5 - Region of the colo (e.g. WEUR)
+	coloRegion?: string;
+};
+
+export class Analytics {
+	private data: Data = {};
+
+	setData(newData: Partial<Data>) {
+		this.data = { ...this.data, ...newData };
+	}
+
+	getData(key: keyof Data) {
+		return this.data[key];
+	}
+
+	write(env: Environment, readyAnalytics?: ReadyAnalytics, hostname?: string) {
+		if (!readyAnalytics) {
+			return;
+		}
+
+		readyAnalytics.logEvent({
+			version: VERSION,
+			accountId: 0, // TODO: need to plumb through
+			indexId: hostname,
+			doubles: [
+				this.data.requestTime ?? -1, // double1
+				this.data.coloId ?? -1, // double2
+				this.data.metalId ?? -1, // double3
+				this.data.coloTier ?? -1, // double4
+			],
+			blobs: [
+				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes
+				this.data.dispatchtype, // blob2
+				this.data.error?.substring(0, 256), // blob3 - trim to 256 bytes
+				this.data.version, // blob4
+				this.data.coloRegion, // blob5
+			],
+		});
+	}
+}

--- a/packages/workers-shared/router-worker/src/performance.ts
+++ b/packages/workers-shared/router-worker/src/performance.ts
@@ -1,0 +1,16 @@
+import type { UnsafePerformanceTimer } from "./types";
+
+export class PerformanceTimer {
+	private performanceTimer;
+
+	constructor(performanceTimer?: UnsafePerformanceTimer) {
+		this.performanceTimer = performanceTimer;
+	}
+
+	now() {
+		if (this.performanceTimer) {
+			return this.performanceTimer.timeOrigin + this.performanceTimer.now();
+		}
+		return Date.now();
+	}
+}

--- a/packages/workers-shared/router-worker/src/types.ts
+++ b/packages/workers-shared/router-worker/src/types.ts
@@ -1,0 +1,25 @@
+export type Environment = "production" | "staging";
+
+export interface ReadyAnalytics {
+	logEvent: (e: ReadyAnalyticsEvent) => void;
+}
+
+export interface ColoMetadata {
+	metalId: number;
+	coloId: number;
+	coloRegion: string;
+	coloTier: number;
+}
+
+export interface UnsafePerformanceTimer {
+	readonly timeOrigin: number;
+	now: () => number;
+}
+
+export interface ReadyAnalyticsEvent {
+	accountId?: number;
+	indexId?: string;
+	version?: number;
+	doubles?: (number | undefined)[];
+	blobs?: (string | undefined)[];
+}

--- a/packages/workers-shared/router-worker/wrangler.toml
+++ b/packages/workers-shared/router-worker/wrangler.toml
@@ -13,6 +13,9 @@ workers_dev = false
 main = "src/index.ts"
 compatibility_date = "2024-07-31"
 
+[version_metadata]
+binding = "VERSION_METADATA"
+
 [[unsafe.bindings]]
 name = "CONFIG"
 type = "param"
@@ -30,3 +33,7 @@ type = "origin"
 [unsafe.metadata.build_options]
 stable_id = "cloudflare/cf_router_worker"
 networks = ["cf","jdc"]
+
+[[unsafe.bindings]]
+name = "workers-router-worker"
+type = "internal_capability_grants"


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #WC-2695

This commit instruments the router worker with analytics such as request time, colo metadata, error, etc, in order for us to have better visibility into the router worker.

These changes were tested using gradual rollouts with a 0% version and a Cloudflare-Workers-Version-Overrides header.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: not a unit-testable change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
