### PR TITLE
fix: allow `wrangler types` when expected entrypoint doesn't exist

### DIFF
--- a/.changeset/silly-news-compete.md
+++ b/.changeset/silly-news-compete.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: allow running `wrangler types` when expected entrypoint doesn't exist

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -540,6 +540,31 @@ describe("generateTypes()", () => {
 	`);
 	});
 
+	it("should not error if expected entrypoint is not found and assume module worker", async () => {
+		fs.writeFileSync(
+			"./wrangler.toml",
+			TOML.stringify({
+				main: "index.ts",
+				vars: bindingsConfigMock.vars,
+			} as unknown as TOML.JsonMap),
+			"utf-8"
+		);
+		// note index.ts does not exist
+
+		await runWrangler("types");
+		expect(std.out).toMatchInlineSnapshot(`
+		"Generating project types...
+
+		interface Env {
+			SOMETHING: \\"asdasdfasdf\\";
+			ANOTHER: \\"thing\\";
+			\\"some-other-var\\": \\"some-other-value\\";
+			OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+		}
+		"
+	`);
+	});
+
 	it("should include secret keys from .dev.vars", async () => {
 		fs.writeFileSync(
 			"./wrangler.toml",

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -549,7 +549,7 @@ describe("generateTypes()", () => {
 			} as unknown as TOML.JsonMap),
 			"utf-8"
 		);
-		// note index.ts does not exist
+		expect(fs.existsSync("index.ts")).toEqual(false);
 
 		await runWrangler("types");
 		expect(std.out).toMatchInlineSnapshot(`


### PR DESCRIPTION
Fixes #7346 
`wrangler types` used to fail if an entrypoint was specified in config, but did not exist (e.g. not built yet), because of an assertion inside `getEntry()`

---

<!--
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
