### PR TITLE
Accept `{ name: string }[]` in kv bulk delete

### DIFF
--- a/.changeset/wise-pens-walk.md
+++ b/.changeset/wise-pens-walk.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Accept a JSON file of the format `{ name: string }[]` in `wrangler kv bulk delete`, as well as the current `string[]` format.

--- a/packages/wrangler/src/__tests__/kv.local.test.ts
+++ b/packages/wrangler/src/__tests__/kv.local.test.ts
@@ -207,7 +207,7 @@ describe("wrangler", () => {
 		`);
 		});
 
-		it("should delete local bulk kv storage", async () => {
+		it("should delete local bulk kv storage (string)", async () => {
 			const keyValues = [
 				{
 					key: "hello",
@@ -253,6 +253,74 @@ describe("wrangler", () => {
 		`);
 
 			await runWrangler(`kv:key list --namespace-id bulk-namespace-id --local`);
+			expect(std.out).toMatchInlineSnapshot(`
+			"Success!
+			[
+			  {
+			    \\"name\\": \\"hello\\"
+			  },
+			  {
+			    \\"name\\": \\"test\\"
+			  }
+			]
+			Success!
+			[]"
+		`);
+		});
+
+		it("should delete local bulk kv storage ({ name })", async () => {
+			const keyValues = [
+				{
+					key: "hello",
+					value: "world",
+				},
+				{
+					key: "test",
+					value: "value",
+				},
+			];
+			writeFileSync("./keys.json", JSON.stringify(keyValues));
+			await runWrangler(
+				`kv bulk put keys.json --namespace-id bulk-namespace-id --local`
+			);
+			await runWrangler(`kv key list --namespace-id bulk-namespace-id --local`);
+			expect(std.out).toMatchInlineSnapshot(`
+			"Success!
+			[
+			  {
+			    \\"name\\": \\"hello\\"
+			  },
+			  {
+			    \\"name\\": \\"test\\"
+			  }
+			]"
+		`);
+			const keys = [
+				{
+					name: "hello",
+				},
+				{
+					name: "test",
+				},
+			];
+			writeFileSync("./keys.json", JSON.stringify(keys));
+			await runWrangler(
+				`kv bulk delete keys.json --namespace-id bulk-namespace-id --local --force`
+			);
+			expect(std.out).toMatchInlineSnapshot(`
+			"Success!
+			[
+			  {
+			    \\"name\\": \\"hello\\"
+			  },
+			  {
+			    \\"name\\": \\"test\\"
+			  }
+			]
+			Success!"
+		`);
+
+			await runWrangler(`kv key list --namespace-id bulk-namespace-id --local`);
 			expect(std.out).toMatchInlineSnapshot(`
 			"Success!
 			[

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -1629,7 +1629,7 @@ describe("wrangler", () => {
 				return requests;
 			}
 
-			it("should delete the keys parsed from a file", async () => {
+			it("should delete the keys parsed from a file (string)", async () => {
 				const keys = ["someKey1", "ns:someKey2"];
 				writeFileSync("./keys.json", JSON.stringify(keys));
 				mockConfirm({
@@ -1637,6 +1637,26 @@ describe("wrangler", () => {
 					result: true,
 				});
 				const requests = mockDeleteRequest("some-namespace-id", keys);
+				await runWrangler(
+					`kv bulk delete --namespace-id some-namespace-id keys.json`
+				);
+				expect(requests.count).toEqual(1);
+				expect(std.out).toMatchInlineSnapshot(`"Success!"`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+				expect(std.err).toMatchInlineSnapshot(`""`);
+			});
+
+			it("should delete the keys parsed from a file ({ name })", async () => {
+				const keys = [{ name: "someKey1" }, { name: "ns:someKey2" }];
+				writeFileSync("./keys.json", JSON.stringify(keys));
+				mockConfirm({
+					text: `Are you sure you want to delete all the keys read from "keys.json" from kv-namespace with id "some-namespace-id"?`,
+					result: true,
+				});
+				const requests = mockDeleteRequest(
+					"some-namespace-id",
+					keys.map((k) => k.name)
+				);
 				await runWrangler(
 					`kv bulk delete --namespace-id some-namespace-id keys.json`
 				);
@@ -1754,7 +1774,7 @@ describe("wrangler", () => {
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(`
 					[Error: Unexpected JSON input from "keys.json".
-					Expected an array of strings.
+					Expected an array of strings or objects with a "name" key.
 					The item at index 1 is type: "number" - 12354
 					The item at index 2 is type: "object" - {"key":"someKey"}
 					The item at index 3 is type: "object" - null]


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/2620

This is a non-breaking fix for #2620 that modifies `wrangler kv bulk delete` to additionally accept the output format from `wrangler kv key list`. The (breaking) proposed solution in the issue of modifying `wrangler kv key list` to output an array of strings turned out not to be viable because of the additional metadata added to the output in that command: `expiration` & `metadata`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
