### PR TITLE
vitest-pool-workers: Support AbortSignal in fetch-mock

### DIFF
--- a/.changeset/hip-penguins-kiss.md
+++ b/.changeset/hip-penguins-kiss.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Add support for AbortSignal to fetch-mock

--- a/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
+++ b/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
@@ -111,24 +111,4 @@ describe("AbortSignal", () => {
 			`[AbortError: The operation was aborted]`
 		);
 	});
-
-	it("aborts if an AbortSignal is already aborted", async () => {
-		const controller = new AbortController();
-		controller.abort();
-
-		fetchMock
-			.get("https://example.com")
-			.intercept({ path: "/" })
-			.reply(200, async () => {
-				return "Delayed response";
-			});
-
-		const fetchPromise = fetch("https://example.com", {
-			signal: controller.signal,
-		});
-
-		await expect(fetchPromise).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[AbortError: The operation was aborted]`
-		);
-	});
 });


### PR DESCRIPTION
## What this PR solves / how to test

This PR introduces support for `AbortSignal` to fetch-mock, allowing signals to 'abort' requests during tests as they do at actual runtime. This makes it significantly easier to test this behaviour when writing tests that rely on signals and their behaviours.

## Author has addressed the following

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because:
    - Unit tests cover changes 
- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
  - [ ] TODO (before merge)
  - [x] Changeset included
  - [ ] Changeset not necessary because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:
    - This not being supported was a little cryptic as it was undocumented but suggested in the discord community to use `AbortSignal` when wanting to time out fetch calls. Supported `AbortSignal` aligns with what is expected of `fetch` in tests reflecting actual usage.
   
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

<!--
**Note for PR author:**
We want to celebrate and highlight awesome PR review!
If you think this PR received a particularly high-caliber review, please assign it the label `highlight pr review` so future reviewers can take inspiration and learn from it.
-->
