### PR TITLE
Default `--x-registry` to on

### DIFF
--- a/.changeset/tricky-bottles-bow.md
+++ b/.changeset/tricky-bottles-bow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Default the file based registry (`--x-registry`) to on. This should improve stability of multi-worker development

--- a/fixtures/unstable_dev/src/wrangler-dev.mjs
+++ b/fixtures/unstable_dev/src/wrangler-dev.mjs
@@ -9,5 +9,3 @@ const text = await resp.text();
 console.log("Invoked worker: ", text);
 
 await worker.stop();
-
-process.exit(0);

--- a/fixtures/unstable_dev/src/wrangler-dev.mjs
+++ b/fixtures/unstable_dev/src/wrangler-dev.mjs
@@ -9,3 +9,5 @@ const text = await resp.text();
 console.log("Invoked worker: ", text);
 
 await worker.stop();
+
+process.exit(0);

--- a/packages/wrangler/e2e/dev-registry.test.ts
+++ b/packages/wrangler/e2e/dev-registry.test.ts
@@ -105,6 +105,8 @@ describe("unstable_dev()", () => {
 						}
 					);
 
+					await setTimeout(2000)
+
 					const parentWorker = await unstable_dev(
 						"src/index.ts",
 						{

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1420,7 +1420,7 @@ describe.sequential("wrangler dev", () => {
 				      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]
 				      --show-interactive-dev-session               Show interactive dev session (defaults to true if the terminal supports interactivity)  [boolean]
 				      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: false]
-				      --experimental-vectorize-bind-to-prod        Bind to production Vectorize indexes in local development mode  [boolean] [default: false]",
+				      --experimental-vectorize-bind-to-prod        Bind to production Vectorize indexes in local development mode  [boolean] [default: true]",
 				  "warn": "",
 				}
 			`);

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1419,7 +1419,7 @@ describe.sequential("wrangler dev", () => {
 				      --test-scheduled                             Test scheduled events by visiting /__scheduled in browser  [boolean] [default: false]
 				      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]
 				      --show-interactive-dev-session               Show interactive dev session (defaults to true if the terminal supports interactivity)  [boolean]
-				      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: false]
+				      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: true]
 				      --experimental-vectorize-bind-to-prod        Bind to production Vectorize indexes in local development mode  [boolean] [default: true]",
 				  "warn": "",
 				}

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1420,7 +1420,7 @@ describe.sequential("wrangler dev", () => {
 				      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"] [default: \\"log\\"]
 				      --show-interactive-dev-session               Show interactive dev session (defaults to true if the terminal supports interactivity)  [boolean]
 				      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: true]
-				      --experimental-vectorize-bind-to-prod        Bind to production Vectorize indexes in local development mode  [boolean] [default: true]",
+				      --experimental-vectorize-bind-to-prod        Bind to production Vectorize indexes in local development mode  [boolean] [default: false]",
 				  "warn": "",
 				}
 			`);

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -125,7 +125,7 @@ export async function unstable_dev(
 		showInteractiveDevSession,
 		testMode,
 		testScheduled,
-		fileBasedRegistry = false,
+		fileBasedRegistry = true,
 		vectorizeBindToProd,
 		// 2. options for alpha/beta products/libs
 		d1Databases,

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -110,7 +110,7 @@ export async function getPlatformProxy<
 
 	const miniflareOptions = await run(
 		{
-			FILE_BASED_REGISTRY: Boolean(options.experimentalRegistry),
+			FILE_BASED_REGISTRY: Boolean(options.experimentalRegistry ?? true),
 			JSON_CONFIG_FILE: Boolean(options.experimentalJsonConfig),
 		},
 		() => getMiniflareOptionsFromConfig(rawConfig, env, options)

--- a/packages/wrangler/src/dev-registry/file-registry.ts
+++ b/packages/wrangler/src/dev-registry/file-registry.ts
@@ -65,6 +65,8 @@ async function devRegistry(
 async function startWorkerRegistry(
 	cb?: (registry: WorkerRegistry | undefined) => void
 ) {
+	await loadWorkerDefinitions();
+	cb?.({ ...globalWorkers });
 	globalWatcher ??= watch(DEV_REGISTRY_PATH, {
 		persistent: true,
 	}).on("all", async () => {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -314,7 +314,7 @@ const command = defineCommand({
 			type: "boolean",
 			describe:
 				"Use the experimental file based dev registry for multi-worker development",
-			default: false,
+			default: true,
 		},
 		"experimental-vectorize-bind-to-prod": {
 			type: "boolean",


### PR DESCRIPTION
Fixes #6955

Use the file based registry by default. It can still be disabled by setting `--x-registry=false` when running `wrangler dev`

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: existing tests should continue to pass
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental flag

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
