### PR TITLE
Handle new D1 workerd behaviour in Miniflare's tests

### DIFF
--- a/packages/miniflare/test/plugins/d1/suite.ts
+++ b/packages/miniflare/test/plugins/d1/suite.ts
@@ -205,7 +205,7 @@ test("D1PreparedStatement: first", async (t) => {
 		)
 		.first();
 
-	// workerd changed it's behaviour from throwing to returning the last result. Miniflare's tests should pass with either version of workerd
+	// workerd changed its behaviour from throwing to returning the last result. Miniflare's tests should pass with either version of workerd
 	try {
 		const d1Result = await resultPromise;
 		t.deepEqual(d1Result, {
@@ -292,7 +292,7 @@ test("D1PreparedStatement: run", async (t) => {
 		)
 		.run();
 
-	// workerd changed it's behaviour from throwing to returning the last result. Miniflare's tests should pass with either version of workerd
+	// workerd changed its behaviour from throwing to returning the last result. Miniflare's tests should pass with either version of workerd
 	try {
 		result = await resultPromise;
 		t.deepEqual(result, {
@@ -377,7 +377,7 @@ test("D1PreparedStatement: all", async (t) => {
 		)
 		.all<ColourRow>();
 
-	// workerd changed it's behaviour from throwing to returning the last result. Miniflare's tests should pass with either version of workerd
+	// workerd changed its behaviour from throwing to returning the last result. Miniflare's tests should pass with either version of workerd
 	try {
 		result = await resultPromise;
 		t.deepEqual(result, {
@@ -456,7 +456,7 @@ test("D1PreparedStatement: raw", async (t) => {
 		)
 		.raw<RawColourRow>();
 
-	// workerd changed it's behaviour from throwing to returning the last result. Miniflare's tests should pass with either version of workerd
+	// workerd changed its behaviour from throwing to returning the last result. Miniflare's tests should pass with either version of workerd
 	try {
 		const result = await resultPromise;
 		t.deepEqual(result, [[3, "blue", 0x0000ff]]);


### PR DESCRIPTION
`workerd` has made a change to how multiple D1 statements are treated and some cases that used to be an error are no longer an error. This change adapts Miniflare's test suite to handle both the old and new behaviour, to unblock a `workerd` release.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: only touching miniflare tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal testing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
