### PR TITLE
fix: C3 experimental template for Solid now uses correct preset

### DIFF
--- a/.changeset/quick-bananas-refuse.md
+++ b/.changeset/quick-bananas-refuse.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: C3 experimental template for Solid now uses correct preset

--- a/packages/create-cloudflare/templates-experimental/solid/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/solid/c3.ts
@@ -2,6 +2,7 @@ import { logRaw, updateStatus } from "@cloudflare/cli";
 import { blue, brandColor, dim } from "@cloudflare/cli/colors";
 import { runFrameworkGenerator } from "frameworks/index";
 import { mergeObjectProperties, transformFile } from "helpers/codemod";
+import { getWorkerdCompatibilityDate } from "helpers/compatDate";
 import { usesTypescript } from "helpers/files";
 import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
@@ -30,6 +31,8 @@ const configure = async (ctx: C3Context) => {
 	usesTypescript(ctx);
 	const filePath = `app.config.${usesTypescript(ctx) ? "ts" : "js"}`;
 
+	const compatDate = await getWorkerdCompatibilityDate();
+
 	updateStatus(`Updating configuration in ${blue(filePath)}`);
 
 	transformFile(filePath, {
@@ -46,60 +49,14 @@ const configure = async (ctx: C3Context) => {
 					b.objectProperty(
 						b.identifier("server"),
 						b.objectExpression([
-							// preset: "cloudflare-pages"
+							// preset: "cloudflare_module"
 							b.objectProperty(
 								b.identifier("preset"),
-								b.stringLiteral("cloudflare-pages"),
+								b.stringLiteral("cloudflare_module"),
 							),
-							// output: {
-							// 	dir: "{{ rootDir }}/dist",
-							// 	publicDir: "{{ output.dir }}/public",
-							// 	serverDir: "{{ output.dir }}/worker",
-							// },
 							b.objectProperty(
-								b.identifier("output"),
-								b.objectExpression([
-									b.objectProperty(
-										b.identifier("dir"),
-										b.stringLiteral("{{ rootDir }}/dist"),
-									),
-									b.objectProperty(
-										b.identifier("publicDir"),
-										b.stringLiteral("{{ output.dir }}/public"),
-									),
-									b.objectProperty(
-										b.identifier("serverDir"),
-										b.stringLiteral("{{ output.dir }}/worker"),
-									),
-								]),
-							),
-							// rollupConfig: {
-							// 	external: ["node:async_hooks"],
-							// },
-							b.objectProperty(
-								b.identifier("rollupConfig"),
-								b.objectExpression([
-									b.objectProperty(
-										b.identifier("external"),
-										b.arrayExpression([b.stringLiteral("node:async_hooks")]),
-									),
-								]),
-							),
-							// hooks: {
-							// 	// Prevent the Pages preset from writing the _routes.json etc.
-							// 	compiled() {},
-							// },
-							b.objectProperty(
-								b.identifier("hooks"),
-								b.objectExpression([
-									b.objectMethod(
-										"method",
-										b.identifier("compiled"),
-										[],
-										b.blockStatement([]),
-										false,
-									),
-								]),
+								b.identifier("compatibilityDate"),
+								b.stringLiteral(compatDate),
 							),
 						]),
 					),

--- a/packages/create-cloudflare/templates-experimental/solid/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/solid/templates/wrangler.toml
@@ -2,8 +2,8 @@
 name = "<TBD>"
 compatibility_date = "<TBD>"
 compatibility_flags = ["nodejs_compat"]
-main = "./dist/worker/index.js"
-assets = { directory = "./dist/public", binding = "ASSETS" }
+main = "./.output/server/index.mjs"
+assets = { directory = "./.output/public", binding = "ASSETS" }
 
 # Workers Logs
 # Docs: https://developers.cloudflare.com/workers/observability/logs/workers-logs/


### PR DESCRIPTION
Fixes #0000

fix: C3 experimental template for Solid now uses correct preset

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ~~covered by current tests~~ (will be covered by https://github.com/cloudflare/workers-sdk/pull/7409)
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no change to the user flow.

