### PR TITLE
chore(create-cloudflare): Make assertions in config tests more exhaustive

### DIFF
--- a/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
+++ b/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
@@ -39,9 +39,11 @@ describe("updateWranglerToml", () => {
 		await updateWranglerToml(ctx);
 
 		const newToml = vi.mocked(writeFile).mock.calls[0][1];
-		expect(newToml).toMatch(`name = "${ctx.project.name}"`);
-		expect(newToml).toMatch(`main = "src/index.ts"`);
-		expect(newToml).toMatch(`compatibility_date = "${mockCompatDate}"`);
+		expect(newToml).toBe(
+			`name = "${ctx.project.name}"\n` +
+				`main = "src/index.ts"\n` +
+				`compatibility_date = "${mockCompatDate}"`,
+		);
 	});
 
 	test("empty replacement", async () => {
@@ -55,9 +57,11 @@ describe("updateWranglerToml", () => {
 		await updateWranglerToml(ctx);
 
 		const newToml = vi.mocked(writeFile).mock.calls[0][1];
-		expect(newToml).toMatch(`name = "${ctx.project.name}"`);
-		expect(newToml).toMatch(`main = "src/index.ts"`);
-		expect(newToml).toMatch(`compatibility_date = "${mockCompatDate}"`);
+		expect(newToml).toBe(
+			`name = "${ctx.project.name}"\n` +
+				`main = "src/index.ts"\n` +
+				`compatibility_date = "${mockCompatDate}"`,
+		);
 	});
 
 	test("string literal replacement", async () => {
@@ -71,6 +75,10 @@ describe("updateWranglerToml", () => {
 		const newToml = vi.mocked(writeFile).mock.calls[0][1];
 		expect(newToml).toMatch(`name = "${ctx.project.name}"`);
 		expect(newToml).toMatch(`main = "src/index.ts"`);
+		expect(newToml).toBe(
+			`compatibility_date = "2024-01-17"name = "test"\n` +
+				`main = "src/index.ts"`,
+		);
 	});
 
 	test("missing name and compat date", async () => {
@@ -83,6 +91,9 @@ describe("updateWranglerToml", () => {
 		expect(newToml).toMatch(`name = "${ctx.project.name}"`);
 		expect(newToml).toMatch(`main = "src/index.ts"`);
 		expect(newToml).toMatch(`compatibility_date = "${mockCompatDate}"`);
+		expect(newToml).toBe(
+			`name = "test"compatibility_date = "2024-01-17"main = "src/index.ts"`,
+		);
 	});
 
 	test("dont replace valid existing compatibility date", async () => {
@@ -95,6 +106,8 @@ describe("updateWranglerToml", () => {
 		await updateWranglerToml(ctx);
 
 		const newToml = vi.mocked(writeFile).mock.calls[0][1];
-		expect(newToml).toMatch(`compatibility_date = "2001-10-12"`);
+		expect(newToml).toBe(
+			`name = "test"\n` + `compatibility_date = "2001-10-12"`,
+		);
 	});
 });


### PR DESCRIPTION
Currently the assertions in create-cloudflare's `updateWranglerToml` unit tests check for the presence of very specific strings in the output (eg. `expect(newToml).toMatch(`name = "${ctx.project.name}"`)`), but not the output's shape overall. Unfortunately, this has resulted in us not detecting a bug where the updated toml does not contain new lines between the prepended configuration lines
(eg. `name = "test"compatibility_date = "2024-01-17"`).

This PR changes those assertions to test against the output's overall shape. The broken output is fixed by https://github.com/cloudflare/workers-sdk/pull/7457

Fixes #000.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: unti test changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unti test changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
