### PR TITLE
fix: Modify Cloudchamber deployment labels in interactive mode

### DIFF
--- a/.changeset/odd-lions-warn.md
+++ b/.changeset/odd-lions-warn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Modify Cloudchamber deployment labels in interactive mode

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -15,7 +15,7 @@ function mockDeployment() {
 			"*/deployments/1234/v2",
 			async ({ request }) => {
 				expect(await request.text()).toBe(
-					`{"image":"hello:modify","location":"sfo06","environment_variables":[{"name":"HELLO","value":"WORLD"},{"name":"YOU","value":"CONQUERED"}],"vcpu":3,"memory":"40MB"}`
+					`{"image":"hello:modify","location":"sfo06","environment_variables":[{"name":"HELLO","value":"WORLD"},{"name":"YOU","value":"CONQUERED"}],"labels":[{"name":"appname","value":"helloworld"},{"name":"region","value":"wnam"}],"vcpu":3,"memory":"40MB"}`
 				);
 				return HttpResponse.json(MOCK_DEPLOYMENTS_COMPLEX[0]);
 			},
@@ -94,7 +94,7 @@ describe("cloudchamber modify", () => {
 		setWranglerConfig({});
 		mockDeployment();
 		await runWrangler(
-			"cloudchamber modify 1234 --image hello:modify --location sfo06 --var HELLO:WORLD --var YOU:CONQUERED --vcpu 3 --memory 40MB"
+			"cloudchamber modify 1234 --image hello:modify --location sfo06 --var HELLO:WORLD --var YOU:CONQUERED --label appname:helloworld --label region:wnam --vcpu 3 --memory 40MB"
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		// so testing the actual UI will be harder than expected
@@ -112,7 +112,7 @@ describe("cloudchamber modify", () => {
 		});
 		mockDeployment();
 		await runWrangler(
-			"cloudchamber modify 1234 --var HELLO:WORLD --var YOU:CONQUERED"
+			"cloudchamber modify 1234 --var HELLO:WORLD --var YOU:CONQUERED --label appname:helloworld --label region:wnam"
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.out).toMatchInlineSnapshot(EXPECTED_RESULT);

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -262,6 +262,7 @@ async function handleModifyCommand(
 			location,
 			ssh_public_key_ids: keys,
 			environment_variables: selectedEnvironmentVariables,
+			labels: selectedLabels,
 			vcpu: args.vcpu ?? config.cloudchamber.vcpu,
 			memory: args.memory ?? config.cloudchamber.memory,
 		})


### PR DESCRIPTION
Depolyment label modification works as expected in non-interactive mode. However, during interactive mode, we do not add the required labels to the final API Request.

Added labels fixture to modification tests as well.

Fixes CC-4451

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Minor UX change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Minor UX change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
