### PR TITLE
Remove v2 warning

### DIFF
--- a/packages/wrangler/README.md
+++ b/packages/wrangler/README.md
@@ -8,10 +8,6 @@
 
 `wrangler` is a command line tool for building [Cloudflare Workers](https://workers.cloudflare.com/).
 
-> [!WARNING]
->
-> Wrangler v2 is **only receiving critical security updates.** We recommend you [migrate to Wrangler v3](https://developers.cloudflare.com/workers/wrangler/migration/update-v2-to-v3/) if you can.
-
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Remove warning about v2 from the main README. It's on the v2 README, and now we're over a year from the release of v3 _most_ new users seeing the README won't have heard of v3.