### PR TITLE
Automatically backport Wrangler patches to v3

### DIFF
--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -1,0 +1,33 @@
+name: v3 Maintenance
+
+on: pull_request
+
+jobs:
+  open-pr:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    name: Open backport PR for patches
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - uses: Ana06/get-changed-files@v1.2
+        id: files
+        with:
+          format: "json"
+
+      - run: node -r esbuild-register tools/deployments/open-v3-pr.ts
+        env:
+          FILES: ${{ steps.files.outputs.all }}
+          PR_NUMBER: ${{ github.event.number }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}

--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -6,7 +6,7 @@ jobs:
   open-pr:
     if: ${{ github.repository_owner == 'cloudflare' }}
     name: Open backport PR for patches
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -7,7 +7,7 @@ if (require.main === module) {
 	const parsedLabels = JSON.parse(process.env.LABELS as string) as string[];
 	if (
 		isWranglerPatch(process.env.FILES as string) &&
-		!parsedLabels.includes("skip-backport")
+		!parsedLabels.includes("skip-v3-pr")
 	) {
 		// Create a new branch for the v3 maintenance PR
 		execSync(`git checkout -b v3-maintenance-${process.env.PR_NUMBER} -f`);
@@ -17,7 +17,7 @@ if (require.main === module) {
 		try {
 			// Open PR
 			execSync(
-				`gh pr create --base main --head v3-maintenance-${process.env.PR_NUMBER} --label "skip-pr-description-validation" --label "skip-backport" --title "Backport #${process.env.PR_NUMBER} to Wrangler v3" --body "This is an automatically opened PR to backport patch changes from #${process.env.PR_NUMBER} to Wrangler v3"`
+				`gh pr create --base main --head v3-maintenance-${process.env.PR_NUMBER} --label "skip-pr-description-validation" --label "skip-v3-pr" --title "Backport #${process.env.PR_NUMBER} to Wrangler v3" --body "This is an automatically opened PR to backport patch changes from #${process.env.PR_NUMBER} to Wrangler v3"`
 			);
 		} catch {
 			// Ignore "PR already created failures"

--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -17,7 +17,7 @@ if (require.main === module) {
 		try {
 			// Open PR
 			execSync(
-				`gh pr create --base next --head v3-maintenance-${process.env.PR_NUMBER} --label "skip-pr-description-validation" --label "skip-backport" --title "Backport #${process.env.PR_NUMBER} to Wrangler v3" --body "This is an automatically opened PR to backport patch changes from #${process.env.PR_NUMBER} to Wrangler v3"`
+				`gh pr create --base main --head v3-maintenance-${process.env.PR_NUMBER} --label "skip-pr-description-validation" --label "skip-backport" --title "Backport #${process.env.PR_NUMBER} to Wrangler v3" --body "This is an automatically opened PR to backport patch changes from #${process.env.PR_NUMBER} to Wrangler v3"`
 			);
 		} catch {
 			// Ignore "PR already created failures"

--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -1,0 +1,43 @@
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import parseChangeset from "@changesets/parse";
+
+/* eslint-disable turbo/no-undeclared-env-vars */
+if (require.main === module) {
+	const parsedLabels = JSON.parse(process.env.LABELS as string) as string[];
+	if (
+		isWranglerPatch(process.env.FILES as string) &&
+		!parsedLabels.includes("skip-backport")
+	) {
+		// Create a new branch for the v3 maintenance PR
+		execSync(`git checkout -b v3-maintenance-${process.env.PR_NUMBER} -f`);
+
+		execSync(`git push origin HEAD --force`);
+
+		try {
+			// Open PR
+			execSync(
+				`gh pr create --base next --head v3-maintenance-${process.env.PR_NUMBER} --label "skip-pr-description-validation" --label "skip-backport" --title "Backport #${process.env.PR_NUMBER} to Wrangler v3" --body "This is an automatically opened PR to backport patch changes from #${process.env.PR_NUMBER} to Wrangler v3"`
+			);
+		} catch {
+			// Ignore "PR already created failures"
+		}
+	}
+}
+
+export function isWranglerPatch(changedFilesJson: string) {
+	const changedFiles = JSON.parse(changedFilesJson) as string[];
+	const changesets = changedFiles
+		.filter((f) => f.startsWith(".changeset/"))
+		.map((c) => parseChangeset(readFileSync(c, "utf8")));
+
+	let hasWranglerPatch = false;
+	for (const changeset of changesets) {
+		for (const release of changeset.releases) {
+			if (release.name === "wrangler" && release.type === "patch") {
+				hasWranglerPatch = true;
+			}
+		}
+	}
+	return hasWranglerPatch;
+}


### PR DESCRIPTION
See https://github.com/cloudflare/workers-sdk/pull/7402 for an example.

This PR adds a workflow that will, for every PR with a Wrangler patch change, open a corresponding PR to the `v3-maintenance` branch (not created yet, but will be after v4 is released). The auto-generated PRs will likely not be perfect, but they should be a good starting point to backporting the fix. Some fixes will not be relevant, and so could just be closed (i.e. a fix for a feature introduced in v4 wouldn't make sense to backport)