### PR TITLE
Modify router-worker logic to allow for running user-worker ahead of assets

### DIFF
--- a/.changeset/funny-dingos-guess.md
+++ b/.changeset/funny-dingos-guess.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Option to invoke user worker ahead of assets

--- a/packages/workers-shared/asset-worker/vitest.config.mts
+++ b/packages/workers-shared/asset-worker/vitest.config.mts
@@ -1,11 +1,11 @@
 import { defineProject, mergeConfig } from "vitest/config";
-import configShared from "../../vitest.shared";
+import configShared from "../../../vitest.shared.js";
 
 export default mergeConfig(
 	configShared,
 	defineProject({
 		test: {
-			include: ["asset-worker/tests/**.{test,spec}.{ts,js}"],
+			include: ["tests/**.{test,spec}.{ts,js}"],
 			globals: true,
 		},
 	})

--- a/packages/workers-shared/asset-worker/wrangler.toml
+++ b/packages/workers-shared/asset-worker/wrangler.toml
@@ -12,6 +12,7 @@ account_id = "0f1b8aa119a907021f659042f95ea9ba"
 workers_dev = false
 main = "src/index.ts"
 compatibility_date = "2024-07-31"
+# nodejs_compat required when using @cloudflare/vitest-pool-workers
 compatibility_flags = ["nodejs_compat"]
 
 [[unsafe.bindings]]

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -30,14 +30,16 @@
 		"bundle:router-worker:prod": "pnpm run bundle:router-worker --minify",
 		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "pnpm run check:type:tests && tsc",
-		"check:type:tests": "tsc -p ./asset-worker/tests/tsconfig.json",
+		"check:type:tests": "tsc -p ./asset-worker/tests/tsconfig.json && tsc -p ./router-worker/tests/tsconfig.json",
 		"clean": "rimraf dist",
 		"deploy": "pnpm run deploy:router-worker && pnpm run deploy:asset-worker",
 		"deploy:asset-worker": "CLOUDFLARE_API_TOKEN=$WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN pnpx wrangler versions upload --experimental-versions -c asset-worker/wrangler.toml",
 		"deploy:router-worker": "CLOUDFLARE_API_TOKEN=$WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN pnpx wrangler versions upload --experimental-versions -c router-worker/wrangler.toml",
 		"dev": "pnpm run clean && concurrently -n bundle:asset-worker,bundle:router-worker -c blue,magenta \"pnpm run bundle:asset-worker --watch\" \"pnpm run bundle:router-worker --watch\"",
-		"test": "vitest",
-		"test:ci": "vitest run",
+		"test": "concurrently --group -n router-worker,asset-worker \"pnpm run test:router-worker\" \"pnpm run test:asset-worker\"",
+		"test:asset-worker": "vitest -c asset-worker/vitest.config.mts --dir asset-worker",
+		"test:ci": "pnpm run test",
+		"test:router-worker": "vitest -c router-worker/vitest.config.mts --dir router-worker",
 		"types:emit": "tsc index.ts --declaration --emitDeclarationOnly --declarationDir ./dist"
 	},
 	"dependencies": {
@@ -46,6 +48,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
+		"@cloudflare/vitest-pool-workers": "latest",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241106.0",
 		"@types/mime": "^3.0.4",

--- a/packages/workers-shared/router-worker/src/index.ts
+++ b/packages/workers-shared/router-worker/src/index.ts
@@ -56,6 +56,19 @@ export default {
 			}
 
 			const maybeSecondRequest = request.clone();
+
+			// User's configuration indicates they want user-Worker to run ahead of any
+			// assets. Do not provide any fallback logic.
+			if (env.CONFIG.invoke_user_worker_ahead_of_assets) {
+				if (!env.CONFIG.has_user_worker) {
+					throw new Error(
+						"Fetch for user worker without having a user worker binding"
+					);
+				}
+				return env.USER_WORKER.fetch(maybeSecondRequest);
+			}
+
+			// Otherwise, we try to first fetch assets, falling back to user-Worker.
 			if (env.CONFIG.has_user_worker) {
 				if (await env.ASSET_WORKER.unstable_canFetch(request)) {
 					analytics.setData({ dispatchtype: DISPATCH_TYPE.ASSETS });

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -1,0 +1,74 @@
+import { createExecutionContext } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { default as worker } from "../src/index";
+
+describe("unit tests", async () => {
+	it("fails if specify running user worker ahead of assets, without user worker", async () => {
+		const request = new Request("https://example.com");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				invoke_user_worker_ahead_of_assets: true,
+				has_user_worker: false,
+			},
+		} as typeof env;
+
+		void expect(
+			async () => await worker.fetch(request, env, ctx)
+		).rejects.toThrowError(
+			"Fetch for user worker without having a user worker binding"
+		);
+	});
+
+	it("it returns fetch from user worker when invoke_user_worker_ahead_of_assets true", async () => {
+		const request = new Request("https://example.com");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				invoke_user_worker_ahead_of_assets: true,
+				has_user_worker: true,
+			},
+			USER_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from user worker");
+				},
+			},
+			ASSET_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from asset worker");
+				},
+				async unstable_canFetch(_: Request): Promise<boolean> {
+					return true;
+				},
+			},
+		} as typeof env;
+
+		const response = await worker.fetch(request, env, ctx);
+		expect(await response.text()).toEqual("hello from user worker");
+	});
+
+	it("it returns fetch from asset worker when matching existing asset path", async () => {
+		const request = new Request("https://example.com");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				invoke_user_worker_ahead_of_assets: false,
+				has_user_worker: false,
+			},
+			ASSET_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from asset worker");
+				},
+				async unstable_canFetch(_: Request): Promise<boolean> {
+					return true;
+				},
+			},
+		} as typeof env;
+
+		const response = await worker.fetch(request, env, ctx);
+		expect(await response.text()).toEqual("hello from asset worker");
+	});
+});

