### PR TITLE
Mark `wrangler versions` as stable

### DIFF
--- a/.changeset/thick-nails-switch.md
+++ b/.changeset/thick-nails-switch.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Mark `wrangler versions` commands as stable 

--- a/.changeset/thick-nails-switch.md
+++ b/.changeset/thick-nails-switch.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Mark `wrangler versions` commands as stable 
+Mark `wrangler versions` commands as stable

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -555,8 +555,7 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 		);
 
 		expect(normalize(upload.output)).toMatchInlineSnapshot(`
-			"▲ [WARNING] 🚧 \`wrangler versions upload\` is an open-beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
-			X [ERROR] Legacy assets does not support uploading versions through \`wrangler versions upload\`. You must use \`wrangler deploy\` instead.
+			"X [ERROR] Legacy assets does not support uploading versions through \`wrangler versions upload\`. You must use \`wrangler deploy\` instead.
 			🪵  Logs were written to "<LOG>""
 		`);
 	});
@@ -590,8 +589,7 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 		const upload = await helper.run(`wrangler versions upload  --x-versions`);
 
 		expect(normalize(upload.output)).toMatchInlineSnapshot(`
-			"▲ [WARNING] 🚧 \`wrangler versions upload\` is an open-beta command. Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
-			X [ERROR] Workers Sites does not support uploading versions through \`wrangler versions upload\`. You must use \`wrangler deploy\` instead.
+			"X [ERROR] Workers Sites does not support uploading versions through \`wrangler versions upload\`. You must use \`wrangler deploy\` instead.
 			🪵  Logs were written to "<LOG>""
 		`);
 	});

--- a/packages/wrangler/src/__tests__/versions/versions.help.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.help.test.ts
@@ -63,10 +63,10 @@ describe("versions --help", () => {
 			🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
 
 			COMMANDS
-			  wrangler versions view <version-id>         View the details of a specific version of your Worker [open-beta]
-			  wrangler versions list                      List the 10 most recent Versions of your Worker [open-beta]
-			  wrangler versions upload                    Uploads your Worker code and config as a new Version [open-beta]
-			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [open-beta]
+			  wrangler versions view <version-id>         View the details of a specific version of your Worker
+			  wrangler versions list                      List the 10 most recent Versions of your Worker
+			  wrangler versions upload                    Uploads your Worker code and config as a new Version
+			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 
 			GLOBAL FLAGS
@@ -88,10 +88,10 @@ describe("versions --help", () => {
 			🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
 
 			COMMANDS
-			  wrangler versions view <version-id>         View the details of a specific version of your Worker [open-beta]
-			  wrangler versions list                      List the 10 most recent Versions of your Worker [open-beta]
-			  wrangler versions upload                    Uploads your Worker code and config as a new Version [open-beta]
-			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [open-beta]
+			  wrangler versions view <version-id>         View the details of a specific version of your Worker
+			  wrangler versions list                      List the 10 most recent Versions of your Worker
+			  wrangler versions upload                    Uploads your Worker code and config as a new Version
+			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 
 			GLOBAL FLAGS
@@ -126,10 +126,10 @@ describe("versions subhelp", () => {
 			🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
 
 			COMMANDS
-			  wrangler versions view <version-id>         View the details of a specific version of your Worker [open-beta]
-			  wrangler versions list                      List the 10 most recent Versions of your Worker [open-beta]
-			  wrangler versions upload                    Uploads your Worker code and config as a new Version [open-beta]
-			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [open-beta]
+			  wrangler versions view <version-id>         View the details of a specific version of your Worker
+			  wrangler versions list                      List the 10 most recent Versions of your Worker
+			  wrangler versions upload                    Uploads your Worker code and config as a new Version
+			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 
 			GLOBAL FLAGS
@@ -152,10 +152,10 @@ describe("versions subhelp", () => {
 			🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
 
 			COMMANDS
-			  wrangler versions view <version-id>         View the details of a specific version of your Worker [open-beta]
-			  wrangler versions list                      List the 10 most recent Versions of your Worker [open-beta]
-			  wrangler versions upload                    Uploads your Worker code and config as a new Version [open-beta]
-			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [open-beta]
+			  wrangler versions view <version-id>         View the details of a specific version of your Worker
+			  wrangler versions list                      List the 10 most recent Versions of your Worker
+			  wrangler versions upload                    Uploads your Worker code and config as a new Version
+			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 
 			GLOBAL FLAGS
@@ -178,10 +178,10 @@ describe("versions subhelp", () => {
 			🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
 
 			COMMANDS
-			  wrangler versions view <version-id>         View the details of a specific version of your Worker [open-beta]
-			  wrangler versions list                      List the 10 most recent Versions of your Worker [open-beta]
-			  wrangler versions upload                    Uploads your Worker code and config as a new Version [open-beta]
-			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [open-beta]
+			  wrangler versions view <version-id>         View the details of a specific version of your Worker
+			  wrangler versions list                      List the 10 most recent Versions of your Worker
+			  wrangler versions upload                    Uploads your Worker code and config as a new Version
+			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 
 			GLOBAL FLAGS
@@ -204,10 +204,10 @@ describe("versions subhelp", () => {
 			🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
 
 			COMMANDS
-			  wrangler versions view <version-id>         View the details of a specific version of your Worker [open-beta]
-			  wrangler versions list                      List the 10 most recent Versions of your Worker [open-beta]
-			  wrangler versions upload                    Uploads your Worker code and config as a new Version [open-beta]
-			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions [open-beta]
+			  wrangler versions view <version-id>         View the details of a specific version of your Worker
+			  wrangler versions list                      List the 10 most recent Versions of your Worker
+			  wrangler versions upload                    Uploads your Worker code and config as a new Version
+			  wrangler versions deploy [version-specs..]  Safely roll out new Versions of your Worker by splitting traffic between multiple Versions
 			  wrangler versions secret                    Generate a secret that can be referenced in a Worker
 
 			GLOBAL FLAGS

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -45,7 +45,7 @@ export const versionsDeployCommand = createCommand({
 		description:
 			"Safely roll out new Versions of your Worker by splitting traffic between multiple Versions",
 		owner: "Workers: Authoring and Testing",
-		status: "open-beta",
+		status: "stable",
 	},
 	args: {
 		name: {

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -13,7 +13,7 @@ export const versionsListCommand = createCommand({
 	metadata: {
 		description: "List the 10 most recent Versions of your Worker",
 		owner: "Workers: Authoring and Testing",
-		status: "open-beta",
+		status: "stable",
 	},
 	args: {
 		name: {

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -131,7 +131,7 @@ export const versionsUploadCommand = createCommand({
 	metadata: {
 		description: "Uploads your Worker code and config as a new Version",
 		owner: "Workers: Authoring and Testing",
-		status: "open-beta",
+		status: "stable",
 	},
 	args: {
 		script: {

--- a/packages/wrangler/src/versions/view.ts
+++ b/packages/wrangler/src/versions/view.ts
@@ -15,7 +15,7 @@ export const versionsViewCommand = createCommand({
 	metadata: {
 		description: "View the details of a specific version of your Worker",
 		owner: "Workers: Authoring and Testing",
-		status: "open-beta",
+		status: "stable",
 	},
 	args: {
 		"version-id": {


### PR DESCRIPTION
`wrangler versions` commands have been GA since Birthday Week—this PR is a minimal change to mark them as stable.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Matching documented behaviour

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
