### PR TITLE
Instrument analytics for invoke_user_worker_ahead_of_assets

### DIFF
--- a/.changeset/funny-impalas-run.md
+++ b/.changeset/funny-impalas-run.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Instrument analytics around assets.serve_directly

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -19,6 +19,8 @@ type Data = {
 	metalId?: number;
 	// double4 - Colo tier (e.g. tier 1, tier 2, tier 3)
 	coloTier?: number;
+	// double5 - Run user worker ahead of assets
+	userWorkerAhead?: boolean;
 
 	// -- Blobs --
 	// blob1 - Hostname of the request
@@ -63,6 +65,9 @@ export class Analytics {
 				this.data.coloId ?? -1, // double2
 				this.data.metalId ?? -1, // double3
 				this.data.coloTier ?? -1, // double4
+				this.data.userWorkerAhead === undefined // double5
+					? -1
+					: Number(this.data.userWorkerAhead),
 			],
 			blobs: [
 				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes

--- a/packages/workers-shared/router-worker/src/index.ts
+++ b/packages/workers-shared/router-worker/src/index.ts
@@ -44,7 +44,7 @@ export default {
 				sentry.setTag("metal", env.COLO_METADATA.metalId);
 			}
 
-			if (env.COLO_METADATA && env.VERSION_METADATA) {
+			if (env.COLO_METADATA && env.VERSION_METADATA && env.CONFIG) {
 				analytics.setData({
 					coloId: env.COLO_METADATA.coloId,
 					metalId: env.COLO_METADATA.metalId,
@@ -52,6 +52,7 @@ export default {
 					coloRegion: env.COLO_METADATA.coloRegion,
 					hostname: url.hostname,
 					version: env.VERSION_METADATA.id,
+					userWorkerAhead: env.CONFIG.invoke_user_worker_ahead_of_assets,
 				});
 			}
 


### PR DESCRIPTION
Provides analytic usage for invoke_user_worker_ahead_of_assets

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: analytics
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: n/a
