### PR TITLE
feat(create-cloudflare): prompt user to correct the answer if the arg value is invalid

### DIFF
--- a/.changeset/shiny-files-jog.md
+++ b/.changeset/shiny-files-jog.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+feat: prompt user to correct the answer if the arg value is invalid

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -47,6 +47,8 @@ export type BasePromptConfig = {
 	helpText?: string;
 	// The value to use by default
 	defaultValue?: Arg;
+	// The error message to display if the initial value is invalid
+	initialError?: string | null;
 	// Accept the initialValue/defaultValue as if the user pressed ENTER when prompted
 	acceptDefault?: boolean;
 	// The status label to be shown after submitting
@@ -141,7 +143,14 @@ export const inputPrompt = async <T = string>(
 
 	// Looks up the needed renderer by the current state ('initial', 'submitted', etc.)
 	const dispatchRender = (props: RenderProps, p: Prompt): string | void => {
-		const renderedLines = renderers[props.state](props, p);
+		let state = props.state;
+
+		if (state === "initial" && promptConfig.initialError) {
+			state = "error";
+			props.error = promptConfig.initialError;
+		}
+
+		const renderedLines = renderers[state](props, p);
 		return renderedLines.join("\n");
 	};
 
@@ -222,7 +231,7 @@ export const inputPrompt = async <T = string>(
 
 		prompt = new TextPrompt({
 			...promptConfig,
-			initialValue: promptConfig.initialValue,
+			initialValue: promptConfig.initialValue ?? initialValue,
 			defaultValue: String(promptConfig.defaultValue ?? ""),
 			render() {
 				return dispatchRender(this, prompt);

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -231,7 +231,7 @@ export const inputPrompt = async <T = string>(
 
 		prompt = new TextPrompt({
 			...promptConfig,
-			initialValue: promptConfig.initialValue ?? initialValue,
+			initialValue: promptConfig.initialValue,
 			defaultValue: String(promptConfig.defaultValue ?? ""),
 			render() {
 				return dispatchRender(this, prompt);

--- a/packages/cli/interactive.ts
+++ b/packages/cli/interactive.ts
@@ -48,7 +48,7 @@ export type BasePromptConfig = {
 	// The value to use by default
 	defaultValue?: Arg;
 	// The error message to display if the initial value is invalid
-	initialError?: string | null;
+	initialErrorMessage?: string | null;
 	// Accept the initialValue/defaultValue as if the user pressed ENTER when prompted
 	acceptDefault?: boolean;
 	// The status label to be shown after submitting
@@ -145,9 +145,9 @@ export const inputPrompt = async <T = string>(
 	const dispatchRender = (props: RenderProps, p: Prompt): string | void => {
 		let state = props.state;
 
-		if (state === "initial" && promptConfig.initialError) {
+		if (state === "initial" && promptConfig.initialErrorMessage) {
 			state = "error";
-			props.error = promptConfig.initialError;
+			props.error = promptConfig.initialErrorMessage;
 		}
 
 		const renderedLines = renderers[state](props, p);

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -157,13 +157,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 									/In which directory do you want to create your application/,
 								input: {
 									type: "text",
-									chunks: [
-										// To delete the existing project name
-										keys.backspace.repeat(existingProjectName.length),
-										// And then type the correct project name
-										projectName,
-										keys.enter,
-									],
+									chunks: [project.path, keys.enter],
 									assertErrorMessage: `ERROR  Directory \`${existingProjectPath}\` already exists and contains files that might conflict. Please choose a new name.`,
 								},
 							},
@@ -282,8 +276,9 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 		test({ experimental }).skipIf(process.platform === "win32")(
 			"Going back and forth between the category, type, framework and lang prompts",
 			async ({ logStream, project }) => {
+				const testProjectPath = "/test-project-path";
 				const { output } = await runC3(
-					["/invalid-project-name", "--git=false", "--no-deploy"],
+					[testProjectPath, "--git=false", "--no-deploy"],
 					[
 						{
 							matcher: /What would you like to start with\?/,

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -54,6 +54,11 @@ export type PromptHandler = {
 	input:
 		| string[]
 		| {
+				type: "text";
+				chunks: string[];
+				assertErrorMessage?: string;
+		  }
+		| {
 				type: "select";
 				target: RegExp | string;
 				assertDefaultSelection?: string;
@@ -115,6 +120,22 @@ export const runC3 = async (
 		if (Array.isArray(currentDialog.input)) {
 			// keyboard input prompt handler
 			currentDialog.input.forEach((keystroke) => {
+				proc.stdin.write(keystroke);
+			});
+		} else if (currentDialog.input.type === "text") {
+			// text prompt handler
+			const { assertErrorMessage, chunks } = currentDialog.input;
+
+			if (
+				assertErrorMessage !== undefined &&
+				!text.includes(assertErrorMessage)
+			) {
+				throw new Error(
+					`The error message does not match; Expected "${assertErrorMessage}" but found "${text}".`,
+				);
+			}
+
+			chunks.forEach((keystroke) => {
 				proc.stdin.write(keystroke);
 			});
 		} else if (currentDialog.input.type === "select") {

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -415,11 +415,14 @@ export const processArgument = async <Key extends keyof C3Args>(
 		disableTelemetry: args[key] !== undefined,
 		async promise() {
 			const value = args[key];
+			const error = promptConfig.validate?.(value) ?? null;
 			const result = await inputPrompt<Required<C3Args>[Key]>({
 				...promptConfig,
 				// Accept the default value if the arg is already set
-				acceptDefault: promptConfig.acceptDefault ?? value !== undefined,
+				acceptDefault:
+					promptConfig.acceptDefault ?? (value !== undefined && !error),
 				defaultValue: value ?? promptConfig.defaultValue,
+				initialError: error,
 				throwOnError: true,
 			});
 

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -422,7 +422,7 @@ export const processArgument = async <Key extends keyof C3Args>(
 				acceptDefault:
 					promptConfig.acceptDefault ?? (value !== undefined && !error),
 				defaultValue: value ?? promptConfig.defaultValue,
-				initialError: error,
+				initialErrorMessage: error,
 				throwOnError: true,
 			});
 


### PR DESCRIPTION
Fixes n/a.

Previously, if you provide an invalid project name on the command, c3 will print an error message and **crash the CLI** immediately:

<img width="1175" alt="Screenshot 2024-10-22 at 17 06 25" src="https://github.com/user-attachments/assets/8826ee8e-c4b7-4db7-87eb-22f760e46fc6">


Now, it will prompt user to correct the answer instead. So it behave consistently as if user provide an invalid project name on the prompt.

<img width="1156" alt="Screenshot 2024-10-22 at 17 06 48" src="https://github.com/user-attachments/assets/937f7bd0-6b3f-41cc-b1de-7f25e10ebe93">

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No impact on other parts
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: UX improvement

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
