### PR TITLE
WC-2972: Allow Workers Assets to be mounted to a path

### DIFF
--- a/.changeset/early-baboons-fly.md
+++ b/.changeset/early-baboons-fly.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: allow routing to Workers with Assets on any HTTP route, not just the root. For example, `example.com/blog/*` can now be used to serve assets.
+These assets will be served as though the assets directly were mounted to the root.
+For example, if you have `assets = { directory = "./public/" }`, a route like `"example.com/blog/*"` and a file `./public/blog/logo.png`, this will be available at `example.com/blog/logo.png`. Assets outside of directories which match the configured HTTP routes can still be accessed with the [Assets binding](https://developers.cloudflare.com/workers/static-assets/binding/#binding) or with a [Service binding](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/) to this Worker.

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import { applyConfigurationDefaults } from "../src/configuration";
 import { handleRequest } from "../src/handler";
 import type { AssetConfig } from "../../utils/types";
 
@@ -99,5 +100,54 @@ describe("[Asset Worker] `handleRequest`", () => {
 		);
 
 		expect(response.status).toBe(200);
+	});
+
+	it("cannot fetch assets outside of configured path", async () => {
+		const assets: Record<string, string> = {
+			"/blog/test.html": "aaaaaaaaaa",
+			"/blog/index.html": "bbbbbbbbbb",
+			"/index.html": "cccccccccc",
+			"/test.html": "dddddddddd",
+		};
+
+		// Attempt to path traverse down to the root /test within asset-server
+		let response = await handleRequest(
+			new Request("https://example.com/blog/../test"),
+			applyConfigurationDefaults({}),
+			async (pathname: string) => {
+				if (pathname.startsWith("/blog/")) {
+					// our route
+					return assets[pathname] ?? null;
+				} else {
+					return null;
+				}
+			},
+			async (_: string) => ({
+				readableStream: new ReadableStream(),
+				contentType: "text/html",
+			})
+		);
+
+		expect(response.status).toBe(404);
+
+		// Attempt to path traverse down to the root /test within asset-server
+		response = await handleRequest(
+			new Request("https://example.com/blog/%2E%2E/test"),
+			applyConfigurationDefaults({}),
+			async (pathname: string) => {
+				if (pathname.startsWith("/blog/")) {
+					// our route
+					return assets[pathname] ?? null;
+				} else {
+					return null;
+				}
+			},
+			async (_: string) => ({
+				readableStream: new ReadableStream(),
+				contentType: "text/html",
+			})
+		);
+
+		expect(response.status).toBe(404);
 	});
 });

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -174,8 +174,10 @@ function errIsStartupErr(err: unknown): err is ParseError & { code: 10021 } {
 	return false;
 }
 
