### PR TITLE
Add additional output fields to pages deployments

### DIFF
--- a/.changeset/little-cheetahs-arrive.md
+++ b/.changeset/little-cheetahs-arrive.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Adds new detailed pages deployment output type

--- a/packages/wrangler/src/__tests__/output.test.ts
+++ b/packages/wrangler/src/__tests__/output.test.ts
@@ -175,6 +175,49 @@ describe("writeOutput()", () => {
 			},
 		]);
 	});
+	it("should write an alias and environment for pages-deploy-detailed outputs", () => {
+		vi.stubEnv("WRANGLER_OUTPUT_FILE_DIRECTORY", "output");
+		vi.stubEnv("WRANGLER_OUTPUT_FILE_PATH", "");
+		writeOutput({
+			type: "wrangler-session",
+			version: 1,
+			wrangler_version: "0.0.0.0",
+			command_line_args: ["--help"],
+			log_file_path: "some/log/path.log",
+		});
+		writeOutput({
+			type: "pages-deploy-detailed",
+			version: 1,
+			pages_project: "pages",
+			deployment_id: "ABCDE12345",
+			url: "test.com",
+			alias: "dev.com",
+			environment: "production",
+		});
+
+		const outputFilePaths = readdirSync("output");
+		expect(outputFilePaths.length).toEqual(1);
+		expect(outputFilePaths[0]).toMatch(/wrangler-output-.+\.json/);
+		const outputFile = readFileSync(join("output", outputFilePaths[0]), "utf8");
+		expect(outputFile).toContainEntries([
+			{
+				type: "wrangler-session",
+				version: 1,
+				wrangler_version: "0.0.0.0",
+				command_line_args: ["--help"],
+				log_file_path: "some/log/path.log",
+			},
+			{
+				type: "pages-deploy-detailed",
+				version: 1,
+				pages_project: "pages",
+				deployment_id: "ABCDE12345",
+				url: "test.com",
+				alias: "dev.com",
+				environment: "production",
+			},
+		]);
+	});
 });
 
 expect.extend({

--- a/packages/wrangler/src/output.ts
+++ b/packages/wrangler/src/output.ts
@@ -70,7 +70,8 @@ export type OutputEntry =
 	| OutputEntryDeployment
 	| OutputEntryPagesDeployment
 	| OutputEntryVersionUpload
-	| OutputEntryVersionDeployment;
+	| OutputEntryVersionDeployment
+	| OutputEntryPagesDeploymentDetailed;
 
 export type StampedOutputEntry = { timestamp: string } & OutputEntry;
 
@@ -106,6 +107,21 @@ export interface OutputEntryPagesDeployment
 	deployment_id: string | null;
 	/** The URL associated with this deployment */
 	url: string | undefined;
+}
+
+export interface OutputEntryPagesDeploymentDetailed
+	extends OutputEntryBase<"pages-deploy-detailed"> {
+	version: 1;
+	/** The name of the Pages project. */
+	pages_project: string | null;
+	/** A GUID that identifies this Pages deployment. */
+	deployment_id: string | null;
+	/** The URL associated with this deployment */
+	url: string | undefined;
+	/** The Alias url, if it exists */
+	alias: string | undefined;
+	/** The environment being deployed to */
+	environment: "production" | "preview";
 }
 
 export interface OutputEntryVersionUpload

--- a/packages/wrangler/src/pages/deploy.tsx
+++ b/packages/wrangler/src/pages/deploy.tsx
@@ -448,6 +448,16 @@ ${failureMessage}`,
 		url: deploymentResponse.url,
 	});
 
+	writeOutput({
+		type: "pages-deploy-detailed",
+		version: 1,
+		pages_project: deploymentResponse.project_name,
+		deployment_id: deploymentResponse.id,
+		url: deploymentResponse.url,
+		alias,
+		environment: deploymentResponse.environment,
+	});
+
 	await metrics.sendMetricsEvent("create pages deployment");
 };
 


### PR DESCRIPTION
## What this PR solves / how to test
https://github.com/cloudflare/wrangler-action/issues/300

Adds additional outputs to wrangler's artifact mechanism for pages deploys. This allows wrangler-action to pull from wrangler's artifacts to get info about pages deploys, adding parity to the outputs pages-action provides.

Test by installing the wrangler prerelease in a local pages project, setting WRANGLER_OUTPUT_FILE_DIRECTORY in the local environment, running a pages deploy, and checking the output file.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because: 
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: This code is not covered by those tests.
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [X] Changeset included
  - [ ] Changeset not necessary because: 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: Internal usage for now

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
