### PR TITLE
chore: restrict changeset version bump to workspace protocol only

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,7 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
+	"bumpVersionsWithWorkspaceProtocolOnly": true,
 	"ignore": [],
 	"privatePackages": {
 		"tag": true,


### PR DESCRIPTION
Fixes #7331

In #7331, we replaced the `latest` tag with a caret version range to avoid an issue on changeset which fails to resolve the latest tag version for comparsion. However, it doesn't solve the issue completely as changeset attempts to bump the version in the CI regardless and fails updating the pnpm lockfile with the following error meesage:

```sh
 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @cloudflare/vitest-pool-workers@^0.5.32

This error happened while installing a direct dependency of /Users/edmund/Workspace/workers-sdk/packages/workers-shared

The latest release of @cloudflare/vitest-pool-workers is "0.5.31".

If you need the full list of all 97 published versions run "$ pnpm view @cloudflare/vitest-pool-workers versions".
Progress: resolved 231, reused 0, downloaded 0
node:child_process:965
    throw err;
    ^

Error: Command failed: pnpm install --lockfile-only
```

This PR resolves the issue by restricting changesets to only bump package versions specified with the workspace protocol. (https://github.com/changesets/changesets/pull/507).

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ci fix
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: ci fix
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