-export const validateRoutes = (routes: Route[], hasAssets: boolean) => {
+export const validateRoutes = (routes: Route[], assets?: AssetsOptions) => {
 	const invalidRoutes: Record<string, string[]> = {};
+	const mountedAssetRoutes: string[] = [];
+
 	for (const route of routes) {
 		if (typeof route !== "string" && route.custom_domain) {
 			if (route.pattern.includes("*")) {
@@ -190,26 +192,17 @@ export const validateRoutes = (routes: Route[], hasAssets: boolean) => {
 					`Paths are not allowed in Custom Domains`
 				);
 			}
-		} else if (hasAssets) {
+			// If we have Assets but we're not always hitting the Worker then validate
+		} else if (
+			assets?.directory !== undefined &&
+			assets.assetConfig.serve_directly !== true
+		) {
 			const pattern = typeof route === "string" ? route : route.pattern;
 			const components = pattern.split("/");
 
-			if (
-				// = ["route.com"]  bare domains are invalid as it would only match exactly that
-				components.length === 1 ||
-				// = ["route.com",""] as above
-				(components.length === 2 && components[1] === "")
-			) {
-				invalidRoutes[pattern] ??= [];
-				invalidRoutes[pattern].push(
-					`Workers which have static assets must end with a wildcard path. Update the route to end with /*`
-				);
-				// ie it doesn't match exactly "route.com/*" = [route.com, *]
-			} else if (!(components.length === 2 && components[1] === "*")) {
-				invalidRoutes[pattern] ??= [];
-				invalidRoutes[pattern].push(
-					`Workers which have static assets cannot be routed on a URL which has a path component. Update the route to replace /${components.slice(1).join("/")} with /*`
-				);
+			// If this isn't `domain.com/*` then we're mounting to a path
+			if (!(components.length === 2 && components[1] === "*")) {
+				mountedAssetRoutes.push(pattern);
 			}
 		}
 	}
@@ -219,6 +212,26 @@ export const validateRoutes = (routes: Route[], hasAssets: boolean) => {
 				Object.entries(invalidRoutes)
 					.map(([route, errors]) => `${route}:\n` + errors.join("\n"))
 					.join(`\n\n`)
+		);
+	}
+
+	if (mountedAssetRoutes.length > 0 && assets?.directory !== undefined) {
+		const relativeAssetsDir = path.relative(process.cwd(), assets.directory);
+
+		logger.once.warn(
+			`Warning: The following routes will attempt to serve Assets on a configured path:\n${mountedAssetRoutes
+				.map((route) => {
+					const routeNoScheme = route.replace(/https?:\/\//g, "");
+					const assetPath = path.join(
+						relativeAssetsDir,
+						routeNoScheme.substring(routeNoScheme.indexOf("/"))
+					);
+					return `  • ${route} (Will match assets: ${assetPath})`;
+				})
+				.join("\n")}` +
+				(assets?.routingConfig.has_user_worker
+					? "\n\nRequests not matching an asset will be forwarded to the Worker's code."
+					: "")
 		);
 	}
 };
@@ -435,7 +448,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	const routes =
 		props.routes ?? config.routes ?? (config.route ? [config.route] : []) ?? [];
-	validateRoutes(routes, Boolean(props.assetsOptions));
+	validateRoutes(routes, props.assetsOptions);
 
 	const jsxFactory = props.jsxFactory || config.jsx_factory;
 	const jsxFragment = props.jsxFragment || config.jsx_fragment;

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -10,6 +10,7 @@ import {
 	convertCfWorkerInitBindingstoBindings,
 	extractBindingsOfType,
 } from "./api/startDevWorker/utils";
+import { getAssetsOptions } from "./assets";
 import { configFileName, formatConfigSnippet } from "./config";
 import { resolveWranglerConfigPath } from "./config/config-helpers";
 import { createCommand } from "./core/create-command";
@@ -868,9 +869,7 @@ export async function getHostAndRoutes(
 				routes?: Extract<Trigger, { type: "route" }>[];
 				assets?: string;
 		  },
-	config: Pick<Config, "route" | "routes" | "assets"> & {
-		dev: Pick<Config["dev"], "host">;
-	}
+	config: Config
 ) {
 	// TODO: if worker_dev = false and no routes, then error (only for dev)
 	// Compute zone info from the `host` and `route` args and config;
@@ -891,7 +890,8 @@ export async function getHostAndRoutes(
 		}
 	});
 	if (routes) {
-		validateRoutes(routes, Boolean(args.assets || config.assets));
+		const assetOptions = getAssetsOptions({ assets: args.assets }, config);
+		validateRoutes(routes, assetOptions);
 	}
 	return { host, routes };
 }

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -42,7 +42,7 @@ export default async function triggersDeploy(
 		props.routes ?? config.routes ?? (config.route ? [config.route] : []) ?? [];
 	const routesOnly: Array<Route> = [];
 	const customDomainsOnly: Array<RouteObject> = [];
-	validateRoutes(routes, Boolean(props.assetsOptions));
+	validateRoutes(routes, props.assetsOptions);
 	for (const route of routes) {
 		if (typeof route !== "string" && route.custom_domain) {
 			customDomainsOnly.push(route);


### PR DESCRIPTION
Fixes [WC-2972](https://jira.cfdata.org/browse/WC-2972).

Allow Workers Assets to be mounted to a wildcard path. We are still limiting unwildcarded paths like `example.com/test` for the minute though.

We will log a warning saying that we will attempt to serve assets along with the asset dir being matched. Also with a note saying unmatched will go to the Worker
<img width="649" alt="image" src="https://github.com/user-attachments/assets/25974e2b-e483-42fd-a4fe-abda1529efbc">

Wording TBD here.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not covered there
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18657
  - [ ] Documentation not necessary because:

