### PR TITLE
fix: pin devtools version

### DIFF
--- a/.changeset/fresh-hounds-study.md
+++ b/.changeset/fresh-hounds-study.md
@@ -1,0 +1,5 @@
+---
+"workers-playground": patch
+---
+
+fix: pin the version of cloudflare-devtools

--- a/.changeset/perfect-planets-lick.md
+++ b/.changeset/perfect-planets-lick.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: pin the version of cloudflare-devtools

--- a/packages/workers-playground/src/QuickEditor/DevtoolsIframe.tsx
+++ b/packages/workers-playground/src/QuickEditor/DevtoolsIframe.tsx
@@ -4,8 +4,12 @@ import FrameErrorBoundary from "./FrameErrorBoundary";
 import { ServiceContext } from "./QuickEditor";
 import type React from "react";
 
+// This URL is hard-coded to ensure specific versions of playground use specific versions of cloudflare-devtools -- enabling rollbacks to work as expected
+// Change the hash subdomain to a specific deployment from https://dash.cloudflare.com/e35fd947284363a46fd7061634477114/pages/view/cloudflare-devtools
+const devtoolsHost = "https://3e6204c5.devtools.devprod.cloudflare.dev";
+
 function getDevtoolsIframeUrl(inspectorUrl: string) {
-	const url = new URL(`https://devtools.devprod.cloudflare.dev/js_app`);
+	const url = new URL(`${devtoolsHost}/js_app`);
 	url.searchParams.set("wss", inspectorUrl.slice(5));
 
 	url.searchParams.set("theme", "systemPreferred");

--- a/packages/wrangler/src/dev/inspect.ts
+++ b/packages/wrangler/src/dev/inspect.ts
@@ -242,6 +242,10 @@ export function maybeHandleNetworkLoadResource(
 	}
 }
 
+// This URL is hard-coded to ensure specific versions of wrangler use specific versions of cloudflare-devtools -- enabling rollbacks to work as expected
+// Change the hash subdomain to a specific deployment from https://dash.cloudflare.com/e35fd947284363a46fd7061634477114/pages/view/cloudflare-devtools
+const devtoolsHost = "https://3e6204c5.devtools.devprod.cloudflare.dev";
+
 /**
  * Opens the chrome debugger
  */
@@ -256,7 +260,7 @@ export const openInspector = async (
 		query.set("domain", worker);
 	}
 	query.set("debugger", "true");
-	const url = `https://devtools.devprod.cloudflare.dev/js_app?${query.toString()}`;
+	const url = `${devtoolsHost}/js_app?${query.toString()}`;
 	const errorMessage =
 		"Failed to open inspector.\nInspector depends on having a Chromium-based browser installed, maybe you need to install one?";
 

--- a/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
+++ b/packages/wrangler/templates/startDevWorker/InspectorProxyWorker.ts
@@ -23,7 +23,7 @@ import type {
 
 const ALLOWED_HOST_HOSTNAMES = ["127.0.0.1", "[::1]", "localhost"];
 const ALLOWED_ORIGIN_HOSTNAMES = [
-	"devtools.devprod.cloudflare.dev",
+	/^([a-z0-9]+\.)?devtools\.devprod\.cloudflare\.dev$/,
 	"cloudflare-devtools.pages.dev",
 	/^[a-z0-9]+\.cloudflare-devtools\.pages\.dev$/,
 	"127.0.0.1",
@@ -58,6 +58,10 @@ function isDevToolsEvent<Method extends DevToolsEvents["method"]>(
 		event.method === name
 	);
 }
+
+// This URL is hard-coded to ensure specific versions of wrangler use specific versions of cloudflare-devtools -- enabling rollbacks to work as expected
+// Change the hash subdomain to a specific deployment from https://dash.cloudflare.com/e35fd947284363a46fd7061634477114/pages/view/cloudflare-devtools
+const devtoolsHost = "https://3e6204c5.devtools.devprod.cloudflare.dev";
 
 export class InspectorProxyWorker implements DurableObject {
 	constructor(
@@ -451,7 +455,7 @@ export class InspectorProxyWorker implements DurableObject {
 		if (url.pathname === "/json" || url.pathname === "/json/list") {
 			// TODO: can we remove the `/ws` here if we only have a single worker?
 			const localHost = `${url.host}/ws`;
-			const devtoolsFrontendUrl = `https://devtools.devprod.cloudflare.dev/js_app?theme=systemPreferred&debugger=true&ws=${localHost}`;
+			const devtoolsFrontendUrl = `${devtoolsHost}/js_app?theme=systemPreferred&debugger=true&ws=${localHost}`;
 
 			return Response.json([
 				{


### PR DESCRIPTION
Fixes n/a.

This PR pins the devtools version used in wrangler and workers-playground.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no feature change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no feature change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
