### PR TITLE
Fix `--test-scheduled` with custom builds & `--x-dev-env`

### DIFF
--- a/.changeset/sweet-toes-check.md
+++ b/.changeset/sweet-toes-check.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix `--test-scheduled` with custom builds & `--x-dev-env`

--- a/packages/wrangler/e2e/__snapshots__/dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/dev.test.ts.snap
@@ -1,10 +1,22 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`basic js dev: 'wrangler dev --no-x-dev-env' > --test-scheduled works with wrangler dev --no-x-dev-env > custom build 1`] = `"Ran scheduled event"`;
+
+exports[`basic js dev: 'wrangler dev --no-x-dev-env' > --test-scheduled works with wrangler dev --no-x-dev-env > no custom build 1`] = `"Ran scheduled event"`;
+
+exports[`basic js dev: 'wrangler dev --no-x-dev-env' > --test-scheduled works with wrangler dev --no-x-dev-env 1`] = `"Ran scheduled event"`;
+
 exports[`basic js dev: 'wrangler dev --no-x-dev-env' > can modify worker during wrangler dev --no-x-dev-env 1`] = `"Hello World!"`;
 
 exports[`basic js dev: 'wrangler dev --no-x-dev-env' > can modify worker during wrangler dev --no-x-dev-env 2`] = `"Updated Worker! value"`;
 
 exports[`basic js dev: 'wrangler dev --no-x-dev-env' > hotkeys can be disabled with wrangler dev --no-x-dev-env 1`] = `"Hello World!"`;
+
+exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > --test-scheduled works with wrangler dev --remote --no-x-dev-env > custom build 1`] = `"Ran scheduled event"`;
+
+exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > --test-scheduled works with wrangler dev --remote --no-x-dev-env > no custom build 1`] = `"Ran scheduled event"`;
+
+exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > --test-scheduled works with wrangler dev --remote --no-x-dev-env 1`] = `"Ran scheduled event"`;
 
 exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > can modify worker during wrangler dev --remote --no-x-dev-env 1`] = `"Hello World!"`;
 
@@ -12,11 +24,23 @@ exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > can modify worke
 
 exports[`basic js dev: 'wrangler dev --remote --no-x-dev-env' > hotkeys can be disabled with wrangler dev --remote --no-x-dev-env 1`] = `"Hello World!"`;
 
+exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > --test-scheduled works with wrangler dev --remote --x-dev-env > custom build 1`] = `"Ran scheduled event"`;
+
+exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > --test-scheduled works with wrangler dev --remote --x-dev-env > no custom build 1`] = `"Ran scheduled event"`;
+
+exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > --test-scheduled works with wrangler dev --remote --x-dev-env 1`] = `"Ran scheduled event"`;
+
 exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > can modify worker during wrangler dev --remote --x-dev-env 1`] = `"Hello World!"`;
 
 exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > can modify worker during wrangler dev --remote --x-dev-env 2`] = `"Updated Worker! value"`;
 
 exports[`basic js dev: 'wrangler dev --remote --x-dev-env' > hotkeys can be disabled with wrangler dev --remote --x-dev-env 1`] = `"Hello World!"`;
+
+exports[`basic js dev: 'wrangler dev --x-dev-env' > --test-scheduled works with wrangler dev --x-dev-env > custom build 1`] = `"Ran scheduled event"`;
+
+exports[`basic js dev: 'wrangler dev --x-dev-env' > --test-scheduled works with wrangler dev --x-dev-env > no custom build 1`] = `"Ran scheduled event"`;
+
+exports[`basic js dev: 'wrangler dev --x-dev-env' > --test-scheduled works with wrangler dev --x-dev-env 1`] = `"Ran scheduled event"`;
 
 exports[`basic js dev: 'wrangler dev --x-dev-env' > can modify worker during wrangler dev --x-dev-env 1`] = `"Hello World!"`;
 

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -110,6 +110,7 @@ describe("defineNavigatorUserAgent is respected", () => {
 				exports: [],
 			},
 			path.resolve("dist"),
+			// @ts-expect-error Ignore the requirement for passing undefined values
 			{
 				bundle: true,
 				additionalModules: [],
@@ -172,6 +173,7 @@ describe("defineNavigatorUserAgent is respected", () => {
 				exports: [],
 			},
 			path.resolve("dist"),
+			// @ts-expect-error Ignore the requirement for passing undefined values
 			{
 				bundle: true,
 				additionalModules: [],

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -133,6 +133,20 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 							config.compatibilityDate,
 							config.compatibilityFlags
 						),
+						testScheduled: config.dev.testScheduled,
+						plugins: undefined,
+
+						// Pages specific options used by wrangler pages commands
+						entryName: undefined,
+						inject: undefined,
+						isOutfile: undefined,
+						external: undefined,
+
+						// We don't use esbuild watching for custom builds
+						watch: undefined,
+
+						// sourcemap defaults to true in dev
+						sourcemap: undefined,
 					});
 			if (buildAborter.signal.aborted) {
 				return;

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -119,6 +119,7 @@ async function convertToConfigBundle(
 		services: bindings.services,
 		serviceBindings: fetchers,
 		bindVectorizeToProd: event.config.dev?.bindVectorizeToProd ?? false,
+		testScheduled: !!event.config.dev.testScheduled,
 	};
 }
 

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -605,6 +605,16 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 							props.compatibilityFlags ?? config.compatibility_flags
 						),
 						plugins: [logBuildOutput(nodejsCompatMode)],
+
+						// Pages specific options used by wrangler pages commands
+						entryName: undefined,
+						inject: undefined,
+						isOutfile: undefined,
+						external: undefined,
+
+						// These options are dev-only
+						testScheduled: undefined,
+						watch: undefined,
 					}
 				);
 

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -115,32 +115,31 @@ export type BundleOptions = {
 	// A module collector enables you to observe what modules are in the Worker.
 	moduleCollector: ModuleCollector;
 	serveLegacyAssetsFromWorker: boolean;
-	legacyAssets?: Config["legacy_assets"];
-	bypassAssetCache?: boolean;
+	legacyAssets: Config["legacy_assets"] | undefined;
+	bypassAssetCache: boolean | undefined;
 	doBindings: DurableObjectBindings;
 	workflowBindings: WorkflowBinding[];
-	jsxFactory?: string;
-	jsxFragment?: string;
-	entryName?: string;
-	watch?: boolean;
-	tsconfig?: string;
-	minify?: boolean;
-	nodejsCompatMode?: NodeJSCompatMode;
+	jsxFactory: string | undefined;
+	jsxFragment: string | undefined;
+	entryName: string | undefined;
+	watch: boolean | undefined;
+	tsconfig: string | undefined;
+	minify: boolean | undefined;
+	nodejsCompatMode: NodeJSCompatMode | undefined;
 	define: Config["define"];
 	alias: Config["alias"];
 	checkFetch: boolean;
 	mockAnalyticsEngineDatasets: Config["analytics_engine_datasets"];
 	targetConsumer: "dev" | "deploy";
-	testScheduled?: boolean;
-	inject?: string[];
-	loader?: Record<string, string>;
-	sourcemap?: esbuild.CommonOptions["sourcemap"];
-	plugins?: esbuild.Plugin[];
-	isOutfile?: boolean;
+	testScheduled: boolean | undefined;
+	inject: string[] | undefined;
+	sourcemap: esbuild.CommonOptions["sourcemap"] | undefined;
+	plugins: esbuild.Plugin[] | undefined;
+	isOutfile: boolean | undefined;
 	local: boolean;
 	projectRoot: string | undefined;
 	defineNavigatorUserAgent: boolean;
-	external?: string[];
+	external: string[] | undefined;
 };
 
 /**
@@ -172,7 +171,6 @@ export async function bundleWorker(
 		targetConsumer,
 		testScheduled,
 		inject: injectOption,
-		loader,
 		sourcemap,
 		plugins,
 		isOutfile,
@@ -424,10 +422,7 @@ export async function bundleWorker(
 				...define,
 			},
 		}),
-		loader: {
-			...COMMON_ESBUILD_OPTIONS.loader,
-			...(loader || {}),
-		},
+		loader: COMMON_ESBUILD_OPTIONS.loader,
 		plugins: [
 			aliasPlugin,
 			moduleCollector.plugin,

--- a/packages/wrangler/src/dev/local.tsx
+++ b/packages/wrangler/src/dev/local.tsx
@@ -112,6 +112,7 @@ export async function localPropsToConfigBundle(
 		services: props.services,
 		serviceBindings,
 		bindVectorizeToProd: props.bindVectorizeToProd,
+		testScheduled: !!props.testScheduled,
 	};
 }
 

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -198,6 +198,7 @@ export interface ConfigBundle {
 	services: Config["services"] | undefined;
 	serviceBindings: Record<string, ServiceFetch>;
 	bindVectorizeToProd: boolean;
+	testScheduled: boolean;
 }
 
 export class WranglerLog extends Log {
@@ -908,7 +909,7 @@ export async function buildMiniflareOptions(
 	internalObjects: CfDurableObject[];
 	entrypointNames: string[];
 }> {
-	if (config.crons.length > 0) {
+	if (config.crons.length > 0 && !config.testScheduled) {
 		if (!didWarnMiniflareCronSupport) {
 			didWarnMiniflareCronSupport = true;
 			log.warn(

--- a/packages/wrangler/src/dev/start-server.ts
+++ b/packages/wrangler/src/dev/start-server.ts
@@ -499,6 +499,16 @@ async function runEsbuild({
 					workflowBindings,
 					projectRoot,
 					defineNavigatorUserAgent,
+
+					// Pages specific options used by wrangler pages commands
+					entryName: undefined,
+					inject: undefined,
+					isOutfile: undefined,
+					external: undefined,
+
+					watch: undefined,
+					sourcemap: undefined,
+					plugins: undefined,
 				})
 			: undefined;
 

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -200,6 +200,15 @@ export function runBuild(
 						local,
 						projectRoot,
 						defineNavigatorUserAgent,
+
+						// Pages specific options used by wrangler pages commands
+						entryName: undefined,
+						inject: undefined,
+						isOutfile: undefined,
+						external: undefined,
+
+						// sourcemap defaults to true in dev
+						sourcemap: undefined,
 					})
 				: undefined;
 

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -114,5 +114,13 @@ export function buildPluginFromFunctions({
 		local,
 		projectRoot: getPagesProjectRoot(),
 		defineNavigatorUserAgent,
+
+		legacyAssets: undefined,
+		bypassAssetCache: undefined,
+		jsxFactory: undefined,
+		jsxFragment: undefined,
+		tsconfig: undefined,
+		testScheduled: undefined,
+		isOutfile: undefined,
 	});
 }

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -68,7 +68,7 @@ export function buildWorkerFromFunctions({
 		additionalModules: [],
 		moduleCollector,
 		inject: [routesModule],
-		...(outdir ? { entryName: "index" } : {}),
+		...(outdir ? { entryName: "index" } : { entryName: undefined }),
 		minify,
 		sourcemap,
 		watch,
@@ -97,7 +97,6 @@ export function buildWorkerFromFunctions({
 		jsxFragment: undefined,
 		tsconfig: undefined,
 		testScheduled: undefined,
-		entryName: undefined,
 	});
 }
 

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -90,6 +90,14 @@ export function buildWorkerFromFunctions({
 		local,
 		projectRoot: getPagesProjectRoot(),
 		defineNavigatorUserAgent,
+
+		legacyAssets: undefined,
+		bypassAssetCache: undefined,
+		jsxFactory: undefined,
+		jsxFragment: undefined,
+		tsconfig: undefined,
+		testScheduled: undefined,
+		entryName: undefined,
 	});
 }
 
@@ -195,6 +203,15 @@ export function buildRawWorker({
 		local,
 		projectRoot: getPagesProjectRoot(),
 		defineNavigatorUserAgent,
+
+		legacyAssets: undefined,
+		bypassAssetCache: undefined,
+		jsxFactory: undefined,
+		jsxFragment: undefined,
+		tsconfig: undefined,
+		testScheduled: undefined,
+		entryName: undefined,
+		inject: undefined,
 	});
 }
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -11,6 +11,7 @@ import {
 } from "../deployment-bundle/bundle-reporter";
 import { getBundleType } from "../deployment-bundle/bundle-type";
 import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
+import { logBuildOutput } from "../deployment-bundle/esbuild-plugins/log-build-output";
 import {
 	findAdditionalModules,
 	writeAdditionalModules,
@@ -321,6 +322,17 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 							props.compatibilityDate ?? config.compatibility_date,
 							props.compatibilityFlags ?? config.compatibility_flags
 						),
+						plugins: [logBuildOutput(nodejsCompatMode)],
+
+						// Pages specific options used by wrangler pages commands
+						entryName: undefined,
+						inject: undefined,
+						isOutfile: undefined,
+						external: undefined,
+
+						// These options are dev-only
+						testScheduled: undefined,
+						watch: undefined,
 					}
 				);
 


### PR DESCRIPTION
Fixes #7152 

Correctly pass the `--test-scheduled` flag in `BundleController` when using a custom build. Previously the types for `bundleWorker()` allowed arguments not to be passed—this PR changes that to require an explicit `undefined` to be passed, which should prevent this type of regression happening again.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
