### PR TITLE
Add default image for cloudchamber create

### DIFF
--- a/.changeset/six-apes-pull.md
+++ b/.changeset/six-apes-pull.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add a default image for cloudchamber create and modify commands

--- a/packages/wrangler/src/__tests__/cloudchamber/common.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/common.test.ts
@@ -1,0 +1,41 @@
+import { parseImageName } from "../../cloudchamber/common";
+
+describe("parseImageName", () => {
+	it("works", () => {
+		type TestCase = [input: string, name: string | undefined, tag: string | undefined, err: boolean];
+		const cases: TestCase[] = [
+			// Multiple domains
+			["docker.io/cloudflare/hello-world:1.0", "docker.io/cloudflare/hello-world", "1.0", false],
+
+			// Domain with port
+			["localhost:7777/web:local", "localhost:7777/web", "local", false],
+
+			// No domain
+			["hello-world:1.0", "hello-world", "1.0", false],
+
+			// Invalid name
+			["bad image name:1", undefined, undefined, true],
+
+			// Missing tag
+			["no-tag", undefined, undefined, true],
+			["no-tag:", undefined, undefined, true],
+
+			// Invalid tag
+			["no-tag::", undefined, undefined, true],
+
+			// latest tag
+			["name:latest", undefined, undefined, true],
+
+			// Too many colons
+			["registry.com:1234/foobar:4444/image:sometag", undefined, undefined, true],
+		];
+
+		for (const c of cases) {
+			let [input, name, tag, isErr] = c;
+			let result = parseImageName(input);
+			expect(result.name).toEqual(name);
+			expect(result.tag).toEqual(tag);
+			expect(result.err !== undefined).toEqual(isErr);
+		}
+	});
+});

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -116,6 +116,22 @@ describe("cloudchamber create", () => {
 		);
 	});
 
+	it("should fail with a nice message when image is invalid", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		await expect(
+			runWrangler("cloudchamber create --image hello:latest --location sfo06")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: "latest" tag is not allowed]`
+		);
+
+		await expect(
+			runWrangler("cloudchamber create --image hello --location sfo06")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Invalid image format: expected NAME:TAG]`
+		);
+	});
+
 	it("should fail with a nice message when parameters are mistyped", async () => {
 		setIsTTY(false);
 		fs.writeFileSync(

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -21,6 +21,7 @@ import {
 	promptForLabels,
 	renderDeploymentConfiguration,
 	renderDeploymentMutationError,
+	parseImageName,
 } from "./common";
 import { wrap } from "./helpers/wrap";
 import { loadAccount } from "./locations";
@@ -33,6 +34,8 @@ import type {
 } from "../yargs-types";
 import type { EnvironmentVariable, Label, SSHPublicKeyID } from "./client";
 import type { Arg } from "@cloudflare/cli/interactive";
+
+const defaultContainerImage = "docker.io/cloudflare/hello-world:1.0";
 
 export function createCommandOptionalYargs(yargs: CommonYargsArgvJSON) {
 	return yargs
@@ -123,6 +126,12 @@ export async function createCommand(
 		}
 
 		const body = checkEverythingIsSet(args, ["image", "location"]);
+
+		const {err} = parseImageName(body.image);
+		if (err !== undefined) {
+			throw new Error(err);
+		}
+
 		const keysToAdd = args.allSshKeys
 			? (await pollSSHKeysUntilCondition(() => true)).map((key) => key.id)
 			: [];
@@ -239,18 +248,19 @@ export async function handleCreateCommand(
 		label: "image",
 		validate: (value) => {
 			if (typeof value !== "string") {
-				return "unknown error";
+				return "Unknown error";
 			}
 			if (value.length === 0) {
-				return "you should fill this input";
+				// validate is called before defaultValue is
+				// applied, so we must set it ourselves
+				value = defaultContainerImage;
 			}
-			if (value.endsWith(":latest")) {
-				return "we don't allow :latest tags";
-			}
+
+			const {err} = parseImageName(value);
+			return err;
 		},
-		defaultValue: givenImage ?? "",
-		initialValue: givenImage ?? "",
-		helpText: 'i.e. "docker.io/org/app:1.2", :latest tags are not allowed!',
+		defaultValue: givenImage ?? defaultContainerImage,
+		helpText: 'NAME:TAG ("latest" tag is not allowed)',
 		type: "text",
 	});
 
@@ -323,4 +333,4 @@ export async function handleCreateCommand(
 	await waitForPlacement(deployment);
 }
 
-const whichImageQuestion = "Which image url should we use for your container?";
+const whichImageQuestion = "Which image should we use for your container?";

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -14,6 +14,7 @@ import {
 	promptForLabels,
 	renderDeploymentConfiguration,
 	renderDeploymentMutationError,
+	parseImageName,
 } from "./common";
 import { wrap } from "./helpers/wrap";
 import { loadAccount } from "./locations";
@@ -192,15 +193,14 @@ async function handleModifyCommand(
 		label: "",
 		validate: (value) => {
 			if (typeof value !== "string") {
-				return "unknown error";
+				return "Unknown error";
 			}
-			if (value.endsWith(":latest")) {
-				return "we don't allow :latest tags";
-			}
+			const {err} = parseImageName(value);
+			return err;
 		},
 		defaultValue: givenImage ?? deployment.image,
 		initialValue: givenImage ?? deployment.image,
-		helpText: "Press Return to leave unchanged",
+		helpText: "press Return to leave unchanged",
 		type: "text",
 	});
 


### PR DESCRIPTION
Add a default image when using `wrangler cloudchamber create`. This image is docker.io/cloudflare/hello-world which is a simple HTTP server that runs on Cloudflare's container platform.

This commit also augments validation to both the `cloudchamber create` and `cloudchamber modify` commands to ensure the provided image contains a tag and adheres to the format in the OCI specification.

Fixes CC-4280.

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] Not required because: minor UX change only (non-functional)
- Public documentation
  - [x] Documentation not necessary because: minor UX change only (non-functional)

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
