### PR TITLE
WfP Assets support

### DIFF
--- a/.changeset/smart-plants-wash.md
+++ b/.changeset/smart-plants-wash.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Allow Workers for Platforms scripts (scripts deployed with `--dispatch-namespace`) to bring along `assets`

--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -68,6 +68,20 @@ export class WranglerE2ETestHelper {
 		return id;
 	}
 
+	async dispatchNamespace(isLocal: boolean) {
+		const name = generateResourceName("dispatch");
+		if (isLocal) {
+			throw new Error(
+				"Dispatch namespaces are not supported in local mode (yet)"
+			);
+		}
+		await this.run(`wrangler dispatch-namespace create ${name}`);
+		onTestFinished(async () => {
+			await this.run(`wrangler dispatch-namespace delete ${name}`);
+		});
+		return name;
+	}
+
 	async r2(isLocal: boolean) {
 		const name = generateResourceName("r2");
 		if (isLocal) {

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -47,8 +47,9 @@ const MAX_UPLOAD_GATEWAY_ERRORS = 5;
 
 export const syncAssets = async (
 	accountId: string | undefined,
+	assetDirectory: string,
 	scriptName: string,
-	assetDirectory: string
+	dispatchNamespace?: string
 ): Promise<string> => {
 	assert(accountId, "Missing accountId");
 
@@ -56,10 +57,14 @@ export const syncAssets = async (
 	logger.info("🌀 Building list of assets...");
 	const manifest = await buildAssetManifest(assetDirectory);
 
+	const url = dispatchNamespace
+		? `/accounts/${accountId}/workers/dispatch/namespaces/${dispatchNamespace}/scripts/${scriptName}/assets-upload-session`
+		: `/accounts/${accountId}/workers/scripts/${scriptName}/assets-upload-session`;
+
 	// 2. fetch buckets w/ hashes
 	logger.info("🌀 Starting asset upload...");
 	const initializeAssetsResponse = await fetchResult<InitializeAssetsResponse>(
-		`/accounts/${accountId}/workers/scripts/${scriptName}/assets-upload-session`,
+		url,
 		{
 			headers: { "Content-Type": "application/json" },
 			method: "POST",

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -650,7 +650,12 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		// Upload assets if assets is being used
 		const assetsJwt =
 			props.assetsOptions && !props.dryRun
-				? await syncAssets(accountId, scriptName, props.assetsOptions.directory)
+				? await syncAssets(
+						accountId,
+						props.assetsOptions.directory,
+						scriptName,
+						props.dispatchNamespace
+					)
 				: undefined;
 
 		const legacyAssets = await syncLegacyAssets(

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -665,7 +665,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		// Upload assets if assets is being used
 		const assetsJwt =
 			props.assetsOptions && !props.dryRun
-				? await syncAssets(accountId, scriptName, props.assetsOptions.directory)
+				? await syncAssets(accountId, props.assetsOptions.directory, scriptName)
 				: undefined;
 
 		const bindings = getBindings({


### PR DESCRIPTION
Fixes WC-2971.

Allows Workers for Platforms scripts to bring along static assets.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: will follow up with related docs soon. This PR doesn't introduce new commands or options that need immediate documentation.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
