### PR TITLE
feat(wrangler): DX optimisations in `wrangler dev --remote`

### DIFF
--- a/.changeset/quick-wombats-battle.md
+++ b/.changeset/quick-wombats-battle.md
@@ -1,0 +1,12 @@
+---
+"wrangler": minor
+---
+
+feat: Make DX improvements in `wrangler dev --remote`
+
+Workers + Assets projects have, in certain situations, a relatively degraded `wrangler dev --remote` developer experience, as opposed to Workers proper projects. This is due to the fact that, for Workers + Assets, we need to make extra API calls to:
+
+1. check for asset files changes
+2. upload the changed assets, if any
+
+This commit improves the `wrangler dev --remote` DX for Workers + Assets, for use cases when the User Worker/assets change while the API calls for previous changes are still in flight. For such use cases, we have put an exit early strategy in place, that drops the event handler execution of the previous changes, in favour of the handler triggered by the new changes.


### PR DESCRIPTION
Fixes DEVX-1523

Workers + Assets projects have, in certain situations, a relatively degraded `wrangler dev --remote` developer experience, as opposed to Workers proper projects. This is due to the fact that, for Workers + Assets, we need to make 
extra API calls to:

1. check for asset files changes
2. upload the changed assets, if any

This commit improves the `wrangler dev --remote` DX for Workers + Assets, for use cases when the User Worker/assets change while the API calls for previous changes are still in flight. For such use cases, we have put an exit early strategy in place, that drops the event handler execution of the previous changes, in favour of the handler triggered by the 
new changes.

For `before`/`after` screenshots pls see DEVX-1523 

**How these changes were tested**

**NOTE**

> For posterity, we did discuss internally the unit/e2e test coverage for this PR, and we all agreed that our current `dev` and `dev --remote` tests give us enough coverage for these changes. Testing these changes would in fact involve testing a core wrangler functionality, aka aborting in progress changes if there’s a new pending change that would run immediately after, which is not specific to assets. This functionality is already covered by tests, so adding more that are specific for assets doesn't seem to add much value. We therefore decided to merge as is, and rely on existing tests.


- Workers + Assets (with changes in both assets and User Worker code)

**Before**
<img width="637" alt="Screenshot 2024-12-19 at 10 51 55" src="https://github.com/user-attachments/assets/30d18895-4637-40ba-aec0-5ba575444246" />

**After**
<img width="640" alt="Screenshot 2024-12-19 at 10 53 09" src="https://github.com/user-attachments/assets/93eb6b02-9725-4276-b5b6-a7a6701996c4" />

- Workers + Assets only

**After**
<img width="639" alt="Screenshot 2024-12-19 at 10 54 23" src="https://github.com/user-attachments/assets/eadc34e2-8c5a-4d1b-ba78-28c21ef48750" />

- Workers proper (no assets)

**After**
<img width="378" alt="Screenshot 2024-12-19 at 12 58 12" src="https://github.com/user-attachments/assets/7436bfe8-4b96-4426-a887-4b1cde05719b" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: we're covered by existing e2e & unit tests here
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: watch mode optimizations

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
