### PR TITLE
Pre-populate existing image when modifying a deployment

### DIFF
--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -187,27 +187,22 @@ async function handleModifyCommand(
 
 	const keys = await handleSSH(args, config, deployment);
 	const givenImage = args.image ?? config.cloudchamber.image;
-	const imagePrompt = await processArgument<string>(
-		{ image: givenImage },
-		"image",
-		{
-			question: modifyImageQuestion,
-			label: "",
-			validate: (value) => {
-				if (typeof value !== "string") {
-					return "unknown error";
-				}
-				if (value.endsWith(":latest")) {
-					return "we don't allow :latest tags";
-				}
-			},
-			defaultValue: givenImage ?? "",
-			initialValue: givenImage ?? "",
-			helpText: "if you don't want to modify the image, press return",
-			type: "text",
-		}
-	);
-	const image = !imagePrompt ? undefined : imagePrompt;
+	const image = await processArgument<string>({ image: givenImage }, "image", {
+		question: modifyImageQuestion,
+		label: "",
+		validate: (value) => {
+			if (typeof value !== "string") {
+				return "unknown error";
+			}
+			if (value.endsWith(":latest")) {
+				return "we don't allow :latest tags";
+			}
+		},
+		defaultValue: givenImage ?? deployment.image,
+		initialValue: givenImage ?? deployment.image,
+		helpText: "Press Return to leave unchanged",
+		type: "text",
+	});
 
 	const locationPick = await getLocation(
 		{ location: args.location ?? config.cloudchamber.location },
@@ -234,7 +229,7 @@ async function handleModifyCommand(
 	);
 
 	renderDeploymentConfiguration("modify", {
-		image: image ?? deployment.image,
+		image,
 		location: location ?? deployment.location.name,
 		vcpu: args.vcpu ?? config.cloudchamber.vcpu ?? deployment.vcpu,
 		memory: args.memory ?? config.cloudchamber.memory ?? deployment.memory,
@@ -247,7 +242,7 @@ async function handleModifyCommand(
 	});
 
 	const yesOrNo = await inputPrompt({
-		question: "Want to go ahead and modify the deployment?",
+		question: "Modify the deployment?",
 		label: "",
 		type: "confirm",
 	});
@@ -280,5 +275,4 @@ async function handleModifyCommand(
 	await waitForPlacement(newDeployment);
 }
 
-const modifyImageQuestion =
-	"Insert the image url you want to change your deployment to";
+const modifyImageQuestion = "URL of the image to use in your deployment";


### PR DESCRIPTION
If a user wants to update a deployment to change only the tag of their image, then they must re-enter the entire image URL with the new tag. Instead, we can pre-populate the image field with the existing image URL (including the tag), which means a user can now simply modify the tag without needing to re-enter the full URL themselves.

For example, if the deployment is currently using image "hello-world:1.0" and they want to modify it to use "hello-world:1.1", currently they would need to write the full text "hello-world:1.1". This can be quite cumbersome if the URL of the image is long (which it often is). With this change, the existing URL is pre-populated, so the user needs only to replace "0" with "1".

If a user does not want to modify the image of the deployment then they can continue to just press "Enter" to keep the existing image as before.


## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: minor UX change only (non-functional)
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: minor UX change only (non-functional)
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [x] Changeset not necessary because: minor UX change only (non-functional)
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is an internal command presently

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
