### PR TITLE
chore: update Wrangler DevTools semver to minor

### DIFF
--- a/.changeset/famous-birds-remain.md
+++ b/.changeset/famous-birds-remain.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/wrangler-devtools": patch
+"@cloudflare/wrangler-devtools": minor
 ---
 
 feat: update devtools patches for release


### PR DESCRIPTION
Fixes N/A.

It was decided that the DevTools work [here](https://github.com/cloudflare/workers-sdk/pull/7137) should be `minor` instead of `patch`.
---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Not touching source code
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Not touching source code
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal only
