### PR TITLE
test: fix system locale override

### DIFF
--- a/packages/wrangler/src/__tests__/vitest.global.ts
+++ b/packages/wrangler/src/__tests__/vitest.global.ts
@@ -1,0 +1,7 @@
+export function setup(): void {
+	// Set `LC_ALL` to fix the language as English for the messages thrown by Yargs,
+	// and to make any uses of datetimes in snapshots consistent.
+	// This needs to be in a globalSetup script - it won't work in a setupFile script.
+	// https://github.com/vitest-dev/vitest/issues/1575#issuecomment-1439286286
+	process.env.LC_ALL = "C";
+}

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -22,9 +22,6 @@ chalk.level = 0;
 	global as unknown as { __RELATIVE_PACKAGE_PATH__: string }
 ).__RELATIVE_PACKAGE_PATH__ = "..";
 
-// Set `LC_ALL` to fix the language as English for the messages thrown by Yargs.
-process.env.LC_ALL = "en";
-
 vi.mock("ansi-escapes", () => {
 	return {
 		__esModule: true,

--- a/packages/wrangler/vitest.config.mts
+++ b/packages/wrangler/vitest.config.mts
@@ -65,6 +65,7 @@ export default defineConfig({
 		// eslint-disable-next-line turbo/no-undeclared-env-vars
 		outputFile: process.env.TEST_REPORT_PATH ?? ".e2e-test-report/index.html",
 		setupFiles: path.resolve(__dirname, "src/__tests__/vitest.setup.ts"),
+		globalSetup: path.resolve(__dirname, "src/__tests__/vitest.global.ts"),
 		reporters: ["default", "html"],
 		globals: true,
 		snapshotFormat: {


### PR DESCRIPTION
Apparently setting `LC_ALL` in `vitest.setup.ts` doesn't work, as this is after the locale settings are read, but it does work in a `globalSetup` file.

This can be observed locally with the Workflows tests:
```
➜  wrangler git:(fix-test-locale) npx vitest run src/__tests__/workflows.test.ts >&/dev/null; echo $?
0
➜  wrangler git:(fix-test-locale) git checkout origin/main vitest.config.mts && LC_ALL=en_UK npx vitest run src/__tests__/workflows.test.ts >&/dev/null; echo $?
Updated 1 path from e1554242a
1
```

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: small improvements to tests, though I guess running with `en_UK` in CI would help verify this?
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Small test improvement
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Not public facing

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
