### PR TITLE
chore: update pages project name for chrome-devtools-patches

### DIFF
--- a/packages/chrome-devtools-patches/Makefile
+++ b/packages/chrome-devtools-patches/Makefile
@@ -21,7 +21,7 @@ devtools-frontend/out/Default/gen/front_end: devtools-frontend
 	cd devtools-frontend && PATH="$(PATH_WITH_DEPOT)" $(ROOT)/depot/autoninja -C out/Default
 
 publish: cleanup devtools-frontend/out/Default/gen/front_end
-	npx wrangler pages deploy --project-name cloudflare-devtools devtools-frontend/out/Default/gen/front_end
+	npx wrangler pages deploy --project-name chrome-devtools-patches devtools-frontend/out/Default/gen/front_end
 
 cleanup:
 	rm -rf devtools-frontend .gclient* .cipd node_modules depot


### PR DESCRIPTION
Fixes #000.

Now that the DevTools pages project has been renamed from `cloudflare-devtools` to `chrome-devtools-patches`, we need to update the deploy command in the package `Makefile`.

<img width="848" alt="Screenshot 2024-11-20 at 08 42 17" src="https://github.com/user-attachments/assets/1179ab24-7ab5-43f8-a894-618d86f87982">

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: No code logic changed
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No code logic changed
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal only