### PR TITLE
wrangler pages deployment (list|tail) env filtering

### DIFF
--- a/.changeset/curly-rice-travel.md
+++ b/.changeset/curly-rice-travel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Fix wrangler pages deployment (list|tail) environment filtering.

--- a/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
@@ -47,20 +47,128 @@ describe("pages deployment list", () => {
 
 		expect(requests.count).toBe(1);
 	});
+
+	it("should pass no environment", async () => {
+		const deployments: Deployment[] = [
+			{
+				id: "87bbc8fe-16be-45cd-81e0-63d722e82cdf",
+				url: "https://87bbc8fe.images.pages.dev",
+				environment: "preview",
+				created_on: "2021-11-17T14:52:26.133835Z",
+				latest_stage: {
+					ended_on: "2021-11-17T14:52:26.133835Z",
+					status: "success",
+				},
+				deployment_trigger: {
+					metadata: {
+						branch: "main",
+						commit_hash: "c7649364c4cb32ad4f65b530b9424e8be5bec9d6",
+					},
+				},
+				project_name: "images",
+			},
+		];
+
+		const requests = mockDeploymentListRequest(deployments);
+		await runWrangler("pages deployment list --project-name=images");
+		expect(requests.count).toBe(1);
+		expect(
+			requests.queryParams[0].find(([key, _]) => {
+				return key === "env";
+			})
+		).toBeUndefined();
+	});
+
+	it("should pass production environment with flag", async () => {
+		const deployments: Deployment[] = [
+			{
+				id: "87bbc8fe-16be-45cd-81e0-63d722e82cdf",
+				url: "https://87bbc8fe.images.pages.dev",
+				environment: "preview",
+				created_on: "2021-11-17T14:52:26.133835Z",
+				latest_stage: {
+					ended_on: "2021-11-17T14:52:26.133835Z",
+					status: "success",
+				},
+				deployment_trigger: {
+					metadata: {
+						branch: "main",
+						commit_hash: "c7649364c4cb32ad4f65b530b9424e8be5bec9d6",
+					},
+				},
+				project_name: "images",
+			},
+		];
+
+		const requests = mockDeploymentListRequest(deployments);
+		await runWrangler(
+			"pages deployment list --project-name=images --environment=production"
+		);
+		expect(requests.count).toBe(1);
+		expect(
+			requests.queryParams[0].find(([key, _]) => {
+				return key === "env";
+			})
+		).toStrictEqual(["env", "production"]);
+	});
+
+	it("should pass preview environment with flag", async () => {
+		const deployments: Deployment[] = [
+			{
+				id: "87bbc8fe-16be-45cd-81e0-63d722e82cdf",
+				url: "https://87bbc8fe.images.pages.dev",
+				environment: "preview",
+				created_on: "2021-11-17T14:52:26.133835Z",
+				latest_stage: {
+					ended_on: "2021-11-17T14:52:26.133835Z",
+					status: "success",
+				},
+				deployment_trigger: {
+					metadata: {
+						branch: "main",
+						commit_hash: "c7649364c4cb32ad4f65b530b9424e8be5bec9d6",
+					},
+				},
+				project_name: "images",
+			},
+		];
+
+		const requests = mockDeploymentListRequest(deployments);
+		await runWrangler(
+			"pages deployment list --project-name=images --environment=preview"
+		);
+		expect(requests.count).toBe(1);
+		expect(
+			requests.queryParams[0].find(([key, _]) => {
+				return key === "env";
+			})
+		).toStrictEqual(["env", "preview"]);
+	});
 });
 
 /* -------------------------------------------------- */
 /*                    Helper Functions                */
 /* -------------------------------------------------- */
 
-function mockDeploymentListRequest(deployments: unknown[]) {
-	const requests = { count: 0 };
+/**
+ * A logger used to check how many times a mock API has been hit.
+ * Useful as a helper in our testing to check if wrangler is making
+ * the correct API calls without actually sending any web traffic.
+ */
+type RequestLogger = {
+	count: number;
+	queryParams: [string, string][][];
+};
+
+function mockDeploymentListRequest(deployments: unknown[]): RequestLogger {
+	const requests: RequestLogger = { count: 0, queryParams: [] };
 	msw.use(
 		http.get(
 			"*/accounts/:accountId/pages/projects/:project/deployments",
-			({ params }) => {
+			({ request, params }) => {
 				requests.count++;
-
+				const url = new URL(request.url);
+				requests.queryParams.push(Array.from(url.searchParams.entries()));
 				expect(params.project).toEqual("images");
 				expect(params.accountId).toEqual("some-account-id");
 

--- a/packages/wrangler/src/pages/deployment-tails.ts
+++ b/packages/wrangler/src/pages/deployment-tails.ts
@@ -163,7 +163,9 @@ export async function Handler({
 	}
 
 	const deployments: Array<Deployment> = await fetchResult(
-		`/accounts/${accountId}/pages/projects/${projectName}/deployments`
+		`/accounts/${accountId}/pages/projects/${projectName}/deployments`,
+		{},
+		new URLSearchParams({ env: environment })
 	);
 
 	const envDeployments = deployments.filter(

--- a/packages/wrangler/src/pages/deployments.ts
+++ b/packages/wrangler/src/pages/deployments.ts
@@ -23,10 +23,15 @@ export function ListOptions(yargs: CommonYargsArgv) {
 			description:
 				"The name of the project you would like to list deployments for",
 		},
+		environment: {
+			type: "string",
+			choices: ["production", "preview"],
+			description: "Environment type to list deployments for",
+		},
 	});
 }
 
-export async function ListHandler({ projectName }: ListArgs) {
+export async function ListHandler({ projectName, environment }: ListArgs) {
 	const config = getConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME);
 	const accountId = await requireAuth(config);
 
@@ -42,7 +47,11 @@ export async function ListHandler({ projectName }: ListArgs) {
 	}
 
 	const deployments: Array<Deployment> = await fetchResult(
-		`/accounts/${accountId}/pages/projects/${projectName}/deployments`
+		`/accounts/${accountId}/pages/projects/${projectName}/deployments`,
+		{},
+		environment
+			? new URLSearchParams({ env: environment })
+			: new URLSearchParams({})
 	);
 
 	const titleCase = (word: string) =>


### PR DESCRIPTION
Adds the --environment flag to `wrangler pages deployment list`, which should allow users to list deployments of a specific type. When the flag it's not provided it will list the latest 25 deployments regardless of type.

Additionally, makes sure we're listing the correct type of deployments when attempting to tail.

Fixes #6234.

Docs PR:
https://github.com/cloudflare/cloudflare-docs/pull/18278

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Unit tests cover the changes.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Included CLI flags.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
