### PR TITLE
ci: remove PR trigger for semgrep

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,5 +1,4 @@
 on:
-  pull_request: {}
   workflow_dispatch: {}
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
semgrep is slow and triggering this on all PR events is clogging the queue.