### PR TITLE
Cleanup dev registry messaging

### DIFF
--- a/.changeset/large-otters-search.md
+++ b/.changeset/large-otters-search.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Clarify dev registry messaging around locally connected services. The connection status of local service bindings & durable object bindings is now indicated by `connected` or `not connected` next to their entry in the bindings summary. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -10,9 +10,9 @@ exports[`Pages 'wrangler pages dev --no-x-dev-env' > should merge (with override
 ▲ [WARNING] This worker is bound to live services: SERVICE_BINDING_1_TOML (SERVICE_NAME_1_TOML), SERVICE_BINDING_2_TOML (SERVICE_NAME_2_TOML)
 Your worker has access to the following bindings:
 - Durable Objects:
-  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 not connected)
-  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML not connected)
-  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS not connected)
+  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 [not connected])
+  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML [not connected])
+  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS [not connected])
 - KV Namespaces:
   - KV_BINDING_1_TOML: NEW_KV_ID_1 (local)
   - KV_BINDING_2_TOML: KV_ID_2_TOML (local)
@@ -26,16 +26,16 @@ Your worker has access to the following bindings:
   - R2_BINDING_2_TOML: R2_BUCKET_2_TOML (local)
   - R2_BINDING_3_TOML: R2_BUCKET_3_ARGS (local)
 - Services:
-  - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1 not connected
-  - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML not connected
-  - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS not connected
+  - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1 [not connected]
+  - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML [not connected]
+  - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS [not connected]
 - AI:
   - Name: AI_BINDING_2_TOML
 - Vars:
   - VAR1: "(hidden)"
   - VAR2: "VAR_2_TOML"
   - VAR3: "(hidden)"
-Service bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by connected or not connected. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
+Service bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
 ▲ [WARNING] ⎔ Support for service bindings in local mode is experimental and may change.
 ▲ [WARNING] ⎔ Support for external Durable Objects in local mode is experimental and may change.
 "
@@ -50,9 +50,9 @@ exports[`Pages 'wrangler pages dev --x-dev-env' > should merge (with override) \
   - {"name":"DO_BINDING_2_TOML","class_name":"DO_2_TOML","script_name":"DO_SCRIPT_2_TOML"}
 Your worker has access to the following bindings:
 - Durable Objects:
-  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 not connected)
-  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML not connected)
-  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS not connected)
+  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 [not connected])
+  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML [not connected])
+  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS [not connected])
 - KV Namespaces:
   - KV_BINDING_1_TOML: NEW_KV_ID_1 (local)
   - KV_BINDING_2_TOML: KV_ID_2_TOML (local)
@@ -66,16 +66,16 @@ Your worker has access to the following bindings:
   - R2_BINDING_2_TOML: R2_BUCKET_2_TOML (local)
   - R2_BINDING_3_TOML: R2_BUCKET_3_ARGS (local)
 - Services:
-  - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1 not connected
-  - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML not connected
-  - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS not connected
+  - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1 [not connected]
+  - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML [not connected]
+  - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS [not connected]
 - AI:
   - Name: AI_BINDING_2_TOML
 - Vars:
   - VAR1: "(hidden)"
   - VAR2: "VAR_2_TOML"
   - VAR3: "(hidden)"
-Service bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by connected or not connected. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
+Service bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
 ▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
 "
 `;

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -10,9 +10,9 @@ exports[`Pages 'wrangler pages dev --no-x-dev-env' > should merge (with override
 ▲ [WARNING] This worker is bound to live services: SERVICE_BINDING_1_TOML (SERVICE_NAME_1_TOML), SERVICE_BINDING_2_TOML (SERVICE_NAME_2_TOML)
 Your worker has access to the following bindings:
 - Durable Objects:
-  - DO_BINDING_1_TOML: NEW_DO_1 (defined in 🔴 NEW_DO_SCRIPT_1)
-  - DO_BINDING_2_TOML: DO_2_TOML (defined in 🔴 DO_SCRIPT_2_TOML)
-  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in 🔴 DO_SCRIPT_3_ARGS)
+  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 not connected)
+  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML not connected)
+  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS not connected)
 - KV Namespaces:
   - KV_BINDING_1_TOML: NEW_KV_ID_1 (local)
   - KV_BINDING_2_TOML: KV_ID_2_TOML (local)
@@ -26,15 +26,16 @@ Your worker has access to the following bindings:
   - R2_BINDING_2_TOML: R2_BUCKET_2_TOML (local)
   - R2_BINDING_3_TOML: R2_BUCKET_3_ARGS (local)
 - Services:
