### PR TITLE
Remove `node_compat` in Wrangler & Miniflare v4

### DIFF
--- a/.changeset/node-compat-v4.md
+++ b/.changeset/node-compat-v4.md
@@ -1,0 +1,7 @@
+---
+"wrangler": major
+---
+
+The `--node-compat` flag and `node_compat` config properties are no longer supported as of Wrangler v4. Instead, use the `nodejs_compat` compatibility flag. This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.
+
+If you need to replicate the behaviour of the legacy `node_compat` feature, refer to https://developers.cloudflare.com/workers/wrangler/migration/update-v3-to-v4/ for a detailed guide.

--- a/.changeset/node-compat-v4.md
+++ b/.changeset/node-compat-v4.md
@@ -1,5 +1,6 @@
 ---
 "wrangler": major
+"miniflare": major
 ---
 
 The `--node-compat` flag and `node_compat` config properties are no longer supported as of Wrangler v4. Instead, use the `nodejs_compat` compatibility flag. This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.

--- a/fixtures/node-app-pages/tests/index.test.ts
+++ b/fixtures/node-app-pages/tests/index.test.ts
@@ -4,13 +4,18 @@ import { describe, it } from "vitest";
 import { runWranglerPagesDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("Pages Dev", () => {
-	it("should work with `--node-compat` when running code requiring polyfills", async ({
+	it("should work with `nodejs_compat` when running code requiring polyfills", async ({
 		expect,
 	}) => {
 		const { ip, port, stop } = await runWranglerPagesDev(
 			resolve(__dirname, ".."),
 			"public",
-			["--node-compat", "--port=0", "--inspector-port=0"]
+			[
+				"--port=0",
+				"--inspector-port=0",
+				"--compatibility-flags=nodejs_compat",
+				"--compatibility-date=2024-11-01",
+			]
 		);
 		try {
 			const response = await fetch(`http://${ip}:${port}/stripe`);

--- a/packages/miniflare/src/plugins/core/node-compat.ts
+++ b/packages/miniflare/src/plugins/core/node-compat.ts
@@ -1,34 +1,27 @@
 /**
  * We can provide Node.js compatibility in a number of different modes:
- * - "legacy" - this mode adds compile-time polyfills that are not well maintained and cannot work with workerd runtime builtins.
  * - "als": this mode tells the workerd runtime to enable only the Async Local Storage builtin library (accessible via `node:async_hooks`).
  * - "v1" - this mode tells the workerd runtime to enable some Node.js builtin libraries (accessible only via `node:...` imports) but no globals.
  * - "v2" - this mode tells the workerd runtime to enable more Node.js builtin libraries (accessible both with and without the `node:` prefix)
  *   and also some Node.js globals such as `Buffer`; it also turns on additional compile-time polyfills for those that are not provided by the runtime.
  *  - null - no Node.js compatibility.
  */
-export type NodeJSCompatMode = "legacy" | "als" | "v1" | "v2" | null;
+export type NodeJSCompatMode = "als" | "v1" | "v2" | null;
 
 /**
  * Computes the Node.js compatibility mode we are running.
  *
  * NOTES:
  * - The v2 mode is configured via `nodejs_compat_v2` compat flag or via `nodejs_compat` plus a compatibility date of Sept 23rd. 2024 or later.
- * - See `EnvironmentInheritable` for `nodeCompat` and `noBundle`.
  *
  * @param compatibilityDateStr The compatibility date
  * @param compatibilityFlags The compatibility flags
- * @param opts.nodeCompat Whether the legacy node_compat arg is being used
  * @returns the mode and flags to indicate specific configuration for validating.
  */
 export function getNodeCompat(
 	compatibilityDate: string = "2000-01-01", // Default to some arbitrary old date
-	compatibilityFlags: string[],
-	opts?: {
-		nodeCompat?: boolean;
-	}
+	compatibilityFlags: string[]
 ) {
-	const { nodeCompat = false } = opts ?? {};
 	const {
 		hasNodejsAlsFlag,
 		hasNodejsCompatFlag,
@@ -38,7 +31,6 @@ export function getNodeCompat(
 	} = parseNodeCompatibilityFlags(compatibilityFlags);
 
 	const nodeCompatSwitchOverDate = "2024-09-23";
-	const legacy = nodeCompat === true;
 	let mode: NodeJSCompatMode = null;
 	if (
 		hasNodejsCompatV2Flag ||
@@ -51,8 +43,6 @@ export function getNodeCompat(
 		mode = "v1";
 	} else if (hasNodejsAlsFlag) {
 		mode = "als";
-	} else if (legacy) {
-		mode = "legacy";
 	}
 
 	return {

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -22,14 +22,14 @@ import { retry } from "./helpers/retry";
  */
 const workerName = generateResourceName();
 
-it("can import URL from 'url' in node_compat mode", async () => {
+it("can import URL from 'url' in nodejs_compat mode", async () => {
 	const helper = new WranglerE2ETestHelper();
 	await helper.seed({
 		"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2023-01-01"
-				node_compat = true
+				compatibility_flags = ["nodejs_compat"]
 		`,
 		"src/index.ts": dedent`
 				const { URL } = require('url');

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -28,7 +28,7 @@ it("can import URL from 'url' in nodejs_compat mode", async () => {
 		"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
-				compatibility_date = "2023-01-01"
+				compatibility_date = "2024-11-11"
 				compatibility_flags = ["nodejs_compat"]
 		`,
 		"src/index.ts": dedent`

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -71,8 +71,6 @@
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "workspace:*",
 		"@cloudflare/workers-shared": "workspace:*",
-		"@esbuild-plugins/node-globals-polyfill": "^0.2.3",
-		"@esbuild-plugins/node-modules-polyfill": "^0.2.2",
 		"blake3-wasm": "^2.1.5",
 		"chokidar": "^4.0.1",
 		"date-fns": "^4.1.0",

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -12,8 +12,6 @@ export const EXTERNAL_DEPENDENCIES = [
 	// todo - bundle miniflare too
 	"selfsigned",
 	"source-map",
-	"@esbuild-plugins/node-globals-polyfill",
-	"@esbuild-plugins/node-modules-polyfill",
 	"chokidar",
 	// @cloudflare/workers-types is an optional peer dependency of wrangler, so users can
 	// get the types by installing the package (to what version they prefer) themselves

--- a/packages/wrangler/src/__tests__/config-validation-pages.test.ts
+++ b/packages/wrangler/src/__tests__/config-validation-pages.test.ts
@@ -232,7 +232,6 @@ describe("validatePagesConfig()", () => {
 					build: {
 						command: "npm run build",
 					},
-					node_compat: true,
 				},
 			};
 			diagnostics = validatePagesConfig(
@@ -243,12 +242,11 @@ describe("validatePagesConfig()", () => {
 			expect(diagnostics.hasWarnings()).toBeFalsy();
 			expect(diagnostics.hasErrors()).toBeTruthy();
 			expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-			"Running configuration file validation for Pages:
-			  - Configuration file for Pages projects does not support \\"triggers\\"
-			  - Configuration file for Pages projects does not support \\"usage_model\\"
-			  - Configuration file for Pages projects does not support \\"build\\"
-			  - Configuration file for Pages projects does not support \\"node_compat\\""
-		`);
+				"Running configuration file validation for Pages:
+				  - Configuration file for Pages projects does not support \\"triggers\\"
+				  - Configuration file for Pages projects does not support \\"usage_model\\"
+				  - Configuration file for Pages projects does not support \\"build\\""
+			`);
 
 			// test with non-inheritable environment config fields
 			// (incl. `queues.consumers`)

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -123,7 +123,6 @@ describe("normalizeAndValidateConfig()", () => {
 			zone_id: undefined,
 			no_bundle: undefined,
 			minify: undefined,
-			node_compat: undefined,
 			first_party_worker: undefined,
 			keep_vars: undefined,
 			logpush: undefined,
@@ -1002,7 +1001,6 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: true,
 				minify: true,
-				node_compat: true,
 				first_party_worker: true,
 				logpush: true,
 				upload_source_maps: true,
@@ -1086,7 +1084,6 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: "INVALID",
 				minify: "INVALID",
-				node_compat: "INVALID",
 				first_party_worker: "INVALID",
 				logpush: "INVALID",
 				upload_source_maps: "INVALID",
@@ -1164,7 +1161,6 @@ describe("normalizeAndValidateConfig()", () => {
 				  - The field \\"define.DEF1\\" should be a string but got 1777.
 				  - Expected \\"no_bundle\\" to be of type boolean but got \\"INVALID\\".
 				  - Expected \\"minify\\" to be of type boolean but got \\"INVALID\\".
-				  - Expected \\"node_compat\\" to be of type boolean but got \\"INVALID\\".
 				  - Expected \\"first_party_worker\\" to be of type boolean but got \\"INVALID\\".
 				  - Expected \\"logpush\\" to be of type boolean but got \\"INVALID\\".
 				  - Expected \\"upload_source_maps\\" to be of type boolean but got \\"INVALID\\".
@@ -3783,7 +3779,6 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: true,
 				minify: true,
-				node_compat: true,
 				first_party_worker: true,
 				logpush: true,
 				upload_source_maps: true,
@@ -3833,7 +3828,6 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: false,
 				minify: false,
-				node_compat: false,
 				first_party_worker: false,
 				logpush: false,
 				upload_source_maps: false,
@@ -3861,7 +3855,6 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: true,
 				minify: true,
-				node_compat: true,
 				first_party_worker: true,
 				logpush: true,
 				upload_source_maps: true,
@@ -4116,6 +4109,23 @@ describe("normalizeAndValidateConfig()", () => {
 			`);
 		});
 
+		it("should error on node_compat", () => {
+			const { diagnostics } = normalizeAndValidateConfig(
+				// @ts-expect-error node_compat has been removed
+				{ env: { ENV1: { node_compat: true } } },
+				undefined,
+				{ env: "ENV1" }
+			);
+			expect(diagnostics.hasErrors()).toBe(true);
+			expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
+				"Processing wrangler configuration:
+
+				  - \\"env.ENV1\\" environment configuration
+				    - [1mRemoved[0m: \\"node_compat\\":
+				      The \\"node_compat\\" field is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information."
+			`);
+		});
+
 		it("should error on invalid environment values", () => {
 			const expectedConfig: RawEnvironment = {
 				name: 111,
@@ -4138,7 +4148,6 @@ describe("normalizeAndValidateConfig()", () => {
 				},
 				no_bundle: "INVALID",
 				minify: "INVALID",
-				node_compat: "INVALID",
 				first_party_worker: "INVALID",
 				logpush: "INVALID",
 				upload_source_maps: "INVALID",
@@ -4177,7 +4186,6 @@ describe("normalizeAndValidateConfig()", () => {
 			    - Expected \\"usage_model\\" field to be one of [\\"bundled\\",\\"unbound\\"] but got \\"INVALID\\".
 			    - Expected \\"no_bundle\\" to be of type boolean but got \\"INVALID\\".
 			    - Expected \\"minify\\" to be of type boolean but got \\"INVALID\\".
-			    - Expected \\"node_compat\\" to be of type boolean but got \\"INVALID\\".
 			    - Expected \\"first_party_worker\\" to be of type boolean but got \\"INVALID\\".
 			    - Expected \\"logpush\\" to be of type boolean but got \\"INVALID\\".
 			    - Expected \\"upload_source_maps\\" to be of type boolean but got \\"INVALID\\"."

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -9654,22 +9654,14 @@ export default{
 	});
 
 	describe("--node-compat", () => {
-		it("should warn when using node compatibility mode", async () => {
+		it("should error when using node compatibility mode", async () => {
 			writeWranglerConfig();
 			writeWorkerSource();
-			await runWrangler("deploy index.js --node-compat --dry-run");
-			expect(std).toMatchInlineSnapshot(`
-				Object {
-				  "debug": "",
-				  "err": "",
-				  "info": "",
-				  "out": "Total Upload: xx KiB / gzip: xx KiB
-				--dry-run: exiting now.",
-				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are using \`node_compat\`, which is a legacy Node.js compatibility option. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.[0m
-
-				",
-				}
-			`);
+			await expect(
+				runWrangler("deploy index.js --node-compat --dry-run")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[Error: The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.]`
+			);
 		});
 
 		it("should recommend node compatibility flag when using node builtins and no node compat is enabled", async () => {
@@ -9721,33 +9713,6 @@ export default{
 
 				  The package \\"path\\" wasn't found on the file system but is built into node.
 				  - Add the \\"nodejs_compat\\" compatibility flag to your project."
-			`);
-		});
-
-		it("should recommend node compatibility flag when using node builtins and `node_compat` is true", async () => {
-			writeWranglerConfig({
-				node_compat: true,
-			});
-			fs.writeFileSync("index.js", "import fs from 'diagnostics_channel';");
-
-			await expect(
-				runWrangler("deploy index.js --dry-run").catch((e) =>
-					normalizeString(
-						esbuild
-							.formatMessagesSync(e?.errors ?? [], { kind: "error" })
-							.join()
-							.trim()
-					)
-				)
-			).resolves.toMatchInlineSnapshot(`
-				"X [ERROR] Could not resolve \\"diagnostics_channel\\"
-
-				    index.js:1:15:
-				      1 │ import fs from 'diagnostics_channel';
-				        ╵                ~~~~~~~~~~~~~~~~~~~~~
-
-				  The package \\"diagnostics_channel\\" wasn't found on the file system but is built into node.
-				  - Try removing the legacy \\"node_compat\\" setting and add the \\"nodejs_compat\\" compatibility flag in your project"
 			`);
 		});
 
@@ -9804,31 +9769,6 @@ export default{
 
 				  The package \\"path\\" wasn't found on the file system but is built into node.
 				  - Make sure to prefix the module name with \\"node:\\" or update your compatibility_date to 2024-09-23 or later."
-			`);
-		});
-
-		it("should polyfill node builtins when enabled", async () => {
-			writeWranglerConfig();
-			fs.writeFileSync(
-				"index.js",
-				`
-      import path from 'path';
-      console.log(path.join("some/path/to", "a/file.txt"));
-      export default {}
-      `
-			);
-			await runWrangler("deploy index.js --node-compat --dry-run"); // this would throw if node compatibility didn't exist
-			expect(std).toMatchInlineSnapshot(`
-				Object {
-				  "debug": "",
-				  "err": "",
-				  "info": "",
-				  "out": "Total Upload: xx KiB / gzip: xx KiB
-				--dry-run: exiting now.",
-				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are using \`node_compat\`, which is a legacy Node.js compatibility option. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.[0m
-
-				",
-				}
 			`);
 		});
 	});
@@ -9917,26 +9857,6 @@ export default{
 		`);
 			expect(fs.readFileSync("dist/index.js", { encoding: "utf-8" })).toContain(
 				`import path from "path";`
-			);
-		});
-
-		it("should conflict with the --node-compat option", async () => {
-			writeWranglerConfig();
-			fs.writeFileSync(
-				"index.js",
-				`
-      import AsyncHooks from 'node:async_hooks';
-      console.log(AsyncHooks);
-      export default {}
-      `
-			);
-
-			await expect(
-				runWrangler(
-					"deploy index.js --dry-run --outdir=dist --compatibility-flag=nodejs_compat --node-compat"
-				)
-			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: The \`nodejs_compat\` compatibility flag cannot be used in conjunction with the legacy \`--node-compat\` flag. If you want to use the Workers \`nodejs_compat\` compatibility flag, please remove the \`--node-compat\` argument from your CLI command or \`node_compat = true\` from your config file.]`
 			);
 		});
 	});
@@ -10333,47 +10253,6 @@ export default{
 
 			"
 		`);
-		});
-	});
-
-	describe("--no-bundle --node-compat", () => {
-		it("should warn that no-bundle and node-compat can't be used together", async () => {
-			writeWranglerConfig();
-			const scriptContent = `
-			const xyz = 123; // a statement that would otherwise be compiled out
-		`;
-			fs.writeFileSync("index.js", scriptContent);
-			await runWrangler(
-				"deploy index.js --no-bundle --node-compat --dry-run --outdir dist"
-			);
-			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--node-compat\` and \`--no-bundle\` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process.[0m
-
-
-				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are using \`node_compat\`, which is a legacy Node.js compatibility option. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.[0m
-
-				"
-			`);
-		});
-
-		it("should warn that no-bundle and node-compat can't be used together", async () => {
-			writeWranglerConfig({
-				no_bundle: true,
-				node_compat: true,
-			});
-			const scriptContent = `
-			const xyz = 123; // a statement that would otherwise be compiled out
-		`;
-			fs.writeFileSync("index.js", scriptContent);
-			await runWrangler("deploy index.js --dry-run --outdir dist");
-			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1m\`--node-compat\` and \`--no-bundle\` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process.[0m
-
-
-				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mYou are using \`node_compat\`, which is a legacy Node.js compatibility option. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.[0m
-
-				"
-			`);
 		});
 	});
 

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1412,7 +1412,6 @@ describe.sequential("wrangler dev", () => {
 				      --tsconfig                                   Path to a custom tsconfig.json file  [string]
 				  -r, --remote                                     Run on the global Cloudflare network with access to production resources  [boolean] [default: false]
 				      --minify                                     Minify the script  [boolean]
-				      --node-compat                                Enable Node.js compatibility  [boolean]
 				      --persist-to                                 Specify directory to use for local persistence (defaults to .wrangler/state)  [string]
 				      --live-reload                                Auto reload HTML pages when change is detected in local mode  [boolean]
 				      --test-scheduled                             Test scheduled events by visiting /__scheduled in browser  [boolean] [default: false]
@@ -1860,21 +1859,6 @@ describe.sequential("wrangler dev", () => {
 				  - SECRET: \\"(hidden)\\"
 				"
 			`);
-		});
-	});
-
-	describe("`nodejs_compat` compatibility flag", () => {
-		it("should conflict with the --node-compat option", async () => {
-			writeWranglerConfig();
-			fs.writeFileSync("index.js", `export default {};`);
-
-			await expect(
-				runWrangler(
-					"dev index.js --compatibility-flag=nodejs_compat --node-compat"
-				)
-			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: The \`nodejs_compat\` compatibility flag cannot be used in conjunction with the legacy \`--node-compat\` flag. If you want to use the Workers \`nodejs_compat\` compatibility flag, please remove the \`--node-compat\` argument from your CLI command or \`node_compat = true\` from your config file.]`
-			);
 		});
 	});
 

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -26,7 +26,6 @@ export interface UnstableDevOptions {
 	site?: string; // Root folder of static assets for Workers Sites
 	siteInclude?: string[]; // Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.
 	siteExclude?: string[]; // Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.
-	nodeCompat?: boolean; // Enable Node.js compatibility
 	compatibilityDate?: string; // Date to use for compatibility checks
 	compatibilityFlags?: string[]; // Flags to use for compatibility checks
 	persist?: boolean; // Enable persistence for local mode, using default path: .wrangler/state
@@ -170,6 +169,7 @@ export async function unstable_dev(
 		enablePagesAssetsServiceBinding,
 		forceLocal,
 		liveReload,
+		nodeCompat: undefined,
 		showInteractiveDevSession,
 		onReady: (address, port) => {
 			readyResolve({ address, port });
@@ -192,7 +192,6 @@ export async function unstable_dev(
 		site: options?.site, // Root folder of static assets for Workers Sites
 		siteInclude: options?.siteInclude, // Array of .gitignore-style patterns that match file or directory names from the sites directory. Only matched items will be uploaded.
 		siteExclude: options?.siteExclude, // Array of .gitignore-style patterns that match file or directory names from the sites directory. Matched items will not be uploaded.
-		nodeCompat: options?.nodeCompat, // Enable Node.js compatibility
 		persist: options?.persist, // Enable persistence for local mode, using default path: .wrangler/state
 		persistTo: options?.persistTo, // Specify directory to use for local persistence (implies --persist)
 		name: undefined,

--- a/packages/wrangler/src/api/pages/deploy.ts
+++ b/packages/wrangler/src/api/pages/deploy.ts
@@ -175,7 +175,6 @@ export async function deploy({
 		config?.compatibility_date ?? deploymentConfig.compatibility_date,
 		config?.compatibility_flags ?? deploymentConfig.compatibility_flags ?? [],
 		{
-			nodeCompat: false,
 			noBundle: config?.no_bundle,
 		}
 	);

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -369,7 +369,6 @@ export const defaultWranglerConfig: Config = {
 	build: { command: undefined, watch_dir: "./src", cwd: undefined },
 	no_bundle: undefined,
 	minify: undefined,
-	node_compat: undefined,
 	dispatch_namespaces: [],
 	first_party_worker: undefined,
 	zone_id: undefined,

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -282,12 +282,6 @@ interface EnvironmentInheritable {
 	minify: boolean | undefined;
 
 	/**
-	 * Add polyfills for node builtin modules and globals
-	 * @inheritable
-	 */
-	node_compat: boolean | undefined;
-
-	/**
 	 * Designates this Worker as an internal-only "first-party" Worker.
 	 *
 	 * @inheritable

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -1086,6 +1086,17 @@ function normalizeAndValidateEnvironment(
 		false // We need to leave this in-place for the moment since `route` commands might use it.
 	);
 
+	deprecated(
+		diagnostics,
+		rawEnv,
+		// @ts-expect-error Removed from the config type
+		"node_compat",
+		`The "node_compat" field is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.`,
+		true,
+		"Removed",
+		"error"
+	);
+
 	// The field "experimental_services" doesn't exist anymore in the config, but we still want to error about any older usage.
 
 	deprecated(
@@ -1512,14 +1523,6 @@ function normalizeAndValidateEnvironment(
 			topLevelEnv,
 			rawEnv,
 			"minify",
-			isBoolean,
-			undefined
-		),
-		node_compat: inheritable(
-			diagnostics,
-			topLevelEnv,
-			rawEnv,
-			"node_compat",
 			isBoolean,
 			undefined
 		),

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -95,7 +95,6 @@ type Props = {
 	tsconfig: string | undefined;
 	isWorkersSite: boolean;
 	minify: boolean | undefined;
-	nodeCompat: boolean | undefined;
 	outDir: string | undefined;
 	dryRun: boolean | undefined;
 	noBundle: boolean | undefined;
@@ -449,7 +448,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		compatibilityDate,
 		compatibilityFlags,
 		{
-			nodeCompat: props.nodeCompat ?? config.node_compat,
 			noBundle: props.noBundle ?? config.no_bundle,
 		}
 	);

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -193,6 +193,8 @@ export function deployOptions(yargs: CommonYargsArgv) {
 			.option("node-compat", {
 				describe: "Enable Node.js compatibility",
 				type: "boolean",
+				hidden: true,
+				deprecated: true,
 			})
 			.option("dry-run", {
 				describe: "Don't actually deploy",
@@ -240,6 +242,12 @@ export async function deployHandler(args: DeployArgs) {
 	if (args._[0] === "publish") {
 		logger.warn(
 			"`wrangler publish` is deprecated and will be removed in the next major version.\nPlease use `wrangler deploy` instead, which accepts exactly the same arguments."
+		);
+	}
+
+	if (args.nodeCompat) {
+		throw new UserError(
+			`The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.`
 		);
 	}
 
@@ -356,7 +364,6 @@ export async function deployHandler(args: DeployArgs) {
 		legacyAssetPaths,
 		legacyEnv: isLegacyEnv(config),
 		minify: args.minify,
-		nodeCompat: args.nodeCompat,
 		isWorkersSite: Boolean(args.site || config.site),
 		outDir: args.outdir,
 		dryRun: args.dryRun,

--- a/packages/wrangler/src/deployment-bundle/build-failures.ts
+++ b/packages/wrangler/src/deployment-bundle/build-failures.ts
@@ -29,8 +29,6 @@ export function rewriteNodeCompatBuildFailure(
 
 			if (compatMode === null || compatMode === "als") {
 				text += `- Add the "nodejs_compat" compatibility flag to your project.\n`;
-			} else if (compatMode === "legacy") {
-				text += `- Try removing the legacy "node_compat" setting and add the "nodejs_compat" compatibility flag in your project\n`;
 			} else if (compatMode === "v1" && !match[1].startsWith("node:")) {
 				text += `- Make sure to prefix the module name with "node:" or update your compatibility_date to 2024-09-23 or later.\n`;
 			}

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -1,7 +1,5 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import NodeGlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill";
-import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill";
 import * as esbuild from "esbuild";
 import {
 	getBuildConditionsFromEnv,
@@ -21,7 +19,6 @@ import { cloudflareInternalPlugin } from "./esbuild-plugins/cloudflare-internal"
 import { configProviderPlugin } from "./esbuild-plugins/config-provider";
 import { nodejsHybridPlugin } from "./esbuild-plugins/hybrid-nodejs-compat";
 import { nodejsCompatPlugin } from "./esbuild-plugins/nodejs-compat";
-import { standardURLPlugin } from "./esbuild-plugins/standard-url";
 import { writeAdditionalModules } from "./find-additional-modules";
 import { noopModuleCollector } from "./module-collection";
 import type { Config } from "../config";
@@ -418,7 +415,6 @@ export async function bundleWorker(
 				// use process.env["NODE_ENV" + ""] so that esbuild doesn't replace it
 				// when we do a build of wrangler. (re: https://github.com/cloudflare/workers-sdk/issues/1477)
 				"process.env.NODE_ENV": `"${process.env["NODE_ENV" + ""]}"`,
-				...(nodejsCompatMode === "legacy" ? { global: "globalThis" } : {}),
 				...define,
 			},
 		}),
@@ -427,13 +423,6 @@ export async function bundleWorker(
 			aliasPlugin,
 			moduleCollector.plugin,
 			...(nodejsCompatMode === "als" ? [asyncLocalStoragePlugin] : []),
-			...(nodejsCompatMode === "legacy"
-				? [
-						NodeGlobalsPolyfills({ buffer: true }),
-						standardURLPlugin(),
-						NodeModulesPolyfills(),
-					]
-				: []),
 			// Runtime Node.js compatibility (will warn if not using nodejs compat flag and are trying to import from a Node.js builtin).
 			...(nodejsCompatMode === "v1" || nodejsCompatMode !== "v2"
 				? [nodejsCompatPlugin(nodejsCompatMode === "v1")]

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/log-build-output.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/log-build-output.ts
@@ -30,9 +30,7 @@ export function logBuildOutput(
 					}
 				} else {
 					if (errors.length > 0) {
-						if (nodejsCompatMode !== "legacy") {
-							rewriteNodeCompatBuildFailure(errors, nodejsCompatMode);
-						}
+						rewriteNodeCompatBuildFailure(errors, nodejsCompatMode);
 						logBuildFailure(errors, warnings);
 						return;
 					}

--- a/packages/wrangler/src/deployment-bundle/node-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/node-compat.ts
@@ -8,33 +8,27 @@ import type { NodeJSCompatMode } from "miniflare";
  *
  * NOTES:
  * - The v2 mode is configured via `nodejs_compat_v2` compat flag or via `nodejs_compat` plus a compatibility date of Sept 23rd. 2024 or later.
- * - See `EnvironmentInheritable` for `nodeCompat` and `noBundle`.
+ * - See `EnvironmentInheritable` for `noBundle`.
  *
  * @param compatibilityDateStr The compatibility date
  * @param compatibilityFlags The compatibility flags
- * @param nodeCompat Whether to add polyfills for node builtin modules and globals
  * @param noBundle Whether to skip internal build steps and directly deploy script
  *
  */ export function validateNodeCompatMode(
 	compatibilityDateStr: string = "2000-01-01", // Default to some arbitrary old date
 	compatibilityFlags: string[],
 	{
-		nodeCompat: legacy = false,
 		noBundle = undefined,
 	}: {
-		nodeCompat?: boolean;
 		noBundle?: boolean;
 	}
 ): NodeJSCompatMode {
 	const {
 		mode,
-		hasNodejsAlsFlag,
 		hasNodejsCompatFlag,
 		hasNodejsCompatV2Flag,
 		hasExperimentalNodejsCompatV2Flag,
-	} = getNodeCompat(compatibilityDateStr, compatibilityFlags, {
-		nodeCompat: legacy,
-	});
+	} = getNodeCompat(compatibilityDateStr, compatibilityFlags);
 
 	if (hasExperimentalNodejsCompatV2Flag) {
 		throw new UserError(
@@ -48,35 +42,9 @@ import type { NodeJSCompatMode } from "miniflare";
 		);
 	}
 
-	if (
-		legacy &&
-		(hasNodejsCompatFlag || hasNodejsCompatV2Flag || hasNodejsAlsFlag)
-	) {
-		const nodejsFlag = hasNodejsCompatFlag
-			? "`nodejs_compat`"
-			: hasNodejsCompatV2Flag
-				? "`nodejs_compat_v2`"
-				: "`nodejs_als`";
-		throw new UserError(
-			`The ${nodejsFlag} compatibility flag cannot be used in conjunction with the legacy \`--node-compat\` flag. If you want to use the Workers ${nodejsFlag} compatibility flag, please remove the \`--node-compat\` argument from your CLI command or \`node_compat = true\` from your config file.`
-		);
-	}
-
-	if (noBundle && legacy) {
-		logger.warn(
-			"`--node-compat` and `--no-bundle` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process."
-		);
-	}
-
 	if (noBundle && hasNodejsCompatV2Flag) {
 		logger.warn(
 			"`nodejs_compat_v2` compatibility flag and `--no-bundle` can't be used together. If you want to polyfill Node.js built-ins and disable Wrangler's bundling, please polyfill as part of your own bundling process."
-		);
-	}
-
-	if (mode === "legacy") {
-		logger.warn(
-			"You are using `node_compat`, which is a legacy Node.js compatibility option. Instead, use the `nodejs_compat` compatibility flag. This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information."
 		);
 	}
 

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -263,6 +263,8 @@ const command = defineCommand({
 		"node-compat": {
 			describe: "Enable Node.js compatibility",
 			type: "boolean",
+			hidden: true,
+			deprecated: true,
 		},
 		"experimental-enable-local-persistence": {
 			describe: "Enable persistence for local mode (deprecated, use --persist)",
@@ -328,6 +330,11 @@ const command = defineCommand({
 		},
 	},
 	async validateArgs(args) {
+		if (args.nodeCompat) {
+			throw new UserError(
+				`The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.`
+			);
+		}
 		if (args.liveReload && args.remote) {
 			throw new UserError(
 				"--live-reload is only supported in local mode. Please just use one of either --remote or --live-reload."
@@ -638,7 +645,6 @@ export async function startDev(args: StartDevOptions) {
 							args.compatibilityDate ?? parsedConfig.compatibility_date,
 							args.compatibilityFlags ?? parsedConfig.compatibility_flags ?? [],
 							{
-								nodeCompat: args.nodeCompat ?? parsedConfig.node_compat,
 								noBundle: args.noBundle ?? parsedConfig.no_bundle,
 							}
 						),

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -9,7 +9,7 @@ import { isBuildFailure } from "../deployment-bundle/build-failures";
 import { shouldCheckFetch } from "../deployment-bundle/bundle";
 import { esbuildAliasExternalPlugin } from "../deployment-bundle/esbuild-plugins/alias-external";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
-import { FatalError } from "../errors";
+import { FatalError, UserError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
@@ -216,6 +216,7 @@ export function Options(yargs: CommonYargsArgv) {
 				default: false,
 				type: "boolean",
 				hidden: true,
+				deprecated: true,
 			},
 			"experimental-local": {
 				describe: "Run on my machine using the Cloudflare Workers runtime",
@@ -268,6 +269,12 @@ export const Handler = async (args: PagesDevArguments) => {
 	}
 
 	await printWranglerBanner();
+
+	if (args.nodeCompat) {
+		throw new UserError(
+			`The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.`
+		);
+	}
 
 	if (args.experimentalDevEnv) {
 		logger.warn(
@@ -372,7 +379,6 @@ export const Handler = async (args: PagesDevArguments) => {
 		args.compatibilityDate ?? config.compatibility_date,
 		args.compatibilityFlags ?? config.compatibility_flags ?? [],
 		{
-			nodeCompat: args.nodeCompat,
 			noBundle: args.noBundle ?? config.no_bundle,
 		}
 	);
@@ -888,7 +894,6 @@ export const Handler = async (args: PagesDevArguments) => {
 		httpsCertPath: args.httpsCertPath,
 		compatibilityDate,
 		compatibilityFlags,
-		nodeCompat: nodejsCompatMode === "legacy",
 		vars,
 		kv: kv_namespaces,
 		durableObjects: do_bindings,

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -91,10 +91,7 @@ export async function typesHandler(
 		const tsconfigTypes = readTsconfigTypes(tsconfigPath);
 		const { mode } = getNodeCompat(
 			config.compatibility_date,
-			config.compatibility_flags,
-			{
-				nodeCompat: config.node_compat,
-			}
+			config.compatibility_flags
 		);
 
 		logRuntimeTypesMessage(

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -174,6 +174,8 @@ function versionsUploadOptions(yargs: CommonYargsArgv) {
 			.option("node-compat", {
 				describe: "Enable Node.js compatibility",
 				type: "boolean",
+				hidden: true,
+				deprecated: true,
 			})
 			.option("dry-run", {
 				describe: "Don't actually deploy",
@@ -214,7 +216,11 @@ async function versionsUploadHandler(
 			sendMetrics: config.send_metrics,
 		}
 	);
-
+	if (args.nodeCompat) {
+		throw new UserError(
+			`The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.`
+		);
+	}
 	if (args.site || config.site) {
 		throw new UserError(
 			"Workers Sites does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead."
@@ -296,7 +302,6 @@ async function versionsUploadHandler(
 		assetsOptions,
 		minify: args.minify,
 		uploadSourceMaps: args.uploadSourceMaps,
-		nodeCompat: args.nodeCompat,
 		isWorkersSite: Boolean(args.site || config.site),
 		outDir: args.outdir,
 		dryRun: args.dryRun,

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -64,7 +64,6 @@ type Props = {
 	isWorkersSite: boolean;
 	minify: boolean | undefined;
 	uploadSourceMaps: boolean | undefined;
-	nodeCompat: boolean | undefined;
 	outDir: string | undefined;
 	dryRun: boolean | undefined;
 	noBundle: boolean | undefined;
@@ -193,7 +192,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		props.compatibilityDate ?? config.compatibility_date,
 		props.compatibilityFlags ?? config.compatibility_flags,
 		{
-			nodeCompat: props.nodeCompat ?? config.node_compat,
 			noBundle: props.noBundle ?? config.no_bundle,
 		}
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1693,12 +1693,6 @@ importers:
       '@cloudflare/workers-shared':
         specifier: workspace:*
         version: link:../workers-shared
-      '@esbuild-plugins/node-globals-polyfill':
-        specifier: ^0.2.3
-        version: 0.2.3(esbuild@0.17.19)
-      '@esbuild-plugins/node-modules-polyfill':
-        specifier: ^0.2.2
-        version: 0.2.2(esbuild@0.17.19)
       blake3-wasm:
         specifier: ^2.1.5
         version: 2.1.5
@@ -2535,16 +2529,6 @@ packages:
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
-
-  '@esbuild-plugins/node-globals-polyfill@0.2.3':
-    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
-    peerDependencies:
-      esbuild: '*'
-
-  '@esbuild-plugins/node-modules-polyfill@0.2.2':
-    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
-    peerDependencies:
-      esbuild: '*'
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -5125,9 +5109,6 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
-  estree-walker@0.6.1:
-    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
-
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -6219,9 +6200,6 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
-
-  magic-string@0.25.9:
-    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
@@ -7327,16 +7305,6 @@ packages:
     resolution: {integrity: sha512-DKiMaEYHoOZ0JyD4Ohr5KRnqybQ162s3ZL/WNO9oy6EUszYvpp0eLYJErc/U4NI96HYnHsbROhFaH4LYuJPnDg==}
     engines: {node: '>=12.0'}
 
-  rollup-plugin-inject@3.0.2:
-    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
-
-  rollup-plugin-node-polyfills@0.2.1:
-    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
-
-  rollup-pluginutils@2.8.2:
-    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
-
   rollup@4.9.6:
     resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -7567,10 +7535,6 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-
-  sourcemap-codec@1.4.8:
-    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   spawn-command@0.0.2:
     resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
@@ -9359,16 +9323,6 @@ snapshots:
     dependencies:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.7.0
-
-  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
-    dependencies:
-      esbuild: 0.17.19
-
-  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19)':
-    dependencies:
-      esbuild: 0.17.19
-      escape-string-regexp: 4.0.0
-      rollup-plugin-node-polyfills: 0.2.1
 
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
@@ -12206,8 +12160,6 @@ snapshots:
 
   estraverse@5.3.0: {}
 
-  estree-walker@0.6.1: {}
-
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -13393,10 +13345,6 @@ snapshots:
 
   lz-string@1.5.0: {}
 
-  magic-string@0.25.9:
-    dependencies:
-      sourcemap-codec: 1.4.8
-
   magic-string@0.30.11:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -14527,20 +14475,6 @@ snapshots:
       globalthis: 1.0.3
       semver-compare: 1.0.0
 
-  rollup-plugin-inject@3.0.2:
-    dependencies:
-      estree-walker: 0.6.1
-      magic-string: 0.25.9
-      rollup-pluginutils: 2.8.2
-
-  rollup-plugin-node-polyfills@0.2.1:
-    dependencies:
-      rollup-plugin-inject: 3.0.2
-
-  rollup-pluginutils@2.8.2:
-    dependencies:
-      estree-walker: 0.6.1
-
   rollup@4.9.6:
     dependencies:
       '@types/estree': 1.0.5
@@ -14803,8 +14737,6 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
-
-  sourcemap-codec@1.4.8: {}
 
   spawn-command@0.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2530,6 +2530,16 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
+  '@esbuild-plugins/node-globals-polyfill@0.2.3':
+    resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
+    peerDependencies:
+      esbuild: '*'
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2':
+    resolution: {integrity: sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==}
+    peerDependencies:
+      esbuild: '*'
+
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
     engines: {node: '>=12'}
@@ -5109,6 +5119,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@0.6.1:
+    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -6200,6 +6213,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-string@0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
@@ -7305,6 +7321,16 @@ packages:
     resolution: {integrity: sha512-DKiMaEYHoOZ0JyD4Ohr5KRnqybQ162s3ZL/WNO9oy6EUszYvpp0eLYJErc/U4NI96HYnHsbROhFaH4LYuJPnDg==}
     engines: {node: '>=12.0'}
 
+  rollup-plugin-inject@3.0.2:
+    resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
+    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
+
+  rollup-plugin-node-polyfills@0.2.1:
+    resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
+
+  rollup-pluginutils@2.8.2:
+    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+
   rollup@4.9.6:
     resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -7535,6 +7561,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sourcemap-codec@1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   spawn-command@0.0.2:
     resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
@@ -9323,6 +9353,16 @@ snapshots:
     dependencies:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.7.0
+
+  '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
+    dependencies:
+      esbuild: 0.17.19
+
+  '@esbuild-plugins/node-modules-polyfill@0.2.2(esbuild@0.17.19)':
+    dependencies:
+      esbuild: 0.17.19
+      escape-string-regexp: 4.0.0
+      rollup-plugin-node-polyfills: 0.2.1
 
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
@@ -12160,6 +12200,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@0.6.1: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -13345,6 +13387,10 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  magic-string@0.25.9:
+    dependencies:
+      sourcemap-codec: 1.4.8
+
   magic-string@0.30.11:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -14475,6 +14521,20 @@ snapshots:
       globalthis: 1.0.3
       semver-compare: 1.0.0
 
+  rollup-plugin-inject@3.0.2:
+    dependencies:
+      estree-walker: 0.6.1
+      magic-string: 0.25.9
+      rollup-pluginutils: 2.8.2
+
+  rollup-plugin-node-polyfills@0.2.1:
+    dependencies:
+      rollup-plugin-inject: 3.0.2
+
+  rollup-pluginutils@2.8.2:
+    dependencies:
+      estree-walker: 0.6.1
+
   rollup@4.9.6:
     dependencies:
       '@types/estree': 1.0.5
@@ -14737,6 +14797,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  sourcemap-codec@1.4.8: {}
 
   spawn-command@0.0.2: {}
 


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/1232, fixes #6189

The `--node-compat` flag and `node_compat` config properties are no longer supported as of Wrangler v4. Instead, use the `nodejs_compat` compatibility flag. This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.

This PR removes support for `node_compat`

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Will be documented as part of general v4 documentation

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
