### PR TITLE
feat(pages-shared): add custom response header when we hit asset preservation cache

### DIFF
--- a/packages/pages-shared/__tests__/asset-server/handler.test.ts
+++ b/packages/pages-shared/__tests__/asset-server/handler.test.ts
@@ -592,6 +592,7 @@ describe("asset-server handler", () => {
 				"cache-control": "public, s-maxage=604800",
 				"x-robots-tag": "noindex",
 				"cf-cache-status": "HIT", // new header
+				"x-cf-pgs-apc": "HIT", // new header
 			});
 
 			// Serve with a fresh cache and ensure we don't get a response

--- a/packages/pages-shared/asset-server/handler.ts
+++ b/packages/pages-shared/asset-server/handler.ts
@@ -29,6 +29,11 @@ export const ASSET_PRESERVATION_CACHE_V1 = "assetPreservationCache";
 // V2 stores the content hash instead of the asset.
 // TODO: Remove V1 once we've fully migrated to V2
 export const ASSET_PRESERVATION_CACHE_V2 = "assetPreservationCacheV2";
+/**
+ * Response header will be present w/ "HIT"
+ * value if served from `ASSET_PRESERVATION_CACHE_V2`
+ */
+const HEADER_ASSET_PRESERVATION_CACHE_V2 = "x-cf-pgs-apc";
 const CACHE_CONTROL_PRESERVATION = "public, s-maxage=604800"; // 1 week
 
 /** The preservation cache should be periodically
@@ -676,7 +681,9 @@ export async function generateHandler<
 						const asset = await fetchAsset(assetKey);
 						if (asset) {
 							// We know the asset hasn't changed, so use the cached headers.
-							return new Response(asset.body, preservedResponse);
+							const response = new Response(asset.body, preservedResponse);
+							response.headers.set(HEADER_ASSET_PRESERVATION_CACHE_V2, "HIT");
+							return response;
 						} else {
 							logError(
 								new Error(


### PR DESCRIPTION
Adds the `x-cf-pgs-apc` response header for the pages asset-server handler if the `ASSET_PRESERVATION_CACHE_V2` was hit. This allows for easier troubleshooting for cache invalidation issues.

Fixes #7295 .


---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no e2e coverage
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
