### PR TITLE
fix(playground-preview-worker): ensure OPTIONS raw HTTP requests are fowarded

### DIFF
--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -266,6 +266,10 @@ app.get(`${previewDomain}/.update-preview-token`, (c) => {
 });
 
 app.all(`${previewDomain}/*`, async (c) => {
+	const url = new URL(c.req.url);
+	if (c.req.headers.has("cf-raw-http")) {
+		return handleRawHttp(c.req.raw, url, c.env);
+	}
 	if (c.req.method === "OPTIONS") {
 		return new Response(null, {
 			headers: {
@@ -278,10 +282,6 @@ app.all(`${previewDomain}/*`, async (c) => {
 				Vary: "Origin, Access-Control-Request-Headers",
 			},
 		});
-	}
-	const url = new URL(c.req.url);
-	if (c.req.headers.has("cf-raw-http")) {
-		return handleRawHttp(c.req.raw, url, c.env);
 	}
 	const token = getCookie(c, "token");
 	if (!token) {

--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -51,6 +51,7 @@ function createResponseHeaders(
 		Vary: "Origin",
 	});
 
+	console.log(`Creating response header for method ${request.method}`);
 	if (request.method === "OPTIONS") {
 		headers.set(
 			"Access-Control-Allow-Headers",
@@ -284,7 +285,7 @@ app.get(`${previewDomain}/.update-preview-token`, (c) => {
 
 app.all(`${previewDomain}/*`, async (c) => {
 	const url = new URL(c.req.url);
-	if (c.req.headers.has("cf-raw-http")) {
+	if (c.req.raw.headers.has("cf-raw-http")) {
 		return handleRawHttp(c.req.raw, url, c.env);
 	}
 	if (c.req.method === "OPTIONS") {

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -246,6 +246,7 @@ describe("Preview Worker", () => {
 	});
 	it("should forward OPTIONS raw HTTP request", async () => {
 		const resp = await fetch(`${PREVIEW_REMOTE}/method`, {
+			method: "OPTIONS",
 			headers: {
 				"X-CF-Token": defaultUserToken,
 				"CF-Raw-HTTP": "true",

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -244,6 +244,17 @@ describe("Preview Worker", () => {
 		);
 		expect(await resp.text()).toMatchInlineSnapshot('"custom"');
 	});
+	it("should forward OPTIONS raw HTTP request", async () => {
+		const resp = await fetch(`${PREVIEW_REMOTE}/method`, {
+			headers: {
+				"X-CF-Token": defaultUserToken,
+				"CF-Raw-HTTP": "true",
+			},
+			redirect: "manual",
+		});
+
+		expect(await resp.text()).toEqual("OPTIONS");
+	});
 	it("should reject no token for raw HTTP response", async () => {
 		const resp = await fetch(`${PREVIEW_REMOTE}/header`, {
 			headers: {


### PR DESCRIPTION
Fixes [DEVX-1449](https://jira.cfdata.org/browse/DEVX-1449).

This PR fixes an issue in which the preview worker does not receive an raw OPTIONS request on both Quick Editor or Workers Playground.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact to wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
