### PR TITLE
chore: move printWranglerBanner for secret delete into handler

### DIFF
--- a/.changeset/giant-bottles-trade.md
+++ b/.changeset/giant-bottles-trade.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: move printWranglerBanner for secret delete into handler

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -235,7 +235,6 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 			"delete <key>",
 			"Delete a secret variable from a Worker",
 			async (yargs) => {
-				await printWranglerBanner();
 				return yargs
 					.positional("key", {
 						describe: "The variable name to be accessible in the Worker",
@@ -248,6 +247,7 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 					});
 			},
 			async (args) => {
+				await printWranglerBanner();
 				const config = readConfig(args.config, args);
 				if (config.pages_build_output_dir) {
 					throw new UserError(


### PR DESCRIPTION
## What this PR solves / how to test

Moves the banner into the `args` handler like the rest of the commands as this command was printing the banner in the `--help` output.

```
➜  ~ npx wrangler secret delete --help

 ⛅️ wrangler 3.78.3 (update available 3.81.0)
-------------------------------------------------------

wrangler secret delete <key>

Delete a secret variable from a Worker

POSITIONALS
  key  The variable name to be accessible in the Worker  [string] [required]

GLOBAL FLAGS
  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
  -c, --config                    Path to .toml configuration file  [string]
  -e, --env                       Environment to use for operations and .env files  [string]
  -h, --help                      Show help  [boolean]
  -v, --version                   Show version number  [boolean]

OPTIONS
      --name  Name of the Worker  [string]
```
```
➜  ~ npx wrangler secret put --help
wrangler secret put <key>

Create or update a secret variable for a Worker

POSITIONALS
  key  The variable name to be accessible in the Worker  [string] [required]

GLOBAL FLAGS
  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
  -c, --config                    Path to .toml configuration file  [string]
  -e, --env                       Environment to use for operations and .env files  [string]
  -h, --help                      Show help  [boolean]
  -v, --version                   Show version number  [boolean]

OPTIONS
      --name  Name of the Worker  [string]
```