### PR TITLE
feat(cloudflare_pages): add `CI` detection on deploy

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -87,7 +87,8 @@
 		"source-map": "^0.6.1",
 		"unenv": "npm:unenv-nightly@2.0.0-20241111-080453-894aa31",
 		"workerd": "1.20241106.1",
-		"xxhash-wasm": "^1.0.1"
+		"xxhash-wasm": "^1.0.1",
+		"std-env": "^3.8.0"
 	},
 	"devDependencies": {
 		"@cloudflare/cli": "workspace:*",

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -1,3 +1,4 @@
+import { env, isCI, provider } from "std-env";
 import { execSync } from "node:child_process";
 import { deploy } from "../api/pages/deploy";
 import { fetchResult } from "../cfetch";
@@ -294,6 +295,15 @@ export const Handler = async (args: PagesDeployArgs) => {
 
 	if (!projectName) {
 		throw new FatalError("Must specify a project name.", 1);
+	}
+
+	if (isCI) {
+		switch(provider) {
+			case 'gitlab':
+				branch = env.CI_COMMIT_BRANCH
+				commitHash = env.CI_COMMIT_SHA
+				commitMessage = env.CI_COMMIT_MESSAGE
+		}
 	}
 
 	// We infer git info by default is not passed in

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1720,6 +1720,9 @@ importers:
       source-map:
         specifier: ^0.6.1
         version: 0.6.1
+      std-env:
+        specifier: ^3.8.0
+        version: 3.8.0
       unenv:
         specifier: npm:unenv-nightly@2.0.0-20241111-080453-894aa31
         version: unenv-nightly@2.0.0-20241111-080453-894aa31
@@ -7578,6 +7581,9 @@ packages:
 
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+
+  std-env@3.8.0:
+    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
@@ -14750,6 +14756,8 @@ snapshots:
   statuses@2.0.1: {}
 
   std-env@3.7.0: {}
+
+  std-env@3.8.0: {}
 
   stoppable@1.1.0: {}
 


### PR DESCRIPTION
This pull request adds support for autofilling parameters when deploying cloudflare pages using CI. Currently on GitLab I have to do something like this:

`npx wrangler pages deploy dist --project-name cf-pages-project --commit-hash "$CI_COMMIT_SHORT_SHA" --commit-message "$CI_COMMIT_MESSAGE" --branch $CI_COMMIT_BRANCH`
---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Deploy already contains tests and if it doesn't work correctly the current tests will detect it.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Deploy already contains tests and if it doesn't work correctly the current tests will detect it.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: It should have worked this way from the beginning.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
