### PR TITLE
fix: ensure that non-inherited fields are not removed when using an inferred named environment

### DIFF
--- a/.changeset/khaki-steaks-sniff.md
+++ b/.changeset/khaki-steaks-sniff.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+fix: ensure that non-inherited fields are not removed when using an inferred named environment
+
+It is an error for the the user to provide an environment name that doesn't match any of the named environments in the Wrangler configuration.
+But if there are no named environments defined at all in the Wrangler configuration, we special case the top-level environment as though it was a named environment.
+Previously, when this happens, we would remove all the nonInheritable fields from the configuration (essentially all the bindings) leaving an incorrect configuration.
+Now we correctly generate a flattened named environment that has the nonInheritable fields, plus correctly applies any transformFn on inheritable fields.

--- a/packages/wrangler/src/config/validation-helpers.ts
+++ b/packages/wrangler/src/config/validation-helpers.ts
@@ -69,7 +69,11 @@ export function inheritable<K extends keyof Environment>(
 ): Environment[K] {
 	validate(diagnostics, field, rawEnv[field], topLevelEnv);
 	return (
-		(rawEnv[field] as Environment[K]) ??
+		// `rawEnv === topLevelEnv` is a special case where the user has provided an environment name
+		// but that named environment is not actually defined in the configuration.
+		// In that case we have reused the topLevelEnv as the rawEnv,
+		// and so we need to process the `transformFn()` anyway rather than just using the field in the `rawEnv`.
+		(rawEnv !== topLevelEnv ? (rawEnv[field] as Environment[K]) : undefined) ??
 		transformFn(topLevelEnv?.[field]) ??
 		defaultValue
 	);

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -224,7 +224,7 @@ export function normalizeAndValidateConfig(
 			activeEnv = normalizeAndValidateEnvironment(
 				envDiagnostics,
 				configPath,
-				{},
+				topLevelEnv, // in this case reuse the topLevelEnv to ensure that nonInherited fields are not removed
 				isDispatchNamespace,
 				envName,
 				topLevelEnv,


### PR DESCRIPTION
Fixes #0000

It is an error for the the user to provide an environment name that doesn't match any of the named environments in the Wrangler configuration. But if there are no named environments defined at all in the Wrangler configuration, we special case the top-level environment as though it was a named environment. Previously, when this happens, we would remove all the nonInheritable fields from the configuration (essentially all the bindings) leaving an incorrect configuration. Now we correctly generate a flattened named environment that has the nonInheritable fields, plus correctly applies any transformFn on inheritable fields.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
