### PR TITLE
Changed port in playwright config file

### DIFF
--- a/.changeset/lovely-kiwis-grab.md
+++ b/.changeset/lovely-kiwis-grab.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Use correct port in playwright config file for generated SvelteKit apps

--- a/packages/create-cloudflare/templates/svelte/c3.ts
+++ b/packages/create-cloudflare/templates/svelte/c3.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { platform } from "node:os";
 import { logRaw, updateStatus } from "@cloudflare/cli";
 import { blue, brandColor, dim } from "@cloudflare/cli/colors";
@@ -9,7 +10,6 @@ import { installPackages } from "helpers/packages";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context, PackageJson } from "types";
-import { existsSync } from "node:fs";
 
 const { npm } = detectPackageManager();
 
@@ -60,8 +60,8 @@ const updatePlaywrightConfig = (shouldUseTypescript: boolean) => {
 	updateStatus(`Changing webServer port in ${blue(filePath)}`);
 
 	transformFile(filePath, {
-		visitObjectExpression: function(n) {
-			const portProp = n.node.properties.find(prop => {
+		visitObjectExpression: function (n) {
+			const portProp = n.node.properties.find((prop) => {
 				if (!("key" in prop) || !("name" in prop.key)) {
 					return false;
 				}
@@ -75,7 +75,7 @@ const updatePlaywrightConfig = (shouldUseTypescript: boolean) => {
 
 			portProp.value.value = 8788;
 			return false;
-		}
+		},
 	});
 };
 


### PR DESCRIPTION
One issue that I had creating a Sveltekit project using create-cloudflare was the fact that the playwright configuration file still had its port set to the default of 4173, which would cause the test to hang. I could either change the `webServer.command` property to override the default port that miniflare uses or to change the port to 8788 (which is what I chose).


<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: The changes are relatively simple.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: The changes are relatively simple.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: It does not change in any way the user experience.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