-  - SERVICE_BINDING_1_TOML: 🔴 NEW_SERVICE_NAME_1
-  - SERVICE_BINDING_2_TOML: 🔴 SERVICE_NAME_2_TOML
-  - SERVICE_BINDING_3_TOML: 🔴 SERVICE_NAME_3_ARGS
+  - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1 not connected
+  - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML not connected
+  - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS not connected
 - AI:
   - Name: AI_BINDING_2_TOML
 - Vars:
   - VAR1: "(hidden)"
   - VAR2: "VAR_2_TOML"
   - VAR3: "(hidden)"
+Service bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by connected or not connected. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
 ▲ [WARNING] ⎔ Support for service bindings in local mode is experimental and may change.
 ▲ [WARNING] ⎔ Support for external Durable Objects in local mode is experimental and may change.
 "
@@ -49,9 +50,9 @@ exports[`Pages 'wrangler pages dev --x-dev-env' > should merge (with override) \
   - {"name":"DO_BINDING_2_TOML","class_name":"DO_2_TOML","script_name":"DO_SCRIPT_2_TOML"}
 Your worker has access to the following bindings:
 - Durable Objects:
-  - DO_BINDING_1_TOML: NEW_DO_1 (defined in 🔴 NEW_DO_SCRIPT_1)
-  - DO_BINDING_2_TOML: DO_2_TOML (defined in 🔴 DO_SCRIPT_2_TOML)
-  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in 🔴 DO_SCRIPT_3_ARGS)
+  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 not connected)
+  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML not connected)
+  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS not connected)
 - KV Namespaces:
   - KV_BINDING_1_TOML: NEW_KV_ID_1 (local)
   - KV_BINDING_2_TOML: KV_ID_2_TOML (local)
@@ -65,16 +66,16 @@ Your worker has access to the following bindings:
   - R2_BINDING_2_TOML: R2_BUCKET_2_TOML (local)
   - R2_BINDING_3_TOML: R2_BUCKET_3_ARGS (local)
 - Services:
-  - SERVICE_BINDING_1_TOML: 🔴 NEW_SERVICE_NAME_1
-  - SERVICE_BINDING_2_TOML: 🔴 SERVICE_NAME_2_TOML
-  - SERVICE_BINDING_3_TOML: 🔴 SERVICE_NAME_3_ARGS
+  - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1 not connected
+  - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML not connected
+  - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS not connected
 - AI:
   - Name: AI_BINDING_2_TOML
 - Vars:
   - VAR1: "(hidden)"
   - VAR2: "VAR_2_TOML"
   - VAR3: "(hidden)"
-▲ [WARNING] This worker is bound to live services: SERVICE_BINDING_1_TOML (NEW_SERVICE_NAME_1), SERVICE_BINDING_3_TOML (SERVICE_NAME_3_ARGS), SERVICE_BINDING_2_TOML (SERVICE_NAME_2_TOML)
+Service bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by connected or not connected. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
 ▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
 "
 `;

--- a/packages/wrangler/e2e/dev-registry.test.ts
+++ b/packages/wrangler/e2e/dev-registry.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
 import { generateResourceName } from "./helpers/generate-resource-name";
+import { normalizeOutput } from "./helpers/normalize";
 import { seed as baseSeed, makeRoot } from "./helpers/setup";
 import type { RequestInit } from "undici";
 
@@ -179,6 +180,10 @@ describe.each([
 			await vi.waitFor(
 				async () => await expect(fetchText(url)).resolves.toBe("hello world"),
 				{ interval: 1000, timeout: 10_000 }
+			);
+
+			expect(normalizeOutput(workerA.currentOutput)).toContain(
+				"bindings connect to other `wrangler dev` processes running locally"
 			);
 		});
 

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -120,7 +120,7 @@ describe.each([
 		expect(normalizeOutput(worker.currentOutput)).toContain(
 			dedent`Your worker has access to the following bindings:
 					- Durable Objects:
-					  - TEST_DO: TestDurableObject (defined in a not connected)
+					  - TEST_DO: TestDurableObject (defined in a [not connected])
 					- KV Namespaces:
 					  - TEST_KV: TEST_KV (local)
 					- D1 Databases:
@@ -128,7 +128,7 @@ describe.each([
 					- R2 Buckets:
 					  - TEST_R2: TEST_R2 (local)
 					- Services:
-					  - TEST_SERVICE: test-worker not connected
+					  - TEST_SERVICE: test-worker [not connected]
 		`
 		);
 	});

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -120,7 +120,7 @@ describe.each([
 		expect(normalizeOutput(worker.currentOutput)).toContain(
 			dedent`Your worker has access to the following bindings:
 					- Durable Objects:
-					  - TEST_DO: TestDurableObject (defined in 🔴 a)
+					  - TEST_DO: TestDurableObject (defined in a not connected)
 					- KV Namespaces:
 					  - TEST_KV: TEST_KV (local)
 					- D1 Databases:
@@ -128,7 +128,7 @@ describe.each([
 					- R2 Buckets:
 					  - TEST_R2: TEST_R2 (local)
 					- Services:
-					  - TEST_SERVICE: 🔴 test-worker
+					  - TEST_SERVICE: test-worker not connected
 		`
 		);
 	});

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1229,9 +1229,9 @@ describe.sequential("wrangler dev", () => {
 				"Your worker has access to the following bindings:
 				- Durable Objects:
 				  - NAME_1: CLASS_1
-				  - NAME_2: CLASS_2 (defined in 🔴 SCRIPT_A)
+				  - NAME_2: CLASS_2 (defined in SCRIPT_A not connected)
 				  - NAME_3: CLASS_3
-				  - NAME_4: CLASS_4 (defined in 🔴 SCRIPT_B)
+				  - NAME_4: CLASS_4 (defined in SCRIPT_B not connected)
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -1809,15 +1809,11 @@ describe.sequential("wrangler dev", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Your worker has access to the following bindings:
 				- Services:
-				  - WorkerA: 🔴 A
-				  - WorkerB: 🔴 B
+				  - WorkerA: A not connected
+				  - WorkerB: B not connected
 				"
 			`);
-			expect(std.warn).toMatchInlineSnapshot(`
-			"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis worker is bound to live services: WorkerA (A), WorkerB (B@staging)[0m
-
-			"
-		`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 	});
 
@@ -1834,15 +1830,11 @@ describe.sequential("wrangler dev", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Your worker has access to the following bindings:
 				- Services:
-				  - WorkerA: 🔴 A
-				  - WorkerB: 🔴 B
+				  - WorkerA: A not connected
+				  - WorkerB: B not connected
 				"
 			`);
-			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis worker is bound to live services: WorkerA (A), WorkerB (B@staging)[0m
-
-				"
-			`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
 		it("should mask vars that were overriden in .dev.vars", async () => {

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1229,9 +1229,9 @@ describe.sequential("wrangler dev", () => {
 				"Your worker has access to the following bindings:
 				- Durable Objects:
 				  - NAME_1: CLASS_1
-				  - NAME_2: CLASS_2 (defined in SCRIPT_A not connected)
+				  - NAME_2: CLASS_2 (defined in SCRIPT_A [not connected])
 				  - NAME_3: CLASS_3
-				  - NAME_4: CLASS_4 (defined in SCRIPT_B not connected)
+				  - NAME_4: CLASS_4 (defined in SCRIPT_B [not connected])
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -1809,8 +1809,8 @@ describe.sequential("wrangler dev", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Your worker has access to the following bindings:
 				- Services:
-				  - WorkerA: A not connected
-				  - WorkerB: B not connected
+				  - WorkerA: A [not connected]
+				  - WorkerB: B [not connected]
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -1830,8 +1830,8 @@ describe.sequential("wrangler dev", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Your worker has access to the following bindings:
 				- Services:
-				  - WorkerA: A not connected
-				  - WorkerB: B not connected
+				  - WorkerA: A [not connected]
+				  - WorkerB: B [not connected]
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/logger.test.ts
+++ b/packages/wrangler/src/__tests__/logger.test.ts
@@ -204,20 +204,38 @@ describe("logger", () => {
 		});
 	});
 
-	describe("warnOnce", () => {
+	describe("once", () => {
 		it("should only log the same message once", () => {
 			const logger = new Logger();
-			logger.warnOnce("This is a warnOnce message");
-			logger.warnOnce("This is a warnOnce message");
-			logger.warnOnce("This is a warnOnce message");
-			logger.warnOnce("This is a warnOnce message");
-			logger.warnOnce("This is a warnOnce message");
+			logger.once.warn("This is a once.warn message");
+			logger.once.warn("This is a once.warn message");
+			logger.once.warn("This is a once.warn message");
+			logger.once.warn("This is a once.warn message");
+			logger.once.warn("This is a once.warn message");
 
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis is a warnOnce message[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis is a once.warn message[0m
 
 				"
 			`);
+		});
+
+		it("should log once per log level", () => {
+			const logger = new Logger();
+			logger.once.warn("This is a once message");
+			logger.once.info("This is a once message");
+			logger.once.warn("This is a once message");
+			logger.once.warn("This is a once message");
+			logger.once.info("This is a once message");
+			logger.once.info("This is a once message");
+			logger.once.warn("This is a once message");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mThis is a once message[0m
+
+				"
+			`);
+			expect(std.info).toMatchInlineSnapshot(`"This is a once message"`);
 		});
 	});
 });

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -316,7 +316,7 @@ async function resolveConfig(
 	validateAssetsArgsAndConfig(resolved);
 
 	const services = extractBindingsOfType("service", resolved.bindings);
-	if (services && services.length > 0) {
+	if (services && services.length > 0 && resolved.dev?.remote) {
 		logger.warn(
 			`This worker is bound to live services: ${services
 				.map(

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -306,9 +306,9 @@ export function printBindings(
 									(d) => d.className === class_name
 								)
 							) {
-								value += ` (defined in ${script_name} ${chalk.green("connected")})`;
+								value += ` (defined in ${script_name} ${chalk.green("[connected]")})`;
 							} else {
-								value += ` (defined in ${script_name} ${chalk.red("not connected")})`;
+								value += ` (defined in ${script_name} ${chalk.red("[not connected]")})`;
 							}
 						} else {
 							value += ` (defined in ${script_name})`;
@@ -473,9 +473,9 @@ export function printBindings(
 						(!entrypoint ||
 							registryDefinition.entrypointAddresses?.[entrypoint])
 					) {
-						value = value + " " + chalk.green("connected");
+						value = value + " " + chalk.green("[connected]");
 					} else {
-						value = value + " " + chalk.red("not connected");
+						value = value + " " + chalk.red("[not connected]");
 					}
 				}
 				return {
@@ -645,7 +645,7 @@ export function printBindings(
 
 	if (hasConnectionStatus) {
 		logger.once.info(
-			`\nService bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by ${chalk.green("connected")} or ${chalk.red("not connected")}. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development\n`
+			`\nService bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by ${chalk.green("[connected]")} or ${chalk.red("[not connected]")}. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development\n`
 		);
 	}
 }

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -237,7 +237,7 @@ export function printBindings(
 		local?: boolean;
 	} = {}
 ) {
-	let someConnectionStatus = false;
+	let hasConnectionStatus = false;
 	const truncate = (item: string | Record<string, unknown>) => {
 		const s = typeof item === "string" ? item : JSON.stringify(item);
 		const maxLength = 40;
@@ -299,7 +299,7 @@ export function printBindings(
 						if (context.local) {
 							const registryDefinition = context.registry?.[script_name];
 
-							someConnectionStatus = true;
+							hasConnectionStatus = true;
 							if (
 								registryDefinition &&
 								registryDefinition.durableObjects.some(
@@ -466,7 +466,7 @@ export function printBindings(
 
 				if (context.local) {
 					const registryDefinition = context.registry?.[service];
-					someConnectionStatus = true;
+					hasConnectionStatus = true;
 
 					if (
 						registryDefinition &&
@@ -643,7 +643,7 @@ export function printBindings(
 
 	logger.log(message);
 
-	if (someConnectionStatus) {
+	if (hasConnectionStatus) {
 		logger.once.info(
 			`\nService bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by ${chalk.green("connected")} or ${chalk.red("not connected")}. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development\n`
 		);

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -284,7 +284,7 @@ export async function deployHandler(args: DeployArgs) {
 	}
 
 	if (config.workflows?.length) {
-		logger.warnOnce("Workflows is currently in open beta.");
+		logger.once.warn("Workflows is currently in open beta.");
 	}
 
 	validateAssetsArgsAndConfig(args, config);

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -241,7 +241,7 @@ export default async function triggersDeploy(
 	}
 
 	if (config.workflows?.length) {
-		logger.warnOnce("Workflows is currently in open beta.");
+		logger.once.warn("Workflows is currently in open beta.");
 
 		for (const workflow of config.workflows) {
 			deployments.push(

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -123,7 +123,7 @@ export async function versionsDeployHandler(args: VersionsDeployArgs) {
 	}
 
 	if (config.workflows?.length) {
-		logger.warnOnce("Workflows is currently in open beta.");
+		logger.once.warn("Workflows is currently in open beta.");
 	}
 
 	const versionCache: VersionCache = new Map();

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -226,7 +226,7 @@ export async function versionsUploadHandler(
 	}
 
 	if (config.workflows?.length) {
-		logger.warnOnce("Workflows is currently in open beta.");
+		logger.once.warn("Workflows is currently in open beta.");
 	}
 
 	validateAssetsArgsAndConfig(


### PR DESCRIPTION
Cleans up & clarifies dev registry messaging (mostly in response to https://github.com/cloudflare/workers-sdk/issues/7009#issuecomment-2427012598) cc @isaac-mcfadyen 

- Shift from inscrutable red & green dots to `connected`/`not connected` with an explanation logged the first time
<img width="604" alt="Screenshot 2024-11-05 at 13 50 49" src="https://github.com/user-attachments/assets/6aa616a3-da23-4b8c-9369-e6e25f376aa4">

- Remove the "Live workers" warning in local mode, where it doesn't apply
---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/17994
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
