### PR TITLE
Added location option for the Wrangler R2 bucket create command

### DIFF
--- a/.changeset/tender-pens-change.md
+++ b/.changeset/tender-pens-change.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Added location hint option for the Wrangler R2 bucket create command

--- a/packages/wrangler/src/r2/constants.ts
+++ b/packages/wrangler/src/r2/constants.ts
@@ -2,3 +2,4 @@
  * The maximum file size we can upload using the V4 API.
  */
 export const MAX_UPLOAD_SIZE = 300 * 1024 * 1024;
+export const LOCATION_CHOICES = ["weur", "eeur", "apac", "wnam", "enam"];

--- a/packages/wrangler/src/r2/create.ts
+++ b/packages/wrangler/src/r2/create.ts
@@ -1,0 +1,76 @@
+import { printWranglerBanner } from "..";
+import { readConfig } from "../config";
+import { UserError } from "../errors";
+import { logger } from "../logger";
+import * as metrics from "../metrics";
+import { requireAuth } from "../user";
+import { LOCATION_CHOICES } from "./constants";
+import { createR2Bucket, isValidR2BucketName } from "./helpers";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+export function Options(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("name", {
+			describe: "The name of the new bucket",
+			type: "string",
+			demandOption: true,
+		})
+		.option("location", {
+			describe:
+				"The optional location hint that determines geographic placement of the R2 bucket",
+			choices: LOCATION_CHOICES,
+			requiresArg: true,
+			type: "string",
+		})
+		.option("storage-class", {
+			describe: "The default storage class for objects uploaded to this bucket",
+			alias: "s",
+			requiresArg: false,
+			type: "string",
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the new bucket will be created",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		});
+}
+
+type HandlerOptions = StrictYargsOptionsToInterface<typeof Options>;
+export async function Handler(args: HandlerOptions) {
+	await printWranglerBanner();
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+	const { name, location, storageClass, jurisdiction } = args;
+
+	if (!isValidR2BucketName(name)) {
+		throw new UserError(
+			`The bucket name "${name}" is invalid. Bucket names can only have alphanumeric and - characters.`
+		);
+	}
+
+	if (jurisdiction && location) {
+		throw new UserError(
+			"Provide either a jurisdiction or location hint - not both."
+		);
+	}
+
+	let fullBucketName = `${name}`;
+	if (jurisdiction !== undefined) {
+		fullBucketName += ` (${jurisdiction})`;
+	}
+
+	logger.log(`Creating bucket '${fullBucketName}'...`);
+	await createR2Bucket(accountId, name, location, jurisdiction, storageClass);
+	logger.log(
+		`✅ Created bucket '${fullBucketName}' with${
+			location ? ` location hint ${location} and` : ``
+		} default storage class of ${storageClass ? storageClass : `Standard`}.`
+	);
+	await metrics.sendMetricsEvent("create r2 bucket", {
+		sendMetrics: config.send_metrics,
+	});
+}

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -48,6 +48,7 @@ export async function listR2Buckets(
 export async function createR2Bucket(
 	accountId: string,
 	bucketName: string,
+	location?: string,
 	jurisdiction?: string,
 	storageClass?: string
 ): Promise<void> {
@@ -60,6 +61,7 @@ export async function createR2Bucket(
 		body: JSON.stringify({
 			name: bucketName,
 			...(storageClass !== undefined && { storageClass }),
+			...(location !== undefined && { locationHint: location }),
 		}),
 		headers,
 	});

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -11,13 +11,12 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { requireAuth } from "../user";
 import { MAX_UPLOAD_SIZE } from "./constants";
+import * as Create from "./create";
 import {
 	bucketAndKeyFromObjectPath,
-	createR2Bucket,
 	deleteR2Bucket,
 	deleteR2Object,
 	getR2Object,
-	isValidR2BucketName,
 	listR2Buckets,
 	putR2Object,
 	updateR2BucketStorageClass,
@@ -434,66 +433,8 @@ export function r2(r2Yargs: CommonYargsArgv, subHelp: SubHelp) {
 			r2BucketYargs.command(
 				"create <name>",
 				"Create a new R2 bucket",
-				(yargs) => {
-					return yargs
-						.positional("name", {
-							describe: "The name of the new bucket",
-							type: "string",
-							demandOption: true,
-						})
-						.option("jurisdiction", {
-							describe: "The jurisdiction where the new bucket will be created",
-							alias: "J",
-							requiresArg: true,
-							type: "string",
-						})
-						.option("storage-class", {
-							describe:
-								"The default storage class for objects uploaded to this bucket",
-							alias: "s",
-							requiresArg: false,
-							type: "string",
-						});
-				},
-				async (args) => {
-					await printWranglerBanner();
-
-					if (!isValidR2BucketName(args.name)) {
-						throw new CommandLineArgsError(
-							`The bucket name "${args.name}" is invalid. Bucket names can only have alphanumeric and - characters.`
-						);
-					}
-
-					const config = readConfig(args.config, args);
-
-					const accountId = await requireAuth(config);
-
-					let fullBucketName = `${args.name}`;
-					if (args.jurisdiction !== undefined) {
-						fullBucketName += ` (${args.jurisdiction})`;
-					}
-
-					let defaultStorageClass = ` with default storage class set to `;
-					if (args.storageClass !== undefined) {
-						defaultStorageClass += args.storageClass;
-					} else {
-						defaultStorageClass += "Standard";
-					}
-
-					logger.log(
-						`Creating bucket ${fullBucketName}${defaultStorageClass}.`
-					);
-					await createR2Bucket(
-						accountId,
-						args.name,
-						args.jurisdiction,
-						args.storageClass
-					);
-					logger.log(`Created bucket ${fullBucketName}${defaultStorageClass}.`);
-					await metrics.sendMetricsEvent("create r2 bucket", {
-						sendMetrics: config.send_metrics,
-					});
-				}
+				Create.Options,
+				Create.Handler
 			);
 
 			r2BucketYargs.command("update", "Update bucket state", (updateYargs) => {


### PR DESCRIPTION
Added location option for the Wrangler R2 bucket create command

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: test changes covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/17787
  - [ ] Documentation not necessary because:

