### PR TITLE
Adds D&C as owners of workers-shared

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,8 @@
 * @cloudflare/wrangler
 
+# D&C ownership
+/packages/workers-shared @cloudflare/deploy-config @cloudflare/wrangler
+
 # Pages ownership
 /packages/pages-shared/ @cloudflare/pages @cloudflare/wrangler
 /packages/wrangler/pages/ @cloudflare/pages @cloudflare/wrangler


### PR DESCRIPTION
Adds the newly minted [Deploy & Config team](https://github.com/orgs/cloudflare/teams/deploy-config) as owners of our stuff (asset-worker, router-worker, etc.) :)

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: codeowner change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: codeowner change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: codeowner change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
