### PR TITLE
chore: update r2 e2e snapshot

### DIFF
--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -20,8 +20,8 @@ describe("r2", () => {
 		const output = await helper.run(`wrangler r2 bucket create ${bucketName}`);
 
 		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
-			"Creating bucket tmp-e2e-r2-00000000-0000-0000-0000-000000000000 with default storage class set to Standard.
-			Created bucket tmp-e2e-r2-00000000-0000-0000-0000-000000000000 with default storage class set to Standard."
+			"Creating bucket 'tmp-e2e-r2-00000000-0000-0000-0000-000000000000'...
+			✅ Created bucket 'tmp-e2e-r2-00000000-0000-0000-0000-000000000000' with default storage class of Standard."
 		`);
 	});
 


### PR DESCRIPTION
Fixes #7092.

This updates the r2 e2e snapshot that is currently broken on main.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: update snapshot

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
