### PR TITLE
feat: add telemetry commands

### DIFF
--- a/.changeset/little-crabs-rule.md
+++ b/.changeset/little-crabs-rule.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
-feat: add new `wrangler telemetry` commands to configure whether Wrangler collects usage telemetry
+feat: add new `wrangler telemetry` commands to configure whether Wrangler collects usage telemetry. These are hidden for now, and will be exposed in a future release once telemetry collection is fully implemented.

--- a/.changeset/little-crabs-rule.md
+++ b/.changeset/little-crabs-rule.md
@@ -1,5 +1,0 @@
----
-"wrangler": patch
----
-
-feat: add new `wrangler telemetry` commands to configure whether Wrangler collects usage telemetry. These are hidden for now, and will be exposed in a future release once telemetry collection is fully implemented.

--- a/.changeset/little-crabs-rule.md
+++ b/.changeset/little-crabs-rule.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: add new `wrangler telemetry` commands to configure whether Wrangler collects usage telemetry

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -18,6 +18,7 @@ import { useMockIsTTY } from "./helpers/mock-istty";
 import { msw, mswSuccessOauthHandlers } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
+import { writeWranglerToml } from "./helpers/write-wrangler-toml";
 import type { MockInstance } from "vitest";
 
 declare const global: { SPARROW_SOURCE_KEY: string | undefined };
