### PR TITLE
Normalize workers assets path

### DIFF
--- a/.changeset/cyan-laws-mate.md
+++ b/.changeset/cyan-laws-mate.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Prevent same-schema attacks

--- a/fixtures/asset-config/redirects.test.ts
+++ b/fixtures/asset-config/redirects.test.ts
@@ -1,0 +1,89 @@
+import { SELF } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyConfigurationDefaults } from "../../packages/workers-shared/asset-worker/src/configuration";
+import Worker from "../../packages/workers-shared/asset-worker/src/index";
+import { getAssetWithMetadataFromKV } from "../../packages/workers-shared/asset-worker/src/utils/kv";
+import type { AssetMetadata } from "../../packages/workers-shared/asset-worker/src/utils/kv";
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+vi.mock("../../packages/workers-shared/asset-worker/src/utils/kv.ts");
+vi.mock("../../packages/workers-shared/asset-worker/src/configuration");
+const existsMock = (fileList: Set<string>) => {
+	vi.spyOn(Worker.prototype, "unstable_exists").mockImplementation(
+		async (pathname: string) => {
+			if (fileList.has(pathname)) {
+				return pathname;
+			}
+		}
+	);
+};
+const BASE_URL = "http://example.com";
+
+describe("[Asset Worker] `test url normalization`", () => {
+	afterEach(() => {
+		vi.mocked(getAssetWithMetadataFromKV).mockRestore();
+	});
+	beforeEach(() => {
+		vi.mocked(getAssetWithMetadataFromKV).mockImplementation(
+			() =>
+				Promise.resolve({
+					value: "no-op",
+					metadata: {
+						contentType: "no-op",
+					},
+				}) as unknown as Promise<
+					KVNamespaceGetWithMetadataResult<ReadableStream, AssetMetadata>
+				>
+		);
+
+		vi.mocked(applyConfigurationDefaults).mockImplementation(() => {
+			return {
+				html_handling: "none",
+				not_found_handling: "none",
+			};
+		});
+	});
+
+	it("returns 404 for non matched encoded url", async () => {
+		const files = ["/christmas/starts/november/first.html"];
+		const requestPath = "/%2f%2fbad.example.com%2f";
+
+		existsMock(new Set(files));
+		const request = new IncomingRequest(BASE_URL + requestPath);
+		let response = await SELF.fetch(request, { redirect: "manual" });
+		expect(response.status).toBe(404);
+	});
+
+	it("returns 200 for matched non encoded url", async () => {
+		const files = ["/you/lost/the/game.bin"];
+		const requestPath = "/you/lost/the/game.bin";
+
+		existsMock(new Set(files));
+		const request = new IncomingRequest(BASE_URL + requestPath);
+		let response = await SELF.fetch(request, { redirect: "manual" });
+		expect(response.status).toBe(200);
+	});
+
+	it("returns redirect for matched encoded url", async () => {
+		const files = ["/awesome/file.bin"];
+		const requestPath = "/awesome/file%2ebin";
+		const finalPath = "/awesome/file.bin";
+
+		existsMock(new Set(files));
+		const request = new IncomingRequest(BASE_URL + requestPath);
+		let response = await SELF.fetch(request, { redirect: "manual" });
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe(finalPath);
+	});
+
+	it("returns 200 for matched non encoded url", async () => {
+		const files = ["/mylittlepony.png"];
+		const requestPath = "/mylittlepony.png";
+
+		existsMock(new Set(files));
+		const request = new IncomingRequest(BASE_URL + requestPath);
+		let response = await SELF.fetch(request, { redirect: "manual" });
+		expect(response.status).toBe(200);
+	});
+});

