### PR TITLE
Remove node_compat flag from C3 templates that use Vitest Pool Workers

### DIFF
--- a/.changeset/calm-lizards-tell.md
+++ b/.changeset/calm-lizards-tell.md
@@ -1,6 +1,0 @@
----
-"@cloudflare/vitest-pool-workers": minor
-"create-cloudflare": minor
----
-
-chore: add nodejs_compat by default in Vitest Pool Workers, and remove nodejs_compat flag from basic C3 templates

--- a/.changeset/calm-lizards-tell.md
+++ b/.changeset/calm-lizards-tell.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/vitest-pool-workers": minor
+"create-cloudflare": minor
+---
+
+chore: add nodejs_compat by default in Vitest Pool Workers, and remove nodejs_compat flag from basic C3 templates

--- a/.changeset/healthy-bags-cry.md
+++ b/.changeset/healthy-bags-cry.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+chore: remove nodejs_compat flag from basic C3 templates

--- a/.changeset/polite-goats-behave.md
+++ b/.changeset/polite-goats-behave.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": minor
+---
+
+chore: add nodejs_compat by default in Vitest Pool Workers

--- a/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/wrangler.toml
@@ -1,4 +1,3 @@
 name = "basics-integration-auxiliary"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]

--- a/fixtures/vitest-pool-workers-examples/basics-unit-integration-self/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/basics-unit-integration-self/wrangler.toml
@@ -1,4 +1,3 @@
 name = "basics-unit-integration-self"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]

--- a/fixtures/vitest-pool-workers-examples/d1/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/d1/wrangler.toml
@@ -1,7 +1,6 @@
 name = "d1"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]
 
 [[env.production.d1_databases]]
 binding = "DATABASE"

--- a/fixtures/vitest-pool-workers-examples/durable-objects/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/durable-objects/wrangler.toml
@@ -1,7 +1,6 @@
 name = "durable-objects"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]
 
 [durable_objects]
 bindings = [

--- a/fixtures/vitest-pool-workers-examples/external-package-resolution/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/external-package-resolution/wrangler.toml
@@ -1,4 +1,3 @@
 name = "external-package-resolution"
 main = "src/index.ts"
 compatibility_date = "2024-04-05"
-compatibility_flags = ["nodejs_compat"]

--- a/fixtures/vitest-pool-workers-examples/hyperdrive/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/hyperdrive/wrangler.toml
@@ -1,7 +1,6 @@
 name = "hyperdrive"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]
 
 [[hyperdrive]]
 binding = "ECHO_SERVER_HYPERDRIVE"

--- a/fixtures/vitest-pool-workers-examples/internal-module-resolution/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/internal-module-resolution/wrangler.toml
@@ -1,3 +1,2 @@
 name = "internal-module-resolution"
 compatibility_date = "2024-04-05"
-compatibility_flags = ["nodejs_compat"]

--- a/fixtures/vitest-pool-workers-examples/kv-r2-caches/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/kv-r2-caches/wrangler.toml
@@ -1,7 +1,6 @@
 name = "kv-r2-caches"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]
 
 kv_namespaces = [
 	{ binding = "KV_NAMESPACE", id = "00000000000000000000000000000000" }

--- a/fixtures/vitest-pool-workers-examples/misc/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/misc/wrangler.toml
@@ -1,5 +1,4 @@
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]
 
 [define]
 WRANGLER_DEFINED_THING = "\"thing\""

--- a/fixtures/vitest-pool-workers-examples/multiple-workers/api-service/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/multiple-workers/api-service/wrangler.toml
@@ -1,7 +1,6 @@
 name = "api-service"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]
 
 [[services]]
 binding = "AUTH_SERVICE"

--- a/fixtures/vitest-pool-workers-examples/multiple-workers/auth-service/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/multiple-workers/auth-service/wrangler.toml
@@ -1,7 +1,6 @@
 name = "auth-service"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]
 
 # `AUTH_PUBLIC_KEY` would be a secret created with `wrangler secret put`, and
 # stored in `.dev.vars` during development

