### PR TITLE
Added the ability to list, add, remove, and update R2 bucket custom domains

### DIFF
--- a/.changeset/tame-dryers-end.md
+++ b/.changeset/tame-dryers-end.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Added the ability to list, add, remove, and update R2 bucket custom domains.

--- a/.changeset/tame-dryers-end.md
+++ b/.changeset/tame-dryers-end.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
 Added the ability to list, add, remove, and update R2 bucket custom domains.

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -97,6 +97,7 @@ describe("r2", () => {
 				  wrangler r2 bucket delete <name>  Delete an R2 bucket
 				  wrangler r2 bucket sippy          Manage Sippy incremental migration on an R2 bucket
 				  wrangler r2 bucket notification   Manage event notification rules for an R2 bucket
+				  wrangler r2 bucket domain         Manage custom domains for an R2 bucket
 
 				GLOBAL FLAGS
 				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
@@ -131,6 +132,7 @@ describe("r2", () => {
 				  wrangler r2 bucket delete <name>  Delete an R2 bucket
 				  wrangler r2 bucket sippy          Manage Sippy incremental migration on an R2 bucket
 				  wrangler r2 bucket notification   Manage event notification rules for an R2 bucket
+				  wrangler r2 bucket domain         Manage custom domains for an R2 bucket
 
 				GLOBAL FLAGS
 				  -j, --experimental-json-config  Experimental: support wrangler.json  [boolean]
@@ -1464,6 +1466,187 @@ describe("r2", () => {
 						  -J, --jurisdiction  The jurisdiction where the bucket exists  [string]"
 
 					`);
+				});
+			});
+		});
+		describe("domain", () => {
+			mockAccountId();
+			mockApiToken();
+			describe("add", () => {
+				it("should add custom domain to the bucket as expected", async () => {
+					const bucketName = "my-bucket";
+					const domainName = "example.com";
+					const zoneId = "zone-id-123";
+					msw.use(
+						http.post(
+							"*/accounts/:accountId/r2/buckets/:bucketName/domains/custom",
+							async ({ request, params }) => {
+								const { accountId, bucketName: bucketParam } = params;
+								expect(accountId).toEqual("some-account-id");
+								expect(bucketName).toEqual(bucketParam);
+								const requestBody = await request.json();
+								expect(requestBody).toEqual({
+									domain: domainName,
+									zoneId: zoneId,
+									enabled: true,
+									minTLS: "1.0",
+								});
+								return HttpResponse.json(createFetchResult({}));
+							},
+							{ once: true }
+						)
+					);
+					await runWrangler(
+						`r2 bucket domain add ${bucketName} --domain ${domainName} --zone-id ${zoneId}`
+					);
+					expect(std.out).toMatchInlineSnapshot(`
+				"Connecting custom domain 'example.com' to bucket 'my-bucket'...
+				✨ Custom domain 'example.com' connected successfully."
+			  `);
+				});
+
+				it("should error if domain and zone-id are not provided", async () => {
+					const bucketName = "my-bucket";
+					await expect(
+						runWrangler(`r2 bucket domain add ${bucketName}`)
+					).rejects.toThrowErrorMatchingInlineSnapshot(
+						`[Error: Missing required arguments: domain, zone-id]`
+					);
+					expect(std.err).toMatchInlineSnapshot(`
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing required arguments: domain, zone-id[0m
+
+				"
+			  `);
+				});
+			});
+			describe("list", () => {
+				it("should list custom domains for a bucket as expected", async () => {
+					const bucketName = "my-bucket";
+					const mockDomains = [
+						{
+							domain: "example.com",
+							enabled: true,
+							status: {
+								ownership: "verified",
+								ssl: "active",
+							},
+							minTLS: "1.2",
+							zoneId: "zone-id-123",
+							zoneName: "example-zone",
+						},
+						{
+							domain: "test.com",
+							enabled: false,
+							status: {
+								ownership: "pending",
+								ssl: "pending",
+							},
+							minTLS: "1.0",
+							zoneId: "zone-id-456",
+							zoneName: "test-zone",
+						},
+					];
+					msw.use(
+						http.get(
+							"*/accounts/:accountId/r2/buckets/:bucketName/domains/custom",
+							async ({ params }) => {
+								const { accountId, bucketName: bucketParam } = params;
+								expect(accountId).toEqual("some-account-id");
+								expect(bucketParam).toEqual(bucketName);
+								return HttpResponse.json(
+									createFetchResult({
+										domains: mockDomains,
+									})
+								);
+							},
+							{ once: true }
+						)
+					);
+					await runWrangler(`r2 bucket domain list ${bucketName}`);
+					expect(std.out).toMatchInlineSnapshot(`
+				"Listing custom domains connected to bucket 'my-bucket'...
+				domain:            example.com
+				enabled:           Yes
+				ownership_status:  verified
+				ssl_status:        active
+				min_tls_version:   1.2
+				zone_id:           zone-id-123
+				zone_name:         example-zone
+
+				domain:            test.com
+				enabled:           No
+				ownership_status:  pending
+				ssl_status:        pending
+				min_tls_version:   1.0
+				zone_id:           zone-id-456
+				zone_name:         test-zone"
+			  `);
+				});
+			});
+			describe("remove", () => {
+				it("should remove a custom domain as expected", async () => {
+					const bucketName = "my-bucket";
+					const domainName = "example.com";
+					msw.use(
+						http.delete(
+							"*/accounts/:accountId/r2/buckets/:bucketName/domains/custom/:domainName",
+							async ({ params }) => {
+								const {
+									accountId,
+									bucketName: bucketParam,
+									domainName: domainParam,
+								} = params;
+								expect(accountId).toEqual("some-account-id");
+								expect(bucketParam).toEqual(bucketName);
+								expect(domainParam).toEqual(domainName);
+								return HttpResponse.json(createFetchResult({}));
+							},
+							{ once: true }
+						)
+					);
+					await runWrangler(
+						`r2 bucket domain remove ${bucketName} --domain ${domainName}`
+					);
+					expect(std.out).toMatchInlineSnapshot(`
+				"Removing custom domain 'example.com' from bucket 'my-bucket'...
+				Custom domain 'example.com' removed successfully."
+			  `);
+				});
+			});
+			describe("update", () => {
+				it("should update a custom domain as expected", async () => {
+					const bucketName = "my-bucket";
+					const domainName = "example.com";
+					msw.use(
+						http.put(
+							"*/accounts/:accountId/r2/buckets/:bucketName/domains/custom/:domainName",
+							async ({ request, params }) => {
+								const {
+									accountId,
+									bucketName: bucketParam,
+									domainName: domainParam,
+								} = params;
+								expect(accountId).toEqual("some-account-id");
+								expect(bucketParam).toEqual(bucketName);
+								expect(domainParam).toEqual(domainName);
+								const requestBody = await request.json();
+								expect(requestBody).toEqual({
+									domain: domainName,
+									enabled: false,
+									minTLS: "1.3",
+								});
+								return HttpResponse.json(createFetchResult({}));
+							},
+							{ once: true }
+						)
+					);
+					await runWrangler(
+						`r2 bucket domain update ${bucketName} --domain ${domainName} --enabled false --min-tls 1.3`
+					);
+					expect(std.out).toMatchInlineSnapshot(`
+				"Updating custom domain 'example.com' for bucket 'my-bucket'...
+				✨ Custom domain 'example.com' updated successfully."
+			  `);
 				});
 			});
 		});

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -1497,7 +1497,7 @@ describe("r2", () => {
 						)
 					);
 					await runWrangler(
-						`r2 bucket domain add ${bucketName} --domain ${domainName} --zone-id ${zoneId}`
+						`r2 bucket domain add ${bucketName} --domain ${domainName} --zone-id ${zoneId} --force`
 					);
 					expect(std.out).toMatchInlineSnapshot(`
 				"Connecting custom domain 'example.com' to bucket 'my-bucket'...
@@ -1508,7 +1508,7 @@ describe("r2", () => {
 				it("should error if domain and zone-id are not provided", async () => {
 					const bucketName = "my-bucket";
 					await expect(
-						runWrangler(`r2 bucket domain add ${bucketName}`)
+						runWrangler(`r2 bucket domain add ${bucketName} --force`)
 					).rejects.toThrowErrorMatchingInlineSnapshot(
 						`[Error: Missing required arguments: domain, zone-id]`
 					);
@@ -1632,7 +1632,6 @@ describe("r2", () => {
 								const requestBody = await request.json();
 								expect(requestBody).toEqual({
 									domain: domainName,
-									enabled: false,
 									minTLS: "1.3",
 								});
 								return HttpResponse.json(createFetchResult({}));
@@ -1641,7 +1640,7 @@ describe("r2", () => {
 						)
 					);
 					await runWrangler(
-						`r2 bucket domain update ${bucketName} --domain ${domainName} --enabled false --min-tls 1.3`
+						`r2 bucket domain update ${bucketName} --domain ${domainName} --min-tls 1.3`
 					);
 					expect(std.out).toMatchInlineSnapshot(`
 				"Updating custom domain 'example.com' for bucket 'my-bucket'...

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -1605,7 +1605,7 @@ describe("r2", () => {
 						)
 					);
 					await runWrangler(
-						`r2 bucket domain remove ${bucketName} --domain ${domainName}`
+						`r2 bucket domain remove ${bucketName} --domain ${domainName} --force`
 					);
 					expect(std.out).toMatchInlineSnapshot(`
 				"Removing custom domain 'example.com' from bucket 'my-bucket'...

--- a/packages/wrangler/src/__tests__/r2/helpers.test.ts
+++ b/packages/wrangler/src/__tests__/r2/helpers.test.ts
@@ -13,7 +13,6 @@ describe("event notifications", () => {
 
 	test("tableFromNotificationsGetResponse", async () => {
 		const bucketName = "my-bucket";
-		const config = { account_id: "my-account" };
 		const response: GetNotificationConfigResponse = {
 			bucketName,
 			queues: [
@@ -48,10 +47,7 @@ describe("event notifications", () => {
 				},
 			],
 		};
-		const tableOutput = await tableFromNotificationGetResponse(
-			config,
-			response
-		);
+		const tableOutput = tableFromNotificationGetResponse(response);
 		logger.log(tableOutput.map((x) => formatLabelledValues(x)).join("\n\n"));
 
 		await expect(std.out).toMatchInlineSnapshot(`

--- a/packages/wrangler/src/r2/domain.ts
+++ b/packages/wrangler/src/r2/domain.ts
@@ -1,0 +1,218 @@
+import { readConfig } from "../config";
+import { logger } from "../logger";
+import { printWranglerBanner } from "../update-check";
+import { requireAuth } from "../user";
+import formatLabelledValues from "../utils/render-labelled-values";
+import {
+	attachCustomDomainToBucket,
+	configureCustomDomainSettings,
+	listCustomDomainsOfBucket,
+	removeCustomDomainFromBucket,
+	tableFromCustomDomainListResponse,
+} from "./helpers";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+export function ListOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("bucket", {
+			describe:
+				"The name of the R2 bucket whose connected custom domains will be listed",
+			type: "string",
+			demandOption: true,
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		});
+}
+
+export async function ListHandler(
+	args: StrictYargsOptionsToInterface<typeof ListOptions>
+) {
+	await printWranglerBanner();
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	const { bucket, jurisdiction } = args;
+
+	logger.log(`Listing custom domains connected to bucket '${bucket}'...`);
+
+	const domains = await listCustomDomainsOfBucket(
+		accountId,
+		bucket,
+		jurisdiction
+	);
+
+	if (domains.length === 0) {
+		logger.log("There are no custom domains connected to this bucket.");
+	} else {
+		const tableOutput = tableFromCustomDomainListResponse(domains);
+		logger.log(tableOutput.map((x) => formatLabelledValues(x)).join("\n\n"));
+	}
+}
+
+export function AddOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("bucket", {
+			describe: "The name of the R2 bucket to connect a custom domain to",
+			type: "string",
+			demandOption: true,
+		})
+		.option("domain", {
+			describe: "The custom domain to connect to the R2 bucket",
+			type: "string",
+			demandOption: true,
+		})
+		.option("zone-id", {
+			describe: "The zone ID associated with the custom domain",
+			type: "string",
+			demandOption: true,
+		})
+		.option("enabled", {
+			describe:
+				"Whether to enable public access at the custom domain (default is enabled)",
+			type: "boolean",
+		})
+		.option("min-tls", {
+			describe:
+				"Set the minimum TLS version for the custom domain (defaults to 1.0 if not set)",
+			choices: ["1.0", "1.1", "1.2", "1.3"],
+			type: "string",
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		});
+}
+
+export async function AddHandler(
+	args: StrictYargsOptionsToInterface<typeof AddOptions>
+) {
+	await printWranglerBanner();
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	const {
+		bucket,
+		domain,
+		zoneId,
+		enabled = true,
+		minTls = "1.0",
+		jurisdiction,
+	} = args;
+
+	logger.log(`Connecting custom domain '${domain}' to bucket '${bucket}'...`);
+
+	await attachCustomDomainToBucket(
+		accountId,
+		bucket,
+		{
+			domain,
+			zoneId,
+			enabled,
+			minTLS: minTls,
+		},
+		jurisdiction
+	);
+
+	logger.log(`✨ Custom domain '${domain}' connected successfully.`);
+}
+
+export function RemoveOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("bucket", {
+			describe: "The name of the R2 bucket to remove the custom domain from",
+			type: "string",
+			demandOption: true,
+		})
+		.option("domain", {
+			describe: "The custom domain to remove from the R2 bucket",
+			type: "string",
+			demandOption: true,
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		});
+}
+
+export async function RemoveHandler(
+	args: StrictYargsOptionsToInterface<typeof RemoveOptions>
+) {
+	await printWranglerBanner();
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	const { bucket, domain, jurisdiction } = args;
+
+	logger.log(`Removing custom domain '${domain}' from bucket '${bucket}'...`);
+
+	await removeCustomDomainFromBucket(accountId, bucket, domain, jurisdiction);
+
+	logger.log(`Custom domain '${domain}' removed successfully.`);
+}
+
+export function UpdateOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("bucket", {
+			describe:
+				"The name of the R2 bucket associated with the custom domain to update",
+			type: "string",
+			demandOption: true,
+		})
+		.option("domain", {
+			describe: "The custom domain whose settings will be updated",
+			type: "string",
+			demandOption: true,
+		})
+		.option("enabled", {
+			describe: "Enable or disable public access at the custom domain",
+			type: "boolean",
+		})
+		.option("min-tls", {
+			describe: "Update the minimum TLS version for the custom domain",
+			choices: ["1.0", "1.1", "1.2", "1.3"],
+			type: "string",
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		});
+}
+
+export async function UpdateHandler(
+	args: StrictYargsOptionsToInterface<typeof UpdateOptions>
+) {
+	await printWranglerBanner();
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	const { bucket, domain, enabled, minTls, jurisdiction } = args;
+
+	logger.log(`Updating custom domain '${domain}' for bucket '${bucket}'...`);
+
+	await configureCustomDomainSettings(
+		accountId,
+		bucket,
+		domain,
+		{
+			domain,
+			enabled,
+			minTLS: minTls,
+		},
+		jurisdiction
+	);
+
+	logger.log(`✨ Custom domain '${domain}' updated successfully.`);
+}

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -610,7 +610,6 @@ export async function deleteEventNotificationConfig(
 
 export interface CustomDomainConfig {
 	domain: string;
-	enabled?: boolean;
 	minTLS?: string;
 	zoneId?: string;
 }
@@ -645,7 +644,10 @@ export async function attachCustomDomainToBucket(
 		{
 			method: "POST",
 			headers,
-			body: JSON.stringify(config),
+			body: JSON.stringify({
+				...config,
+				enabled: true,
+			}),
 		}
 	);
 }

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -12,6 +12,7 @@ import * as metrics from "../metrics";
 import { requireAuth } from "../user";
 import { MAX_UPLOAD_SIZE } from "./constants";
 import * as Create from "./create";
+import * as Domain from "./domain";
 import {
 	bucketAndKeyFromObjectPath,
 	deleteR2Bucket,
@@ -604,6 +605,38 @@ export function r2(r2Yargs: CommonYargsArgv, subHelp: SubHelp) {
 							"Delete an event notification rule from an R2 bucket",
 							Notification.DeleteOptions,
 							Notification.DeleteHandler
+						);
+				}
+			);
+
+			r2BucketYargs.command(
+				"domain",
+				"Manage custom domains for an R2 bucket",
+				(domainYargs) => {
+					return domainYargs
+						.command(
+							"list <bucket>",
+							"List custom domains for an R2 bucket",
+							Domain.ListOptions,
+							Domain.ListHandler
+						)
+						.command(
+							"add <bucket>",
+							"Connect a custom domain to an R2 bucket",
+							Domain.AddOptions,
+							Domain.AddHandler
+						)
+						.command(
+							"remove <bucket>",
+							"Remove a custom domain from an R2 bucket",
+							Domain.RemoveOptions,
+							Domain.RemoveHandler
+						)
+						.command(
+							"update <bucket>",
+							"Update settings for a custom domain connected to an R2 bucket",
+							Domain.UpdateOptions,
+							Domain.UpdateHandler
 						);
 				}
 			);

--- a/packages/wrangler/src/r2/notification.ts
+++ b/packages/wrangler/src/r2/notification.ts
@@ -51,7 +51,7 @@ export async function ListHandler(
 		bucket,
 		jurisdiction
 	);
-	const tableOutput = await tableFromNotificationGetResponse(config, resp);
+	const tableOutput = tableFromNotificationGetResponse(resp);
 	logger.log(tableOutput.map((x) => formatLabelledValues(x)).join("\n\n"));
 }
 


### PR DESCRIPTION
Added the ability to list, add, remove, and update R2 bucket custom domains.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: test changes covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/17802
  - [ ] Documentation not necessary because:
