### PR TITLE
chore(wrangler): update unenv dependency version

### DIFF
--- a/.changeset/shy-seas-wave.md
+++ b/.changeset/shy-seas-wave.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore(wrangler): update unenv dependency version

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -85,7 +85,7 @@
 		"resolve.exports": "^2.0.2",
 		"selfsigned": "^2.0.1",
 		"source-map": "^0.6.1",
-		"unenv": "npm:unenv-nightly@2.0.0-20241024-111401-d4156ac",
+		"unenv": "npm:unenv-nightly@2.0.0-20241111-080453-894aa31",
 		"workerd": "1.20241106.1",
 		"xxhash-wasm": "^1.0.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.1.3
+      version: 2.1.3
+    '@vitest/snapshot':
+      specifier: ~2.1.3
+      version: 2.1.3
     '@vitest/ui':
       specifier: ~2.1.3
       version: 2.1.3
@@ -1724,8 +1730,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       unenv:
-        specifier: npm:unenv-nightly@2.0.0-20241024-111401-d4156ac
-        version: unenv-nightly@2.0.0-20241024-111401-d4156ac
+        specifier: npm:unenv-nightly@2.0.0-20241111-080453-894aa31
+        version: unenv-nightly@2.0.0-20241111-080453-894aa31
       workerd:
         specifier: 1.20241106.1
         version: 1.20241106.1
@@ -8204,8 +8210,8 @@ packages:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
 
-  unenv-nightly@2.0.0-20241024-111401-d4156ac:
-    resolution: {integrity: sha512-xJO1hfY+Te+/XnfCYrCbFbRcgu6XEODND1s5wnVbaBCkuQX7JXF7fHEXPrukFE2j8EOH848P8QN19VO47XN8hw==}
+  unenv-nightly@2.0.0-20241111-080453-894aa31:
+    resolution: {integrity: sha512-0W39QQOQ9VE8kVVUpGwEG+pZcsCXk5wqNG6rDPE6Gr+fiA69LR0qERM61hW5KCOkC1/ArCFrfCGjwHyyv/bI0Q==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -15547,7 +15553,7 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  unenv-nightly@2.0.0-20241024-111401-d4156ac:
+  unenv-nightly@2.0.0-20241111-080453-894aa31:
     dependencies:
       defu: 6.1.4
       ohash: 1.1.4


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

Update unenv

The newer version on unenv uses the native impl of "path/win32" and "path/posix", see the [workerd changes](https://github.com/cloudflare/workerd/releases/tag/v1.20241106.0#:~:text=in%20%232288-,add%20missing,-tests%20for%20node)

/cc @anonrig 

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: dep udate
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: dep update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
