### PR TITLE
require --x-workflows flag to deploy a workflow

### DIFF
--- a/.changeset/rare-planes-warn.md
+++ b/.changeset/rare-planes-warn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+require --x-workflows flag to deploy a workflow

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -11413,7 +11413,7 @@ export default{
 
 			const result = runWrangler("deploy"); // no --x-workflows flag
 
-			expect(result).rejects.toMatchInlineSnapshot(
+			await expect(result).rejects.toMatchInlineSnapshot(
 				`[Error: To deploy Workflows, you must use the --experimental-workflows flag (or --x-workflows).]`
 			);
 		});

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -90,6 +90,9 @@ export function mockUploadWorkerRequest(
 		}
 
 		if ("expectedBindings" in options) {
+			console.dir(metadata.bindings);
+			console.dir(expectedBindings);
+
 			expect(metadata.bindings).toEqual(expectedBindings);
 		}
 		if ("expectedCompatibilityDate" in options) {

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -106,6 +106,7 @@ type Props = {
 	projectRoot: string | undefined;
 	dispatchNamespace: string | undefined;
 	experimentalVersions: boolean | undefined;
+	experimentalWorkflows: boolean | undefined;
 };
 
 export type RouteObject = ZoneIdRoute | ZoneNameRoute | CustomDomainRoute;

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -228,6 +228,11 @@ export function deployOptions(yargs: CommonYargsArgv) {
 					"Name of a dispatch namespace to deploy the Worker to (Workers for Platforms)",
 				type: "string",
 			})
+			.option("experimental-workflows", {
+				alias: "x-workflows",
+				describe: "Enable the deployment of Workflows",
+				type: "boolean",
+			})
 	);
 }
 
@@ -280,6 +285,12 @@ export async function deployHandler(args: DeployArgs) {
 	) {
 		throw new UserError(
 			"Cannot use legacy assets and Workers Sites in the same Worker."
+		);
+	}
+
+	if (!args.experimentalWorkflows && config.workflows?.length) {
+		throw new UserError(
+			"To deploy Workflows, you must use the --experimental-workflows flag (or --x-workflows)."
 		);
 	}
 
@@ -363,6 +374,7 @@ export async function deployHandler(args: DeployArgs) {
 		projectRoot,
 		dispatchNamespace: args.dispatchNamespace,
 		experimentalVersions: args.experimentalVersions,
+		experimentalWorkflows: args.experimentalWorkflows,
 	});
 
 	writeOutput({

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -29,8 +29,9 @@ type Props = {
 	routes: string[] | undefined;
 	legacyEnv: boolean | undefined;
 	dryRun: boolean | undefined;
-	experimentalVersions: boolean | undefined;
 	assetsOptions: AssetsOptions | undefined;
+	experimentalVersions: boolean | undefined;
+	experimentalWorkflows: boolean | undefined;
 };
 
 export default async function triggersDeploy(
@@ -240,7 +241,12 @@ export default async function triggersDeploy(
 		deployments.push(...updateConsumers);
 	}
 
-	if (config.workflows?.length) {
+	if (!props.experimentalWorkflows && config.workflows?.length) {
+		throw new UserError(
+			"To deploy Workflows, you must use the --experimental-workflows flag (or --x-workflows)"
+		);
+	}
+	if (props.experimentalWorkflows && config.workflows?.length) {
 		for (const workflow of config.workflows) {
 			deployments.push(
 				fetchResult(`/accounts/${accountId}/workflows/${workflow.name}`, {

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -49,6 +49,11 @@ export function triggersDeployOptions(yargs: CommonYargsArgv) {
 			type: "boolean",
 			describe: "Use legacy environments",
 			hidden: true,
+		})
+		.option("experimental-workflows", {
+			alias: "x-workflows",
+			describe: "Enable the deployment of Workflows",
+			type: "boolean",
 		});
 }
 
@@ -78,7 +83,8 @@ export async function triggersDeployHandler(
 		routes: args.routes,
 		legacyEnv: isLegacyEnv(config),
 		dryRun: args.dryRun,
-		experimentalVersions: args.experimentalJsonConfig,
 		assetsOptions,
+		experimentalVersions: args.experimentalVersions,
+		experimentalWorkflows: args.experimentalWorkflows,
 	});
 }

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -97,6 +97,11 @@ export function versionsDeployOptions(yargs: CommonYargsArgv) {
 			describe: "Maximum allowed versions to select",
 			type: "number",
 			default: 2, // (when server-side limitation is lifted, we can update this default or just remove the option entirely)
+		})
+		.option("experimental-workflows", {
+			alias: "x-workflows",
+			describe: "Enable the deployment of Workflows",
+			type: "boolean",
 		});
 }
 
@@ -118,6 +123,12 @@ export async function versionsDeployHandler(args: VersionsDeployArgs) {
 	if (workerName === undefined) {
 		throw new UserError(
 			'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+		);
+	}
+
+	if (!args.experimentalWorkflows && config.workflows?.length) {
+		throw new UserError(
+			"To deploy Workflows, you must use the --experimental-workflows flag (or --x-workflows)"
 		);
 	}
 

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -191,6 +191,11 @@ export function versionsUploadOptions(yargs: CommonYargsArgv) {
 				type: "string",
 				requiresArg: true,
 			})
+			.option("experimental-workflows", {
+				alias: "x-workflows",
+				describe: "Enable the deployment of Workflows",
+				type: "boolean",
+			})
 	);
 }
 
@@ -222,6 +227,12 @@ export async function versionsUploadHandler(
 	if (args.legacyAssets || config.legacy_assets) {
 		throw new UserError(
 			"Legacy assets does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead."
+		);
+	}
+
+	if (!args.experimentalWorkflows && config.workflows?.length) {
+		throw new UserError(
+			"To include Workflows in your Worker Versions upload, you must use the --experimental-workflows flag (or --x-workflows)."
 		);
 	}
 


### PR DESCRIPTION
Fixes #0000. Addresses https://github.com/cloudflare/workers-sdk/pull/7012#discussion_r1809165316

This PR implements the `–x-workflows` flag on `wrangler deploy`, `wrangler versions upload`, `wrangler versions deploy` and `wrangler trigger deploy`.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by other tests
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
