### PR TITLE
feat: change trigger command to comply with new endpoint

### DIFF
--- a/.changeset/grumpy-eggs-rest.md
+++ b/.changeset/grumpy-eggs-rest.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Change trigger command to comply with the current workflows endpoint.
+
+This also adds an id option to allow users to optionally customize the new instance id.

--- a/packages/wrangler/src/workflows/commands/trigger.ts
+++ b/packages/wrangler/src/workflows/commands/trigger.ts
@@ -24,6 +24,12 @@ defineCommand({
 			type: "string",
 			default: "",
 		},
+		id: {
+			describe:
+				"Custom instance ID, if not provided it will default to a random UUIDv4",
+			type: "string",
+			default: undefined,
+		},
 	},
 	positionalArgs: ["name", "params"],
 
@@ -45,7 +51,11 @@ defineCommand({
 			`/accounts/${accountId}/workflows/${args.name}/instances`,
 			{
 				method: "POST",
-				body: args.params.length != 0 ? args.params : undefined,
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					instance_id: args.id,
+					params: args.params.length != 0 ? args.params : undefined,
+				}),
 			}
 		);
 


### PR DESCRIPTION
Fixes WOR-280

Because the body for the trigger command changed, we also need to change it here. As a consequence we also add an optional `--id` to let users to optionally customize the new instance ID. 