### PR TITLE
[Queues] Output suggested wrangler.toml changes after creating a Queue

### DIFF
--- a/.changeset/spicy-pigs-remember.md
+++ b/.changeset/spicy-pigs-remember.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Output suggested wrangler.toml changes after creating a Queue

--- a/packages/wrangler/src/__tests__/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues.test.ts
@@ -258,8 +258,19 @@ describe("wrangler", () => {
 				const requests = mockCreateRequest("testQueue");
 				await runWrangler("queues create testQueue");
 				expect(std.out).toMatchInlineSnapshot(`
-					"Creating queue testQueue.
-					Created queue testQueue."
+					"🌀 Creating queue 'testQueue'
+					✅ Created queue 'testQueue'
+
+					Configure your Worker to send messages to this queue:
+
+					[[queues.producers]]
+					queue = \\"testQueue\\"
+					binding = \\"testQueue\\"
+
+					Configure your Worker to consume messages from this queue:
+
+					[[queues.consumers]]
+					queue = \\"testQueue\\""
 			  `);
 				expect(requests.count).toEqual(1);
 			});
@@ -290,7 +301,7 @@ describe("wrangler", () => {
 					runWrangler(`queues create ${queueName}`)
 				).rejects.toThrowError();
 				expect(std.out).toMatchInlineSnapshot(`
-			"Creating queue testQueue.
+			"🌀 Creating queue 'testQueue'
 			Queues is not currently enabled on this account. Go to https://dash.cloudflare.com/some-account-id/workers/queues to enable it.
 
 			[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/queues) failed.[0m
@@ -308,8 +319,19 @@ describe("wrangler", () => {
 				const requests = mockCreateRequest("testQueue", { delivery_delay: 10 });
 				await runWrangler("queues create testQueue --delivery-delay-secs=10");
 				expect(std.out).toMatchInlineSnapshot(`
-					"Creating queue testQueue.
-					Created queue testQueue."
+					"🌀 Creating queue 'testQueue'
+					✅ Created queue 'testQueue'
+
+					Configure your Worker to send messages to this queue:
+
+					[[queues.producers]]
+					queue = \\"testQueue\\"
+					binding = \\"testQueue\\"
+
+					Configure your Worker to consume messages from this queue:
+
+					[[queues.consumers]]
+					queue = \\"testQueue\\""
 			  `);
 				expect(requests.count).toEqual(1);
 			});

--- a/packages/wrangler/src/queues/cli/commands/create.ts
+++ b/packages/wrangler/src/queues/cli/commands/create.ts
@@ -1,6 +1,7 @@
 import { readConfig } from "../../../config";
 import { CommandLineArgsError } from "../../../errors";
 import { logger } from "../../../logger";
+import { getValidBindingName } from "../../../utils/getValidBindingName";
 import { createQueue } from "../../client";
 import { handleFetchError } from "../../utils";
 import type {
@@ -53,9 +54,18 @@ export async function handler(
 	const config = readConfig(args.config, args);
 	const body = createBody(args);
 	try {
-		logger.log(`Creating queue ${args.name}.`);
+		logger.log(`🌀 Creating queue '${args.name}'`);
 		await createQueue(config, body);
-		logger.log(`Created queue ${args.name}.`);
+		logger.log(
+			`✅ Created queue '${args.name}'\n\n` +
+				"Configure your Worker to send messages to this queue:\n\n" +
+				"[[queues.producers]]\n" +
+				`queue = "${args.name}"\n` +
+				`binding = "${getValidBindingName(args.name, "queue")}"\n\n` +
+				"Configure your Worker to consume messages from this queue:\n\n" +
+				"[[queues.consumers]]\n" +
+				`queue = "${args.name}"`
+		);
 	} catch (e) {
 		handleFetchError(e as { code?: number });
 	}


### PR DESCRIPTION
Fixes #MQ-800.

Outputs suggested wrangler.toml changes after creating a Queue

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: captured by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this changes what we log after creating a Queue

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
