### PR TITLE
fix(wrangler):  Show `wrangler pages dev --proxy` warning

### DIFF
--- a/.changeset/odd-months-bake.md
+++ b/.changeset/odd-months-bake.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Show `wrangler pages dev --proxy` warning
+
+On Node.js 17+, wrangler will default to fetching only the IPv6 address. With these changes we warn users that the process listening on the port specified via `--proxy` should be configured for IPv6.

--- a/fixtures/pages-dev-proxy-with-script/tests/index.test.ts
+++ b/fixtures/pages-dev-proxy-with-script/tests/index.test.ts
@@ -20,6 +20,14 @@ describe("Pages dev with proxy and a script file", () => {
 					"Specifying a `-- <command>` or `--proxy` is deprecated and will be removed in a future version of Wrangler."
 				)
 		).toBeTruthy();
+
+		expect(
+			process
+				.getOutput()
+				.includes(
+					"On Node.js 17+, wrangler will default to fetching only the IPv6 address. Please ensure that the process listening on the port specified via `--proxy` is configured for IPv6."
+				)
+		).toBeTruthy();
 	});
 
 	it("should handle requests using a script from a custom script path", async () => {

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -1000,6 +1000,11 @@ async function spawnProxyProcess({
 			`Specifying a \`-- <command>\` or \`--proxy\` is deprecated and will be removed in a future version of Wrangler.\nBuild your application to a directory and run the \`wrangler pages dev <directory>\` instead.\nThis results in a more faithful emulation of production behavior.`
 		);
 	}
+	if (port !== undefined) {
+		logger.warn(
+			"On Node.js 17+, wrangler will default to fetching only the IPv6 address. Please ensure that the process listening on the port specified via `--proxy` is configured for IPv6."
+		);
+	}
 	if (command.length === 0) {
 		if (port !== undefined) {
 			return port;


### PR DESCRIPTION
On Node.js 17+, wrangler will default to fetching only the IPv6 address. With these changes we warn users that the process listening on the port specified via `--proxy` should be configured for IPv6.

Fixes #2244.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by fixture tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: simply adds a warning message

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
