### PR TITLE
test: fix timezone for tests

### DIFF
--- a/fixtures/vitest-pool-workers-examples/vitest.global.ts
+++ b/fixtures/vitest-pool-workers-examples/vitest.global.ts
@@ -1,0 +1,3 @@
+export function setup(): void {
+	process.env.TZ = "UTC";
+}

--- a/fixtures/vitest-pool-workers-examples/vitest.workers.config.ts
+++ b/fixtures/vitest-pool-workers-examples/vitest.workers.config.ts
@@ -14,6 +14,7 @@ class FilteredPushArray<T> extends Array<T> {
 
 export default defineConfig({
 	test: {
+		globalSetup: ["./vitest.global.ts"],
 		// Configure the `vite-node` server used by Vitest code to import configs,
 		// custom pools and tests. By default, Vitest effectively applies Vite
 		// transforms to all files outside `node_modules`. This means by default,


### PR DESCRIPTION
Fixes #000.

When running tests locally, the machine's timezone can cause issues with tests that rely on `Date`. This PR pins the timezone to `UTC`, so that it's the same for everyone, whether running locally or in CI.

Before 😞 

<img width="636" alt="Screenshot 2024-11-29 at 11 30 10" src="https://github.com/user-attachments/assets/d05f0eb5-e9d2-49d6-8479-6161de4fa853">

After 😄 

<img width="292" alt="Screenshot 2024-11-29 at 11 29 19" src="https://github.com/user-attachments/assets/697c0781-41c8-4f5d-b85f-f395f947fac2">

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Covered already
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal only