### PR TITLE
fix: error in angular c3 template

### DIFF
--- a/.changeset/witty-dolphins-appear.md
+++ b/.changeset/witty-dolphins-appear.md
@@ -2,6 +2,6 @@
 "create-cloudflare": patch
 ---
 
-fixed: related to issues-7341
-AngularAppEngine class does not have '.render' method,
-instead it should be '.handle' method.
+fix: Angular template should call `handle()` method on `AngularAppEngine` not 'render()'
+
+Fixes #7341

--- a/.changeset/witty-dolphins-appear.md
+++ b/.changeset/witty-dolphins-appear.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+fixed: related to issues-7341
+AngularAppEngine class does not have '.render' method,
+instead it should be '.handle' method.

--- a/packages/create-cloudflare/templates/angular/c3.ts
+++ b/packages/create-cloudflare/templates/angular/c3.ts
@@ -28,14 +28,11 @@ const configure = async (ctx: C3Context) => {
 };
 
 async function installCFWorker() {
-	await installPackages(
-		["@cloudflare/workers-types", "@miniflare/tre@next", "wrangler@beta"],
-		{
-			dev: true,
-			startText: "Installing adapter dependencies",
-			doneText: `${brandColor("installed")} ${dim(`via \`${npm} install\``)}`,
-		},
-	);
+	await installPackages(["xhr2"], {
+		dev: true,
+		startText: "Installing additional dependencies",
+		doneText: `${brandColor("installed")} ${dim(`via \`${npm} install\``)}`,
+	});
 }
 async function updateAppCode() {
 	const s = spinner();
@@ -102,11 +99,12 @@ const config: TemplateConfig = {
 	},
 	devScript: "start",
 	deployScript: "deploy",
+	previewScript: "start",
 	generate,
 	configure,
 	transformPackageJson: async () => ({
 		scripts: {
-			start: `${npm} run build && wrangler pages dev dist/cloudflare ${await compatDateFlag()} --experimental-local`,
+			start: `${npm} run build && wrangler pages dev dist/cloudflare ${await compatDateFlag()}`,
 			build: `ng build && ${npm} run process`,
 			process: "node ./tools/copy-files.mjs",
 			deploy: `${npm} run build && wrangler pages deploy dist/cloudflare`,

--- a/packages/create-cloudflare/templates/angular/templates/src/server.ts
+++ b/packages/create-cloudflare/templates/angular/templates/src/server.ts
@@ -6,7 +6,7 @@ const angularApp = new AngularAppEngine();
  * This is a request handler used by the Angular CLI (dev-server and during build).
  */
 export const reqHandler = createRequestHandler(async (req) => {
-	const res = await angularApp.render(req);
+	const res = await angularApp.handle(req);
 
 	return res ?? new Response('Page not found.', { status: 404 });
 });


### PR DESCRIPTION
AngularAppEngine class does not have .render method, instead it should be .handle method

Fixes #[insert GH or internal issue link(s)].
https://github.com/cloudflare/workers-sdk/issues/7341
_Describe your change..._
AngularAppEngine class does not have .render method, instead it should be .handle method

changed method name from ".render" to ".handle" as the official doc below
https://angular.dev/api/ssr/AngularAppEngine

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: only changing template for create-cloudflare with angular framework
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because:  only changing template for create-cloudflare with angular framework
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:  only changing template for create-cloudflare with angular framework

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
