### PR TITLE
chore: convert deployments to createCommand

### DIFF
--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.list.test.ts
@@ -23,7 +23,7 @@ describe("deployments list", () => {
 			const result = runWrangler("deployments list  --experimental-versions");
 
 			await expect(result).rejects.toMatchInlineSnapshot(
-				`[Error: You need to provide a name of your worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = "<name>"\`]`
+				`[Error: You need to provide a name for your Worker. Either pass it as a cli arg with \`--name <name>\` or in your configuration file as \`name = "<name>"\`]`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
+++ b/packages/wrangler/src/__tests__/versions/deployments/deployments.status.test.ts
@@ -25,7 +25,7 @@ describe("deployments list", () => {
 			);
 
 			await expect(result).rejects.toMatchInlineSnapshot(
-				`[Error: You need to provide a name of your worker. Either pass it as a cli arg with \`--name <name>\` or in your config file as \`name = "<name>"\`]`
+				`[Error: You need to provide a name for your Worker. Either pass it as a cli arg with \`--name <name>\` or in your configuration file as \`name = "<name>"\`]`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -163,7 +163,10 @@ import { debugLogFilepath } from "./utils/log-file";
 import { vectorize } from "./vectorize/index";
 import { versionsNamespace } from "./versions";
 import { versionsDeployCommand } from "./versions/deploy";
-import registerVersionsDeploymentsSubcommands from "./versions/deployments";
+import { deploymentsNamespace } from "./versions/deployments";
+import { deploymentsListCommand } from "./versions/deployments/list";
+import { deploymentsStatusCommand } from "./versions/deployments/status";
+import { deploymentsViewCommand } from "./versions/deployments/view";
 import { versionsListCommand } from "./versions/list";
 import registerVersionsRollbackCommand from "./versions/rollback";
 import { versionsSecretNamespace } from "./versions/secrets";
@@ -477,55 +480,65 @@ export function createCLIParser(argv: string[]) {
 		deployHandler
 	);
 
-	// deployments
-	const deploymentsDescription =
-		"🚢 List and view the current and past deployments for your Worker";
-
 	if (experimentalGradualRollouts) {
+		registry.define([
+			{ command: "wrangler deployments", definition: deploymentsNamespace },
+			{
+				command: "wrangler deployments list",
+				definition: deploymentsListCommand,
+			},
+			{
+				command: "wrangler deployments status",
+				definition: deploymentsStatusCommand,
+			},
+			{
+				command: "wrangler deployments view",
+				definition: deploymentsViewCommand,
+			},
+		]);
+		registry.registerNamespace("deployments");
+	} else {
 		wrangler.command(
 			"deployments",
-			deploymentsDescription,
-			registerVersionsDeploymentsSubcommands
-		);
-	} else {
-		wrangler.command("deployments", deploymentsDescription, (yargs) =>
-			yargs
-				.option("name", {
-					describe: "The name of your Worker",
-					type: "string",
-				})
-				.command(
-					"list",
-					"Displays the 10 most recent deployments for a Worker",
-					async (listYargs) => listYargs,
-					async (listYargs) => {
-						const { accountId, scriptName, config } =
-							await commonDeploymentCMDSetup(listYargs);
-						await deployments(accountId, scriptName, config);
-					}
-				)
-				.command(
-					"view [deployment-id]",
-					"View a deployment",
-					async (viewYargs) =>
-						viewYargs.positional("deployment-id", {
-							describe: "The ID of the deployment you want to inspect",
-							type: "string",
-							demandOption: false,
-						}),
-					async (viewYargs) => {
-						const { accountId, scriptName, config } =
-							await commonDeploymentCMDSetup(viewYargs);
+			"🚢 List and view the current and past deployments for your Worker",
+			(yargs) =>
+				yargs
+					.option("name", {
+						describe: "The name of your Worker",
+						type: "string",
+					})
+					.command(
+						"list",
+						"Displays the 10 most recent deployments for a Worker",
+						async (listYargs) => listYargs,
+						async (listYargs) => {
+							const { accountId, scriptName, config } =
+								await commonDeploymentCMDSetup(listYargs);
+							await deployments(accountId, scriptName, config);
+						}
+					)
+					.command(
+						"view [deployment-id]",
+						"View a deployment",
+						async (viewYargs) =>
+							viewYargs.positional("deployment-id", {
+								describe: "The ID of the deployment you want to inspect",
+								type: "string",
+								demandOption: false,
+							}),
+						async (viewYargs) => {
+							const { accountId, scriptName, config } =
+								await commonDeploymentCMDSetup(viewYargs);
 
-						await viewDeployment(
-							accountId,
-							scriptName,
-							config,
-							viewYargs.deploymentId
-						);
-					}
-				)
-				.command(subHelp)
+							await viewDeployment(
+								accountId,
+								scriptName,
+								config,
+								viewYargs.deploymentId
+							);
+						}
+					)
+					.command(subHelp)
 		);
 	}
 

--- a/packages/wrangler/src/versions/deployments/index.ts
+++ b/packages/wrangler/src/versions/deployments/index.ts
@@ -1,37 +1,10 @@
-import {
-	versionsDeploymentsListHandler,
-	versionsDeploymentsListOptions,
-} from "./list";
-import {
-	versionsDeploymentsStatusHandler,
-	versionsDeploymentsStatusOptions,
-} from "./status";
-import {
-	versionsDeploymentsViewHandler,
-	versionsDeploymentsViewOptions,
-} from "./view";
-import type { CommonYargsArgv } from "../../yargs-types";
+import { createNamespace } from "../../core/create-command";
 
-export default function registerVersionsDeploymentsSubcommands(
-	versionDeploymentsYargs: CommonYargsArgv
-) {
-	versionDeploymentsYargs
-		.command(
-			"list",
-			"Displays the 10 most recent deployments of your Worker",
-			versionsDeploymentsListOptions,
-			versionsDeploymentsListHandler
-		)
-		.command(
-			"status",
-			"View the current state of your production",
-			versionsDeploymentsStatusOptions,
-			versionsDeploymentsStatusHandler
-		)
-		.command(
-			"view [deployment-id]",
-			false,
-			versionsDeploymentsViewOptions,
-			versionsDeploymentsViewHandler
-		);
-}
+export const deploymentsNamespace = createNamespace({
+	metadata: {
+		description:
+			"🚢 List and view the current and past deployments for your Worker",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+	},
+});

--- a/packages/wrangler/src/versions/deployments/list.ts
+++ b/packages/wrangler/src/versions/deployments/list.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { logRaw } from "@cloudflare/cli";
 import { brandColor, gray } from "@cloudflare/cli/colors";
-import { readConfig } from "../../config";
+import { createCommand } from "../../core/create-command";
 import { UserError } from "../../errors";
 import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
@@ -9,107 +9,100 @@ import formatLabelledValues from "../../utils/render-labelled-values";
 import { printWranglerBanner } from "../../wrangler-banner";
 import { fetchLatestDeployments, fetchVersions } from "../api";
 import { getVersionSource } from "../list";
-import type {
-	CommonYargsArgv,
-	StrictYargsOptionsToInterface,
-} from "../../yargs-types";
 import type { ApiDeployment, VersionCache } from "../types";
 
 const BLANK_INPUT = "-"; // To be used where optional user-input is displayed and the value is nullish
 
-export type VersionsDeloymentsListArgs = StrictYargsOptionsToInterface<
-	typeof versionsDeploymentsListOptions
->;
-
-export function versionsDeploymentsListOptions(yargs: CommonYargsArgv) {
-	return yargs
-		.option("name", {
+export const deploymentsListCommand = createCommand({
+	metadata: {
+		description: "Displays the 10 most recent deployments of your Worker",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+	},
+	args: {
+		name: {
 			describe: "Name of the worker",
 			type: "string",
 			requiresArg: true,
-		})
-		.option("json", {
+		},
+		json: {
 			describe: "Display output as clean JSON",
 			type: "boolean",
 			default: false,
-		});
-}
-
-export async function versionsDeploymentsListHandler(
-	args: VersionsDeloymentsListArgs
-) {
-	if (!args.json) {
-		await printWranglerBanner();
-	}
-
-	const config = readConfig(args);
-	metrics.sendMetricsEvent(
-		"list versioned deployments",
-		{ json: args.json },
-		{
-			sendMetrics: config.send_metrics,
-		}
-	);
-
-	const accountId = await requireAuth(config);
-	const workerName = args.name ?? config.name;
-
-	if (workerName === undefined) {
-		throw new UserError(
-			'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+		},
+	},
+	behaviour: {
+		printBanner: false,
+	},
+	handler: async function versionsDeploymentsListHandler(args, { config }) {
+		metrics.sendMetricsEvent(
+			"list versioned deployments",
+			{ json: args.json },
+			{
+				sendMetrics: config.send_metrics,
+			}
 		);
-	}
 
-	const deployments = (
-		await fetchLatestDeployments(accountId, workerName)
-	).sort((a, b) => a.created_on.localeCompare(b.created_on));
+		const accountId = await requireAuth(config);
+		const workerName = args.name ?? config.name;
 
-	if (args.json) {
-		logRaw(JSON.stringify(deployments, null, 2));
-		return;
-	}
-
-	const versionCache: VersionCache = new Map();
-	const versionIds = deployments.flatMap((d) =>
-		d.versions.map((v) => v.version_id)
-	);
-	await fetchVersions(accountId, workerName, versionCache, ...versionIds);
-
-	const formattedDeployments = deployments.map((deployment) => {
-		const formattedVersions = deployment.versions.map((traffic) => {
-			const version = versionCache.get(traffic.version_id);
-			assert(version);
-
-			const percentage = brandColor(`(${traffic.percentage}%)`);
-			const details = formatLabelledValues(
-				{
-					Created: new Date(version.metadata["created_on"]).toISOString(),
-					Tag: version.annotations?.["workers/tag"] || BLANK_INPUT,
-					Message: version.annotations?.["workers/message"] || BLANK_INPUT,
-				},
-				{
-					indentationCount: 4,
-					labelJustification: "right",
-					formatLabel: (label) => gray(label + ":"),
-					formatValue: (value) => gray(value),
-				}
+		if (workerName === undefined) {
+			throw new UserError(
+				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
 			);
+		}
 
-			return `${percentage} ${version.id}\n${details}`;
+		const deployments = (
+			await fetchLatestDeployments(accountId, workerName)
+		).sort((a, b) => a.created_on.localeCompare(b.created_on));
+
+		if (args.json) {
+			logRaw(JSON.stringify(deployments, null, 2));
+			return;
+		}
+
+		const versionCache: VersionCache = new Map();
+		const versionIds = deployments.flatMap((d) =>
+			d.versions.map((v) => v.version_id)
+		);
+		await fetchVersions(accountId, workerName, versionCache, ...versionIds);
+
+		const formattedDeployments = deployments.map((deployment) => {
+			const formattedVersions = deployment.versions.map((traffic) => {
+				const version = versionCache.get(traffic.version_id);
+				assert(version);
+
+				const percentage = brandColor(`(${traffic.percentage}%)`);
+				const details = formatLabelledValues(
+					{
+						Created: new Date(version.metadata["created_on"]).toISOString(),
+						Tag: version.annotations?.["workers/tag"] || BLANK_INPUT,
+						Message: version.annotations?.["workers/message"] || BLANK_INPUT,
+					},
+					{
+						indentationCount: 4,
+						labelJustification: "right",
+						formatLabel: (label) => gray(label + ":"),
+						formatValue: (value) => gray(value),
+					}
+				);
+
+				return `${percentage} ${version.id}\n${details}`;
+			});
+
+			return formatLabelledValues({
+				// explicitly not outputting Deployment ID
+				Created: new Date(deployment.created_on).toISOString(),
+				Author: deployment.author_email,
+				Source: getDeploymentSource(deployment),
+				Message: deployment.annotations?.["workers/message"] || BLANK_INPUT,
+				"Version(s)": formattedVersions.join("\n\n"),
+			});
 		});
 
-		return formatLabelledValues({
-			// explicitly not outputting Deployment ID
-			Created: new Date(deployment.created_on).toISOString(),
-			Author: deployment.author_email,
-			Source: getDeploymentSource(deployment),
-			Message: deployment.annotations?.["workers/message"] || BLANK_INPUT,
-			"Version(s)": formattedVersions.join("\n\n"),
-		});
-	});
-
-	logRaw(formattedDeployments.join("\n\n"));
-}
+		logRaw(formattedDeployments.join("\n\n"));
+	},
+});
 
 export function getDeploymentSource(deployment: ApiDeployment) {
 	return getVersionSource({

--- a/packages/wrangler/src/versions/deployments/list.ts
+++ b/packages/wrangler/src/versions/deployments/list.ts
@@ -47,7 +47,7 @@ export const deploymentsListCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+				'You need to provide a name for your Worker. Either pass it as a cli arg with `--name <name>` or in your configuration file as `name = "<name>"`'
 			);
 		}
 

--- a/packages/wrangler/src/versions/deployments/list.ts
+++ b/packages/wrangler/src/versions/deployments/list.ts
@@ -6,7 +6,6 @@ import { UserError } from "../../errors";
 import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
 import formatLabelledValues from "../../utils/render-labelled-values";
-import { printWranglerBanner } from "../../wrangler-banner";
 import { fetchLatestDeployments, fetchVersions } from "../api";
 import { getVersionSource } from "../list";
 import type { ApiDeployment, VersionCache } from "../types";

--- a/packages/wrangler/src/versions/deployments/list.ts
+++ b/packages/wrangler/src/versions/deployments/list.ts
@@ -20,7 +20,7 @@ export const deploymentsListCommand = createCommand({
 	},
 	args: {
 		name: {
-			describe: "Name of the worker",
+			describe: "Name of the Worker",
 			type: "string",
 			requiresArg: true,
 		},

--- a/packages/wrangler/src/versions/deployments/status.ts
+++ b/packages/wrangler/src/versions/deployments/status.ts
@@ -21,7 +21,7 @@ export const deploymentsStatusCommand = createCommand({
 	},
 	args: {
 		name: {
-			describe: "Name of the worker",
+			describe: "Name of the Worker",
 			type: "string",
 			requiresArg: true,
 		},

--- a/packages/wrangler/src/versions/deployments/status.ts
+++ b/packages/wrangler/src/versions/deployments/status.ts
@@ -52,7 +52,7 @@ export const deploymentsStatusCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+				'You need to provide a name for your Worker. Either pass it as a cli arg with `--name <name>` or in your configuration file as `name = "<name>"`'
 			);
 		}
 

--- a/packages/wrangler/src/versions/deployments/status.ts
+++ b/packages/wrangler/src/versions/deployments/status.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { logRaw } from "@cloudflare/cli";
 import { brandColor, gray } from "@cloudflare/cli/colors";
-import { readConfig } from "../../config";
+import { createCommand } from "../../core/create-command";
 import { UserError } from "../../errors";
 import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
@@ -9,102 +9,99 @@ import formatLabelledValues from "../../utils/render-labelled-values";
 import { printWranglerBanner } from "../../wrangler-banner";
 import { fetchLatestDeployment, fetchVersions } from "../api";
 import { getDeploymentSource } from "./list";
-import type {
-	CommonYargsArgv,
-	StrictYargsOptionsToInterface,
-} from "../../yargs-types";
 import type { VersionCache } from "../types";
 
 const BLANK_INPUT = "-"; // To be used where optional user-input is displayed and the value is nullish
 
-export type VersionsDeploymentsStatusArgs = StrictYargsOptionsToInterface<
-	typeof versionsDeploymentsStatusOptions
->;
-
-export function versionsDeploymentsStatusOptions(yargs: CommonYargsArgv) {
-	return yargs
-		.option("name", {
+export const deploymentsStatusCommand = createCommand({
+	metadata: {
+		description: "View the current state of your production",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+	},
+	args: {
+		name: {
 			describe: "Name of the worker",
 			type: "string",
 			requiresArg: true,
-		})
-		.option("json", {
+		},
+		json: {
 			describe: "Display output as clean JSON",
 			type: "boolean",
 			default: false,
-		});
-}
-
-export async function versionsDeploymentsStatusHandler(
-	args: VersionsDeploymentsStatusArgs
-) {
-	if (!args.json) {
-		await printWranglerBanner();
-	}
-
-	const config = readConfig(args);
-	metrics.sendMetricsEvent(
-		"view latest versioned deployment",
-		{},
-		{
-			sendMetrics: config.send_metrics,
+		},
+	},
+	behaviour: {
+		printBanner: false,
+	},
+	handler: async function versionsDeploymentsStatusHandler(args, { config }) {
+		if (!args.json) {
+			await printWranglerBanner();
 		}
-	);
 
-	const accountId = await requireAuth(config);
-	const workerName = args.name ?? config.name;
-
-	if (workerName === undefined) {
-		throw new UserError(
-			'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
-		);
-	}
-
-	const latestDeployment = await fetchLatestDeployment(accountId, workerName);
-
-	if (!latestDeployment) {
-		throw new UserError(`The worker ${workerName} has no deployments.`);
-	}
-
-	if (args.json) {
-		logRaw(JSON.stringify(latestDeployment, null, 2));
-		return;
-	}
-
-	const versionCache: VersionCache = new Map();
-	const versionIds = latestDeployment.versions.map((v) => v.version_id);
-	await fetchVersions(accountId, workerName, versionCache, ...versionIds);
-
-	const formattedVersions = latestDeployment.versions.map((traffic) => {
-		const version = versionCache.get(traffic.version_id);
-		assert(version);
-
-		const percentage = brandColor(`(${traffic.percentage}%)`);
-		const details = formatLabelledValues(
+		metrics.sendMetricsEvent(
+			"view latest versioned deployment",
+			{},
 			{
-				Created: new Date(version.metadata["created_on"]).toISOString(),
-				Tag: version.annotations?.["workers/tag"] || BLANK_INPUT,
-				Message: version.annotations?.["workers/message"] || BLANK_INPUT,
-			},
-			{
-				indentationCount: 4,
-				labelJustification: "right",
-				formatLabel: (label) => gray(label + ":"),
-				formatValue: (value) => gray(value),
+				sendMetrics: config.send_metrics,
 			}
 		);
 
-		return `${percentage} ${version.id}\n${details}`;
-	});
+		const accountId = await requireAuth(config);
+		const workerName = args.name ?? config.name;
 
-	const formattedDeployment = formatLabelledValues({
-		// explicitly not outputting Deployment ID
-		Created: new Date(latestDeployment.created_on).toISOString(),
-		Author: latestDeployment.author_email,
-		Source: getDeploymentSource(latestDeployment),
-		Message: latestDeployment.annotations?.["workers/message"] || BLANK_INPUT,
-		"Version(s)": formattedVersions.join("\n\n"),
-	});
+		if (workerName === undefined) {
+			throw new UserError(
+				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+			);
+		}
 
-	logRaw(formattedDeployment);
-}
+		const latestDeployment = await fetchLatestDeployment(accountId, workerName);
+
+		if (!latestDeployment) {
+			throw new UserError(`The worker ${workerName} has no deployments.`);
+		}
+
+		if (args.json) {
+			logRaw(JSON.stringify(latestDeployment, null, 2));
+			return;
+		}
+
+		const versionCache: VersionCache = new Map();
+		const versionIds = latestDeployment.versions.map((v) => v.version_id);
+		await fetchVersions(accountId, workerName, versionCache, ...versionIds);
+
+		const formattedVersions = latestDeployment.versions.map((traffic) => {
+			const version = versionCache.get(traffic.version_id);
+			assert(version);
+
+			const percentage = brandColor(`(${traffic.percentage}%)`);
+			const details = formatLabelledValues(
+				{
+					Created: new Date(version.metadata["created_on"]).toISOString(),
+					Tag: version.annotations?.["workers/tag"] || BLANK_INPUT,
+					Message: version.annotations?.["workers/message"] || BLANK_INPUT,
+				},
+				{
+					indentationCount: 4,
+					labelJustification: "right",
+					formatLabel: (label) => gray(label + ":"),
+					formatValue: (value) => gray(value),
+				}
+			);
+
+			return `${percentage} ${version.id}\n${details}`;
+		});
+
+		const formattedDeployment = formatLabelledValues({
+			// explicitly not outputting Deployment ID
+			Created: new Date(latestDeployment.created_on).toISOString(),
+			Author: latestDeployment.author_email,
+			Source: getDeploymentSource(latestDeployment),
+			Message: latestDeployment.annotations?.["workers/message"] || BLANK_INPUT,
+			"Version(s)": formattedVersions.join("\n\n"),
+		});
+
+		logRaw(formattedDeployment);
+	},
+});

--- a/packages/wrangler/src/versions/deployments/status.ts
+++ b/packages/wrangler/src/versions/deployments/status.ts
@@ -59,7 +59,7 @@ export const deploymentsStatusCommand = createCommand({
 		const latestDeployment = await fetchLatestDeployment(accountId, workerName);
 
 		if (!latestDeployment) {
-			throw new UserError(`The worker ${workerName} has no deployments.`);
+			throw new UserError(`The Worker ${workerName} has no deployments.`);
 		}
 
 		if (args.json) {

--- a/packages/wrangler/src/versions/deployments/view.ts
+++ b/packages/wrangler/src/versions/deployments/view.ts
@@ -1,41 +1,36 @@
+import { createCommand } from "../../core/create-command";
 import { UserError } from "../../errors";
 import { printWranglerBanner } from "../../wrangler-banner";
-import type {
-	CommonYargsArgv,
-	StrictYargsOptionsToInterface,
-} from "../../yargs-types";
 
-export type VersionsDeploymentsViewArgs = StrictYargsOptionsToInterface<
-	typeof versionsDeploymentsViewOptions
->;
-
-export function versionsDeploymentsViewOptions(yargs: CommonYargsArgv) {
-	return yargs
-		.option("name", {
+export const deploymentsViewCommand = createCommand({
+	metadata: {
+		description: "View a deployment of a Worker",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+	},
+	args: {
+		name: {
 			describe: "Name of the worker",
 			type: "string",
 			requiresArg: true,
-		})
-		.positional("deployment-id", {
+		},
+		["deployment-id"]: {
 			describe:
 				"Deprecated. Deployment ID is now referred to as Version ID. Please use `wrangler versions view [version-id]` instead.",
 			type: "string",
 			requiresArg: true,
-		});
-}
-
-export async function versionsDeploymentsViewHandler(
-	args: VersionsDeploymentsViewArgs
-) {
-	await printWranglerBanner();
-
-	if (args.deploymentId === undefined) {
-		throw new UserError(
-			"`wrangler deployments view` has been renamed `wrangler deployments status`. Please use that command instead."
-		);
-	} else {
-		throw new UserError(
-			"`wrangler deployments view <deployment-id>` has been renamed `wrangler versions view [version-id]`. Please use that command instead."
-		);
-	}
-}
+		},
+	},
+	positionalArgs: ["deployment-id"],
+	handler: async function versionsDeploymentsViewHandler(args) {
+		if (args.deploymentId === undefined) {
+			throw new UserError(
+				"`wrangler deployments view` has been renamed `wrangler deployments status`. Please use that command instead."
+			);
+		} else {
+			throw new UserError(
+				"`wrangler deployments view <deployment-id>` has been renamed `wrangler versions view [version-id]`. Please use that command instead."
+			);
+		}
+	},
+});

--- a/packages/wrangler/src/versions/deployments/view.ts
+++ b/packages/wrangler/src/versions/deployments/view.ts
@@ -1,6 +1,5 @@
 import { createCommand } from "../../core/create-command";
 import { UserError } from "../../errors";
-import { printWranglerBanner } from "../../wrangler-banner";
 
 export const deploymentsViewCommand = createCommand({
 	metadata: {

--- a/packages/wrangler/src/versions/deployments/view.ts
+++ b/packages/wrangler/src/versions/deployments/view.ts
@@ -7,6 +7,7 @@ export const deploymentsViewCommand = createCommand({
 		description: "View a deployment of a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
+		hidden: true,
 	},
 	args: {
 		name: {

--- a/packages/wrangler/src/versions/deployments/view.ts
+++ b/packages/wrangler/src/versions/deployments/view.ts
@@ -10,7 +10,7 @@ export const deploymentsViewCommand = createCommand({
 	},
 	args: {
 		name: {
-			describe: "Name of the worker",
+			describe: "Name of the Worker",
 			type: "string",
 			requiresArg: true,
 		},


### PR DESCRIPTION
Fixes #000.

Converts `deployments` to `createCommand`.

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only
