### PR TITLE
Wranger dev support with serve_directly

### DIFF
--- a/.changeset/strong-kings-visit.md
+++ b/.changeset/strong-kings-visit.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/workers-shared": minor
+"wrangler": minor
+---
+
+Support for `assets.experimental_serve_directly` with `wrangler dev`

--- a/fixtures/workers-with-assets-serve-directly/README.md
+++ b/fixtures/workers-with-assets-serve-directly/README.md
@@ -1,0 +1,17 @@
+# workers-assets-with-user-worker"
+
+`workers-assets-with-user-worker-serve-directly"` is a test fixture that showcases Workers with Assets using the serve_directly option. This particular fixture forces a user Worker to be invoked, even if it otherwise would have matched an assets request.
+
+## dev
+
+To start a dev session you can run
+
+```
+wrangler dev
+```
+
+## Run tests
+
+```
+npm run test
+```

--- a/fixtures/workers-with-assets-serve-directly/package.json
+++ b/fixtures/workers-with-assets-serve-directly/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "workers-assets-with-user-worker-serve-directly",
+	"private": true,
+	"scripts": {
+		"check:type": "tsc",
+		"dev": "npx wrangler dev",
+		"test:ci": "vitest run",
+		"test:watch": "vitest",
+		"type:tests": "tsc -p ./tests/tsconfig.json"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "^4.20241106.0",
+		"undici": "catalog:default",
+		"wrangler": "workspace:*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/fixtures/workers-with-assets-serve-directly/public/index.html
+++ b/fixtures/workers-with-assets-serve-directly/public/index.html
@@ -1,0 +1,1 @@
+<h1>Hello Workers + Assets World 🚀!</h1>

--- a/fixtures/workers-with-assets-serve-directly/src/index.ts
+++ b/fixtures/workers-with-assets-serve-directly/src/index.ts
@@ -1,0 +1,22 @@
+export interface Env {
+	// Example binding to a Service. Learn more at https://developers.cloudflare.com/workers/runtime-apis/service-bindings/
+	ASSETS: Fetcher;
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const auth = request.headers.get("Authorization");
+
+		if (!auth) {
+			return new Response("Forbidden", {
+				status: 403,
+				statusText: "Forbidden",
+				headers: {
+					"Content-Type": "text/plain",
+				},
+			});
+		}
+
+		return await env.ASSETS.fetch(request);
+	},
+};

--- a/fixtures/workers-with-assets-serve-directly/tests/index.test.ts
+++ b/fixtures/workers-with-assets-serve-directly/tests/index.test.ts
@@ -1,0 +1,37 @@
+import { resolve } from "node:path";
+import { fetch } from "undici";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
+
+describe("[Workers + Assets] serve_directly false", () => {
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
+
+	beforeAll(async () => {
+		({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
+			"--port=0",
+			"--inspector-port=0",
+		]));
+	});
+
+	afterAll(async () => {
+		await stop?.();
+	});
+
+	it("should return a 403 without an Authorization header", async ({
+		expect,
+	}) => {
+		let response = await fetch(`http://${ip}:${port}/index.html`);
+		let text = await response.text();
+		expect(response.status).toBe(403);
+	});
+
+	it("should return a 200 with an Authorization header", async ({ expect }) => {
+		let response = await fetch(`http://${ip}:${port}/index.html`, {
+			headers: { Authorization: "some auth header" },
+		});
+		let text = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(text).toContain(`<h1>Hello Workers + Assets World 🚀!</h1>`);
+	});
+});

--- a/fixtures/workers-with-assets-serve-directly/tests/tsconfig.json
+++ b/fixtures/workers-with-assets-serve-directly/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"types": ["node"]
+	},
+	"include": ["**/*.ts", "../../../node-types.d.ts"]
+}

--- a/fixtures/workers-with-assets-serve-directly/tsconfig.json
+++ b/fixtures/workers-with-assets-serve-directly/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "CommonJS",
+		"lib": ["ES2020"],
+		"types": ["@cloudflare/workers-types"],
+		"moduleResolution": "node",
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["**/*.ts"],
+	"exclude": ["tests"]
+}

--- a/fixtures/workers-with-assets-serve-directly/wrangler.toml
+++ b/fixtures/workers-with-assets-serve-directly/wrangler.toml
@@ -1,0 +1,10 @@
+#:schema node_modules/wrangler/config-schema.json
+
+name = "worker-with-assets-serve-directly"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[assets]
+directory = "./public"
+binding="ASSETS"
+experimental_serve_directly = false

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -71,4 +71,26 @@ describe("unit tests", async () => {
 		const response = await worker.fetch(request, env, ctx);
 		expect(await response.text()).toEqual("hello from asset worker");
 	});
