### PR TITLE
Turn on `--x-registry` for Pages by default

### DIFF
--- a/.changeset/seven-eels-reflect.md
+++ b/.changeset/seven-eels-reflect.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Turn on `--x-registry` for Pages by default

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -77,7 +77,7 @@ describe("pages", () => {
 			      --persist-to                                 Specify directory to use for local persistence (defaults to .wrangler/state)  [string]
 			      --log-level                                  Specify logging level  [choices: \\"debug\\", \\"info\\", \\"log\\", \\"warn\\", \\"error\\", \\"none\\"]
 			      --show-interactive-dev-session               Show interactive dev session (defaults to true if the terminal supports interactivity)  [boolean]
-			      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: false]
+			      --experimental-registry, --x-registry        Use the experimental file based dev registry for multi-worker development  [boolean] [default: true]
 			      --experimental-vectorize-bind-to-prod        Bind to production Vectorize indexes in local development mode  [boolean] [default: false]"
 		`);
 	});

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -249,7 +249,7 @@ export function Options(yargs: CommonYargsArgv) {
 				type: "boolean",
 				describe:
 					"Use the experimental file based dev registry for multi-worker development",
-				default: false,
+				default: true,
 			},
 			"experimental-vectorize-bind-to-prod": {
 				type: "boolean",


### PR DESCRIPTION
Fixes #7322

When flipping the `--x-registry` default, we forgot to turn it on for Pages, resulting in Pages and Workers not being able to connect over service bindings unless `--x-registry=false` was specified on the Worker invocation. Our tests didn't catch this because they always specified the `--x-registry` flag (for both the true and false case), and so the defaults weren't being tested. This PR:
- Switches the default to `true` for Pages
- Changes our E2E tests to correctly test the default (i.e. only the false branch has a flag provided)
- Adds additional Pages E2E tests

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
