### PR TITLE
bump C3's create-next-app to 15.0.3

### DIFF
--- a/.changeset/shy-waves-prove.md
+++ b/.changeset/shy-waves-prove.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+update Next.js template to use Next.js v.15

--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -484,6 +484,7 @@ function getFrameworkTests(opts: {
 					"--tailwind",
 					"--src-dir",
 					"--app",
+					"--turbopack",
 					"--import-alias",
 					"@/*",
 				],

--- a/packages/create-cloudflare/src/frameworks/index.ts
+++ b/packages/create-cloudflare/src/frameworks/index.ts
@@ -13,7 +13,7 @@ export const getFrameworkCli = (ctx: C3Context, withVersion = true) => {
 	const frameworkCli = ctx.template
 		.frameworkCli as keyof typeof frameworksPackageJson.dependencies;
 	const version =
-		ctx.template.frameworkCliVersion ??
+		ctx.template.pinFrameworkCli ??
 		frameworksPackageJson.dependencies[frameworkCli];
 	return withVersion ? `${frameworkCli}@${version}` : frameworkCli;
 };

--- a/packages/create-cloudflare/src/frameworks/index.ts
+++ b/packages/create-cloudflare/src/frameworks/index.ts
@@ -12,7 +12,9 @@ export const getFrameworkCli = (ctx: C3Context, withVersion = true) => {
 
 	const frameworkCli = ctx.template
 		.frameworkCli as keyof typeof frameworksPackageJson.dependencies;
-	const version = frameworksPackageJson.dependencies[frameworkCli];
+	const version =
+		ctx.template.frameworkCliVersion ??
+		frameworksPackageJson.dependencies[frameworkCli];
 	return withVersion ? `${frameworkCli}@${version}` : frameworkCli;
 };
 

--- a/packages/create-cloudflare/src/frameworks/index.ts
+++ b/packages/create-cloudflare/src/frameworks/index.ts
@@ -13,7 +13,7 @@ export const getFrameworkCli = (ctx: C3Context, withVersion = true) => {
 	const frameworkCli = ctx.template
 		.frameworkCli as keyof typeof frameworksPackageJson.dependencies;
 	const version =
-		ctx.template.pinFrameworkCli ??
+		ctx.template.frameworkCliPinnedVersion ??
 		frameworksPackageJson.dependencies[frameworkCli];
 	return withVersion ? `${frameworkCli}@${version}` : frameworkCli;
 };

--- a/packages/create-cloudflare/src/frameworks/package.json
+++ b/packages/create-cloudflare/src/frameworks/package.json
@@ -10,7 +10,7 @@
 		"@angular/create": "19.0.4",
 		"create-docusaurus": "3.6.3",
 		"create-hono": "0.14.3",
-		"create-next-app": "14.2.5",
+		"create-next-app": "15.0.3",
 		"create-qwik": "1.11.0",
 		"create-vite": "6.0.1",
 		"create-remix": "2.15.0",

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -65,16 +65,21 @@ export type TemplateConfig = {
 	 * to handle config version skew between different versions of c3
 	 */
 	configVersion: number;
-	/** The id by which template is referred to internally and keyed in lookup maps*/
+	/** The id by which template is referred to internally and keyed in lookup maps */
 	id: string;
-	/** A string that controls how the template is presented to the user in the selection menu*/
+	/** A string that controls how the template is presented to the user in the selection menu */
 	displayName: string;
-	/** A string that explains what is inside the template, including any resources and how those will be used*/
+	/** A string that explains what is inside the template, including any resources and how those will be used */
 	description?: string;
 	/** The deployment platform for this template */
 	platform: "workers" | "pages";
-	/** The name of the framework cli tool that is used to generate this project or undefined if none. */
+	/** The name of the framework cli tool that is used to generate this project or undefined if none */
 	frameworkCli?: string;
+	/**
+	 * The version of the framework cli tool to use.
+	 * If omitted the cli version is taken from src/frameworks/package.json, which is the default/standard behavior.
+	 */
+	frameworkCliVersion?: string;
 	/** When set to true, hides this template from the selection menu */
 	hidden?: boolean;
 	/** Specifies a set of files that will be copied to the project directory during creation.

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -79,7 +79,7 @@ export type TemplateConfig = {
 	 * A specific version of the framework cli tool to use instead of the standard one taken from the src/frameworks/package.json
 	 * (which gets managed and bumped by dependabot)
 	 */
-	pinFrameworkCli?: string;
+	frameworkCliPinnedVersion?: string;
 	/** When set to true, hides this template from the selection menu */
 	hidden?: boolean;
 	/** Specifies a set of files that will be copied to the project directory during creation.

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -76,10 +76,10 @@ export type TemplateConfig = {
 	/** The name of the framework cli tool that is used to generate this project or undefined if none */
 	frameworkCli?: string;
 	/**
-	 * The version of the framework cli tool to use.
-	 * If omitted the cli version is taken from src/frameworks/package.json, which is the default/standard behavior.
+	 * A specific version of the framework cli tool to use instead of the standard one taken from the src/frameworks/package.json
+	 * (which gets managed and bumped by dependabot)
 	 */
-	frameworkCliVersion?: string;
+	pinFrameworkCli?: string;
 	/** When set to true, hides this template from the selection menu */
 	hidden?: boolean;
 	/** Specifies a set of files that will be copied to the project directory during creation.

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -30,6 +30,10 @@ export default {
 	configVersion: 1,
 	id: "next",
 	frameworkCli: "create-next-app",
+	// TODO: here we need to specify a version of create-next-app which is different from the
+	//       standard one used in the stable Next.js template, that's because our open-next adapter
+	//       is not yet fully ready for Next.js 15, once it is we should remove the following
+	frameworkCliVersion: "14.2.5",
 	platform: "workers",
 	displayName: "Next (using Node.js compat + Workers Assets)",
 	path: "templates-experimental/next",

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -33,7 +33,7 @@ export default {
 	// TODO: here we need to specify a version of create-next-app which is different from the
 	//       standard one used in the stable Next.js template, that's because our open-next adapter
 	//       is not yet fully ready for Next.js 15, once it is we should remove the following
-	pinFrameworkCli: "14.2.5",
+	frameworkCliPinnedVersion: "14.2.5",
 	platform: "workers",
 	displayName: "Next (using Node.js compat + Workers Assets)",
 	path: "templates-experimental/next",

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -18,14 +18,7 @@ const generate = async (ctx: C3Context) => {
 };
 
 const configure = async () => {
-	const packages = [
-		// Note: this is using the experimental pkg.pr.new prerelease
-		//       we do this because the stable @opennextjs/cloudflare package
-		//       does not yet support Next 15, we should move away from this
-		//       as soon as possible
-		"https://pkg.pr.new/@opennextjs/cloudflare@experimental",
-		"@cloudflare/workers-types",
-	];
+	const packages = ["@opennextjs/cloudflare", "@cloudflare/workers-types"];
 	await installPackages(packages, {
 		dev: true,
 		startText: "Adding the Cloudflare adapter",

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -18,7 +18,14 @@ const generate = async (ctx: C3Context) => {
 };
 
 const configure = async () => {
-	const packages = ["@opennextjs/cloudflare", "@cloudflare/workers-types"];
+	const packages = [
+		// Note: this is using the experimental pkg.pr.new prerelease
+		//       we do this because the stable @opennextjs/cloudflare package
+		//       does not yet support Next 15, we should move away from this
+		//       as soon as possible
+		"https://pkg.pr.new/@opennextjs/cloudflare@experimental",
+		"@cloudflare/workers-types",
+	];
 	await installPackages(packages, {
 		dev: true,
 		startText: "Adding the Cloudflare adapter",

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -33,7 +33,7 @@ export default {
 	// TODO: here we need to specify a version of create-next-app which is different from the
 	//       standard one used in the stable Next.js template, that's because our open-next adapter
 	//       is not yet fully ready for Next.js 15, once it is we should remove the following
-	frameworkCliVersion: "14.2.5",
+	pinFrameworkCli: "14.2.5",
 	platform: "workers",
 	displayName: "Next (using Node.js compat + Workers Assets)",
 	path: "templates-experimental/next",

--- a/packages/create-cloudflare/templates/next/README.md
+++ b/packages/create-cloudflare/templates/next/README.md
@@ -46,7 +46,7 @@ In order to enable the example:
   ```ts
   // KV Example:
   ```
-  and uncomment the commented lines below it.
+  and uncomment the commented lines below it (also uncomment the relevant imports).
 - Do the same in the `wrangler.toml` file, where
   the comment is:
   ```

--- a/packages/create-cloudflare/templates/next/app/js/app/api/hello/route.js
+++ b/packages/create-cloudflare/templates/next/app/js/app/api/hello/route.js
@@ -1,9 +1,9 @@
-import { getRequestContext } from '@cloudflare/next-on-pages'
+// import { getRequestContext } from '@cloudflare/next-on-pages'
 
 export const runtime = 'edge'
 
-export async function GET(request) {
-  let responseText = 'Hello World'
+export async function GET() {
+  const responseText = 'Hello World'
 
   // In the edge runtime you can use Bindings that are available in your application
   // (for more details see:
@@ -15,7 +15,7 @@ export async function GET(request) {
   // const myKv = getRequestContext().env.MY_KV_NAMESPACE
   // await myKv.put('suffix', ' from a KV store!')
   // const suffix = await myKv.get('suffix')
-  // responseText += suffix
+  // return new Response(responseText + suffix)
 
   return new Response(responseText)
 }

--- a/packages/create-cloudflare/templates/next/app/ts/app/api/hello/route.ts
+++ b/packages/create-cloudflare/templates/next/app/ts/app/api/hello/route.ts
@@ -1,10 +1,9 @@
-import type { NextRequest } from 'next/server'
-import { getRequestContext } from '@cloudflare/next-on-pages'
+// import { getRequestContext } from '@cloudflare/next-on-pages'
 
 export const runtime = 'edge'
 
-export async function GET(request: NextRequest) {
-  let responseText = 'Hello World'
+export async function GET() {
+  const responseText = 'Hello World'
 
   // In the edge runtime you can use Bindings that are available in your application
   // (for more details see:
@@ -16,7 +15,7 @@ export async function GET(request: NextRequest) {
   // const myKv = getRequestContext().env.MY_KV_NAMESPACE
   // await myKv.put('suffix', ' from a KV store!')
   // const suffix = await myKv.get('suffix')
-  // responseText += suffix
+  // return new Response(responseText + suffix)
 
   return new Response(responseText)
 }

--- a/packages/create-cloudflare/templates/next/c3.ts
+++ b/packages/create-cloudflare/templates/next/c3.ts
@@ -49,10 +49,10 @@ const generate = async (ctx: C3Context) => {
 	updateStatus("Created wrangler.toml file");
 };
 
-const updateNextConfig = () => {
+const updateNextConfig = (usesTs: boolean) => {
 	const s = spinner();
 
-	const configFile = "next.config.mjs";
+	const configFile = `next.config.${usesTs ? "ts" : "mjs"}`;
 	s.start(`Updating \`${configFile}\``);
 
 	const configContent = readFile(configFile);
@@ -107,7 +107,7 @@ const configure = async (ctx: C3Context) => {
 		await writeEslintrc(ctx);
 	}
 
-	updateNextConfig();
+	updateNextConfig(usesTs);
 
 	copyFile(
 		join(getTemplatePath(ctx), "README.md"),


### PR DESCRIPTION
This PR is for updating C3 to create a Next.js 15 app in non-experimental mode

However (see comments below) the bump of create-next-app for non-experimental mode currently applies to both the non-experimental and experimental Next.js templates, forcing us to either make sure that both templates can work with Next.js 15 or that we find a way to have each use a different version of create-next-app

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included (the quarantined e2e Next.js test has been updated)
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: I think that the Next.js (non-experimental) e2e test isn't run because it is quarantined
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's just a version bump

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
