### PR TITLE
Include Version Preview URL in Wrangler output file

### DIFF
--- a/.changeset/mighty-beds-grab.md
+++ b/.changeset/mighty-beds-grab.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Include Version Preview URL in Wrangler's output file

--- a/packages/wrangler/src/output.ts
+++ b/packages/wrangler/src/output.ts
@@ -128,6 +128,8 @@ interface OutputEntryVersionUpload extends OutputEntryBase<"version-upload"> {
 	worker_tag: string | null;
 	/** A GUID that identifies this uploaded, but not yet deployed, version of the Worker. This version will need to be "deployed" to receive traffic. */
 	version_id: string | null;
+	/** The preview URL associated with this version upload */
+	preview_url: string | undefined;
 }
 
 interface OutputEntryVersionDeployment

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -274,7 +274,7 @@ async function versionsUploadHandler(
 	if (!args.dryRun) {
 		await standardPricingWarning(config);
 	}
-	const { versionId, workerTag } = await versionsUpload({
+	const { versionId, workerTag, versionPreviewUrl } = await versionsUpload({
 		config,
 		accountId,
 		name,
@@ -313,6 +313,7 @@ async function versionsUploadHandler(
 		worker_name: name ?? null,
 		worker_tag: workerTag,
 		version_id: versionId,
+		preview_url: versionPreviewUrl,
 	});
 }
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -112,9 +112,11 @@ function errIsStartupErr(err: unknown): err is ParseError & { code: 10021 } {
 	return false;
 }
 
-export default async function versionsUpload(
-	props: Props
-): Promise<{ versionId: string | null; workerTag: string | null }> {
+export default async function versionsUpload(props: Props): Promise<{
+	versionId: string | null;
+	workerTag: string | null;
+	versionPreviewUrl?: string | undefined;
+}> {
 	// TODO: warn if git/hg has uncommitted changes
 	const { config, accountId, name } = props;
 	let versionId: string | null = null;
@@ -565,6 +567,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	logger.log("Uploaded", workerName, formatTime(uploadMs));
 	logger.log("Worker Version ID:", versionId);
 
+	let versionPreviewUrl: string | undefined = undefined;
+
 	if (versionId && hasPreview) {
 		const { enabled: available_on_subdomain } = await fetchResult<{
 			enabled: boolean;
@@ -573,9 +577,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		if (available_on_subdomain) {
 			const userSubdomain = await getWorkersDevSubdomain(accountId);
 			const shortVersion = versionId.slice(0, 8);
-			logger.log(
-				`Version Preview URL: https://${shortVersion}-${workerName}.${userSubdomain}.workers.dev`
-			);
+			versionPreviewUrl = `https://${shortVersion}-${workerName}.${userSubdomain}.workers.dev`;
+			logger.log(`Version Preview URL: ${versionPreviewUrl}`);
 		}
 	}
 
@@ -591,7 +594,7 @@ Changes to triggers (routes, custom domains, cron schedules, etc) must be applie
 `)
 	);
 
-	return { versionId, workerTag };
+	return { versionId, workerTag, versionPreviewUrl };
 }
 
 function helpIfErrorIsSizeOrScriptStartup(


### PR DESCRIPTION
Fixes #7240

Include the version preview URL from `wrangler versions upload` in Wrangler's output file.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Wrangler's output file is not currently documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
