### PR TITLE
Add default image for cloudchamber create

### DIFF
--- a/.changeset/six-apes-pull.md
+++ b/.changeset/six-apes-pull.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add a default image for cloudchamber create and modify commands

--- a/packages/wrangler/src/__tests__/cloudchamber/common.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/common.test.ts
@@ -1,0 +1,62 @@
+import { parseImageName } from "../../cloudchamber/common";
+
+describe("parseImageName", () => {
+	it("works", () => {
+		type TestCase = [
+			input: string,
+			expected: { name?: string; tag?: string; digest?: string; err?: boolean },
+		];
+		const cases: TestCase[] = [
+			// Multiple domains
+			[
+				"docker.io/cloudflare/hello-world:1.0",
+				{ name: "docker.io/cloudflare/hello-world", tag: "1.0" },
+			],
+
+			// Domain with port
+			[
+				"localhost:7777/web:local",
+				{ name: "localhost:7777/web", tag: "local" },
+			],
+
+			// No domain
+			["hello-world:1.0", { name: "hello-world", tag: "1.0" }],
+
+			// With sha256 digest
+			[
+				"hello/world:1.0@sha256:abcdef0123456789",
+				{ name: "hello/world", tag: "1.0", digest: "abcdef0123456789" },
+			],
+
+			// sha256 digest but no tag
+			[
+				"hello/world@sha256:abcdef0123456789",
+				{ name: "hello/world", digest: "sha256:abcdef0123456789" },
+			],
+
+			// Invalid name
+			["bad image name:1", { err: true }],
+
+			// Missing tag
+			["no-tag", { err: true }],
+			["no-tag:", { err: true }],
+
+			// Invalid tag
+			["no-tag::", { err: true }],
+
+			// latest tag
+			["name:latest", { err: true }],
+
+			// Too many colons
+			["registry.com:1234/foobar:4444/image:sometag", { err: true }],
+		];
+
+		for (const c of cases) {
+			const [input, expected] = c;
+			const result = parseImageName(input);
+			expect(result.name).toEqual(expected.name);
+			expect(result.tag).toEqual(expected.tag);
+			expect(result.err !== undefined).toEqual(expected.err === true);
+		}
+	});
+});

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -116,6 +116,22 @@ describe("cloudchamber create", () => {
 		);
 	});
 
+	it("should fail with a nice message when image is invalid", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		await expect(
+			runWrangler("cloudchamber create --image hello:latest --location sfo06")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: "latest" tag is not allowed]`
+		);
+
+		await expect(
+			runWrangler("cloudchamber create --image hello --location sfo06")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Invalid image format: expected NAME:TAG[@DIGEST] or NAME@DIGEST]`
+		);
+	});
+
 	it("should fail with a nice message when parameters are mistyped", async () => {
 		setIsTTY(false);
 		fs.writeFileSync(

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -10,6 +10,7 @@ import {
 	collectLabels,
 	interactWithUser,
 	loadAccountSpinner,
+	parseImageName,
 	promptForEnvironmentVariables,
 	promptForLabels,
 	renderDeploymentConfiguration,
@@ -192,15 +193,14 @@ async function handleModifyCommand(
 		label: "",
 		validate: (value) => {
 			if (typeof value !== "string") {
-				return "unknown error";
+				return "Unknown error";
 			}
-			if (value.endsWith(":latest")) {
-				return "we don't allow :latest tags";
-			}
+			const { err } = parseImageName(value);
+			return err;
 		},
 		defaultValue: givenImage ?? deployment.image,
 		initialValue: givenImage ?? deployment.image,
-		helpText: "Press Return to leave unchanged",
+		helpText: "press Return to leave unchanged",
 		type: "text",
 	});
 


### PR DESCRIPTION
Add a default image when using "wrangler cloudchamber create". This image is docker.io/cloudflare/hello-world which is a simple HTTP server that runs on Cloudflare's container platform.

This commit also augments validation to both the `cloudchamber create` and `cloudchamber modify` commands to ensure the provided image contains a tag and adheres to the format in the OCI specification.

Fixes CC-4280.

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: UX changes only
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: does not impact user-facing features

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
