### PR TITLE
Synchronize observability settings during versions deploy

### DIFF
--- a/.changeset/chilled-apes-repeat.md
+++ b/.changeset/chilled-apes-repeat.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+fix: synchronize observability settings during `wrangler versions deploy`
+
+When running `wrangler versions deploy`, Wrangler will now update `observability` settings in addition to `logpush` and `tail_consumers`. Unlike `wrangler deploy`, it will not disable observability when `observability` is undefined in `wrangler.toml`.


### PR DESCRIPTION
In addition to logpush and tail_consumers, patch observability settings
on version deploy. This still doesn't quite match the behavior of
"wrangler deploy", which will disable observability if it is not defined
in wrangler.toml (as of #6776), but at least this is more correct for now.

- Tests
  - [x] Tests included
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] Required
- Public documentation
  - [x] Documentation not necessary because: already exists: https://developers.cloudflare.com/workers/wrangler/configuration/#observability

