### PR TITLE
fix: allow the asset directory to be omitted in Wrangler config for commands that don't need it

### DIFF
--- a/.changeset/forty-gifts-grab.md
+++ b/.changeset/forty-gifts-grab.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: allow the asset directory to be omitted in Wrangler config for commands that don't need it

--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -1792,7 +1792,6 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 					"Processing wrangler configuration:
-					  - \\"assets.directory\\" is a required field.
 					  - Expected \\"assets.binding\\" to be of type string but got 2."
 				`);
 			});
@@ -1843,27 +1842,6 @@ describe("normalizeAndValidateConfig()", () => {
 				expect(config).toEqual(expect.objectContaining(expectedConfig));
 				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.hasErrors()).toBe(false);
-			});
-
-			it("should error if `directory` is an empty string", () => {
-				const expectedConfig = {
-					assets: {
-						directory: "",
-					},
-				};
-
-				const { config, diagnostics } = normalizeAndValidateConfig(
-					expectedConfig as unknown as RawConfig,
-					undefined,
-					{ env: undefined }
-				);
-
-				expect(config).toEqual(expect.objectContaining(expectedConfig));
-				expect(diagnostics.hasWarnings()).toBeFalsy();
-				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-					"Processing wrangler configuration:
-					  - Expected \\"assets.directory\\" to be a non-empty string."
-				`);
 			});
 
 			it("should error on invalid additional fields", () => {

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -1,5 +1,5 @@
 import { kCurrentWorker, Miniflare } from "miniflare";
-import { processAssetsArg } from "../../../assets";
+import { getAssetsOptions } from "../../../assets";
 import { readConfig } from "../../../config";
 import { DEFAULT_MODULE_RULES } from "../../../deployment-bundle/rules";
 import { getBindings } from "../../../dev";
@@ -309,7 +309,7 @@ export function unstable_getMiniflareWorkerOptions(
 		? getLegacyAssetPaths(config, undefined)
 		: getSiteAssetPaths(config);
 	const sitesOptions = buildSitesOptions({ legacyAssetPaths });
-	const processedAssetOptions = processAssetsArg({ assets: undefined }, config);
+	const processedAssetOptions = getAssetsOptions({ assets: undefined }, config);
 	const assetOptions = processedAssetOptions
 		? buildAssetOptions({ assets: processedAssetOptions })
 		: {};

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -9,7 +9,7 @@ import {
 	getScriptName,
 	isLegacyEnv,
 } from "../..";
-import { processAssetsArg, validateAssetsArgsAndConfig } from "../../assets";
+import { getAssetsOptions, validateAssetsArgsAndConfig } from "../../assets";
 import { printBindings, readConfig } from "../../config";
 import { getEntry } from "../../deployment-bundle/entry";
 import {
@@ -248,7 +248,7 @@ async function resolveConfig(
 
 	const { bindings, unsafe } = await resolveBindings(config, input);
 
-	const assetsOptions = processAssetsArg(
+	const assetsOptions = getAssetsOptions(
 		{
 			assets: input?.assets,
 			script: input.entrypoint,

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -940,14 +940,21 @@ export interface UserLimits {
 
 export type Assets = {
 	/** Absolute path to assets directory */
-	directory: string;
+	directory?: string;
+	/** Name of `env` binding property in the User Worker. */
 	binding?: string;
+	/** How to handle HTML requests. */
 	html_handling?:
 		| "auto-trailing-slash"
 		| "force-trailing-slash"
 		| "drop-trailing-slash"
 		| "none";
+	/** How to handle requests that do not match an asset. */
 	not_found_handling?: "single-page-application" | "404-page" | "none";
+	/**
+	 * If true, then respond to requests that match an asset with that asset directly.
+	 * If false, route every request to the User Worker, whether or not it matches an asset.
+	 * */
 	experimental_serve_directly?: boolean;
 };
 

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -232,27 +232,6 @@ export const isString: ValidatorFn = (diagnostics, field, value) => {
 };
 
 /**
- * Validate that the field is a non-empty string.
- */
-export const isNonEmptyString: ValidatorFn = (
-	diagnostics,
-	field,
-	value,
-	topLevelEnv
-) => {
-	if (!isString(diagnostics, field, value, topLevelEnv)) {
-		return false;
-	}
-
-	if ((value as string)?.trim() === "") {
-		diagnostics.errors.push(`Expected "${field}" to be a non-empty string.`);
-		return false;
-	}
-
-	return true;
-};
-
-/**
  * Validate that the `name` field is compliant with EWC constraints.
  */
 export const isValidName: ValidatorFn = (diagnostics, field, value) => {

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -15,7 +15,6 @@ import {
 	inheritableInLegacyEnvironments,
 	isBoolean,
 	isMutuallyExclusiveWith,
-	isNonEmptyString,
 	isObjectWith,
 	isOneOf,
 	isOptionalProperty,
@@ -2122,20 +2121,12 @@ const validateAssetsConfig: ValidatorFn = (diagnostics, field, value) => {
 	// ensure we validate all props before we show the validation errors
 	// this way users have all the necessary info to fix all errors in one go
 	isValid =
-		validateRequiredProperty(
+		validateOptionalProperty(
 			diagnostics,
 			field,
 			"directory",
 			(value as Assets).directory,
 			"string"
-		) && isValid;
-
-	isValid =
-		isNonEmptyString(
-			diagnostics,
-			`${field}.directory`,
-			(value as Assets).directory,
-			undefined
 		) && isValid;
 
 	isValid =

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import path from "node:path";
-import { processAssetsArg, validateAssetsArgsAndConfig } from "../assets";
+import { getAssetsOptions, validateAssetsArgsAndConfig } from "../assets";
 import { configFileName, findWranglerConfig, readConfig } from "../config";
 import { getEntry } from "../deployment-bundle/entry";
 import { UserError } from "../errors";
@@ -301,7 +301,7 @@ async function deployWorker(args: DeployArgs) {
 
 	validateAssetsArgsAndConfig(args, config);
 
-	const assetsOptions = processAssetsArg(args, config);
+	const assetsOptions = getAssetsOptions(args, config);
 
 	if (args.latest) {
 		logger.warn(

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -1,4 +1,4 @@
-import { processAssetsArg } from "../assets";
+import { getAssetsOptions } from "../assets";
 import { readConfig } from "../config";
 import { getScriptName, isLegacyEnv, printWranglerBanner } from "../index";
 import * as metrics from "../metrics";
@@ -58,7 +58,7 @@ async function triggersDeployHandler(
 	await printWranglerBanner();
 
 	const config = readConfig(undefined, args);
-	const assetsOptions = processAssetsArg({ assets: undefined }, config);
+	const assetsOptions = getAssetsOptions({ assets: undefined }, config);
 	await metrics.sendMetricsEvent(
 		"deploy worker triggers",
 		{},

--- a/packages/wrangler/src/versions/index.ts
+++ b/packages/wrangler/src/versions/index.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import path from "node:path";
-import { processAssetsArg, validateAssetsArgsAndConfig } from "../assets";
+import { getAssetsOptions, validateAssetsArgsAndConfig } from "../assets";
 import { configFileName, findWranglerConfig, readConfig } from "../config";
 import { getEntry } from "../deployment-bundle/entry";
 import { UserError } from "../errors";
@@ -242,7 +242,7 @@ async function versionsUploadHandler(
 		config
 	);
 
-	const assetsOptions = processAssetsArg(args, config);
+	const assetsOptions = getAssetsOptions(args, config);
 
 	if (args.latest) {
 		logger.warn(


### PR DESCRIPTION
Fixes #0000

We want to allow build tools (e.g. Nuxt/Vite/Next.js etc) to own the `main` and `assets.directory` fields in deployment configuration since they are the ones that generate these files.
In that case it doesn't makes sense for the user to provide them in their user configuration.
The `main` field is already optional from the point of view of the syntax check of the user's configuration file (e.g. wrangler.toml); this PR just makes the `assets.directory` field the same.
It is still an error to attempt to deploy or dev a Worker with an `assets` field but no `assets.directory`.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the docs don't specify that the wrangler.toml must have a directory, just that a directory is required.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
