### PR TITLE
fix: relax PR description validation

### DIFF
--- a/tools/deployments/__tests__/validate-pr-description.test.ts
+++ b/tools/deployments/__tests__/validate-pr-description.test.ts
@@ -5,8 +5,9 @@ describe("validateDescription()", () => {
 	it("should skip validation with the `skip-pr-description-validation` label", () => {
 		expect(
 			validateDescription("", "", '["skip-pr-description-validation"]')
-		).toMatchInlineSnapshot(`[]`);
+		).toHaveLength(0);
 	});
+
 	it("should show errors with default template + TODOs checked", () => {
 		expect(
 			validateDescription(
@@ -76,7 +77,7 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
 `,
 				"[]"
 			)
-		).toMatchInlineSnapshot(`[]`);
+		).toHaveLength(0);
 	});
 
 	it("should not accept e2e unknown", () => {
@@ -151,6 +152,7 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
 			]
 		`);
 	});
+
 	it("should accept e2e with e2e label", () => {
 		expect(
 			validateDescription(
@@ -180,6 +182,38 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
 `,
 				'["e2e"]'
 			)
-		).toMatchInlineSnapshot(`[]`);
+		).toHaveLength(0);
+	});
+
+	it("should accept e2e with e2e label - uppercase X", () => {
+		expect(
+			validateDescription(
+				"",
+				`## What this PR solves / how to test
+
+Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
+
+## Author has addressed the following
+
+- Tests
+  - [ ] TODO (before merge)
+  - [X] Tests included
+  - [ ] Tests not necessary because:
+- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
+  - [ ] I don't know
+  - [X] Required
+  - [ ] Not required because: test
+- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
+  - [ ] TODO (before merge)
+  - [X] Changeset included
+  - [ ] Changeset not necessary because:
+- Public documentation
+  - [ ] TODO (before merge)
+  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/123
+  - [ ] Documentation not necessary because:
+`,
+				'["e2e"]'
+			)
+		).toHaveLength(0);
 	});
 });

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -31,7 +31,7 @@ export function validateDescription(
 		return [];
 	}
 
-	if (/- \[x\] TODO \(before merge\)/.test(body)) {
+	if (/- \[x\] TODO \(before merge\)/i.test(body)) {
 		errors.push(
 			"All TODO checkboxes in your PR description must be unchecked before merging"
 		);
@@ -39,8 +39,8 @@ export function validateDescription(
 
 	if (
 		!(
-			/- \[x\] Tests included/.test(body) ||
-			/- \[x\] Tests not necessary because: .+/.test(body)
+			/- \[x\] Tests included/i.test(body) ||
+			/- \[x\] Tests not necessary because: .+/i.test(body)
 		)
 	) {
 		errors.push(
@@ -48,7 +48,7 @@ export function validateDescription(
 		);
 	}
 
-	if (/- \[x\] I don't know/.test(body)) {
+	if (/- \[x\] I don't know/i.test(body)) {
 		errors.push(
 			"Your PR cannot be merged with a status of `I don't know` for e2e tests. When your PR is reviewed by the Wrangler team they'll decide whether e2e tests need to be run"
 		);
@@ -56,8 +56,8 @@ export function validateDescription(
 
 	if (
 		!(
-			/- \[x\] Required/.test(body) ||
-			/- \[x\] Not required because: .+/.test(body)
+			/- \[x\] Required/i.test(body) ||
+			/- \[x\] Not required because: .+/i.test(body)
 		)
 	) {
 		errors.push(
@@ -65,7 +65,7 @@ export function validateDescription(
 		);
 	}
 
-	if (/- \[x\] Required/.test(body) && !parsedLabels.includes("e2e")) {
+	if (/- \[x\] Required/i.test(body) && !parsedLabels.includes("e2e")) {
 		errors.push(
 			"Since your PR requires E2E tests to be run, it needs to have the `e2e` label applied on GitHub"
 		);
@@ -73,8 +73,8 @@ export function validateDescription(
 
 	if (
 		!(
-			/- \[x\] Changeset included/.test(body) ||
-			/- \[x\] Changeset not necessary because: .+/.test(body)
+			/- \[x\] Changeset included/i.test(body) ||
+			/- \[x\] Changeset not necessary because: .+/i.test(body)
 		)
 	) {
 		errors.push(
@@ -84,9 +84,9 @@ export function validateDescription(
 
 	if (
 		!(
-			/- \[x\] Cloudflare docs PR\(s\): https:\/\/github\.com\/cloudflare\/cloudflare-docs\/(pull|issues)\/\d+/.test(
+			/- \[x\] Cloudflare docs PR\(s\): https:\/\/github\.com\/cloudflare\/cloudflare-docs\/(pull|issues)\/\d+/i.test(
 				body
-			) || /- \[x\] Documentation not necessary because: .+/.test(body)
+			) || /- \[x\] Documentation not necessary because: .+/i.test(body)
 		)
 	) {
 		errors.push(


### PR DESCRIPTION
The validation expects `/\[x\]/` for checkboxes while github accepts `/\[x\]/i`. This PR then makes the whole regexps case insensitive as case should not matter anyway.

Also removed a bunch a unnecessary snapshots.

I had the description test failed on https://github.com/cloudflare/workers-sdk/pull/6957 because of that.

## What this PR solves / how to test

Fixes N/A.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [X] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [ ] Changeset included
  - [X] Changeset not necessary because: CI fix
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: CI fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
