### PR TITLE
chore: enable observability for infra bots + devprod status bot

### DIFF
--- a/.changeset/cool-dragons-brush.md
+++ b/.changeset/cool-dragons-brush.md
@@ -1,0 +1,8 @@
+---
+"edge-preview-authenticated-proxy": patch
+"playground-preview-worker": patch
+"devprod-status-bot": patch
+"format-errors": patch
+---
+
+chore: enable observability on our internal infra Workers + bots

--- a/packages/devprod-status-bot/wrangler.toml
+++ b/packages/devprod-status-bot/wrangler.toml
@@ -18,3 +18,5 @@ crons = [
 [ai]
 binding = "AI"
 
+[observability]
+enabled = true

--- a/packages/edge-preview-authenticated-proxy/wrangler.toml
+++ b/packages/edge-preview-authenticated-proxy/wrangler.toml
@@ -22,3 +22,6 @@ host = "preview.devprod.cloudflare.dev"
 binding = "TOKEN_LOOKUP"
 id = "76afd4161617490b9d2addc59b1e22e4"
 preview_id = "76afd4161617490b9d2addc59b1e22e4"
+
+[observability]
+enabled = true

--- a/packages/format-errors/wrangler.toml
+++ b/packages/format-errors/wrangler.toml
@@ -13,3 +13,5 @@ routes = [
 [vars]
 SENTRY_DSN = "https://1ff9df95733c4e7d9c31dc13ab05d44a@sentry10.cfdata.org/891"
 
+[observability]
+enabled = true

--- a/packages/playground-preview-worker/wrangler.json
+++ b/packages/playground-preview-worker/wrangler.json
@@ -42,6 +42,10 @@
 		}
 	],
 
+	"observability": {
+		"enabled": true
+	},
+
 	"env": {
 		"testing": {
 			"vars": {


### PR DESCRIPTION
Fixes N/A

Sometimes devprod status bot doesn't post, and mostly I just wanted to try out observability.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: not testable
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not testable
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
