### PR TITLE
Export config types/utils

### DIFF
--- a/.changeset/breezy-cats-matter.md
+++ b/.changeset/breezy-cats-matter.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Export RawConfig and RawEnvironment types from Wrangler

--- a/.changeset/breezy-cats-matter.md
+++ b/.changeset/breezy-cats-matter.md
@@ -2,4 +2,5 @@
 "wrangler": patch
 ---
 
-Export RawConfig and RawEnvironment types from Wrangler
+Export unstable_readConfig function and UnstableConfig, UnstableRawConfig, UnstableRawEnvironment and UnstableMiniflareWorkerOptions types from Wrangler.
+Overload unstable_getMiniflareWorkerOptions function to accept a config that has already been loaded.

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -16,11 +16,12 @@ import { getLegacyAssetPaths, getSiteAssetPaths } from "../../../sites";
 import { CacheStorage } from "./caches";
 import { ExecutionContext } from "./executionContext";
 import { getServiceBindings } from "./services";
-import type { Config } from "../../../config";
+import type { Config, RawConfig, RawEnvironment } from "../../../config";
 import type { IncomingRequestCfProperties } from "@cloudflare/workers-types/experimental";
 import type { MiniflareOptions, ModuleRule, WorkerOptions } from "miniflare";
 
-export type { RawConfig, RawEnvironment } from "../../../config";
+export { readConfig };
+export type { RawConfig, RawEnvironment };
 
 /**
  * Options for the `getPlatformProxy` utility

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -20,6 +20,8 @@ import type { Config } from "../../../config";
 import type { IncomingRequestCfProperties } from "@cloudflare/workers-types/experimental";
 import type { MiniflareOptions, ModuleRule, WorkerOptions } from "miniflare";
 
+export type { RawConfig, RawEnvironment } from "../../../config";
+
 /**
  * Options for the `getPlatformProxy` utility
  */

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -240,17 +240,27 @@ export type SourcelessWorkerOptions = Omit<
 	"script" | "scriptPath" | "modules" | "modulesRoot"
 > & { modulesRules?: ModuleRule[] };
 
-export function unstable_getMiniflareWorkerOptions(
-	configPath: string,
-	env?: string
-): {
+interface MiniflareWorkerOptions {
 	workerOptions: SourcelessWorkerOptions;
 	define: Record<string, string>;
 	main?: string;
-} {
-	const config = readConfig(configPath, {
-		env,
-	});
+}
+
+export function unstable_getMiniflareWorkerOptions(
+	configPath: string,
+	env?: string
+): MiniflareWorkerOptions;
+export function unstable_getMiniflareWorkerOptions(
+	config: Config
+): MiniflareWorkerOptions;
+export function unstable_getMiniflareWorkerOptions(
+	configOrConfigPath: string | Config,
+	env?: string
+): MiniflareWorkerOptions {
+	const config =
+		typeof configOrConfigPath === "string"
+			? readConfig(configOrConfigPath, { env })
+			: configOrConfigPath;
 
 	const modulesRules: ModuleRule[] = config.rules
 		.concat(DEFAULT_MODULE_RULES)

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -21,7 +21,7 @@ import type { IncomingRequestCfProperties } from "@cloudflare/workers-types/expe
 import type { MiniflareOptions, ModuleRule, WorkerOptions } from "miniflare";
 
 export { readConfig };
-export type { RawConfig, RawEnvironment };
+export type { Config, RawConfig, RawEnvironment };
 
 /**
  * Options for the `getPlatformProxy` utility

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -20,8 +20,12 @@ import type { Config, RawConfig, RawEnvironment } from "../../../config";
 import type { IncomingRequestCfProperties } from "@cloudflare/workers-types/experimental";
 import type { MiniflareOptions, ModuleRule, WorkerOptions } from "miniflare";
 
-export { readConfig };
-export type { Config, RawConfig, RawEnvironment };
+export { readConfig as unstable_readConfig };
+export type {
+	Config as UnstableConfig,
+	RawConfig as UnstableRawConfig,
+	RawEnvironment as UnstableRawEnvironment,
+};
 
 /**
  * Options for the `getPlatformProxy` utility
@@ -240,7 +244,7 @@ export type SourcelessWorkerOptions = Omit<
 	"script" | "scriptPath" | "modules" | "modulesRoot"
 > & { modulesRules?: ModuleRule[] };
 
-interface MiniflareWorkerOptions {
+export interface UnstableMiniflareWorkerOptions {
 	workerOptions: SourcelessWorkerOptions;
 	define: Record<string, string>;
 	main?: string;
@@ -249,14 +253,14 @@ interface MiniflareWorkerOptions {
 export function unstable_getMiniflareWorkerOptions(
 	configPath: string,
 	env?: string
-): MiniflareWorkerOptions;
+): UnstableMiniflareWorkerOptions;
 export function unstable_getMiniflareWorkerOptions(
 	config: Config
-): MiniflareWorkerOptions;
+): UnstableMiniflareWorkerOptions;
 export function unstable_getMiniflareWorkerOptions(
 	configOrConfigPath: string | Config,
 	env?: string
-): MiniflareWorkerOptions {
+): UnstableMiniflareWorkerOptions {
 	const config =
 		typeof configOrConfigPath === "string"
 			? readConfig(configOrConfigPath, { env })


### PR DESCRIPTION
In the Vite plugin we are looking at generating `wrangler.json` files as part of the build process. Exporting these utils and types enables us to do this.

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: type exports only
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: type exports only
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not currently for general usage
