### PR TITLE
URL encode project names

### DIFF
--- a/fixtures/vitest-pool-workers-examples/durable-objects/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/durable-objects/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineWorkersProject } from "@cloudflare/vitest-pool-workers/config";
 
 export default defineWorkersProject({
 	test: {
+		name: "@scoped/durable-objects",
 		poolOptions: {
 			workers: {
 				singleWorker: true,

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -174,7 +174,7 @@ interface Project {
 const allProjects = new Map<string /* projectName */, Project>();
 
 function getRunnerName(project: WorkspaceProject, testFile?: string) {
-	const name = `${WORKER_NAME_PREFIX}runner-${project.getName()}`;
+	const name = `${WORKER_NAME_PREFIX}runner-${encodeURIComponent(project.getName())}`;
 	if (testFile === undefined) {
 		return name;
 	}


### PR DESCRIPTION
Fixes #6954

URL encode project names to support scoped names (e.g. `@scoped/durable-objects`) when using `runInDurableObject()`

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by fixtures
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
