### PR TITLE
Modify readConfig and readPagesConfig function signatures to make them more readable/concise

### DIFF
--- a/packages/wrangler/src/__tests__/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/configuration.test.ts
@@ -19,7 +19,7 @@ describe("readConfig()", () => {
 			main: "index.py",
 			compatibility_flags: ["python_workers"],
 		});
-		const config = readConfig("wrangler.toml", {});
+		const config = readConfig({ configPath: "wrangler.toml", args: {} });
 		expect(config.rules).toMatchInlineSnapshot(`
 			Array [
 			  Object {
@@ -36,7 +36,7 @@ describe("readConfig()", () => {
 			main: "index.py",
 		});
 		try {
-			readConfig("wrangler.toml", {});
+			readConfig({ configPath: "wrangler.toml", args: {} });
 			expect.fail();
 		} catch (e) {
 			expect(e).toMatchInlineSnapshot(

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -103,8 +103,11 @@ export async function getPlatformProxy<
 ): Promise<PlatformProxy<Env, CfProperties>> {
 	const env = options.environment;
 
-	const rawConfig = readConfig(options.configPath, {
-		env,
+	const rawConfig = readConfig({
+		configPath: options.configPath,
+		args: {
+			env,
+		},
 	});
 
 	const miniflareOptions = await run(
@@ -263,7 +266,7 @@ export function unstable_getMiniflareWorkerOptions(
 ): Unstable_MiniflareWorkerOptions {
 	const config =
 		typeof configOrConfigPath === "string"
-			? readConfig(configOrConfigPath, { env })
+			? readConfig({ configPath: configOrConfigPath, args: { env } })
 			: configOrConfigPath;
 
 	const modulesRules: ModuleRule[] = config.rules

--- a/packages/wrangler/src/api/pages/deploy.ts
+++ b/packages/wrangler/src/api/pages/deploy.ts
@@ -160,7 +160,7 @@ export async function deploy({
 	let config: Config | undefined;
 
 	try {
-		config = readPagesConfig(undefined, { ...args, env });
+		config = readPagesConfig({ configPath: undefined, args: { ...args, env } });
 	} catch (err) {
 		if (
 			!(

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -414,23 +414,26 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 		const signal = this.#abortController.signal;
 		this.latestInput = input;
 		try {
-			const fileConfig = readConfig(input.config, {
-				env: input.env,
-				"dispatch-namespace": undefined,
-				"legacy-env": !input.legacy?.enableServiceEnvironments,
-				remote: input.dev?.remote,
-				upstreamProtocol:
-					input.dev?.origin?.secure === undefined
-						? undefined
-						: input.dev?.origin?.secure
-							? "https"
-							: "http",
-				localProtocol:
-					input.dev?.server?.secure === undefined
-						? undefined
-						: input.dev?.server?.secure
-							? "https"
-							: "http",
+			const fileConfig = readConfig({
+				configPath: input.config,
+				args: {
+					env: input.env,
+					"dispatch-namespace": undefined,
+					"legacy-env": !input.legacy?.enableServiceEnvironments,
+					remote: input.dev?.remote,
+					upstreamProtocol:
+						input.dev?.origin?.secure === undefined
+							? undefined
+							: input.dev?.origin?.secure
+								? "https"
+								: "http",
+					localProtocol:
+						input.dev?.server?.secure === undefined
+							? undefined
+							: input.dev?.server?.secure
+								? "https"
+								: "http",
+				},
 			});
 
 			if (typeof vitest === "undefined") {

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -105,7 +105,7 @@ export function handleFailure<
 ) => Promise<void> {
 	return async (t) => {
 		try {
-			const config = readConfig(t.config, t);
+			const config = readConfig({ configPath: t.config, args: t });
 			await fillOpenAPIConfiguration(config, t.json);
 			await cb(t, config);
 		} catch (err) {

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -72,15 +72,13 @@ type ReadConfigCommandArgs = NormalizeAndValidateConfigArgs;
  * Get the Wrangler configuration; read it from the give `configPath` if available.
  */
 export function readConfig(
-	configPath: string | undefined,
-	args: ReadConfigCommandArgs,
-	options?: { hideWarnings?: boolean }
-): Config;
-export function readConfig(
-	configPath: string | undefined,
-	args: ReadConfigCommandArgs,
-	{ hideWarnings = false }: { hideWarnings?: boolean } = {}
+	params: { configPath: string | undefined; args: ReadConfigCommandArgs },
+	options: { hideWarnings?: boolean } = {}
 ): Config {
+	let { configPath } = params;
+	const { args } = params;
+	const { hideWarnings } = options;
+
 	if (!configPath) {
 		configPath = findWranglerConfig(process.cwd());
 	}
@@ -104,10 +102,13 @@ export function readConfig(
 }
 
 export function readPagesConfig(
-	configPath: string | undefined,
-	args: ReadConfigCommandArgs,
-	{ hideWarnings = false }: { hideWarnings?: boolean } = {}
+	params: { configPath: string | undefined; args: ReadConfigCommandArgs },
+	options: { hideWarnings?: boolean } = {}
 ): Omit<Config, "pages_build_output_dir"> & { pages_build_output_dir: string } {
+	let { configPath } = params;
+	const { args } = params;
+	const { hideWarnings } = options;
+
 	if (!configPath) {
 		configPath = findWranglerConfig(process.cwd());
 	}
@@ -662,10 +663,13 @@ export function withConfig<T>(
 	handler: (
 		t: OnlyCamelCase<T & CommonYargsOptions> & { config: Config }
 	) => Promise<void>,
-	options?: Parameters<typeof readConfig>[2]
+	options?: Parameters<typeof readConfig>[1]
 ) {
 	return (t: OnlyCamelCase<T & CommonYargsOptions>) => {
-		return handler({ ...t, config: readConfig(t.config, t, options) });
+		return handler({
+			...t,
+			config: readConfig({ configPath: t.config, args: t }, options),
+		});
 	};
 }
 

--- a/packages/wrangler/src/config/validation-pages.ts
+++ b/packages/wrangler/src/config/validation-pages.ts
@@ -7,7 +7,7 @@
  * Pages.
  */
 
-import { FatalError, UserError } from "../errors";
+import { FatalError } from "../errors";
 import { defaultWranglerConfig } from "./config";
 import { Diagnostics } from "./diagnostics";
 import { isRequiredProperty } from "./validation-helpers";

--- a/packages/wrangler/src/config/validation-pages.ts
+++ b/packages/wrangler/src/config/validation-pages.ts
@@ -7,7 +7,7 @@
  * Pages.
  */
 
-import { FatalError } from "../errors";
+import { FatalError, UserError } from "../errors";
 import { defaultWranglerConfig } from "./config";
 import { Diagnostics } from "./diagnostics";
 import { isRequiredProperty } from "./validation-helpers";

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -82,9 +82,12 @@ function createHandler(def: CommandDefinition) {
 			await def.handler(args, {
 				config:
 					def.behaviour?.provideConfig ?? true
-						? readConfig(args.config, args, {
-								hideWarnings: !(def.behaviour?.printConfigWarnings ?? true),
-							})
+						? readConfig(
+								{ configPath: args.config, args },
+								{
+									hideWarnings: !(def.behaviour?.printConfigWarnings ?? true),
+								}
+							)
 						: defaultWranglerConfig,
 				errors: { UserError, FatalError },
 				logger,

--- a/packages/wrangler/src/d1/execute.ts
+++ b/packages/wrangler/src/d1/execute.ts
@@ -111,7 +111,7 @@ export const Handler = async (args: HandlerOptions): Promise<void> => {
 	}
 	await printWranglerBanner();
 
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	if (file && command) {
 		throw createFatalError(

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -74,7 +74,7 @@ type HandlerOptions = StrictYargsOptionsToInterface<typeof Options>;
 export const Handler = async (args: HandlerOptions): Promise<void> => {
 	const { local, remote, name, output, schema, data, table } = args;
 	await printWranglerBanner();
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	if (!local && !remote) {
 		throw new UserError(`You must specify either --local or --remote`);

--- a/packages/wrangler/src/delete.ts
+++ b/packages/wrangler/src/delete.ts
@@ -97,7 +97,7 @@ export async function deleteHandler(args: DeleteArgs) {
 	const configPath =
 		args.config ||
 		(args.script && findWranglerConfig(path.dirname(args.script)));
-	const config = readConfig(configPath, args);
+	const config = readConfig({ configPath, args });
 	if (config.pages_build_output_dir) {
 		throw new UserError(
 			"It looks like you've run a Workers-specific command in a Pages project.\n" +

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -266,7 +266,7 @@ async function deployWorker(args: DeployArgs) {
 		args.config ||
 		(args.script && findWranglerConfig(path.dirname(args.script)));
 	const projectRoot = configPath && path.dirname(configPath);
-	const config = readConfig(configPath, args);
+	const config = readConfig({ configPath, args });
 	if (config.pages_build_output_dir) {
 		throw new UserError(
 			"It looks like you've run a Workers-specific command in a Pages project.\n" +

--- a/packages/wrangler/src/deployments.ts
+++ b/packages/wrangler/src/deployments.ts
@@ -323,7 +323,7 @@ export async function commonDeploymentCMDSetup(
 	yargs: ArgumentsCamelCase<CommonYargsOptions>
 ) {
 	await printWranglerBanner();
-	const config = readConfig(yargs.config, yargs);
+	const config = readConfig({ configPath: yargs.config, args: yargs });
 	const accountId = await requireAuth(config);
 	const scriptName = getScriptName(
 		{ name: yargs.name as string, env: undefined },

--- a/packages/wrangler/src/dispatch-namespace.ts
+++ b/packages/wrangler/src/dispatch-namespace.ts
@@ -113,7 +113,7 @@ export function workerNamespaceCommands(
 			"List all dispatch namespaces",
 			(args) => args,
 			async (args) => {
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const accountId = await requireAuth(config);
 				await listWorkerNamespaces(accountId);
 				metrics.sendMetricsEvent("list dispatch namespaces", {
@@ -132,7 +132,7 @@ export function workerNamespaceCommands(
 				});
 			},
 			async (args) => {
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const accountId = await requireAuth(config);
 				await getWorkerNamespaceInfo(accountId, args.name);
 				metrics.sendMetricsEvent("view dispatch namespace", {
@@ -152,7 +152,7 @@ export function workerNamespaceCommands(
 			},
 			async (args) => {
 				await printWranglerBanner();
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const accountId = await requireAuth(config);
 				await createWorkerNamespace(accountId, args.name);
 				metrics.sendMetricsEvent("create dispatch namespace", {
@@ -172,7 +172,7 @@ export function workerNamespaceCommands(
 			},
 			async (args) => {
 				await printWranglerBanner();
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const accountId = await requireAuth(config);
 				await deleteWorkerNamespace(accountId, args.name);
 				metrics.sendMetricsEvent("delete dispatch namespace", {
@@ -198,7 +198,7 @@ export function workerNamespaceCommands(
 			},
 			async (args) => {
 				await printWranglerBanner();
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const accountId = await requireAuth(config);
 				await renameWorkerNamespace(accountId, args.oldName, args.newName);
 				metrics.sendMetricsEvent("rename dispatch namespace", {

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -24,7 +24,7 @@ export function options(commonYargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 	const origin = getOriginFromArgs(false, args);
 
 	logger.log(`🚧 Creating '${args.name}'`);

--- a/packages/wrangler/src/hyperdrive/delete.ts
+++ b/packages/wrangler/src/hyperdrive/delete.ts
@@ -17,7 +17,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	logger.log(`🗑️ Deleting Hyperdrive database config ${args.id}`);
 	await deleteConfig(config, args.id);

--- a/packages/wrangler/src/hyperdrive/get.ts
+++ b/packages/wrangler/src/hyperdrive/get.ts
@@ -17,7 +17,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	const database = await getConfig(config, args.id);
 	logger.log(JSON.stringify(database, null, 2));

--- a/packages/wrangler/src/hyperdrive/list.ts
+++ b/packages/wrangler/src/hyperdrive/list.ts
@@ -13,7 +13,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	logger.log(`📋 Listing Hyperdrive configs`);
 	const databases = await listConfigs(config);

--- a/packages/wrangler/src/hyperdrive/update.ts
+++ b/packages/wrangler/src/hyperdrive/update.ts
@@ -24,7 +24,7 @@ export function options(commonYargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 	const origin = getOriginFromArgs(true, args);
 
 	logger.log(`🚧 Updating '${args.id}'`);

--- a/packages/wrangler/src/init.ts
+++ b/packages/wrangler/src/init.ts
@@ -219,7 +219,7 @@ export async function initHandler(args: InitArgs) {
 
 			return;
 		} else {
-			const config = readConfig(args.config, args);
+			const config = readConfig({ configPath: args.config, args });
 			accountId = await requireAuth(config);
 			try {
 				await fetchResult<ServiceMetadataRes>(

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -116,7 +116,7 @@ export const kvNamespaceCreateCommand = createCommand({
 	positionalArgs: ["namespace"],
 
 	async handler(args) {
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 		if (!config.name) {
 			logger.warn(
 				"No configured name present, using `worker` as a prefix for the title"
@@ -173,7 +173,7 @@ export const kvNamespaceListCommand = createCommand({
 
 	behaviour: { printBanner: false },
 	async handler(args) {
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 
 		const accountId = await requireAuth(config);
 
@@ -215,7 +215,7 @@ export const kvNamespaceDeleteCommand = createCommand({
 	},
 
 	async handler(args) {
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 
 		let id;
 		try {
@@ -324,7 +324,7 @@ export const kvKeyPutCommand = createCommand({
 	},
 
 	async handler({ key, ttl, expiration, metadata, ...args }) {
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 		const namespaceId = getKVNamespaceId(args, config);
 		// One of `args.path` and `args.value` must be defined
 		const value = args.path
@@ -426,7 +426,7 @@ export const kvKeyListCommand = createCommand({
 	behaviour: { printBanner: false },
 	async handler({ prefix, ...args }) {
 		// TODO: support for limit+cursor (pagination)
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 		const namespaceId = getKVNamespaceId(args, config);
 
 		let result: NamespaceKeyInfo[];
@@ -505,7 +505,7 @@ export const kvKeyGetCommand = createCommand({
 
 	behaviour: { printBanner: false },
 	async handler({ key, ...args }) {
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 		const namespaceId = getKVNamespaceId(args, config);
 
 		let bufferKVValue;
@@ -589,7 +589,7 @@ export const kvKeyDeleteCommand = createCommand({
 	},
 
 	async handler({ key, ...args }) {
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 		const namespaceId = getKVNamespaceId(args, config);
 
 		logger.log(`Deleting the key "${key}" on namespace ${namespaceId}.`);
@@ -676,7 +676,7 @@ export const kvBulkPutCommand = createCommand({
 		// This could be made more efficient with a streaming parser/uploader
 		// but we'll do that in the future if needed.
 
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 		const namespaceId = getKVNamespaceId(args, config);
 		const content = parseJSON(readFileSync(filename), filename);
 
@@ -802,7 +802,7 @@ export const kvBulkDeleteCommand = createCommand({
 	},
 
 	async handler({ filename, ...args }) {
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 		const namespaceId = getKVNamespaceId(args, config);
 
 		if (!args.force) {

--- a/packages/wrangler/src/pages/build-env.ts
+++ b/packages/wrangler/src/pages/build-env.ts
@@ -56,10 +56,13 @@ export const Handler = async (args: PagesBuildEnvArgs) => {
 		pages_build_output_dir: string;
 	};
 	try {
-		config = readPagesConfig(configPath, {
-			...args,
-			// eslint-disable-next-line turbo/no-undeclared-env-vars
-			env: process.env.PAGES_ENVIRONMENT,
+		config = readPagesConfig({
+			configPath,
+			args: {
+				...args,
+				// eslint-disable-next-line turbo/no-undeclared-env-vars
+				env: process.env.PAGES_ENVIRONMENT,
+			},
 		});
 	} catch (err) {
 		// found `wrangler.toml` but `pages_build_output_dir` is not specified

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -359,10 +359,13 @@ async function maybeReadPagesConfig(
 		return undefined;
 	}
 	try {
-		const config = readPagesConfig(configPath, {
-			...args,
-			// eslint-disable-next-line turbo/no-undeclared-env-vars
-			env: process.env.PAGES_ENVIRONMENT,
+		const config = readPagesConfig({
+			configPath,
+			args: {
+				...args,
+				// eslint-disable-next-line turbo/no-undeclared-env-vars
+				env: process.env.PAGES_ENVIRONMENT,
+			},
 		});
 
 		return {

--- a/packages/wrangler/src/pages/deploy.ts
+++ b/packages/wrangler/src/pages/deploy.ts
@@ -123,7 +123,7 @@ export const Handler = async (args: PagesDeployArgs) => {
 		 * need for now. We will perform a second config file read later
 		 * in `/api/pages/deploy`, that will get the environment specific config
 		 */
-		config = readPagesConfig(configPath, { ...args, env: undefined });
+		config = readPagesConfig({ configPath, args: { ...args, env: undefined } });
 	} catch (err) {
 		if (
 			!(

--- a/packages/wrangler/src/pages/deployment-tails.ts
+++ b/packages/wrangler/src/pages/deployment-tails.ts
@@ -131,7 +131,7 @@ export async function Handler({
 		await printWranglerBanner();
 	}
 
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 	const pagesConfig = getConfigCache<PagesConfigCache>(
 		PAGES_CONFIG_CACHE_FILENAME
 	);

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -303,7 +303,10 @@ export const Handler = async (args: PagesDevArguments) => {
 
 	// for `dev` we always use the top-level config, which means we need
 	// to read the config file with `env` set to `undefined`
-	const config = readConfig(undefined, { ...args, env: undefined });
+	const config = readConfig({
+		args: { ...args, env: undefined },
+		configPath: undefined,
+	});
 	const resolvedDirectory = args.directory ?? config.pages_build_output_dir;
 	const [_pages, _dev, ...remaining] = args._;
 	const command = remaining;

--- a/packages/wrangler/src/pages/secret/index.ts
+++ b/packages/wrangler/src/pages/secret/index.ts
@@ -53,7 +53,7 @@ async function pagesProject(
 		 * return the top-level config. This contains all the information we
 		 * need.
 		 */
-		config = readPagesConfig(configPath, { env: undefined });
+		config = readPagesConfig({ configPath, args: { env: undefined } });
 	} catch (err) {
 		if (
 			!(

--- a/packages/wrangler/src/pipelines/index.ts
+++ b/packages/wrangler/src/pipelines/index.ts
@@ -183,7 +183,7 @@ export function pipelines(pipelineYargs: CommonYargsArgv) {
 			async (args) => {
 				await printWranglerBanner();
 
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const bucket = args.r2;
 				const name = args.pipeline;
 				const compression =
@@ -302,7 +302,7 @@ export function pipelines(pipelineYargs: CommonYargsArgv) {
 			"List current pipelines",
 			(yargs) => yargs,
 			async (args) => {
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const accountId = await requireAuth(config);
 
 				// TODO: we should show bindings & transforms if they exist for given ids
@@ -332,7 +332,7 @@ export function pipelines(pipelineYargs: CommonYargsArgv) {
 			},
 			async (args) => {
 				await printWranglerBanner();
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const accountId = await requireAuth(config);
 				const name = args.pipeline;
 
@@ -368,7 +368,7 @@ export function pipelines(pipelineYargs: CommonYargsArgv) {
 
 				const name = args.pipeline;
 				// only the fields set will be updated - other fields will use the existing config
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const accountId = await requireAuth(config);
 
 				const pipelineConfig = await getPipeline(accountId, name);
@@ -494,7 +494,7 @@ export function pipelines(pipelineYargs: CommonYargsArgv) {
 			},
 			async (args) => {
 				await printWranglerBanner();
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				const accountId = await requireAuth(config);
 				const name = args.pipeline;
 

--- a/packages/wrangler/src/pubsub/pubsub-commands.ts
+++ b/packages/wrangler/src/pubsub/pubsub-commands.ts
@@ -38,7 +38,7 @@ export function pubSubCommands(
 								.epilogue(pubsub.pubSubBetaWarning);
 						},
 						async (args) => {
-							const config = readConfig(args.config, args);
+							const config = readConfig({ configPath: args.config, args });
 							const accountId = await requireAuth(config);
 
 							const namespace: pubsub.PubSubNamespace = {
@@ -63,7 +63,7 @@ export function pubSubCommands(
 							return yargs.epilogue(pubsub.pubSubBetaWarning);
 						},
 						async (args) => {
-							const config = readConfig(args.config, args);
+							const config = readConfig({ configPath: args.config, args });
 							const accountId = await requireAuth(config);
 
 							logger.log(await pubsub.listPubSubNamespaces(accountId));
@@ -85,7 +85,7 @@ export function pubSubCommands(
 								.epilogue(pubsub.pubSubBetaWarning);
 						},
 						async (args) => {
-							const config = readConfig(args.config, args);
+							const config = readConfig({ configPath: args.config, args });
 							const accountId = await requireAuth(config);
 
 							if (
@@ -115,7 +115,7 @@ export function pubSubCommands(
 								.epilogue(pubsub.pubSubBetaWarning);
 						},
 						async (args) => {
-							const config = readConfig(args.config, args);
+							const config = readConfig({ configPath: args.config, args });
 							const accountId = await requireAuth(config);
 
 							logger.log(
@@ -164,7 +164,7 @@ export function pubSubCommands(
 						})
 						.epilogue(pubsub.pubSubBetaWarning),
 				async (args) => {
-					const config = readConfig(args.config, args);
+					const config = readConfig({ configPath: args.config, args });
 					const accountId = await requireAuth(config);
 
 					const broker: pubsub.PubSubBroker = {
@@ -229,7 +229,7 @@ export function pubSubCommands(
 						})
 						.epilogue(pubsub.pubSubBetaWarning),
 				async (args) => {
-					const config = readConfig(args.config, args);
+					const config = readConfig({ configPath: args.config, args });
 					const accountId = await requireAuth(config);
 
 					const broker: pubsub.PubSubBrokerUpdate = {};
@@ -283,7 +283,7 @@ export function pubSubCommands(
 						.epilogue(pubsub.pubSubBetaWarning);
 				},
 				async (args) => {
-					const config = readConfig(args.config, args);
+					const config = readConfig({ configPath: args.config, args });
 					const accountId = await requireAuth(config);
 
 					logger.log(await pubsub.listPubSubBrokers(accountId, args.namespace));
@@ -313,7 +313,7 @@ export function pubSubCommands(
 							.epilogue(pubsub.pubSubBetaWarning);
 					},
 					async (args) => {
-						const config = readConfig(args.config, args);
+						const config = readConfig({ configPath: args.config, args });
 						const accountId = await requireAuth(config);
 
 						if (
@@ -353,7 +353,7 @@ export function pubSubCommands(
 							.epilogue(pubsub.pubSubBetaWarning);
 					},
 					async (args) => {
-						const config = readConfig(args.config, args);
+						const config = readConfig({ configPath: args.config, args });
 						const accountId = await requireAuth(config);
 
 						logger.log(
@@ -412,7 +412,7 @@ export function pubSubCommands(
 						.epilogue(pubsub.pubSubBetaWarning);
 				},
 				async (args) => {
-					const config = readConfig(args.config, args);
+					const config = readConfig({ configPath: args.config, args });
 					const accountId = await requireAuth(config);
 
 					let parsedExpiration: number | undefined;
@@ -472,7 +472,7 @@ export function pubSubCommands(
 						.epilogue(pubsub.pubSubBetaWarning);
 				},
 				async (args) => {
-					const config = readConfig(args.config, args);
+					const config = readConfig({ configPath: args.config, args });
 					const accountId = await requireAuth(config);
 
 					const numTokens = args.jti.length;
@@ -520,7 +520,7 @@ export function pubSubCommands(
 						.epilogue(pubsub.pubSubBetaWarning);
 				},
 				async (args) => {
-					const config = readConfig(args.config, args);
+					const config = readConfig({ configPath: args.config, args });
 					const accountId = await requireAuth(config);
 
 					const numTokens = args.jti.length;
@@ -561,7 +561,7 @@ export function pubSubCommands(
 						.epilogue(pubsub.pubSubBetaWarning);
 				},
 				async (args) => {
-					const config = readConfig(args.config, args);
+					const config = readConfig({ configPath: args.config, args });
 					const accountId = await requireAuth(config);
 
 					logger.log(`Listing previously revoked tokens for ${args.name}...`);
@@ -597,7 +597,7 @@ export function pubSubCommands(
 						.epilogue(pubsub.pubSubBetaWarning);
 				},
 				async (args) => {
-					const config = readConfig(args.config, args);
+					const config = readConfig({ configPath: args.config, args });
 					const accountId = await requireAuth(config);
 
 					logger.log(

--- a/packages/wrangler/src/queues/cli/commands/consumer/http-pull/add.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/http-pull/add.ts
@@ -60,7 +60,7 @@ function createBody(
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	if (Array.isArray(args.retryDelaySecs)) {
 		throw new CommandLineArgsError(

--- a/packages/wrangler/src/queues/cli/commands/consumer/http-pull/remove.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/http-pull/remove.ts
@@ -17,7 +17,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	logger.log(`Removing consumer from queue ${args.queueName}.`);
 	await deletePullConsumer(config, args.queueName);

--- a/packages/wrangler/src/queues/cli/commands/consumer/worker/add.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/worker/add.ts
@@ -74,7 +74,7 @@ function createBody(
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	if (Array.isArray(args.retryDelaySecs)) {
 		throw new CommandLineArgsError(

--- a/packages/wrangler/src/queues/cli/commands/consumer/worker/remove.ts
+++ b/packages/wrangler/src/queues/cli/commands/consumer/worker/remove.ts
@@ -23,7 +23,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	logger.log(`Removing consumer from queue ${args.queueName}.`);
 	await deleteWorkerConsumer(config, args.queueName, args.scriptName, args.env);

--- a/packages/wrangler/src/queues/cli/commands/create.ts
+++ b/packages/wrangler/src/queues/cli/commands/create.ts
@@ -52,7 +52,7 @@ function createBody(
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 	const body = createBody(args);
 	try {
 		logger.log(`🌀 Creating queue '${args.name}'`);

--- a/packages/wrangler/src/queues/cli/commands/delete.ts
+++ b/packages/wrangler/src/queues/cli/commands/delete.ts
@@ -18,7 +18,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	logger.log(`Deleting queue ${args.name}.`);
 	await deleteQueue(config, args.name);

--- a/packages/wrangler/src/queues/cli/commands/info.ts
+++ b/packages/wrangler/src/queues/cli/commands/info.ts
@@ -20,7 +20,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 	const queue: QueueResponse = await getQueue(config, args.name);
 	const accountId = await requireAuth(config);
 

--- a/packages/wrangler/src/queues/cli/commands/list.ts
+++ b/packages/wrangler/src/queues/cli/commands/list.ts
@@ -18,7 +18,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	const queues = await listQueues(config, args.page);
 	logger.table(

--- a/packages/wrangler/src/r2/object.ts
+++ b/packages/wrangler/src/r2/object.ts
@@ -366,7 +366,7 @@ export const r2ObjectDeleteCommand = createCommand({
 	},
 	async handler(args) {
 		const { objectPath, jurisdiction } = args;
-		const config = readConfig(args.config, args);
+		const config = readConfig({ configPath: args.config, args });
 		const { bucket, key } = bucketAndKeyFromObjectPath(objectPath);
 		let fullBucketName = bucket;
 		if (jurisdiction !== undefined) {

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -154,7 +154,7 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 			},
 			async (args) => {
 				await printWranglerBanner();
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				if (config.pages_build_output_dir) {
 					throw new UserError(
 						"It looks like you've run a Workers-specific command in a Pages project.\n" +
@@ -262,7 +262,7 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 			},
 			async (args) => {
 				await printWranglerBanner();
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				if (config.pages_build_output_dir) {
 					throw new UserError(
 						"It looks like you've run a Workers-specific command in a Pages project.\n" +
@@ -324,7 +324,7 @@ export const secret = (secretYargs: CommonYargsArgv) => {
 					});
 			},
 			async (args) => {
-				const config = readConfig(args.config, args);
+				const config = readConfig({ configPath: args.config, args });
 				if (config.pages_build_output_dir) {
 					throw new UserError(
 						"It looks like you've run a Workers-specific command in a Pages project.\n" +
@@ -391,7 +391,10 @@ type SecretBulkArgs = StrictYargsOptionsToInterface<typeof secretBulkOptions>;
 
 export const secretBulkHandler = async (secretBulkArgs: SecretBulkArgs) => {
 	await printWranglerBanner();
-	const config = readConfig(secretBulkArgs.config, secretBulkArgs);
+	const config = readConfig({
+		configPath: secretBulkArgs.config,
+		args: secretBulkArgs,
+	});
 	if (config.pages_build_output_dir) {
 		throw new UserError(
 			"It looks like you've run a Workers-specific command in a Pages project.\n" +

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -92,7 +92,7 @@ export async function tailHandler(args: TailArgs) {
 	if (args.format === "pretty") {
 		await printWranglerBanner();
 	}
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 	if (config.pages_build_output_dir) {
 		throw new UserError(
 			"It looks like you've run a Workers-specific command in a Pages project.\n" +

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -57,7 +57,7 @@ async function triggersDeployHandler(
 ) {
 	await printWranglerBanner();
 
-	const config = readConfig(undefined, args);
+	const config = readConfig({ configPath: undefined, args });
 	const assetsOptions = getAssetsOptions({ assets: undefined }, config);
 	metrics.sendMetricsEvent(
 		"deploy worker triggers",

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -76,7 +76,7 @@ export async function typesHandler(
 		return;
 	}
 
-	const config = readConfig(configPath, args);
+	const config = readConfig({ configPath, args });
 
 	// args.xRuntime will be a string if the user passes "--x-include-runtime" or "--x-include-runtime=..."
 	if (typeof args.experimentalIncludeRuntime === "string") {

--- a/packages/wrangler/src/vectorize/create.ts
+++ b/packages/wrangler/src/vectorize/create.ts
@@ -67,7 +67,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	let indexConfig;
 	if (args.preset) {

--- a/packages/wrangler/src/vectorize/createMetadataIndex.ts
+++ b/packages/wrangler/src/vectorize/createMetadataIndex.ts
@@ -36,7 +36,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	const reqOptions: VectorizeMetadataIndexProperty = {
 		propertyName: args.propertyName,

--- a/packages/wrangler/src/vectorize/delete.ts
+++ b/packages/wrangler/src/vectorize/delete.ts
@@ -32,7 +32,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	logger.log(`Deleting Vectorize index ${args.name}`);
 	if (!args.force) {

--- a/packages/wrangler/src/vectorize/deleteByIds.ts
+++ b/packages/wrangler/src/vectorize/deleteByIds.ts
@@ -30,7 +30,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	if (args.ids.length === 0) {
 		logger.error("🚨 Please provide valid vector identifiers for deletion.");

--- a/packages/wrangler/src/vectorize/deleteMetadataIndex.ts
+++ b/packages/wrangler/src/vectorize/deleteMetadataIndex.ts
@@ -26,7 +26,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	const reqOptions: VectorizeMetadataIndexPropertyName = {
 		propertyName: args.propertyName,

--- a/packages/wrangler/src/vectorize/get.ts
+++ b/packages/wrangler/src/vectorize/get.ts
@@ -31,7 +31,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 	const index = await getIndex(config, args.name, args.deprecatedV1);
 
 	if (args.json) {

--- a/packages/wrangler/src/vectorize/getByIds.ts
+++ b/packages/wrangler/src/vectorize/getByIds.ts
@@ -30,7 +30,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	if (args.ids.length === 0) {
 		logger.error("🚨 Please provide valid vector identifiers.");

--- a/packages/wrangler/src/vectorize/info.ts
+++ b/packages/wrangler/src/vectorize/info.ts
@@ -25,7 +25,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	logger.log(`📋 Fetching index info...`);
 	const info = await indexInfo(config, args.name);

--- a/packages/wrangler/src/vectorize/insert.ts
+++ b/packages/wrangler/src/vectorize/insert.ts
@@ -56,7 +56,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 	const rl = createInterface({ input: createReadStream(args.file) });
 
 	if (

--- a/packages/wrangler/src/vectorize/list.ts
+++ b/packages/wrangler/src/vectorize/list.ts
@@ -25,7 +25,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	logger.log(`📋 Listing Vectorize indexes...`);
 	const indexes = await listIndexes(config, args.deprecatedV1);

--- a/packages/wrangler/src/vectorize/listMetadataIndex.ts
+++ b/packages/wrangler/src/vectorize/listMetadataIndex.ts
@@ -25,7 +25,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	logger.log(`📋 Fetching metadata indexes...`);
 	const res = await listMetadataIndex(config, args.name);

--- a/packages/wrangler/src/vectorize/query.ts
+++ b/packages/wrangler/src/vectorize/query.ts
@@ -96,7 +96,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 
 	const queryOptions: VectorizeQueryOptions = {
 		topK: args.topK,

--- a/packages/wrangler/src/vectorize/upsert.ts
+++ b/packages/wrangler/src/vectorize/upsert.ts
@@ -47,7 +47,7 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	const config = readConfig(args.config, args);
+	const config = readConfig({ configPath: args.config, args });
 	const rl = createInterface({ input: createReadStream(args.file) });
 
 	if (Number(args.batchSize) > VECTORIZE_MAX_BATCH_SIZE) {

--- a/packages/wrangler/src/versions/deployments/list.ts
+++ b/packages/wrangler/src/versions/deployments/list.ts
@@ -42,7 +42,7 @@ export async function versionsDeploymentsListHandler(
 		await printWranglerBanner();
 	}
 
-	const config = getConfig(args);
+	const config = getConfig({ args });
 	metrics.sendMetricsEvent(
 		"list versioned deployments",
 		{ json: args.json },

--- a/packages/wrangler/src/versions/deployments/status.ts
+++ b/packages/wrangler/src/versions/deployments/status.ts
@@ -42,7 +42,7 @@ export async function versionsDeploymentsStatusHandler(
 		await printWranglerBanner();
 	}
 
-	const config = getConfig(args);
+	const config = getConfig({ args });
 	metrics.sendMetricsEvent(
 		"view latest versioned deployment",
 		{},

--- a/packages/wrangler/src/versions/rollback/index.ts
+++ b/packages/wrangler/src/versions/rollback/index.ts
@@ -58,7 +58,7 @@ function versionsRollbackOptions(rollbackYargs: CommonYargsArgv) {
 }
 
 async function versionsRollbackHandler(args: VersionsRollbackArgs) {
-	const config = getConfig(args);
+	const config = getConfig({ args });
 	const accountId = await requireAuth(config);
 	const workerName = args.name ?? config.name;
 

--- a/packages/wrangler/src/versions/secrets/bulk.ts
+++ b/packages/wrangler/src/versions/secrets/bulk.ts
@@ -45,7 +45,7 @@ export const versionsSecretBulkCommand = createCommand({
 	},
 	positionalArgs: ["json"],
 	handler: async function versionsSecretPutBulkHandler(args) {
-		const config = getConfig(args, { hideWarnings: true });
+		const config = getConfig({ args }, { hideWarnings: true });
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {
 			throw new UserError(

--- a/packages/wrangler/src/versions/secrets/delete.ts
+++ b/packages/wrangler/src/versions/secrets/delete.ts
@@ -43,7 +43,7 @@ export const versionsSecretDeleteCommand = createCommand({
 	},
 	positionalArgs: ["key"],
 	handler: async function versionsSecretDeleteHandler(args) {
-		const config = getConfig(args, { hideWarnings: true });
+		const config = getConfig({ args }, { hideWarnings: true });
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {
 			throw new UserError(

--- a/packages/wrangler/src/versions/secrets/list.ts
+++ b/packages/wrangler/src/versions/secrets/list.ts
@@ -32,7 +32,7 @@ export const versionsSecretsListCommand = createCommand({
 		},
 	},
 	handler: async function versionsSecretListHandler(args) {
-		const config = getConfig(args, { hideWarnings: true });
+		const config = getConfig({ args }, { hideWarnings: true });
 
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {

--- a/packages/wrangler/src/versions/secrets/put.ts
+++ b/packages/wrangler/src/versions/secrets/put.ts
@@ -44,7 +44,7 @@ export const versionsSecretPutCommand = createCommand({
 	},
 	positionalArgs: ["key"],
 	handler: async function versionsSecretPutHandler(args) {
-		const config = getConfig(args, { hideWarnings: true });
+		const config = getConfig({ args }, { hideWarnings: true });
 		const scriptName = getLegacyScriptName(args, config);
 		if (!scriptName) {
 			throw new UserError(

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -285,7 +285,7 @@ export const versionsUploadCommand = createCommand({
 		provideConfig: false,
 	},
 	handler: async function versionsUploadHandler(args) {
-		const config = getConfig(args, {}, args.script);
+		const config = getConfig({ args, entryPath: args.script });
 		const entry = await getEntry(args, config, "versions upload");
 		metrics.sendMetricsEvent(
 			"upload worker version",

--- a/packages/wrangler/src/versions/utils/config.ts
+++ b/packages/wrangler/src/versions/utils/config.ts
@@ -1,11 +1,15 @@
 import path from "node:path";
 import { findWranglerConfig, readConfig } from "../../config";
+import type { NormalizeAndValidateConfigArgs } from "../../config/validation";
 
-type Args = Parameters<typeof readConfig>[1] & { config?: string };
-type Options = Parameters<typeof readConfig>[2];
+type Args = NormalizeAndValidateConfigArgs & { config?: string };
+type Options = Parameters<typeof readConfig>[1];
 
-export function getConfig(args: Args, options?: Options, entryPath?: string) {
+export function getConfig(
+	{ entryPath, args }: { entryPath?: string; args: Args },
+	options?: Options
+) {
 	const configPath =
 		args.config || (entryPath && findWranglerConfig(path.dirname(entryPath)));
-	return readConfig(configPath, args, options);
+	return readConfig({ configPath, args }, options);
 }


### PR DESCRIPTION
Fixes #000.

**Before**

Things like this:
```ts
readConfig(undefined, input.args); // 'undefined' is ugly and confusing
readConfig(args.script, args);
readConfig("wrangler.toml", {}); // what is the '{}' for?
```
And it's not clear what each of those arguments mean. Especially given the complexity surrounding how we define the configPath in different circumstances (e.g. the use of the `getConfig` function) - this is just much clearer if we specify the arguments as objects.

So, this PR has the arguments to `readConfig` and `readPagesConfig` as two objects:

```ts
readConfig(params, options);
```

Making these calls much more readable.

**After**

```ts
readConfig({ configPath: undefined, args: input.args });
readConfig({ configPath: args.script, args });
readConfig({ configPath: "wrangler.toml", args: {} });
```

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only

