### PR TITLE
Fix relative project root

### DIFF
--- a/.changeset/sixty-news-relax.md
+++ b/.changeset/sixty-news-relax.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Rename `directory` to `projectRoot` and ensure it's relative to the `wrangler.toml`. This fixes a regression which meant that `.wrangler` temporary folders were inadvertently generated relative to `process.cwd()` rather than the location of the `wrangler.toml` file. It also renames `directory` to `projectRoot`, which affects the `unstable_startWorker() interface.

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -193,29 +193,31 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 			},
 		);
 
-		test({ experimental }).skipIf(process.platform === "win32")(
-			"Cloning remote template with full GitHub URL",
-			async ({ logStream, project }) => {
-				const { output } = await runC3(
-					[
-						project.path,
-						"--template=https://github.com/cloudflare/templates/worker-router",
-						"--no-deploy",
-						"--git=false",
-					],
-					[],
-					logStream,
-				);
+		test({ experimental })
+			.skipIf(process.platform === "win32")
+			.only(
+				"Cloning remote template with full GitHub URL",
+				async ({ logStream, project }) => {
+					const { output } = await runC3(
+						[
+							project.path,
+							"--template=https://github.com/cloudflare/templates/d1-template",
+							"--no-deploy",
+							"--git=false",
+						],
+						[],
+						logStream,
+					);
 
-				expect(output).toContain(
-					`repository https://github.com/cloudflare/templates/worker-router`,
-				);
-				expect(output).toContain(
-					`Cloning template from: https://github.com/cloudflare/templates/worker-router`,
-				);
-				expect(output).toContain(`template cloned and validated`);
-			},
-		);
+					expect(output).toContain(
+						`repository https://github.com/cloudflare/templates/d1-template`,
+					);
+					expect(output).toContain(
+						`Cloning template from: https://github.com/cloudflare/templates/d1-template`,
+					);
+					expect(output).toContain(`template cloned and validated`);
+				},
+			);
 
 		test({ experimental }).skipIf(process.platform === "win32")(
 			"Inferring the category, type and language if the type is `hello-world-python`",

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -193,31 +193,29 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 			},
 		);
 
