### PR TITLE
cloudchamber: Start `cloudchamber apply`, the new command to deploy

### DIFF
--- a/.changeset/angry-apricots-swim.md
+++ b/.changeset/angry-apricots-swim.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Introduce a new cloudchamber command `wrangler cloudchamber apply`, which will be used by customers to deploy container-apps

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -1,0 +1,617 @@
+import * as fs from "node:fs";
+import * as TOML from "@iarna/toml";
+import { http, HttpResponse } from "msw";
+import patchConsole from "patch-console";
+import { SchedulingPolicy, SecretAccessType } from "../../cloudchamber/client";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockCLIOutput } from "../helpers/mock-console";
+import { useMockIsTTY } from "../helpers/mock-istty";
+import { msw } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+import { mockAccount } from "./utils";
+import type {
+	Application,
+	CreateApplicationRequest,
+	ModifyApplicationRequestBody,
+} from "../../cloudchamber/client";
+import type { ContainerApp } from "../../config/environment";
+
+function writeAppConfiguration(...app: ContainerApp[]) {
+	fs.writeFileSync(
+		"./wrangler.toml",
+		TOML.stringify({
+			name: "my-container",
+			containers: { app },
+		}),
+
+		"utf-8"
+	);
+}
+
+function mockGetApplications(applications: Application[]) {
+	msw.use(
+		http.get(
+			"*/applications",
+			async () => {
+				return HttpResponse.json(applications);
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockCreateApplication(expected?: Application) {
+	msw.use(
+		http.post(
+			"*/applications",
+			async ({ request }) => {
+				const json = (await request.json()) as ModifyApplicationRequestBody;
+				if (expected !== undefined) {
+					expect(json).toEqual(expected);
+				}
+				return HttpResponse.json(json);
+			},
+			{ once: true }
+		)
+	);
+}
+
+function mockModifyApplication(
+	expected?: Application
+): Promise<ModifyApplicationRequestBody> {
+	let response: (value: ModifyApplicationRequestBody) => void;
+	const promise = new Promise<ModifyApplicationRequestBody>((res) => {
+		response = res;
+	});
+
+	msw.use(
+		http.patch(
+			"*/applications/:id",
+			async ({ request }) => {
+				const json = await request.json();
+				if (expected !== undefined) {
+					expect(json).toEqual(expected);
+				}
+				console.log(json);
+				expect((json as CreateApplicationRequest).name).toBeUndefined();
+				response(json as ModifyApplicationRequestBody);
+				return HttpResponse.json(json);
+			},
+			{ once: true }
+		)
+	);
+
+	return promise;
+}
+
+describe("cloudchamber apply", () => {
+	const { setIsTTY } = useMockIsTTY();
+	const std = mockCLIOutput();
+
+	mockAccountId();
+	mockApiToken();
+	beforeEach(mockAccount);
+	runInTempDir();
+	afterEach(() => {
+		patchConsole(() => {});
+		msw.resetHandlers();
+	});
+
+	test("can apply a simple application", async () => {
+		setIsTTY(false);
+		writeAppConfiguration({
+			name: "my-container-app",
+			instances: 3,
+			configuration: {
+				image: "./Dockerfile",
+			},
+			constraints: {
+				tier: 2,
+			},
+		});
+		mockGetApplications([]);
+		mockCreateApplication();
+		await runWrangler("cloudchamber apply --json");
+		/* eslint-disable */
+		expect(std.stderr).toMatchInlineSnapshot(`""`);
+		expect(std.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ NEW my-container-app
+			│
+			│   [[containers.app]]
+			│   name = \\"my-container-app\\"
+			│   instances = 3
+			│   scheduling_policy = \\"regional\\"
+			│
+			│   [containers.app.configuration]
+			│   image = \\"./Dockerfile\\"
+			│
+			│   [containers.app.constraints]
+			│   tier = 2
+			│
+			├ Do you want to apply these changes?
+			│ yes
+			│
+			│
+			│  SUCCESS  Created application my-container-app
+			│
+			╰ Applied changes
+
+			"
+		`);
+		/* eslint-enable */
+	});
+
+	test("can apply a simple existing application", async () => {
+		setIsTTY(false);
+		writeAppConfiguration({
+			name: "my-container-app",
+			instances: 4,
+			configuration: {
+				image: "./Dockerfile",
+			},
+			constraints: {
+				tier: 2,
+			},
+		});
+		mockGetApplications([
+			{
+				id: "abc",
+				name: "my-container-app",
+				instances: 3,
+				created_at: new Date().toString(),
+				account_id: "1",
+				scheduling_policy: SchedulingPolicy.REGIONAL,
+				configuration: {
+					image: "./Dockerfile",
+				},
+				constraints: {
+					tier: 3,
+				},
+			},
+		]);
+		const applicationReqBodyPromise = mockModifyApplication();
+		await runWrangler("cloudchamber apply --json");
+		/* eslint-disable */
+		expect(std.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ EDIT my-container-app
+			│
+			│   [[containers.app]]
+			│ - instances = 3
+			│ + instances = 4
+			│   name = \\"my-container-app\\"
+			│
+			│   [containers.app.constraints]
+			│ - tier = 3
+			│ + tier = 2
+			│
+			├ Do you want to apply these changes?
+			│ yes
+			│
+			│
+			│  SUCCESS  Modified application my-container-app
+			│
+			╰ Applied changes
+
+			"
+		`);
+		expect(std.stderr).toMatchInlineSnapshot(`""`);
+		const app = await applicationReqBodyPromise;
+		expect(app.constraints?.tier).toEqual(2);
+		expect(app.instances).toEqual(4);
+		/* eslint-enable */
+	});
+
+	test("can apply a simple existing application and create other", async () => {
+		setIsTTY(false);
+		writeAppConfiguration(
+			{
+				name: "my-container-app",
+				instances: 4,
+				configuration: {
+					image: "./Dockerfile",
+				},
+			},
+			{
+				name: "my-container-app-2",
+				instances: 1,
+				configuration: {
+					image: "other-app/Dockerfile",
+				},
+			}
+		);
+		mockGetApplications([
+			{
+				id: "abc",
+				name: "my-container-app",
+				instances: 3,
+				created_at: new Date().toString(),
+				account_id: "1",
+				scheduling_policy: SchedulingPolicy.REGIONAL,
+				configuration: {
+					image: "./Dockerfile",
+				},
+				constraints: {
+					tier: 1,
+				},
+			},
+		]);
+		const res = mockModifyApplication();
+		mockCreateApplication();
+		await runWrangler("cloudchamber apply --json");
+		await res;
+		/* eslint-disable */
+		expect(std.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ EDIT my-container-app
+			│
+			│   [[containers.app]]
+			│ - instances = 3
+			│ + instances = 4
+			│   name = \\"my-container-app\\"
+			│
+			├ NEW my-container-app-2
+			│
+			│   [[containers.app]]
+			│   name = \\"my-container-app-2\\"
+			│   instances = 1
+			│   scheduling_policy = \\"regional\\"
+			│
+			│   [containers.app.configuration]
+			│   image = \\"other-app/Dockerfile\\"
+			│
+			│   [containers.app.constraints]
+			│   tier = 1
+			│
+			├ Do you want to apply these changes?
+			│ yes
+			│
+			│
+			│  SUCCESS  Modified application my-container-app
+			│
+			│
+			│  SUCCESS  Created application my-container-app-2
+			│
+			╰ Applied changes
+
+			"
+		`);
+		expect(std.stderr).toMatchInlineSnapshot(`""`);
+		/* eslint-enable */
+	});
+
+	test("can apply a simple existing application (labels)", async () => {
+		setIsTTY(false);
+		writeAppConfiguration({
+			name: "my-container-app",
+			instances: 4,
+			configuration: {
+				image: "./Dockerfile",
+				labels: [
+					{
+						name: "name",
+						value: "value",
+					},
+					{
+						name: "name-1",
+						value: "value-1",
+					},
+					{
+						name: "name-2",
+						value: "value-2",
+					},
+				],
+				secrets: [
+					{
+						name: "MY_SECRET",
+						type: "env",
+						secret: "SECRET_NAME",
+					},
+					{
+						name: "MY_SECRET_2",
+						type: "env",
+						secret: "SECRET_NAME_2",
+					},
+				],
+			},
+		});
+		mockGetApplications([
+			{
+				id: "abc",
+				name: "my-container-app",
+				instances: 3,
+				created_at: new Date().toString(),
+				account_id: "1",
+				scheduling_policy: SchedulingPolicy.REGIONAL,
+				configuration: {
+					image: "./Dockerfile",
+					labels: [
+						{
+							name: "name",
+							value: "value",
+						},
+						{
+							name: "name-2",
+							value: "value-2",
+						},
+					],
+					secrets: [
+						{
+							name: "MY_SECRET",
+							type: SecretAccessType.ENV,
+							secret: "SECRET_NAME",
+						},
+						{
+							name: "MY_SECRET_1",
+							type: SecretAccessType.ENV,
+							secret: "SECRET_NAME_1",
+						},
+						{
+							name: "MY_SECRET_2",
+							type: SecretAccessType.ENV,
+							secret: "SECRET_NAME_2",
+						},
+					],
+				},
+				constraints: {
+					tier: 1,
+				},
+			},
+		]);
+		const res = mockModifyApplication();
+		await runWrangler("cloudchamber apply --json");
+		await res;
+		/* eslint-disable */
+		expect(std.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ EDIT my-container-app
+			│
+			│   [[containers.app]]
+			│ - instances = 3
+			│ + instances = 4
+			│   name = \\"my-container-app\\"
+			│
+			│   [[containers.app.configuration.labels]]
+			│ + name = \\"name-1\\"
+			│ + value = \\"value-1\\"
+			│
+			│ + [[containers.app.configuration.labels]]
+			│   name = \\"name-2\\"
+			│
+			│   [[containers.app.configuration.secrets]]
+			│ - name = \\"MY_SECRET_1\\"
+			│ - secret = \\"SECRET_NAME_1\\"
+			│ - type = \\"env\\"
+			│
+			│ - [[containers.app.configuration.secrets]]
+			│   name = \\"MY_SECRET_2\\"
+			│
+			├ Do you want to apply these changes?
+			│ yes
+			│
+			│
+			│  SUCCESS  Modified application my-container-app
+			│
+			╰ Applied changes
+
+			"
+		`);
+		expect(std.stderr).toMatchInlineSnapshot(`""`);
+		/* eslint-enable */
+	});
+
+	test("can apply an application, and there is no changes", async () => {
+		setIsTTY(false);
+		writeAppConfiguration({
+			name: "my-container-app",
+			instances: 3,
+			configuration: {
+				image: "./Dockerfile",
+				labels: [
+					{
+						name: "name",
+						value: "value",
+					},
+					{
+						name: "name-2",
+						value: "value-2",
+					},
+				],
+				secrets: [
+					{
+						name: "MY_SECRET",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME",
+					},
+					{
+						name: "MY_SECRET_1",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME_1",
+					},
+					{
+						name: "MY_SECRET_2",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME_2",
+					},
+				],
+			},
+		});
+		mockGetApplications([
+			{
+				id: "abc",
+				name: "my-container-app",
+				instances: 3,
+				created_at: new Date().toString(),
+				account_id: "1",
+				scheduling_policy: SchedulingPolicy.REGIONAL,
+				configuration: {
+					image: "./Dockerfile",
+					labels: [
+						{
+							name: "name",
+							value: "value",
+						},
+						{
+							name: "name-2",
+							value: "value-2",
+						},
+					],
+					secrets: [
+						{
+							name: "MY_SECRET",
+							type: SecretAccessType.ENV,
+							secret: "SECRET_NAME",
+						},
+						{
+							name: "MY_SECRET_1",
+							type: SecretAccessType.ENV,
+							secret: "SECRET_NAME_1",
+						},
+						{
+							name: "MY_SECRET_2",
+							type: SecretAccessType.ENV,
+							secret: "SECRET_NAME_2",
+						},
+					],
+				},
+
+				constraints: {
+					tier: 1,
+				},
+			},
+		]);
+		await runWrangler("cloudchamber apply --json");
+		/* eslint-disable */
+		expect(std.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ no changes my-container-app
+			│
+			╰ No changes to be made
+
+			"
+		`);
+		expect(std.stderr).toMatchInlineSnapshot(`""`);
+		/* eslint-enable */
+	});
+
+	test("can apply an application, and there is no changes (two applications)", async () => {
+		setIsTTY(false);
+		const app = {
+			name: "my-container-app",
+			instances: 3,
+			configuration: {
+				image: "./Dockerfile",
+				labels: [
+					{
+						name: "name",
+						value: "value",
+					},
+					{
+						name: "name-2",
+						value: "value-2",
+					},
+				],
+				secrets: [
+					{
+						name: "MY_SECRET",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME",
+					},
+					{
+						name: "MY_SECRET_1",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME_1",
+					},
+					{
+						name: "MY_SECRET_2",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME_2",
+					},
+				],
+			},
+		};
+		writeAppConfiguration(app, { ...app, name: "my-container-app-2" });
+
+		const completeApp = {
+			id: "abc",
+			name: "my-container-app",
+			instances: 3,
+			created_at: new Date().toString(),
+			account_id: "1",
+			scheduling_policy: SchedulingPolicy.REGIONAL,
+			configuration: {
+				image: "./Dockerfile",
+				labels: [
+					{
+						name: "name",
+						value: "value",
+					},
+					{
+						name: "name-2",
+						value: "value-2",
+					},
+				],
+				secrets: [
+					{
+						name: "MY_SECRET",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME",
+					},
+					{
+						name: "MY_SECRET_1",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME_1",
+					},
+					{
+						name: "MY_SECRET_2",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME_2",
+					},
+				],
+			},
+
+			constraints: {
+				tier: 1,
+			},
+		};
+
+		mockGetApplications([
+			completeApp,
+			{ ...completeApp, name: "my-container-app-2", id: "abc2" },
+		]);
+		await runWrangler("cloudchamber apply --json");
+		/* eslint-disable */
+		expect(std.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ no changes my-container-app
+			│
+			├ no changes my-container-app-2
+			│
+			╰ No changes to be made
+
+			"
+		`);
+		expect(std.stderr).toMatchInlineSnapshot(`""`);
+		/* eslint-enable */
+	});
+});

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -73,6 +73,7 @@ describe("normalizeAndValidateConfig()", () => {
 				upstream_protocol: "http",
 				host: undefined,
 			},
+			containers: { app: [] },
 			cloudchamber: {},
 			durable_objects: {
 				bindings: [],

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -165,6 +165,7 @@ const bindingsConfigMock: Omit<
 		],
 	},
 	workflows: [],
+	containers: { app: [] },
 	r2_buckets: [
 		{
 			binding: "R2_BUCKET_BINDING",

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -1,0 +1,585 @@
+import {
+	cancel,
+	crash,
+	endSection,
+	log,
+	logRaw,
+	shapes,
+	startSection,
+	success,
+	updateStatus,
+} from "@cloudflare/cli";
+import { processArgument } from "@cloudflare/cli/args";
+import { bold, brandColor, dim, green, red } from "@cloudflare/cli/colors";
+import { formatConfigSnippet } from "../config";
+import {
+	ApiError,
+	ApplicationsService,
+	DeploymentMutationError,
+	SchedulingPolicy,
+} from "./client";
+import { promiseSpinner } from "./common";
+import { diffLines } from "./helpers/diff";
+import { wrap } from "./helpers/wrap";
+import type { Config } from "../config";
+import type { ContainerApp } from "../config/environment";
+import type {
+	CommonYargsArgvJSON,
+	StrictYargsOptionsToInterfaceJSON,
+} from "../yargs-types";
+import type {
+	Application,
+	ApplicationID,
+	ApplicationName,
+	CreateApplicationRequest,
+	ModifyApplicationRequestBody,
+	UserDeploymentConfiguration,
+} from "./client";
+import type { JsonMap } from "@iarna/toml";
+
+export function applyCommandOptionalYargs(yargs: CommonYargsArgvJSON) {
+	return yargs.option("skip-defaults", {
+		requiresArg: true,
+		type: "boolean",
+		demandOption: false,
+		describe: "Skips recommended defaults added by apply",
+	});
+}
+
+function createApplicationToModifyApplication(
+	req: CreateApplicationRequest
+): ModifyApplicationRequestBody {
+	return {
+		configuration: req.configuration,
+		instances: req.instances,
+		constraints: req.constraints,
+		affinities: req.affinities,
+		scheduling_policy: req.scheduling_policy,
+	};
+}
+
+function applicationToCreateApplication(
+	application: Application
+): CreateApplicationRequest {
+	return {
+		configuration: application.configuration,
+		constraints: application.constraints,
+		name: application.name,
+		scheduling_policy: application.scheduling_policy,
+		affinities: application.affinities,
+		instances: application.instances,
+		jobs: application.jobs ? true : undefined,
+	};
+}
+
+function containerAppToCreateApplication(
+	containerApp: ContainerApp,
+	skipDefaults = false
+): CreateApplicationRequest {
+	const configuration =
+		containerApp.configuration as UserDeploymentConfiguration;
+	return {
+		...containerApp,
+		configuration,
+		scheduling_policy:
+			(containerApp.scheduling_policy as SchedulingPolicy) ??
+			SchedulingPolicy.REGIONAL,
+		constraints: {
+			...(containerApp.constraints ??
+				(!skipDefaults ? { tier: 1 } : undefined)),
+			cities: containerApp.constraints?.cities?.map((city) =>
+				city.toLowerCase()
+			),
+			regions: containerApp.constraints?.regions?.map((region) =>
+				region.toUpperCase()
+			),
+		},
+	};
+}
+
+function isNumber(c: string | number) {
+	if (typeof c === "number") {
+		return true;
+	}
+	const code = c.charCodeAt(0);
+	const zero = "0".charCodeAt(0);
+	const nine = "9".charCodeAt(0);
+	return code >= zero && code <= nine;
+}
+
+/**
+ * createLine takes a string and goes through each character, rendering possibly syntax highlighting.
+ * Useful to render TOML files.
+ */
+function createLine(el: string, startWith = ""): string {
+	let line = startWith;
+	let lastAdded = 0;
+	const addToLine = (i: number, color = (s: string) => s) => {
+		line += color(el.slice(lastAdded, i));
+		lastAdded = i;
+	};
+
+	const state = {
+		render: "left" as "quotes" | "number" | "left" | "right" | "section",
+	};
+	for (let i = 0; i < el.length; i++) {
+		const current = el[i];
+		const peek = i + 1 < el.length ? el[i + 1] : null;
+		const prev = i === 0 ? null : el[i - 1];
+
+		switch (state.render) {
+			case "left":
+				if (current === "=") {
+					state.render = "right";
+				}
+
+				break;
+			case "right":
+				if (current === '"') {
+					addToLine(i);
+					state.render = "quotes";
+					break;
+				}
+
+				if (isNumber(current)) {
+					addToLine(i);
+					state.render = "number";
+					break;
+				}
+
+				if (current === "[" && peek === "[") {
+					state.render = "section";
+				}
+
+				break;
+			case "quotes":
+				if (current === '"') {
+					addToLine(i + 1, brandColor);
+					state.render = "right";
+				}
+
+				break;
+			case "number":
+				if (!isNumber(el)) {
+					addToLine(i, red);
+					state.render = "right";
+				}
+
+				break;
+			case "section":
+				if (current === "]" && prev === "]") {
+					addToLine(i + 1);
+					state.render = "right";
+				}
+		}
+	}
+
+	switch (state.render) {
+		case "left":
+			addToLine(el.length);
+			break;
+		case "right":
+			addToLine(el.length);
+			break;
+		case "quotes":
+			addToLine(el.length, brandColor);
+			break;
+		case "number":
+			addToLine(el.length, red);
+			break;
+		case "section":
+			// might be unreachable
+			addToLine(el.length, bold);
+			break;
+	}
+
+	return line;
+}
+
+/**
+ * printLine takes a line and prints it by using createLine and use printFunc
+ */
+function printLine(el: string, startWith = "", printFunc = log) {
+	printFunc(createLine(el, startWith));
+}
+
+/**
+ * Removes from the object every undefined property
+ */
+function stripUndefined<T = Record<string, unknown>>(r: T): T {
+	for (const k in r) {
+		if (r[k] === undefined) {
+			delete r[k];
+		}
+	}
+
+	return r;
+}
+
+/**
+ * Take an object and sort its keys in alphabetical order.
+ */
+function sortObjectKeys(unordered: Record<string | number, unknown>) {
+	if (Array.isArray(unordered)) {
+		return unordered;
+	}
+
+	return Object.keys(unordered)
+		.sort()
+		.reduce(
+			(obj, key) => {
+				obj[key] = unordered[key];
+				return obj;
+			},
+			{} as Record<string, unknown>
+		);
+}
+
+/**
+ * Take an object and sort its keys in alphabetical order recursively.
+ * Useful to normalize objects so they can be compared when rendered.
+ * It will copy the object and not mutate it.
+ */
+function sortObjectRecursive<T = Record<string | number, unknown>>(
+	object: Record<string | number, unknown> | Record<string | number, unknown>[]
+): T {
+	if (typeof object !== "object") {
+		return object;
+	}
+
+	if (Array.isArray(object)) {
+		return object.map((obj) => sortObjectRecursive(obj)) as T;
+	}
+
+	const objectCopy: Record<string | number, unknown> = { ...object };
+	for (const [key, value] of Object.entries(object)) {
+		if (typeof value === "object") {
+			if (value === null) {
+				continue;
+			}
+			objectCopy[key] = sortObjectRecursive(
+				value as Record<string, unknown>
+			) as unknown;
+		}
+	}
+
+	return sortObjectKeys(objectCopy) as T;
+}
+
+/**
+ * applyCommand is able to take the wrangler.toml file and render the changes that it
+ * detects.
+ */
+export async function applyCommand(
+	args: StrictYargsOptionsToInterfaceJSON<typeof applyCommandOptionalYargs>,
+	config: Config
+) {
+	startSection(
+		"Deploy a container application",
+		"deploy changes to your application"
+	);
+
+	if (config.containers.app.length === 0) {
+		endSection(
+			"You don't have any container applications defined in your wrangler.toml",
+			"You can set the following configuration in your wrangler.toml"
+		);
+		const configuration = {
+			configuration: {
+				image: "docker.io/cloudflare/hello-world:1.0",
+			},
+			instances: 2,
+			name: config.name ?? "my-containers-application",
+		};
+		const endConfig: JsonMap =
+			args.env !== undefined
+				? {
+						env: { [args.env]: { containers: { app: [configuration] } } },
+					}
+				: { containers: { app: [configuration] } };
+		formatConfigSnippet(endConfig, config.configPath)
+			.split("\n")
+			.forEach((el) => {
+				printLine(el, "  ", logRaw);
+			});
+		return;
+	}
+
+	const applications = await promiseSpinner(
+		ApplicationsService.listApplications(),
+		{ json: args.json, message: "Loading applications" }
+	);
+	const applicationByNames: Record<ApplicationName, Application> = {};
+	// TODO: this is not correct right now as there can be multiple applications
+	// with the same name.
+	for (const application of applications) {
+		applicationByNames[application.name] = application;
+	}
+
+	const actions: (
+		| { action: "create"; application: CreateApplicationRequest }
+		| {
+				action: "modify";
+				application: ModifyApplicationRequestBody;
+				id: ApplicationID;
+				name: ApplicationName;
+		  }
+	)[] = [];
+
+	// TODO: JSON formatting is a bit bad due to the trimming.
+	// Try to do a conditional on `configFormat`
+
+	log(dim("Container application changes\n"));
+
+	for (const appConfigNoDefaults of config.containers.app) {
+		const appConfig = containerAppToCreateApplication(
+			appConfigNoDefaults,
+			args.skipDefaults
+		);
+		const application = applicationByNames[appConfig.name];
+		if (application !== undefined && application !== null) {
+			// we need to sort the objects (by key) because the diff algorithm works with
+			// lines
+			const prevApp = sortObjectRecursive<CreateApplicationRequest>(
+				stripUndefined(applicationToCreateApplication(application))
+			);
+
+			const prev = formatConfigSnippet(
+				{ containers: { app: [prevApp as ContainerApp] } },
+				config.configPath
+			);
+			const now = formatConfigSnippet(
+				{
+					containers: {
+						app: [
+							sortObjectRecursive<CreateApplicationRequest>(
+								appConfig
+							) as ContainerApp,
+						],
+					},
+				},
+				config.configPath
+			);
+			const results = diffLines(prev, now);
+			const changes = results.find((l) => l.added || l.removed) !== undefined;
+			if (!changes) {
+				updateStatus(`no changes ${brandColor(application.name)}`);
+				continue;
+			}
+
+			updateStatus(
+				`${brandColor.underline("EDIT")} ${application.name}`,
+				false
+			);
+
+			let printedLines: string[] = [];
+			let printedDiff = false;
+			// prints the lines we accumulated to bring context to the edited line
+			const printContext = () => {
+				let index = 0;
+				for (let i = printedLines.length - 1; i >= 0; i--) {
+					if (printedLines[i].trim().startsWith("[")) {
+						log("");
+						index = i;
+						break;
+					}
+				}
+
+				for (let i = index; i < printedLines.length; i++) {
+					log(printedLines[i]);
+					if (printedLines.length - i > 2) {
+						i = printedLines.length - 2;
+						printLine(dim("..."), "  ");
+					}
+				}
+
+				printedLines = [];
+			};
+
+			// go line by line and print diff results
+			for (const lines of results) {
+				const trimmedLines = (lines.value ?? "")
+					.split("\n")
+					.map((e) => e.trim())
+					.filter((e) => e !== "");
+
+				for (const l of trimmedLines) {
+					if (lines.added) {
+						printContext();
+						if (l.startsWith("[")) {
+							printLine("");
+						}
+
+						printedDiff = true;
+						printLine(l, green("+ "));
+					} else if (lines.removed) {
+						printContext();
+						if (l.startsWith("[")) {
+							printLine("");
+						}
+
+						printedDiff = true;
+						printLine(l, red("- "));
+					} else {
+						// if we had printed a diff before this line, print a little bit more
+						// so the user has a bit more context on where the edit happens
+						if (printedDiff) {
+							let printDots = false;
+							if (l.startsWith("[")) {
+								printLine("");
+								printDots = true;
+							}
+
+							printedDiff = false;
+							printLine(l, "  ");
+							if (printDots) {
+								printLine(dim("..."), "  ");
+							}
+							continue;
+						}
+
+						printedLines.push(createLine(l, "  "));
+					}
+				}
+			}
+
+			actions.push({
+				action: "modify",
+				application: createApplicationToModifyApplication(appConfig),
+				id: application.id,
+				name: application.name,
+			});
+
+			printLine("");
+			continue;
+		}
+
+		// print the header of the app
+		updateStatus(bold.underline(green.underline("NEW")) + ` ${appConfig.name}`);
+
+		const s = formatConfigSnippet(
+			{ containers: { app: [appConfig as ContainerApp] } },
+			config.configPath
+		);
+
+		// go line by line and pretty print it
+		s.split("\n")
+			.map((line) => line.trim())
+			.forEach((el) => {
+				printLine(el, "  ");
+			});
+
+		// add to the actions array to create the app later
+		actions.push({
+			action: "create",
+			application: appConfig,
+		});
+	}
+
+	if (actions.length == 0) {
+		endSection("No changes to be made");
+		return;
+	}
+
+	const yes = await processArgument<boolean>(
+		{ confirm: args.json ? true : undefined },
+		"confirm",
+		{
+			type: "confirm",
+			question: "Do you want to apply these changes?",
+			label: "",
+		}
+	);
+	if (!yes) {
+		cancel("Not applying changes");
+		return;
+	}
+
+	function formatError(err: ApiError): string {
+		// TODO: this is bad bad. Please fix like we do in create.ts.
+		// On Cloudchamber API side, we have to improve as well the object validation errors,
+		// so we can detect them here better and pinpoint to the user what's going on.
+		if (
+			err.body.error === DeploymentMutationError.VALIDATE_INPUT &&
+			err.body.details !== undefined
+		) {
+			let message = "";
+			for (const key in err.body.details) {
+				message += `  ${brandColor(key)} ${err.body.details[key]}\n`;
+			}
+
+			return message;
+		}
+
+		return `  ${err.body.error}`;
+	}
+
+	for (const action of actions) {
+		if (action.action === "create") {
+			const [_result, err] = await wrap(
+				promiseSpinner(
+					ApplicationsService.createApplication(action.application),
+					{ json: args.json, message: `creating ${action.application.name}` }
+				)
+			);
+			if (err !== null) {
+				if (!(err instanceof ApiError)) {
+					crash(`Unexpected error creating application: ${err.message}`);
+				}
+
+				if (err.status === 400) {
+					crash(
+						`Error creating application due to a misconfiguration\n${formatError(err)}`
+					);
+				}
+
+				crash(
+					`Error creating application due to an internal error (request id: ${err.body.request_id}): ${formatError(err)}`
+				);
+			}
+
+			success(`Created application ${brandColor(action.application.name)}`, {
+				shape: shapes.bar,
+			});
+			printLine("");
+			continue;
+		}
+
+		if (action.action === "modify") {
+			const [_result, err] = await wrap(
+				promiseSpinner(
+					ApplicationsService.modifyApplication(action.id, action.application),
+					{
+						json: args.json,
+						message: `modifying application ${action.name}`,
+					}
+				)
+			);
+			if (err !== null) {
+				if (!(err instanceof ApiError)) {
+					crash(
+						`Unexpected error modifying application ${action.name}: ${err.message}`
+					);
+				}
+
+				if (err.status === 400) {
+					crash(
+						`Error modifying application ${action.name} due to a ${brandColor.underline("misconfiguration")}\n\n\t${formatError(err)}`
+					);
+				}
+
+				crash(
+					`Error modifying application ${action.name} due to an internal error (request id: ${err.body.request_id}): ${formatError(err)}`
+				);
+			}
+
+			success(`Modified application ${brandColor(action.name)}`, {
+				shape: shapes.bar,
+			});
+			printLine("");
+			continue;
+		}
+	}
+
+	endSection("Applied changes");
+}

--- a/packages/wrangler/src/cloudchamber/client/models/ModifyApplicationRequestBody.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/ModifyApplicationRequestBody.ts
@@ -2,6 +2,11 @@
 /* tslint:disable */
 /* eslint-disable */
 
+import type { ApplicationAffinities } from "./ApplicationAffinities";
+import type { ApplicationConstraints } from "./ApplicationConstraints";
+import type { SchedulingPolicy } from "./SchedulingPolicy";
+import type { UserDeploymentConfiguration } from "./UserDeploymentConfiguration";
+
 /**
  * Request body for modifying an application
  */
@@ -9,5 +14,16 @@ export type ModifyApplicationRequestBody = {
 	/**
 	 * Number of deployments to maintain within this applicaiton. This can be used to scale the appliation up/down.
 	 */
-	instances: number;
+	instances?: number;
+	affinities?: ApplicationAffinities;
+	scheduling_policy?: SchedulingPolicy;
+	constraints?: ApplicationConstraints;
+	/**
+	 * The deployment configuration of all deployments created by this application.
+	 * Right now, if you modify the application configuration, only new deployments
+	 * created will have the new configuration. You can delete old deployments to
+	 * release new instances.
+	 *
+	 */
+	configuration?: UserDeploymentConfiguration;
 };

--- a/packages/wrangler/src/cloudchamber/helpers/diff.ts
+++ b/packages/wrangler/src/cloudchamber/helpers/diff.ts
@@ -1,0 +1,315 @@
+// Code from package jsdiff (https://github.com/kpdecker/jsdiff/tree/master)
+// It's been simplified so it can basically do line diffing only
+// and we can avoid the 600kb sized package.
+
+class Diff {
+	diff(oldString: string[], newString: string[], callback: Callback) {
+		function done(value: Result[]) {
+			callback(value);
+			return true;
+		}
+
+		const newLen = newString.length,
+			oldLen = oldString.length;
+		let editLength = 1;
+		const bestPath: (BestPath | undefined)[] = [
+			{ oldPos: -1, lastComponent: undefined },
+		];
+
+		if (bestPath[0] === undefined) {
+			throw new Error("unreachable");
+		}
+
+		// Seed editLength = 0, i.e. the content starts with the same values
+		let newPos = this.extractCommon(bestPath[0], newString, oldString, 0);
+		if (bestPath[0].oldPos + 1 >= oldLen && newPos + 1 >= newLen) {
+			// Identity per the equality and tokenizer
+			return done(
+				buildValues(
+					this,
+					bestPath[0].lastComponent,
+					newString,
+					oldString,
+					false
+				)
+			);
+		}
+
+		// Once we hit the right edge of the edit graph on some diagonal k, we can
+		// definitely reach the end of the edit graph in no more than k edits, so
+		// there's no point in considering any moves to diagonal k+1 any more (from
+		// which we're guaranteed to need at least k+1 more edits).
+		// Similarly, once we've reached the bottom of the edit graph, there's no
+		// point considering moves to lower diagonals.
+		// We record this fact by setting minDiagonalToConsider and
+		// maxDiagonalToConsider to some finite value once we've hit the edge of
+		// the edit graph.
+		// This optimization is not faithful to the original algorithm presented in
+		// Myers's paper, which instead pointlessly extends D-paths off the end of
+		// the edit graph - see page 7 of Myers's paper which notes this point
+		// explicitly and illustrates it with a diagram. This has major performance
+		// implications for some common scenarios. For instance, to compute a diff
+		// where the new text simply appends d characters on the end of the
+		// original text of length n, the true Myers algorithm will take O(n+d^2)
+		// time while this optimization needs only O(n+d) time.
+		let minDiagonalToConsider = -Infinity,
+			maxDiagonalToConsider = Infinity;
+
+		// Main method. checks all permutations of a given edit length for acceptance.
+		const execEditLength = () => {
+			for (
+				let diagonalPath = Math.max(minDiagonalToConsider, -editLength);
+				diagonalPath <= Math.min(maxDiagonalToConsider, editLength);
+				diagonalPath += 2
+			) {
+				let basePath: BestPath;
+				const removePath = bestPath[diagonalPath - 1],
+					addPath = bestPath[diagonalPath + 1];
+				if (removePath) {
+					// No one else is going to attempt to use this value, clear it
+					bestPath[diagonalPath - 1] = undefined;
+				}
+
+				let canAdd = false;
+				if (addPath) {
+					// what newPos will be after we do an insertion:
+					const addPathNewPos = addPath.oldPos - diagonalPath;
+					canAdd = addPath && 0 <= addPathNewPos && addPathNewPos < newLen;
+				}
+
+				const canRemove = removePath && removePath.oldPos + 1 < oldLen;
+				if (!canAdd && !canRemove) {
+					// If this path is a terminal then prune
+					bestPath[diagonalPath] = undefined;
+					continue;
+				}
+
+				// Select the diagonal that we want to branch from. We select the prior
+				// path whose position in the old string is the farthest from the origin
+				// and does not pass the bounds of the diff graph
+				if (
+					addPath &&
+					(!canRemove ||
+						(canAdd && (removePath?.oldPos ?? 0) < (addPath?.oldPos ?? 0)))
+				) {
+					basePath = this.addToPath(addPath, true, false, 0);
+				} else if (removePath) {
+					basePath = this.addToPath(removePath, false, true, 1);
+				} else {
+					throw new Error("unreachable");
+				}
+
+				newPos = this.extractCommon(
+					basePath,
+					newString,
+					oldString,
+					diagonalPath
+				);
+
+				if (basePath.oldPos + 1 >= oldLen && newPos + 1 >= newLen) {
+					// If we have hit the end of both strings, then we are done
+					return done(
+						buildValues(
+							this,
+							basePath.lastComponent,
+							newString,
+							oldString,
+							false
+						)
+					);
+				} else {
+					bestPath[diagonalPath] = basePath;
+					if (basePath.oldPos + 1 >= oldLen) {
+						maxDiagonalToConsider = Math.min(
+							maxDiagonalToConsider,
+							diagonalPath - 1
+						);
+					}
+					if (newPos + 1 >= newLen) {
+						minDiagonalToConsider = Math.max(
+							minDiagonalToConsider,
+							diagonalPath + 1
+						);
+					}
+				}
+			}
+
+			editLength++;
+		};
+
+		while (!execEditLength()) {}
+	}
+
+	addToPath(
+		path: BestPath,
+		added: boolean,
+		removed: boolean,
+		oldPosInc: number
+	): BestPath {
+		const last = path.lastComponent;
+		if (last && last.added === added && last.removed === removed) {
+			return {
+				oldPos: path.oldPos + oldPosInc,
+				lastComponent: {
+					count: last.count + 1,
+					added: added,
+					removed: removed,
+					previousComponent: last.previousComponent,
+				},
+			};
+		}
+
+		return {
+			oldPos: path.oldPos + oldPosInc,
+			lastComponent: {
+				count: 1,
+				added: added,
+				removed: removed,
+				previousComponent: last,
+			},
+		};
+	}
+
+	extractCommon(
+		basePath: BestPath,
+		newString: string[],
+		oldString: string[],
+		diagonalPath: number
+	) {
+		const newLen = newString.length;
+		const oldLen = oldString.length;
+		let oldPos = basePath.oldPos,
+			newPos = oldPos - diagonalPath,
+			commonCount = 0;
+		while (
+			newPos + 1 < newLen &&
+			oldPos + 1 < oldLen &&
+			oldString[oldPos + 1] === newString[newPos + 1]
+		) {
+			newPos++;
+			oldPos++;
+			commonCount++;
+		}
+
+		if (commonCount) {
+			basePath.lastComponent = {
+				count: commonCount,
+				previousComponent: basePath.lastComponent,
+				added: false,
+				removed: false,
+			};
+		}
+
+		basePath.oldPos = oldPos;
+		return newPos;
+	}
+
+	equals(left: string, right: string) {
+		return left === right;
+	}
+
+	join(chars: string[]) {
+		return chars.join("");
+	}
+}
+
+function buildValues(
+	diff: Diff,
+	lastComponent: Result | undefined,
+	newString: string[],
+	oldString: string[],
+	useLongestToken: boolean
+): Result[] {
+	// First we convert our linked list of components in reverse order to an
+	// array in the right order:
+	const components = [];
+	let nextComponent;
+	while (lastComponent) {
+		components.push(lastComponent);
+		nextComponent = lastComponent.previousComponent;
+		delete lastComponent.previousComponent;
+		lastComponent = nextComponent;
+	}
+	components.reverse();
+
+	const componentLen = components.length;
+	let componentPos = 0,
+		newPos = 0,
+		oldPos = 0;
+
+	for (; componentPos < componentLen; componentPos++) {
+		const component = components[componentPos];
+		if (!component.removed) {
+			if (!component.added && useLongestToken) {
+				let value = newString.slice(newPos, newPos + component.count);
+				value = value.map((el, i) => {
+					const oldValue = oldString[oldPos + i];
+					return oldValue.length > el.length ? oldValue : el;
+				});
+
+				component.value = diff.join(value);
+			} else {
+				component.value = diff.join(
+					newString.slice(newPos, newPos + component.count)
+				);
+			}
+			newPos += component.count;
+
+			// Common case
+			if (!component.added) {
+				oldPos += component.count;
+			}
+		} else {
+			component.value = diff.join(
+				oldString.slice(oldPos, oldPos + component.count)
+			);
+			oldPos += component.count;
+		}
+	}
+
+	return components;
+}
+
+export const lineDiff = new Diff();
+
+export type Result = {
+	count: number;
+	added: boolean;
+	removed: boolean;
+	value?: string;
+	previousComponent?: Result;
+};
+
+type BestPath = {
+	oldPos: number;
+	lastComponent?: Result;
+};
+
+type Callback = (result: Result[]) => void;
+
+function tokenize(value: string) {
+	const retLines = [],
+		linesAndNewlines = value.split(/(\n|\r\n)/);
+
+	// Ignore the final empty token that occurs if the string ends with a new line
+	if (!linesAndNewlines[linesAndNewlines.length - 1]) {
+		linesAndNewlines.pop();
+	}
+
+	// Merge the content and line separators into single tokens
+	for (let i = 0; i < linesAndNewlines.length; i++) {
+		const line = linesAndNewlines[i];
+		retLines.push(line);
+	}
+
+	return retLines.filter((s) => s !== "");
+}
+
+export function diffLines(oldStr: string, newStr: string): Result[] {
+	let res: Result[] = [];
+	lineDiff.diff(tokenize(oldStr), tokenize(newStr), (r) => {
+		res = r;
+	});
+
+	return res;
+}

--- a/packages/wrangler/src/cloudchamber/index.ts
+++ b/packages/wrangler/src/cloudchamber/index.ts
@@ -1,3 +1,4 @@
+import { applyCommand, applyCommandOptionalYargs } from "./apply";
 import { handleFailure } from "./common";
 import { createCommand, createCommandOptionalYargs } from "./create";
 import { curlCommand, yargsCurl } from "./curl";
@@ -61,5 +62,11 @@ export const cloudchamber = (
 			"send a request to an arbitrary cloudchamber endpoint",
 			(args) => yargsCurl(args),
 			(args) => handleFailure(curlCommand)(args)
+		)
+		.command(
+			"apply",
+			"apply the changes in the container applications to deploy",
+			(args) => applyCommandOptionalYargs(args),
+			(args) => handleFailure(applyCommand)(args)
 		);
 };

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -371,6 +371,7 @@ export const defaultWranglerConfig: Config = {
 	/** NON-INHERITABLE ENVIRONMENT FIELDS **/
 	define: {},
 	cloudchamber: {},
+	containers: { app: [] },
 	send_email: [],
 	browser: undefined,
 	unsafe: {},

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -40,6 +40,32 @@ export type CloudchamberConfig = {
 };
 
 /**
+ * Configuration for a container application
+ */
+export type ContainerApp = {
+	// TODO: fill out the entire type
+
+	/* Name of the application*/
+	name: string;
+	/* Number of application instances */
+	instances: number;
+	/* The scheduling policy of the application, default is regional */
+	scheduling_policy?: "regional" | "moon";
+	/* Configuration of the container */
+	configuration: {
+		image: string;
+		labels?: { name: string; value: string }[];
+		secrets?: { name: string; type: "env"; secret: string }[];
+	};
+	/* Scheduling constraints */
+	constraints?: {
+		regions?: string[];
+		cities?: string[];
+		tier?: number;
+	};
+};
+
+/**
  * Configuration in wrangler for Durable Object Migrations
  */
 export type DurableObjectMigration = {
@@ -458,6 +484,22 @@ export interface EnvironmentNonInheritable {
 	 * @nonInheritable
 	 */
 	cloudchamber: CloudchamberConfig;
+
+	/**
+	 * Container related configuration
+	 */
+	containers: {
+		/**
+		 * Container app configuration
+		 *
+		 * NOTE: This field is not automatically inherited from the top level environment,
+		 * and so must be specified in every named environment.
+		 *
+		 * @default `{}`
+		 * @nonInheritable
+		 */
+		app: ContainerApp[];
+	};
 
 	/**
 	 * These specify any Workers KV Namespaces you want to


### PR DESCRIPTION
container app changes

This command is able to take the [[container-app]] configurations, and deploy them to Cloudchamber.

To render the differences, we are introducing a new dependency with "diff". This was already included in the pnpm lock, however we could consider not rolling out a new dependency into wrangler unless absolutely necessary.

The command is designed to be CI friendly. In the tests there is some example command renders from different kind of configurations.

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No e2e test for Cloudchamber yet.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: product is private only for certain users