### PR TITLE
feat: support extending the user configuration

### DIFF
--- a/.changeset/slow-dolphins-decide.md
+++ b/.changeset/slow-dolphins-decide.md
@@ -1,0 +1,15 @@
+---
+"wrangler": patch
+---
+
+feat: support extending the user configuration
+
+The main goal here is to enable tools to generate a partial configuration file that is merged into the user configuration when Wrangler commands are run.
+
+The file must be written to `./.wrangler/config/extra.json`, where the path is relative to the project path, which is the directory containing the wrangler.toml or the current working directory if there is no wrangler.toml.
+
+The format of the file is a JSON object whose properties are the inheritable and non-inheritable options described in the Wrangler configuration documentation. Notably it cannot contain the "top level" configuration properties.
+
+The contents of the file will be merged into the configuration of the currently selected environment before being used in all Wrangler commands.
+
+The user does not need to manually specify that this merging should happen. It is done automatically when the file is found.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
 		"cloudflareaccess",
 		"cloudflared",
 		"Codespaces",
+		"defu",
 		"esbuild",
 		"eslintcache",
 		"execa",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -61,7 +61,7 @@
 		"generate-json-schema": "pnpm exec ts-json-schema-generator --no-type-check --path src/config/config.ts --type RawConfig --out config-schema.json",
 		"prepublishOnly": "SOURCEMAPS=false pnpm run -w build",
 		"start": "pnpm run bundle && cross-env NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
-		"test": "pnpm run assert-git-version && LC_ALL=C vitest",
+		"test": "pnpm run assert-git-version && cross-env LC_ALL=C vitest",
 		"test:ci": "pnpm run test run",
 		"test:debug": "pnpm run test --silent=false --verbose=true",
 		"test:e2e": "vitest -c ./e2e/vitest.config.mts",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -61,7 +61,7 @@
 		"generate-json-schema": "pnpm exec ts-json-schema-generator --no-type-check --path src/config/config.ts --type RawConfig --out config-schema.json",
 		"prepublishOnly": "SOURCEMAPS=false pnpm run -w build",
 		"start": "pnpm run bundle && cross-env NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
-		"test": "pnpm run assert-git-version && vitest",
+		"test": "pnpm run assert-git-version && LC_ALL=C vitest",
 		"test:ci": "pnpm run test run",
 		"test:debug": "pnpm run test --silent=false --verbose=true",
 		"test:e2e": "vitest -c ./e2e/vitest.config.mts",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -125,6 +125,7 @@
 		"cmd-shim": "^4.1.0",
 		"command-exists": "^1.2.9",
 		"concurrently": "^8.2.2",
