### PR TITLE
chore: split readConfig and readPages config to simplify and lower responsibilities

### DIFF
--- a/packages/wrangler/src/api/pages/deploy.ts
+++ b/packages/wrangler/src/api/pages/deploy.ts
@@ -5,7 +5,7 @@ import path, { join, resolve as resolvePath } from "node:path";
 import { cwd } from "node:process";
 import { File, FormData } from "undici";
 import { fetchResult } from "../../cfetch";
-import { readConfig } from "../../config";
+import { readPagesConfig } from "../../config";
 import { shouldCheckFetch } from "../../deployment-bundle/bundle";
 import { validateNodeCompatMode } from "../../deployment-bundle/node-compat";
 import { FatalError } from "../../errors";
@@ -160,11 +160,7 @@ export async function deploy({
 	let config: Config | undefined;
 
 	try {
-		config = readConfig(
-			undefined,
-			{ ...args, env },
-			{ requirePagesConfig: true }
-		);
+		config = readPagesConfig(undefined, { ...args, env });
 	} catch (err) {
 		if (
 			!(

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -1,6 +1,6 @@
 import { existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { configFileName, findWranglerConfig, readConfig } from "../config";
+import { configFileName, findWranglerConfig, readPagesConfig } from "../config";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
 import {
@@ -56,15 +56,11 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 		pages_build_output_dir: string;
 	};
 	try {
-		config = readConfig(
-			configPath,
-			{
-				...args,
-				// eslint-disable-next-line turbo/no-undeclared-env-vars
-				env: process.env.PAGES_ENVIRONMENT,
-			},
-			{ requirePagesConfig: true }
-		);
+		config = readPagesConfig(configPath, {
+			...args,
+			// eslint-disable-next-line turbo/no-undeclared-env-vars
+			env: process.env.PAGES_ENVIRONMENT,
+		});
 	} catch (err) {
 		// found `wrangler.toml` but `pages_build_output_dir` is not specified
 		if (

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -8,7 +8,7 @@ import path, {
 	resolve as resolvePath,
 } from "node:path";
 import { createUploadWorkerBundleContents } from "../api/pages/create-worker-bundle-contents";
-import { findWranglerConfig, readConfig } from "../config";
+import { findWranglerConfig, readPagesConfig } from "../config";
 import { shouldCheckFetch } from "../deployment-bundle/bundle";
 import { writeAdditionalModules } from "../deployment-bundle/find-additional-modules";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
@@ -359,15 +359,11 @@ async function maybeReadPagesConfig(
 		return undefined;
 	}
 	try {
-		const config = readConfig(
-			configPath,
-			{
-				...args,
-				// eslint-disable-next-line turbo/no-undeclared-env-vars
-				env: process.env.PAGES_ENVIRONMENT,
-			},
-			{ requirePagesConfig: true }
-		);
+		const config = readPagesConfig(configPath, {
+			...args,
+			// eslint-disable-next-line turbo/no-undeclared-env-vars
+			env: process.env.PAGES_ENVIRONMENT,
+		});
 
 		return {
 			...config,

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { deploy } from "../api/pages/deploy";
 import { fetchResult } from "../cfetch";
-import { configFileName, findWranglerConfig, readConfig } from "../config";
+import { configFileName, findWranglerConfig, readPagesConfig } from "../config";
 import { getConfigCache, saveToConfigCache } from "../config-cache";
 import { prompt, select } from "../dialogs";
 import { FatalError } from "../errors";
@@ -123,11 +123,7 @@ export const Handler = async (args: PagesDeployArgs) => {
 		 * need for now. We will perform a second config file read later
 		 * in `/api/pages/deploy`, that will get the environment specific config
 		 */
-		config = readConfig(
-			configPath,
-			{ ...args, env: undefined },
-			{ requirePagesConfig: true }
-		);
+		config = readPagesConfig(configPath, { ...args, env: undefined });
 	} catch (err) {
 		if (
 			!(

--- a/packages/wrangler/src/pages/secret/index.ts
+++ b/packages/wrangler/src/pages/secret/index.ts
@@ -2,7 +2,11 @@ import path from "node:path";
 import readline from "node:readline";
 import chalk from "chalk";
 import { fetchResult } from "../../cfetch";
-import { configFileName, findWranglerConfig, readConfig } from "../../config";
+import {
+	configFileName,
+	findWranglerConfig,
+	readPagesConfig,
+} from "../../config";
 import { getConfigCache } from "../../config-cache";
 import { confirm, prompt } from "../../dialogs";
 import { FatalError } from "../../errors";
@@ -49,11 +53,7 @@ async function pagesProject(
 		 * return the top-level config. This contains all the information we
 		 * need.
 		 */
-		config = readConfig(
-			configPath,
-			{ env: undefined },
-			{ requirePagesConfig: true }
-		);
+		config = readPagesConfig(configPath, { env: undefined });
 	} catch (err) {
 		if (
 			!(


### PR DESCRIPTION
Fixes #000.

The `readConfig` function currently does too much:

- it needs to know about pages config quirks
- it needs to know how to modify config to get python scripts to work

Added to that, the `readConfig` function currently takes a `requirePagesConfig` flag, but actually does more than just checking for its existence - it also does pages-specific normalisation and validation, and changes the behaviour of errors and logs within the function.

This refactor splits up `readConfig` into `readConfig` + `readPagesConfig`.

The goal is to simplify the top level function and make it easier to read and modify in the future.

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal changes only
