### PR TITLE
Added the ability to enable, disable, and get r2.dev public access URLs for R2 buckets

### DIFF
--- a/.changeset/thin-hairs-explain.md
+++ b/.changeset/thin-hairs-explain.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Added the ability to enable, disable, and get r2.dev public access URLs for R2 buckets.

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -742,6 +742,56 @@ export async function configureCustomDomainSettings(
 	);
 }
 
+export interface R2DevDomainInfo {
+	bucketId: string;
+	domain: string;
+	enabled: boolean;
+}
+
+export async function getR2DevDomain(
+	accountId: string,
+	bucketName: string,
+	jurisdiction?: string
+): Promise<R2DevDomainInfo> {
+	const headers: HeadersInit = {};
+	if (jurisdiction) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
+
+	const result = await fetchResult<R2DevDomainInfo>(
+		`/accounts/${accountId}/r2/buckets/${bucketName}/domains/managed`,
+		{
+			method: "GET",
+			headers,
+		}
+	);
+	return result;
+}
+
+export async function updateR2DevDomain(
+	accountId: string,
+	bucketName: string,
+	enabled: boolean,
+	jurisdiction?: string
+): Promise<R2DevDomainInfo> {
+	const headers: HeadersInit = {
+		"Content-Type": "application/json",
+	};
+	if (jurisdiction) {
+		headers["cf-r2-jurisdiction"] = jurisdiction;
+	}
+
+	const result = await fetchResult<R2DevDomainInfo>(
+		`/accounts/${accountId}/r2/buckets/${bucketName}/domains/managed`,
+		{
+			method: "PUT",
+			headers,
+			body: JSON.stringify({ enabled }),
+		}
+	);
+	return result;
+}
+
 /**
  * R2 bucket names must only contain alphanumeric and - characters.
  */

--- a/packages/wrangler/src/r2/index.ts
+++ b/packages/wrangler/src/r2/index.ts
@@ -24,6 +24,7 @@ import {
 	usingLocalBucket,
 } from "./helpers";
 import * as Notification from "./notification";
+import * as PublicDevUrl from "./public-dev-url";
 import * as Sippy from "./sippy";
 import type { CommonYargsArgv, SubHelp } from "../yargs-types";
 import type { R2PutOptions } from "@cloudflare/workers-types/experimental";
@@ -637,6 +638,31 @@ export function r2(r2Yargs: CommonYargsArgv, subHelp: SubHelp) {
 							"Update settings for a custom domain connected to an R2 bucket",
 							Domain.UpdateOptions,
 							Domain.UpdateHandler
+						);
+				}
+			);
+			r2BucketYargs.command(
+				"dev-url",
+				"Manage public access via the r2.dev URL for an R2 bucket",
+				(devUrlYargs) => {
+					return devUrlYargs
+						.command(
+							"enable <bucket>",
+							"Enable public access via the r2.dev URL for an R2 bucket",
+							PublicDevUrl.EnableOptions,
+							PublicDevUrl.EnableHandler
+						)
+						.command(
+							"disable <bucket>",
+							"Disable public access via the r2.dev URL for an R2 bucket",
+							PublicDevUrl.DisableOptions,
+							PublicDevUrl.DisableHandler
+						)
+						.command(
+							"get <bucket>",
+							"Get the r2.dev URL and status for an R2 bucket",
+							PublicDevUrl.GetOptions,
+							PublicDevUrl.GetHandler
 						);
 				}
 			);

--- a/packages/wrangler/src/r2/public-dev-url.ts
+++ b/packages/wrangler/src/r2/public-dev-url.ts
@@ -1,0 +1,151 @@
+import { readConfig } from "../config";
+import { confirm } from "../dialogs";
+import { logger } from "../logger";
+import { printWranglerBanner } from "../update-check";
+import { requireAuth } from "../user";
+import { getR2DevDomain, updateR2DevDomain } from "./helpers";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+
+export function GetOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("bucket", {
+			describe: "The name of the R2 bucket whose r2.dev URL status to retrieve",
+			type: "string",
+			demandOption: true,
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		});
+}
+
+export async function GetHandler(
+	args: StrictYargsOptionsToInterface<typeof GetOptions>
+) {
+	await printWranglerBanner();
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	const { bucket, jurisdiction } = args;
+
+	const devDomain = await getR2DevDomain(accountId, bucket, jurisdiction);
+
+	if (devDomain.enabled) {
+		logger.log(`Public access is enabled at 'https://${devDomain.domain}'.`);
+	} else {
+		logger.log(`Public access via the r2.dev URL is disabled.`);
+	}
+}
+
+export function EnableOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("bucket", {
+			describe:
+				"The name of the R2 bucket to enable public access via its r2.dev URL",
+			type: "string",
+			demandOption: true,
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		})
+		.option("force", {
+			describe: "Skip confirmation",
+			type: "boolean",
+			alias: "y",
+			default: false,
+		});
+}
+
+export async function EnableHandler(
+	args: StrictYargsOptionsToInterface<typeof EnableOptions>
+) {
+	await printWranglerBanner();
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	const { bucket, jurisdiction, force } = args;
+
+	if (!force) {
+		const confirmedAdd = await confirm(
+			`Are you sure you enable public access for bucket '${bucket}'? ` +
+				`The contents of your bucket will be made publicly available at its r2.dev URL`
+		);
+		if (!confirmedAdd) {
+			logger.log("Enable cancelled.");
+			return;
+		}
+	}
+
+	logger.log(`Enabling public access for bucket '${bucket}'...`);
+
+	const devDomain = await updateR2DevDomain(
+		accountId,
+		bucket,
+		true,
+		jurisdiction
+	);
+
+	logger.log(`✨ Public access enabled at 'https://${devDomain.domain}'.`);
+}
+
+export function DisableOptions(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("bucket", {
+			describe:
+				"The name of the R2 bucket to disable public access via its r2.dev URL",
+			type: "string",
+			demandOption: true,
+		})
+		.option("jurisdiction", {
+			describe: "The jurisdiction where the bucket exists",
+			alias: "J",
+			requiresArg: true,
+			type: "string",
+		})
+		.option("force", {
+			describe: "Skip confirmation",
+			type: "boolean",
+			alias: "y",
+			default: false,
+		});
+}
+
+export async function DisableHandler(
+	args: StrictYargsOptionsToInterface<typeof DisableOptions>
+) {
+	await printWranglerBanner();
+	const config = readConfig(args.config, args);
+	const accountId = await requireAuth(config);
+
+	const { bucket, jurisdiction, force } = args;
+
+	if (!force) {
+		const confirmedAdd = await confirm(
+			`Are you sure you disable public access for bucket '${bucket}'? ` +
+				`The contents of your bucket will no longer be publicly available at its r2.dev URL`
+		);
+		if (!confirmedAdd) {
+			logger.log("Disable cancelled.");
+			return;
+		}
+	}
+
+	logger.log(`Disabling public access for bucket '${bucket}'...`);
+
+	const devDomain = await updateR2DevDomain(
+		accountId,
+		bucket,
+		false,
+		jurisdiction
+	);
+
+	logger.log(`Public access disabled at 'https://${devDomain.domain}'.`);
+}


### PR DESCRIPTION
Added the ability to enable, disable, and get r2.dev public access URLs for R2 buckets.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: test changes covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/17941
  - [ ] Documentation not necessary because:

