### PR TITLE
Add support for Tail Consumers with Assets

### DIFF
--- a/.changeset/nice-chefs-hang.md
+++ b/.changeset/nice-chefs-hang.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: Tail Consumers are now supported for Workers with assets.
+
+You can now configure `tail_consumers` in conjunction with `assets` in your `wrangler.toml` file. Read more about [Static Assets](https://developers.cloudflare.com/workers/static-assets/) and [Tail Consumers](https://developers.cloudflare.com/workers/observability/logs/tail-workers/) in the documentation.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4352,31 +4352,6 @@ addEventListener('fetch', event => {});`
 			);
 		});
 
-		it("should error if --assets and config.tail_consumers are used together", async () => {
-			writeWranglerToml({
-				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
-			});
-			fs.mkdirSync("public");
-			await expect(
-				runWrangler("deploy --assets public")
-			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets.]`
-			);
-		});
-
-		it("should error if config.assets and config.tail_consumers are used together", async () => {
-			writeWranglerToml({
-				assets: { directory: "./public" },
-				tail_consumers: [{ service: "<TAIL_WORKER_NAME>" }],
-			});
-			fs.mkdirSync("public");
-			await expect(
-				runWrangler("deploy")
-			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Cannot use assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets.]`
-			);
-		});
-
 		it("should error if directory specified by flag --assets does not exist", async () => {
 			await expect(runWrangler("deploy --assets abc")).rejects.toThrow(
 				new RegExp(

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -406,13 +406,6 @@ export function validateAssetsArgsAndConfig(
 		);
 	}
 
-	// tail_consumers don't exist in dev, so ignore SDW here
-	if ((args.assets || config?.assets) && config?.tail_consumers?.length) {
-		throw new UserError(
-			"Cannot use assets and tail consumers in the same Worker. Tail Workers are not yet supported for Workers with assets."
-		);
-	}
-
 	const noOpEntrypoint = path.resolve(
 		getBasePath(),
 		"templates/no-op-worker.js"


### PR DESCRIPTION
Fixes WC-2707.

Adds support for Tail Consumers with Workers which have Assets

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18063/files
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
