### PR TITLE
fix(create-cloudflare): add a newline character to the line prepended to wrangler.toml

### DIFF
--- a/.changeset/large-mails-relax.md
+++ b/.changeset/large-mails-relax.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix(create-cloudflare): add a newline character to the line prepended to wrangler.toml

--- a/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
+++ b/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
@@ -73,10 +73,9 @@ describe("updateWranglerToml", () => {
 		await updateWranglerToml(ctx);
 
 		const newToml = vi.mocked(writeFile).mock.calls[0][1];
-		expect(newToml).toMatch(`name = "${ctx.project.name}"`);
-		expect(newToml).toMatch(`main = "src/index.ts"`);
 		expect(newToml).toBe(
-			`compatibility_date = "2024-01-17"name = "test"\n` +
+			`compatibility_date = "${mockCompatDate}"\n` +
+				`name = "${ctx.project.name}"\n` +
 				`main = "src/index.ts"`,
 		);
 	});
@@ -88,11 +87,10 @@ describe("updateWranglerToml", () => {
 		await updateWranglerToml(ctx);
 
 		const newToml = vi.mocked(writeFile).mock.calls[0][1];
-		expect(newToml).toMatch(`name = "${ctx.project.name}"`);
-		expect(newToml).toMatch(`main = "src/index.ts"`);
-		expect(newToml).toMatch(`compatibility_date = "${mockCompatDate}"`);
 		expect(newToml).toBe(
-			`name = "test"compatibility_date = "2024-01-17"main = "src/index.ts"`,
+			`name = "${ctx.project.name}"\n` +
+				`compatibility_date = "${mockCompatDate}"\n` +
+				`main = "src/index.ts"`,
 		);
 	});
 

--- a/packages/create-cloudflare/src/wrangler/config.ts
+++ b/packages/create-cloudflare/src/wrangler/config.ts
@@ -31,7 +31,7 @@ export const updateWranglerToml = async (ctx: C3Context) => {
 		}
 	} else {
 		newToml.prepend(
-			`compatibility_date = "${await getWorkerdCompatibilityDate()}"`,
+			`compatibility_date = "${await getWorkerdCompatibilityDate()}"\n`,
 		);
 	}
 
@@ -39,7 +39,7 @@ export const updateWranglerToml = async (ctx: C3Context) => {
 	if (wranglerToml.match(nameRe)) {
 		newToml.replace(nameRe, `name = "${ctx.project.name}"`);
 	} else {
-		newToml.prepend(`name = "${ctx.project.name}"`);
+		newToml.prepend(`name = "${ctx.project.name}"\n`);
 	}
 
 	writeWranglerToml(ctx, newToml.toString());


### PR DESCRIPTION
This PR adds a newline character to the line prepended to wrangler.toml (when `name` or `compatibility_date` is missing in the template).
Without this change, the prepended line would cause a syntax error.

example:

original wrangler.toml (in template)
```toml
main = "index.js"
```

prepended wrangler.toml
```toml
name = "foo"compatibility_date = "2024-11-06"main = "index.js"
```

after this PR:
```toml
name = "foo"
compatibility_date = "2024-11-06"
main = "index.js"
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: This PR contains only minor changes.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: `remote-template` format is originally undocumented.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
