### PR TITLE
chore: convert rollback to createCommand

### DIFF
--- a/packages/wrangler/src/__tests__/deployments.test.ts
+++ b/packages/wrangler/src/__tests__/deployments.test.ts
@@ -383,7 +383,7 @@ describe("deployments", () => {
 
 			it("should require a worker name", async () => {
 				await expect(runWrangler("rollback")).rejects.toMatchInlineSnapshot(
-					`[Error: You need to provide a name of your worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = "<name>"\`]`
+					`[Error: You need to provide a name for your Worker. Either pass it as a cli arg with \`--name <name>\` or in your configuration file as \`name = "<name>"\`]`
 				);
 
 				expect(requests.count).toEqual(0);

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -168,7 +168,7 @@ import { deploymentsListCommand } from "./versions/deployments/list";
 import { deploymentsStatusCommand } from "./versions/deployments/status";
 import { deploymentsViewCommand } from "./versions/deployments/view";
 import { versionsListCommand } from "./versions/list";
-import registerVersionsRollbackCommand from "./versions/rollback";
+import { versionsRollbackCommand } from "./versions/rollback";
 import { versionsSecretNamespace } from "./versions/secrets";
 import { versionsSecretBulkCommand } from "./versions/secrets/bulk";
 import { versionsSecretDeleteCommand } from "./versions/secrets/delete";
@@ -546,7 +546,10 @@ export function createCLIParser(argv: string[]) {
 	const rollbackDescription = "🔙 Rollback a deployment for a Worker";
 
 	if (experimentalGradualRollouts) {
-		registerVersionsRollbackCommand(wrangler, rollbackDescription);
+		registry.define([
+			{ command: "wrangler rollback", definition: versionsRollbackCommand },
+		]);
+		registry.registerNamespace("rollback");
 	} else {
 		wrangler.command(
 			"rollback [deployment-id]",

--- a/packages/wrangler/src/versions/rollback/index.ts
+++ b/packages/wrangler/src/versions/rollback/index.ts
@@ -20,7 +20,7 @@ export const versionsRollbackCommand = createCommand({
 			demandOption: false,
 		},
 		name: {
-			describe: "The name of your worker",
+			describe: "The name of your Worker",
 			type: "string",
 		},
 		message: {

--- a/packages/wrangler/src/versions/rollback/index.ts
+++ b/packages/wrangler/src/versions/rollback/index.ts
@@ -1,6 +1,6 @@
 import * as cli from "@cloudflare/cli";
 import { spinnerWhile } from "@cloudflare/cli/interactive";
-import { readConfig } from "../../config";
+import { createCommand } from "../../core/create-command";
 import { confirm, prompt } from "../../dialogs";
 import { UserError } from "../../errors";
 import { logger } from "../../logger";
@@ -8,146 +8,131 @@ import { APIError } from "../../parse";
 import { requireAuth } from "../../user";
 import { createDeployment, fetchLatestDeployments, fetchVersion } from "../api";
 import { printLatestDeployment, printVersions } from "../deploy";
-import type {
-	CommonYargsArgv,
-	StrictYargsOptionsToInterface,
-} from "../../yargs-types";
 import type { VersionId } from "../types";
 
 export const CANNOT_ROLLBACK_WITH_MODIFIED_SECERT_CODE = 10220;
 
-type VersionsRollbackArgs = StrictYargsOptionsToInterface<
-	typeof versionsRollbackOptions
->;
-
-export default function registerVersionsRollbackCommand(
-	yargs: CommonYargsArgv,
-	description = "🔙 Rollback to a Worker Version"
-) {
-	return yargs.command(
-		"rollback [version-id]",
-		description,
-		versionsRollbackOptions,
-		versionsRollbackHandler
-	);
-}
-
-function versionsRollbackOptions(rollbackYargs: CommonYargsArgv) {
-	return rollbackYargs
-		.positional("version-id", {
+export const versionsRollbackCommand = createCommand({
+	args: {
+		"version-id": {
 			describe: "The ID of the Worker Version to rollback to",
 			type: "string",
 			demandOption: false,
-		})
-		.option("name", {
+		},
+		name: {
 			describe: "The name of your worker",
 			type: "string",
-		})
-		.option("message", {
+		},
+		message: {
 			alias: "m",
 			describe: "The reason for this rollback",
 			type: "string",
 			default: undefined,
-		})
-		.option("yes", {
+		},
+		yes: {
 			alias: "y",
 			describe: "Automatically accept defaults to prompts",
 			type: "boolean",
 			default: false,
-		});
-}
+		},
+	},
+	positionalArgs: ["version-id"],
+	metadata: {
+		description: "🔙 Rollback a deployment for a Worker",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+	},
+	handler: async function handleRollback(args, { config }) {
+		const accountId = await requireAuth(config);
+		const workerName = args.name ?? config.name;
 
-async function versionsRollbackHandler(args: VersionsRollbackArgs) {
-	const config = readConfig(args);
-	const accountId = await requireAuth(config);
-	const workerName = args.name ?? config.name;
-
-	if (workerName === undefined) {
-		throw new UserError(
-			'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
-		);
-	}
-
-	await printLatestDeployment(accountId, workerName, new Map());
-
-	const versionId =
-		args.versionId ??
-		(await spinnerWhile({
-			promise: fetchDefaultRollbackVersionId(accountId, workerName),
-			startMessage: "Finding latest stable Worker Version to rollback to",
-			endMessage: "",
-		}));
-
-	const message = await prompt(
-		"Please provide an optional message for this rollback (120 characters max)",
-		{
-			defaultValue: args.message ?? "Rollback",
+		if (workerName === undefined) {
+			throw new UserError(
+				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+			);
 		}
-	);
 
-	const version = await fetchVersion(accountId, workerName, versionId);
-	cli.warn(
-		`You are about to rollback to Worker Version ${versionId}.\nThis will immediately replace the current deployment and become the active deployment across all your deployed triggers.\nHowever, your local development environment will not be affected by this rollback.\nRolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).`,
-		{ multiline: true, shape: cli.shapes.leftT }
-	);
-	const rollbackTraffic = new Map([[versionId, 100]]);
-	printVersions([version], rollbackTraffic);
+		await printLatestDeployment(accountId, workerName, new Map());
 
-	const confirmed = await confirm(
-		"Are you sure you want to deploy this Worker Version to 100% of traffic?",
-		{ defaultValue: true }
-	);
-	if (!confirmed) {
-		cli.cancel("Aborting rollback...");
-		return;
-	}
+		const versionId =
+			args.versionId ??
+			(await spinnerWhile({
+				promise: fetchDefaultRollbackVersionId(accountId, workerName),
+				startMessage: "Finding latest stable Worker Version to rollback to",
+				endMessage: "",
+			}));
 
-	logger.log("Performing rollback...");
-	try {
-		await createDeployment(accountId, workerName, rollbackTraffic, message);
-	} catch (e) {
-		if (
-			e instanceof APIError &&
-			e.code === CANNOT_ROLLBACK_WITH_MODIFIED_SECERT_CODE
-		) {
-			// This is not great but is the best way I could think to handle for now
-			const errorMsg = e.notes[0].text.replace(
-				` [code: ${CANNOT_ROLLBACK_WITH_MODIFIED_SECERT_CODE}]`,
-				""
-			);
-			const targetString = "The following secrets have changed:";
-			const changedSecrets = errorMsg
-				.substring(errorMsg.indexOf(targetString) + targetString.length + 1)
-				.split(", ");
-
-			const secretConfirmation = await confirm(
-				`The following secrets have changed since version ${versionId} was deployed. ` +
-					`Please confirm you wish to continue with the rollback\n` +
-					changedSecrets.map((secret) => `  * ${secret}`).join("\n")
-			);
-
-			if (secretConfirmation) {
-				await createDeployment(
-					accountId,
-					workerName,
-					rollbackTraffic,
-					message,
-					true
-				);
-			} else {
-				cli.cancel("Aborting rollback...");
+		const message = await prompt(
+			"Please provide an optional message for this rollback (120 characters max)",
+			{
+				defaultValue: args.message ?? "Rollback",
 			}
-		} else {
-			throw e;
+		);
+
+		const version = await fetchVersion(accountId, workerName, versionId);
+		cli.warn(
+			`You are about to rollback to Worker Version ${versionId}.\nThis will immediately replace the current deployment and become the active deployment across all your deployed triggers.\nHowever, your local development environment will not be affected by this rollback.\nRolling back to a previous deployment will not rollback any of the bound resources (Durable Object, D1, R2, KV, etc).`,
+			{ multiline: true, shape: cli.shapes.leftT }
+		);
+		const rollbackTraffic = new Map([[versionId, 100]]);
+		printVersions([version], rollbackTraffic);
+
+		const confirmed = await confirm(
+			"Are you sure you want to deploy this Worker Version to 100% of traffic?",
+			{ defaultValue: true }
+		);
+		if (!confirmed) {
+			cli.cancel("Aborting rollback...");
+			return;
 		}
-	}
 
-	cli.success(
-		`Worker Version ${versionId} has been deployed to 100% of traffic.`
-	);
+		logger.log("Performing rollback...");
+		try {
+			await createDeployment(accountId, workerName, rollbackTraffic, message);
+		} catch (e) {
+			if (
+				e instanceof APIError &&
+				e.code === CANNOT_ROLLBACK_WITH_MODIFIED_SECERT_CODE
+			) {
+				// This is not great but is the best way I could think to handle for now
+				const errorMsg = e.notes[0].text.replace(
+					` [code: ${CANNOT_ROLLBACK_WITH_MODIFIED_SECERT_CODE}]`,
+					""
+				);
+				const targetString = "The following secrets have changed:";
+				const changedSecrets = errorMsg
+					.substring(errorMsg.indexOf(targetString) + targetString.length + 1)
+					.split(", ");
 
-	logger.log("\nCurrent Version ID: " + versionId);
-}
+				const secretConfirmation = await confirm(
+					`The following secrets have changed since version ${versionId} was deployed. ` +
+						`Please confirm you wish to continue with the rollback\n` +
+						changedSecrets.map((secret) => `  * ${secret}`).join("\n")
+				);
+
+				if (secretConfirmation) {
+					await createDeployment(
+						accountId,
+						workerName,
+						rollbackTraffic,
+						message,
+						true
+					);
+				} else {
+					cli.cancel("Aborting rollback...");
+				}
+			} else {
+				throw e;
+			}
+		}
+
+		cli.success(
+			`Worker Version ${versionId} has been deployed to 100% of traffic.`
+		);
+
+		logger.log("\nCurrent Version ID: " + versionId);
+	},
+});
 
 async function fetchDefaultRollbackVersionId(
 	accountId: string,

--- a/packages/wrangler/src/versions/rollback/index.ts
+++ b/packages/wrangler/src/versions/rollback/index.ts
@@ -48,7 +48,7 @@ export const versionsRollbackCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+				'You need to provide a name for your Worker. Either pass it as a cli arg with `--name <name>` or in your configuration file as `name = "<name>"`'
 			);
 		}
 


### PR DESCRIPTION
Fixes #000.

Converts `rollback` to `createCommand`

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only
