### PR TITLE
feat(wrangler): makes resource identifier optional

### DIFF
--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -81,7 +81,7 @@ export interface CfVars {
  */
 export interface CfKvNamespace {
 	binding: string;
-	id: string;
+	id?: string;
 }
 
 /**
@@ -167,14 +167,14 @@ export interface CfQueue {
 
 export interface CfR2Bucket {
 	binding: string;
-	bucket_name: string;
+	bucket_name?: string;
 	jurisdiction?: string;
 }
 
 // TODO: figure out if this is duplicated in packages/wrangler/src/config/environment.ts
 export interface CfD1Database {
 	binding: string;
-	database_id: string;
+	database_id?: string;
 	database_name: string;
 	preview_database_id?: string;
 	database_internal_env?: string;

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -303,13 +303,13 @@ async function buildSourceOptions(
 }
 
 function kvNamespaceEntry({ binding, id }: CfKvNamespace): [string, string] {
-	return [binding, id];
+	return [binding, id ?? binding];
 }
 function r2BucketEntry({ binding, bucket_name }: CfR2Bucket): [string, string] {
-	return [binding, bucket_name];
+	return [binding, bucket_name ?? binding];
 }
 function d1DatabaseEntry(db: CfD1Database): [string, string] {
-	return [db.binding, db.preview_database_id ?? db.database_id];
+	return [db.binding, db.preview_database_id ?? db.database_id ?? db.binding];
 }
 function queueProducerEntry(
 	queue: CfQueue


### PR DESCRIPTION
Fixes [DEVX-1417](https://jira.cfdata.org/browse/DEVX-1417).



---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: To be done with [DEVX-1422](https://jira.cfdata.org/browse/DEVX-1422)

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
