### PR TITLE
fix(create-cloudflare): update to Analog 1.9.0 w/latest template

### DIFF
--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -131,13 +131,12 @@ function getFrameworkTests(opts: {
 				],
 			},
 			analog: {
-				quarantine: true,
 				testCommitMessage: true,
 				timeout: LONG_TIMEOUT,
 				unsupportedOSs: ["win32"],
 				// The analog template works with yarn, but the build takes so long that it
 				// becomes flaky in CI
-				unsupportedPms: ["yarn", "bun"],
+				unsupportedPms: ["yarn"],
 				verifyDeploy: {
 					route: "/",
 					expectedText: "The fullstack meta-framework for Angular!",

--- a/packages/create-cloudflare/templates/analog/c3.ts
+++ b/packages/create-cloudflare/templates/analog/c3.ts
@@ -14,11 +14,7 @@ import type { C3Context } from "types";
 const { npm, name: pm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
-	await runFrameworkGenerator(ctx, [
-		ctx.project.name,
-		"--template",
-		"angular-v17",
-	]);
+	await runFrameworkGenerator(ctx, [ctx.project.name, "--template", "latest"]);
 
 	logRaw(""); // newline
 };
@@ -29,8 +25,6 @@ const configure = async (ctx: C3Context) => {
 		const packages = [];
 		packages.push("nitropack");
 		packages.push("h3");
-		packages.push("@ngtools/webpack");
-		packages.push("@angular-devkit/build-angular");
 
 		await installPackages(packages, {
 			dev: true,


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

- Updates Analog to use `latest` upon installation
- Removes installation of `@ngtools/webpack`
- Removes Analog e2e test from quarantine.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [x] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