--- a/packages/workers-shared/router-worker/tests/tsconfig.json
+++ b/packages/workers-shared/router-worker/tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ES2020",
+		"lib": ["ES2020"],
+		"types": [
+			"@cloudflare/workers-types/experimental",
+			"@cloudflare/vitest-pool-workers"
+		],
+		"moduleResolution": "bundler",
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["**/*.ts"]
+}

--- a/packages/workers-shared/router-worker/vitest.config.mts
+++ b/packages/workers-shared/router-worker/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+	test: {
+		poolOptions: {
+			workers: {
+				wrangler: {
+					configPath: "./wrangler.toml",
+				},
+			},
+		},
+	},
+});

--- a/packages/workers-shared/router-worker/wrangler.toml
+++ b/packages/workers-shared/router-worker/wrangler.toml
@@ -12,6 +12,8 @@ account_id = "0f1b8aa119a907021f659042f95ea9ba"
 workers_dev = false
 main = "src/index.ts"
 compatibility_date = "2024-07-31"
+# nodejs_compat required when using @cloudflare/vitest-pool-workers
+compatibility_flags = ["nodejs_compat", "no_nodejs_compat_v2"]
 
 [version_metadata]
 binding = "VERSION_METADATA"

--- a/packages/workers-shared/tsconfig.json
+++ b/packages/workers-shared/tsconfig.json
@@ -5,7 +5,7 @@
 		"sourceMap": true,
 		"forceConsistentCasingInFileNames": true,
 		"useUnknownInCatchVariables": false,
-		"types": ["@cloudflare/workers-types/experimental"]
+		"types": ["@cloudflare/workers-types/experimental", "@types/node"]
 	},
 	"include": ["**/*.ts", "vitest.config.mts"],
 	"exclude": ["node_modules", "dist", "**/tests", "**/*.test.ts"]

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const RoutingConfigSchema = z.object({
 	has_user_worker: z.boolean().optional(),
+	invoke_user_worker_ahead_of_assets: z.boolean().optional(),
 });
 
 export const AssetConfigSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1588,6 +1588,9 @@ importers:
       '@cloudflare/eslint-config-worker':
         specifier: workspace:*
         version: link:../eslint-config-worker
+      '@cloudflare/vitest-pool-workers':
+        specifier: latest
+        version: 0.5.29(@cloudflare/workers-types@4.20241106.0)(@vitest/runner@2.1.3)(@vitest/snapshot@2.1.3)(vitest@2.1.3)
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../workers-tsconfig
@@ -2426,6 +2429,10 @@ packages:
     peerDependencies:
       react: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
 
+  '@cloudflare/kv-asset-handler@0.3.4':
+    resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
+    engines: {node: '>=16.13'}
+
   '@cloudflare/style-const@5.7.3':
     resolution: {integrity: sha512-N9Y8bcFXoO7htm+sSVsBmQOVbjLeEY2hy1CBmvt0AoH1zWvs3izwJrnlL0ee4kJ6DkyjaY6SIAkUGUtTOApF3Q==}
     peerDependencies:
@@ -2465,6 +2472,13 @@ packages:
   '@cloudflare/util-markdown@1.2.15':
     resolution: {integrity: sha512-H8q/Msk+9Fga6iqqmff7i4mi+kraBCQWFbMEaKIRq3+HBNN5gkpizk05DSG6iIHVxCG1M3WR1FkN9CQ0ZtK4Cw==}
 
+  '@cloudflare/vitest-pool-workers@0.5.29':
+    resolution: {integrity: sha512-UFRT/pUWj8O7FDrdKowjucaiMukMg6mwaDhbXU9FgZvnwhS958Y6TxjMZoUY/5UMp9vNY6wF1V1WeUfkBiB74Q==}
+    peerDependencies:
+      '@vitest/runner': 2.0.x - 2.1.x
+      '@vitest/snapshot': 2.0.x - 2.1.x
+      vitest: 2.0.x - 2.1.x
+
   '@cloudflare/workerd-darwin-64@1.20241106.1':
     resolution: {integrity: sha512-zxvaToi1m0qzAScrxFt7UvFVqU8DxrCO2CinM1yQkv5no7pA1HolpIrwZ0xOhR3ny64Is2s/J6BrRjpO5dM9Zw==}
     engines: {node: '>=16'}
