### PR TITLE
fix(create-cloudflare): enable nodejs_compact on astro template

### DIFF
--- a/.changeset/famous-chairs-sin.md
+++ b/.changeset/famous-chairs-sin.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: missing nodejs_compact flag on astro template

--- a/packages/create-cloudflare/templates/astro/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates/astro/templates/wrangler.toml
@@ -1,6 +1,7 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "<TBD>"
 compatibility_date = "<TBD>"
+compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./dist"
 
 # Automatically place your workloads in an optimal location to minimize latency.


### PR DESCRIPTION
Fixes n/a.

Our create-cloudflare e2e test has been failing getting the preview running on astro for a while (e.g. [This CI run](https://github.com/cloudflare/workers-sdk/actions/runs/11683132429/job/32531697289#step:4:245)). This PR should fix the issue.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no feature change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no feature change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
