### PR TITLE
Restore turbo loose mode

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -36,6 +36,7 @@ runs:
         echo TURBO_TEAM=${{ inputs.turbo-team }} >> .env
         echo TURBO_TOKEN=${{ inputs.turbo-token }} >> .env
         echo TURBO_REMOTE_CACHE_SIGNATURE_KEY=${{ inputs.turbo-signature }} >> .env
+        echo TURBO_ENV_MODE=loose >> .env
 
     - name: Install NPM Dependencies
       shell: bash


### PR DESCRIPTION
Restore turbo loose mode after a change in defaults after Turbo v2: https://turbo.build/blog/turbo-2-0#correctness

(we can investigate strict mode as a follow-up, but this is currently causing our tests to fail and so is an okay bandaid)

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tooling
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tooling

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
