### PR TITLE
Add test for custom build with `unstable_dev()`

### DIFF
--- a/fixtures/unstable_dev/src/wrangler-dev.mjs
+++ b/fixtures/unstable_dev/src/wrangler-dev.mjs
@@ -1,7 +1,7 @@
 import { unstable_dev } from "wrangler";
 
 //since the script is invoked from the directory above, need to specify index.js is in src/
-const worker = await unstable_dev("src/index.js");
+const worker = await unstable_dev("dist/out.js", { config: "wrangler.toml" });
 
 const resp = await worker.fetch("http://localhost:8787/");
 const text = await resp.text();

--- a/fixtures/unstable_dev/wrangler.toml
+++ b/fixtures/unstable_dev/wrangler.toml
@@ -1,0 +1,6 @@
+name = "unstable_dev"
+main = "dist/out.js"
+compatibility_date = "2022-12-08"
+
+[build]
+command = "npx esbuild src/index.js --outfile=dist/out.js"


### PR DESCRIPTION
Test to validate that #2389 is no longer an issue

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Adds a fixture test
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: validating a bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
