### PR TITLE
Added Oceania (oc) location hint as acceptable choice when creating an R2 bucket.

### DIFF
--- a/.changeset/famous-dragons-retire.md
+++ b/.changeset/famous-dragons-retire.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Added Oceania (oc) location hint as acceptable choice when creating an R2 bucket.

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -247,7 +247,7 @@ describe("r2", () => {
 					  -v, --version  Show version number  [boolean]
 
 					OPTIONS
-					      --location       The optional location hint that determines geographic placement of the R2 bucket  [string] [choices: \\"weur\\", \\"eeur\\", \\"apac\\", \\"wnam\\", \\"enam\\"]
+					      --location       The optional location hint that determines geographic placement of the R2 bucket  [string] [choices: \\"weur\\", \\"eeur\\", \\"apac\\", \\"wnam\\", \\"enam\\", \\"oc\\"]
 					  -s, --storage-class  The default storage class for objects uploaded to this bucket  [string]
 					  -J, --jurisdiction   The jurisdiction where the new bucket will be created  [string]"
 				`);
@@ -280,7 +280,7 @@ describe("r2", () => {
 					  -v, --version  Show version number  [boolean]
 
 					OPTIONS
-					      --location       The optional location hint that determines geographic placement of the R2 bucket  [string] [choices: \\"weur\\", \\"eeur\\", \\"apac\\", \\"wnam\\", \\"enam\\"]
+					      --location       The optional location hint that determines geographic placement of the R2 bucket  [string] [choices: \\"weur\\", \\"eeur\\", \\"apac\\", \\"wnam\\", \\"enam\\", \\"oc\\"]
 					  -s, --storage-class  The default storage class for objects uploaded to this bucket  [string]
 					  -J, --jurisdiction   The jurisdiction where the new bucket will be created  [string]"
 				`);

--- a/packages/wrangler/src/r2/constants.ts
+++ b/packages/wrangler/src/r2/constants.ts
@@ -2,4 +2,4 @@
  * The maximum file size we can upload using the V4 API.
  */
 export const MAX_UPLOAD_SIZE = 300 * 1024 * 1024;
-export const LOCATION_CHOICES = ["weur", "eeur", "apac", "wnam", "enam"];
+export const LOCATION_CHOICES = ["weur", "eeur", "apac", "wnam", "enam", "oc"];


### PR DESCRIPTION
Added Oceania (oc) location hint as acceptable choice when creating an R2 bucket.

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: test changes covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18308
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