--- a/fixtures/vitest-pool-workers-examples/multiple-workers/database-service/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/multiple-workers/database-service/wrangler.toml
@@ -1,7 +1,6 @@
 name = "database-service"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]
 
 kv_namespaces = [
 	{ binding = "KV_NAMESPACE", id = "00000000000000000000000000000000" }

--- a/fixtures/vitest-pool-workers-examples/pages-with-config/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/pages-with-config/wrangler.toml
@@ -1,6 +1,5 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "pages-with-config"
 compatibility_date = "2024-09-19"
-compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "public"
 

--- a/fixtures/vitest-pool-workers-examples/queues/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/queues/wrangler.toml
@@ -1,7 +1,6 @@
 name = "queues"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]
 
 kv_namespaces = [
 	{ binding = "QUEUE_RESULTS", id = "00000000000000000000000000000000" }

--- a/fixtures/vitest-pool-workers-examples/request-mocking/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/request-mocking/wrangler.toml
@@ -1,4 +1,3 @@
 name = "request-mocking"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]

--- a/fixtures/vitest-pool-workers-examples/rpc/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/rpc/wrangler.toml
@@ -1,7 +1,7 @@
 name = "rpc"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat", "rpc"]
+compatibility_flags = ["rpc"]
 
 kv_namespaces = [
 	{ binding = "KV_NAMESPACE", id = "00000000000000000000000000000000" }

--- a/fixtures/vitest-pool-workers-examples/web-assembly/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/web-assembly/wrangler.toml
@@ -1,4 +1,3 @@
 name = "web-assembly"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
-compatibility_flags = ["nodejs_compat"]

--- a/fixtures/vitest-pool-workers-examples/workers-assets-only/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/workers-assets-only/wrangler.toml
@@ -1,7 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "workers-static-assets-only"
 compatibility_date = "2024-09-19"
-compatibility_flags = ["nodejs_compat"]
 
 [assets]
 directory = "./public"

--- a/fixtures/vitest-pool-workers-examples/workers-assets/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/workers-assets/wrangler.toml
@@ -2,7 +2,6 @@
 name = "workers-static-assets-with-user-worker"
 main = "src/index.ts"
 compatibility_date = "2024-09-19"
-compatibility_flags = ["nodejs_compat"]
 
 [assets]
 directory = "./public"

--- a/packages/create-cloudflare/templates/hello-world/js/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world/js/wrangler.toml
@@ -2,7 +2,6 @@
 name = "<TBD>"
 main = "src/index.js"
 compatibility_date = "<TBD>"
-compatibility_flags = ["nodejs_compat"]
 
 # Workers Logs
 # Docs: https://developers.cloudflare.com/workers/observability/logs/workers-logs/

--- a/packages/create-cloudflare/templates/hello-world/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates/hello-world/ts/wrangler.toml
@@ -2,7 +2,6 @@
 name = "<TBD>"
 main = "src/index.ts"
 compatibility_date = "<TBD>"
-compatibility_flags = ["nodejs_compat"]
 
 # Workers Logs
 # Docs: https://developers.cloudflare.com/workers/observability/logs/workers-logs/

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -9,6 +9,7 @@ import { createBirpc } from "birpc";
 import * as devalue from "devalue";
 import {
 	compileModuleRules,
+	getNodeCompat,
 	kCurrentWorker,
 	kUnsafeEphemeralUniqueKey,
 	Log,
@@ -355,11 +356,6 @@ function buildProjectWorkerOptions(
 				disableFlag: "export_commonjs_namespace",
 				defaultOnDate: "2022-10-31",
 			}),
-		() =>
-			flagAssertions.assertAtLeastOneFlagExists([
-				"nodejs_compat",
-				"nodejs_compat_v2",
-			]),
 	];
 
 	for (const assertion of assertions) {
@@ -367,6 +363,18 @@ function buildProjectWorkerOptions(
 		if (!result.isValid) {
 			throw new Error(result.errorMessage);
 		}
+	}
+
+	const { mode } = getNodeCompat(
+		runnerWorker.compatibilityDate,
+		runnerWorker.compatibilityFlags
+	);
+
+	if (mode !== "v1" && mode !== "v2") {
+		runnerWorker.compatibilityFlags.push(
+			"nodejs_compat",
+			"no_nodejs_compat_v2"
+		);
 	}
 
 	// Required for `workerd:unsafe` module. We don't require this flag to be set


### PR DESCRIPTION
Fixes #000.

Removes the need to add `nodejs_compat` flag in C3 templates just to use Vitest Pool Workers. Vitest Pool Workers will now inject the flag if it doesn't exist.

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Covered by existing
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18495
  - [ ] Documentation not necessary because:

