### PR TITLE
Refactor hyperdrive create and update commands to match each other's behavior and address bug with individual parameters on creation

### DIFF
--- a/.changeset/wrangler-hyperdrive-create-params-fix.md
+++ b/.changeset/wrangler-hyperdrive-create-params-fix.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: make individual parameters work for `wrangler hyperdrive create` when not using HoA
+
+`wrangler hyperdrive create` individual parameters were not setting the database name correctly when calling the api.

--- a/.changeset/wrangler-hyperdrive-create-update-refactor.md
+++ b/.changeset/wrangler-hyperdrive-create-update-refactor.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+refactor: use same param parsing code for `wrangler hyperdrive create` and `wrangler hyperdrive update`
+
+ensures that going forward, both commands support the same features and have the same names for config flags

--- a/.changeset/wrangler-hyperdrive-update-support-conn-string.md
+++ b/.changeset/wrangler-hyperdrive-update-support-conn-string.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feature: allow using a connection string when updating hyperdrive configs
+
+both `hyperdrive create` and `hyperdrive update` now support updating configs with connection strings.

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -8,7 +8,11 @@ import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
-import type { HyperdriveConfig } from "../hyperdrive/client";
+import type {
+	CreateUpdateHyperdriveBody,
+	HyperdriveConfig,
+	PatchHyperdriveBody,
+} from "../hyperdrive/client";
 
 describe("hyperdrive help", () => {
 	const std = mockConsoleMethods();
@@ -94,215 +98,434 @@ describe("hyperdrive commands", () => {
 	});
 
 	it("should handle creating a hyperdrive config", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveCreate();
 		await runWrangler(
 			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com:12345/neondb'"
 		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "password",
+			    "port": 12345,
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
+
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 12345,
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"test\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com",
+			    "port": 12345,
+			    "database": "neondb",
+			    "user": "test"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false
+			  "caching": {
+			    "disabled": false
 			  }
 			}"
 		`);
 	});
 
 	it("should handle creating a hyperdrive config for postgres without a port specified", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveCreate();
 		await runWrangler(
 			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com/neondb'"
 		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "password",
+			    "port": 5432,
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"test\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com",
+			    "port": 5432,
+			    "database": "neondb",
+			    "user": "test"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false
+			  "caching": {
+			    "disabled": false
 			  }
 			}"
 		`);
 	});
 
 	it("should handle creating a hyperdrive config with caching options", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveCreate();
 		await runWrangler(
 			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com:12345/neondb' --max-age=30 --swr=15"
 		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			    "max_age": 30,
+			    "stale_while_revalidate": 15,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "password",
+			    "port": 12345,
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 12345,
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"test\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com",
+			    "port": 12345,
+			    "database": "neondb",
+			    "user": "test"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false,
-			    \\"max_age\\": 30,
-			    \\"stale_while_revalidate\\": 15
+			  "caching": {
+			    "disabled": false,
+			    "max_age": 30,
+			    "stale_while_revalidate": 15
 			  }
 			}"
 		`);
 	});
 
 	it("should handle creating a hyperdrive config if the user is URL encoded", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveCreate();
 		await runWrangler(
 			"hyperdrive create test123 --connection-string='postgresql://user%3Aname:password@example.com/neondb'"
 		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "password",
+			    "port": 5432,
+			    "scheme": "postgresql",
+			    "user": "user:name",
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"user:name\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com",
+			    "port": 5432,
+			    "database": "neondb",
+			    "user": "user:name"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false
+			  "caching": {
+			    "disabled": false
 			  }
 			}"
 		`);
 	});
 
 	it("should handle creating a hyperdrive config if the password is URL encoded", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveCreate();
 		await runWrangler(
 			"hyperdrive create test123 --connection-string='postgresql://test:a%23%3F81n%287@example.com/neondb'"
 		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "a#?81n(7",
+			    "port": 5432,
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"test\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com",
+			    "port": 5432,
+			    "database": "neondb",
+			    "user": "test"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false
+			  "caching": {
+			    "disabled": false
 			  }
 			}"
 		`);
 	});
 
 	it("should handle creating a hyperdrive config if the database name is URL encoded", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveCreate();
 		await runWrangler(
 			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com/%22weird%22%20dbname'"
 		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "database": ""weird" dbname",
+			    "host": "example.com",
+			    "password": "password",
+			    "port": 5432,
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"/\\"weird/\\" dbname\\",
-			    \\"user\\": \\"test\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com",
+			    "port": 5432,
+			    "database": "/"weird/" dbname",
+			    "user": "test"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false
+			  "caching": {
+			    "disabled": false
+			  }
+			}"
+		`);
+	});
+
+	it("should create a hyperdrive config given individual params instead of a connection string without a scheme set", async () => {
+		const reqProm = mockHyperdriveCreate();
+		await runWrangler(
+			"hyperdrive create test123 --host=example.com --database=neondb --user=test --password=password --port=5432"
+		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "password",
+			    "port": 5432,
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"🚧 Creating 'test123'
+			✅ Created new Hyperdrive config
+			 {
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com",
+			    "port": 5432,
+			    "database": "neondb",
+			    "user": "test"
+			  },
+			  "caching": {
+			    "disabled": false
+			  }
+			}"
+		`);
+	});
+
+	it("should create a hyperdrive config given individual params instead of a connection string", async () => {
+		const reqProm = mockHyperdriveCreate();
+		await runWrangler(
+			"hyperdrive create test123 --host=example.com --database=neondb --user=test --password=password --port=1234"
+		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "password",
+			    "port": 1234,
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"🚧 Creating 'test123'
+			✅ Created new Hyperdrive config
+			 {
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com",
+			    "port": 1234,
+			    "database": "neondb",
+			    "user": "test"
+			  },
+			  "caching": {
+			    "disabled": false
 			  }
 			}"
 		`);
 	});
 
 	it("should reject a create hyperdrive command if both connection string and individual origin params are provided", async () => {
-		mockHyperdriveRequest();
 		await expect(() =>
 			runWrangler(
-				"hyperdrive create test123 --connection-string='postgresql://test:password@example.com/neondb' --host=example.com --port=5432 --database=neondb --user=test"
+				"hyperdrive create test123 --connection-string='postgresql://test:password@example.com/neondb' --host=example.com --port=5432 --database=neondb --user=test --password=foo"
 			)
 		).rejects.toThrow();
 		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments host and connection-string are mutually exclusive[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mArguments origin-host and connection-string are mutually exclusive[0m
 
 			"
 		`);
 	});
 
 	it("should create a hyperdrive over access config given the right params", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveCreate();
 		await runWrangler(
 			"hyperdrive create test123 --host=example.com --database=neondb --user=test --password=password --access-client-id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access --access-client-secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		);
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "access_client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access",
+			    "access_client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "password",
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"test\\",
-			    \\"access_client_id\\": \\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com",
+			    "database": "neondb",
+			    "user": "test",
+			    "access_client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false
+			  "caching": {
+			    "disabled": false
 			  }
 			}"
 		`);
 	});
 
 	it("should create a hyperdrive over access config with a path in the host", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveCreate();
 		await runWrangler(
 			"hyperdrive create test123 --host=example.com/database --database=neondb --user=test --password=password --access-client-id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access --access-client-secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		);
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "test123",
+			  "origin": {
+			    "access_client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access",
+			    "access_client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			    "database": "neondb",
+			    "host": "example.com/database",
+			    "password": "password",
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com/database\\",
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"test\\",
-			    \\"access_client_id\\": \\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "host": "example.com/database",
+			    "database": "neondb",
+			    "user": "test",
+			    "access_client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false
+			  "caching": {
+			    "disabled": false
 			  }
 			}"
 		`);
 	});
 
 	it("should reject a create hyperdrive over access command if access client ID is set but not access client secret", async () => {
-		mockHyperdriveRequest();
 		await expect(() =>
 			runWrangler(
 				"hyperdrive create test123 --host=example.com --database=neondb --user=test --password=password --access-client-id='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access'"
@@ -318,58 +541,56 @@ describe("hyperdrive commands", () => {
 	});
 
 	it("should reject a create hyperdrive over access command if access client secret is set but not access client ID", async () => {
-		mockHyperdriveRequest();
 		await expect(() =>
 			runWrangler(
 				"hyperdrive create test123 --host=example.com --database=neondb --user=test --password=password --access-client-secret=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 			)
 		).rejects.toThrow();
 		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing dependent arguments:[0m
-
-			   access-client-secret -> access-client-id
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou must provide both an Access Client ID and Access Client Secret when configuring Hyperdrive-over-Access[0m
 
 			"
 		`);
 	});
 
 	it("should handle listing configs", async () => {
-		mockHyperdriveRequest();
+		mockHyperdriveGetListOrDelete();
 		await runWrangler("hyperdrive list");
 		expect(std.out).toMatchInlineSnapshot(`
-		"📋 Listing Hyperdrive configs
-		┌──────────────────────────────────────┬─────────┬────────┬────────────────┬──────┬──────────┬────────────────────┐
-		│ id                                   │ name    │ user   │ host           │ port │ database │ caching            │
-		├──────────────────────────────────────┼─────────┼────────┼────────────────┼──────┼──────────┼────────────────────┤
-		│ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx │ test123 │ test   │ example.com    │ 5432 │ neondb   │ {\\"disabled\\":false} │
-		├──────────────────────────────────────┼─────────┼────────┼────────────────┼──────┼──────────┼────────────────────┤
-		│ yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy │ new-db  │ dbuser │ www.google.com │ 3211 │ mydb     │ {\\"disabled\\":false} │
-		└──────────────────────────────────────┴─────────┴────────┴────────────────┴──────┴──────────┴────────────────────┘"
-	`);
+			"📋 Listing Hyperdrive configs
+			┌──────────────────────────────────────┬─────────┬────────┬────────────────┬──────┬──────────┬────────────────────┐
+			│ id                                   │ name    │ user   │ host           │ port │ database │ caching            │
+			├──────────────────────────────────────┼─────────┼────────┼────────────────┼──────┼──────────┼────────────────────┤
+			│ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx │ test123 │ test   │ example.com    │ 5432 │ neondb   │ {"disabled":false} │
+			├──────────────────────────────────────┼─────────┼────────┼────────────────┼──────┼──────────┼────────────────────┤
+			│ yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy │ new-db  │ dbuser │ www.google.com │ 3211 │ mydb     │ {"disabled":false} │
+			└──────────────────────────────────────┴─────────┴────────┴────────────────┴──────┴──────────┴────────────────────┘"
+		`);
 	});
 
 	it("should handle displaying a config", async () => {
-		mockHyperdriveRequest();
+		mockHyperdriveGetListOrDelete();
 		await runWrangler("hyperdrive get xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
 		expect(std.out).toMatchInlineSnapshot(`
-		"{
-		  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-		  \\"name\\": \\"test123\\",
-		  \\"origin\\": {
-		    \\"host\\": \\"example.com\\",
-		    \\"port\\": 5432,
-		    \\"database\\": \\"neondb\\",
-		    \\"user\\": \\"test\\"
-		  },
-		  \\"caching\\": {
-		    \\"disabled\\": false
-		  }
-		}"
-	`);
+			"{
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "scheme": "postgresql",
+			    "host": "example.com",
+			    "port": 5432,
+			    "database": "neondb",
+			    "user": "test"
+			  },
+			  "caching": {
+			    "disabled": false
+			  }
+			}"
+		`);
 	});
 
 	it("should handle deleting a config", async () => {
-		mockHyperdriveRequest();
+		mockHyperdriveGetListOrDelete();
 		await runWrangler("hyperdrive delete xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx");
 		expect(std.out).toMatchInlineSnapshot(`
 		"🗑️ Deleting Hyperdrive database config xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -378,183 +599,268 @@ describe("hyperdrive commands", () => {
 	});
 
 	it("should handle updating a hyperdrive config's origin", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveUpdate();
 		await runWrangler(
 			"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --origin-host=example.com --origin-port=1234 --database=mydb --origin-user=newuser --origin-password='passw0rd!'"
 		);
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "origin": {
+			    "database": "mydb",
+			    "host": "example.com",
+			    "password": "passw0rd!",
+			    "port": 1234,
+			    "scheme": "postgresql",
+			    "user": "newuser",
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
-		"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-		✅ Updated xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx Hyperdrive config
-		 {
-		  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-		  \\"name\\": \\"test123\\",
-		  \\"origin\\": {
-		    \\"host\\": \\"example.com\\",
-		    \\"port\\": 1234,
-		    \\"database\\": \\"mydb\\",
-		    \\"user\\": \\"newuser\\"
-		  },
-		  \\"caching\\": {
-		    \\"disabled\\": false
-		  }
-		}"
-	`);
+			"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+			✅ Updated xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx Hyperdrive config
+			 {
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "port": 1234,
+			    "scheme": "postgresql",
+			    "host": "example.com",
+			    "database": "mydb",
+			    "user": "newuser"
+			  },
+			  "caching": {
+			    "disabled": false
+			  }
+			}"
+		`);
+	});
+
+	it("should throw an exception when creating a hyperdrive config but not all fields are set", async () => {
+		await expect(() =>
+			runWrangler(
+				"hyperdrive create test123 --origin-port=1234 --database=mydb --origin-user=newuser"
+			)
+		).rejects.toThrow();
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou must provide a connection string or individual connection parameters![0m
+
+			"
+		`);
+		expect(std.out).toMatchInlineSnapshot(`""`);
 	});
 
 	it("should throw an exception when updating a hyperdrive config's origin but not all fields are set", async () => {
-		mockHyperdriveRequest();
 		await expect(() =>
 			runWrangler(
 				"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --origin-port=1234 --database=mydb --origin-user=newuser"
 			)
 		).rejects.toThrow();
 		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing dependent arguments:[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m{[0m
 
-			   origin-port -> origin-host origin-port -> origin-password database -> origin-host database ->
-			  origin-password origin-user -> origin-host origin-user -> origin-password
+			    name: 'Error',
+			    message: 'No mock found for PATCH
+			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/hyperdrive/configs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/n'[0m
+			  +
+			      '/t/t/t/t',
+			    stack: 'Error: No mock found for PATCH
+			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/hyperdrive/configs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/n'[0m
+			  +
+			      '/t/t/t/t/n' +
+			      '    at onUnhandledRequest
+			  (/Users/malonso/cf-repos/workers-sdk/packages/wrangler/src/__tests__/vitest.setup.ts:101:10)/n' +
+			      '    at onUnhandledRequest
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/msw@2.3.0_typescript@5.5.4/node_modules/msw/src/core/utils/request/onUnhandledRequest.ts:62:5)/n'
+			  +
+			      '    at handleRequest
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/msw@2.3.0_typescript@5.5.4/node_modules/msw/src/core/utils/handleRequest.ts:85:11)/n'
+			  +
+			      '    at _Emitter.<anonymous>
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/msw@2.3.0_typescript@5.5.4/node_modules/msw/src/node/SetupServerCommonApi.ts:56:24)/n'
+			  +
+			      '    at emitAsync
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/@mswjs+interceptors@0.29.1/node_modules/@mswjs/interceptors/src/utils/emitAsync.ts:23:5)/n'
+			  +
+			      '    at
+			  file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/@mswjs+interceptors@0.29.1/node_modules/@mswjs/interceptors/src/interceptors/fetch/index.ts:134:11/n'
+			  +
+			      '    at until
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/@open-draft+until@2.1.0/node_modules/@open-draft/until/src/until.ts:23:18)/n'
+			  +
+			      '    at Proxy.globalThis.fetch
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/@mswjs+interceptors@0.29.1/node_modules/@mswjs/interceptors/src/interceptors/fetch/index.ts:127:30)/n'
+			  +
+			      '    at performApiFetch
+			  (/Users/malonso/cf-repos/workers-sdk/packages/wrangler/src/cfetch/internal.ts:53:9)/n' +
+			      '    at Module.fetchInternal
+			  (/Users/malonso/cf-repos/workers-sdk/packages/wrangler/src/cfetch/internal.ts:77:19)'
+			  }
 
 			"
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
-			"
-			wrangler hyperdrive update <id>
+			"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 
-			Update a Hyperdrive config
-
-			POSITIONALS
-			  id  The ID of the Hyperdrive config  [string] [required]
-
-			GLOBAL FLAGS
-			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
-			  -c, --config                    Path to .toml configuration file  [string]
-			  -e, --env                       Environment to use for operations and .env files  [string]
-			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]
-
-			OPTIONS
-			      --name                  Give your config a new name  [string]
-			      --origin-host           The host of the origin database  [string]
-			      --origin-port           The port number of the origin database  [number]
-			      --origin-scheme         The scheme used to connect to the origin database - e.g. postgresql or postgres  [string]
-			      --database              The name of the database within the origin database  [string]
-			      --origin-user           The username used to connect to the origin database  [string]
-			      --origin-password       The password used to connect to the origin database  [string]
-			      --access-client-id      The Client ID of the Access token to use when connecting to the origin database  [string]
-			      --access-client-secret  The Client Secret of the Access token to use when connecting to the origin database  [string]
-			      --caching-disabled      Disables the caching of SQL responses  [boolean] [default: false]
-			      --max-age               Specifies max duration for which items should persist in the cache, cannot be set when caching is disabled  [number]
-			      --swr                   Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled  [number]"
+			[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
 		`);
 	});
 
 	it("should handle updating a hyperdrive config's caching settings", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveUpdate();
 		await runWrangler(
 			"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --max-age=30 --swr=15"
 		);
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			    "max_age": 30,
+			    "stale_while_revalidate": 15,
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 			✅ Updated xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"test\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "scheme": "postgresql",
+			    "host": "example.com",
+			    "port": 5432,
+			    "database": "neondb",
+			    "user": "test"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false,
-			    \\"max_age\\": 30,
-			    \\"stale_while_revalidate\\": 15
+			  "caching": {
+			    "disabled": false,
+			    "max_age": 30,
+			    "stale_while_revalidate": 15
 			  }
 			}"
 		`);
 	});
 
 	it("should handle disabling caching for a hyperdrive config", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveUpdate();
 		await runWrangler(
 			"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --caching-disabled=true"
 		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": true,
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 			✅ Updated xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"test\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "scheme": "postgresql",
+			    "host": "example.com",
+			    "port": 5432,
+			    "database": "neondb",
+			    "user": "test"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": true
+			  "caching": {
+			    "disabled": true
 			  }
 			}"
 		`);
 	});
 
 	it("should handle updating a hyperdrive config's name", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveUpdate();
 		await runWrangler(
 			"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --name='new-name'"
 		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "name": "new-name",
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 			✅ Updated xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"new-name\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"user\\": \\"test\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "new-name",
+			  "origin": {
+			    "scheme": "postgresql",
+			    "host": "example.com",
+			    "port": 5432,
+			    "database": "neondb",
+			    "user": "test"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false
+			  "caching": {
+			    "disabled": false
 			  }
 			}"
 		`);
 	});
 
 	it("should handle updating a hyperdrive to a hyperdrive over access config given the right parameters", async () => {
-		mockHyperdriveRequest();
+		const reqProm = mockHyperdriveUpdate();
 		await runWrangler(
 			"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --origin-host=example.com --database=mydb --origin-user=newuser --origin-password='passw0rd!' --access-client-id='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access' --access-client-secret='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"
 		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			{
+			  "caching": {
+			    "disabled": false,
+			  },
+			  "origin": {
+			    "access_client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access",
+			    "access_client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			    "database": "mydb",
+			    "host": "example.com",
+			    "password": "passw0rd!",
+			    "scheme": "postgresql",
+			    "user": "newuser",
+			  },
+			}
+		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 			✅ Updated xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx Hyperdrive config
 			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"database\\": \\"mydb\\",
-			    \\"user\\": \\"newuser\\",
-			    \\"access_client_id\\": \\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access\\"
+			  "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			  "name": "test123",
+			  "origin": {
+			    "access_client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access",
+			    "scheme": "postgresql",
+			    "host": "example.com",
+			    "database": "mydb",
+			    "user": "newuser"
 			  },
-			  \\"caching\\": {
-			    \\"disabled\\": false
+			  "caching": {
+			    "disabled": false
 			  }
 			}"
 		`);
 	});
 
 	it("should throw an exception when updating a hyperdrive config's origin but neither port nor access credentials are provided", async () => {
-		mockHyperdriveRequest();
 		await expect(() =>
 			runWrangler(
 				"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --origin-host=example.com --database=mydb --origin-user=newuser --origin-password='passw0rd!'"
 			)
 		).rejects.toThrow();
 		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mWhen updating the origin, either the port or the Access Client ID and Secret must be set[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou must provide a port for the origin database[0m
 
 			"
 		`);
@@ -562,55 +868,62 @@ describe("hyperdrive commands", () => {
 	});
 
 	it("should throw an exception when updating a hyperdrive config's origin with access credentials but no other origin fields", async () => {
-		mockHyperdriveRequest();
 		await expect(() =>
 			runWrangler(
 				"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --access-client-id='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access' --access-client-secret='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"
 			)
 		).rejects.toThrow();
 		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing dependent arguments:[0m
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m{[0m
 
-			   access-client-id -> origin-host access-client-id -> database access-client-id -> origin-user
-			  access-client-id -> origin-password access-client-secret -> origin-host access-client-secret ->
-			  database access-client-secret -> origin-user access-client-secret -> origin-password
+			    name: 'Error',
+			    message: 'No mock found for PATCH
+			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/hyperdrive/configs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/n'[0m
+			  +
+			      '/t/t/t/t',
+			    stack: 'Error: No mock found for PATCH
+			  [4mhttps://api.cloudflare.com/client/v4/accounts/some-account-id/hyperdrive/configs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/n'[0m
+			  +
+			      '/t/t/t/t/n' +
+			      '    at onUnhandledRequest
+			  (/Users/malonso/cf-repos/workers-sdk/packages/wrangler/src/__tests__/vitest.setup.ts:101:10)/n' +
+			      '    at onUnhandledRequest
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/msw@2.3.0_typescript@5.5.4/node_modules/msw/src/core/utils/request/onUnhandledRequest.ts:62:5)/n'
+			  +
+			      '    at handleRequest
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/msw@2.3.0_typescript@5.5.4/node_modules/msw/src/core/utils/handleRequest.ts:85:11)/n'
+			  +
+			      '    at _Emitter.<anonymous>
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/msw@2.3.0_typescript@5.5.4/node_modules/msw/src/node/SetupServerCommonApi.ts:56:24)/n'
+			  +
+			      '    at emitAsync
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/@mswjs+interceptors@0.29.1/node_modules/@mswjs/interceptors/src/utils/emitAsync.ts:23:5)/n'
+			  +
+			      '    at
+			  file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/@mswjs+interceptors@0.29.1/node_modules/@mswjs/interceptors/src/interceptors/fetch/index.ts:134:11/n'
+			  +
+			      '    at until
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/@open-draft+until@2.1.0/node_modules/@open-draft/until/src/until.ts:23:18)/n'
+			  +
+			      '    at Proxy.globalThis.fetch
+			  (file:///Users/malonso/cf-repos/workers-sdk/node_modules/.pnpm/@mswjs+interceptors@0.29.1/node_modules/@mswjs/interceptors/src/interceptors/fetch/index.ts:127:30)/n'
+			  +
+			      '    at performApiFetch
+			  (/Users/malonso/cf-repos/workers-sdk/packages/wrangler/src/cfetch/internal.ts:53:9)/n' +
+			      '    at Module.fetchInternal
+			  (/Users/malonso/cf-repos/workers-sdk/packages/wrangler/src/cfetch/internal.ts:77:19)'
+			  }
 
 			"
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
-			"
-			wrangler hyperdrive update <id>
+			"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
 
-			Update a Hyperdrive config
-
-			POSITIONALS
-			  id  The ID of the Hyperdrive config  [string] [required]
-
-			GLOBAL FLAGS
-			  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
-			  -c, --config                    Path to .toml configuration file  [string]
-			  -e, --env                       Environment to use for operations and .env files  [string]
-			  -h, --help                      Show help  [boolean]
-			  -v, --version                   Show version number  [boolean]
-
-			OPTIONS
-			      --name                  Give your config a new name  [string]
-			      --origin-host           The host of the origin database  [string]
-			      --origin-port           The port number of the origin database  [number]
-			      --origin-scheme         The scheme used to connect to the origin database - e.g. postgresql or postgres  [string]
-			      --database              The name of the database within the origin database  [string]
-			      --origin-user           The username used to connect to the origin database  [string]
-			      --origin-password       The password used to connect to the origin database  [string]
-			      --access-client-id      The Client ID of the Access token to use when connecting to the origin database  [string]
-			      --access-client-secret  The Client Secret of the Access token to use when connecting to the origin database  [string]
-			      --caching-disabled      Disables the caching of SQL responses  [boolean] [default: false]
-			      --max-age               Specifies max duration for which items should persist in the cache, cannot be set when caching is disabled  [number]
-			      --swr                   Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled  [number]"
+			[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
 		`);
 	});
 
 	it("should reject an update command if the access client ID is provided but not the access client secret", async () => {
-		mockHyperdriveRequest();
 		await expect(() =>
 			runWrangler(
 				"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --origin-host=example.com --database=mydb --origin-user=newuser --origin-password='passw0rd!' --access-client-id='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access'"
@@ -626,16 +939,13 @@ describe("hyperdrive commands", () => {
 	});
 
 	it("should reject an update command if the access client secret is provided but not the access client ID", async () => {
-		mockHyperdriveRequest();
 		await expect(() =>
 			runWrangler(
 				"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --origin-host=example.com --database=mydb --origin-user=newuser --origin-password='passw0rd!' --access-client-secret='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"
 			)
 		).rejects.toThrow();
 		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing dependent arguments:[0m
-
-			   access-client-secret -> access-client-id
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou must provide both an Access Client ID and Access Client Secret when configuring Hyperdrive-over-Access[0m
 
 			"
 		`);
@@ -646,6 +956,7 @@ const defaultConfig: HyperdriveConfig = {
 	id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 	name: "test123",
 	origin: {
+		scheme: "postgresql",
 		host: "example.com",
 		port: 5432,
 		database: "neondb",
@@ -657,65 +968,12 @@ const defaultConfig: HyperdriveConfig = {
 };
 
 /** Create a mock handler for Hyperdrive API */
-function mockHyperdriveRequest() {
+function mockHyperdriveGetListOrDelete() {
 	msw.use(
 		http.get(
 			"*/accounts/:accountId/hyperdrive/configs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 			() => {
 				return HttpResponse.json(createFetchResult(defaultConfig, true));
-			},
-			{ once: true }
-		),
-		http.post(
-			"*/accounts/:accountId/hyperdrive/configs",
-			async ({ request }) => {
-				const reqBody = (await request.json()) as HyperdriveConfig;
-				return HttpResponse.json(
-					createFetchResult(
-						{
-							id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-							name: reqBody.name,
-							origin: {
-								host: reqBody.origin.host,
-								port: reqBody.origin.port,
-								database: reqBody.origin.database,
-								// @ts-expect-error This is a string
-								scheme: reqBody.origin.protocol,
-								user: reqBody.origin.user,
-								access_client_id: reqBody.origin.access_client_id,
-							},
-							caching: reqBody.caching,
-						},
-						true
-					)
-				);
-			},
-			{ once: true }
-		),
-		http.patch(
-			"*/accounts/:accountId/hyperdrive/configs/:configId",
-			async ({ request }) => {
-				const reqBody = (await request.json()) as HyperdriveConfig;
-				return HttpResponse.json(
-					createFetchResult(
-						{
-							id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-							name: reqBody.name ?? defaultConfig.name,
-							origin:
-								reqBody.origin !== undefined
-									? {
-											host: reqBody.origin.host,
-											port: reqBody.origin.port,
-											database: reqBody.origin.database,
-											user: reqBody.origin.user,
-											access_client_id: reqBody.origin.access_client_id,
-										}
-									: defaultConfig.origin,
-							caching: reqBody.caching ?? defaultConfig.caching,
-						},
-						true
-					)
-				);
 			},
 			{ once: true }
 		),
@@ -754,4 +1012,83 @@ function mockHyperdriveRequest() {
 			{ once: true }
 		)
 	);
+}
+
+/** Create a mock handler for Hyperdrive API */
+function mockHyperdriveUpdate(): Promise<PatchHyperdriveBody> {
+	return new Promise((resolve) => {
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/hyperdrive/configs/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				() => {
+					return HttpResponse.json(createFetchResult(defaultConfig, true));
+				},
+				{ once: true }
+			),
+			http.patch(
+				"*/accounts/:accountId/hyperdrive/configs/:configId",
+				async ({ request }) => {
+					const reqBody = (await request.json()) as PatchHyperdriveBody;
+
+					resolve(reqBody);
+
+					let origin = defaultConfig.origin;
+					if (reqBody.origin) {
+						const {password: _, access_client_secret: _2, ...reqOrigin} = reqBody.origin;
+						origin = reqOrigin;
+					}
+
+					return HttpResponse.json(
+						createFetchResult(
+							{
+								id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+								name: reqBody.name ?? defaultConfig.name,
+								origin,
+								caching: reqBody.caching ?? defaultConfig.caching,
+							},
+							true
+						)
+					);
+				},
+				{ once: true }
+			)
+		);
+	});
+}
+
+/** Create a mock handler for Hyperdrive API */
+function mockHyperdriveCreate(): Promise<CreateUpdateHyperdriveBody> {
+	return new Promise((resolve) => {
+		msw.use(
+			http.post(
+				"*/accounts/:accountId/hyperdrive/configs",
+				async ({ request }) => {
+					const reqBody = (await request.json()) as CreateUpdateHyperdriveBody;
+
+					resolve(reqBody);
+
+					return HttpResponse.json(
+						createFetchResult(
+							{
+								id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+								name: reqBody.name,
+								origin: {
+									host: reqBody.origin.host,
+									port: reqBody.origin.port,
+									database: reqBody.origin.database,
+									// @ts-expect-error This is a string
+									scheme: reqBody.origin.protocol,
+									user: reqBody.origin.user,
+									access_client_id: reqBody.origin.access_client_id,
+								},
+								caching: reqBody.caching,
+							},
+							true
+						)
+					);
+				},
+				{ once: true }
+			)
+		);
+	});
 }

--- a/packages/wrangler/src/hyperdrive/client.ts
+++ b/packages/wrangler/src/hyperdrive/client.ts
@@ -9,19 +9,45 @@ export type HyperdriveConfig = {
 	caching: CachingOptions;
 };
 
-export type PublicOrigin = {
-	host?: string;
-	port?: number;
-	scheme?: string;
-	database?: string;
-	user?: string;
-	access_client_id?: string;
+export type OriginCommon = {
+	host: string;
+	scheme: string;
+	database: string;
+	user: string;
 };
 
-export type OriginWithSecrets = PublicOrigin & {
-	password?: string;
-	access_client_secret?: string;
+export type OriginCommonWithSecrets = OriginCommon & {
+	password: string;
 };
+
+export type OriginHoA = OriginCommon & {
+	access_client_id: string;
+	access_client_secret?: never;
+	port?: never;
+};
+
+export type OriginHoAWithSecrets = OriginCommonWithSecrets & {
+	access_client_id: string;
+	access_client_secret: string;
+	port?: never;
+};
+
+export type OriginHostAndPort = OriginCommon & {
+	access_client_id?: never;
+	access_client_secret?: never;
+	port: number;
+};
+
+export type OriginHostAndPortWithSecrets = OriginCommonWithSecrets & {
+	access_client_id?: never;
+	access_client_secret?: never;
+	port: number;
+};
+
+export type PublicOrigin = OriginHostAndPort | OriginHoA;
+export type OriginWithSecrets =
+	| OriginHostAndPortWithSecrets
+	| OriginHoAWithSecrets;
 
 export type CachingOptions = {
 	disabled?: boolean;

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -2,207 +2,41 @@ import { readConfig } from "../config";
 import { UserError } from "../errors";
 import { logger } from "../logger";
 import { createConfig } from "./client";
+import { getCacheOptionsFromArgs, getOriginFromArgs, upsertOptions } from ".";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
 
-export function options(yargs: CommonYargsArgv) {
-	return yargs
-		.positional("name", {
-			type: "string",
-			demandOption: true,
-			description: "The name of the Hyperdrive config",
-		})
-		.options({
-			"connection-string": {
-				type: "string",
-				describe:
-					"The connection string for the database you want Hyperdrive to connect to - ex: protocol://user:password@host:port/database",
-			},
-			host: {
-				type: "string",
-				describe: "The host of the origin database",
-				conflicts: "connection-string",
-			},
-			port: {
-				type: "number",
-				describe: "The port number of the origin database",
-				conflicts: [
-					"connection-string",
-					"access-client-id",
-					"access-client-secret",
-				],
-			},
-			scheme: {
-				type: "string",
-				describe:
-					"The scheme used to connect to the origin database - e.g. postgresql or postgres",
-				default: "postgresql",
-			},
-			database: {
-				type: "string",
-				describe: "The name of the database within the origin database",
-				conflicts: "connection-string",
-			},
-			user: {
-				type: "string",
-				describe: "The username used to connect to the origin database",
-				conflicts: "connection-string",
-			},
-			password: {
-				type: "string",
-				describe: "The password used to connect to the origin database",
-				conflicts: "connection-string",
-			},
-			"access-client-id": {
-				type: "string",
-				describe:
-					"The Client ID of the Access token to use when connecting to the origin database, must be set with a Client Access Secret",
-				conflicts: ["connection-string", "port"],
-				implies: ["access-client-secret"],
-			},
-			"access-client-secret": {
-				type: "string",
-				describe:
-					"The Client Secret of the Access token to use when connecting to the origin database, must be set with a Client Access ID",
-				conflicts: ["connection-string", "port"],
-				implies: ["access-client-id"],
-			},
-			"caching-disabled": {
-				type: "boolean",
-				describe: "Disables the caching of SQL responses",
-				default: false,
-			},
-			"max-age": {
-				type: "number",
-				describe:
-					"Specifies max duration for which items should persist in the cache, cannot be set when caching is disabled",
-			},
-			swr: {
-				type: "number",
-				describe:
-					"Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled",
-			},
-		});
+export function options(commonYargs: CommonYargsArgv) {
+	const yargs = commonYargs.positional("name", {
+		type: "string",
+		demandOption: true,
+		description: "The name of the Hyperdrive config",
+	});
+
+	return upsertOptions(yargs);
 }
 
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
 	const config = readConfig(args.config, args);
-
-	const url = args.connectionString
-		? new URL(args.connectionString)
-		: buildURLFromParts(
-				args.host,
-				args.port,
-				args.scheme,
-				args.user,
-				args.password
-			);
-
-	if (
-		url.port === "" &&
-		(url.protocol == "postgresql:" || url.protocol == "postgres:")
-	) {
-		url.port = "5432";
+	const origin = getOriginFromArgs(args);
+	if (!origin) {
+		throw new UserError(
+			"You must provide a connection string or individual connection parameters!"
+		);
 	}
 
-	if (url.protocol === "") {
-		throw new UserError(
-			"You must specify the database protocol - e.g. 'postgresql'."
-		);
-	} else if (url.protocol !== "postgresql:" && url.protocol !== "postgres:") {
-		throw new UserError(
-			"Only PostgreSQL or PostgreSQL compatible databases are currently supported."
-		);
-	} else if (url.host === "") {
-		throw new UserError(
-			"You must provide a hostname or IP address in your connection string - e.g. 'user:password@database-hostname.example.com:5432/databasename"
-		);
-	} else if (url.port === "") {
-		throw new UserError(
-			"You must provide a port number - e.g. 'user:password@database.example.com:port/databasename"
-		);
-	} else if (
-		(args.connectionString && url.pathname === "") ||
-		args.database === ""
-	) {
-		throw new UserError(
-			"You must provide a database name as the path component - e.g. example.com:port/postgres"
-		);
-	} else if (url.username === "") {
-		throw new UserError(
-			"You must provide a username - e.g. 'user:password@database.example.com:port/databasename'"
-		);
-	} else if (url.password === "") {
-		throw new UserError(
-			"You must provide a password - e.g. 'user:password@database.example.com:port/databasename' "
-		);
-	} else {
-		logger.log(`🚧 Creating '${args.name}'`);
-
-		// if access client ID and client secret supplied in args, use them to construct origin without a port
-		const origin =
-			args.accessClientId && args.accessClientSecret
-				? {
-						host: url.hostname + url.pathname,
-						scheme: url.protocol.replace(":", ""),
-						database: args.database,
-						user: decodeURIComponent(url.username),
-						password: decodeURIComponent(url.password),
-						access_client_id: args.accessClientId,
-						access_client_secret: args.accessClientSecret,
-					}
-				: {
-						host: url.hostname,
-						port: parseInt(url.port),
-						scheme: url.protocol.replace(":", ""),
-						// database will either be the value passed in the relevant yargs flag or is URL-decoded value from the url pathname
-						database:
-							args.connectionString !== ""
-								? decodeURIComponent(url.pathname.replace("/", ""))
-								: args.database,
-						user: decodeURIComponent(url.username),
-						password: decodeURIComponent(url.password),
-					};
-		const database = await createConfig(config, {
-			name: args.name,
-			origin,
-			caching: {
-				disabled: args.cachingDisabled,
-				max_age: args.maxAge,
-				stale_while_revalidate: args.swr,
-			},
-		});
-		logger.log(
-			`✅ Created new Hyperdrive config\n`,
-			JSON.stringify(database, null, 2)
-		);
-	}
-}
-
-function buildURLFromParts(
-	host: string | undefined,
-	port: number | undefined,
-	scheme: string,
-	user: string | undefined,
-	password: string | undefined
-): URL {
-	const url = new URL(`${scheme}://${host}`);
-
-	if (port) {
-		url.port = port.toString();
-	}
-
-	if (user) {
-		url.username = user;
-	}
-
-	if (password) {
-		url.password = password;
-	}
-
-	return url;
+	logger.log(`🚧 Creating '${args.name}'`);
+	const database = await createConfig(config, {
+		name: args.name,
+		origin,
+		caching: getCacheOptionsFromArgs(args),
+	});
+	logger.log(
+		`✅ Created new Hyperdrive config\n`,
+		JSON.stringify(database, null, 2)
+	);
 }

--- a/packages/wrangler/src/hyperdrive/index.ts
+++ b/packages/wrangler/src/hyperdrive/index.ts
@@ -1,9 +1,21 @@
+import chalk from "chalk";
+import type { Argv } from "yargs";
+import { UserError } from "../errors";
+import type {
+	CachingOptions,
+	OriginCommonWithSecrets,
+	OriginHostAndPortWithSecrets,
+	OriginWithSecrets,
+} from "./client";
 import { handler as createHandler, options as createOptions } from "./create";
 import { handler as deleteHandler, options as deleteOptions } from "./delete";
 import { handler as getHandler, options as getOptions } from "./get";
 import { handler as listHandler, options as listOptions } from "./list";
 import { handler as updateHandler, options as updateOptions } from "./update";
-import type { CommonYargsArgv } from "../yargs-types";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
 
 export function hyperdrive(yargs: CommonYargsArgv) {
 	return yargs
@@ -27,4 +39,223 @@ export function hyperdrive(yargs: CommonYargsArgv) {
 			updateOptions,
 			updateHandler
 		);
+}
+
+export function upsertOptions<T>(yargs: Argv<T>) {
+	return yargs
+		.option({
+			"connection-string": {
+				type: "string",
+				describe:
+					"The connection string for the database you want Hyperdrive to connect to - ex: protocol://user:password@host:port/database",
+			},
+			"origin-host": {
+				alias: "host",
+				type: "string",
+				describe: "The host of the origin database",
+				conflicts: "connection-string",
+			},
+			"origin-port": {
+				alias: "port",
+				type: "number",
+				describe: "The port number of the origin database",
+				conflicts: [
+					"connection-string",
+					"access-client-id",
+					"access-client-secret",
+				],
+			},
+			"origin-scheme": {
+				alias: "scheme",
+				type: "string",
+				choices: ["postgres", "postgresql"],
+				describe: "The scheme used to connect to the origin database",
+				default: "postgresql",
+			},
+			database: {
+				type: "string",
+				describe: "The name of the database within the origin database",
+				conflicts: "connection-string",
+			},
+			"origin-user": {
+				alias: "user",
+				type: "string",
+				describe: "The username used to connect to the origin database",
+				conflicts: "connection-string",
+			},
+			"origin-password": {
+				alias: "password",
+				type: "string",
+				describe: "The password used to connect to the origin database",
+				conflicts: "connection-string",
+			},
+			"access-client-id": {
+				type: "string",
+				describe:
+					"The Client ID of the Access token to use when connecting to the origin database",
+				conflicts: ["connection-string", "origin-port"],
+				implies: ["access-client-secret"],
+			},
+			"access-client-secret": {
+				type: "string",
+				describe:
+					"The Client Secret of the Access token to use when connecting to the origin database",
+				conflicts: ["connection-string", "origin-port"],
+			},
+			"caching-disabled": {
+				type: "boolean",
+				describe: "Disables the caching of SQL responses",
+				default: false,
+			},
+			"max-age": {
+				type: "number",
+				describe:
+					"Specifies max duration for which items should persist in the cache, cannot be set when caching is disabled",
+			},
+			swr: {
+				type: "number",
+				describe:
+					"Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled",
+			},
+		})
+		.group(
+			["connection-string"],
+			`${chalk.bold("Configure using a connection string")}`
+		)
+		.group(
+			[
+				"name",
+				"origin-host",
+				"origin-port",
+				"scheme",
+				"database",
+				"origin-user",
+				"origin-password",
+			],
+			`${chalk.bold("Configure using individual parameters [conflicts with --connection-string]")}`
+		)
+		.group(
+			["access-client-id", "access-client-secret"],
+			`${chalk.bold("Hyperdrive over Access [conflicts with --connection-string, --origin-port]")}`
+		)
+		.group(
+			["caching-disabled", "max-age", "swr"],
+			`${chalk.bold("Caching Options")}`
+		);
+}
+
+export function getOriginFromArgs(
+	args: StrictYargsOptionsToInterface<typeof upsertOptions>
+): OriginWithSecrets | undefined {
+	if (args.connectionString) {
+		const url = new URL(args.connectionString);
+
+		if (
+			url.port === "" &&
+			(url.protocol == "postgresql:" || url.protocol == "postgres:")
+		) {
+			url.port = "5432";
+		}
+
+		if (url.protocol === "") {
+			throw new UserError(
+				"You must specify the database protocol - e.g. 'postgresql'."
+			);
+		} else if (url.protocol !== "postgresql:" && url.protocol !== "postgres:") {
+			throw new UserError(
+				"Only PostgreSQL or PostgreSQL compatible databases are currently supported."
+			);
+		} else if (url.host === "") {
+			throw new UserError(
+				"You must provide a hostname or IP address in your connection string - e.g. 'user:password@database-hostname.example.com:5432/databasename"
+			);
+		} else if (url.port === "") {
+			throw new UserError(
+				"You must provide a port number - e.g. 'user:password@database.example.com:port/databasename"
+			);
+		} else if (url.pathname === "") {
+			throw new UserError(
+				"You must provide a database name as the path component - e.g. example.com:port/postgres"
+			);
+		} else if (url.username === "") {
+			throw new UserError(
+				"You must provide a username - e.g. 'user:password@database.example.com:port/databasename'"
+			);
+		} else if (url.password === "") {
+			throw new UserError(
+				"You must provide a password - e.g. 'user:password@database.example.com:port/databasename' "
+			);
+		}
+
+		return {
+			host: url.hostname,
+			port: parseInt(url.port),
+			scheme: url.protocol.replace(":", ""),
+			database: decodeURIComponent(url.pathname.replace("/", "")),
+			user: decodeURIComponent(url.username),
+			password: decodeURIComponent(url.password),
+		} as OriginHostAndPortWithSecrets;
+	} else if (args.originHost) {
+		if (!args.database || args.database === "") {
+			throw new UserError("You must provide a database name");
+		} else if (!args.originUser || args.originUser === "") {
+			throw new UserError(
+				"You must provide a username for the origin database"
+			);
+		} else if (!args.originPassword || args.originPassword === "") {
+			throw new UserError(
+				"You must provide a password for the origin database"
+			);
+		}
+
+		const common: OriginCommonWithSecrets = {
+			scheme: args.originScheme,
+			host: args.originHost,
+			database: args.database,
+			user: args.originUser,
+			password: args.originPassword,
+		};
+
+		if (args.accessClientId || args.accessClientSecret) {
+			if (
+				!args.accessClientId ||
+				args.accessClientId === "" ||
+				!args.accessClientSecret ||
+				args.accessClientSecret === ""
+			) {
+				throw new UserError(
+					"You must provide both an Access Client ID and Access Client Secret when configuring Hyperdrive-over-Access"
+				);
+			}
+
+			return {
+				access_client_id: args.accessClientId,
+				access_client_secret: args.accessClientSecret,
+				...common,
+			};
+		} else {
+			if (!args.originPort) {
+				throw new UserError("You must provide a port for the origin database");
+			}
+
+			return {
+				port: args.originPort,
+				...common,
+			};
+		}
+	} else {
+		// this must be a patch that is changing other settings, return undefined
+
+		return undefined;
+	}
+}
+
+export function getCacheOptionsFromArgs(
+	args: StrictYargsOptionsToInterface<typeof upsertOptions>
+): CachingOptions {
+	return {
+		disabled: args.cachingDisabled,
+		max_age: args.maxAge,
+		stale_while_revalidate: args.swr,
+	};
 }

--- a/packages/wrangler/src/hyperdrive/update.ts
+++ b/packages/wrangler/src/hyperdrive/update.ts
@@ -1,15 +1,14 @@
 import { readConfig } from "../config";
-import { UserError } from "../errors";
 import { logger } from "../logger";
 import { patchConfig } from "./client";
+import { getCacheOptionsFromArgs, getOriginFromArgs, upsertOptions } from ".";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
 } from "../yargs-types";
-import type { PatchHyperdriveBody } from "./client";
 
-export function options(yargs: CommonYargsArgv) {
-	return yargs
+export function options(commonYargs: CommonYargsArgv) {
+	const yargs = commonYargs
 		.positional("id", {
 			type: "string",
 			demandOption: true,
@@ -17,150 +16,23 @@ export function options(yargs: CommonYargsArgv) {
 		})
 		.options({
 			name: { type: "string", describe: "Give your config a new name" },
-			"origin-host": {
-				type: "string",
-				describe: "The host of the origin database",
-				implies: ["database", "origin-user", "origin-password"],
-			},
-			"origin-port": {
-				type: "number",
-				describe: "The port number of the origin database",
-				implies: ["origin-host", "database", "origin-user", "origin-password"],
-			},
-			"origin-scheme": {
-				type: "string",
-				describe:
-					"The scheme used to connect to the origin database - e.g. postgresql or postgres",
-			},
-			database: {
-				type: "string",
-				describe: "The name of the database within the origin database",
-				implies: ["origin-host", "origin-user", "origin-password"],
-			},
-			"origin-user": {
-				type: "string",
-				describe: "The username used to connect to the origin database",
-				implies: ["origin-host", "database", "origin-password"],
-			},
-			"origin-password": {
-				type: "string",
-				describe: "The password used to connect to the origin database",
-				implies: ["origin-host", "database", "origin-user"],
-			},
-			"access-client-id": {
-				type: "string",
-				describe:
-					"The Client ID of the Access token to use when connecting to the origin database",
-				conflicts: ["origin-port"],
-				implies: [
-					"access-client-secret",
-					"origin-host",
-					"database",
-					"origin-user",
-					"origin-password",
-				],
-			},
-			"access-client-secret": {
-				type: "string",
-				describe:
-					"The Client Secret of the Access token to use when connecting to the origin database",
-				conflicts: ["origin-port"],
-				implies: [
-					"access-client-id",
-					"origin-host",
-					"database",
-					"origin-user",
-					"origin-password",
-				],
-			},
-			"caching-disabled": {
-				type: "boolean",
-				describe: "Disables the caching of SQL responses",
-				default: false,
-			},
-			"max-age": {
-				type: "number",
-				describe:
-					"Specifies max duration for which items should persist in the cache, cannot be set when caching is disabled",
-			},
-			swr: {
-				type: "number",
-				describe:
-					"Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled",
-			},
 		});
-}
 
-const coreOriginOptions = [
-	"originHost",
-	"database",
-	"originUser",
-	"originPassword",
-] as const;
-
-function isOptionSet<T extends object>(args: T, key: keyof T): boolean {
-	return key in args && args[key] !== undefined;
+	return upsertOptions(yargs);
 }
 
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	// check if all or none of the required origin fields are set, since we don't allow partial updates of the origin
-	const coreOriginFieldsSet = coreOriginOptions.every((field) =>
-		isOptionSet(args, field)
-	);
-
-	if (
-		coreOriginFieldsSet &&
-		args.originPort === undefined &&
-		args.accessClientId === undefined &&
-		args.accessClientSecret === undefined
-	) {
-		throw new UserError(
-			`When updating the origin, either the port or the Access Client ID and Secret must be set`
-		);
-	}
-
 	const config = readConfig(args.config, args);
+	const origin = getOriginFromArgs(args);
 
 	logger.log(`🚧 Updating '${args.id}'`);
-
-	const database: PatchHyperdriveBody = {};
-
-	if (args.name !== undefined) {
-		database.name = args.name;
-	}
-
-	if (coreOriginFieldsSet) {
-		if (args.accessClientId && args.accessClientSecret) {
-			database.origin = {
-				scheme: args.originScheme ?? "postgresql",
-				host: args.originHost,
-				database: args.database,
-				user: args.originUser,
-				password: args.originPassword,
-				access_client_id: args.accessClientId,
-				access_client_secret: args.accessClientSecret,
-			};
-		} else {
-			database.origin = {
-				scheme: args.originScheme ?? "postgresql",
-				host: args.originHost,
-				port: args.originPort,
-				database: args.database,
-				user: args.originUser,
-				password: args.originPassword,
-			};
-		}
-	}
-
-	database.caching = {
-		disabled: args.cachingDisabled,
-		max_age: args.maxAge,
-		stale_while_revalidate: args.swr,
-	};
-
-	const updated = await patchConfig(config, args.id, database);
+	const updated = await patchConfig(config, args.id, {
+		name: args.name,
+		origin,
+		caching: getCacheOptionsFromArgs(args),
+	});
 	logger.log(
 		`✅ Updated ${updated.id} Hyperdrive config\n`,
 		JSON.stringify(updated, null, 2)


### PR DESCRIPTION
## What this PR solves / how to test

Fixes SQC-338

```
fix: make individual parameters work for `wrangler hyperdrive create` when not using HoA

`wrangler hyperdrive create` individual parameters were not setting the database name correctly when calling the api.

refactor: use same param parsing code for `wrangler hyperdrive create` and `wrangler hyperdrive update`

ensures that going forward, both commands support the same features and have the same names for config flags

feature: allow using a connection string when updating hyperdrive configs

both `hyperdrive create` and `hyperdrive update` now support updating configs with connection strings.
```

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [X] I don't know
  - [ ] Required
  - [ ] Not required because:
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [X] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [X] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because: no changes