-		test({ experimental })
-			.skipIf(process.platform === "win32")
-			.only(
-				"Cloning remote template with full GitHub URL",
-				async ({ logStream, project }) => {
-					const { output } = await runC3(
-						[
-							project.path,
-							"--template=https://github.com/cloudflare/templates/d1-template",
-							"--no-deploy",
-							"--git=false",
-						],
-						[],
-						logStream,
-					);
+		test({ experimental }).skipIf(process.platform === "win32")(
+			"Cloning remote template with full GitHub URL",
+			async ({ logStream, project }) => {
+				const { output } = await runC3(
+					[
+						project.path,
+						"--template=https://github.com/cloudflare/templates/d1-template",
+						"--no-deploy",
+						"--git=false",
+					],
+					[],
+					logStream,
+				);
 
-					expect(output).toContain(
-						`repository https://github.com/cloudflare/templates/d1-template`,
-					);
-					expect(output).toContain(
-						`Cloning template from: https://github.com/cloudflare/templates/d1-template`,
-					);
-					expect(output).toContain(`template cloned and validated`);
-				},
-			);
+				expect(output).toContain(
+					`repository https://github.com/cloudflare/templates/d1-template`,
+				);
+				expect(output).toContain(
+					`Cloning template from: https://github.com/cloudflare/templates/d1-template`,
+				);
+				expect(output).toContain(`template cloned and validated`);
+			},
+		);
 
 		test({ experimental }).skipIf(process.platform === "win32")(
 			"Inferring the category, type and language if the type is `hello-world-python`",

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -199,7 +199,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 				const { output } = await runC3(
 					[
 						project.path,
-						"--template=https://github.com/cloudflare/templates/d1-template",
+						"--template=https://github.com/cloudflare/workers-graphql-server",
 						"--no-deploy",
 						"--git=false",
 					],
@@ -208,10 +208,10 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 				);
 
 				expect(output).toContain(
-					`repository https://github.com/cloudflare/templates/d1-template`,
+					`repository https://github.com/cloudflare/workers-graphql-server`,
 				);
 				expect(output).toContain(
-					`Cloning template from: https://github.com/cloudflare/templates/d1-template`,
+					`Cloning template from: https://github.com/cloudflare/workers-graphql-server`,
 				);
 				expect(output).toContain(`template cloned and validated`);
 			},

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -40,7 +40,7 @@ function configDefaults(
 	const persist = path.join(process.cwd(), ".wrangler/persist");
 	return {
 		entrypoint: "NOT_REAL",
-		directory: "NOT_REAL",
+		projectRoot: "NOT_REAL",
 		build: unusable<StartDevWorkerOptions["build"]>(),
 		legacy: {},
 		dev: { persist },
@@ -68,7 +68,7 @@ describe("BundleController", () => {
 				legacy: {},
 				name: "worker",
 				entrypoint: path.resolve("src/index.ts"),
-				directory: path.resolve("src"),
+				projectRoot: path.resolve("src"),
 				build: {
 					additionalModules: [],
 					processEntrypoint: false,
@@ -141,7 +141,7 @@ describe("BundleController", () => {
 				legacy: {},
 				name: "worker",
 				entrypoint: path.resolve("src/index.ts"),
-				directory: path.resolve("src"),
+				projectRoot: path.resolve("src"),
 				build: {
 					additionalModules: [],
 					processEntrypoint: false,
@@ -207,7 +207,7 @@ describe("BundleController", () => {
 				legacy: {},
 				name: "worker",
 				entrypoint: path.resolve("out.ts"),
-				directory: path.resolve("."),
+				projectRoot: path.resolve("."),
 				build: {
 					additionalModules: [],
 					processEntrypoint: false,
@@ -287,7 +287,7 @@ describe("BundleController", () => {
 			legacy: {},
 			name: "worker",
 			entrypoint: path.resolve("src/index.ts"),
-			directory: path.resolve("src"),
+			projectRoot: path.resolve("src"),
 			build: {
 				additionalModules: [],
 				processEntrypoint: false,
@@ -345,7 +345,7 @@ describe("BundleController", () => {
 				legacy: {},
 				name: "worker",
 				entrypoint: path.resolve("src/index.ts"),
-				directory: path.resolve("src"),
+				projectRoot: path.resolve("src"),
 
 				build: {
 					additionalModules: [],
@@ -391,7 +391,7 @@ describe("BundleController", () => {
 			const configCustom: Partial<StartDevWorkerOptions> = {
 				name: "worker",
 				entrypoint: path.resolve("out.ts"),
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				build: {
 					additionalModules: [],
 					processEntrypoint: false,
@@ -464,7 +464,7 @@ describe("BundleController", () => {
 			const configCustom: Partial<StartDevWorkerOptions> = {
 				name: "worker",
 				entrypoint: path.resolve("out.ts"),
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 
 				build: {
 					additionalModules: [],
@@ -513,7 +513,7 @@ describe("BundleController", () => {
 				legacy: {},
 				name: "worker",
 				entrypoint: path.resolve("src/index.ts"),
-				directory: path.resolve("src"),
+				projectRoot: path.resolve("src"),
 
 				build: {
 					additionalModules: [],

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -51,7 +51,7 @@ describe("ConfigController", () => {
 					moduleRoot: path.join(process.cwd(), "src"),
 					moduleRules: [],
 				},
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				entrypoint: path.join(process.cwd(), "src/index.ts"),
 			},
 		});
@@ -87,7 +87,7 @@ base_dir = \"./some/base_dir\"`,
 					moduleRoot: path.join(process.cwd(), "./some/base_dir"),
 					moduleRules: [],
 				},
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				entrypoint: path.join(process.cwd(), "./some/base_dir/nested/index.js"),
 			},
 		});
@@ -114,7 +114,7 @@ base_dir = \"./some/base_dir\"`,
 			type: "configUpdate",
 			config: {
 				entrypoint: path.join(process.cwd(), "src/index.ts"),
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				build: {
 					additionalModules: [],
 					define: {},
@@ -138,7 +138,7 @@ base_dir = \"./some/base_dir\"`,
 			type: "configUpdate",
 			config: {
 				entrypoint: path.join(process.cwd(), "src/index.ts"),
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				build: {
 					additionalModules: [],
 					define: {},
@@ -168,7 +168,7 @@ base_dir = \"./some/base_dir\"`,
 			type: "configUpdate",
 			config: {
 				entrypoint: path.join(process.cwd(), "src/index.ts"),
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				build: {
 					alias: {
 						foo: "bar",

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -88,7 +88,7 @@ function makeEsbuildBundle(testBundle: TestBundle): Bundle {
 		entrypointSource: "",
 		entry: {
 			file: "index.mjs",
-			directory: "/virtual/",
+			projectRoot: "/virtual/",
 			format: "modules",
 			moduleRoot: "/virtual",
 			name: undefined,
@@ -127,7 +127,7 @@ function configDefaults(
 ): StartDevWorkerOptions {
 	return {
 		entrypoint: "NOT_REAL",
-		directory: "NOT_REAL",
+		projectRoot: "NOT_REAL",
 		build: unusable<StartDevWorkerOptions["build"]>(),
 		legacy: {},
 		dev: { persist: "./persist" },
@@ -232,7 +232,7 @@ describe("LocalRuntimeController", () => {
 			`,
 				entry: {
 					file: "esm/index.mjs",
-					directory: "/virtual/",
+					projectRoot: "/virtual/",
 					format: "modules",
 					moduleRoot: "/virtual",
 					name: undefined,
@@ -346,7 +346,7 @@ describe("LocalRuntimeController", () => {
 				path: "/virtual/index.js",
 				entry: {
 					file: "index.js",
-					directory: "/virtual/",
+					projectRoot: "/virtual/",
 					format: "service-worker",
 					moduleRoot: "/virtual",
 					name: undefined,

--- a/packages/wrangler/src/__tests__/find-additional-modules.test.ts
+++ b/packages/wrangler/src/__tests__/find-additional-modules.test.ts
@@ -39,7 +39,7 @@ describe("traverse module graph", () => {
 		const modules = await findAdditionalModules(
 			{
 				file: path.join(process.cwd(), "./index.js"),
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				format: "modules",
 				moduleRoot: process.cwd(),
 				exports: [],
@@ -75,7 +75,7 @@ describe("traverse module graph", () => {
 		const modules = await findAdditionalModules(
 			{
 				file: path.join(process.cwd(), "./index.js"),
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				format: "modules",
 				moduleRoot: process.cwd(),
 				exports: [],
@@ -109,7 +109,7 @@ describe("traverse module graph", () => {
 		const modules = await findAdditionalModules(
 			{
 				file: path.join(process.cwd(), "./src/nested/index.js"),
-				directory: path.join(process.cwd(), "./src/nested"),
+				projectRoot: path.join(process.cwd(), "./src/nested"),
 				format: "modules",
 				// The default module root is dirname(file)
 				moduleRoot: path.join(process.cwd(), "./src/nested"),
@@ -144,7 +144,7 @@ describe("traverse module graph", () => {
 		const modules = await findAdditionalModules(
 			{
 				file: path.join(process.cwd(), "./src/nested/index.js"),
-				directory: path.join(process.cwd(), "./src/nested"),
+				projectRoot: path.join(process.cwd(), "./src/nested"),
 				format: "modules",
 				// The default module root is dirname(file)
 				moduleRoot: path.join(process.cwd(), "./src"),
@@ -179,7 +179,7 @@ describe("traverse module graph", () => {
 		const modules = await findAdditionalModules(
 			{
 				file: path.join(process.cwd(), "./src/nested/index.js"),
-				directory: path.join(process.cwd(), "./src/nested"),
+				projectRoot: path.join(process.cwd(), "./src/nested"),
 				format: "modules",
 				// The default module root is dirname(file)
 				moduleRoot: path.join(process.cwd(), "./src"),
@@ -214,7 +214,7 @@ describe("traverse module graph", () => {
 		const modules = await findAdditionalModules(
 			{
 				file: path.join(process.cwd(), "./src/index.js"),
-				directory: path.join(process.cwd(), "./src"),
+				projectRoot: path.join(process.cwd(), "./src"),
 				format: "modules",
 				// The default module root is dirname(file)
 				moduleRoot: path.join(process.cwd(), "./src"),
@@ -249,7 +249,7 @@ describe("traverse module graph", () => {
 			findAdditionalModules(
 				{
 					file: path.join(process.cwd(), "./src/index.js"),
-					directory: path.join(process.cwd(), "./src"),
+					projectRoot: path.join(process.cwd(), "./src"),
 					format: "modules",
 					// The default module root is dirname(file)
 					moduleRoot: path.join(process.cwd(), "./src"),

--- a/packages/wrangler/src/__tests__/get-entry.test.ts
+++ b/packages/wrangler/src/__tests__/get-entry.test.ts
@@ -1,19 +1,20 @@
-import { writeFile } from "fs/promises";
 import path from "path";
 import dedent from "ts-dedent";
-import { Config } from "../config";
 import { defaultWranglerConfig } from "../config/config";
-import { Entry, getEntry } from "../deployment-bundle/entry";
-import guessWorkerFormat from "../deployment-bundle/guess-worker-format";
+import { getEntry } from "../deployment-bundle/entry";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { seed } from "./helpers/seed";
+import type { Entry } from "../deployment-bundle/entry";
 
 function normalize(entry: Entry): Entry {
 	return JSON.parse(
-		JSON.stringify(entry).replaceAll(process.cwd(), "/tmp/dir")
+		JSON.stringify(entry)
+			.replaceAll(process.cwd(), "/tmp/dir")
+			.replaceAll(path.sep, "/")
 	);
 }
+
 describe("getEntry()", () => {
 	runInTempDir();
 	mockConsoleMethods();

--- a/packages/wrangler/src/__tests__/get-entry.test.ts
+++ b/packages/wrangler/src/__tests__/get-entry.test.ts
@@ -17,112 +17,118 @@ function normalize(entry: Entry): Entry {
 describe("getEntry()", () => {
 	runInTempDir();
 	mockConsoleMethods();
-	it.each([
-		[
-			"--script index.ts",
-			{
-				"index.ts": dedent/* javascript */ `
-						export default {
-							fetch() {
 
+	it("--script index.ts", async () => {
+		await seed({
+			"index.ts": dedent/* javascript */ `
+							export default {
+								fetch() {
+
+								}
 							}
-						}
-					`,
-			},
+						`,
+		});
+		const entry = await getEntry(
 			{ script: "index.ts" },
-			{},
-			{
-				directory: "/tmp/dir",
-				file: "/tmp/dir/index.ts",
-				moduleRoot: "/tmp/dir",
-			},
-		],
-		[
-			"--script src/index.ts",
-			{
-				"src/index.ts": dedent/* javascript */ `
-						export default {
-							fetch() {
+			defaultWranglerConfig,
+			"deploy"
+		);
+		expect(normalize(entry)).toMatchObject({
+			directory: "/tmp/dir",
+			file: "/tmp/dir/index.ts",
+			moduleRoot: "/tmp/dir",
+		});
+	});
 
+	it("--script src/index.ts", async () => {
+		await seed({
+			"src/index.ts": dedent/* javascript */ `
+							export default {
+								fetch() {
+
+								}
 							}
-						}
-					`,
-			},
+						`,
+		});
+		const entry = await getEntry(
 			{ script: "src/index.ts" },
-			{},
-			{
-				directory: "/tmp/dir",
-				file: "/tmp/dir/src/index.ts",
-				moduleRoot: "/tmp/dir/src",
-			},
-		],
-		[
-			"main = index.ts",
-			{
-				"index.ts": dedent/* javascript */ `
-						export default {
-							fetch() {
+			defaultWranglerConfig,
+			"deploy"
+		);
+		expect(normalize(entry)).toMatchObject({
+			directory: "/tmp/dir",
+			file: "/tmp/dir/src/index.ts",
+			moduleRoot: "/tmp/dir/src",
+		});
+	});
 
-							}
-						}
-					`,
-			},
-			{},
-			{ main: "index.ts" },
-			{
-				directory: "/tmp/dir",
-				file: "/tmp/dir/index.ts",
-				moduleRoot: "/tmp/dir",
-			},
-		],
-		[
-			"main = src/index.ts",
-			{
-				"src/index.ts": dedent/* javascript */ `
-						export default {
-							fetch() {
+	it("main = index.ts", async () => {
+		await seed({
+			"index.ts": dedent/* javascript */ `
+							export default {
+								fetch() {
 
+								}
 							}
-						}
-					`,
-			},
+						`,
+		});
+		const entry = await getEntry(
 			{},
-			{ main: "src/index.ts" },
-			{
-				directory: "/tmp/dir",
-				file: "/tmp/dir/src/index.ts",
-				moduleRoot: "/tmp/dir/src",
-			},
-		],
-		[
-			"main = src/index.ts w/ configPath",
-			{
-				"other-worker/src/index.ts": dedent/* javascript */ `
-						export default {
-							fetch() {
+			{ ...defaultWranglerConfig, main: "index.ts" },
+			"deploy"
+		);
+		expect(normalize(entry)).toMatchObject({
+			directory: "/tmp/dir",
+			file: "/tmp/dir/index.ts",
+			moduleRoot: "/tmp/dir",
+		});
+	});
 
+	it("main = src/index.ts", async () => {
+		await seed({
+			"src/index.ts": dedent/* javascript */ `
+							export default {
+								fetch() {
+
+								}
 							}
-						}
-					`,
-			},
+						`,
+		});
+		const entry = await getEntry(
+			{},
+			{ ...defaultWranglerConfig, main: "src/index.ts" },
+			"deploy"
+		);
+		expect(normalize(entry)).toMatchObject({
+			directory: "/tmp/dir",
+			file: "/tmp/dir/src/index.ts",
+			moduleRoot: "/tmp/dir/src",
+		});
+	});
+
+	it("main = src/index.ts w/ configPath", async () => {
+		await seed({
+			"other-worker/src/index.ts": dedent/* javascript */ `
+							export default {
+								fetch() {
+
+								}
+							}
+						`,
+		});
+		const entry = await getEntry(
 			{},
 			{
+				...defaultWranglerConfig,
 				main: "src/index.ts",
 				configPath: "other-worker/wrangler.toml",
 			},
-			{
-				directory: "/tmp/dir/other-worker",
-				file: "/tmp/dir/other-worker/src/index.ts",
-				moduleRoot: "/tmp/dir/other-worker/src",
-			},
-		],
-	])("%s", async (_name, files, args, config, result) => {
-		await seed(files);
-		const entry = await getEntry(
-			args,
-			{ ...defaultWranglerConfig, ...config },
 			"deploy"
 		);
-		expect(normalize(entry)).toMatchObject(result);
+		expect(normalize(entry)).toMatchObject({
+			directory: "/tmp/dir/other-worker",
+			file: "/tmp/dir/other-worker/src/index.ts",
+			moduleRoot: "/tmp/dir/other-worker/src",
+		});
 	});
 });

--- a/packages/wrangler/src/__tests__/get-entry.test.ts
+++ b/packages/wrangler/src/__tests__/get-entry.test.ts
@@ -1,0 +1,128 @@
+import { writeFile } from "fs/promises";
+import path from "path";
+import dedent from "ts-dedent";
+import { Config } from "../config";
+import { defaultWranglerConfig } from "../config/config";
+import { Entry, getEntry } from "../deployment-bundle/entry";
+import guessWorkerFormat from "../deployment-bundle/guess-worker-format";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { seed } from "./helpers/seed";
+
+function normalize(entry: Entry): Entry {
+	return JSON.parse(
+		JSON.stringify(entry).replaceAll(process.cwd(), "/tmp/dir")
+	);
+}
+describe("getEntry()", () => {
+	runInTempDir();
+	mockConsoleMethods();
+	it.each([
+		[
+			"--script index.ts",
+			{
+				"index.ts": dedent/* javascript */ `
+						export default {
+							fetch() {
+
+							}
+						}
+					`,
+			},
+			{ script: "index.ts" },
+			{},
+			{
+				directory: "/tmp/dir",
+				file: "/tmp/dir/index.ts",
+				moduleRoot: "/tmp/dir",
+			},
+		],
+		[
+			"--script src/index.ts",
+			{
+				"src/index.ts": dedent/* javascript */ `
+						export default {
+							fetch() {
+
+							}
+						}
+					`,
+			},
+			{ script: "src/index.ts" },
+			{},
+			{
+				directory: "/tmp/dir",
+				file: "/tmp/dir/src/index.ts",
+				moduleRoot: "/tmp/dir/src",
+			},
+		],
+		[
+			"main = index.ts",
+			{
+				"index.ts": dedent/* javascript */ `
+						export default {
+							fetch() {
+
+							}
+						}
+					`,
+			},
+			{},
+			{ main: "index.ts" },
+			{
+				directory: "/tmp/dir",
+				file: "/tmp/dir/index.ts",
+				moduleRoot: "/tmp/dir",
+			},
+		],
+		[
+			"main = src/index.ts",
+			{
+				"src/index.ts": dedent/* javascript */ `
+						export default {
+							fetch() {
+
+							}
+						}
+					`,
+			},
+			{},
+			{ main: "src/index.ts" },
+			{
+				directory: "/tmp/dir",
+				file: "/tmp/dir/src/index.ts",
+				moduleRoot: "/tmp/dir/src",
+			},
+		],
+		[
+			"main = src/index.ts w/ configPath",
+			{
+				"other-worker/src/index.ts": dedent/* javascript */ `
+						export default {
+							fetch() {
+
+							}
+						}
+					`,
+			},
+			{},
+			{
+				main: "src/index.ts",
+				configPath: "other-worker/wrangler.toml",
+			},
+			{
+				directory: "/tmp/dir/other-worker",
+				file: "/tmp/dir/other-worker/src/index.ts",
+				moduleRoot: "/tmp/dir/other-worker/src",
+			},
+		],
+	])("%s", async (_name, files, args, config, result) => {
+		await seed(files);
+		const entry = await getEntry(
+			args,
+			{ ...defaultWranglerConfig, ...config },
+			"deploy"
+		);
+		expect(normalize(entry)).toMatchObject(result);
+	});
+});

--- a/packages/wrangler/src/__tests__/get-entry.test.ts
+++ b/packages/wrangler/src/__tests__/get-entry.test.ts
@@ -34,7 +34,7 @@ describe("getEntry()", () => {
 			"deploy"
 		);
 		expect(normalize(entry)).toMatchObject({
-			directory: "/tmp/dir",
+			projectRoot: "/tmp/dir",
 			file: "/tmp/dir/index.ts",
 			moduleRoot: "/tmp/dir",
 		});
@@ -56,7 +56,7 @@ describe("getEntry()", () => {
 			"deploy"
 		);
 		expect(normalize(entry)).toMatchObject({
-			directory: "/tmp/dir",
+			projectRoot: "/tmp/dir",
 			file: "/tmp/dir/src/index.ts",
 			moduleRoot: "/tmp/dir/src",
 		});
@@ -78,7 +78,7 @@ describe("getEntry()", () => {
 			"deploy"
 		);
 		expect(normalize(entry)).toMatchObject({
-			directory: "/tmp/dir",
+			projectRoot: "/tmp/dir",
 			file: "/tmp/dir/index.ts",
 			moduleRoot: "/tmp/dir",
 		});
@@ -100,7 +100,7 @@ describe("getEntry()", () => {
 			"deploy"
 		);
 		expect(normalize(entry)).toMatchObject({
-			directory: "/tmp/dir",
+			projectRoot: "/tmp/dir",
 			file: "/tmp/dir/src/index.ts",
 			moduleRoot: "/tmp/dir/src",
 		});
@@ -126,7 +126,7 @@ describe("getEntry()", () => {
 			"deploy"
 		);
 		expect(normalize(entry)).toMatchObject({
-			directory: "/tmp/dir/other-worker",
+			projectRoot: "/tmp/dir/other-worker",
 			file: "/tmp/dir/other-worker/src/index.ts",
 			moduleRoot: "/tmp/dir/other-worker/src",
 		});

--- a/packages/wrangler/src/__tests__/get-entry.test.ts
+++ b/packages/wrangler/src/__tests__/get-entry.test.ts
@@ -8,11 +8,19 @@ import { seed } from "./helpers/seed";
 import type { Entry } from "../deployment-bundle/entry";
 
 function normalize(entry: Entry): Entry {
-	return JSON.parse(
-		JSON.stringify(entry)
-			.replaceAll(process.cwd(), "/tmp/dir")
-			.replaceAll(path.sep, "/")
-	);
+	const tmpDir = process.cwd();
+	const tmpDirName = path.basename(tmpDir);
+
+	return Object.fromEntries(
+		Object.entries(entry).map(([k, v]) => [
+			k,
+			typeof v === "string"
+				? v
+						.replaceAll("\\", "/")
+						.replace(new RegExp(`(.*${tmpDirName})`), `/tmp/dir`)
+				: v,
+		])
+	) as Entry;
 }
 
 describe("getEntry()", () => {

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -104,7 +104,7 @@ describe("defineNavigatorUserAgent is respected", () => {
 		await bundleWorker(
 			{
 				file: path.resolve("src/index.js"),
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				format: "modules",
 				moduleRoot: path.dirname(path.resolve("src/index.js")),
 				exports: [],
@@ -167,7 +167,7 @@ describe("defineNavigatorUserAgent is respected", () => {
 		await bundleWorker(
 			{
 				file: path.resolve("src/index.js"),
-				directory: process.cwd(),
+				projectRoot: process.cwd(),
 				format: "modules",
 				moduleRoot: path.dirname(path.resolve("src/index.js")),
 				exports: [],

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -51,7 +51,7 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 		// Since `this.#customBuildAborter` will change as new builds are scheduled, store the specific AbortController that will be used for this build
 		const buildAborter = this.#customBuildAborter;
 		const relativeFile =
-			path.relative(config.directory, config.entrypoint) || ".";
+			path.relative(config.projectRoot, config.entrypoint) || ".";
 		logger.log(`The file ${filePath} changed, restarting build...`);
 		this.emitBundleStartEvent(config);
 		try {
@@ -74,7 +74,7 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 
 			const entry: Entry = {
 				file: config.entrypoint,
-				directory: config.directory,
+				projectRoot: config.projectRoot,
 				format: config.build.format,
 				moduleRoot: config.build.moduleRoot,
 				exports: config.build.exports,
@@ -131,7 +131,7 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 						// This could potentially cause issues as we no longer have identical behaviour between dev and deploy?
 						targetConsumer: "dev",
 						local: !config.dev?.remote,
-						projectRoot: config.directory,
+						projectRoot: config.projectRoot,
 						defineNavigatorUserAgent: isNavigatorDefined(
 							config.compatibilityDate,
 							config.compatibilityFlags
@@ -229,7 +229,7 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 		assert(this.#tmpDir);
 		const entry: Entry = {
 			file: config.entrypoint,
-			directory: config.directory,
+			projectRoot: config.projectRoot,
 			format: config.build.format,
 			moduleRoot: config.build.moduleRoot,
 			exports: config.build.exports,
@@ -264,7 +264,7 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 				// startDevWorker only applies to "dev"
 				targetConsumer: "dev",
 				testScheduled: Boolean(config.dev?.testScheduled),
-				projectRoot: config.directory,
+				projectRoot: config.projectRoot,
 				onStart: () => {
 					this.emitBundleStartEvent(config);
 				},
@@ -325,7 +325,7 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 	onConfigUpdate(event: ConfigUpdateEvent) {
 		this.#tmpDir?.remove();
 		try {
-			this.#tmpDir = getWranglerTmpDir(event.config.directory, "dev");
+			this.#tmpDir = getWranglerTmpDir(event.config.projectRoot, "dev");
 		} catch (e) {
 			logger.error(
 				"Failed to create temporary directory to store built files."

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -256,7 +256,7 @@ async function resolveConfig(
 		compatibilityDate: getDevCompatibilityDate(config, input.compatibilityDate),
 		compatibilityFlags: input.compatibilityFlags ?? config.compatibility_flags,
 		entrypoint: entry.file,
-		directory: entry.directory,
+		projectRoot: entry.projectRoot,
 		bindings,
 		migrations: input.migrations ?? config.migrations,
 		sendMetrics: input.sendMetrics ?? config.send_metrics,

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -174,7 +174,7 @@ export interface StartDevWorkerInput {
 
 export type StartDevWorkerOptions = Omit<StartDevWorkerInput, "assets"> & {
 	/** A worker's directory. Usually where the wrangler.toml file is located */
-	directory: string;
+	projectRoot: string;
 	build: StartDevWorkerInput["build"] & {
 		nodejsCompatMode: NodeJSCompatMode;
 		format: CfScriptFormat;

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -329,7 +329,7 @@ export async function deployHandler(args: DeployArgs) {
 		await verifyWorkerMatchesCITag(
 			accountId,
 			name,
-			path.relative(entry.directory, config.configPath ?? "wrangler.toml")
+			path.relative(entry.projectRoot, config.configPath ?? "wrangler.toml")
 		);
 	}
 	const { sourceMapSize, versionId, workerTag, targets } = await deploy({

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -373,7 +373,7 @@ export async function bundleWorker(
 						path: require.resolve(aliasPath, {
 							// From the esbuild alias docs: "Note that when an import path is substituted using an alias, the resulting import path is resolved in the working directory instead of in the directory containing the source file with the import path."
 							// https://esbuild.github.io/api/#alias:~:text=Note%20that%20when%20an%20import%20path%20is%20substituted%20using%20an%20alias%2C%20the%20resulting%20import%20path%20is%20resolved%20in%20the%20working%20directory%20instead%20of%20in%20the%20directory%20containing%20the%20source%20file%20with%20the%20import%20path.
-							paths: [entry.directory],
+							paths: [entry.projectRoot],
 						}),
 					};
 				}
@@ -385,7 +385,7 @@ export async function bundleWorker(
 		// Don't use entryFile here as the file may have been changed when applying the middleware
 		entryPoints: [entry.file],
 		bundle,
-		absWorkingDir: entry.directory,
+		absWorkingDir: entry.projectRoot,
 		outdir: destination,
 		keepNames: true,
 		entryNames: entryName || path.parse(entryFile).name,
@@ -526,7 +526,7 @@ export async function bundleWorker(
 	)[0];
 
 	const resolvedEntryPointPath = path.resolve(
-		entry.directory,
+		entry.projectRoot,
 		entryPoint.relativePath
 	);
 
@@ -548,7 +548,7 @@ export async function bundleWorker(
 		sourceMapPath,
 		sourceMapMetadata: {
 			tmpDir: tmpDir.path,
-			entryDirectory: entry.directory,
+			entryDirectory: entry.projectRoot,
 		},
 	};
 }

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -22,7 +22,7 @@ export type Entry = {
 	/** A worker's entrypoint */
 	file: string;
 	/** A worker's directory. Usually where the wrangler.toml file is located */
-	directory: string;
+	projectRoot: string;
 	/** Is this a module worker or a service worker? */
 	format: CfScriptFormat;
 	/** The directory that contains all of a `--no-bundle` worker's modules. Usually `${directory}/src`. Defaults to path.dirname(file) */
@@ -50,11 +50,10 @@ export async function getEntry(
 	config: Config,
 	command: "dev" | "deploy" | "versions upload" | "types"
 ): Promise<Entry> {
-	const directory = process.cwd();
 	const entryPoint = config.site?.["entry-point"];
 
 	let paths:
-		| { absolutePath: string; relativePath: string; directory?: string }
+		| { absolutePath: string; relativePath: string; projectRoot?: string }
 		| undefined;
 
 	if (args.script) {
@@ -83,7 +82,7 @@ export async function getEntry(
 	}
 	await runCustomBuild(paths.absolutePath, paths.relativePath, config.build);
 
-	const projectRoot = paths.directory ?? directory;
+	const projectRoot = paths.projectRoot ?? process.cwd();
 	const { format, exports } = await guessWorkerFormat(
 		paths.absolutePath,
 		projectRoot,
@@ -120,7 +119,7 @@ export async function getEntry(
 
 	return {
 		file: paths.absolutePath,
-		directory: projectRoot,
+		projectRoot,
 		format,
 		moduleRoot:
 			args.moduleRoot ?? config.base_dir ?? path.dirname(paths.absolutePath),

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -53,7 +53,9 @@ export async function getEntry(
 	const directory = process.cwd();
 	const entryPoint = config.site?.["entry-point"];
 
-	let paths: { absolutePath: string; relativePath: string } | undefined;
+	let paths:
+		| { absolutePath: string; relativePath: string; directory?: string }
+		| undefined;
 
 	if (args.script) {
 		paths = resolveEntryWithScript(args.script);
@@ -81,9 +83,10 @@ export async function getEntry(
 	}
 	await runCustomBuild(paths.absolutePath, paths.relativePath, config.build);
 
+	const projectRoot = paths.directory ?? directory;
 	const { format, exports } = await guessWorkerFormat(
 		paths.absolutePath,
-		directory,
+		projectRoot,
 		args.format ?? config.build?.upload?.format,
 		config.tsconfig
 	);
@@ -117,7 +120,7 @@ export async function getEntry(
 
 	return {
 		file: paths.absolutePath,
-		directory,
+		directory: projectRoot,
 		format,
 		moduleRoot:
 			args.moduleRoot ?? config.base_dir ?? path.dirname(paths.absolutePath),

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -72,7 +72,7 @@ export async function findAdditionalModules(
 		let pythonRequirements = "";
 		try {
 			pythonRequirements = await readFile(
-				path.resolve(entry.directory, "requirements.txt"),
+				path.resolve(entry.projectRoot, "requirements.txt"),
 				"utf-8"
 			);
 		} catch (e) {

--- a/packages/wrangler/src/deployment-bundle/resolve-entry.ts
+++ b/packages/wrangler/src/deployment-bundle/resolve-entry.ts
@@ -16,11 +16,12 @@ export function resolveEntryWithMain(
 ): {
 	absolutePath: string;
 	relativePath: string;
+	directory: string;
 } {
 	const directory = path.resolve(path.dirname(configPath ?? "."));
 	const file = path.resolve(directory, main);
 	const relativePath = path.relative(directory, file) || ".";
-	return { absolutePath: file, relativePath };
+	return { absolutePath: file, relativePath, directory };
 }
 
 export function resolveEntryWithEntryPoint(
@@ -29,13 +30,14 @@ export function resolveEntryWithEntryPoint(
 ): {
 	absolutePath: string;
 	relativePath: string;
+	directory: string;
 } {
 	const directory = path.resolve(path.dirname(configPath ?? "."));
 	const file = path.extname(entryPoint)
 		? path.resolve(entryPoint)
 		: path.resolve(entryPoint, "index.js");
 	const relativePath = path.relative(directory, file) || ".";
-	return { absolutePath: file, relativePath };
+	return { absolutePath: file, relativePath, directory };
 }
 
 export function resolveEntryWithAssets(): {

--- a/packages/wrangler/src/deployment-bundle/resolve-entry.ts
+++ b/packages/wrangler/src/deployment-bundle/resolve-entry.ts
@@ -16,12 +16,12 @@ export function resolveEntryWithMain(
 ): {
 	absolutePath: string;
 	relativePath: string;
-	directory: string;
+	projectRoot: string;
 } {
-	const directory = path.resolve(path.dirname(configPath ?? "."));
-	const file = path.resolve(directory, main);
-	const relativePath = path.relative(directory, file) || ".";
-	return { absolutePath: file, relativePath, directory };
+	const projectRoot = path.resolve(path.dirname(configPath ?? "."));
+	const file = path.resolve(projectRoot, main);
+	const relativePath = path.relative(projectRoot, file) || ".";
+	return { absolutePath: file, relativePath, projectRoot };
 }
 
 export function resolveEntryWithEntryPoint(
@@ -30,14 +30,14 @@ export function resolveEntryWithEntryPoint(
 ): {
 	absolutePath: string;
 	relativePath: string;
-	directory: string;
+	projectRoot: string;
 } {
-	const directory = path.resolve(path.dirname(configPath ?? "."));
+	const projectRoot = path.resolve(path.dirname(configPath ?? "."));
 	const file = path.extname(entryPoint)
 		? path.resolve(entryPoint)
 		: path.resolve(entryPoint, "index.js");
-	const relativePath = path.relative(directory, file) || ".";
-	return { absolutePath: file, relativePath, directory };
+	const relativePath = path.relative(projectRoot, file) || ".";
+	return { absolutePath: file, relativePath, projectRoot };
 }
 
 export function resolveEntryWithAssets(): {

--- a/packages/wrangler/src/dev/use-esbuild.ts
+++ b/packages/wrangler/src/dev/use-esbuild.ts
@@ -193,7 +193,7 @@ export function runBuild(
 			// Check whether we need to watch a Python requirements.txt file.
 			const watchPythonRequirements =
 				getBundleType(entry.format, entry.file) === "python"
-					? path.resolve(entry.directory, "requirements.txt")
+					? path.resolve(entry.projectRoot, "requirements.txt")
 					: undefined;
 
 			if (watchPythonRequirements) {

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -29,7 +29,7 @@ export function buildPluginFromFunctions({
 }: Options) {
 	const entry: Entry = {
 		file: resolve(getBasePath(), "templates/pages-template-plugin.ts"),
-		directory: functionsDirectory,
+		projectRoot: functionsDirectory,
 		format: "modules",
 		moduleRoot: functionsDirectory,
 		exports: [],

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -55,7 +55,7 @@ export function buildWorkerFromFunctions({
 }: Options) {
 	const entry: Entry = {
 		file: resolve(getBasePath(), "templates/pages-template-worker.ts"),
-		directory: functionsDirectory,
+		projectRoot: functionsDirectory,
 		format: "modules",
 		moduleRoot: functionsDirectory,
 		exports: [],
@@ -151,7 +151,7 @@ export function buildRawWorker({
 }: RawOptions) {
 	const entry: Entry = {
 		file: workerScriptPath,
-		directory: resolve(directory),
+		projectRoot: resolve(directory),
 		format: "modules",
 		moduleRoot: resolve(directory),
 		exports: [],
@@ -240,7 +240,7 @@ export async function produceWorkerBundleForWorkerJSDirectory({
 	const additionalModules = await findAdditionalModules(
 		{
 			file: entrypoint,
-			directory: resolve(workerJSDirectory),
+			projectRoot: resolve(workerJSDirectory),
 			format: "modules",
 			moduleRoot: resolve(workerJSDirectory),
 			exports: [],

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -267,7 +267,7 @@ async function versionsUploadHandler(
 		await verifyWorkerMatchesCITag(
 			accountId,
 			name,
-			path.relative(entry.directory, config.configPath ?? "wrangler.toml")
+			path.relative(entry.projectRoot, config.configPath ?? "wrangler.toml")
 		);
 	}
 


### PR DESCRIPTION
https://github.com/cloudflare/workers-sdk/pull/6971 introduced a small regression in the `getEntry()` function that meant that `Entry.directory` was always `process.cwd()` rather than relative to the found `wrangler.toml` file. This PR fixes the regression & adds a regression test that fails on `main` but passes prior to #6971.

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
