### PR TITLE
fix: ensure that version secrets commands do not write wrangler config warnings

### DIFF
--- a/.changeset/yellow-cooks-battle.md
+++ b/.changeset/yellow-cooks-battle.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: ensure that version secrets commands do not write wrangler config warnings

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -9,7 +9,7 @@ import { runWrangler } from "../../helpers/run-wrangler";
 import { mockPostVersion, mockSetupApiCalls } from "./utils";
 import type { Interface } from "node:readline";
 
-describe("versions secret put", () => {
+describe("versions secret bulk", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
 	mockAccountId();
@@ -72,6 +72,18 @@ describe("versions secret put", () => {
 			➡️  To deploy this version to production traffic use the command \\"wrangler versions deploy\\"."
 		`
 		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	test("no wrangler configuration warnings shown", async () => {
+		await writeFile("secrets.json", JSON.stringify({ SECRET_1: "secret-1" }));
+		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
+		mockSetupApiCalls();
+		mockPostVersion();
+		await runWrangler(
+			`versions secret bulk secrets.json --name script-name --x-versions`
+		);
+		expect(std.warn).toMatchInlineSnapshot(`""`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import { describe, expect, test } from "vitest";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
@@ -8,7 +9,7 @@ import { runWrangler } from "../../helpers/run-wrangler";
 import { writeWranglerConfig } from "../../helpers/write-wrangler-config";
 import { mockGetVersion, mockPostVersion, mockSetupApiCalls } from "./utils";
 
-describe("versions secret put", () => {
+describe("versions secret delete", () => {
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
 	runInTempDir();
@@ -101,6 +102,22 @@ describe("versions secret put", () => {
 			✨ Success! Created version id with deleted secret SECRET.
 			➡️  To deploy this version without the secret SECRET to production traffic use the command \\"wrangler versions deploy\\"."
 		`);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	test("no wrangler configuration warnings shown", async () => {
+		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
+		setIsTTY(false);
+
+		mockSetupApiCalls();
+		mockGetVersion();
+		mockPostVersion();
+
+		await runWrangler(
+			"versions secret delete SECRET --name script-name --x-versions"
+		);
+
+		expect(std.warn).toMatchInlineSnapshot(`""`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import { http, HttpResponse } from "msw";
 import { File, FormData } from "undici";
 import { describe, expect, test } from "vitest";
@@ -54,39 +55,58 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
-	// For some reason, this always hangs. Not sure why
-	test.skip("can add a new secret (non-interactive)", async () => {
-		setIsTTY(false);
-		const mockStdIn = useMockStdin({ isTTY: false });
+	test("no wrangler configuration warnings shown", async () => {
+		await writeFile("wrangler.json", JSON.stringify({ invalid_field: true }));
+		setIsTTY(true);
 
-		mockSetupApiCalls();
-		mockPostVersion((metadata) => {
-			expect(metadata.bindings).toStrictEqual([
-				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
-			]);
-			expect(metadata.keep_bindings).toStrictEqual([
-				"secret_key",
-				"secret_text",
-			]);
-			expect(metadata.keep_assets).toBeTruthy();
+		mockPrompt({
+			text: "Enter a secret value:",
+			options: { isSecret: true },
+			result: "the-secret",
 		});
 
-		mockStdIn.send(
-			`the`,
-			`-`,
-			`secret
-			` // whitespace & newline being removed
-		);
+		mockSetupApiCalls();
+		mockPostVersion();
 		await runWrangler(
 			"versions secret put NEW_SECRET --name script-name --x-versions"
 		);
 
-		expect(std.out).toMatchInlineSnapshot(`
-			"🌀 Creating the secret for the Worker \\"script-name\\"
-			✨ Success! Created version id with secret NEW_SECRET.
-			➡️  To deploy this version with secret NEW_SECRET to production traffic use the command wrangler versions deploy."
-		`);
+		expect(std.warn).toMatchInlineSnapshot(`""`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	describe("(non-interactive)", () => {
+		const mockStdIn = useMockStdin({ isTTY: false });
+		test("can add a new secret (non-interactive)", async () => {
+			mockSetupApiCalls();
+			mockPostVersion((metadata) => {
+				expect(metadata.bindings).toStrictEqual([
+					{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
+				]);
+				expect(metadata.keep_bindings).toStrictEqual([
+					"secret_key",
+					"secret_text",
+				]);
+				expect(metadata.keep_assets).toBeTruthy();
+			});
+
+			mockStdIn.send(
+				`the`,
+				`-`,
+				`secret
+			` // whitespace & newline being removed
+			);
+			await runWrangler(
+				"versions secret put NEW_SECRET --name script-name --x-versions"
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"🌀 Creating the secret for the Worker \\"script-name\\"
+				✨ Success! Created version id with secret NEW_SECRET.
+				➡️  To deploy this version with secret NEW_SECRET to production traffic use the command \\"wrangler versions deploy\\"."
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
 	});
 
 	test("can add a new secret, read Worker name from wrangler.toml", async () => {

--- a/packages/wrangler/src/__tests__/versions/secrets/utils.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/utils.ts
@@ -82,8 +82,12 @@ export function mockGetVersion(versionInfo?: VersionDetails) {
 function mockGetVersionContent() {
 	msw.use(
 		http.get(
-			`*/accounts/:accountId/workers/scripts/:scriptName/content/v2?version=ce15c78b-cc43-4f60-b5a9-15ce4f298c2a`,
-			async ({ params }) => {
+			`*/accounts/:accountId/workers/scripts/:scriptName/content/v2`,
+			async ({ params, request }) => {
+				const url = new URL(request.url);
+				expect(url.searchParams.get("version")).toEqual(
+					"ce15c78b-cc43-4f60-b5a9-15ce4f298c2a"
+				);
 				expect(params.accountId).toEqual("some-account-id");
 				expect(params.scriptName).toEqual("script-name");
 

--- a/packages/wrangler/src/api/pages/deploy.ts
+++ b/packages/wrangler/src/api/pages/deploy.ts
@@ -160,7 +160,11 @@ export async function deploy({
 	let config: Config | undefined;
 
 	try {
-		config = readConfig(undefined, { ...args, env }, true);
+		config = readConfig(
+			undefined,
+			{ ...args, env },
+			{ requirePagesConfig: true }
+		);
 	} catch (err) {
 		if (
 			!(

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -105,10 +105,7 @@ export function handleFailure<
 ) => Promise<void> {
 	return async (t) => {
 		try {
-			const config = readConfig(
-				t.config,
-				t as unknown as Parameters<typeof readConfig>[1]
-			);
+			const config = readConfig(t.config, t);
 			await fillOpenAPIConfiguration(config, t.json);
 			await cb(t, config);
 		} catch (err) {

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -75,21 +75,22 @@ export function readConfig(
 	configPath: string | undefined,
 	// Include command specific args as well as the wrangler global flags
 	args: ReadConfigCommandArgs,
-	requirePagesConfig: true
+	options: { requirePagesConfig: true }
 ): Omit<Config, "pages_build_output_dir"> & { pages_build_output_dir: string };
 export function readConfig(
 	configPath: string | undefined,
 	// Include command specific args as well as the wrangler global flags
 	args: ReadConfigCommandArgs,
-	requirePagesConfig?: boolean,
-	hideWarnings?: boolean
+	options?: { requirePagesConfig?: boolean; hideWarnings?: boolean }
 ): Config;
 export function readConfig(
 	configPath: string | undefined,
 	// Include command specific args as well as the wrangler global flags
 	args: ReadConfigCommandArgs,
-	requirePagesConfig?: boolean,
-	hideWarnings: boolean = false
+	{
+		requirePagesConfig,
+		hideWarnings = false,
+	}: { requirePagesConfig?: boolean; hideWarnings?: boolean } = {}
 ): Config {
 	let rawConfig: RawConfig = {};
 
@@ -686,10 +687,11 @@ export function printBindings(
 export function withConfig<T>(
 	handler: (
 		t: OnlyCamelCase<T & CommonYargsOptions> & { config: Config }
-	) => Promise<void>
+	) => Promise<void>,
+	options?: Parameters<typeof readConfig>[2]
 ) {
 	return (t: OnlyCamelCase<T & CommonYargsOptions>) => {
-		return handler({ ...t, config: readConfig(t.config, t) });
+		return handler({ ...t, config: readConfig(t.config, t, options) });
 	};
 }
 

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -82,12 +82,9 @@ function createHandler(def: CommandDefinition) {
 			await def.handler(args, {
 				config:
 					def.behaviour?.provideConfig ?? true
-						? readConfig(
-								args.config,
-								args,
-								undefined,
-								!(def.behaviour?.printConfigWarnings ?? true)
-							)
+						? readConfig(args.config, args, {
+								hideWarnings: !(def.behaviour?.printConfigWarnings ?? true),
+							})
 						: defaultWranglerConfig,
 				errors: { UserError, FatalError },
 				logger,

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -63,10 +63,10 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 				// eslint-disable-next-line turbo/no-undeclared-env-vars
 				env: process.env.PAGES_ENVIRONMENT,
 			},
-			true
+			{ requirePagesConfig: true }
 		);
 	} catch (err) {
-		// found `wrangler.toml` but `pages_build_output_dir` is not specififed
+		// found `wrangler.toml` but `pages_build_output_dir` is not specified
 		if (
 			err instanceof FatalError &&
 			err.code === EXIT_CODE_INVALID_PAGES_CONFIG

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -366,7 +366,7 @@ async function maybeReadPagesConfig(
 				// eslint-disable-next-line turbo/no-undeclared-env-vars
 				env: process.env.PAGES_ENVIRONMENT,
 			},
-			true
+			{ requirePagesConfig: true }
 		);
 
 		return {

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -123,7 +123,11 @@ export const Handler = async (args: PagesDeployArgs) => {
 		 * need for now. We will perform a second config file read later
 		 * in `/api/pages/deploy`, that will get the environment specific config
 		 */
-		config = readConfig(configPath, { ...args, env: undefined }, true);
+		config = readConfig(
+			configPath,
+			{ ...args, env: undefined },
+			{ requirePagesConfig: true }
+		);
 	} catch (err) {
 		if (
 			!(

--- a/packages/wrangler/src/pages/secret/index.ts
+++ b/packages/wrangler/src/pages/secret/index.ts
@@ -49,7 +49,11 @@ async function pagesProject(
 		 * return the top-level config. This contains all the information we
 		 * need.
 		 */
-		config = readConfig(configPath, { env: undefined }, true);
+		config = readConfig(
+			configPath,
+			{ env: undefined },
+			{ requirePagesConfig: true }
+		);
 	} catch (err) {
 		if (
 			!(

--- a/packages/wrangler/src/versions/secrets/bulk.ts
+++ b/packages/wrangler/src/versions/secrets/bulk.ts
@@ -9,6 +9,7 @@ import { logger } from "../../logger";
 import { parseJSON, readFileSync } from "../../parse";
 import { validateJSONFileSecrets } from "../../secret";
 import { requireAuth } from "../../user";
+import { getConfig } from "../utils/config";
 import { copyWorkerVersionWithNewSecrets } from "./index";
 import type { WorkerVersion } from "./index";
 
@@ -17,6 +18,9 @@ export const versionsSecretBulkCommand = createCommand({
 		description: "Create or update a secret variable for a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
+	},
+	behaviour: {
+		provideConfig: false,
 	},
 	args: {
 		json: {
@@ -40,7 +44,8 @@ export const versionsSecretBulkCommand = createCommand({
 		},
 	},
 	positionalArgs: ["json"],
-	handler: async function versionsSecretPutBulkHandler(args, { config }) {
+	handler: async function versionsSecretPutBulkHandler(args) {
+		const config = getConfig(args, { hideWarnings: true });
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {
 			throw new UserError(

--- a/packages/wrangler/src/versions/secrets/delete.ts
+++ b/packages/wrangler/src/versions/secrets/delete.ts
@@ -6,6 +6,7 @@ import { UserError } from "../../errors";
 import { getLegacyScriptName, isLegacyEnv } from "../../index";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
+import { getConfig } from "../utils/config";
 import { copyWorkerVersionWithNewSecrets } from "./index";
 import type { VersionDetails, WorkerVersion } from "./index";
 
@@ -14,6 +15,9 @@ export const versionsSecretDeleteCommand = createCommand({
 		description: "Delete a secret variable from a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
+	},
+	behaviour: {
+		provideConfig: false,
 	},
 	args: {
 		key: {
@@ -38,7 +42,8 @@ export const versionsSecretDeleteCommand = createCommand({
 		},
 	},
 	positionalArgs: ["key"],
-	handler: async function versionsSecretDeleteHandler(args, { config }) {
+	handler: async function versionsSecretDeleteHandler(args) {
+		const config = getConfig(args, { hideWarnings: true });
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {
 			throw new UserError(

--- a/packages/wrangler/src/versions/secrets/list.ts
+++ b/packages/wrangler/src/versions/secrets/list.ts
@@ -1,11 +1,12 @@
 import { fetchResult } from "../../cfetch";
-import { configFileName, readConfig } from "../../config";
+import { configFileName } from "../../config";
 import { createCommand } from "../../core/create-command";
 import { UserError } from "../../errors";
 import { getLegacyScriptName } from "../../index";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
 import { fetchDeploymentVersions, fetchLatestDeployment } from "../api";
+import { getConfig } from "../utils/config";
 import type { VersionDetails } from ".";
 import type { ApiVersion, VersionCache } from "../types";
 
@@ -14,6 +15,9 @@ export const versionsSecretsListCommand = createCommand({
 		description: "List the secrets currently deployed",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
+	},
+	behaviour: {
+		provideConfig: false,
 	},
 	args: {
 		name: {
@@ -28,7 +32,7 @@ export const versionsSecretsListCommand = createCommand({
 		},
 	},
 	handler: async function versionsSecretListHandler(args) {
-		const config = readConfig(args.config, args, false, true);
+		const config = getConfig(args, { hideWarnings: true });
 
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {

--- a/packages/wrangler/src/versions/secrets/put.ts
+++ b/packages/wrangler/src/versions/secrets/put.ts
@@ -7,6 +7,7 @@ import { getLegacyScriptName } from "../../index";
 import { logger } from "../../logger";
 import { requireAuth } from "../../user";
 import { readFromStdin, trimTrailingWhitespace } from "../../utils/std";
+import { getConfig } from "../utils/config";
 import { copyWorkerVersionWithNewSecrets } from "./index";
 import type { WorkerVersion } from "./index";
 
@@ -15,6 +16,9 @@ export const versionsSecretPutCommand = createCommand({
 		description: "Create or update a secret variable for a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
+	},
+	behaviour: {
+		provideConfig: false,
 	},
 	args: {
 		key: {
@@ -39,7 +43,8 @@ export const versionsSecretPutCommand = createCommand({
 		},
 	},
 	positionalArgs: ["key"],
-	handler: async function versionsSecretPutHandler(args, { config }) {
+	handler: async function versionsSecretPutHandler(args) {
+		const config = getConfig(args, { hideWarnings: true });
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {
 			throw new UserError(

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -8,13 +8,7 @@ import {
 	validateAssetsArgsAndConfig,
 } from "../assets";
 import { fetchResult } from "../cfetch";
-import {
-	configFileName,
-	findWranglerConfig,
-	formatConfigSnippet,
-	printBindings,
-	readConfig,
-} from "../config";
+import { configFileName, formatConfigSnippet, printBindings } from "../config";
 import { createCommand } from "../core/create-command";
 import { getBindings } from "../deployment-bundle/bindings";
 import { bundleWorker } from "../deployment-bundle/bundle";
@@ -57,6 +51,7 @@ import {
 import { requireAuth } from "../user";
 import { collectKeyValues } from "../utils/collectKeyValues";
 import { retryOnError } from "../utils/retry";
+import { getConfig } from "./utils/config";
 import type { AssetsOptions } from "../assets";
 import type { Config } from "../config";
 import type { Rule } from "../config/environment";
@@ -290,10 +285,7 @@ export const versionsUploadCommand = createCommand({
 		provideConfig: false,
 	},
 	handler: async function versionsUploadHandler(args) {
-		const configPath =
-			args.config ||
-			(args.script && findWranglerConfig(path.dirname(args.script)));
-		const config = readConfig(configPath, args);
+		const config = getConfig(args, {}, args.script);
 		const entry = await getEntry(args, config, "versions upload");
 		await metrics.sendMetricsEvent(
 			"upload worker version",

--- a/packages/wrangler/src/versions/utils/config.ts
+++ b/packages/wrangler/src/versions/utils/config.ts
@@ -1,13 +1,11 @@
-import path from "path";
+import path from "node:path";
 import { findWranglerConfig, readConfig } from "../../config";
 
-export function getConfig<
-	T extends {
-		name?: string;
-		config?: string;
-	},
->(args: Pick<T, "config" | "name">) {
+type Args = Parameters<typeof readConfig>[1] & { config?: string };
+type Options = Parameters<typeof readConfig>[2];
+
+export function getConfig(args: Args, options?: Options, entryPath?: string) {
 	const configPath =
-		args.config || (args.name && findWranglerConfig(path.dirname(args.name)));
-	return readConfig(configPath, args);
+		args.config || (entryPath && findWranglerConfig(path.dirname(entryPath)));
+	return readConfig(configPath, args, options);
 }


### PR DESCRIPTION
Fixes #0000

Ensures that version secrets commands do not write wrangler config warnings.
This was a regression introduced by https://github.com/cloudflare/workers-sdk/pull/7437.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
