### PR TITLE
Try and ensure the `d.ts` types are definitely the ones loaded in `quick-edit-extension`

### DIFF
--- a/.changeset/pink-geckos-peel.md
+++ b/.changeset/pink-geckos-peel.md
@@ -1,5 +1,4 @@
 ---
-"quick-edit-extension": patch
 "@cloudflare/quick-edit": patch
 ---
 

--- a/.changeset/pink-geckos-peel.md
+++ b/.changeset/pink-geckos-peel.md
@@ -1,0 +1,6 @@
+---
+"quick-edit-extension": patch
+"@cloudflare/quick-edit": patch
+---
+
+Try and ensure the `d.ts` types are definitely the ones loaded in `quick-edit-extension`

--- a/packages/quick-edit-extension/scripts/bundle.ts
+++ b/packages/quick-edit-extension/scripts/bundle.ts
@@ -1,4 +1,6 @@
+import assert from "assert";
 import { readFile } from "fs/promises";
+import path from "path";
 import * as esbuild from "esbuild";
 
 type BuildFlags = {
@@ -18,12 +20,11 @@ async function buildMain(flags: BuildFlags = {}) {
 				name: "workers-types",
 				setup(build) {
 					build.onResolve({ filter: /^raw:.*/ }, async (args) => {
-						const result = await build.resolve(args.path.slice(4), {
-							kind: "import-statement",
-							resolveDir: args.resolveDir,
-						});
+						const result = path.resolve(
+							"node_modules/@cloudflare/workers-types/experimental/index.d.ts"
+						);
 						return {
-							path: result.path,
+							path: result,
 							namespace: "raw-file",
 						};
 					});
@@ -32,6 +33,11 @@ async function buildMain(flags: BuildFlags = {}) {
 						{ filter: /.*/, namespace: "raw-file" },
 						async (args) => {
 							const contents = await readFile(args.path);
+							// Make sure we're loading the .d.ts and not the .ts version of the types.
+							// Occasionally the wrong version has been loaded in CI, causing spurious typing errors
+							// for users in the playground & quick edit.
+							// The .d.ts file should not include `export declare` anywhere, while the .ts does
+							assert(!/export declare/.test(contents.toString()));
 							return { contents, loader: "text" };
 						}
 					);

--- a/packages/quick-edit-extension/src/cfs.ts
+++ b/packages/quick-edit-extension/src/cfs.ts
@@ -4,7 +4,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import workersTypes from "raw:@cloudflare/workers-types/experimental/index.d.ts";
+import workersTypes from "raw:workers-types";
 import {
 	Disposable,
 	EventEmitter,


### PR DESCRIPTION
Make sure we're loading the .d.ts and not the .ts version of the types. Occasionally the wrong version has been loaded in CI, causing spurious typing errors for users in the playground & quick edit. This PR simplifies the loading, and adds an assertion to make sure builds will fail if the wrong version is loaded. 

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tooling change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: tooling change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal tooling change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
