### PR TITLE
Remove await from user Worker fetch in router-worker

### DIFF
--- a/.changeset/gorgeous-paws-compare.md
+++ b/.changeset/gorgeous-paws-compare.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+chore: remove awaits from Asset Worker fetches. This has no user-facing impact.

--- a/packages/workers-shared/router-worker/src/index.ts
+++ b/packages/workers-shared/router-worker/src/index.ts
@@ -72,7 +72,7 @@ export default {
 			if (env.CONFIG.has_user_worker) {
 				if (await env.ASSET_WORKER.unstable_canFetch(request)) {
 					analytics.setData({ dispatchtype: DISPATCH_TYPE.ASSETS });
-					return await env.ASSET_WORKER.fetch(maybeSecondRequest);
+					return env.ASSET_WORKER.fetch(maybeSecondRequest);
 				} else {
 					analytics.setData({ dispatchtype: DISPATCH_TYPE.WORKER });
 					return env.USER_WORKER.fetch(maybeSecondRequest);
@@ -80,7 +80,7 @@ export default {
 			}
 
 			analytics.setData({ dispatchtype: DISPATCH_TYPE.ASSETS });
-			return await env.ASSET_WORKER.fetch(request);
+			return env.ASSET_WORKER.fetch(request);
 		} catch (err) {
 			if (err instanceof Error) {
 				analytics.setData({ error: err.message });


### PR DESCRIPTION
Fixes N/A

Stops us waiting on asset Worker to return and escalating the errors upwards. We don't need to do this and it currently skews metrics as well.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no material change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no e2e tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no public facing change
