### PR TITLE
ci: don't watch for changes on the workers-shared test:ci job

### DIFF
--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -38,7 +38,7 @@
 		"dev": "pnpm run clean && concurrently -n bundle:asset-worker,bundle:router-worker -c blue,magenta \"pnpm run bundle:asset-worker --watch\" \"pnpm run bundle:router-worker --watch\"",
 		"test": "concurrently --group -n router-worker,asset-worker \"pnpm run test:router-worker\" \"pnpm run test:asset-worker\"",
 		"test:asset-worker": "vitest -c asset-worker/vitest.config.mts --dir asset-worker",
-		"test:ci": "pnpm run test",
+		"test:ci": "concurrently --group -n router-worker,asset-worker \"pnpm run test:router-worker --run\" \"pnpm run test:asset-worker --run\"",
 		"test:router-worker": "vitest -c router-worker/vitest.config.mts --dir router-worker",
 		"types:emit": "tsc index.ts --declaration --emitDeclarationOnly --declarationDir ./dist"
 	},


### PR DESCRIPTION
Super simple. This is only apparent if you disable concurrent tests when running locally.
But if you do that then the whole test run grinds to a halt after this job since it is waiting for further changes rather than exiting and moving on to the next job.