### PR TITLE
improve(wrangler): fix subdomain tests

### DIFF
--- a/.changeset/clean-tigers-breathe.md
+++ b/.changeset/clean-tigers-breathe.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Avoid an unnecessary GET request during `wrangler deploy`.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -29,7 +29,11 @@ import {
 	mockOAuthFlow,
 } from "./helpers/mock-oauth-flow";
 import { mockUploadWorkerRequest } from "./helpers/mock-upload-worker";
-import { mockSubDomainRequest } from "./helpers/mock-workers-subdomain";
+import {
+	mockGetWorkerSubdomain,
+	mockSubDomainRequest,
+	mockUpdateWorkerSubdomain,
+} from "./helpers/mock-workers-subdomain";
 import {
 	createFetchResult,
 	msw,
@@ -94,9 +98,9 @@ describe("deploy", () => {
 			routes: ["example.com/some-route/*"],
 			workers_dev: true,
 		});
-		mockSubDomainRequest();
 		mockUploadWorkerRequest();
-		mockUpdateWorkerRequest({ enabled: false });
+		mockSubDomainRequest();
+		mockGetWorkerSubdomain({ enabled: true });
 		mockPublishRoutesRequest({ routes: ["example.com/some-route/*"] });
 
 		await runWrangler("deploy ./index.js");
@@ -150,9 +154,10 @@ describe("deploy", () => {
 			scriptName: "test-name",
 			script: { id: "test-name", tag: "abc123" },
 		});
-		mockSubDomainRequest();
 		mockUploadWorkerRequest();
-		mockUpdateWorkerRequest({ enabled: false });
+		mockSubDomainRequest();
+		mockGetWorkerSubdomain({ enabled: false });
+		mockUpdateWorkerSubdomain({ enabled: true });
 		mockPublishRoutesRequest({ routes: ["example.com/some-route/*"] });
 
 		await runWrangler("deploy ./index.js");
@@ -995,7 +1000,7 @@ describe("deploy", () => {
 				routes: ["example.com/some-route/*"],
 			});
 			writeWorkerSource();
-			mockUpdateWorkerRequest({ enabled: false });
+			mockUpdateWorkerSubdomain({ enabled: false });
 			mockUploadWorkerRequest({ expectedType: "esm" });
 			mockPublishRoutesRequest({ routes: ["example.com/some-route/*"] });
 			await runWrangler("deploy ./index");
@@ -1006,7 +1011,7 @@ describe("deploy", () => {
 				route: "",
 			});
 			writeWorkerSource();
-			mockUpdateWorkerRequest({ enabled: false });
+			mockUpdateWorkerSubdomain({ enabled: false });
 			mockUploadWorkerRequest({ expectedType: "esm" });
 			mockSubDomainRequest();
 			mockPublishRoutesRequest({ routes: [] });
@@ -1045,7 +1050,7 @@ describe("deploy", () => {
 				],
 			});
 			writeWorkerSource();
