### PR TITLE
Open devtools in default browser

### DIFF
--- a/.changeset/hungry-hornets-taste.md
+++ b/.changeset/hungry-hornets-taste.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Open devtools in default browser

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -1,13 +1,12 @@
 import { readFileSync } from "fs";
-import os from "node:os";
 import { fileURLToPath, URL } from "node:url";
 import path from "path";
-import open from "open";
 import {
 	isAllowedSourceMapPath,
 	isAllowedSourcePath,
 } from "../api/startDevWorker/bundle-allowed-paths";
 import { logger } from "../logger";
+import openInBrowser from "../open-in-browser";
 import { getSourceMappedString } from "../sourcemap";
 import type { EsbuildBundle } from "../dev/use-esbuild";
 import type Protocol from "devtools-protocol";
@@ -257,22 +256,6 @@ export const openInspector = async (
 	}
 	query.set("debugger", "true");
 	const url = `https://devtools.devprod.cloudflare.dev/js_app?${query.toString()}`;
-	const errorMessage =
-		"Failed to open inspector.\nInspector depends on having a Chromium-based browser installed, maybe you need to install one?";
 
-	// see: https://github.com/sindresorhus/open/issues/177#issue-610016699
-	let braveBrowser: string;
-	switch (os.platform()) {
-		case "darwin":
-		case "win32":
-			braveBrowser = "Brave";
-			break;
-		default:
-			braveBrowser = "brave";
-	}
-
-	const childProcess = await open(url);
-	childProcess.on("error", () => {
-		logger.warn(errorMessage);
-	});
+	await openInBrowser(url);
 };

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -271,22 +271,7 @@ export const openInspector = async (
 			braveBrowser = "brave";
 	}
 
-	const childProcess = await open(url, {
-		app: [
-			{
-				name: open.apps.chrome,
-			},
-			{
-				name: braveBrowser,
-			},
-			{
-				name: open.apps.edge,
-			},
-			{
-				name: open.apps.firefox,
-			},
-		],
-	});
+	const childProcess = await open(url);
 	childProcess.on("error", () => {
 		logger.warn(errorMessage);
 	});


### PR DESCRIPTION
Fixes #1445 

In the latest version of devtools (#7008), Safari is supported! This means we can finally just use the users default browser when opening a debugger.

Blocked on #7008

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: can't really be tested
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no test coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
