### PR TITLE
fix(wrangler): keypress event name is optional

### DIFF
--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -62,17 +62,22 @@ export default function (
 	}
 
 	const unregisterKeyPress = onKeyPress(async (key) => {
-		let char = key.name.toLowerCase();
+		const entries: string[] = [];
 
-		if (key?.meta) {
-			char = "meta+" + char;
+		if (key.name) {
+			entries.push(key.name.toLowerCase());
 		}
-		if (key?.ctrl) {
-			char = "ctrl+" + char;
+		if (key.meta) {
+			entries.unshift("meta");
 		}
-		if (key?.shift) {
-			char = "shift+" + char;
+		if (key.ctrl) {
+			entries.unshift("ctrl");
 		}
+		if (key.shift) {
+			entries.unshift("shift");
+		}
+
+		const char = entries.join("+");
 
 		for (const { keys, handler, disabled } of options) {
 			if (unwrapHook(disabled)) {

--- a/packages/wrangler/src/utils/onKeyPress.ts
+++ b/packages/wrangler/src/utils/onKeyPress.ts
@@ -1,16 +1,9 @@
-import readline from "readline";
+import readline from "node:readline";
 import { PassThrough } from "stream";
 import isInteractive from "../is-interactive";
+import type { Key } from "node:readline";
 
-export type KeypressEvent = {
-	name: string;
-	sequence: string;
-	ctrl: boolean;
-	meta: boolean;
-	shift: boolean;
-};
-
-export function onKeyPress(callback: (key: KeypressEvent) => void) {
+export function onKeyPress(callback: (key: Key) => void) {
 	// Listening for events on process.stdin (eg .on('keypress')) causes it to go into 'old mode'
 	// which keeps this nodejs process alive even after calling .off('keypress')
 	// WORKAROUND: piping stdin via a transform stream allows us to call stream.destroy()
@@ -24,7 +17,7 @@ export function onKeyPress(callback: (key: KeypressEvent) => void) {
 		process.stdin.setRawMode(true);
 	}
 
-	const handler = async (_char: string, key: KeypressEvent) => {
+	const handler = async (_char: string, key: Key) => {
 		if (key) {
 			callback(key);
 		}


### PR DESCRIPTION
Fixes n/a.

We were incorrectly treating the `name` property of the Keypress event as required. This PR fixes the type issue and updates the implementation accordingly.

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: bugfix
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