+
+	it("it returns fetch from asset worker when matching existing asset path and invoke_user_worker_ahead_of_assets is not provided", async () => {
+		const request = new Request("https://example.com");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				has_user_worker: false,
+			},
+			ASSET_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from asset worker");
+				},
+				async unstable_canFetch(_: Request): Promise<boolean> {
+					return true;
+				},
+			},
+		} as typeof env;
+
+		const response = await worker.fetch(request, env, ctx);
+		expect(await response.text()).toEqual("hello from asset worker");
+	});
 });

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -354,6 +354,9 @@ export function getAssetsOptions(
 
 	const routingConfig = {
 		has_user_worker: Boolean(args.script || config.main),
+		invoke_user_worker_ahead_of_assets: !(
+			config.assets?.experimental_serve_directly ?? true
+		),
 	};
 	// defaults are set in asset worker
 	const assetConfig = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -731,6 +731,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/workers-with-assets-serve-directly:
+    devDependencies:
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20241106.0
+        version: 4.20241106.0
+      undici:
+        specifier: catalog:default
+        version: 5.28.4
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/workflow:
     devDependencies:
       '@cloudflare/workers-types':
@@ -2479,7 +2494,7 @@ packages:
       vitest: 2.0.x - 2.1.x
 
   '@cloudflare/workerd-darwin-64@1.20241106.1':
-    resolution: {integrity: sha512-zxvaToi1m0qzAScrxFt7UvFVqU8DxrCO2CinM1yQkv5no7pA1HolpIrwZ0xOhR3ny64Is2s/J6BrRjpO5dM9Zw==}
+    resolution: {integrity: sha512-zxvaToi1m0qzAScrxFt7UvFVqU8DxrCO2CinM1yQkv5no7pA1HolpIrwZ0xOhR3ny64Is2s/J6BrRjpO5dM9Zw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241106.1.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -2491,7 +2506,7 @@ packages:
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20241106.1':
-    resolution: {integrity: sha512-j3dg/42D/bPgfNP3cRUBxF+4waCKO/5YKwXNj+lnVOwHxDu+ne5pFw9TIkKYcWTcwn0ZUkbNZNM5rhJqRn4xbg==}
+    resolution: {integrity: sha512-j3dg/42D/bPgfNP3cRUBxF+4waCKO/5YKwXNj+lnVOwHxDu+ne5pFw9TIkKYcWTcwn0ZUkbNZNM5rhJqRn4xbg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241106.1.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -2503,7 +2518,7 @@ packages:
     os: [darwin]
 
   '@cloudflare/workerd-linux-64@1.20241106.1':
-    resolution: {integrity: sha512-Ih+Ye8E1DMBXcKrJktGfGztFqHKaX1CeByqshmTbODnWKHt6O65ax3oTecUwyC0+abuyraOpAtdhHNpFMhUkmw==}
+    resolution: {integrity: sha512-Ih+Ye8E1DMBXcKrJktGfGztFqHKaX1CeByqshmTbODnWKHt6O65ax3oTecUwyC0+abuyraOpAtdhHNpFMhUkmw==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241106.1.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -2515,7 +2530,7 @@ packages:
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20241106.1':
-    resolution: {integrity: sha512-mdQFPk4+14Yywn7n1xIzI+6olWM8Ybz10R7H3h+rk0XulMumCWUCy1CzIDauOx6GyIcSgKIibYMssVHZR30ObA==}
+    resolution: {integrity: sha512-mdQFPk4+14Yywn7n1xIzI+6olWM8Ybz10R7H3h+rk0XulMumCWUCy1CzIDauOx6GyIcSgKIibYMssVHZR30ObA==, tarball: https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241106.1.tgz}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -2527,7 +2542,7 @@ packages:
     os: [linux]
 
   '@cloudflare/workerd-windows-64@1.20241106.1':
-    resolution: {integrity: sha512-4rtcss31E/Rb/PeFocZfr+B9i1MdrkhsTBWizh8siNR4KMmkslU2xs2wPaH1z8+ErxkOsHrKRa5EPLh5rIiFeg==}
+    resolution: {integrity: sha512-4rtcss31E/Rb/PeFocZfr+B9i1MdrkhsTBWizh8siNR4KMmkslU2xs2wPaH1z8+ErxkOsHrKRa5EPLh5rIiFeg==, tarball: https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241106.1.tgz}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]


### PR DESCRIPTION
Add support in wrangler dev for invoking user worker ahead of assets via `experimental_serve_directly = false`. Additionally adds several unit, integration, and e2e tests for serve_directly behavior.

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [X] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: n/a
