### PR TITLE
Reduce assets upload max bucket size

### DIFF
--- a/.changeset/warm-zebras-allow.md
+++ b/.changeset/warm-zebras-allow.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: Reduce the maximum size of asset upload requests when creating a Pages deployment
+
+We're continuing to investigate upstream changes that we can make to further improve reliability and allow for high-bandwidth uploads, but in the meantime, we've found that reducing the maximum size of asset upload requests can improve the reliability of deployment creation.

--- a/packages/wrangler/src/pages/constants.ts
+++ b/packages/wrangler/src/pages/constants.ts
@@ -5,7 +5,7 @@ const isWindows = process.platform === "win32";
 export const MAX_ASSET_COUNT = 20_000;
 export const MAX_ASSET_SIZE = 25 * 1024 * 1024;
 export const PAGES_CONFIG_CACHE_FILENAME = "pages.json";
-export const MAX_BUCKET_SIZE = 40 * 1024 * 1024;
+export const MAX_BUCKET_SIZE = 30 * 1024 * 1024;
 // Reduce the maximum number of files in a bucket on Windows
 // This helps to avoid EMFILE errors when reading them into memory.
 export const MAX_BUCKET_FILE_COUNT = isWindows ? 1000 : 2000;


### PR DESCRIPTION
## What this PR solves / how to test

Reduces the per-request load of asset uploads.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: untested
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: untested
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
