### PR TITLE
Remove incorrect logic in Asset Worker

### DIFF
--- a/.changeset/metal-flies-cross.md
+++ b/.changeset/metal-flies-cross.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Remove incorrect logic in Asset Worker.

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -117,9 +117,8 @@ export default class extends WorkerEntrypoint<Env> {
 		}
 	}
 
-	async unstable_canFetch(request: Request): Promise<boolean | Response> {
+	async unstable_canFetch(request: Request): Promise<boolean> {
 		const url = new URL(request.url);
-		const method = request.method.toUpperCase();
 		const decodedPathname = decodePath(url.pathname);
 		const intent = await getIntent(
 			decodedPathname,
@@ -129,10 +128,6 @@ export default class extends WorkerEntrypoint<Env> {
 			},
 			this.unstable_exists.bind(this)
 		);
-		// if asset exists but non GET/HEAD method, 405
-		if (intent && ["GET", "HEAD"].includes(method)) {
-			return new MethodNotAllowedResponse();
-		}
 		if (intent === null) {
 			return false;
 		}

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -5,10 +5,7 @@ import { Analytics } from "./analytics";
 import { AssetsManifest } from "./assets-manifest";
 import { applyConfigurationDefaults } from "./configuration";
 import { decodePath, getIntent, handleRequest } from "./handler";
-import {
-	InternalServerErrorResponse,
-	MethodNotAllowedResponse,
-} from "./responses";
+import { InternalServerErrorResponse } from "./responses";
 import { getAssetWithMetadataFromKV } from "./utils/kv";
 import type { AssetConfig, UnsafePerformanceTimer } from "../../utils/types";
 import type { ColoMetadata, Environment, ReadyAnalytics } from "./types";


### PR DESCRIPTION
When I was looking through the Asset Worker code I spotted an error:

https://github.com/cloudflare/workers-sdk/blob/afe9850931b7730989e005a612ea74887f5d5e72/packages/workers-shared/asset-worker/src/index.ts#L132-L135

This currently does the opposite of what it should and returns the `MethodNotAllowedResponse` for `GET` and `HEAD` methods. The only reason that the Router Worker is still functioning correctly is because it treats the `MethodNotAllowedResponse` as truthy.

https://github.com/cloudflare/workers-sdk/blob/afe9850931b7730989e005a612ea74887f5d5e72/packages/workers-shared/router-worker/src/index.ts#L60

I've removed method handling from `unstable_canFetch` altogether as I feel that it should only return a boolean. The Asset Worker already returns a `MethodNotAllowedResponse` for methods other than `GET` and `HEAD`.

https://github.com/cloudflare/workers-sdk/blob/afe9850931b7730989e005a612ea74887f5d5e72/packages/workers-shared/asset-worker/src/handler.ts#L32-L34

If this also needs to occur earlier then the request method could be checked in the Router Worker.

I haven't added tests as there aren't any others for the Asset Worker beyond the KV store at present.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: not currently implemented
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented