### PR TITLE
feat(create-cloudflare): update experimental remix template to be based on its worker template

### DIFF
--- a/.changeset/young-lions-type.md
+++ b/.changeset/young-lions-type.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+feat: update experimental remix template to be based on its worker template

--- a/packages/create-cloudflare/templates-experimental/remix/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/remix/c3.ts
@@ -14,7 +14,7 @@ const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,
 		"--template",
-		"https://github.com/remix-run/remix/tree/main/templates/cloudflare",
+		"https://github.com/remix-run/remix/tree/main/templates/cloudflare-workers",
 	]);
 
 	logRaw(""); // newline
@@ -26,27 +26,6 @@ const configure = async () => {
 		startText: "Updating the Wrangler version",
 		doneText: `${brandColor(`updated`)} ${dim("wrangler@latest")}`,
 	});
-
-	const typeDefsPath = "load-context.ts";
-
-	const s = spinner();
-	s.start(`Updating \`${typeDefsPath}\``);
-
-	// Remove the empty Env declaration from the template to allow the type from
-	// worker-configuration.d.ts to take over
-	transformFile(typeDefsPath, {
-		visitTSInterfaceDeclaration(n) {
-			if (n.node.id.type === "Identifier" && n.node.id.name !== "Env") {
-				return this.traverse(n);
-			}
-
-			// Removes the node
-			n.replace();
-			return false;
-		},
-	});
-
-	s.stop(`${brandColor("updated")} \`${dim(typeDefsPath)}\``);
 };
 
 const config: TemplateConfig = {
@@ -63,9 +42,6 @@ const config: TemplateConfig = {
 	configure,
 	transformPackageJson: async () => ({
 		scripts: {
-			build:
-				"remix vite:build && wrangler pages functions build --outdir build/worker",
-			deploy: `${npm} run build && wrangler deploy`,
 			preview: `${npm} run build && wrangler dev`,
 			"cf-typegen": `wrangler types`,
 		},

--- a/packages/create-cloudflare/templates-experimental/remix/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/remix/c3.ts
@@ -40,6 +40,7 @@ const config: TemplateConfig = {
 	configure,
 	transformPackageJson: async () => ({
 		scripts: {
+			deploy: `${npm} run build && wrangler deploy`,
 			preview: `${npm} run build && wrangler dev`,
 			"cf-typegen": `wrangler types`,
 		},

--- a/packages/create-cloudflare/templates-experimental/remix/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/remix/c3.ts
@@ -1,8 +1,6 @@
 import { logRaw } from "@cloudflare/cli";
 import { brandColor, dim } from "@cloudflare/cli/colors";
-import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
-import { transformFile } from "helpers/codemod";
 import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import type { TemplateConfig } from "../../src/templates";

--- a/packages/create-cloudflare/templates-experimental/remix/templates/public/.assetsignore
+++ b/packages/create-cloudflare/templates-experimental/remix/templates/public/.assetsignore
@@ -1,4 +1,0 @@
-_worker.js
-_routes.json
-_headers
-_redirects

--- a/packages/create-cloudflare/templates-experimental/remix/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/remix/templates/wrangler.toml
@@ -1,7 +1,7 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "<TBD>"
 compatibility_date = "<TBD>"
-main = "./build/worker/index.js"
+main = "./server.ts"
 assets = { directory = "./build/client" }
 
 # Workers Logs


### PR DESCRIPTION
Fixes n/a.

This PR updates the experimental remix template to be based on its worker template.
Ref: https://github.com/remix-run/remix/pull/10034

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: No feature change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: template config change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No feature change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
