### PR TITLE
Only enable hotkeys after authenticating if hotkeys were previously enabled

### DIFF
--- a/.changeset/smooth-kiwis-clean.md
+++ b/.changeset/smooth-kiwis-clean.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler dev --remote --show-interactive-dev-session=false` by only enabling hotkeys after account selection if hotkeys were previously enabled

--- a/packages/wrangler/e2e/__snapshots__/dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/dev.test.ts.snap
@@ -4,14 +4,22 @@ exports[`basic js dev: 'wrangler dev --no-x-dev-env' > can modify worker during 
 
 exports[`basic js dev: 'wrangler dev --no-x-dev-env' > can modify worker during wrangler dev --no-x-dev-env 2`] = `"Updated Worker! value"`;
 
+exports[`basic js dev: 'wrangler dev --no-x-dev-env' > hotkeys can be disabled with wrangler dev --no-x-dev-env 1`] = `"Hello World!"`;
+
 exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > can modify worker during wrangler dev --remote --no-x-dev-env 1`] = `"Hello World!"`;
 
 exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > can modify worker during wrangler dev --remote --no-x-dev-env 2`] = `"Updated Worker! value"`;
+
+exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > hotkeys can be disabled with wrangler dev --remote --no-x-dev-env 1`] = `"Hello World!"`;
 
 exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > can modify worker during wrangler dev --remote --x-dev-env 1`] = `"Hello World!"`;
 
 exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > can modify worker during wrangler dev --remote --x-dev-env 2`] = `"Updated Worker! value"`;
 
+exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > hotkeys can be disabled with wrangler dev --remote --x-dev-env 1`] = `"Hello World!"`;
+
 exports[`basic js dev: 'wrangler dev --x-dev-env' > can modify worker during wrangler dev --x-dev-env 1`] = `"Hello World!"`;
 
 exports[`basic js dev: 'wrangler dev --x-dev-env' > can modify worker during wrangler dev --x-dev-env 2`] = `"Updated Worker! value"`;
+
+exports[`basic js dev: 'wrangler dev --x-dev-env' > hotkeys can be disabled with wrangler dev --x-dev-env 1`] = `"Hello World!"`;

--- a/packages/wrangler/src/dev.tsx
+++ b/packages/wrangler/src/dev.tsx
@@ -711,11 +711,14 @@ export async function startDev(args: StartDevOptions) {
 					},
 					dev: {
 						auth: async (config) => {
+							const hotkeysDisplayed = !!unregisterHotKeys;
 							let accountId = args.accountId;
 							if (!accountId) {
 								unregisterHotKeys?.();
 								accountId = await requireAuth(config);
-								unregisterHotKeys = registerDevHotKeys(devEnv, args);
+								if (hotkeysDisplayed) {
+									unregisterHotKeys = registerDevHotKeys(devEnv, args);
+								}
 							}
 							return {
 								accountId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.1.1
+      version: 2.1.1
+    '@vitest/snapshot':
+      specifier: ~2.1.1
+      version: 2.1.1
     vitest:
       specifier: ~2.1.1
       version: 2.1.1


### PR DESCRIPTION
Fixes #7025

In `--x-dev-env` we temporarily disable hotkeys while doing account selection. Previously we'd been unconditionally re-enabling them, but this meant that `--remote --show-interactive-dev-session` would eventually show the hotkeys. This PR changes things to only re-enable hotkeys if they'd previously been enabled.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