@@ -469,6 +470,22 @@ describe("metrics", () => {
 				"Status: Enabled
 
 				Status: Disabled
+				"
+			`);
+		});
+
+		it("prints a global and project status if a wrangler.toml with send_metrics is present", async () => {
+			writeMetricsConfig({
+				permission: {
+					enabled: true,
+					date: new Date(2022, 6, 4),
+				},
+			});
+			writeWranglerToml({ send_metrics: false });
+			await runWrangler("telemetry status");
+			expect(std.out).toMatchInlineSnapshot(`
+				"Global status: Enabled
+				Project status: Disabled
 				"
 			`);
 		});

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -49,6 +49,7 @@ import { initHandler, initOptions } from "./init";
 import "./kv";
 import "./workflows";
 import "./user/commands";
+import "./metrics/commands";
 import { demandSingleValue } from "./core";
 import { logBuildFailure, logger, LOGGER_LEVELS } from "./logger";
 import { mTlsCertificateCommands } from "./mtls-certificate/cli";
@@ -594,6 +595,7 @@ export function createCLIParser(argv: string[]) {
 	register.registerNamespace("login");
 	register.registerNamespace("logout");
 	register.registerNamespace("whoami");
+	register.registerNamespace("telemetry");
 
 	/******************************************************/
 	/*               DEPRECATED COMMANDS                  */

--- a/packages/wrangler/src/metrics/commands.ts
+++ b/packages/wrangler/src/metrics/commands.ts
@@ -55,16 +55,14 @@ defineCommand({
 	async handler(_, { config }) {
 		const savedConfig = readMetricsConfig();
 		if (config.send_metrics !== undefined) {
-			// TODO: update this to fallback to true
-			const globalPermission = savedConfig.permission?.enabled ?? false;
+			const globalPermission = savedConfig.permission?.enabled ?? true;
 			const projectPermission = config.send_metrics;
 			logger.log(
 				`Global status: ${globalPermission ? chalk.green("Enabled") : chalk.red("Disabled")}\n` +
 					`Project status: ${projectPermission ? chalk.green("Enabled") : chalk.red("Disabled")}\n`
 			);
 		} else {
-			// TODO: update this to fallback to true
-			logTelemetryStatus(savedConfig.permission?.enabled ?? false);
+			logTelemetryStatus(savedConfig.permission?.enabled ?? true);
 		}
 	},
 });

--- a/packages/wrangler/src/metrics/commands.ts
+++ b/packages/wrangler/src/metrics/commands.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { defineCommand, defineNamespace } from "../core";
 import { logger } from "../logger";
-import { getMetricsConfig, updateMetricsPermission } from "./metrics-config";
+import { readMetricsConfig, updateMetricsPermission } from "./metrics-config";
 
 defineNamespace({
 	command: "wrangler telemetry",
@@ -26,7 +26,6 @@ defineCommand({
 		logger.log(
 			"Wrangler is no longer collecting telemetry about your usage.\n"
 		);
-		return;
 	},
 });
 
@@ -43,7 +42,6 @@ defineCommand({
 		logger.log(
 			"Wrangler is now collecting telemetry about your usage. Thank you for helping make Wrangler better 🧡\n"
 		);
-		return;
 	},
 });
 
@@ -55,11 +53,19 @@ defineCommand({
 		status: "stable",
 	},
 	async handler(_, { config }) {
-		const metricsConfig = await getMetricsConfig({
-			sendMetrics: config.send_metrics,
-		});
-		logTelemetryStatus(metricsConfig.enabled);
-		return;
+		const savedConfig = readMetricsConfig();
+		if (config.send_metrics !== undefined) {
+			// TODO: update this to fallback to true
+			const globalPermission = savedConfig.permission?.enabled ?? false;
+			const projectPermission = config.send_metrics;
+			logger.log(
+				`Global status: ${globalPermission ? chalk.green("Enabled") : chalk.red("Disabled")}\n` +
+					`Project status: ${projectPermission ? chalk.green("Enabled") : chalk.red("Disabled")}\n`
+			);
+		} else {
+			// TODO: update this to fallback to true
+			logTelemetryStatus(savedConfig.permission?.enabled ?? false);
+		}
 	},
 });
 

--- a/packages/wrangler/src/metrics/commands.ts
+++ b/packages/wrangler/src/metrics/commands.ts
@@ -1,0 +1,70 @@
+import chalk from "chalk";
+import { defineCommand, defineNamespace } from "../core";
+import { logger } from "../logger";
+import { getMetricsConfig, updateMetricsPermission } from "./metrics-config";
+
+defineNamespace({
+	command: "wrangler telemetry",
+	metadata: {
+		description: "📈 Configure whether Wrangler collects telemetry",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+		hidden: true,
+	},
+});
+
+defineCommand({
+	command: "wrangler telemetry disable",
+	metadata: {
+		description: "Disable Wrangler telemetry collection",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+	},
+	async handler() {
+		updateMetricsPermission(false);
+		logTelemetryStatus(false);
+		logger.log(
+			"Wrangler is no longer collecting telemetry about your usage.\n"
+		);
+		return;
+	},
+});
+
+defineCommand({
+	command: "wrangler telemetry enable",
+	metadata: {
+		description: "Enable Wrangler telemetry collection",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+	},
+	async handler() {
+		updateMetricsPermission(true);
+		logTelemetryStatus(true);
+		logger.log(
+			"Wrangler is now collecting telemetry about your usage. Thank you for helping make Wrangler better 🧡\n"
+		);
+		return;
+	},
+});
+
+defineCommand({
+	command: "wrangler telemetry status",
+	metadata: {
+		description: "Check whether Wrangler telemetry collection is enabled",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+	},
+	async handler(_, { config }) {
+		const metricsConfig = await getMetricsConfig({
+			sendMetrics: config.send_metrics,
+		});
+		logTelemetryStatus(metricsConfig.enabled);
+		return;
+	},
+});
+
+const logTelemetryStatus = (enabled: boolean) => {
+	logger.log(
+		`Status: ${enabled ? chalk.green("Enabled") : chalk.red("Disabled")}\n`
+	);
+};

--- a/packages/wrangler/src/metrics/metrics-config.ts
+++ b/packages/wrangler/src/metrics/metrics-config.ts
@@ -125,7 +125,7 @@ export async function getMetricsConfig({
 		...config,
 		permission: {
 			enabled,
-			date: CURRENT_METRICS_DATE,
+			date: new Date(),
 		},
 		deviceId,
 	});
@@ -163,13 +163,9 @@ export function readMetricsConfig(): MetricsConfigFile {
 
 export function updateMetricsPermission(enabled: boolean) {
 	const config = readMetricsConfig();
-	if (config.permission?.enabled === enabled) {
-		// Do nothing if the enabled state is the same
-		return;
-	}
 	config.permission = {
 		enabled,
-		date: CURRENT_METRICS_DATE,
+		date: new Date(),
 	};
 	writeMetricsConfig(config);
 }

--- a/packages/wrangler/src/metrics/metrics-config.ts
+++ b/packages/wrangler/src/metrics/metrics-config.ts
@@ -3,7 +3,6 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fetchResult } from "../cfetch";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
-import { confirm } from "../dialogs";
 import { getWranglerSendMetricsFromEnv } from "../environment-variables/misc-variables";
 import { getGlobalWranglerConfigPath } from "../global-wrangler-config-path";
 import { CI } from "../is-ci";
@@ -107,29 +106,16 @@ export async function getMetricsConfig({
 		return { enabled: false, deviceId, userId };
 	}
 
-	// Otherwise, let's ask the user and store the result in the metrics config.
-	// TODO: remove this and default to true.
-	const enabled = await confirm(
-		"Would you like to help improve Wrangler by sending usage metrics to Cloudflare?"
-	);
-	logger.log(
-		`Your choice has been saved in the following file: ${path.relative(
-			process.cwd(),
-			getMetricsConfigPath()
-		)}.\n\n` +
-			"  You can override the user level setting for a project in `wrangler.toml`:\n\n" +
-			"   - to disable sending metrics for a project: `send_metrics = false`\n" +
-			"   - to enable sending metrics for a project: `send_metrics = true`"
-	);
+	// Otherwise, default to true
 	writeMetricsConfig({
 		...config,
 		permission: {
-			enabled,
+			enabled: true,
 			date: new Date(),
 		},
 		deviceId,
 	});
-	return { enabled, deviceId, userId };
+	return { enabled: true, deviceId, userId };
 }
 
 /**

--- a/packages/wrangler/src/metrics/metrics-config.ts
+++ b/packages/wrangler/src/metrics/metrics-config.ts
@@ -108,6 +108,7 @@ export async function getMetricsConfig({
 	}
 
 	// Otherwise, let's ask the user and store the result in the metrics config.
+	// TODO: remove this and default to true.
 	const enabled = await confirm(
 		"Would you like to help improve Wrangler by sending usage metrics to Cloudflare?"
 	);
@@ -121,6 +122,7 @@ export async function getMetricsConfig({
 			"   - to enable sending metrics for a project: `send_metrics = true`"
 	);
 	writeMetricsConfig({
+		...config,
 		permission: {
 			enabled,
 			date: CURRENT_METRICS_DATE,
@@ -159,6 +161,19 @@ export function readMetricsConfig(): MetricsConfigFile {
 	}
 }
 
+export function updateMetricsPermission(enabled: boolean) {
+	const config = readMetricsConfig();
+	if (config.permission?.enabled === enabled) {
+		// Do nothing if the enabled state is the same
+		return;
+	}
+	config.permission = {
+		enabled,
+		date: CURRENT_METRICS_DATE,
+	};
+	writeMetricsConfig(config);
+}
+
 /**
  * Get the path to the metrics config file.
  */
@@ -172,6 +187,12 @@ function getMetricsConfigPath(): string {
 export interface MetricsConfigFile {
 	permission?: {
 		/** True if Wrangler should send metrics to Cloudflare. */
+		enabled: boolean;
+		/** The date that this permission was set. */
+		date: Date;
+	};
+	c3permission?: {
+		/** True if c3 should send metrics to Cloudflare. */
 		enabled: boolean;
 		/** The date that this permission was set. */
 		date: Date;


### PR DESCRIPTION
Fixes [DEVX-1480](https://jira.cfdata.org/browse/DEVX-1480)

Adds new `wrangler telemetry disable` and `wrangler telemetry enable` commands which globally toggle telemetry collection across all projects on that machine.

Adds a new `wrangler telemetry status` command which shows the current telemetry setting, resolved to the current project.

With send_metrics set in wrangler.toml
<img width="792" alt="Screenshot 2024-11-15 at 09 44 59" src="https://github.com/user-attachments/assets/243b9b12-e226-4331-aeef-97af5632d136">

With WRANGLER_SEND_METRICS environment variable set
<img width="796" alt="Screenshot 2024-11-15 at 09 45 20" src="https://github.com/user-attachments/assets/3cb684a3-c7d6-46a5-817b-be09a89748b2">

Without either send_metrics or WRANGLER_SEND_METRICS set
<img width="795" alt="Screenshot 2024-11-15 at 09 44 18" src="https://github.com/user-attachments/assets/db85b9d7-f72c-4b48-8e74-fc56a9f79bc8">

We prioritise env var > wrangler.toml > global setting via command.

NB we're using a feature branch so will add one changeset when we merge that in.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because:  no existing e2e's, adequately covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: currently hidden. Will add later.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
