### PR TITLE
Don't require Hyperdrive local connection string when using wrangler dev --remote

### DIFF
--- a/.changeset/nervous-jeans-obey.md
+++ b/.changeset/nervous-jeans-obey.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix to not require local connection string when using Hyperdrive and wrangler dev --remote

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -557,10 +557,6 @@ describe("hyperdrive dev tests", () => {
 
 	it("does not require local connection string when running `wrangler dev --remote`", async () => {
 		const helper = new WranglerE2ETestHelper();
-		let port = 5432;
-		if (server.address() && typeof server.address() !== "string") {
-			port = (server.address() as nodeNet.AddressInfo).port;
-		}
 		await helper.seed({
 			"wrangler.toml": dedent`
 					name = "${workerName}"

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -555,6 +555,53 @@ describe("hyperdrive dev tests", () => {
 		await socketMsgPromise;
 	});
 
+	it("does not require local connection string when running `wrangler dev --remote`", async () => {
+		const helper = new WranglerE2ETestHelper();
+		let port = 5432;
+		if (server.address() && typeof server.address() !== "string") {
+			port = (server.address() as nodeNet.AddressInfo).port;
+		}
+		await helper.seed({
+			"wrangler.toml": dedent`
+					name = "${workerName}"
+					main = "src/index.ts"
+					compatibility_date = "2023-10-25"
+
+					[[hyperdrive]]
+					binding = "HYPERDRIVE"
+					id = "hyperdrive_id"
+			`,
+			"src/index.ts": dedent`
+					export default {
+						async fetch(request, env) {
+							if (request.url.includes("connect")) {
+								const conn = env.HYPERDRIVE.connect();
+								await conn.writable.getWriter().write(new TextEncoder().encode("test string"));
+							}
+							return new Response(env.HYPERDRIVE?.connectionString ?? "no")
+						}
+					}`,
+			"package.json": dedent`
+					{
+						"name": "worker",
+						"version": "0.0.0",
+						"private": true
+					}
+					`,
+		});
+
+		const worker = helper.runLongLived("wrangler dev --remote");
+
+		const { url } = await worker.waitForReady()
+		const text = await fetchText(url);
+
+		const hyperdrive = new URL(text);
+		expect(hyperdrive.pathname).toBe("/some_db");
+		expect(hyperdrive.username).toBe("user");
+		expect(hyperdrive.password).toBe("!pass");
+		expect(hyperdrive.host).not.toBe("localhost");
+	});
+
 	afterEach(() => {
 		if (server.listening) {
 			server.close();

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -592,7 +592,7 @@ describe("hyperdrive dev tests", () => {
 
 		const worker = helper.runLongLived("wrangler dev --remote");
 
-		const { url } = await worker.waitForReady()
+		const { url } = await worker.waitForReady();
 		const text = await fetchText(url);
 
 		const hyperdrive = new URL(text);

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -1046,7 +1046,11 @@ export function getBindings(
 				`WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_${hyperdrive.binding}`
 			];
 		// only require a local connection string in the wrangler file or the env if not using dev --remote
-		if (local && !connectionStringFromEnv && !hyperdrive.localConnectionString) {
+		if (
+			local &&
+			!connectionStringFromEnv &&
+			!hyperdrive.localConnectionString
+		) {
 			throw new UserError(
 				`When developing locally, you should use a local Postgres connection string to emulate Hyperdrive functionality. Please setup Postgres locally and set the value of the 'WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_${hyperdrive.binding}' variable or "${hyperdrive.binding}"'s "localConnectionString" to the Postgres connection string.`
 			);

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -1045,7 +1045,8 @@ export function getBindings(
 			process.env[
 				`WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_${hyperdrive.binding}`
 			];
-		if (!connectionStringFromEnv && !hyperdrive.localConnectionString) {
+		// only require a local connection string in the wrangler file or the env if not using dev --remote
+		if (local && !connectionStringFromEnv && !hyperdrive.localConnectionString) {
 			throw new UserError(
 				`When developing locally, you should use a local Postgres connection string to emulate Hyperdrive functionality. Please setup Postgres locally and set the value of the 'WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_${hyperdrive.binding}' variable or "${hyperdrive.binding}"'s "localConnectionString" to the Postgres connection string.`
 			);


### PR DESCRIPTION
Fixes [SQC-349](https://jira.cfdata.org/browse/SQC-349).

This is a small fix that addresses an issue customers have been facing, when trying to use `wrangler dev --remote` we are throwing errors because the local connection string is not set in the Wrangler file or the environment, when it shouldn't be necessary.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This does change the publicly documented behaviour of Hyperdrive with Wrangler.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
