### PR TITLE
fix: update queues max_batch_timeout in miniflare

### DIFF
--- a/.changeset/sour-pugs-agree.md
+++ b/.changeset/sour-pugs-agree.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: update queues max_batch_timeout limit from 30s to 60s

--- a/packages/miniflare/src/workers/queues/schemas.ts
+++ b/packages/miniflare/src/workers/queues/schemas.ts
@@ -26,7 +26,7 @@ export const QueueConsumerOptionsSchema = /* @__PURE__ */ z
 		// https://developers.cloudflare.com/queues/platform/configuration/#consumer
 		// https://developers.cloudflare.com/queues/platform/limits/
 		maxBatchSize: z.number().min(0).max(100).optional(),
-		maxBatchTimeout: z.number().min(0).max(30).optional(), // seconds
+		maxBatchTimeout: z.number().min(0).max(60).optional(), // seconds
 		maxRetires: z.number().min(0).max(100).optional(), // deprecated
 		maxRetries: z.number().min(0).max(100).optional(),
 		deadLetterQueue: z.ostring(),

--- a/packages/miniflare/test/plugins/queues/index.spec.ts
+++ b/packages/miniflare/test/plugins/queues/index.spec.ts
@@ -3,6 +3,7 @@ import {
 	DeferredPromise,
 	LogLevel,
 	Miniflare,
+	MiniflareCoreError,
 	QUEUES_PLUGIN_NAME,
 	QueuesError,
 	Response,
@@ -39,6 +40,34 @@ async function getControlStub(
 	await stub.enableFakeTimers(1_000_000);
 	return stub;
 }
+
+test.only("maxBatchTimeout validation", async (t) => {
+	const mf = new Miniflare({
+		verbose: true,
+		queueConsumers: {
+			QUEUE: { maxBatchTimeout: 60 },
+		},
+		modules: true,
+		script: "",
+	});
+	t.throws(
+		() =>
+			new Miniflare({
+				verbose: true,
+				queueConsumers: {
+					QUEUE: { maxBatchTimeout: 61 },
+				},
+				modules: true,
+				script: "",
+			}),
+		{
+			instanceOf: MiniflareCoreError,
+			code: "ERR_VALIDATION",
+			message: /Number must be less than or equal to 60/,
+		}
+	);
+	t.teardown(() => mf.dispose());
+});
 
 test("flushes partial and full batches", async (t) => {
 	let batches: string[][] = [];

--- a/packages/miniflare/test/plugins/queues/index.spec.ts
+++ b/packages/miniflare/test/plugins/queues/index.spec.ts
@@ -41,7 +41,7 @@ async function getControlStub(
 	return stub;
 }
 
-test.only("maxBatchTimeout validation", async (t) => {
+test("maxBatchTimeout validation", async (t) => {
 	const mf = new Miniflare({
 		verbose: true,
 		queueConsumers: {


### PR DESCRIPTION
Fixes #7398 

[max_batch_timeout](https://developers.cloudflare.com/queues/platform/limits/) seems to have been increased (30s -> 60s), updating miniflare validation schema to match. 


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: unit tests should be ok
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: documentation already showed limit is 60s now 🫠 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
