### PR TITLE
Upgrade to turbo v2

### DIFF
--- a/fixtures/additional-modules/turbo.json
+++ b/fixtures/additional-modules/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/fixtures/nodejs-als-app/turbo.json
+++ b/fixtures/nodejs-als-app/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/fixtures/nodejs-hybrid-app/turbo.json
+++ b/fixtures/nodejs-hybrid-app/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/fixtures/pages-plugin-example/turbo.json
+++ b/fixtures/pages-plugin-example/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/fixtures/pages-proxy-app/turbo.json
+++ b/fixtures/pages-proxy-app/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/fixtures/pages-ws-app/turbo.json
+++ b/fixtures/pages-ws-app/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/lint-turbo.mjs
+++ b/lint-turbo.mjs
@@ -26,7 +26,7 @@ for (const p of paths) {
 			console.log("Failed to read turbo.json for", pkg.name);
 			process.exit(1);
 		}
-		const buildOutputs = turboConfig.pipeline.build.outputs;
+		const buildOutputs = turboConfig.tasks.build.outputs;
 		assert(buildOutputs.length > 0);
 	}
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"prettier-plugin-packagejson": "^2.2.18",
 		"rimraf": "^5.0.1",
 		"tree-kill": "^1.2.2",
-		"turbo": "^1.13.4",
+		"turbo": "^2.2.3",
 		"typescript": "^5.5.2",
 		"vite": "^5.0.12",
 		"vitest": "catalog:default"

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-
-	"pipeline": {}
+	"tasks": {}
 }

--- a/packages/create-cloudflare/turbo.json
+++ b/packages/create-cloudflare/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"env": [
 				"TEST_PM",

--- a/packages/create-cloudflare/turbo.json
+++ b/packages/create-cloudflare/turbo.json
@@ -23,7 +23,8 @@
 				"E2E_PROJECT_PATH",
 				"E2E_RETRIES",
 				"E2E_NO_DEPLOY",
-				"E2E_EXPERIMENTAL"
+				"E2E_EXPERIMENTAL",
+				"TEST_PM"
 			],
 			"dependsOn": ["build"]
 		}

--- a/packages/format-errors/turbo.json
+++ b/packages/format-errors/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/packages/kv-asset-handler/turbo.json
+++ b/packages/kv-asset-handler/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/packages/miniflare/turbo.json
+++ b/packages/miniflare/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"inputs": ["src/**", "scripts/**", "types/**", "*.mjs", "*.js", "*.json"],
 			"outputs": ["dist/**", "bootstrap.js", "worker-metafiles/**"],

--- a/packages/prerelease-registry/turbo.json
+++ b/packages/prerelease-registry/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/packages/turbo-r2-archive/turbo.json
+++ b/packages/turbo-r2-archive/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"],
 			"inputs": ["src/**"]

--- a/packages/vitest-pool-workers/turbo.json
+++ b/packages/vitest-pool-workers/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"]
 		}

--- a/packages/workers-editor-shared/turbo.json
+++ b/packages/workers-editor-shared/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"],
 			"env": ["NODE_ENV"]

--- a/packages/workers-playground/turbo.json
+++ b/packages/workers-playground/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["dist/**"],
 			"env": ["NODE_ENV", "VITE_PLAYGROUND_PREVIEW", "VITE_PLAYGROUND_ROOT"]

--- a/packages/workers-shared/turbo.json
+++ b/packages/workers-shared/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"inputs": [
 				"asset-worker/**",

--- a/packages/workflows-shared/turbo.json
+++ b/packages/workflows-shared/turbo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"inputs": ["src/**", "*.js", "*.ts", "*.json"],
 			"outputs": ["dist/**"]

--- a/packages/wrangler/turbo.json
+++ b/packages/wrangler/turbo.json
@@ -1,11 +1,11 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"inputs": [
-				"!**/__tests__/**",
-				"!**/.wrangler/**",
+				"!*/**/__tests__/**",
+				"!*/**/.wrangler/**",
 				"bin/**",
 				"src/**",
 				"scripts/**",
@@ -61,7 +61,7 @@
 			]
 		},
 		"test:ci": {
-			"inputs": ["!**/.wrangler/**", "**/__tests__/**"],
+			"inputs": ["!*/**/.wrangler/**", "**/__tests__/**"],
 			"dependsOn": ["build"]
 		},
 		"test:e2e": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2
       turbo:
-        specifier: ^1.13.4
-        version: 1.13.4
+        specifier: ^2.2.3
+        version: 2.2.3
       typescript:
         specifier: ^5.5.2
         version: 5.5.4
@@ -2065,7 +2065,7 @@ packages:
   '@azure/core-http@3.0.4':
     resolution: {integrity: sha512-Fok9VVhMdxAFOtqiiAtg74fL0UJkt0z3D+ouUUxcRLzZNBioPRAMJFVxiWoJljYpXsRi4GDQHzQHDc9AiYaIUQ==}
     engines: {node: '>=14.0.0'}
-    deprecated: This package is no longer supported. Please migrate to use @azure/core-rest-pipeline
+    deprecated: deprecating as we migrated to core v2
 
   '@azure/core-lro@2.5.4':
     resolution: {integrity: sha512-3GJiMVH7/10bulzOKGrrLeG/uCBH/9VtxqaMcB9lIqAeamI/xYQSHJL/KcsLDuH+yTjYpro/u6D/MuRe4dN70Q==}
