### PR TITLE
docs: better wording on DevTools readme

### DIFF
--- a/packages/wrangler-devtools/README.md
+++ b/packages/wrangler-devtools/README.md
@@ -52,9 +52,15 @@ Two methods are available for testing updates:
 
 **Preview Builds:**
 
-- Add `preview:wrangler-devtools` label to PRs
-- Use deployed preview URL for testing
-- If you want to see this preview working in Playground, you can also add the `preview:wrangler-playground` label to deploy the Playground with the DevTools preview enabled.
+On any pull request to the repo on GitHub, you can add labels to trigger preview builds of both the DevTools frontend, and the Playground. This is useful because it will allow you to manually test your changes in a live environment, and with one-click.
+
+There are two labels you can use:
+- `preview:wrangler-devtools` - this will trigger the DevTools preview
+- `preview:wrangler-playground` - this will trigger the Playground preview
+
+If you add **both** labels, Playground will embed the DevTools preview, so you can test them together.
+
+Once the previews are built, you will see a comment on the PR with links to the live URLs.
 
 ## Acceptance Criteria
 

--- a/packages/wrangler-devtools/README.md
+++ b/packages/wrangler-devtools/README.md
@@ -55,6 +55,7 @@ Two methods are available for testing updates:
 On any pull request to the repo on GitHub, you can add labels to trigger preview builds of both the DevTools frontend, and the Playground. This is useful because it will allow you to manually test your changes in a live environment, and with one-click.
 
 There are two labels you can use:
+
 - `preview:wrangler-devtools` - this will trigger the DevTools preview
 - `preview:wrangler-playground` - this will trigger the Playground preview
 


### PR DESCRIPTION
Fixes #000.

Adds some documentation surrounding labels and previews for DevTools and Playground, specifically mentioning the PR comment that is created when a preview build completes.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: docs only
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: docs only
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: docs only