--- a/fixtures/asset-config/url-normalization.test.ts
+++ b/fixtures/asset-config/url-normalization.test.ts
@@ -1,0 +1,77 @@
+import { SELF } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyConfigurationDefaults } from "../../packages/workers-shared/asset-worker/src/configuration";
+import Worker from "../../packages/workers-shared/asset-worker/src/index";
+import { getAssetWithMetadataFromKV } from "../../packages/workers-shared/asset-worker/src/utils/kv";
+import type { AssetMetadata } from "../../packages/workers-shared/asset-worker/src/utils/kv";
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+vi.mock("../../packages/workers-shared/asset-worker/src/utils/kv.ts");
+vi.mock("../../packages/workers-shared/asset-worker/src/configuration");
+const existsMock = (fileList: Set<string>) => {
+	vi.spyOn(Worker.prototype, "unstable_exists").mockImplementation(
+		async (pathname: string) => {
+			if (fileList.has(pathname)) {
+				return pathname;
+			}
+		}
+	);
+};
+const BASE_URL = "http://example.com";
+
+describe("[Asset Worker] `test redirects`", () => {
+	afterEach(() => {
+		vi.mocked(getAssetWithMetadataFromKV).mockRestore();
+	});
+	beforeEach(() => {
+		vi.mocked(getAssetWithMetadataFromKV).mockImplementation(
+			() =>
+				Promise.resolve({
+					value: "no-op",
+					metadata: {
+						contentType: "no-op",
+					},
+				}) as unknown as Promise<
+					KVNamespaceGetWithMetadataResult<ReadableStream, AssetMetadata>
+				>
+		);
+
+		vi.mocked(applyConfigurationDefaults).mockImplementation(() => {
+			return {
+				html_handling: "none",
+				not_found_handling: "none",
+			};
+		});
+	});
+
+	it("returns 200 leading encoded double slash", async () => {
+		const files = ["/blog/index.html"];
+		const requestPath = "/%2fblog/index.html";
+
+		existsMock(new Set(files));
+		const request = new IncomingRequest(BASE_URL + requestPath);
+		let response = await SELF.fetch(request);
+		expect(response.status).toBe(200);
+	});
+
+	it("returns 200 leading non encoded double slash", async () => {
+		const files = ["/blog/index.html"];
+		const requestPath = "//blog/index.html";
+
+		existsMock(new Set(files));
+		const request = new IncomingRequest(BASE_URL + requestPath);
+		let response = await SELF.fetch(request);
+		expect(response.status).toBe(200);
+	});
+
+	it("returns 404 for non matched url", async () => {
+		const files = ["/blog/index.html"];
+		const requestPath = "/%2fexample.com/";
+
+		existsMock(new Set(files));
+		const request = new IncomingRequest(BASE_URL + requestPath);
+		let response = await SELF.fetch(request);
+		expect(response.status).toBe(404);
+	});
+});

--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -18,7 +18,10 @@ export const handleRequest = async (
 ) => {
 	const { pathname, search } = new URL(request.url);
 
-	const decodedPathname = decodePath(pathname);
+	let decodedPathname = decodePath(pathname);
+	// normalize the path
+	decodedPathname = decodedPathname.replaceAll('//', '/');
+
 	const intent = await getIntent(decodedPathname, configuration, exists);
 
 	if (!intent) {
@@ -42,6 +45,8 @@ export const handleRequest = async (
 	 * We combine this with other redirects (e.g. for html_handling) to avoid multiple redirects.
 	 */
 	if (encodedDestination !== pathname || intent.redirect) {
+		console.log(encodedDestination, pathname);
+
 		return new TemporaryRedirectResponse(encodedDestination + search);
 	}
 
@@ -637,6 +642,8 @@ const safeRedirect = async (
 	if (skip) {
 		return null;
 	}
+
+	console.log(file, destination, configuration);
 
 	if (!(await exists(destination))) {
 		const intent = await getIntent(destination, configuration, exists, true);

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -96,37 +96,4 @@ describe("[Asset Worker] `handleRequest`", () => {
 
 		expect(response.status).toBe(200);
 	});
-
-	it("normalizes double slashes", async () => {
-		const configuration: Required<AssetConfig> = {
-			html_handling: "none",
-			not_found_handling: "none",
-		};
-		const eTag = "some-etag";
-		const exists = vi.fn().mockReturnValue(eTag);
-		const getByETag = vi.fn().mockReturnValue({
-			readableStream: new ReadableStream(),
-			contentType: "text/html",
-		});
-
-		let response = await handleRequest(
-			new Request("https://example.com/abc/def//123/456"),
-			configuration,
-			exists,
-			getByETag
-		);
-
-		expect(response.status).toBe(307);
-		expect(response.headers.get('location')).toBe('/abc/def/123/456');
-
-		response = await handleRequest(
-			new Request("https://example.com/%2fexample.com/"),
-			configuration,
-			exists,
-			getByETag
-		);
-
-		expect(response.status).toBe(307);
-		expect(response.headers.get('location')).toBe('/example.com/');
-	});
 });


### PR DESCRIPTION
Prevents same-schema redirect attacks by collapsing multiple slashes in the path.

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: n/a

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
