### PR TITLE
fix: allow assets in multiworker setup

### DIFF
--- a/.changeset/poor-otters-drop.md
+++ b/.changeset/poor-otters-drop.md
@@ -1,0 +1,10 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+fix: add support for workers with assets when running multiple workers in one `wrangler dev` instance
+
+https://github.com/cloudflare/workers-sdk/pull/7251 added support for running multiple Workers in one `wrangler dev`/miniflare session. e.g. `wrangler dev -c wrangler.toml -c ../worker2/wrangler.toml`, which among other things, allowed cross-service RPC to Durable Objects.
+
+However this did not work in the same way as production when there was a Worker with assets - this PR should fix that.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1282,7 +1282,6 @@ export class Miniflare {
 					address,
 					service: {
 						name: workerOpts.assets.assets
-							? `${ROUTER_SERVICE_NAME}-${workerName}`
 							: getUserServiceName(workerName),
 						entrypoint: entrypoint === "default" ? undefined : entrypoint,
 					},
@@ -1305,7 +1304,7 @@ export class Miniflare {
 				!this.#workerOpts[0].core.name?.startsWith(
 					"vitest-pool-workers-runner-"
 				)
-					? `${ROUTER_SERVICE_NAME}-${this.#workerOpts[0].core.name}`
+					? `${ROUTER_SERVICE_NAME}:${this.#workerOpts[0].core.name}`
 					: getUserServiceName(this.#workerOpts[0].core.name),
 			loopbackPort,
 			log: this.#log,

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1295,9 +1295,7 @@ export class Miniflare {
 					name,
 					address,
 					service: {
-						name: workerOpts.assets.assets
-							? `${ROUTER_SERVICE_NAME}:${workerName}`
-							: getUserServiceName(workerName),
+						name: getUserServiceName(workerName),
 						entrypoint: entrypoint === "default" ? undefined : entrypoint,
 					},
 					http: {

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -40,7 +40,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 				// binding between User Worker and Asset Worker
 				name: options.assets.binding,
 				service: {
-					name: `${ASSETS_SERVICE_NAME}-${options.assets.workerName}`,
+					name: `${ASSETS_SERVICE_NAME}:${options.assets.workerName}`,
 				},
 			},
 		];
@@ -70,8 +70,10 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 			options.assets.directory
 		);
 
+		const id = options.assets.workerName;
+
 		const namespaceService: Service = {
-			name: `${ASSETS_KV_SERVICE_NAME}-${options.assets.workerName}`,
+			name: `${ASSETS_KV_SERVICE_NAME}:${id}`,
 			worker: {
 				compatibilityDate: "2023-07-24",
 				compatibilityFlags: ["nodejs_compat"],
@@ -95,7 +97,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		};
 
 		const assetService: Service = {
-			name: `${ASSETS_SERVICE_NAME}-${options.assets.workerName}`,
+			name: `${ASSETS_SERVICE_NAME}:${id}`,
 			worker: {
 				compatibilityDate: "2024-08-01",
 				modules: [
@@ -108,7 +110,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 					{
 						name: "ASSETS_KV_NAMESPACE",
 						kvNamespace: {
-							name: `${ASSETS_KV_SERVICE_NAME}-${options.assets.workerName}`,
+							name: `${ASSETS_KV_SERVICE_NAME}:${id}`,
 						},
 					},
 					{
@@ -124,7 +126,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		};
 
 		const routerService: Service = {
-			name: `${ROUTER_SERVICE_NAME}-${options.assets.workerName}`,
+			name: `${ROUTER_SERVICE_NAME}:${id}`,
 			worker: {
 				compatibilityDate: "2024-08-01",
 				modules: [
@@ -137,12 +139,12 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 					{
 						name: "ASSET_WORKER",
 						service: {
-							name: `${ASSETS_SERVICE_NAME}-${options.assets.workerName}`,
+							name: `${ASSETS_SERVICE_NAME}:${id}`,
 						},
 					},
 					{
 						name: "USER_WORKER",
-						service: { name: getUserServiceName(options.assets.workerName) },
+						service: { name: getUserServiceName(id) },
 					},
 					{
 						name: "CONFIG",

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -39,7 +39,9 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 			{
 				// binding between User Worker and Asset Worker
 				name: options.assets.binding,
-				service: { name: ASSETS_SERVICE_NAME },
+				service: {
+					name: `${ASSETS_SERVICE_NAME}-${options.assets.workerName}`,
+				},
 			},
 		];
 	},
@@ -69,7 +71,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		);
 
 		const namespaceService: Service = {
-			name: ASSETS_KV_SERVICE_NAME,
+			name: `${ASSETS_KV_SERVICE_NAME}-${options.assets.workerName}`,
 			worker: {
 				compatibilityDate: "2023-07-24",
 				compatibilityFlags: ["nodejs_compat"],
@@ -93,7 +95,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		};
 
 		const assetService: Service = {
-			name: ASSETS_SERVICE_NAME,
+			name: `${ASSETS_SERVICE_NAME}-${options.assets.workerName}`,
 			worker: {
 				compatibilityDate: "2024-08-01",
 				modules: [
@@ -105,7 +107,9 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 				bindings: [
 					{
 						name: "ASSETS_KV_NAMESPACE",
-						kvNamespace: { name: ASSETS_KV_SERVICE_NAME },
+						kvNamespace: {
+							name: `${ASSETS_KV_SERVICE_NAME}-${options.assets.workerName}`,
+						},
 					},
 					{
 						name: "ASSETS_MANIFEST",
@@ -120,7 +124,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		};
 
 		const routerService: Service = {
-			name: ROUTER_SERVICE_NAME,
+			name: `${ROUTER_SERVICE_NAME}-${options.assets.workerName}`,
 			worker: {
 				compatibilityDate: "2024-08-01",
 				modules: [
@@ -132,7 +136,9 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 				bindings: [
 					{
 						name: "ASSET_WORKER",
-						service: { name: ASSETS_SERVICE_NAME },
+						service: {
+							name: `${ASSETS_SERVICE_NAME}-${options.assets.workerName}`,
+						},
 					},
 					{
 						name: "USER_WORKER",

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -262,7 +262,7 @@ function getCustomServiceDesignator(
 	} else if (service === kCurrentWorker) {
 		// Sets SELF binding to point to router worker instead if assets are present.
 		serviceName = hasAssetsAndIsVitest
-			? ROUTER_SERVICE_NAME
+			? `${ROUTER_SERVICE_NAME}-${refererName}`
 			: getUserServiceName(refererName);
 	} else {
 		// Regular user worker

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -262,7 +262,7 @@ function getCustomServiceDesignator(
 	} else if (service === kCurrentWorker) {
 		// Sets SELF binding to point to router worker instead if assets are present.
 		serviceName = hasAssetsAndIsVitest
-			? `${ROUTER_SERVICE_NAME}-${refererName}`
+			? `${ROUTER_SERVICE_NAME}:${refererName}`
 			: getUserServiceName(refererName);
 	} else {
 		// Regular user worker


### PR DESCRIPTION
#7251 will allow running multiple workers in one Miniflare instance. Currently we only set up the router/asset worker for the first worker passed to miniflare, assuming this will be the only user worker. This PR will make sure assets works regardless of how many 'user workers' are passed in and at what point.

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge): once #7251 is in. 
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: I don't think there are any existing docs covering this.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
