### PR TITLE
[build] Upgrade CI runners from macOS 13 => 15

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-2022, ubuntu-22.04]
+        os: [macos-15, windows-2022, ubuntu-22.04]
         node: ["18"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-13]
+        os: [windows-latest, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15]
         filter: ["./packages/*", "./fixtures/*"]
         # Things in the tools folder are for running in CI, and so only need to run on linux
         include:


### PR DESCRIPTION
Update to the latest OS version, which should speed up CI based on using Apple Silicon CPUs.

This will help us with runner exhaustion encountered before we have a long-term solution for that. As noted below, E2E tests must run on this to confirm that things still work on the new image version.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Changing CI itself, running existing tests will show whether this works as intended
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI-only change