-			mockUpdateWorkerRequest({ enabled: false });
+			mockUpdateWorkerSubdomain({ enabled: false });
 			mockUploadWorkerRequest({ expectedType: "esm" });
 			mockPublishRoutesRequest({
 				routes: [
@@ -1091,8 +1096,8 @@ describe("deploy", () => {
 				],
 			});
 			writeWorkerSource();
-			mockUpdateWorkerRequest({ enabled: false });
-			mockUploadWorkerRequest({ available_on_subdomain: false });
+			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: false });
 			mockGetZones("owned-zone.com", [{ id: "owned-zone-id-1" }]);
 			mockGetWorkerRoutes("owned-zone-id-1");
 			mockPublishRoutesRequest({
@@ -1131,8 +1136,8 @@ describe("deploy", () => {
 				],
 			});
 			writeWorkerSource();
-			mockUpdateWorkerRequest({ enabled: false });
-			mockUploadWorkerRequest({ available_on_subdomain: false });
+			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: false });
 			mockGetZones("owned-zone.com", [{ id: "owned-zone-id-1" }]);
 			mockGetWorkerRoutes("owned-zone-id-1");
 			mockPublishRoutesRequest({
@@ -1179,7 +1184,7 @@ describe("deploy", () => {
 			});
 			mockSubDomainRequest();
 			writeWorkerSource();
-			mockUpdateWorkerRequest({
+			mockUpdateWorkerSubdomain({
 				enabled: false,
 				env: "staging",
 				legacyEnv: false,
@@ -1240,7 +1245,11 @@ describe("deploy", () => {
 				},
 			});
 			writeWorkerSource();
-			mockUpdateWorkerRequest({ enabled: false, legacyEnv: true, env: "dev" });
+			mockUpdateWorkerSubdomain({
+				enabled: false,
+				legacyEnv: true,
+				env: "dev",
+			});
 			mockUploadWorkerRequest({
 				expectedType: "esm",
 				legacyEnv: true,
@@ -1264,7 +1273,7 @@ describe("deploy", () => {
 				},
 			});
 			writeWorkerSource();
-			mockUpdateWorkerRequest({ enabled: false, env: "dev" });
+			mockUpdateWorkerSubdomain({ enabled: false, env: "dev" });
 			mockUploadWorkerRequest({
 				expectedType: "esm",
 				env: "dev",
@@ -1281,7 +1290,7 @@ describe("deploy", () => {
 				routes: ["example.com/some-route/*"],
 			});
 			writeWorkerSource();
-			mockUpdateWorkerRequest({ enabled: false });
+			mockUpdateWorkerSubdomain({ enabled: false });
 			mockUploadWorkerRequest({ expectedType: "esm" });
 			// Simulate the bulk-routes API failing with a not authorized error.
 			mockUnauthorizedPublishRoutesRequest();
@@ -1333,7 +1342,7 @@ describe("deploy", () => {
 				legacy_env: false,
 			});
 			writeWorkerSource();
-			mockUpdateWorkerRequest({ env: "staging", enabled: false });
+			mockUpdateWorkerSubdomain({ env: "staging", enabled: false });
 			mockUploadWorkerRequest({ env: "staging", expectedType: "esm" });
 			// Simulate the bulk-routes API failing with a not authorized error.
 			mockUnauthorizedPublishRoutesRequest({ env: "staging" });
@@ -1362,7 +1371,7 @@ describe("deploy", () => {
 					routes: [{ pattern: "api.example.com", custom_domain: true }],
 				});
 				writeWorkerSource();
-				mockUpdateWorkerRequest({ enabled: false });
+				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				mockCustomDomainsChangesetRequest({});
 				mockPublishCustomDomainsRequest({
@@ -1382,7 +1391,7 @@ describe("deploy", () => {
 					routes: [{ pattern: "api.example.com", custom_domain: true }],
 				});
 				writeWorkerSource();
-				mockUpdateWorkerRequest({ enabled: false });
+				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				mockCustomDomainsChangesetRequest({
 					originConflicts: [
@@ -1427,7 +1436,7 @@ Update them to point to this script instead?`,
 					routes: [{ pattern: "api.example.com", custom_domain: true }],
 				});
 				writeWorkerSource();
-				mockUpdateWorkerRequest({ enabled: false });
+				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				mockCustomDomainsChangesetRequest({
 					dnsRecordConflicts: [
@@ -1464,7 +1473,7 @@ Update them to point to this script instead?`,
 					routes: [{ pattern: "api.example.com", custom_domain: true }],
 				});
 				writeWorkerSource();
-				mockUpdateWorkerRequest({ enabled: false });
+				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				mockCustomDomainsChangesetRequest({
 					originConflicts: [
@@ -1556,7 +1565,7 @@ Update them to point to this script instead?`,
 					routes: [{ pattern: "api.example.com", custom_domain: true }],
 				});
 				writeWorkerSource();
-				mockUpdateWorkerRequest({ enabled: false });
+				mockUpdateWorkerSubdomain({ enabled: false });
 				mockUploadWorkerRequest({ expectedType: "esm" });
 				mockCustomDomainsChangesetRequest({
 					originConflicts: [
@@ -5001,7 +5010,9 @@ addEventListener('fetch', event => {});`
 			writeWranglerToml();
 			writeWorkerSource();
 			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: false });
 			mockSubDomainRequest();
+			mockUpdateWorkerSubdomain({ enabled: true });
 
 			await runWrangler("deploy ./index");
 
@@ -5021,9 +5032,10 @@ addEventListener('fetch', event => {});`
 				workers_dev: true,
 			});
 			writeWorkerSource();
-			mockUploadWorkerRequest({ available_on_subdomain: false });
+			mockUploadWorkerRequest();
 			mockSubDomainRequest();
-			mockUpdateWorkerRequest({ enabled: true });
+			mockGetWorkerSubdomain({ enabled: false });
+			mockUpdateWorkerSubdomain({ enabled: true });
 
 			await runWrangler("deploy ./index");
 
@@ -5043,7 +5055,8 @@ addEventListener('fetch', event => {});`
 				workers_dev: true,
 			});
 			writeWorkerSource();
-			mockUploadWorkerRequest({ available_on_subdomain: true });
+			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: true });
 			mockSubDomainRequest();
 
 			await runWrangler("deploy ./index");
@@ -5065,7 +5078,8 @@ addEventListener('fetch', event => {});`
 			});
 			writeWorkerSource();
 			mockUploadWorkerRequest();
-			mockUpdateWorkerRequest({ enabled: false });
+			mockGetWorkerSubdomain({ enabled: true });
+			mockUpdateWorkerSubdomain({ enabled: false });
 
 			await runWrangler("deploy ./index");
 
@@ -5084,8 +5098,8 @@ addEventListener('fetch', event => {});`
 				workers_dev: false,
 			});
 			writeWorkerSource();
-			mockSubDomainRequest("test-sub-domain", false);
-			mockUploadWorkerRequest({ available_on_subdomain: false });
+			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: false });
 
 			// note the lack of a mock for the subdomain disable request
 
@@ -5114,7 +5128,8 @@ addEventListener('fetch', event => {});`
 				env: "dev",
 				useOldUploadApi: true,
 			});
-			mockUpdateWorkerRequest({ enabled: false, env: "dev" });
+			mockGetWorkerSubdomain({ enabled: true, env: "dev" });
+			mockUpdateWorkerSubdomain({ enabled: false, env: "dev" });
 
 			await runWrangler("deploy ./index --env dev --legacy-env false");
 
@@ -5141,7 +5156,8 @@ addEventListener('fetch', event => {});`
 			mockUploadWorkerRequest({
 				env: "dev",
 			});
-			mockUpdateWorkerRequest({ enabled: false, env: "dev" });
+			mockGetWorkerSubdomain({ enabled: true, env: "dev" });
+			mockUpdateWorkerSubdomain({ enabled: false, env: "dev" });
 
 			await runWrangler("deploy ./index --env dev --legacy-env false");
 
@@ -5168,8 +5184,9 @@ addEventListener('fetch', event => {});`
 				env: "dev",
 				useOldUploadApi: true,
 			});
+			mockGetWorkerSubdomain({ enabled: false, env: "dev" });
 			mockSubDomainRequest();
-			mockUpdateWorkerRequest({ enabled: true, env: "dev" });
+			mockUpdateWorkerSubdomain({ enabled: true, env: "dev" });
 
 			await runWrangler("deploy ./index --env dev --legacy-env false");
 
@@ -5198,8 +5215,9 @@ addEventListener('fetch', event => {});`
 				env: "dev",
 				useOldUploadApi: true,
 			});
+			mockGetWorkerSubdomain({ enabled: false, env: "dev" });
 			mockSubDomainRequest();
-			mockUpdateWorkerRequest({ enabled: true, env: "dev" });
+			mockUpdateWorkerSubdomain({ enabled: true, env: "dev" });
 
 			await runWrangler("deploy ./index --env dev --legacy-env false");
 
@@ -5230,7 +5248,7 @@ addEventListener('fetch', event => {});`
 				useOldUploadApi: true,
 			});
 			mockSubDomainRequest();
-			mockUpdateWorkerRequest({ enabled: true, env: "dev" });
+			mockGetWorkerSubdomain({ enabled: true, env: "dev" });
 
 			await runWrangler("deploy ./index --env dev --legacy-env false");
 
@@ -5263,8 +5281,8 @@ addEventListener('fetch', event => {});`
 				expectedCompatibilityFlags: ["global_navigator"],
 				useOldUploadApi: true,
 			});
