### PR TITLE
Adds a HTTP header to indicate retried requests

### DIFF
--- a/.changeset/clean-brooms-exercise.md
+++ b/.changeset/clean-brooms-exercise.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore: Add instrumentation for retries

--- a/packages/wrangler/src/__tests__/utils/retry.test.ts
+++ b/packages/wrangler/src/__tests__/utils/retry.test.ts
@@ -1,0 +1,113 @@
+import { setTimeout } from "node:timers/promises";
+import {
+	alsAttemptCounter,
+	ExponentialBackoff,
+	LinearBackoff,
+	retryOnError,
+} from "../../utils/retry";
+
+const countTo = (n: number): number[] =>
+	Array.from({ length: n }, (_, i) => i + 1); // [1, 2, ..., n]
+
+describe("retryOnError", () => {
+	beforeEach(() => {
+		vi.mock("node:timers/promises", async () => {
+			const mockSetTimeout = vi.fn();
+			mockSetTimeout.mockImplementation(async () => {
+				return Promise.resolve(null);
+			});
+			return { setTimeout: mockSetTimeout };
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("[sync] it retries an action the maxAttempts times", async () => {
+		const alsAttempts: (number | undefined)[] = [];
+		let actualAttemptCount = 0;
+		const result = retryOnError(() => {
+			actualAttemptCount += 1;
+			const reportedAttemptCount = alsAttemptCounter.getStore();
+			expect(reportedAttemptCount).toBe(actualAttemptCount);
+			alsAttempts.push(reportedAttemptCount);
+			throw new Error("bang");
+		}, 5);
+		await expect(result).rejects.toThrow("bang");
+		expect(actualAttemptCount).toBe(5);
+		expect(alsAttempts).toEqual(countTo(5));
+	});
+
+	test("[async] it retries an action the maxAttempts times", async () => {
+		const alsAttempts: (number | undefined)[] = [];
+		let actualAttemptCount = 0;
+		const result = retryOnError(async () => {
+			actualAttemptCount += 1;
+			const reportedAttemptCount = alsAttemptCounter.getStore();
+			expect(reportedAttemptCount).toBe(actualAttemptCount);
+			alsAttempts.push(reportedAttemptCount);
+			throw new Error("bang");
+		}, 5);
+		await expect(result).rejects.toThrow("bang");
+		expect(actualAttemptCount).toBe(5);
+		expect(alsAttempts).toEqual(countTo(5));
+	});
+
+	test("exits early on success", async () => {
+		let actualAttemptCount = 0;
+		const result = retryOnError(() => {
+			actualAttemptCount += 1;
+			if (actualAttemptCount === 3) {
+				return "success";
+			}
+			throw new Error("bang");
+		}, 5);
+		await expect(result).resolves.toEqual("success");
+		expect(actualAttemptCount).toBe(3);
+	});
+
+	test("constant backoff", async () => {
+		await expect(
+			retryOnError(() => {
+				throw new Error("bang");
+			}, 5)
+		).rejects.toThrow("bang");
+		expect(setTimeout).toHaveBeenNthCalledWith(1, 2000);
+		expect(setTimeout).toHaveBeenNthCalledWith(2, 2000);
+		expect(setTimeout).toHaveBeenNthCalledWith(3, 2000);
+		expect(setTimeout).toHaveBeenNthCalledWith(4, 2000);
+	});
+
+	test("linear backoff", async () => {
+		await expect(
+			retryOnError(
+				() => {
+					throw new Error("bang");
+				},
+				5,
+				{ strategy: LinearBackoff }
+			)
+		).rejects.toThrow("bang");
+		expect(setTimeout).toHaveBeenNthCalledWith(1, 2000);
+		expect(setTimeout).toHaveBeenNthCalledWith(2, 4000);
+		expect(setTimeout).toHaveBeenNthCalledWith(3, 6000);
+		expect(setTimeout).toHaveBeenNthCalledWith(4, 8000);
+	});
+
+	test("exponential backoff", async () => {
+		await expect(
+			retryOnError(
+				() => {
+					throw new Error("bang");
+				},
+				5,
+				{ strategy: ExponentialBackoff }
+			)
+		).rejects.toThrow("bang");
+		expect(setTimeout).toHaveBeenNthCalledWith(1, 2000);
+		expect(setTimeout).toHaveBeenNthCalledWith(2, 4000);
+		expect(setTimeout).toHaveBeenNthCalledWith(3, 8000);
+		expect(setTimeout).toHaveBeenNthCalledWith(4, 16000);
+	});
+});

--- a/packages/wrangler/src/utils/retry.ts
+++ b/packages/wrangler/src/utils/retry.ts
@@ -1,18 +1,57 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { setTimeout } from "node:timers/promises";
+
+export const alsAttemptCounter = new AsyncLocalStorage<number>();
+
+type BackoffStrategy = (ms: number, initMs: number) => number;
+
+export const ConstantBackoff: BackoffStrategy = (ms) => ms;
+export const LinearBackoff: BackoffStrategy = (ms, initMs) => ms + initMs;
+export const ExponentialBackoff: BackoffStrategy = (ms) => ms * 2;
+
+interface Backoff {
+	ms: number;
+	initMs: number;
+	strategy: BackoffStrategy;
+}
+
+async function retryOnErrorInner<T>(
+	action: () => T | Promise<T>,
+	maxAttempts: number,
+	backoff: Backoff,
+	attempt: number
+): Promise<T> {
+	try {
+		return await alsAttemptCounter.run(attempt, action);
+	} catch (err) {
+		if (attempt >= maxAttempts) {
+			throw err;
+		}
+		await setTimeout(backoff.ms);
+		return retryOnErrorInner(
+			action,
+			maxAttempts,
+			{
+				...backoff,
+				ms: backoff.strategy(backoff.ms, backoff.initMs),
+			},
+			attempt + 1
+		);
+	}
+}
 
 export async function retryOnError<T>(
 	action: () => T | Promise<T>,
-	backoff = 2_000,
-	attempts = 3
+	maxAttempts = 3,
+	{
+		ms = 2_000,
+		strategy = ConstantBackoff,
+	}: { ms?: number; strategy?: BackoffStrategy } = {}
 ): Promise<T> {
-	try {
-		return await action();
-	} catch (err) {
-		if (attempts <= 1) {
-			throw err;
-		}
-
-		await setTimeout(backoff);
-		return retryOnError(action, backoff, attempts - 1);
-	}
+	return retryOnErrorInner(
+		action,
+		maxAttempts,
+		{ ms, initMs: ms, strategy },
+		1
+	);
 }


### PR DESCRIPTION
Firms up the retry logic a bit, and adds a HTTP header (`X-Attempt-Count`) to retried requests for better tracking of when our APIs are flaking. We'll add instrumentation for this on the API side.

Callouts:

1. This introduces `AsyncLocalStorage` to this codebase! A bit controversial to introduce a context thing like this, I know! But I figured it was okay for this metrics-y use-case. I had considered a few other options:

  - prop drilling the attempt count from the caller all the way down into our cfFetch stuff.

      - rejected because this was insanely messy. To get all the way down to the `performApiFetch()`, this would be need to be plumbed through loads and loads of functions, which felt like overkill for this (quite rarely used) utility.

  -  a global variable and keying off of some fetch prop (e.g. URL and method).

      - felt like this would go wrong more often than right. Better to just let the client tell you when it's doing retries since it has all that logic for it already anyway.

2. I also had considered modifying the user agent rather than adding a new header, and although that would have made analysis quick and easy, figured it was more messy.

3. This is always-on, for everyone, unlike the error reporting. Figured there's no sensitive information here, so we're okay to just turn this on for everyone.

I'm very much not sold on this approach though. It's pretty quick and dirty, and we could probably piece this together behind-the-scenes without this at all. This was just a thing I could quickly add to make a start on tracking this problem. If someone objects, or if anyone has any better ideas for implementation, I'm all ears!

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not covered
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: undocumented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
