### PR TITLE
feat: add type declaration files if they do not exist in Astro templates

### DIFF
--- a/packages/create-cloudflare/templates-experimental/astro/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/astro/c3.ts
@@ -1,3 +1,4 @@
+import { existsSync, writeFileSync } from "fs";
 import { logRaw, updateStatus } from "@cloudflare/cli";
 import { blue, brandColor, dim } from "@cloudflare/cli/colors";
 import { runFrameworkGenerator } from "frameworks/index";
@@ -32,6 +33,9 @@ const configure = async (ctx: C3Context) => {
 
 const updateAstroConfig = () => {
 	const filePath = "astro.config.mjs";
+	if (!existsSync(filePath)) {
+		writeFileSync(filePath, '/// <reference path="../.astro/types.d.ts" />', { encoding: "utf-8" });
+	}
 
 	updateStatus(`Updating configuration in ${blue(filePath)}`);
 

--- a/packages/create-cloudflare/templates/astro/c3.ts
+++ b/packages/create-cloudflare/templates/astro/c3.ts
@@ -1,3 +1,4 @@
+import { existsSync, writeFileSync } from "fs";
 import { logRaw, updateStatus } from "@cloudflare/cli";
 import { blue, brandColor, dim } from "@cloudflare/cli/colors";
 import { runFrameworkGenerator } from "frameworks/index";
@@ -65,6 +66,9 @@ const updateEnvDeclaration = (ctx: C3Context) => {
 	}
 
 	const filePath = "src/env.d.ts";
+	if (!existsSync(filePath)) {
+		writeFileSync(filePath, '/// <reference path="../.astro/types.d.ts" />', { encoding: "utf-8" });
+	}
 
 	updateStatus(`Adding type declarations in ${blue(filePath)}`);
 


### PR DESCRIPTION
Fixes #7416 
Fixes #6930 

_Describe your change..._

Add type declaration files if they do not exist in Astro templates

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: bug fix
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
