### PR TITLE
Fix Cloudflare Pages command for Solid

### DIFF
--- a/.changeset/little-lamps-provide.md
+++ b/.changeset/little-lamps-provide.md
@@ -1,5 +1,5 @@
 ---
-"create-cloudflare": minor
+"create-cloudflare": patch
 ---
 
-fix cloudflare pages command for solid
+fix invalid preset config on the experimental solid template

--- a/.changeset/little-lamps-provide.md
+++ b/.changeset/little-lamps-provide.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+fix cloudflare pages command for solid

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-cloudflare",
-	"version": "2.31.1",
+	"version": "2.31.2",
 	"description": "A CLI for creating and deploying new applications to Cloudflare.",
 	"keywords": [
 		"cloudflare",

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "create-cloudflare",
-	"version": "2.31.2",
+	"version": "2.31.1",
 	"description": "A CLI for creating and deploying new applications to Cloudflare.",
 	"keywords": [
 		"cloudflare",

--- a/packages/create-cloudflare/templates-experimental/solid/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/solid/c3.ts
@@ -49,7 +49,7 @@ const configure = async (ctx: C3Context) => {
 							// preset: "cloudflare-pages"
 							b.objectProperty(
 								b.identifier("preset"),
-								b.stringLiteral("./cloudflare-pages"),
+								b.stringLiteral("cloudflare-pages"),
 							),
 							// output: {
 							// 	dir: "{{ rootDir }}/dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.1.3
+      version: 2.1.3
+    '@vitest/snapshot':
+      specifier: ~2.1.3
+      version: 2.1.3
     '@vitest/ui':
       specifier: ~2.1.3
       version: 2.1.3


### PR DESCRIPTION
Fix Cloudflare Pages command for Solid. Replaced `./cloudflare-pages` by `cloudflare-pages`

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: It is a config string change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: It is a config string change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): 
  - [x] Documentation not necessary because: It is a config string change
