### PR TITLE
chore: pin runner image of non test related workflows to ubuntu-22.04

### DIFF
--- a/.github/workflows/c3-dependabot-versioning-prs.yml
+++ b/.github/workflows/c3-dependabot-versioning-prs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   generate-changeset:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]'
     steps:

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Handle Changesets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/create-pullrequest-prerelease.yml
+++ b/.github/workflows/create-pullrequest-prerelease.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Build & Publish a Prerelease to the Adhoc Registry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/d1.yml
+++ b/.github/workflows/d1.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -30,7 +30,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-project-cleanup.yml
+++ b/.github/workflows/e2e-project-cleanup.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 30
     name: "Cleanup Test Projects"
     if: ${{ github.repository_owner == 'cloudflare' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/holopin.yml
+++ b/.github/workflows/holopin.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   issue_lava_lamp_holobyte:
     name: Issue Lava Lamp Holobyte
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event.pull_request.merged }}
     steps:
       - id: check_if_contributor_is_external
@@ -26,7 +26,7 @@ jobs:
           LABELS: contribution
   issue_global_contribution_badge:
     name: Issue Global Contribution badge
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.label.name == 'outstanding contribution'
     steps:
       - name: Issue Global Contribution badge

--- a/.github/workflows/miniflare-dependabot-versioning-prs.yml
+++ b/.github/workflows/miniflare-dependabot-versioning-prs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   generate-changeset:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event.pull_request.user.login == 'dependabot[bot]'
     steps:

--- a/.github/workflows/prerelease-workflows.yml
+++ b/.github/workflows/prerelease-workflows.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/prereleases.yml
+++ b/.github/workflows/prereleases.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Build & Publish a beta release to NPM
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     timeout-minutes: 30
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/worker-playground-preview-testing-env-deploy-and-test.yml
+++ b/.github/workflows/worker-playground-preview-testing-env-deploy-and-test.yml
@@ -24,7 +24,7 @@ jobs:
   e2e-test:
     if: github.repository_owner == 'cloudflare' && (github.event_name != 'pull_request' || contains(github.event.*.labels.*.name, 'playground-worker'))
     name: "Deploy Playground Preview Worker (testing)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/write-prerelease-comment.yml
+++ b/.github/workflows/write-prerelease-comment.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   comment:
     if: ${{ github.repository_owner == 'cloudflare' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Write comment to the PR
     steps:
       - name: "Put PR and workflow ID on the environment"


### PR DESCRIPTION
Fixes n/a.

Github updates the `ubuntu-latest` image tag to `ubuntu-24.04` recently which missed a few dependencies that is required for our release setup last week. They [rolled back to `ubuntu-22.04`](https://github.com/actions/runner-images/issues/10636#issuecomment-2417293457) but it is probably safer to lock the version. 

This PR pins the runner image of non test related workflows to `ubuntu-22.04`.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no feature change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no feature change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
