### PR TITLE
refactor: Ensure that unstable type exports are all prefixed with `Unstable_` rather than just `Unstable`

### DIFF
--- a/.changeset/breezy-cats-matter.md
+++ b/.changeset/breezy-cats-matter.md
@@ -2,5 +2,5 @@
 "wrangler": patch
 ---
 
-Export unstable_readConfig function and UnstableConfig, UnstableRawConfig, UnstableRawEnvironment and UnstableMiniflareWorkerOptions types from Wrangler.
+Export unstable_readConfig function and Unstable_Config, Unstable_RawConfig, Unstable_RawEnvironment and Unstable_MiniflareWorkerOptions types from Wrangler.
 Overload unstable_getMiniflareWorkerOptions function to accept a config that has already been loaded.

--- a/.changeset/lemon-panthers-arrive.md
+++ b/.changeset/lemon-panthers-arrive.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+refactor: Ensure that unstable type exports are all prefixed with `Unstable_` rather than just `Unstable`

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
@@ -3,7 +3,7 @@ import { D1Database, R2Bucket } from "@cloudflare/workers-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getPlatformProxy } from "./shared";
 import type { Hyperdrive, KVNamespace } from "@cloudflare/workers-types";
-import type { UnstableDevWorker } from "wrangler";
+import type { Unstable_DevWorker } from "wrangler";
 
 type Env = {
 	MY_VAR: string;
@@ -20,7 +20,7 @@ type Env = {
 const wranglerTomlFilePath = path.join(__dirname, "..", "wrangler.toml");
 
 describe("getPlatformProxy - env", () => {
-	let devWorkers: UnstableDevWorker[];
+	let devWorkers: Unstable_DevWorker[];
 
 	beforeEach(() => {
 		// Hide stdout messages from the test logs

--- a/fixtures/local-mode-tests/tests/module.test.ts
+++ b/fixtures/local-mode-tests/tests/module.test.ts
@@ -1,10 +1,10 @@
 import path from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { unstable_dev } from "wrangler";
-import type { UnstableDevWorker } from "wrangler";
+import type { Unstable_DevWorker } from "wrangler";
 
 describe("module worker", () => {
-	let worker: UnstableDevWorker;
+	let worker: Unstable_DevWorker;
 
 	let originalNodeEnv: string | undefined;
 

--- a/fixtures/local-mode-tests/tests/ports.test.ts
+++ b/fixtures/local-mode-tests/tests/ports.test.ts
@@ -1,10 +1,10 @@
 import path from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { unstable_dev } from "wrangler";
-import type { UnstableDevWorker } from "wrangler";
+import type { Unstable_DevWorker } from "wrangler";
 
 describe("multiple workers", () => {
-	let workers: UnstableDevWorker[];
+	let workers: Unstable_DevWorker[];
 
 	beforeAll(async () => {
 		//since the script is invoked from the directory above, need to specify index.js is in src/

--- a/fixtures/local-mode-tests/tests/specified-port.test.ts
+++ b/fixtures/local-mode-tests/tests/specified-port.test.ts
@@ -3,7 +3,7 @@ import nodeNet from "node:net";
 import path from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { unstable_dev } from "wrangler";
-import type { UnstableDevWorker } from "wrangler";
+import type { Unstable_DevWorker } from "wrangler";
 
 function getPort() {
 	return new Promise<number>((resolve, reject) => {
@@ -20,7 +20,7 @@ function getPort() {
 }
 
 describe("specific port", () => {
-	let worker: UnstableDevWorker;
+	let worker: Unstable_DevWorker;
 
 	beforeAll(async () => {
 		worker = await unstable_dev(

--- a/fixtures/local-mode-tests/tests/sw.test.ts
+++ b/fixtures/local-mode-tests/tests/sw.test.ts
@@ -1,10 +1,10 @@
 import path from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { unstable_dev } from "wrangler";
-import type { UnstableDevWorker } from "wrangler";
+import type { Unstable_DevWorker } from "wrangler";
 
 describe("service worker", () => {
-	let worker: UnstableDevWorker;
+	let worker: Unstable_DevWorker;
 
 	let originalNodeEnv: string | undefined;
 

--- a/fixtures/no-bundle-import/src/index.test.ts
+++ b/fixtures/no-bundle-import/src/index.test.ts
@@ -1,10 +1,10 @@
 import path from "path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { unstable_dev } from "wrangler";
-import type { UnstableDevWorker } from "wrangler";
+import type { Unstable_DevWorker } from "wrangler";
 
 describe("Worker", () => {
-	let worker: UnstableDevWorker;
+	let worker: Unstable_DevWorker;
 
 	beforeAll(async () => {
 		worker = await unstable_dev(path.resolve(__dirname, "index.js"), {

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -4,7 +4,7 @@ import os from "os";
 import path from "path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { unstable_dev } from "wrangler";
-import type { UnstableDevWorker } from "wrangler";
+import type { Unstable_DevWorker } from "wrangler";
 
 function removeUUID(str: string) {
 	return str.replace(
@@ -14,8 +14,8 @@ function removeUUID(str: string) {
 }
 
 describe("Preview Worker", () => {
-	let worker: UnstableDevWorker;
-	let remote: UnstableDevWorker;
+	let worker: Unstable_DevWorker;
+	let remote: Unstable_DevWorker;
 	let tmpDir: string;
 
 	beforeAll(async () => {
@@ -301,8 +301,8 @@ compatibility_date = "2023-01-01"
 });
 
 describe("Raw HTTP preview", () => {
-	let worker: UnstableDevWorker;
-	let remote: UnstableDevWorker;
+	let worker: Unstable_DevWorker;
+	let remote: Unstable_DevWorker;
 	let tmpDir: string;
 
 	beforeAll(async () => {

--- a/packages/vitest-pool-workers/src/config/pages.ts
+++ b/packages/vitest-pool-workers/src/config/pages.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "miniflare";
-import type { UnstableASSETSBindingsOptions } from "wrangler";
+import type { Unstable_ASSETSBindingsOptions } from "wrangler";
 
 export async function buildPagesASSETSBinding(
 	assetsPath: string
@@ -17,6 +17,6 @@ export async function buildPagesASSETSBinding(
 		debugWithSanitization: console.debug,
 		loggerLevel: "info",
 		columns: process.stdout.columns,
-	} as unknown as UnstableASSETSBindingsOptions["log"];
+	} as unknown as Unstable_ASSETSBindingsOptions["log"];
 	return unstable_generateASSETSBinding({ log, directory: assetsPath });
 }

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -11,7 +11,7 @@ import type { EnablePagesAssetsServiceBindingOptions } from "../miniflare-cli/ty
 import type { Json } from "miniflare";
 import type { RequestInfo, RequestInit, Response } from "undici";
 
-export interface UnstableDevOptions {
+export interface Unstable_DevOptions {
 	config?: string; // Path to .toml configuration file, relative to cwd
 	env?: string; // Environment to use for operations and .env files
 	ip?: string; // IP address to listen on
@@ -86,7 +86,7 @@ export interface UnstableDevOptions {
 	};
 }
 
-export interface UnstableDevWorker {
+export interface Unstable_DevWorker {
 	port: number;
 	address: string;
 	stop: () => Promise<void>;
@@ -98,9 +98,9 @@ export interface UnstableDevWorker {
  */
 export async function unstable_dev(
 	script: string,
-	options?: UnstableDevOptions,
+	options?: Unstable_DevOptions,
 	apiOptions?: unknown
-): Promise<UnstableDevWorker> {
+): Promise<Unstable_DevWorker> {
 	// Note that not every experimental option is passed directly through to the underlying dev API - experimental options can be used here in unstable_dev. Otherwise we could just pass experimental down to dev blindly.
 
 	const experimentalOptions = {

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -1,5 +1,5 @@
 export { unstable_dev } from "./dev";
-export type { UnstableDevWorker, UnstableDevOptions } from "./dev";
+export type { Unstable_DevWorker, Unstable_DevOptions } from "./dev";
 export { unstable_pages } from "./pages";
 export {
 	uploadMTlsCertificate,

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -22,9 +22,9 @@ import type { MiniflareOptions, ModuleRule, WorkerOptions } from "miniflare";
 
 export { readConfig as unstable_readConfig };
 export type {
-	Config as UnstableConfig,
-	RawConfig as UnstableRawConfig,
-	RawEnvironment as UnstableRawEnvironment,
+	Config as Unstable_Config,
+	RawConfig as Unstable_RawConfig,
+	RawEnvironment as Unstable_RawEnvironment,
 };
 
 /**
@@ -244,7 +244,7 @@ export type SourcelessWorkerOptions = Omit<
 	"script" | "scriptPath" | "modules" | "modulesRoot"
 > & { modulesRules?: ModuleRule[] };
 
-export interface UnstableMiniflareWorkerOptions {
+export interface Unstable_MiniflareWorkerOptions {
 	workerOptions: SourcelessWorkerOptions;
 	define: Record<string, string>;
 	main?: string;
@@ -253,14 +253,14 @@ export interface UnstableMiniflareWorkerOptions {
 export function unstable_getMiniflareWorkerOptions(
 	configPath: string,
 	env?: string
-): UnstableMiniflareWorkerOptions;
+): Unstable_MiniflareWorkerOptions;
 export function unstable_getMiniflareWorkerOptions(
 	config: Config
-): UnstableMiniflareWorkerOptions;
+): Unstable_MiniflareWorkerOptions;
 export function unstable_getMiniflareWorkerOptions(
 	configOrConfigPath: string | Config,
 	env?: string
-): UnstableMiniflareWorkerOptions {
+): Unstable_MiniflareWorkerOptions {
 	const config =
 		typeof configOrConfigPath === "string"
 			? readConfig(configOrConfigPath, { env })

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -8,7 +8,7 @@ import {
 } from "./api";
 import { FatalError } from "./errors";
 import { main } from ".";
-import type { UnstableDevOptions, UnstableDevWorker } from "./api";
+import type { Unstable_DevOptions, Unstable_DevWorker } from "./api";
 import type { Logger } from "./logger";
 import type { Request, Response } from "miniflare";
 
@@ -32,7 +32,7 @@ if (typeof vitest === "undefined" && require.main === module) {
  * and call wrangler.unstable_dev().
  */
 export { unstable_dev, unstable_pages, unstable_DevEnv, unstable_startWorker };
-export type { UnstableDevWorker, UnstableDevOptions };
+export type { Unstable_DevWorker, Unstable_DevOptions };
 
 export * from "./api/integrations";
 
@@ -47,13 +47,13 @@ export { startWorkerRegistryServer as unstable_startWorkerRegistryServer } from 
 // We `require` instead of `import`ing here to avoid polluting the main
 // `wrangler` TypeScript project with the `global` augmentations. This
 // relies on the fact that `require` is untyped.
-export interface UnstableASSETSBindingsOptions {
+export interface Unstable_ASSETSBindingsOptions {
 	log: Logger;
 	proxyPort?: number;
 	directory?: string;
 }
 const generateASSETSBinding: (
-	opts: UnstableASSETSBindingsOptions
+	opts: Unstable_ASSETSBindingsOptions
 ) => (request: Request) => Promise<Response> =
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
 	require("./miniflare-cli/assets").default;

--- a/packages/wrangler/templates/init-tests/test-vitest-new-worker.ts
+++ b/packages/wrangler/templates/init-tests/test-vitest-new-worker.ts
@@ -1,9 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { unstable_dev } from "wrangler";
-import type { UnstableDevWorker } from "wrangler";
+import type { Unstable_DevWorker } from "wrangler";
 
 describe("Worker", () => {
-	let worker: UnstableDevWorker;
+	let worker: Unstable_DevWorker;
 
 	beforeAll(async () => {
 		worker = await unstable_dev("src/index.ts", {


### PR DESCRIPTION
Fixes #0000

We use `unstable_` as a prefix for experimental/unstable functions, but we were using just `Unstable` without the underscore as a prefix for types.

This change ensures that all unstable type exports are prefixed with `Unstable_` rather than just `Unstable`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
