### PR TITLE
Support multi-worker Durable Object RPC

### DIFF
--- a/fixtures/do-bound/index.ts
+++ b/fixtures/do-bound/index.ts
@@ -1,4 +1,4 @@
-import { DurableObject } from "cloudflare:workers";
+import { DurableObject, RpcTarget } from "cloudflare:workers";
 
 export class ThingObject extends DurableObject {
 	fetch(request) {
@@ -7,9 +7,24 @@ export class ThingObject extends DurableObject {
 	get property() {
 		return "property:ping";
 	}
+	get prop1() {
+		return new Deep1();
+	}
 	method() {
 		return "method:ping";
 	}
 }
+
+class Deep1 extends RpcTarget {
+	get prop2() {
+		return "deep:prop2";
+	}
+}
+
+// class Deep2 extends RpcTarget {
+// 	get prop3() {
+// 		return "deep property";
+// 	}
+// }
 
 export default {}; // Required to treat as modules format worker

--- a/fixtures/do-bound/index.ts
+++ b/fixtures/do-bound/index.ts
@@ -1,0 +1,15 @@
+import { DurableObject } from "cloudflare:workers";
+
+export class ThingObject extends DurableObject {
+	fetch(request) {
+		return new Response("hello world");
+	}
+	get property() {
+		return "property:ping";
+	}
+	method() {
+		return "method:ping";
+	}
+}
+
+export default {}; // Required to treat as modules format worker

--- a/fixtures/do-bound/package.json
+++ b/fixtures/do-bound/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "do-bound",
+	"private": true,
+	"scripts": {
+		"test:ci": "vitest run",
+		"test:watch": "vitest"
+	},
+	"devDependencies": {
+		"wrangler": "workspace:*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/fixtures/do-bound/wrangler.toml
+++ b/fixtures/do-bound/wrangler.toml
@@ -1,8 +1,13 @@
 
 name = "do-bound"
 main = "index.ts"
+compatibility_date = "2024-10-28"
 
 [durable_objects]
 bindings = [
     { name = "OBJECT", class_name = "ThingObject" }
 ]
+
+[[migrations]]
+tag = "v1" # Should be unique for each
+new_classes = ["ThingObject"]

--- a/fixtures/do-bound/wrangler.toml
+++ b/fixtures/do-bound/wrangler.toml
@@ -1,6 +1,6 @@
-name = "worker-ts"
-main = "src/index.ts"
-compatibility_date = "2023-05-04"
+
+name = "do-bound"
+main = "index.ts"
 
 [durable_objects]
 bindings = [

--- a/fixtures/do-entry/index.ts
+++ b/fixtures/do-entry/index.ts
@@ -5,7 +5,15 @@ export default {
 
 		const { pathname } = new URL(request.url);
 		if (pathname === "/rpc") {
+			// stub.prop1.prop2.method('arg1')
+			// stub.prop1.method('arg1')
+			// stub.prop1 -> .then(...)
+			// stub.method('arg1')
 			return Response.json(await stub.method());
+		}
+
+		if (pathname === "/property") {
+			return Response.json(await stub.property);
 		}
 
 		return stub.fetch("https://placeholder:9999/", {

--- a/fixtures/do-entry/index.ts
+++ b/fixtures/do-entry/index.ts
@@ -16,6 +16,14 @@ export default {
 			return Response.json(await stub.property);
 		}
 
+		if (pathname === "/deep-1") {
+			return Response.json(await stub.prop1.prop2);
+		}
+
+		if (pathname === "/deep-2") {
+			return Response.json(await stub.prop1.prop2.prop3);
+		}
+
 		return stub.fetch("https://placeholder:9999/", {
 			method: "POST",
 			cf: { thing: true },

--- a/fixtures/do-entry/index.ts
+++ b/fixtures/do-entry/index.ts
@@ -1,0 +1,16 @@
+export default {
+	async fetch(request, env, ctx) {
+		const id = env.OBJECT.newUniqueId();
+		const stub = env.OBJECT.get(id);
+
+		const { pathname } = new URL(request.url);
+		if (pathname === "/rpc") {
+			return Response.json(await stub.method());
+		}
+
+		return stub.fetch("https://placeholder:9999/", {
+			method: "POST",
+			cf: { thing: true },
+		});
+	},
+};

--- a/fixtures/do-entry/package.json
+++ b/fixtures/do-entry/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "do-entry",
+	"private": true,
+	"scripts": {
+		"test:ci": "vitest run",
+		"test:watch": "vitest"
+	},
+	"devDependencies": {
+		"wrangler": "workspace:*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/fixtures/do-entry/wrangler.toml
+++ b/fixtures/do-entry/wrangler.toml
@@ -1,6 +1,7 @@
 
 name = "do-entry"
 main = "index.ts"
+compatibility_date = "2024-10-28"
 
 [durable_objects]
 bindings = [

--- a/fixtures/do-entry/wrangler.toml
+++ b/fixtures/do-entry/wrangler.toml
@@ -1,0 +1,8 @@
+
+name = "do-entry"
+main = "index.ts"
+
+[durable_objects]
+bindings = [
+    { name = "OBJECT", class_name = "ThingObject", script_name = "do-bound" }
+]

--- a/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
+++ b/fixtures/entrypoints-rpc-tests/tests/entrypoints.spec.ts
@@ -557,6 +557,7 @@ test.only("should support binding to Durable Object in another worker", async ({
 
 					const { pathname } = new URL(request.url);
 					if (pathname === "/rpc") {
+						return Response.json(await stub.property);
 						return Response.json(await stub.method());
 					}
 

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -3,12 +3,12 @@ import { randomBytes } from "isomorphic-random-example";
 import { now } from "./dep";
 import { logErrors } from "./log";
 
-console.log("startup log");
+// console.log("startup log");
 
-console.log("The following error is a fake for testing");
-console.error(
-	"*** Received structured exception #0xc0000005: access violation; stack: 7ffe71872f57 7ff7834b643b 7ff7834b643b"
-);
+// console.log("The following error is a fake for testing");
+// console.error(
+// 	"*** Received structured exception #0xc0000005: access violation; stack: 7ffe71872f57 7ff7834b643b 7ff7834b643b"
+// );
 
 /** @param {Uint8Array} array */
 function hexEncode(array) {
@@ -19,6 +19,8 @@ function hexEncode(array) {
 
 export default {
 	async fetch(request, env) {
+		return Response.json(env.REMOTE_RPC.method());
+
 		console.log("request log");
 
 		const { pathname, origin, hostname, host } = new URL(request.url);

--- a/fixtures/worker-app/wrangler.toml
+++ b/fixtures/worker-app/wrangler.toml
@@ -8,3 +8,8 @@ crons = ["1 * * * *"]
 
 [version_metadata]
 binding = "METADATA"
+
+[durable_objects]
+bindings = [
+    { name = "REMOTE_RPC", class_name = "ThingObject", script_name = "worker-ts" }
+]

--- a/fixtures/worker-ts/src/index.ts
+++ b/fixtures/worker-ts/src/index.ts
@@ -1,3 +1,5 @@
+import { DurableObject } from "cloudflare:workers";
+
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
@@ -32,3 +34,15 @@ export default {
 		return new Response("Hello World!");
 	},
 };
+
+export class ThingObject extends DurableObject {
+	fetch() {
+		return new Response("hello");
+	}
+	get property() {
+		return "property:ping";
+	}
+	method() {
+		return "method:ping";
+	}
+}

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -393,7 +393,7 @@ type MiniflareBindingsConfig = Pick<
 function createExternalServiceBinding(
 	service: NonNullable<MiniflareBindingsConfig["services"]>[0],
 	config: MiniflareBindingsConfig,
-	notFoundServices: Set<string> | undefined
+	notFoundServices: Set<string>
 ) {
 	const target = config.workerDefinitions?.[service.service];
 	if (target?.host === undefined || target.port === undefined) {
@@ -561,7 +561,7 @@ export function buildMiniflareBindingOptions(config: MiniflareBindingsConfig): {
 							entrypoint: EXTERNAL_SERVICE_RECEIVER_NAME,
 						},
 						config,
-						undefined
+						notFoundServices
 					),
 				];
 			})
@@ -580,9 +580,6 @@ export function buildMiniflareBindingOptions(config: MiniflareBindingsConfig): {
 			// Add stub object classes that proxy requests to the correct session
 			externalObjects
 				.map(({ class_name, script_name }) => {
-					assert(script_name !== undefined);
-					const target = config.workerDefinitions?.[script_name];
-
 					const proxyDOClassName = getIdentifier(
 						`do_${script_name}_${class_name}`
 					);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/do-bound:
+    devDependencies:
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
+  fixtures/do-entry:
+    devDependencies:
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/durable-objects-app:
     devDependencies:
       '@cloudflare/workers-tsconfig':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.1.1
+      version: 2.1.1
+    '@vitest/snapshot':
+      specifier: ~2.1.1
+      version: 2.1.1
     vitest:
       specifier: ~2.1.1
       version: 2.1.1

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -19,6 +19,6 @@ export default defineConfig({
 		restoreMocks: true,
 		// A lot of the fixture tests are extremely flaky because of the dev registry
 		// Retry tests by default so that only real errors are reported
-		retry: 2,
+		retry: 0,
 	},
 });


### PR DESCRIPTION
Fixes #5918

Support Durable Object RPC across multiple wrangler instances

Only supports RPC method calls right now. RPC property access is coming shortly (in this PR)

The entire implementation is in src/dev/miniflare.ts

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
