### PR TITLE
fix: remove an unnecessary await for metrics.sendMetricsEvent

### DIFF
--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -295,7 +295,7 @@ export const versionsUploadCommand = createCommand({
 			(args.script && findWranglerConfig(path.dirname(args.script)));
 		const config = readConfig(configPath, args);
 		const entry = await getEntry(args, config, "versions upload");
-		await metrics.sendMetricsEvent(
+		metrics.sendMetricsEvent(
 			"upload worker version",
 			{
 				usesTypeScript: /\.tsx?$/.test(entry.file),


### PR DESCRIPTION
fixup a stray await that was missed after making sendMetricsEvent sync

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: typo fix
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: typo fix
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: typo fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
