### PR TITLE
Configuration file for Pages projects does not support "observability"

### DIFF
--- a/packages/wrangler/src/config/validation-pages.ts
+++ b/packages/wrangler/src/config/validation-pages.ts
@@ -39,6 +39,7 @@ const supportedPagesConfigFields = [
 	// normalizeAndValidateConfig() sets this value
 	"configPath",
 	"upload_source_maps",
+	"observability",
 ] as const;
 
 export function validatePagesConfig(


### PR DESCRIPTION
I've been trying to get my worker project working with [observability via the documentation](https://developers.cloudflare.com/workers/observability/logs/workers-logs/#enable-workers-logs)

```
compatibility_date = "2024-11-12"

[observability]
enabled = true
head_sampling_rate = 1
```

I have the latest version of wrangler: `3.87.0`

However, I get this error: `Configuration file for Pages projects does not support "observability"`

I have checked `node_modules/wrangler/config-schema.json` and observability is in there, I have also tried closing and reopening the app as well as wiping out `node_modules` and installing again.

I looked at `node_modules/wrangler/wrangler-dist/cli.js` and saw that `"observability"` was missing from an array, which is why it was showing an error. Adding it to the array seems to have fixed the problem, but would appreciate some expert help.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because: