### PR TITLE
fix: better errors for workers commands in pages projects

### DIFF
--- a/.changeset/nine-cougars-repeat.md
+++ b/.changeset/nine-cougars-repeat.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: improve error messaging when accidentally using Workers commands in Pages project
+
+If we detect a Workers command used with a Pages project (i.e. wrangler.toml contains `pages_output_build_dir`), error with Pages version of command rather than "missing entry-point" etc.

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -234,7 +234,10 @@ describe("delete", () => {
 		await expect(
 			runWrangler("delete")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: This command is for Workers, for Pages please run \`wrangler pages project delete\`.]`
+			`
+			[Error: It looks like you've run a Workers-specific command in a Pages project.
+			For Pages, please run \`wrangler pages project delete\` instead.]
+		`
 		);
 	});
 	describe("force deletes", () => {

--- a/packages/wrangler/src/__tests__/delete.test.ts
+++ b/packages/wrangler/src/__tests__/delete.test.ts
@@ -229,6 +229,14 @@ describe("delete", () => {
 	`);
 	});
 
+	it("should error helpfully if pages_build_output_dir is set", async () => {
+		writeWranglerToml({ pages_build_output_dir: "dist", name: "test" });
+		await expect(
+			runWrangler("delete")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: This command is for Workers, for Pages please run \`wrangler pages project delete\`.]`
+		);
+	});
 	describe("force deletes", () => {
 		it("should prompt for extra confirmation when service is depended on and use force", async () => {
 			mockConfirm({

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -385,7 +385,10 @@ describe("deploy", () => {
 		await expect(
 			runWrangler("deploy")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: This command is for Workers, for Pages please run \`wrangler pages deploy\`.]`
+			`
+			[Error: It looks like you've run a Workers-specific command in a Pages project.
+			For Pages, please run \`wrangler pages deploy\` instead.]
+		`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -377,6 +377,18 @@ describe("deploy", () => {
 	`);
 	});
 
+	it("should error helpfully if pages_build_output_dir is set in wrangler.toml", async () => {
+		writeWranglerToml({
+			pages_build_output_dir: "public",
+			name: "test-name",
+		});
+		await expect(
+			runWrangler("deploy")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: This command is for Workers, for Pages please run \`wrangler pages deploy\`.]`
+		);
+	});
+
 	describe("output additional script information", () => {
 		it("for first party workers, it should print worker information at log level", async () => {
 			setIsTTY(false);

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1890,7 +1890,10 @@ describe.sequential("wrangler dev", () => {
 	it("should error helpfully if pages_build_output_dir is set", async () => {
 		writeWranglerToml({ pages_build_output_dir: "dist", name: "test" });
 		await expect(runWrangler("dev")).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: This command is for Workers, for Pages please run \`wrangler pages dev\`.]`
+			`
+			[Error: It looks like you've run a Workers-specific command in a Pages project.
+			For Pages, please run \`wrangler pages dev\` instead.]
+		`
 		);
 	});
 });

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1886,6 +1886,13 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 	});
+
+	it("should error helpfully if pages_build_output_dir is set", async () => {
+		writeWranglerToml({ pages_build_output_dir: "dist", name: "test" });
+		await expect(runWrangler("dev")).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: This command is for Workers, for Pages please run \`wrangler pages dev\`.]`
+		);
+	});
 });
 
 function mockGetZones(domain: string, zones: { id: string }[] = []) {

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -83,6 +83,22 @@ describe("wrangler secret", () => {
 			);
 		}
 
+		it("should error helpfully if pages_build_output_dir is set", async () => {
+			fs.writeFileSync(
+				"wrangler.toml",
+				TOML.stringify({
+					pages_build_output_dir: "public",
+					name: "script-name",
+				}),
+				"utf-8"
+			);
+			await expect(
+				runWrangler("secret put secret-name")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: This command is for Workers, for Pages please run \`wrangler pages secret put\`.]`
+			);
+		});
+
 		describe("interactive", () => {
 			beforeEach(() => {
 				setIsTTY(true);
@@ -389,6 +405,22 @@ describe("wrangler secret", () => {
 			);
 		}
 
+		it("should error helpfully if pages_build_output_dir is set", async () => {
+			fs.writeFileSync(
+				"wrangler.toml",
+				TOML.stringify({
+					pages_build_output_dir: "public",
+					name: "script-name",
+				}),
+				"utf-8"
+			);
+			await expect(
+				runWrangler("secret delete secret-name")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: This command is for Workers, for Pages please run \`wrangler pages secret delete\`.]`
+			);
+		});
+
 		it("should delete a secret", async () => {
 			mockDeleteRequest({ scriptName: "script-name", secretName: "the-key" });
 			mockConfirm({
@@ -499,6 +531,22 @@ describe("wrangler secret", () => {
 			);
 		}
 
+		it("should error helpfully if pages_build_output_dir is set", async () => {
+			fs.writeFileSync(
+				"wrangler.toml",
+				TOML.stringify({
+					pages_build_output_dir: "public",
+					name: "script-name",
+				}),
+				"utf-8"
+			);
+			await expect(
+				runWrangler("secret list")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: This command is for Workers, for Pages please run \`wrangler pages secret list\`.]`
+			);
+		});
+
 		it("should list secrets", async () => {
 			mockListRequest({ scriptName: "script-name" });
 			await runWrangler("secret list --name script-name");
@@ -565,6 +613,22 @@ describe("wrangler secret", () => {
 	});
 
 	describe("bulk", () => {
+		it("should error helpfully if pages_build_output_dir is set", async () => {
+			fs.writeFileSync(
+				"wrangler.toml",
+				TOML.stringify({
+					pages_build_output_dir: "public",
+					name: "script-name",
+				}),
+				"utf-8"
+			);
+			await expect(
+				runWrangler("secret bulk")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: This command is for Workers, for Pages please run \`wrangler pages secret bulk\`.]`
+			);
+		});
+
 		it("should fail secret bulk w/ no pipe or JSON input", async () => {
 			vi.spyOn(readline, "createInterface").mockImplementation(
 				() => null as unknown as Interface

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -95,7 +95,10 @@ describe("wrangler secret", () => {
 			await expect(
 				runWrangler("secret put secret-name")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: This command is for Workers, for Pages please run \`wrangler pages secret put\`.]`
+				`
+				[Error: It looks like you've run a Workers-specific command in a Pages project.
+				For Pages, please run \`wrangler pages secret put\` instead.]
+			`
 			);
 		});
 
@@ -417,7 +420,10 @@ describe("wrangler secret", () => {
 			await expect(
 				runWrangler("secret delete secret-name")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: This command is for Workers, for Pages please run \`wrangler pages secret delete\`.]`
+				`
+				[Error: It looks like you've run a Workers-specific command in a Pages project.
+				For Pages, please run \`wrangler pages secret delete\` instead.]
+			`
 			);
 		});
 
@@ -543,7 +549,10 @@ describe("wrangler secret", () => {
 			await expect(
 				runWrangler("secret list")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: This command is for Workers, for Pages please run \`wrangler pages secret list\`.]`
+				`
+				[Error: It looks like you've run a Workers-specific command in a Pages project.
+				For Pages, please run \`wrangler pages secret list\` instead.]
+			`
 			);
 		});
 
@@ -625,7 +634,10 @@ describe("wrangler secret", () => {
 			await expect(
 				runWrangler("secret bulk")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: This command is for Workers, for Pages please run \`wrangler pages secret bulk\`.]`
+				`
+				[Error: It looks like you've run a Workers-specific command in a Pages project.
+				For Pages, please run \`wrangler pages secret bulk\` instead.]
+			`
 			);
 		});
 

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -10,6 +10,7 @@ import { MockWebSocket } from "./helpers/mock-web-socket";
 import { createFetchResult, msw, mswSucessScriptHandlers } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
+import { writeWranglerToml } from "./helpers/write-wrangler-toml";
 import type {
 	AlarmEvent,
 	EmailEvent,
@@ -842,6 +843,18 @@ describe("tail", () => {
 			);
 			await api.closeHelper();
 		});
+	});
+
+	it("should error helpfully if pages_build_output_dir is set in wrangler.toml", async () => {
+		writeWranglerToml({
+			pages_build_output_dir: "public",
+			name: "test-name",
+		});
+		await expect(
+			runWrangler("tail")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: This command is for Workers, for Pages please run \`wrangler pages deployment tail\`.]`
+		);
 	});
 });
 

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -853,7 +853,10 @@ describe("tail", () => {
 		await expect(
 			runWrangler("tail")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: This command is for Workers, for Pages please run \`wrangler pages deployment tail\`.]`
+			`
+			[Error: It looks like you've run a Workers-specific command in a Pages project.
+			For Pages, please run \`wrangler pages deployment tail\` instead.]
+		`
 		);
 	});
 });

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -97,6 +97,11 @@ export async function deleteHandler(args: DeleteArgs) {
 	const configPath =
 		args.config || (args.script && findWranglerToml(path.dirname(args.script)));
 	const config = readConfig(configPath, args);
+	if (config.pages_build_output_dir) {
+		throw new UserError(
+			"This command is for Workers, for Pages please run `wrangler pages project delete`."
+		);
+	}
 	await metrics.sendMetricsEvent(
 		"delete worker script",
 		{},

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -99,7 +99,8 @@ export async function deleteHandler(args: DeleteArgs) {
 	const config = readConfig(configPath, args);
 	if (config.pages_build_output_dir) {
 		throw new UserError(
-			"This command is for Workers, for Pages please run `wrangler pages project delete`."
+			"It looks like you've run a Workers-specific command in a Pages project.\n" +
+				"For Pages, please run `wrangler pages project delete` instead."
 		);
 	}
 	await metrics.sendMetricsEvent(

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -256,7 +256,8 @@ export async function deployHandler(args: DeployArgs) {
 	const config = readConfig(configPath, args);
 	if (config.pages_build_output_dir) {
 		throw new UserError(
-			"This command is for Workers, for Pages please run `wrangler pages deploy`."
+			"It looks like you've run a Workers-specific command in a Pages project.\n" +
+				"For Pages, please run `wrangler pages deploy` instead."
 		);
 	}
 

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -254,6 +254,12 @@ export async function deployHandler(args: DeployArgs) {
 		args.config || (args.script && findWranglerToml(path.dirname(args.script)));
 	const projectRoot = configPath && path.dirname(configPath);
 	const config = readConfig(configPath, args);
+	if (config.pages_build_output_dir) {
+		throw new UserError(
+			"This command is for Workers, for Pages please run `wrangler pages deploy`."
+		);
+	}
+
 	const entry = await getEntry(args, config, "deploy");
 
 	if (args.public) {

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -66,6 +66,11 @@ export async function getEntry(
 	) {
 		paths = resolveEntryWithAssets();
 	} else {
+		if (config.pages_build_output_dir && command === "dev") {
+			throw new UserError(
+				"This command is for Workers, for Pages please run `wrangler pages dev`."
+			);
+		}
 		throw new UserError(
 			`Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler ${command} path/to/script\`) or the \`main\` config field.`
 		);

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -68,7 +68,8 @@ export async function getEntry(
 	} else {
 		if (config.pages_build_output_dir && command === "dev") {
 			throw new UserError(
-				"This command is for Workers, for Pages please run `wrangler pages dev`."
+				"It looks like you've run a Workers-specific command in a Pages project.\n" +
+					"For Pages, please run `wrangler pages dev` instead."
 			);
 		}
 		throw new UserError(

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -146,7 +146,8 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 				const config = readConfig(args.config, args);
 				if (config.pages_build_output_dir) {
 					throw new UserError(
-						"This command is for Workers, for Pages please run `wrangler pages secret put`."
+						"It looks like you've run a Workers-specific command in a Pages project.\n" +
+							"For Pages, please run `wrangler pages secret put` instead."
 					);
 				}
 
@@ -250,7 +251,8 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 				const config = readConfig(args.config, args);
 				if (config.pages_build_output_dir) {
 					throw new UserError(
-						"This command is for Workers, for Pages please run `wrangler pages secret delete`."
+						"It looks like you've run a Workers-specific command in a Pages project.\n" +
+							"For Pages, please run `wrangler pages secret delete` instead."
 					);
 				}
 
@@ -311,7 +313,8 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 				const config = readConfig(args.config, args);
 				if (config.pages_build_output_dir) {
 					throw new UserError(
-						"This command is for Workers, for Pages please run `wrangler pages secret list`."
+						"It looks like you've run a Workers-specific command in a Pages project.\n" +
+							"For Pages, please run `wrangler pages secret list` instead."
 					);
 				}
 
@@ -377,7 +380,8 @@ export const secretBulkHandler = async (secretBulkArgs: SecretBulkArgs) => {
 	const config = readConfig(secretBulkArgs.config, secretBulkArgs);
 	if (config.pages_build_output_dir) {
 		throw new UserError(
-			"This command is for Workers, for Pages please run `wrangler pages secret bulk`."
+			"It looks like you've run a Workers-specific command in a Pages project.\n" +
+				"For Pages, please run `wrangler pages secret bulk` instead."
 		);
 	}
 

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -144,6 +144,11 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 			async (args) => {
 				await printWranglerBanner();
 				const config = readConfig(args.config, args);
+				if (config.pages_build_output_dir) {
+					throw new UserError(
+						"This command is for Workers, for Pages please run `wrangler pages secret put`."
+					);
+				}
 
 				const scriptName = getLegacyScriptName(args, config);
 				if (!scriptName) {
@@ -243,6 +248,11 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 			},
 			async (args) => {
 				const config = readConfig(args.config, args);
+				if (config.pages_build_output_dir) {
+					throw new UserError(
+						"This command is for Workers, for Pages please run `wrangler pages secret delete`."
+					);
+				}
 
 				const scriptName = getLegacyScriptName(args, config);
 				if (!scriptName) {
@@ -299,6 +309,11 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 			},
 			async (args) => {
 				const config = readConfig(args.config, args);
+				if (config.pages_build_output_dir) {
+					throw new UserError(
+						"This command is for Workers, for Pages please run `wrangler pages secret list`."
+					);
+				}
 
 				const scriptName = getLegacyScriptName(args, config);
 				if (!scriptName) {
@@ -360,6 +375,11 @@ type SecretBulkArgs = StrictYargsOptionsToInterface<typeof secretBulkOptions>;
 export const secretBulkHandler = async (secretBulkArgs: SecretBulkArgs) => {
 	await printWranglerBanner();
 	const config = readConfig(secretBulkArgs.config, secretBulkArgs);
+	if (config.pages_build_output_dir) {
+		throw new UserError(
+			"This command is for Workers, for Pages please run `wrangler pages secret bulk`."
+		);
+	}
 
 	if (secretBulkArgs._.includes("secret:bulk")) {
 		logger.warn(

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -95,7 +95,8 @@ export async function tailHandler(args: TailArgs) {
 	const config = readConfig(args.config, args);
 	if (config.pages_build_output_dir) {
 		throw new UserError(
-			"This command is for Workers, for Pages please run `wrangler pages deployment tail`."
+			"It looks like you've run a Workers-specific command in a Pages project.\n" +
+				"For Pages, please run `wrangler pages deployment tail` instead."
 		);
 	}
 	await metrics.sendMetricsEvent("begin log stream", {

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -93,6 +93,11 @@ export async function tailHandler(args: TailArgs) {
 		await printWranglerBanner();
 	}
 	const config = readConfig(args.config, args);
+	if (config.pages_build_output_dir) {
+		throw new UserError(
+			"This command is for Workers, for Pages please run `wrangler pages deployment tail`."
+		);
+	}
 	await metrics.sendMetricsEvent("begin log stream", {
 		sendMetrics: config.send_metrics,
 	});


### PR DESCRIPTION
## What this PR solves / how to test

Fixes #6793 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered adequately by unit tests
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just some better errors

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
