### PR TITLE
fix: add better error for user binding called ASSETS in pages projects

### DIFF
--- a/.changeset/eleven-cobras-repeat.md
+++ b/.changeset/eleven-cobras-repeat.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: throw a better error if there is an "ASSETS" user binding in a Pages projects

--- a/packages/wrangler/src/__tests__/configuration.pages.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.pages.test.ts
@@ -767,5 +767,47 @@ describe("normalizeAndValidateConfig()", () => {
 				);
 			});
 		});
+
+		it("should error if there is a user binding named ASSETS at the top-level", () => {
+			const { diagnostics } = normalizeAndValidateConfig(
+				{
+					...pagesRawConfig,
+					kv_namespaces: [
+						{
+							binding: "ASSETS",
+							id: "1234",
+						},
+					],
+				},
+				undefined,
+				{ env: undefined }
+			);
+
+			expect(diagnostics.errors).toEqual([
+				"The name 'ASSETS' is reserved in Pages projects. Please use a different name for your KV Namespaces binding.",
+			]);
+		});
+
+		it("should error if there is a user binding named ASSETS in a named environment", () => {
+			const { diagnostics } = normalizeAndValidateConfig(
+				{
+					...pagesRawConfig,
+					env: {
+						preview: {
+							...pagesRawConfig.env?.preview,
+							vars: { ASSETS: "test_value" },
+						},
+					},
+				},
+				undefined,
+				{
+					env: "preview",
+				}
+			);
+
+			expect(diagnostics.errors).toEqual([
+				"The name 'ASSETS' is reserved in Pages projects. Please use a different name for your Vars binding.",
+			]);
+		});
 	});
 });

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2773,6 +2773,12 @@ const validateBindingsHaveUniqueNames = (
 				bindingsGroupedByName[bindingName] = [];
 			}
 
+			if (bindingName === "ASSETS" && isPagesConfig(config)) {
+				diagnostics.errors.push(
+					`The name 'ASSETS' is reserved in Pages projects. Please use a different name for your ${bindingType} binding.`
+				);
+			}
+
 			bindingsGroupedByName[bindingName].push(bindingType);
 		}
 	}

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2773,7 +2773,7 @@ const validateBindingsHaveUniqueNames = (
 				bindingsGroupedByName[bindingName] = [];
 			}
 
-			if (bindingName.toUpperCase() === "ASSETS" && isPagesConfig(config)) {
+			if (bindingName === "ASSETS" && isPagesConfig(config)) {
 				diagnostics.errors.push(
 					`The name 'ASSETS' is reserved in Pages projects. Please use a different name for your ${bindingType} binding.`
 				);

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2773,7 +2773,7 @@ const validateBindingsHaveUniqueNames = (
 				bindingsGroupedByName[bindingName] = [];
 			}
 
-			if (bindingName === "ASSETS" && isPagesConfig(config)) {
+			if (bindingName.toUpperCase() === "ASSETS" && isPagesConfig(config)) {
 				diagnostics.errors.push(
 					`The name 'ASSETS' is reserved in Pages projects. Please use a different name for your ${bindingType} binding.`
 				);


### PR DESCRIPTION
Fixes #6266 
The binding name "ASSETS" is used internally by pages projects. If a user had a binding with this name (totally sensible binding name for an r2 bucket for example) it would fail cryptically (see linked issue). 


---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no changes to e2es
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: error message fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
