### PR TITLE
Fixes bug where indexId was never provided to analytics

### DIFF
--- a/.changeset/seven-parents-report.md
+++ b/.changeset/seven-parents-report.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Fixes bug where indexId was never set for router-worker and asset-worker

--- a/packages/workers-shared/asset-worker/src/analytics.ts
+++ b/packages/workers-shared/asset-worker/src/analytics.ts
@@ -48,7 +48,7 @@ export class Analytics {
 		return this.data[key];
 	}
 
-	write(hostname?: string) {
+	write() {
 		if (!this.readyAnalytics) {
 			return;
 		}
@@ -56,7 +56,7 @@ export class Analytics {
 		this.readyAnalytics.logEvent({
 			version: VERSION,
 			accountId: 0, // TODO: need to plumb through
-			indexId: hostname,
+			indexId: this.data.hostname?.substring(0, 96),
 			doubles: [
 				this.data.requestTime ?? -1, // double1
 				this.data.coloId ?? -1, // double2

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -1,4 +1,4 @@
-import type { Environment, ReadyAnalytics } from "./types";
+import type { ReadyAnalytics } from "./types";
 
 // This will allow us to make breaking changes to the analytic schema
 const VERSION = 1;
@@ -35,6 +35,11 @@ type Data = {
 
 export class Analytics {
 	private data: Data = {};
+	private readyAnalytics?: ReadyAnalytics;
+
+	constructor(readyAnalytics?: ReadyAnalytics) {
+		this.readyAnalytics = readyAnalytics;
+	}
 
 	setData(newData: Partial<Data>) {
 		this.data = { ...this.data, ...newData };
@@ -44,15 +49,15 @@ export class Analytics {
 		return this.data[key];
 	}
 
-	write(env: Environment, readyAnalytics?: ReadyAnalytics, hostname?: string) {
-		if (!readyAnalytics) {
+	write() {
+		if (!this.readyAnalytics) {
 			return;
 		}
 
-		readyAnalytics.logEvent({
+		this.readyAnalytics.logEvent({
 			version: VERSION,
 			accountId: 0, // TODO: need to plumb through
-			indexId: hostname,
+			indexId: this.data.hostname?.substring(0, 96),
 			doubles: [
 				this.data.requestTime ?? -1, // double1
 				this.data.coloId ?? -1, // double2

--- a/packages/workers-shared/router-worker/src/index.ts
+++ b/packages/workers-shared/router-worker/src/index.ts
@@ -24,7 +24,7 @@ interface Env {
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		let sentry: ReturnType<typeof setupSentry> | undefined;
-		const analytics = new Analytics();
+		const analytics = new Analytics(env.ANALYTICS);
 		const performance = new PerformanceTimer(env.UNSAFE_PERFORMANCE);
 		const startTimeMs = performance.now();
 
@@ -80,7 +80,7 @@ export default {
 			throw err;
 		} finally {
 			analytics.setData({ requestTime: performance.now() - startTimeMs });
-			analytics.write(env.ENVIRONMENT, env.ANALYTICS);
+			analytics.write();
 		}
 	},
 };


### PR DESCRIPTION
Fixes bug where indexId was never provided to analytics.

_Describe your change..._
---
Hostname was never provided as a param to write, causing indexId to never be set. In addition, small refactor to remove all params from Analytics.write().

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: n/a
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: not necessary
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: not documented