### PR TITLE
chore: Improve readme for devtools package

### DIFF
--- a/packages/wrangler-devtools/README.md
+++ b/packages/wrangler-devtools/README.md
@@ -38,8 +38,7 @@ We perform quarterly updates to stay current with upstream Chrome DevTools. The 
 4. Regenerating patches
 5. Thorough testing across all integration points
 
-**For detailed instructions on updating DevTools, please refer to our internal documentation at:
-https://wiki.cfdata.org/display/WX/Keeping+DevTools+up-to-date**
+**For detailed instructions on updating DevTools, please refer to our internal documentation on keeping devtools up-to-date.**
 
 ## Testing
 

--- a/packages/wrangler-devtools/README.md
+++ b/packages/wrangler-devtools/README.md
@@ -1,6 +1,79 @@
 # Wrangler Devtools Pages Project
 
-This package contains a Workers specific version of Chrome Devtools that is used by the Wrangler dev command.
+This package contains a Workers specific version of Chrome Devtools that is used by the Wrangler dev command. It is a customized fork of Chrome DevTools specifically tailored for debugging Cloudflare Workers. This package provides Worker-specific functionality through carefully maintained patches on top of Chrome DevTools.
+
+## Overview
+
+This package is used across multiple Cloudflare products:
+
+- Workers Playground (`workers-playground`)
+- Quick Editor (`@cloudflare/quick-edit`)
+- Wrangler CLI via the `InspectorProxy`
+
+## Features
+
+Our customized DevTools implementation provides:
+
+- Source code viewing and live updates
+- Network request inspection
+- Worker-specific UI optimizations
+
+## Development
+
+We maintain this fork by applying patches on top of Chrome DevTools. These patches need to be periodically rebased as Chrome DevTools evolves.
+
+**Key Development Tasks:**
+
+- Generating patches from our customizations
+- Rebasing patches onto new Chrome DevTools versions
+- Testing functionality across all integration points
+
+## Updating DevTools
+
+We perform quarterly updates to stay current with upstream Chrome DevTools. The update process involves:
+
+1. Cloning the devtools-frontend repo
+2. Applying our existing patches
+3. Rebasing onto the latest Chrome DevTools
+4. Regenerating patches
+5. Thorough testing across all integration points
+
+**For detailed instructions on updating DevTools, please refer to our internal documentation at:
+https://wiki.cfdata.org/display/WX/Keeping+DevTools+up-to-date**
+
+## Testing
+
+Two methods are available for testing updates:
+
+**Local Development:**
+
+- Build and serve DevTools locally
+- Test against local Playground instance
+- Make targeted fixes as needed
+
+**Preview Builds:**
+
+- Add `preview:wrangler-devtools` label to PRs
+- Use deployed preview URL for testing
+- Verify functionality in Playground
+
+## Acceptance Criteria
+
+Our DevTools implementation must maintain full functionality across:
+
+- Console operations (logging, errors, filters)
+- Source code viewing and debugging
+- Network request inspection
+- Worker-specific UI customizations
+
+## Contributing
+
+When making changes:
+
+- Keep patches minimal and targeted
+- Prefer CSS-based UI modifications
+- Test thoroughly across all integration points
+- Document any new patches or modifications
 
 ## Deployment
 


### PR DESCRIPTION
Fixes #000.

Improves the documentation surrounding our usage and maintenance of the Chrome DevTools patches.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Readme changes
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Readme changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal readme only