+			mockGetWorkerSubdomain({ enabled: true, env: "dev" });
 			mockSubDomainRequest();
-			mockUpdateWorkerRequest({ enabled: true, env: "dev" });
 
 			await runWrangler("deploy ./index --env dev --legacy-env false");
 
@@ -5296,8 +5314,8 @@ addEventListener('fetch', event => {});`
 				expectedCompatibilityDate: "2022-01-14",
 				expectedCompatibilityFlags: ["url_standard"],
 			});
+			mockGetWorkerSubdomain({ enabled: true, env: "dev" });
 			mockSubDomainRequest();
-			mockUpdateWorkerRequest({ enabled: true, env: "dev" });
 
 			await runWrangler(
 				"deploy ./index --env dev --legacy-env false --compatibility-date 2022-01-14 --compatibility-flags url_standard"
@@ -5359,9 +5377,10 @@ addEventListener('fetch', event => {});`
 		it("should enable the workers.dev domain if workers_dev is undefined and subdomain is not already available", async () => {
 			writeWranglerToml();
 			writeWorkerSource();
-			mockUploadWorkerRequest({ available_on_subdomain: false });
+			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: false });
 			mockSubDomainRequest();
-			mockUpdateWorkerRequest({ enabled: true });
+			mockUpdateWorkerSubdomain({ enabled: true });
 
 			await runWrangler("deploy ./index");
 
