### PR TITLE
Print copyable wrangler.toml text when creating a hyperdrive config

### DIFF
--- a/.changeset/cuddly-chicken-visit.md
+++ b/.changeset/cuddly-chicken-visit.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Print wrangler.toml snippet when creating new Hyperdrive Config

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -8,6 +8,7 @@ import { useMockIsTTY } from "./helpers/mock-istty";
 import { createFetchResult, msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
+import { writeWranglerConfig } from "./helpers/write-wrangler-config";
 import type {
 	CreateUpdateHyperdriveBody,
 	HyperdriveConfig,
@@ -117,8 +118,47 @@ describe("hyperdrive commands", () => {
 
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
+		`);
+	});
+
+	it("should handle creating a hyperdrive and printing a TOML snipped", async () => {
+		const reqProm = mockHyperdriveCreate();
+		writeWranglerConfig();
+		await runWrangler(
+			"hyperdrive create test123 --connection-string='postgresql://test:password@example.com:12345/neondb'"
+		);
+
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			Object {
+			  "name": "test123",
+			  "origin": Object {
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "password",
+			    "port": 12345,
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
+
+		expect(std.out).toMatchInlineSnapshot(`
+			"🚧 Creating 'test123'
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your wrangler.toml file:
+
+			[[hyperdrive]]
 			binding = \\"HYPERDRIVE\\"
 			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
 			"
@@ -146,11 +186,17 @@ describe("hyperdrive commands", () => {
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
-			binding = \\"HYPERDRIVE\\"
-			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
-			"
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
 		`);
 	});
 
@@ -179,11 +225,17 @@ describe("hyperdrive commands", () => {
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
-			binding = \\"HYPERDRIVE\\"
-			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
-			"
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
 		`);
 	});
 
@@ -208,11 +260,17 @@ describe("hyperdrive commands", () => {
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
-			binding = \\"HYPERDRIVE\\"
-			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
-			"
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
 		`);
 	});
 
@@ -237,11 +295,17 @@ describe("hyperdrive commands", () => {
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
-			binding = \\"HYPERDRIVE\\"
-			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
-			"
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
 		`);
 	});
 
@@ -266,11 +330,17 @@ describe("hyperdrive commands", () => {
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
-			binding = \\"HYPERDRIVE\\"
-			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
-			"
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
 		`);
 	});
 
@@ -295,11 +365,17 @@ describe("hyperdrive commands", () => {
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
-			binding = \\"HYPERDRIVE\\"
-			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
-			"
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
 		`);
 	});
 
@@ -324,11 +400,17 @@ describe("hyperdrive commands", () => {
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
-			binding = \\"HYPERDRIVE\\"
-			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
-			"
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
 		`);
 	});
 
@@ -379,11 +461,17 @@ describe("hyperdrive commands", () => {
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
-			binding = \\"HYPERDRIVE\\"
-			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
-			"
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
 		`);
 	});
 
@@ -408,11 +496,17 @@ describe("hyperdrive commands", () => {
 		`);
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
-			✅ Created new Hyperdrive config
-			 [[hyperdrive]]
-			binding = \\"HYPERDRIVE\\"
-			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
-			"
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
 		`);
 	});
 

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -118,17 +118,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 12345,
-			    \\"database\\": \\"neondb\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"test\\"
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 
@@ -154,17 +147,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"test\\"
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 
@@ -194,21 +180,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 12345,
-			    \\"database\\": \\"neondb\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"test\\"
-			  },
-			  \\"caching\\": {
-			    \\"max_age\\": 30,
-			    \\"stale_while_revalidate\\": 15
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 
@@ -234,17 +209,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"user:name\\"
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 
@@ -270,17 +238,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"test\\"
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 
@@ -306,17 +267,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"/\\"weird/\\" dbname\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"test\\"
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 
@@ -342,17 +296,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 5432,
-			    \\"database\\": \\"neondb\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"test\\"
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 
@@ -378,17 +325,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"port\\": 1234,
-			    \\"database\\": \\"neondb\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"test\\"
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 
@@ -440,17 +380,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com\\",
-			    \\"database\\": \\"neondb\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"test\\",
-			    \\"access_client_id\\": \\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access\\"
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 
@@ -476,17 +409,10 @@ describe("hyperdrive commands", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"🚧 Creating 'test123'
 			✅ Created new Hyperdrive config
-			 {
-			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
-			  \\"name\\": \\"test123\\",
-			  \\"origin\\": {
-			    \\"host\\": \\"example.com/database\\",
-			    \\"database\\": \\"neondb\\",
-			    \\"scheme\\": \\"postgresql\\",
-			    \\"user\\": \\"test\\",
-			    \\"access_client_id\\": \\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.access\\"
-			  }
-			}"
+			 [[hyperdrive]]
+			binding = \\"HYPERDRIVE\\"
+			id = \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			"
 		`);
 	});
 

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -1,5 +1,4 @@
-import TOML from "@iarna/toml";
-import { readConfig } from "../config";
+import { configFileName, formatConfigSnippet, readConfig } from "../config";
 import { logger } from "../logger";
 import { createConfig } from "./client";
 import { getCacheOptionsFromArgs, getOriginFromArgs, upsertOptions } from ".";
@@ -34,12 +33,16 @@ export async function handler(
 		origin,
 		caching: getCacheOptionsFromArgs(args),
 	});
+	logger.log(`✅ Created new Hyperdrive config: ${database.id}`);
 	logger.log(
-		`✅ Created new Hyperdrive config\n`,
-		TOML.stringify({
-			hyperdrive: [
-				{binding: "HYPERDRIVE", id: database.id}
-			]
-		})
+		`📋 To start using your config from a Worker, add the following binding configuration to your ${configFileName(config.configPath)} file:\n`
+	);
+	logger.log(
+		formatConfigSnippet(
+			{
+				hyperdrive: [{ binding: "HYPERDRIVE", id: database.id }],
+			},
+			config.configPath
+		)
 	);
 }

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -1,3 +1,4 @@
+import TOML from "@iarna/toml";
 import { readConfig } from "../config";
 import { logger } from "../logger";
 import { createConfig } from "./client";
@@ -35,6 +36,10 @@ export async function handler(
 	});
 	logger.log(
 		`✅ Created new Hyperdrive config\n`,
-		JSON.stringify(database, null, 2)
+		TOML.stringify({
+			hyperdrive: [
+				{binding: "HYPERDRIVE", id: database.id}
+			]
+		})
 	);
 }


### PR DESCRIPTION
Fixes #[SQC-348].

This change gives wrangler users a quality of life improvement when creating a Hyperdrive config, giving them a copyable snippet to paste in their `wrangler.toml` file to bind their new Hyperdrive Config to their Worker.

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Does not change logic around creating or updating Hyperdrive configs, only printing the results.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Does not change the API surface for the Hyperdrive command.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
