### PR TITLE
Workflows open beta warning on deploy

### DIFF
--- a/.changeset/rare-planes-warn.md
+++ b/.changeset/rare-planes-warn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+log warning of Workflows open-beta status when running deploying a Worker that contains a Workflow binding

--- a/packages/wrangler/src/__tests__/logger.test.ts
+++ b/packages/wrangler/src/__tests__/logger.test.ts
@@ -189,16 +189,35 @@ describe("logger", () => {
 			expect(std.debug).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`"This is a log message"`);
 			expect(std.warn).toMatchInlineSnapshot(`
-        "Unrecognised WRANGLER_LOG value \\"everything\\", expected \\"none\\" | \\"error\\" | \\"warn\\" | \\"info\\" | \\"log\\" | \\"debug\\", defaulting to \\"log\\"...
-        [33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis is a warn message[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUnrecognised WRANGLER_LOG value \\"everything\\", expected \\"none\\" | \\"error\\" | \\"warn\\" | \\"info\\" | \\"log\\" | \\"debug\\", defaulting to \\"log\\"...[0m
 
-        "
-      `);
+
+				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis is a warn message[0m
+
+				"
+			`);
 			expect(std.err).toMatchInlineSnapshot(`
         "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mThis is a error message[0m
 
         "
       `);
+		});
+	});
+
+	describe("warnOnce", () => {
+		it("should only log the same message once", () => {
+			const logger = new Logger();
+			logger.warnOnce("This is a warnOnce message");
+			logger.warnOnce("This is a warnOnce message");
+			logger.warnOnce("This is a warnOnce message");
+			logger.warnOnce("This is a warnOnce message");
+			logger.warnOnce("This is a warnOnce message");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis is a warnOnce message[0m
+
+				"
+			`);
 		});
 	});
 });

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -283,6 +283,10 @@ export async function deployHandler(args: DeployArgs) {
 		);
 	}
 
+	if (config.workflows?.length) {
+		logger.warnOnce("Workflows is currently in open beta.");
+	}
+
 	validateAssetsArgsAndConfig(args, config);
 
 	const assetsOptions = processAssetsArg(args, config);

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -241,6 +241,8 @@ export default async function triggersDeploy(
 	}
 
 	if (config.workflows?.length) {
+		logger.warnOnce("Workflows is currently in open beta.");
+
 		for (const workflow of config.workflows) {
 			deployments.push(
 				fetchResult(`/accounts/${accountId}/workflows/${workflow.name}`, {

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -78,7 +78,7 @@ export async function triggersDeployHandler(
 		routes: args.routes,
 		legacyEnv: isLegacyEnv(config),
 		dryRun: args.dryRun,
-		experimentalVersions: args.experimentalJsonConfig,
+		experimentalVersions: args.experimentalVersions,
 		assetsOptions,
 	});
 }

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -13,6 +13,7 @@ import { findWranglerToml, readConfig } from "../config";
 import { UserError } from "../errors";
 import { CI } from "../is-ci";
 import isInteractive from "../is-interactive";
+import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { writeOutput } from "../output";
 import { APIError } from "../parse";
@@ -119,6 +120,10 @@ export async function versionsDeployHandler(args: VersionsDeployArgs) {
 		throw new UserError(
 			'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
 		);
+	}
+
+	if (config.workflows?.length) {
+		logger.warnOnce("Workflows is currently in open beta.");
 	}
 
 	const versionCache: VersionCache = new Map();

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -225,6 +225,10 @@ export async function versionsUploadHandler(
 		);
 	}
 
+	if (config.workflows?.length) {
+		logger.warnOnce("Workflows is currently in open beta.");
+	}
+
 	validateAssetsArgsAndConfig(
 		{
 			// given that legacyAssets and sites are not supported by


### PR DESCRIPTION
Supersedes https://github.com/cloudflare/workers-sdk/pull/7047

Fixes #7047

Adds a warning reminding the user that Workflows is in open beta – if their config file contains any workflows – in `wrangler deploy`, `wrangler versions upload`, `wrangler versions deploy` and `wrangler trigger deploy`.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by other tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: already documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
