### PR TITLE
[D1] fix console output for `wrangler d1 migrations create`

### DIFF
--- a/.changeset/new-adults-float.md
+++ b/.changeset/new-adults-float.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix console output for `wrangler d1 migrations create`

--- a/packages/wrangler/src/d1/migrations/create.ts
+++ b/packages/wrangler/src/d1/migrations/create.ts
@@ -55,7 +55,7 @@ export const CreateHandler = withConfig<CreateHandlerOptions>(
 
 		logger.log(`✅ Successfully created Migration '${newMigrationName}'!\n`);
 		logger.log(`The migration is available for editing here`);
-		logger.log(`${migrationsPath}/{newMigrationName}`);
+		logger.log(`${migrationsPath}/${newMigrationName}`);
 	}
 );
 


### PR DESCRIPTION
Fixes wrong console output after using `wrangler d1 migrations create`

Before: /home/user/path/{newMigrationName}
After: /home/user/path/0001_migration.sql

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no existing tests, just log output so not worth adding
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no existing e2e tests print this log message I think
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: messaging change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
