### PR TITLE
fix(wrangler): fix failing R2 e2e test

### DIFF
--- a/packages/wrangler/e2e/helpers/normalize.ts
+++ b/packages/wrangler/e2e/helpers/normalize.ts
@@ -11,6 +11,7 @@ export function normalizeOutput(
 		removeWorkersDev,
 		removeWorkerPreviewUrl,
 		removeUUID,
+		removeBinding,
 		normalizeErrorMarkers,
 		replaceByte,
 		stripTrailingWhitespace,
@@ -62,10 +63,17 @@ function removeTimestamp(str: string) {
 		.replace(/\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+?Z/g, "TIMESTAMP")
 		.replace(/\d\d:\d\d:\d\d/g, "TIMESTAMP");
 }
+
 function removeUUID(str: string) {
 	return str.replace(
 		/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/g,
 		"00000000-0000-0000-0000-000000000000"
+	);
+}
+function removeBinding(str: string) {
+	return str.replace(
+		/\w{8}_\w{4}_\w{4}_\w{4}_\w{12}/g,
+		"00000000_0000_0000_0000_000000000000"
 	);
 }
 

--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -21,7 +21,11 @@ describe("r2", () => {
 
 		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
 			"Creating bucket 'tmp-e2e-r2-00000000-0000-0000-0000-000000000000'...
-			✅ Created bucket 'tmp-e2e-r2-00000000-0000-0000-0000-000000000000' with default storage class of Standard."
+			✅ Created bucket 'tmp-e2e-r2-00000000-0000-0000-0000-000000000000' with default storage class of Standard.
+			Configure your Worker to write objects to this bucket:
+			[[r2_buckets]]
+			bucket_name = "tmp-e2e-r2-00000000-0000-0000-0000-000000000000"
+			binding = "tmp_e2e_r2_00000000_0000_0000_0000_000000000000""
 		`);
 	});
 


### PR DESCRIPTION
Fixes n/a.

https://github.com/cloudflare/workers-sdk/commit/ad51d1d77483bf0b4dc73fd392f5cdefe4ddf5d8 broke a related R2 e2e test, which we didn't see due to the fact that e2es were not run on that PR. This PR fixes the breakage.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: e2e test fix
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: e2e test fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
