### PR TITLE
Add guidance to c3 on where to file issues 

### DIFF
--- a/.changeset/metal-ladybugs-teach.md
+++ b/.changeset/metal-ladybugs-teach.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Added link to where to file issues

--- a/packages/create-cloudflare/src/__tests__/dialog.test.ts
+++ b/packages/create-cloudflare/src/__tests__/dialog.test.ts
@@ -95,6 +95,9 @@ describe("dialog helpers", () => {
 				📖 Explore Documentation
 				https://developers.cloudflare.com/workers
 
+				🐛 Report an Issue
+				https://github.com/cloudflare/workers-sdk/issues/new/choose
+
 				💬 Join our Community
 				https://discord.cloudflare.com
 				────────────────────────────────────────────────────────────
@@ -126,6 +129,9 @@ describe("dialog helpers", () => {
 
 				📖 Explore Documentation
 				https://developers.cloudflare.com/pages
+
+				🐛 Report an Issue
+				https://github.com/cloudflare/workers-sdk/issues/new/choose
 
 				💬 Join our Community
 				https://discord.cloudflare.com

--- a/packages/create-cloudflare/src/dialog.ts
+++ b/packages/create-cloudflare/src/dialog.ts
@@ -68,6 +68,7 @@ export const printSummary = (ctx: C3Context) => {
 	]);
 	const documentationUrl = `https://developers.cloudflare.com/${ctx.template.platform}`;
 	const discordUrl = `https://discord.cloudflare.com`;
+    const reportIssueUrl = "https://github.com/cloudflare/workers-sdk/issues/new/choose";
 
 	// Prepare the dialog
 	const lines = [
@@ -95,6 +96,9 @@ export const printSummary = (ctx: C3Context) => {
 		``,
 		`💬 Join our Community`,
 		`${blue.underline(hyperlink(discordUrl))}`,
+        ``,
+        `🐛 Report an Issue`,
+		`${blue.underline(hyperlink(reportIssueUrl))}`,
 	);
 
 	const dialog = createDialog(lines);

--- a/packages/create-cloudflare/src/dialog.ts
+++ b/packages/create-cloudflare/src/dialog.ts
@@ -94,11 +94,11 @@ export const printSummary = (ctx: C3Context) => {
 		`📖 Explore Documentation`,
 		`${blue.underline(hyperlink(documentationUrl))}`,
 		``,
-		`💬 Join our Community`,
-		`${blue.underline(hyperlink(discordUrl))}`,
-        ``,
         `🐛 Report an Issue`,
 		`${blue.underline(hyperlink(reportIssueUrl))}`,
+        ``,
+		`💬 Join our Community`,
+		`${blue.underline(hyperlink(discordUrl))}`,
 	);
 
 	const dialog = createDialog(lines);

--- a/packages/create-cloudflare/src/dialog.ts
+++ b/packages/create-cloudflare/src/dialog.ts
@@ -68,7 +68,8 @@ export const printSummary = (ctx: C3Context) => {
 	]);
 	const documentationUrl = `https://developers.cloudflare.com/${ctx.template.platform}`;
 	const discordUrl = `https://discord.cloudflare.com`;
-    const reportIssueUrl = "https://github.com/cloudflare/workers-sdk/issues/new/choose";
+	const reportIssueUrl =
+		"https://github.com/cloudflare/workers-sdk/issues/new/choose";
 
 	// Prepare the dialog
 	const lines = [
@@ -94,9 +95,9 @@ export const printSummary = (ctx: C3Context) => {
 		`📖 Explore Documentation`,
 		`${blue.underline(hyperlink(documentationUrl))}`,
 		``,
-        `🐛 Report an Issue`,
+		`🐛 Report an Issue`,
 		`${blue.underline(hyperlink(reportIssueUrl))}`,
-        ``,
+		``,
 		`💬 Join our Community`,
 		`${blue.underline(hyperlink(discordUrl))}`,
 	);


### PR DESCRIPTION
Fixes DEVX-1388.

Adds a link to c3 message on where to go to file issues.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: minor update to messaging
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor update to messaging

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
