### PR TITLE
chore(quick-edit): fix build config

### DIFF
--- a/.changeset/poor-phones-fail.md
+++ b/.changeset/poor-phones-fail.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/quick-edit": patch
+---
+
+chore: fix build config


### PR DESCRIPTION
## What this PR solves / how to test

Fixes n/a

The quick edit release [failed](https://github.com/cloudflare/workers-sdk/actions/runs/11365154729/job/31612714816#step:7:249) with an error from node-gyp. This might be because the `ubuntu-latest` image is updated to `ubuntu-24.04` 3 weeks ago. 

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no feature changes
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no feature changes
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