@@ -7960,38 +7960,38 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
-  turbo-darwin-64@1.13.4:
-    resolution: {integrity: sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==}
+  turbo-darwin-64@2.2.3:
+    resolution: {integrity: sha512-Rcm10CuMKQGcdIBS3R/9PMeuYnv6beYIHqfZFeKWVYEWH69sauj4INs83zKMTUiZJ3/hWGZ4jet9AOwhsssLyg==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@1.13.4:
-    resolution: {integrity: sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==}
+  turbo-darwin-arm64@2.2.3:
+    resolution: {integrity: sha512-+EIMHkuLFqUdJYsA3roj66t9+9IciCajgj+DVek+QezEdOJKcRxlvDOS2BUaeN8kEzVSsNiAGnoysFWYw4K0HA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@1.13.4:
-    resolution: {integrity: sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==}
+  turbo-linux-64@2.2.3:
+    resolution: {integrity: sha512-UBhJCYnqtaeOBQLmLo8BAisWbc9v9daL9G8upLR+XGj6vuN/Nz6qUAhverN4Pyej1g4Nt1BhROnj6GLOPYyqxQ==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@1.13.4:
-    resolution: {integrity: sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==}
+  turbo-linux-arm64@2.2.3:
+    resolution: {integrity: sha512-hJYT9dN06XCQ3jBka/EWvvAETnHRs3xuO/rb5bESmDfG+d9yQjeTMlhRXKrr4eyIMt6cLDt1LBfyi+6CQ+VAwQ==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@1.13.4:
-    resolution: {integrity: sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==}
+  turbo-windows-64@2.2.3:
+    resolution: {integrity: sha512-NPrjacrZypMBF31b4HE4ROg4P3nhMBPHKS5WTpMwf7wydZ8uvdEHpESVNMOtqhlp857zbnKYgP+yJF30H3N2dQ==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@1.13.4:
-    resolution: {integrity: sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==}
+  turbo-windows-arm64@2.2.3:
+    resolution: {integrity: sha512-fnNrYBCqn6zgKPKLHu4sOkihBI/+0oYFr075duRxqUZ+1aLWTAGfHZLgjVeLh3zR37CVzuerGIPWAEkNhkWEIw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@1.13.4:
-    resolution: {integrity: sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==}
+  turbo@2.2.3:
+    resolution: {integrity: sha512-5lDvSqIxCYJ/BAd6rQGK/AzFRhBkbu4JHVMLmGh/hCb7U3CqSnr5Tjwfy9vc+/5wG2DJ6wttgAaA7MoCgvBKZQ==}
     hasBin: true
 
   twirp-ts@2.5.0:
@@ -15238,32 +15238,32 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  turbo-darwin-64@1.13.4:
+  turbo-darwin-64@2.2.3:
     optional: true
 
-  turbo-darwin-arm64@1.13.4:
+  turbo-darwin-arm64@2.2.3:
     optional: true
 
-  turbo-linux-64@1.13.4:
+  turbo-linux-64@2.2.3:
     optional: true
 
-  turbo-linux-arm64@1.13.4:
+  turbo-linux-arm64@2.2.3:
     optional: true
 
-  turbo-windows-64@1.13.4:
+  turbo-windows-64@2.2.3:
     optional: true
 
-  turbo-windows-arm64@1.13.4:
+  turbo-windows-arm64@2.2.3:
     optional: true
 
-  turbo@1.13.4:
+  turbo@2.2.3:
     optionalDependencies:
-      turbo-darwin-64: 1.13.4
-      turbo-darwin-arm64: 1.13.4
-      turbo-linux-64: 1.13.4
-      turbo-linux-arm64: 1.13.4
-      turbo-windows-64: 1.13.4
-      turbo-windows-arm64: 1.13.4
+      turbo-darwin-64: 2.2.3
+      turbo-darwin-arm64: 2.2.3
+      turbo-linux-64: 2.2.3
+      turbo-linux-arm64: 2.2.3
+      turbo-windows-64: 2.2.3
+      turbo-windows-arm64: 2.2.3
 
   twirp-ts@2.5.0(@protobuf-ts/plugin@2.9.3):
     dependencies:

--- a/tools/turbo.json
+++ b/tools/turbo.json
@@ -1,8 +1,7 @@
 {
 	"$schema": "http://turbo.build/schema.json",
 	"extends": ["//"],
-
-	"pipeline": {
+	"tasks": {
 		"test:ci": {
 			"inputs": ["../packages/*/package.json"],
 			"dependsOn": ["build"]

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
 		"signature": true
 	},
 	"globalEnv": ["CI_OS", "NODE_VERSION", "VITEST"],
-	"pipeline": {
+	"tasks": {
 		"dev": {
 			"persistent": true,
 			"cache": false


### PR DESCRIPTION
Fixes #6992

The result of running `pnpx @turbo/codemod migrate` from https://turbo.build/blog/turbo-2-0

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tooling upgrade
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: tooling upgrade
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tooling upgrade

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
