### PR TITLE
Rename the framework name

### DIFF
--- a/.changeset/happy-items-buy.md
+++ b/.changeset/happy-items-buy.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Rename the framework as it appears in the CLI
+
+The name currently displayed in the CLI is `Svelte`. However, all of the options actually create a `SvelteKit` app, and the name `SvelteKit` is also used in the [documentation](https://developers.cloudflare.com/pages/framework-guides/deploy-a-svelte-site/).

--- a/.changeset/happy-items-buy.md
+++ b/.changeset/happy-items-buy.md
@@ -2,6 +2,6 @@
 "create-cloudflare": patch
 ---
 
-Rename the framework as it appears in the CLI
+Rename the framework name
 
 The name currently displayed in the CLI is `Svelte`. However, all of the options actually create a `SvelteKit` app, and the name `SvelteKit` is also used in the [documentation](https://developers.cloudflare.com/pages/framework-guides/deploy-a-svelte-site/).

--- a/packages/create-cloudflare/templates-experimental/svelte/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/svelte/c3.ts
@@ -98,7 +98,7 @@ const config: TemplateConfig = {
 	configVersion: 1,
 	id: "svelte",
 	frameworkCli: "sv",
-	displayName: "Svelte",
+	displayName: "SvelteKit",
 	platform: "workers",
 	copyFiles: {
 		variants: {

--- a/packages/create-cloudflare/templates/svelte/c3.ts
+++ b/packages/create-cloudflare/templates/svelte/c3.ts
@@ -98,7 +98,7 @@ const config: TemplateConfig = {
 	configVersion: 1,
 	id: "svelte",
 	frameworkCli: "sv",
-	displayName: "Svelte",
+	displayName: "SvelteKit",
 	platform: "pages",
 	copyFiles: {
 		variants: {


### PR DESCRIPTION
The name currently displayed in the CLI is `Svelte`. However, all of the options actually create a `SvelteKit` app, and the name `SvelteKit` is also used in the [documentation](https://developers.cloudflare.com/pages/framework-guides/deploy-a-svelte-site/).

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: only display name change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it matches existing features with documentation.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
