### PR TITLE
Change Pipelines to use name instead of id

### DIFF
--- a/.changeset/friendly-ears-breathe.md
+++ b/.changeset/friendly-ears-breathe.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Change Pipelines to use name instead of ID

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -573,8 +573,6 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 				pipeline = "my-pipeline"
 			`,
 			"src/index.ts": dedent`
-				import { Pipeline } from "cloudflare:workers";
-
 				export default {
 					async fetch(request, env, ctx) {
 						if (env.PIPELINE === undefined) {

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -561,6 +561,39 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 		);
 	});
 
+	it.skipIf(!isLocal)("exposes Pipelines bindings", async () => {
+		await helper.seed({
+			"wrangler.toml": dedent`
+				name = "${workerName}"
+				main = "src/index.ts"
+				compatibility_date = "2024-10-20"
+
+				[[pipelines]]
+				binding = "PIPELINE"
+				pipeline = "my-pipeline"
+			`,
+			"src/index.ts": dedent`
+				import { Pipeline } from "cloudflare:workers";
+
+				export default {
+					async fetch(request, env, ctx) {
+						if (env.PIPELINE === undefined) {
+							return new Response("env.PIPELINE is undefined");
+						}
+
+						return new Response("env.PIPELINE is available");
+					}
+				}
+			`,
+		});
+
+		const worker = helper.runLongLived(`wrangler dev ${flags}`);
+		const { url } = await worker.waitForReady();
+		const res = await fetch(url);
+
+		await expect(res.text()).resolves.toBe("env.PIPELINE is available");
+	});
+
 	it.skipIf(!isLocal)("exposes queue producer/consumer bindings", async () => {
 		const queueName = generateResourceName("queue");
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -11239,7 +11239,7 @@ export default{
 				pipelines: [
 					{
 						binding: "MY_PIPELINE",
-						pipeline: "0123456789ABCDEF0123456789ABCDEF",
+						pipeline: "my-pipeline",
 					},
 				],
 			});
@@ -11250,7 +11250,7 @@ export default{
 					{
 						type: "pipelines",
 						name: "MY_PIPELINE",
-						id: "0123456789ABCDEF0123456789ABCDEF",
+						pipeline: "my-pipeline",
 					},
 				],
 			});
@@ -11261,7 +11261,7 @@ export default{
 			Worker Startup Time: 100 ms
 			Your worker has access to the following bindings:
 			- Pipelines:
-			  - MY_PIPELINE: 0123456789ABCDEF0123456789ABCDEF
+			  - MY_PIPELINE: my-pipeline
 			Uploaded test-name (TIMINGS)
 			Deployed test-name triggers (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev

--- a/packages/wrangler/src/__tests__/init.test.ts
+++ b/packages/wrangler/src/__tests__/init.test.ts
@@ -2445,7 +2445,7 @@ describe("init", () => {
 					{
 						type: "pipelines",
 						name: "PIPELINE_BINDING",
-						id: "some-id",
+						pipeline: "some-name",
 					},
 					{
 						type: "mtls_certificate",
@@ -2670,7 +2670,7 @@ describe("init", () => {
 				pipelines: [
 					{
 						binding: "PIPELINE_BINDING",
-						pipeline: "some-id",
+						pipeline: "some-name",
 					},
 				],
 				queues: {
@@ -3212,7 +3212,7 @@ describe("init", () => {
 
 					[[pipelines]]
 					binding = \\"PIPELINE_BINDING\\"
-					pipeline = \\"some-id\\"
+					pipeline = \\"some-name\\"
 
 					[[mtls_certificates]]
 					binding = \\"MTLS_BINDING\\"

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -119,7 +119,7 @@ export type WorkerMetadataBinding =
 			};
 	  }
 	| { type: "mtls_certificate"; name: string; certificate_id: string }
-	| { type: "pipelines"; name: string; id: string }
+	| { type: "pipelines"; name: string; pipeline: string }
 	| {
 			type: "logfwdr";
 			name: string;
@@ -358,7 +358,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 		metadataBindings.push({
 			name: binding,
 			type: "pipelines",
-			id: pipeline,
+			pipeline: pipeline,
 		});
 	});
 

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -1221,7 +1221,7 @@ export async function mapBindings(
 							...(configObj.pipelines ?? []),
 							{
 								binding: binding.name,
-								pipeline: binding.id,
+								pipeline: binding.pipeline,
 							},
 						];
 						break;


### PR DESCRIPTION
Fixes [PIPE-124](https://jira.cfdata.org/browse/PIPE-124).

Replaces PR #7100

Recently, Pipelines switched to binding by pipeline names instead of pipeline IDs. This change formalizes that. 

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: non e2e tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unreleased product

