### PR TITLE
chore: add more useful information in the PR coment for previews

### DIFF
--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -79,11 +79,34 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           VITE_DEVTOOLS_PREVIEW_URL: ${{ env.VITE_DEVTOOLS_PREVIEW_URL }}
 
+      - name: "Comment on PR with Devtools Link"
+        if: contains(github.event.*.labels.*.name, 'preview:wrangler-devtools')
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: ${{ steps.finder.outputs.pr }}
+          message: |
+            The Wrangler DevTools preview is now live. You can access it directly at: ${{ env.VITE_DEVTOOLS_PREVIEW_URL }}/js_app
+
+            In order to test the DevTools preview in `wrangler`:
+
+            1. `npx wrangler dev`.
+            2. Hit `d` to open the DevTools in a fresh browser window.
+            3. Paste the DevTools preview URL into the address bar (keeping all existing query parameters), e.g:
+
+            ```
+            - https://devtools.devprod.cloudflare.dev/js_app?theme=systemPreferred&ws=127.0.0.1%3A9229%2Fws&domain=tester&debugger=true
+            + https://8afc7d3d.cloudflare-devtools.pages.dev/js_app?theme=systemPreferred&ws=127.0.0.1%3A9229%2Fws&domain=tester&debugger=true
+            ```
+
       - name: "Comment on PR with Workers Playground Link"
         if: contains(github.event.*.labels.*.name, 'preview:wrangler-devtools') && contains(github.event.*.labels.*.name, 'preview:workers-playground')
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          number: ${{ steps.finder.outputs.pr }}
+          header: ${{ steps.finder.outputs.pr }}
+          append: true
           message: |
-            The Wrangler DevTools and Workers Playground previews are now live. The Playground preview embeds the DevTools preview, so you can see them working together at:
+
+            ---
+
+            The Workers Playground preview is also now live. The Playground preview embeds the above DevTools preview, so you can see them working together at:
             ${{ env.PLAYGROUND_URL }}/playground


### PR DESCRIPTION
Fixes N/A.

We already have a PR comment for when you have the `preview:workers-playground` and `preview:wrangler-devtools` labels, but it would also be useful to display a link to the DevTools preview even if the Playground preview has not been requested. 

This PR ensures that the DevTools preview link is displayed in the comment along with some simple instructions of how to test it.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: QoL
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Doesn't touch any source code
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: QoL (internal)