### PR TITLE
chore(wrangler): update unenv dependency version

### DIFF
--- a/.changeset/curly-queens-breathe.md
+++ b/.changeset/curly-queens-breathe.md
@@ -1,0 +1,11 @@
+---
+"wrangler": patch
+---
+
+chore(wrangler): update unenv dependency version
+
+Pull in:
+
+- refactor(cloudflare): reimplement module:createRequire for latest workerd (unjs/unenv#351)
+- refactor: use node:events instead of relative path (unjs/unenv#354)
+- refactor(http, cloudflare): use unenv/ imports inside node:http (unjs/unenv#363)

--- a/.changeset/curly-queens-breathe.md
+++ b/.changeset/curly-queens-breathe.md
@@ -9,3 +9,4 @@ Pull in:
 - refactor(cloudflare): reimplement module:createRequire for latest workerd (unjs/unenv#351)
 - refactor: use node:events instead of relative path (unjs/unenv#354)
 - refactor(http, cloudflare): use unenv/ imports inside node:http (unjs/unenv#363)
+- refactor(node:process): set process.domain to undefined (unjs/unenv#367)

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -84,7 +84,7 @@
 		"resolve": "^1.22.8",
 		"selfsigned": "^2.0.1",
 		"source-map": "^0.6.1",
-		"unenv": "npm:unenv-nightly@2.0.0-20241203-175523-4e76a66",
+		"unenv": "npm:unenv-nightly@2.0.0-20241204-140205-a5d5190",
 		"workerd": "1.20241106.2",
 		"xxhash-wasm": "^1.0.1"
 	},

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -84,7 +84,7 @@
 		"resolve": "^1.22.8",
 		"selfsigned": "^2.0.1",
 		"source-map": "^0.6.1",
-		"unenv": "npm:unenv-nightly@2.0.0-20241121-161142-806b5c0",
+		"unenv": "npm:unenv-nightly@2.0.0-20241203-175523-4e76a66",
 		"workerd": "1.20241106.2",
 		"xxhash-wasm": "^1.0.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1735,8 +1735,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       unenv:
-        specifier: npm:unenv-nightly@2.0.0-20241121-161142-806b5c0
-        version: unenv-nightly@2.0.0-20241121-161142-806b5c0
+        specifier: npm:unenv-nightly@2.0.0-20241203-175523-4e76a66
+        version: unenv-nightly@2.0.0-20241203-175523-4e76a66
       workerd:
         specifier: 1.20241106.2
         version: 1.20241106.2
@@ -8100,8 +8100,8 @@ packages:
   unenv-nightly@2.0.0-20241111-080453-894aa31:
     resolution: {integrity: sha512-0W39QQOQ9VE8kVVUpGwEG+pZcsCXk5wqNG6rDPE6Gr+fiA69LR0qERM61hW5KCOkC1/ArCFrfCGjwHyyv/bI0Q==}
 
-  unenv-nightly@2.0.0-20241121-161142-806b5c0:
-    resolution: {integrity: sha512-RnFOasE/O0Q55gBkNB1b84OgKttgLEijGO0JCWpbn+O4XxpyCQg89NmcqQ5RGUiy4y+rMIrKzePTquQcLQF5pQ==}
+  unenv-nightly@2.0.0-20241203-175523-4e76a66:
+    resolution: {integrity: sha512-fbNIOwdC13PnNvF+McuGyG0e4aVetsT7yv9GLWFyJi1iP+r39Q7nVq8SCZfJyOTLiAGDOnynP4Pt7u2Gvpgp3g==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -15361,7 +15361,7 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.5.4
 
-  unenv-nightly@2.0.0-20241121-161142-806b5c0:
+  unenv-nightly@2.0.0-20241203-175523-4e76a66:
     dependencies:
       defu: 6.1.4
       ohash: 1.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1735,8 +1735,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       unenv:
-        specifier: npm:unenv-nightly@2.0.0-20241203-175523-4e76a66
-        version: unenv-nightly@2.0.0-20241203-175523-4e76a66
+        specifier: npm:unenv-nightly@2.0.0-20241204-140205-a5d5190
+        version: unenv-nightly@2.0.0-20241204-140205-a5d5190
       workerd:
         specifier: 1.20241106.2
         version: 1.20241106.2
@@ -8100,8 +8100,8 @@ packages:
   unenv-nightly@2.0.0-20241111-080453-894aa31:
     resolution: {integrity: sha512-0W39QQOQ9VE8kVVUpGwEG+pZcsCXk5wqNG6rDPE6Gr+fiA69LR0qERM61hW5KCOkC1/ArCFrfCGjwHyyv/bI0Q==}
 
-  unenv-nightly@2.0.0-20241203-175523-4e76a66:
-    resolution: {integrity: sha512-fbNIOwdC13PnNvF+McuGyG0e4aVetsT7yv9GLWFyJi1iP+r39Q7nVq8SCZfJyOTLiAGDOnynP4Pt7u2Gvpgp3g==}
+  unenv-nightly@2.0.0-20241204-140205-a5d5190:
+    resolution: {integrity: sha512-jpmAytLeiiW01pl5bhVn9wYJ4vtiLdhGe10oXlJBuQEX8mxjxO8BlEXGHU4vr4yEikjFP1wsomTHt/CLU8kUwg==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -15361,7 +15361,7 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.5.4
 
-  unenv-nightly@2.0.0-20241203-175523-4e76a66:
+  unenv-nightly@2.0.0-20241204-140205-a5d5190:
     dependencies:
       defu: 6.1.4
       ohash: 1.1.4


### PR DESCRIPTION
Fixes https://github.com/opennextjs/opennextjs-cloudflare/issues/147
Fixes https://github.com/cloudflare/workers-sdk/issues/7072

Pulls in:

- refactor(cloudflare): reimplement module:createRequire for latest workerd (unjs/unenv#351)
- refactor: use node:events instead of relative path (unjs/unenv#354)
- refactor(http, cloudflare): use unenv/ imports inside node:http (unjs/unenv#363)

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: dep update
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: dep update
