### PR TITLE
feat(create-cloudflare): Add support for wrangler.json(c) in templates

### DIFF
--- a/.changeset/hot-ads-return.md
+++ b/.changeset/hot-ads-return.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+feature: Add support for wrangler.json(c) in templates

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -218,6 +218,30 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 		);
 
 		test({ experimental }).skipIf(process.platform === "win32")(
+			"Cloning remote template that uses wrangler.json",
+			async ({ logStream, project }) => {
+				const { output } = await runC3(
+					[
+						project.path,
+						"--template=cloudflare/templates/multiplayer-globe-template",
+						"--no-deploy",
+						"--git=false",
+					],
+					[],
+					logStream,
+				);
+
+				expect(output).toContain(
+					`repository cloudflare/templates/multiplayer-globe-template`,
+				);
+				expect(output).toContain(
+					`Cloning template from: cloudflare/templates/multiplayer-globe-template`,
+				);
+				expect(output).toContain(`template cloned and validated`);
+			},
+		);
+
+		test({ experimental }).skipIf(process.platform === "win32")(
 			"Inferring the category, type and language if the type is `hello-world-python`",
 			async ({ logStream, project }) => {
 				// The `hello-world-python` template is now the python variant of the `hello-world` template

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -625,9 +625,15 @@ const validateTemplate = (path: string, config: TemplateConfig) => {
 const validateTemplateSrcDirectory = (path: string, config: TemplateConfig) => {
 	if (config.platform === "workers") {
 		const wranglerTomlPath = resolve(path, "wrangler.toml");
-		if (!existsSync(wranglerTomlPath)) {
+		const wranglerJsonPath = resolve(path, "wrangler.json");
+		const wranglerJsoncPath = resolve(path, "wrangler.jsonc");
+		if (
+			!existsSync(wranglerTomlPath) &&
+			!existsSync(wranglerJsonPath) &&
+			!existsSync(wranglerJsoncPath)
+		) {
 			throw new Error(
-				`create-cloudflare templates must contain a "wrangler.toml" file.`,
+				`create-cloudflare templates must contain a "wrangler.toml" or "wrangler.json(c)" file.`,
 			);
 		}
 	}

--- a/packages/create-cloudflare/src/wrangler/config.ts
+++ b/packages/create-cloudflare/src/wrangler/config.ts
@@ -49,14 +49,37 @@ const getWranglerTomlPath = (ctx: C3Context) => {
 	return resolve(ctx.project.path, "wrangler.toml");
 };
 
+const getWranglerJsonPath = (ctx: C3Context) => {
+	return resolve(ctx.project.path, "wrangler.json");
+};
+
+const getWranglerJsoncPath = (ctx: C3Context) => {
+	return resolve(ctx.project.path, "wrangler.jsonc");
+};
+
 export const wranglerTomlExists = (ctx: C3Context) => {
 	const wranglerTomlPath = getWranglerTomlPath(ctx);
 	return existsSync(wranglerTomlPath);
 };
 
+export const wranglerJsonExists = (ctx: C3Context) => {
+	const wranglerJsonPath = getWranglerJsonPath(ctx);
+	const wranglerJsoncPath = getWranglerJsoncPath(ctx);
+	return existsSync(wranglerJsonPath) || existsSync(wranglerJsoncPath);
+};
+
 export const readWranglerToml = (ctx: C3Context) => {
 	const wranglerTomlPath = getWranglerTomlPath(ctx);
 	return readFile(wranglerTomlPath);
+};
+
+export const readWranglerJson = (ctx: C3Context) => {
+	const wranglerJsonPath = getWranglerJsonPath(ctx);
+	if (existsSync(wranglerJsonPath)) {
+		return readFile(wranglerJsonPath);
+	}
+	const wranglerJsoncPath = getWranglerJsoncPath(ctx);
+	return readFile(wranglerJsoncPath);
 };
 
 export const writeWranglerToml = (ctx: C3Context, contents: string) => {


### PR DESCRIPTION
Fixes WP-1369.

- If wrangler.toml is missing from template, check for wrangler.json(c) and use that instead
- All templates in [cloudflare/templates](https://github.com/cloudflare/templates) use wrangler.json
  - We need to support these templates in C3 before public launch

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: I'm adding support for an existing, documented feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
