### PR TITLE
update Vue C3 experimental template to work with Worker Assets

### DIFF
--- a/.changeset/thirty-turkeys-turn.md
+++ b/.changeset/thirty-turkeys-turn.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+update Vue C3 experimental template to work with Worker Assets

--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -262,6 +262,19 @@ function getFrameworkTests(opts: {
 					expectedText: "C3_TEST",
 				},
 			},
+			vue: {
+				testCommitMessage: true,
+				unsupportedOSs: ["win32"],
+				verifyDeploy: {
+					route: "/",
+					expectedText: "Vite App",
+				},
+				verifyPreview: {
+					route: "/",
+					expectedText: "Vite App",
+				},
+				flags: ["--ts"],
+			},
 		};
 	} else {
 		// These are ordered based on speed and reliability for ease of debugging
@@ -592,7 +605,6 @@ function getFrameworkTests(opts: {
 					expectedText: "Vite App",
 				},
 				flags: ["--ts"],
-				quarantine: true,
 			},
 		};
 	}

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -32,6 +32,7 @@ import qwikTemplateExperimental from "templates-experimental/qwik/c3";
 import remixTemplateExperimental from "templates-experimental/remix/c3";
 import solidTemplateExperimental from "templates-experimental/solid/c3";
 import svelteTemplateExperimental from "templates-experimental/svelte/c3";
+import vueTemplateExperimental from "templates-experimental/vue/c3";
 import analogTemplate from "templates/analog/c3";
 import angularTemplate from "templates/angular/c3";
 import astroTemplate from "templates/astro/c3";
@@ -174,6 +175,7 @@ export function getFrameworkMap({ experimental = false }): TemplateMap {
 			remix: remixTemplateExperimental,
 			solid: solidTemplateExperimental,
 			svelte: svelteTemplateExperimental,
+			vue: vueTemplateExperimental,
 		};
 	} else {
 		return {

--- a/packages/create-cloudflare/templates-experimental/vue/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/vue/c3.ts
@@ -1,0 +1,33 @@
+import { runFrameworkGenerator } from "frameworks/index";
+import { detectPackageManager } from "helpers/packageManagers";
+import type { TemplateConfig } from "../../src/templates";
+import type { C3Context } from "types";
+
+const { npm } = detectPackageManager();
+
+const generate = async (ctx: C3Context) => {
+	await runFrameworkGenerator(ctx, [ctx.project.name]);
+};
+
+const config: TemplateConfig = {
+	configVersion: 1,
+	id: "vue",
+	frameworkCli: "create-vue",
+	platform: "workers",
+	displayName: "Vue",
+	copyFiles: {
+		path: "./templates",
+	},
+	path: "templates-experimental/vue",
+	generate,
+	transformPackageJson: async () => ({
+		scripts: {
+			deploy: `${npm} run build && wrangler deploy`,
+			preview: `${npm} run build && wrangler dev`,
+		},
+	}),
+	devScript: "dev",
+	deployScript: "deploy",
+	previewScript: "preview",
+};
+export default config;

--- a/packages/create-cloudflare/templates-experimental/vue/templates/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/vue/templates/wrangler.toml
@@ -1,0 +1,10 @@
+#:schema node_modules/wrangler/config-schema.json
+name = "<TBD>"
+compatibility_date = "<TBD>"
+assets = { directory = "./dist" }
+
+# Workers Logs
+# Docs: https://developers.cloudflare.com/workers/observability/logs/workers-logs/
+# Configuration: https://developers.cloudflare.com/workers/observability/logs/workers-logs/#enable-workers-logs
+[observability]
+enabled = true


### PR DESCRIPTION
Fixes #0000

Adds experimental C3 template for Vue (frontend only) framework and updates it to use Workers Assets.
Also moves Vue out of quarantine.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: C3 change
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18607
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