@@ -2494,6 +2508,10 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-shared@0.7.1':
+    resolution: {integrity: sha512-46cP5FCrl3TrvHeoHLb5SRuiDMKH5kc9Yvo36SAfzt8dqJI/qJRoY1GP3ioHn/gP7v2QIoUOTAzIl7Ml7MnfrA==}
+    engines: {node: '>=16.7.0'}
 
   '@cloudflare/workers-types@4.20241106.0':
     resolution: {integrity: sha512-pI4ivacmp+vgNO/siHDsZ6BdITR0LC4Mh/1+yzVLcl9U75pt5DUDCOWOiqIRFXRq6H65DPnJbEPFo3x9UfgofQ==}
@@ -6316,6 +6334,11 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  miniflare@3.20241106.0:
+    resolution: {integrity: sha512-PjOoJKjUUofCueQskfhXlGvvHxZj36UAJAp1DnquMK88MFF50zCULblh0KXMSNM+bXeQYA94Gj06a7kfmBGxPw==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
     engines: {node: 20 || >=22}
@@ -8326,6 +8349,16 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  wrangler@3.88.0:
+    resolution: {integrity: sha512-1yM5cgerjKkIBL9GOzIWhl8MsyEGNTsN4emJCiLLHJFz52TSNjJJlMbd1x0hX351mfy2MsGgUqKcx8iRL51PcQ==}
+    engines: {node: '>=16.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20241106.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -9193,6 +9226,10 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  '@cloudflare/kv-asset-handler@0.3.4':
+    dependencies:
+      mime: 3.0.0
+
   '@cloudflare/style-const@5.7.3(react@18.3.1)':
     dependencies:
       '@cloudflare/types': 6.23.6(react@18.3.1)
@@ -9257,6 +9294,25 @@ snapshots:
       lodash.memoize: 4.1.2
       marked: 0.3.19
 
+  '@cloudflare/vitest-pool-workers@0.5.29(@cloudflare/workers-types@4.20241106.0)(@vitest/runner@2.1.3)(@vitest/snapshot@2.1.3)(vitest@2.1.3)':
+    dependencies:
+      '@vitest/runner': 2.1.3
+      '@vitest/snapshot': 2.1.3
+      birpc: 0.2.14
+      cjs-module-lexer: 1.2.3
+      devalue: 4.3.2
+      esbuild: 0.17.19
+      miniflare: 3.20241106.0
+      semver: 7.5.4
+      vitest: 2.1.3(@types/node@18.19.59)(@vitest/ui@2.1.3)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
+      wrangler: 3.88.0(@cloudflare/workers-types@4.20241106.0)
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@cloudflare/workerd-darwin-64@1.20241106.1':
     optional: true
 
@@ -9271,6 +9327,11 @@ snapshots:
 
   '@cloudflare/workerd-windows-64@1.20241106.1':
     optional: true
+
+  '@cloudflare/workers-shared@0.7.1':
+    dependencies:
+      mime: 3.0.0
+      zod: 3.22.3
 
   '@cloudflare/workers-types@4.20241106.0': {}
 
@@ -13419,6 +13480,25 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  miniflare@3.20241106.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      capnp-ts: 0.7.0(patch_hash=l4yimnxyvkiyj6alnps2ec3sii)
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      stoppable: 1.1.0
+      undici: 5.28.4
+      workerd: 1.20241106.1
+      ws: 8.18.0
+      youch: 3.2.3
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   minimatch@10.0.1:
     dependencies:
       brace-expansion: 2.0.1
@@ -15532,6 +15612,35 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20241106.1
       '@cloudflare/workerd-linux-arm64': 1.20241106.1
       '@cloudflare/workerd-windows-64': 1.20241106.1
+
+  wrangler@3.88.0(@cloudflare/workers-types@4.20241106.0):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.3.4
+      '@cloudflare/workers-shared': 0.7.1
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      chokidar: 4.0.1
+      date-fns: 4.1.0
+      esbuild: 0.17.19
+      itty-time: 1.0.6
+      miniflare: 3.20241106.0
+      nanoid: 3.3.7
+      path-to-regexp: 6.3.0
+      resolve: 1.22.8
+      resolve.exports: 2.0.2
+      selfsigned: 2.1.1
+      source-map: 0.6.1
+      unenv: unenv-nightly@2.0.0-20241111-080453-894aa31
+      workerd: 1.20241106.1
+      xxhash-wasm: 1.0.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20241106.0
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   wrap-ansi@6.2.0:
     dependencies:


### PR DESCRIPTION
This PR provides the option for user worker to run ahead of assets.
- Adds logic to run user-worker ahead of assets
- Moves vitest from worker-shared root into asset-worker
- Creates new vitest unit test suite for router-worker

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: not user facing through this mechanism