### PR TITLE
Fix `fromVitest` conditional

### DIFF
--- a/.changeset/lemon-deers-speak.md
+++ b/.changeset/lemon-deers-speak.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Support Yarn `.store` directory

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -71,7 +71,7 @@ const monkeypatchedSetTimeout = (...args: Parameters<typeof setTimeout>) => {
 	const [callback, delay, ...restArgs] = args;
 	const callbackName = args[0]?.name ?? "";
 	const callerFileName = getCallerFileName(monkeypatchedSetTimeout);
-	const fromVitest = callerFileName?.includes("/vitest");
+	const fromVitest = /\/node_modules\/(\.store\/)?vitest/.test(callerFileName);
 
 	// If this `setTimeout()` isn't from Vitest, or has a non-zero delay,
 	// just call the original function

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -71,7 +71,7 @@ const monkeypatchedSetTimeout = (...args: Parameters<typeof setTimeout>) => {
 	const [callback, delay, ...restArgs] = args;
 	const callbackName = args[0]?.name ?? "";
 	const callerFileName = getCallerFileName(monkeypatchedSetTimeout);
-	const fromVitest = callerFileName?.includes("/node_modules/vitest/");
+	const fromVitest = callerFileName?.includes("/vitest");
 
 	// If this `setTimeout()` isn't from Vitest, or has a non-zero delay,
 	// just call the original function

--- a/packages/vitest-pool-workers/src/worker/index.ts
+++ b/packages/vitest-pool-workers/src/worker/index.ts
@@ -71,7 +71,9 @@ const monkeypatchedSetTimeout = (...args: Parameters<typeof setTimeout>) => {
 	const [callback, delay, ...restArgs] = args;
 	const callbackName = args[0]?.name ?? "";
 	const callerFileName = getCallerFileName(monkeypatchedSetTimeout);
-	const fromVitest = /\/node_modules\/(\.store\/)?vitest/.test(callerFileName);
+	const fromVitest = /\/node_modules\/(\.store\/)?vitest/.test(
+		callerFileName ?? ""
+	);
 
 	// If this `setTimeout()` isn't from Vitest, or has a non-zero delay,
 	// just call the original function


### PR DESCRIPTION
Checking for `/node_modules/vitest/` does not work with Yarn's pnpm linker, where the path is something like `node_modules/.store/vitest-virtual-ee893ec3ea/`

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: e2e does not cover vitest
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
