### PR TITLE
fix: ask for confirmation before creating a new worker when uploading secrets

### DIFF
--- a/.changeset/hungry-news-own.md
+++ b/.changeset/hungry-news-own.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: ask for confirmation before creating a new Worker when uploading secrets
+
+Previously, `wrangler secret put KEY --name non-existent-worker` would automatically create a new Worker with the name `non-existent-worker`. This fix asks for confirmation before doing so (if running in an interactive context). Behaviour in non-interactive/CI contexts should be unchanged.

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -1003,6 +1003,7 @@ describe("wrangler secret", () => {
 		});
 
 		it("should, in interactive mode, ask to create a new worker if no worker is found under the provided name", async () => {
+			setIsTTY(true);
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({
@@ -1024,6 +1025,7 @@ describe("wrangler secret", () => {
 		});
 
 		it("should, in non-interactive mode, create a new worker if no worker is found under the provided name", async () => {
+			setIsTTY(false);
 			writeFileSync(
 				"secret.json",
 				JSON.stringify({

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -249,16 +249,15 @@ describe("wrangler secret", () => {
 				);
 			});
 
-			it("should ask to create a new worker if no worker is found under the provided name", async () => {
+			it("should ask to create a new Worker if no Worker is found under the provided name and abort if declined", async () => {
 				mockPrompt({
 					text: "Enter a secret value:",
 					options: { isSecret: true },
-					result: `hunter2
-				  `,
+					result: `hunter2`,
 				});
 				mockNoWorkerFound();
 				mockConfirm({
-					text: `No Worker called "non-existent-worker" appears to exist. Do you want to create a new Worker and add secrets to it?`,
+					text: `There doesn't seem to be a Worker called "non-existent-worker". Do you want to create a new Worker with that name and add secrets to it?`,
 					result: false,
 				});
 				expect(
@@ -1002,7 +1001,7 @@ describe("wrangler secret", () => {
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
-		it("should, in interactive mode, ask to create a new worker if no worker is found under the provided name", async () => {
+		it("should, in interactive mode, ask to create a new Worker if no Worker is found under the provided name", async () => {
 			setIsTTY(true);
 			writeFileSync(
 				"secret.json",
@@ -1013,7 +1012,7 @@ describe("wrangler secret", () => {
 			);
 			mockNoWorkerFound(true);
 			mockConfirm({
-				text: `No Worker called "non-existent-worker" appears to exist. Do you want to create a new Worker and add secrets to it?`,
+				text: `There doesn't seem to be a Worker called "non-existent-worker". Do you want to create a new Worker with that name and add secrets to it?`,
 				result: false,
 			});
 

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -57,7 +57,15 @@ async function createDraftWorker({
 	accountId: string;
 	scriptName: string;
 }) {
-	// TODO: log a warning
+	const confirmation = await confirm(
+		`No Worker called "${scriptName}" appears to exist. Do you want to create a new Worker and add secrets to it?`,
+		// we want to default to true in non-interactive/CI contexts to preserve existing behaviour
+		{ defaultValue: true, fallbackValue: true }
+	);
+	if (!confirmation) {
+		logger.log("Aborting. No secrets added.");
+		return null;
+	}
 	await fetchResult(
 		!isLegacyEnv(config) && args.env
 			? `/accounts/${accountId}/workers/services/${scriptName}/environments/${args.env}`
@@ -216,12 +224,15 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 				} catch (e) {
 					if (isMissingWorkerError(e)) {
 						// create a draft worker and try again
-						await createDraftWorker({
+						const result = await createDraftWorker({
 							config,
 							args,
 							accountId,
 							scriptName,
 						});
+						if (result === null) {
+							return;
+						}
 						await submitSecret();
 						// TODO: delete the draft worker if this failed too?
 					} else {
@@ -477,12 +488,15 @@ export const secretBulkHandler = async (secretBulkArgs: SecretBulkArgs) => {
 	} catch (e) {
 		if (isMissingWorkerError(e)) {
 			// create a draft worker before patching
-			await createDraftWorker({
+			const result = await createDraftWorker({
 				config,
 				args: secretBulkArgs,
 				accountId,
 				scriptName,
 			});
+			if (result === null) {
+				return;
+			}
 			existingBindings = [];
 		} else {
 			throw e;

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -58,13 +58,15 @@ async function createDraftWorker({
 	scriptName: string;
 }) {
 	const confirmation = await confirm(
-		`No Worker called "${scriptName}" appears to exist. Do you want to create a new Worker and add secrets to it?`,
+		`There doesn't seem to be a Worker called "${scriptName}". Do you want to create a new Worker with that name and add secrets to it?`,
 		// we want to default to true in non-interactive/CI contexts to preserve existing behaviour
 		{ defaultValue: true, fallbackValue: true }
 	);
 	if (!confirmation) {
 		logger.log("Aborting. No secrets added.");
 		return null;
+	} else {
+		logger.log(`🌀 Creating new Worker "${scriptName}"...`);
 	}
 	await fetchResult(
 		!isLegacyEnv(config) && args.env


### PR DESCRIPTION
Fixes [WC-2856](https://jira.cfdata.org/browse/WC-2856)
In interactive mode, if someone specifies a worker name that does not yet exist, ask for confirmation before actually creating that worker (e.g. in case it was a typo).

In non-interactive contexts (CI etc.), always create a worker to maintain existing behaviour.
---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: trivial interaction change