+		"defu": "^6.1.4",
 		"devtools-protocol": "^0.0.1182435",
 		"dotenv": "^16.0.0",
 		"execa": "^6.1.0",

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -76,7 +76,7 @@ describe("readConfig()", () => {
 				Object {
 				  "debug": "",
 				  "err": "",
-				  "info": "Extending with configuration found in .wrangler/config/extra.json.",
+				  "info": "Loading additional configuration from .wrangler/config/extra.json.",
 				  "out": "",
 				  "warn": "",
 				}
@@ -177,19 +177,23 @@ describe("readConfig()", () => {
 			}
 
 			expect(error.toString().replaceAll("\\", "/")).toMatchInlineSnapshot(`
-				"Error: Extending with configuration found in .wrangler/config/extra.json.
-				  - Expected \\"compatibility_date\\" to be of type string but got 2021."
+				"Error: Processing wrangler.toml configuration:
+
+				  - Processing extra configuration found in .wrangler/config/extra.json.
+				    - Expected \\"compatibility_date\\" to be of type string but got 2021."
 			`);
 
 			expect(std).toMatchInlineSnapshot(`
 				Object {
 				  "debug": "",
 				  "err": "",
-				  "info": "",
+				  "info": "Loading additional configuration from .wrangler/config/extra.json.",
 				  "out": "",
-				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mExtending with configuration found in .wrangler/config/extra.json.[0m
+				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mProcessing wrangler.toml configuration:[0m
 
-				    - Unexpected fields found in extended config field: \\"unexpected_property\\"
+
+				    - Processing extra configuration found in .wrangler/config/extra.json.
+				      - Unexpected fields found in extended config field: \\"unexpected_property\\"
 
 				",
 				}
@@ -241,6 +245,32 @@ describe("readConfig()", () => {
 					no_bundle: true,
 				})
 			);
+		});
+
+		it("should support extending with a Pages output directory property", () => {
+			const pages_build_output_dir = "./public";
+
+			writeWranglerToml({});
+			writeExtraJson({
+				pages_build_output_dir,
+			});
+
+			const config = readConfig("wrangler.toml", {});
+			expect(config).toEqual(
+				expect.objectContaining({
+					pages_build_output_dir: "./public",
+				})
+			);
+
+			expect(std).toMatchInlineSnapshot(`
+				Object {
+				  "debug": "",
+				  "err": "",
+				  "info": "Loading additional configuration from .wrangler/config/extra.json.",
+				  "out": "",
+				  "warn": "",
+				}
+			`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -169,11 +169,18 @@ describe("readConfig()", () => {
 				unexpected_property: true,
 			} as unknown as RawEnvironment);
 
-			expect(() => readConfig("wrangler.toml", {}))
-				.toThrowErrorMatchingInlineSnapshot(`
-				[Error: Extending with configuration found in .wrangler/config/extra.json.
-				  - Expected "compatibility_date" to be of type string but got 2021.]
+			let error = new Error("Missing expected error");
+			try {
+				readConfig("wrangler.toml", {});
+			} catch (e) {
+				error = e as Error;
+			}
+
+			expect(error.toString().replaceAll("\\", "/")).toMatchInlineSnapshot(`
+				"Error: Extending with configuration found in .wrangler/config/extra.json.
+				  - Expected \\"compatibility_date\\" to be of type string but got 2021."
 			`);
+
 			expect(std).toMatchInlineSnapshot(`
 				Object {
 				  "debug": "",

--- a/packages/wrangler/src/__tests__/helpers/write-wrangler-toml.ts
+++ b/packages/wrangler/src/__tests__/helpers/write-wrangler-toml.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import TOML from "@iarna/toml";
-import type { RawConfig } from "../../config";
+import { ensureDirectoryExistsSync } from "../../utils/filesystem";
+import type { RawConfig, RawEnvironment } from "../../config";
 
 /** Write a mock wrangler.toml file to disk. */
 export function writeWranglerToml(
@@ -32,4 +33,12 @@ export function writeWranglerJson(
 
 		"utf-8"
 	);
+}
+
+export function writeExtraJson(
+	config: RawEnvironment = {},
+	path = "./.wrangler/config/extra.json"
+) {
+	ensureDirectoryExistsSync(path);
+	fs.writeFileSync(path, JSON.stringify(config), "utf-8");
 }

--- a/packages/wrangler/src/__tests__/helpers/write-wrangler-toml.ts
+++ b/packages/wrangler/src/__tests__/helpers/write-wrangler-toml.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import TOML from "@iarna/toml";
+import { PagesConfigFields } from "../../config/config";
 import { ensureDirectoryExistsSync } from "../../utils/filesystem";
 import type { RawConfig, RawEnvironment } from "../../config";
 
@@ -36,7 +37,7 @@ export function writeWranglerJson(
 }
 
 export function writeExtraJson(
-	config: RawEnvironment = {},
+	config: RawEnvironment & Partial<PagesConfigFields> = {},
 	path = "./.wrangler/config/extra.json"
 ) {
 	ensureDirectoryExistsSync(path);

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
+import assert from "node:assert";
 import { resolve } from "path";
 import { PassThrough } from "stream";
 import chalk from "chalk";
@@ -22,8 +23,10 @@ chalk.level = 0;
 	global as unknown as { __RELATIVE_PACKAGE_PATH__: string }
 ).__RELATIVE_PACKAGE_PATH__ = "..";
 
-// Set `LC_ALL` to fix the language as English for the messages thrown by Yargs.
-process.env.LC_ALL = "en";
+assert(
+	process.env.LC_ALL === "C",
+	"Expected `LC_ALL` env var to be 'C' in order get deterministic localized messages in tests"
+);
 
 vi.mock("ansi-escapes", () => {
 	return {

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -30,18 +30,6 @@ export type RawConfig = Partial<ConfigFields<RawDevConfig>> &
 	DeprecatedConfigFields &
 	EnvironmentMap & { $schema?: string };
 
-// Pages-specific configuration fields
-interface PagesConfigFields {
-	/**
-	 * The directory of static assets to serve.
-	 *
-	 * The presence of this field in `wrangler.toml` indicates a Pages project,
-	 * and will prompt the handling of the configuration file according to the
-	 * Pages-specific validation rules.
-	 */
-	pages_build_output_dir?: string;
-}
-
 export interface ConfigFields<Dev extends RawDevConfig> {
 	configPath: string | undefined;
 
@@ -185,7 +173,7 @@ export interface ConfigFields<Dev extends RawDevConfig> {
 }
 
 // Pages-specific configuration fields
-interface PagesConfigFields {
+export interface PagesConfigFields {
 	/**
 	 * The directory of static assets to serve.
 	 *

--- a/packages/wrangler/src/config/extra.ts
+++ b/packages/wrangler/src/config/extra.ts
@@ -1,0 +1,83 @@
+import { existsSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { defu } from "defu";
+import { UserError } from "../errors";
+import { logger } from "../logger";
+import { parseJSONC, readFileSync } from "../parse";
+import { Diagnostics } from "./diagnostics";
+import { normalizeAndValidateEnvironment } from "./validation";
+import { validateAdditionalProperties } from "./validation-helpers";
+import type { Config } from "./config";
+import type { Environment } from "./environment";
+
+/**
+ * Merge additional configuration loaded from `.wrangler/config/extra.json`,
+ * if it exists, into the user provided configuration.
+ */
+export function extendConfiguration(
+	configPath: string | undefined,
+	userConfig: Config,
+	hideWarnings: boolean
+): Config {
+	// Handle extending the user configuration
+	const extraPath = getExtraConfigPath(configPath && dirname(configPath));
+	const extra = loadExtraConfig(extraPath);
+	if (extra === undefined) {
+		return userConfig;
+	}
+
+	const { config, diagnostics } = extra;
+	if (!hideWarnings && !diagnostics.hasWarnings() && !diagnostics.hasErrors()) {
+		logger.info(diagnostics.description);
+	}
+	if (diagnostics.hasWarnings() && !hideWarnings) {
+		logger.warn(diagnostics.renderWarnings());
+	}
+	if (diagnostics.hasErrors()) {
+		throw new UserError(diagnostics.renderErrors());
+	}
+	return defu<Config, [Config]>(config, userConfig);
+}
+
+/**
+ * Get the path to a file that might contain additional configuration to be merged into the user's configuration.
+ *
+ * This supports the case where a custom build tool wants to extend the user's configuration as well as pre-bundled files.
+ */
+function getExtraConfigPath(projectRoot: string | undefined): string {
+	return resolve(projectRoot ?? ".", ".wrangler/config/extra.json");
+}
+
+/**
+ * Attempt to load and validate extra config from the `.wrangler/config/extra.json` file if it exists.
+ */
+function loadExtraConfig(configPath: string):
+	| {
+			config: Environment;
+			diagnostics: Diagnostics;
+	  }
+	| undefined {
+	if (!existsSync(configPath)) {
+		return undefined;
+	}
+
+	const diagnostics = new Diagnostics(
+		`Extending with configuration found in ${relative(process.cwd(), configPath)}.`
+	);
+	const raw = parseJSONC<Environment>(readFileSync(configPath), configPath);
+	const config = normalizeAndValidateEnvironment(
+		diagnostics,
+		configPath,
+		raw,
+		/* isDispatchNamespace */ false
+	);
+
+	validateAdditionalProperties(
+		diagnostics,
+		"extended config",
+		Object.keys(raw),
+		[...Object.keys(config)]
+	);
+
+	return { config, diagnostics };
+}

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -86,6 +86,18 @@ export function readConfig(
 		}
 	}
 
+	// Process the top-level configuration. This is common for both
+	// Workers and Pages
+	let { config, diagnostics } = normalizeAndValidateConfig(
+		rawConfig,
+		configPath,
+		args
+	);
+
+	const extra = extendConfiguration(configPath, config, hideWarnings);
+	config = extra.config;
+	diagnostics.addChild(extra.diagnostics);
+
 	/**
 	 * Check if configuration file belongs to a Pages project.
 	 *
@@ -116,14 +128,6 @@ export function readConfig(
 		);
 	}
 
-	// Process the top-level configuration. This is common for both
-	// Workers and Pages
-	const { config, diagnostics } = normalizeAndValidateConfig(
-		rawConfig,
-		configPath,
-		args
-	);
-
 	if (diagnostics.hasWarnings() && !hideWarnings) {
 		logger.warn(diagnostics.renderWarnings());
 	}
@@ -152,7 +156,7 @@ export function readConfig(
 
 	applyPythonConfig(config, args);
 
-	return extendConfiguration(configPath, config, hideWarnings);
+	return config;
 }
 
 /**

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -7,6 +7,7 @@ import { getFlag } from "../experimental-flags";
 import { logger } from "../logger";
 import { EXIT_CODE_INVALID_PAGES_CONFIG } from "../pages/errors";
 import { parseJSONC, parseTOML, readFileSync } from "../parse";
+import { extendConfiguration } from "./extra";
 import { isPagesConfig, normalizeAndValidateConfig } from "./validation";
 import { validatePagesConfig } from "./validation-pages";
 import type { CfWorkerInit } from "../deployment-bundle/worker";
@@ -151,7 +152,7 @@ export function readConfig(
 
 	applyPythonConfig(config, args);
 
-	return config;
+	return extendConfiguration(configPath, config, hideWarnings);
 }
 
 /**

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1028,7 +1028,7 @@ const validateTailConsumers: ValidatorFn = (diagnostics, field, value) => {
 /**
  * Validate top-level environment configuration and return the normalized values.
  */
-function normalizeAndValidateEnvironment(
+export function normalizeAndValidateEnvironment(
 	diagnostics: Diagnostics,
 	configPath: string | undefined,
 	topLevelEnv: RawEnvironment,
@@ -1037,7 +1037,7 @@ function normalizeAndValidateEnvironment(
 /**
  * Validate the named environment configuration and return the normalized values.
  */
-function normalizeAndValidateEnvironment(
+export function normalizeAndValidateEnvironment(
 	diagnostics: Diagnostics,
 	configPath: string | undefined,
 	rawEnv: RawEnvironment,
@@ -1050,7 +1050,7 @@ function normalizeAndValidateEnvironment(
 /**
  * Validate the named environment configuration and return the normalized values.
  */
-function normalizeAndValidateEnvironment(
+export function normalizeAndValidateEnvironment(
 	diagnostics: Diagnostics,
 	configPath: string | undefined,
 	rawEnv: RawEnvironment,
@@ -1060,7 +1060,7 @@ function normalizeAndValidateEnvironment(
 	isLegacyEnv?: boolean,
 	rawConfig?: RawConfig
 ): Environment;
-function normalizeAndValidateEnvironment(
+export function normalizeAndValidateEnvironment(
 	diagnostics: Diagnostics,
 	configPath: string | undefined,
 	rawEnv: RawEnvironment,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@vitest/runner':
+      specifier: ~2.1.3
+      version: 2.1.3
+    '@vitest/snapshot':
+      specifier: ~2.1.3
+      version: 2.1.3
     '@vitest/ui':
       specifier: ~2.1.3
       version: 2.1.3
@@ -1824,6 +1830,9 @@ importers:
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
+      defu:
+        specifier: ^6.1.4
+        version: 6.1.4
       devtools-protocol:
         specifier: ^0.0.1182435
         version: 0.0.1182435


### PR DESCRIPTION
Fixes #DEVDASH-330

This feature is described in an internal doc: **MINI-SPEC:Allow 3rd party build tools to generate Worker code and configuration**

The main goal here is to enable tools to generate a partial configuration file that is merged into the user configuration when Wrangler commands are run.

The file must be written to `./.wrangler/config/extra.json`, where the path is relative to the project path, which is the directory containing the wrangler.toml or the current working directory if there is no wrangler.toml.

The format of the file is a JSON object whose properties are the inheritable and non-inheritable options described in the Wrangler configuration documentation. Notably it cannot contain the "top level" configuration properties.

The contents of the file will be merged into the configuration of the currently selected environment before being used in all Wrangler commands.

The user does not need to manually specify that this merging should happen. It is done automatically when the file is found.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18146
  - [ ] Documentation not necessary because:
