### PR TITLE
fix: use correct main file in wrangler.toml for astro + workers assets template

### DIFF
--- a/.changeset/kind-tomatoes-smile.md
+++ b/.changeset/kind-tomatoes-smile.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: astro + Workers static assets template now has the correct `main` file in wrangler.toml

--- a/packages/create-cloudflare/templates-experimental/astro/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/astro/templates/wrangler.toml
@@ -2,7 +2,7 @@
 name = "<TBD>"
 compatibility_date = "<TBD>"
 compatibility_flags = ["nodejs_compat_v2"]
-main = "./dist/_worker.js"
+main = "./dist/_worker.js/index.js"
 assets = { directory = "./dist", binding = "ASSETS" }
 
 # Workers Logs


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6980 
## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no relevant tests, tested manually
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no e2e tests for experimental assets templates yet
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