@@ -5379,9 +5398,10 @@ addEventListener('fetch', event => {});`
 		it("should enable the workers.dev domain if workers_dev is true and subdomain is not already available", async () => {
 			writeWranglerToml({ workers_dev: true });
 			writeWorkerSource();
-			mockUploadWorkerRequest({ available_on_subdomain: false });
+			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: false });
 			mockSubDomainRequest();
-			mockUpdateWorkerRequest({ enabled: true });
+			mockUpdateWorkerSubdomain({ enabled: true });
 
 			await runWrangler("deploy ./index");
 
@@ -5399,7 +5419,8 @@ addEventListener('fetch', event => {});`
 		it("should fail to deploy to the workers.dev domain if email is unverified", async () => {
 			writeWranglerToml({ workers_dev: true });
 			writeWorkerSource();
-			mockUploadWorkerRequest({ available_on_subdomain: false });
+			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: false });
 			mockSubDomainRequest();
 			msw.use(
 				http.post(
@@ -5435,6 +5456,7 @@ addEventListener('fetch', event => {});`
 			});
 			writeWorkerSource();
 			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: false });
 			mockSubDomainRequest("does-not-exist", false);
 
 			mockConfirm({
@@ -5454,11 +5476,11 @@ addEventListener('fetch', event => {});`
 				routes: ["http://example.com/*"],
 			});
 			writeWorkerSource();
-			mockSubDomainRequest();
 			mockUploadWorkerRequest();
-			mockUpdateWorkerRequest({
-				enabled: false,
-			});
+			mockGetWorkerSubdomain({ enabled: false });
+			// no set-subdomain call
+			mockGetZones("example.com", [{ id: "example-id" }]);
+			mockGetWorkerRoutes("example-id");
 			mockPublishRoutesRequest({ routes: ["http://example.com/*"] });
 			await runWrangler("deploy index.js");
 
@@ -5484,13 +5506,14 @@ addEventListener('fetch', event => {});`
 				},
 			});
 			writeWorkerSource();
-			mockSubDomainRequest();
 			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
-			mockUpdateWorkerRequest({
+			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
 				legacyEnv: true,
 			});
+			mockGetZones("production.example.com", [{ id: "example-id" }]);
+			mockGetWorkerRoutes("example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
@@ -5521,11 +5544,13 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
-			mockUpdateWorkerRequest({
+			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
 				legacyEnv: true,
 			});
+			mockGetZones("production.example.com", [{ id: "example-id" }]);
+			mockGetWorkerRoutes("example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
@@ -5553,8 +5578,11 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			mockSubDomainRequest();
 			mockUploadWorkerRequest();
-			mockUpdateWorkerRequest({
+			mockGetWorkerSubdomain({
 				enabled: false,
+			});
+			mockUpdateWorkerSubdomain({
+				enabled: true,
 			});
 			mockPublishRoutesRequest({
 				routes: ["http://example.com/*"],
@@ -5586,8 +5614,13 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
-			mockUpdateWorkerRequest({
+			mockGetWorkerSubdomain({
 				enabled: false,
+				env: "production",
+				legacyEnv: true,
+			});
+			mockUpdateWorkerSubdomain({
+				enabled: true,
 				env: "production",
 				legacyEnv: true,
 			});
@@ -5623,8 +5656,13 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
-			mockUpdateWorkerRequest({
+			mockGetWorkerSubdomain({
 				enabled: false,
+				env: "production",
+				legacyEnv: true,
+			});
+			mockUpdateWorkerSubdomain({
+				enabled: true,
 				env: "production",
 				legacyEnv: true,
 			});
@@ -5660,11 +5698,13 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
-			mockUpdateWorkerRequest({
+			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
 				legacyEnv: true,
 			});
+			mockGetZones("production.example.com", [{ id: "example-id" }]);
+			mockGetWorkerRoutes("example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
@@ -5696,11 +5736,13 @@ addEventListener('fetch', event => {});`
 			writeWorkerSource();
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({ env: "production", legacyEnv: true });
-			mockUpdateWorkerRequest({
+			mockGetWorkerSubdomain({
 				enabled: false,
 				env: "production",
 				legacyEnv: true,
 			});
+			mockGetZones("production.example.com", [{ id: "example-id" }]);
+			mockGetWorkerRoutes("example-id");
 			mockPublishRoutesRequest({
 				routes: ["http://production.example.com/*"],
 				env: "production",
@@ -11518,40 +11560,6 @@ function mockDeploymentsListRequest() {
 
 function mockLastDeploymentRequest() {
 	msw.use(...mswSuccessDeploymentScriptMetadata);
-}
-
-/** Create a mock handler to toggle a <script>.<user>.workers.dev subdomain */
-function mockUpdateWorkerRequest({
-	env,
-	enabled,
-	legacyEnv = false,
-}: {
-	enabled: boolean;
-	env?: string | undefined;
-	legacyEnv?: boolean | undefined;
-}) {
-	const requests = { count: 0 };
-	const servicesOrScripts = env && !legacyEnv ? "services" : "scripts";
-	const environment = env && !legacyEnv ? "/environments/:envName" : "";
-	msw.use(
-		http.post(
-			`*/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/subdomain`,
-			async ({ request, params }) => {
-				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toEqual(
-					legacyEnv && env ? `test-name-${env}` : "test-name"
-				);
-				if (!legacyEnv) {
-					expect(params.envName).toEqual(env);
-				}
-				const body = await request.json();
-				expect(body).toEqual({ enabled });
-				return HttpResponse.json(createFetchResult(null));
-			},
-			{ once: true }
-		)
-	);
-	return requests;
 }
 
 function mockPublishRoutesRequest({

--- a/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
@@ -32,3 +32,74 @@ export function mockSubDomainRequest(
 		);
 	}
 }
+
+/** Create a mock handler to fetch the  <script>.<user>.workers.dev subdomain status*/
+export function mockGetWorkerSubdomain({
+	enabled,
+	env,
+	legacyEnv = false,
+	expectedScriptName = "test-name",
+}: {
+	enabled: boolean;
+	env?: string | undefined;
+	legacyEnv?: boolean | undefined;
+	expectedScriptName?: string;
+}) {
+	const url =
+		env && !legacyEnv
+			? `*/accounts/:accountId/workers/services/:scriptName/environments/:envName/subdomain`
+			: `*/accounts/:accountId/workers/scripts/:scriptName/subdomain`;
+	msw.use(
+		http.get(
+			url,
+			({ params }) => {
+				expect(params.accountId).toEqual("some-account-id");
+				expect(params.scriptName).toEqual(
+					legacyEnv && env ? `${expectedScriptName}-${env}` : expectedScriptName
+				);
+				if (!legacyEnv) {
+					expect(params.envName).toEqual(env);
+				}
+
+				return HttpResponse.json(createFetchResult({ enabled }));
+			},
+			{ once: true }
+		)
+	);
+}
+
+/** Create a mock handler to toggle a <script>.<user>.workers.dev subdomain status */
+export function mockUpdateWorkerSubdomain({
+	enabled,
+	env,
+	legacyEnv = false,
+	expectedScriptName = "test-name",
+}: {
+	enabled: boolean;
+	env?: string | undefined;
+	legacyEnv?: boolean | undefined;
+	expectedScriptName?: string;
+}) {
+	const url =
+		env && !legacyEnv
+			? `*/accounts/:accountId/workers/services/:scriptName/environments/:envName/subdomain`
+			: `*/accounts/:accountId/workers/scripts/:scriptName/subdomain`;
+	msw.use(
+		http.post(
+			url,
+			async ({ request, params }) => {
+				expect(params.accountId).toEqual("some-account-id");
+				expect(params.scriptName).toEqual(
+					legacyEnv && env ? `${expectedScriptName}-${env}` : expectedScriptName
+				);
+				if (!legacyEnv) {
+					expect(params.envName).toEqual(env);
+				}
+				const body = await request.json();
+				expect(body).toEqual({ enabled });
+				return HttpResponse.json(createFetchResult({ enabled }));
+			},
+			{ once: true }
+		)
+	);
+}

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -12,7 +12,10 @@ import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { mockUploadWorkerRequest } from "../helpers/mock-upload-worker";
-import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
+import {
+	mockGetWorkerSubdomain,
+	mockSubDomainRequest,
+} from "../helpers/mock-workers-subdomain";
 import {
 	msw,
 	mswGetVersion,
@@ -57,8 +60,9 @@ describe("versions deploy", () => {
 			);
 			writeWranglerToml();
 			writeWorkerSource();
-			mockSubDomainRequest();
 			mockUploadWorkerRequest();
+			mockGetWorkerSubdomain({ enabled: true });
+			mockSubDomainRequest();
 
 			await runWrangler("deploy ./index");
 

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -2,7 +2,10 @@ import { http, HttpResponse } from "msw";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
-import { mockSubDomainRequest } from "../helpers/mock-workers-subdomain";
+import {
+	mockGetWorkerSubdomain,
+	mockSubDomainRequest,
+} from "../helpers/mock-workers-subdomain";
 import { createFetchResult, msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
@@ -21,7 +24,7 @@ describe("versions upload", () => {
 			http.get(
 				`*/accounts/:accountId/workers/services/:scriptName`,
 				({ params }) => {
-					expect(params.scriptName).toEqual("test-worker");
+					expect(params.scriptName).toEqual("test-name");
 
 					return HttpResponse.json(
 						createFetchResult({
@@ -47,7 +50,7 @@ describe("versions upload", () => {
 						return HttpResponse.error();
 					}
 
-					expect(params.scriptName).toEqual("test-worker");
+					expect(params.scriptName).toEqual("test-name");
 
 					return HttpResponse.json(
 						createFetchResult({
@@ -63,27 +66,13 @@ describe("versions upload", () => {
 		);
 	}
 
-	function mockGetWorkerSubdomain(available_on_subdomain: boolean) {
-		msw.use(
-			http.get(
-				`*/accounts/:accountId/workers/scripts/:scriptName/subdomain`,
-				({ params }) => {
-					expect(params.scriptName).toEqual("test-worker");
-					return HttpResponse.json(
-						createFetchResult({ enabled: available_on_subdomain })
-					);
-				}
-			)
-		);
-	}
-
 	test("should print bindings & startup time on versions upload", async () => {
 		mockGetScript();
 		mockUploadVersion(false);
 
 		// Setup
 		writeWranglerToml({
-			name: "test-worker",
+			name: "test-name",
 			main: "./index.js",
 			vars: {
 				TEST: "test-string",
@@ -113,7 +102,7 @@ describe("versions upload", () => {
 			 \\"abc\\": \\"def\\",
 			 \\"bool\\": true
 			}
-			Uploaded test-worker (TIMINGS)
+			Uploaded test-name (TIMINGS)
 			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993"
 		`);
 	});
@@ -121,12 +110,12 @@ describe("versions upload", () => {
 	test("should print preview url if version has preview", async () => {
 		mockGetScript();
 		mockUploadVersion(true);
-		mockGetWorkerSubdomain(true);
+		mockGetWorkerSubdomain({ enabled: true });
 		mockSubDomainRequest();
 
 		// Setup
 		writeWranglerToml({
-			name: "test-worker",
+			name: "test-name",
 			main: "./index.js",
 			vars: {
 				TEST: "test-string",
@@ -145,20 +134,20 @@ describe("versions upload", () => {
 			Your worker has access to the following bindings:
 			- Vars:
 			  - TEST: \\"test-string\\"
-			Uploaded test-worker (TIMINGS)
+			Uploaded test-name (TIMINGS)
 			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993
-			Version Preview URL: https://51e4886e-test-worker.test-sub-domain.workers.dev"
+			Version Preview URL: https://51e4886e-test-name.test-sub-domain.workers.dev"
 		`);
 	});
 
 	it("should not print preview url workers_dev is false", async () => {
 		mockGetScript();
 		mockUploadVersion(true);
-		mockGetWorkerSubdomain(false);
+		mockGetWorkerSubdomain({ enabled: false });
 
 		// Setup
 		writeWranglerToml({
-			name: "test-worker",
+			name: "test-name",
 			main: "./index.js",
 			vars: {
 				TEST: "test-string",
@@ -177,7 +166,7 @@ describe("versions upload", () => {
 			Your worker has access to the following bindings:
 			- Vars:
 			  - TEST: \\"test-string\\"
-			Uploaded test-worker (TIMINGS)
+			Uploaded test-name (TIMINGS)
 			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993"
 		`);
 	});

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -813,10 +813,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			let bindingsPrinted = false;
 
 			// Upload the script so it has time to propagate.
-			// We can also now tell whether available_on_subdomain is set
 			try {
 				let result: {
-					available_on_subdomain: boolean;
 					id: string | null;
 					etag: string | null;
 					pipeline_hash: string | null;
@@ -854,12 +852,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 						observability: worker.observability ?? { enabled: false },
 					});
 
-					const { available_on_subdomain } = await fetchResult<{
-						available_on_subdomain: boolean;
-					}>(`/accounts/${accountId}/workers/scripts/${scriptName}/subdomain`);
-
 					result = {
-						available_on_subdomain,
 						id: null, // fpw - ignore
 						etag: versionResult.resources.script.etag,
 						pipeline_hash: null, // fpw - ignore
@@ -870,7 +863,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				} else {
 					result = await retryOnError(async () =>
 						fetchResult<{
-							available_on_subdomain: boolean;
 							id: string | null;
 							etag: string | null;
 							pipeline_hash: string | null;
@@ -885,7 +877,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 								headers: await getMetricsUsageHeaders(config.send_metrics),
 							},
 							new URLSearchParams({
-								include_subdomain_availability: "true",
 								// pass excludeScript so the whole body of the
 								// script doesn't get included in the response
 								excludeScript: "true",


### PR DESCRIPTION
Many tests had mocks that weren't called, or had false assertions about not updating subdomain routes when they actually were being updated.

Additionally, available_on_subdomain is now unecessary during script-upload, as it is not read there, due to being handled entirely within triggers-deploy. This also saves a double call to get /subdomain in the new-api path.

The get/update subdomain helpers are refactored from deploy/version tests, and unified to standardize default workername and legacyEnv.

I wanted to remove the getSubdomain mock from mockUpload entirely, but there were a bit too many callsites... At least every test now that makes assertions about workers.dev deployments does explicitly reset the mock return value.

Fixes N/A

- Tests
  - [x] Tests included
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] Not required because: this pr fixes unit-tests & mocks
- Public documentation
  - [x] Documentation not necessary because: no functional changes