### PR TITLE
feat: notify users when they are running C3 in experimental mode

### DIFF
--- a/.changeset/smooth-vans-share.md
+++ b/.changeset/smooth-vans-share.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+feat: notify users when they are running C3 in experimental mode

--- a/packages/create-cloudflare/src/__tests__/dialog.test.ts
+++ b/packages/create-cloudflare/src/__tests__/dialog.test.ts
@@ -15,33 +15,69 @@ describe("dialog helpers", () => {
 		process.stdout.columns = originalColumns;
 	});
 
-	test("printWelcomeMessage with telemetry disabled", () => {
-		printWelcomeMessage("0.0.0", false);
+	describe("printWelcomeMessage", () => {
+		test("with telemetry disabled", () => {
+			printWelcomeMessage("0.0.0", false, {});
 
-		expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-			"────────────────────────────────────────────────────────────
-			👋 Welcome to create-cloudflare v0.0.0!
-			🧡 Let's get started.
-			────────────────────────────────────────────────────────────
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+				"────────────────────────────────────────────────────────────
+				👋 Welcome to create-cloudflare v0.0.0!
+				🧡 Let's get started.
+				────────────────────────────────────────────────────────────
 
-			"
-		`);
-	});
+				"
+			`);
+		});
 
-	test("printWelcomeMessage with telemetry enabled", () => {
-		printWelcomeMessage("0.0.0", true);
+		test("with telemetry enabled", () => {
+			printWelcomeMessage("0.0.0", true, {});
 
-		expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-			"────────────────────────────────────────────────────────────
-			👋 Welcome to create-cloudflare v0.0.0!
-			🧡 Let's get started.
-			📊 Cloudflare collects telemetry about your usage of Create-Cloudflare.
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+				"────────────────────────────────────────────────────────────
+				👋 Welcome to create-cloudflare v0.0.0!
+				🧡 Let's get started.
+				📊 Cloudflare collects telemetry about your usage of Create-Cloudflare.
 
-			Learn more at: https://github.com/cloudflare/workers-sdk/blob/main/packages/create-cloudflare/telemetry.md
-			────────────────────────────────────────────────────────────
+				Learn more at: https://github.com/cloudflare/workers-sdk/blob/main/packages/create-cloudflare/telemetry.md
+				────────────────────────────────────────────────────────────
 
-			"
-		`);
+				"
+			`);
+		});
+
+		test("with telemetry disabled in experimental mode", () => {
+			printWelcomeMessage("0.0.0", false, { experimental: true });
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+				"────────────────────────────────────────────────────────────
+				👋 Welcome to create-cloudflare v0.0.0!
+				🧡 Let's get started.
+
+				🧪 Running in experimental mode
+				────────────────────────────────────────────────────────────
+
+				"
+			`);
+		});
+
+		test("with telemetry enabled in experimental mode", () => {
+			printWelcomeMessage("0.0.0", true, { experimental: true });
+
+			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+				"────────────────────────────────────────────────────────────
+				👋 Welcome to create-cloudflare v0.0.0!
+				🧡 Let's get started.
+
+				🧪 Running in experimental mode
+
+				📊 Cloudflare collects telemetry about your usage of Create-Cloudflare.
+
+				Learn more at: https://github.com/cloudflare/workers-sdk/blob/main/packages/create-cloudflare/telemetry.md
+				────────────────────────────────────────────────────────────
+
+				"
+			`);
+		});
 	});
 
 	describe("printSummary", () => {

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -102,7 +102,7 @@ export const runLatest = async () => {
 
 // Entrypoint to c3
 export const runCli = async (args: Partial<C3Args>) => {
-	printBanner();
+	printBanner(args);
 
 	const ctx = await createContext(args);
 
@@ -186,8 +186,8 @@ const deploy = async (ctx: C3Context) => {
 	endSection("Done");
 };
 
-const printBanner = () => {
-	printWelcomeMessage(version, reporter.isEnabled);
+const printBanner = (args: Partial<C3Args>) => {
+	printWelcomeMessage(version, reporter.isEnabled, args);
 	startSection(`Create an application with Cloudflare`, "Step 1 of 3");
 };
 

--- a/packages/create-cloudflare/src/dialog.ts
+++ b/packages/create-cloudflare/src/dialog.ts
@@ -3,7 +3,7 @@ import { hyperlink, logRaw, shapes, stripAnsi } from "@cloudflare/cli";
 import { bgGreen, blue, gray } from "@cloudflare/cli/colors";
 import { quoteShellArgs } from "helpers/command";
 import { detectPackageManager } from "helpers/packageManagers";
-import type { C3Context } from "types";
+import type { C3Args, C3Context } from "types";
 
 /**
  * Wrap the lines with a border and inner padding
@@ -27,18 +27,27 @@ export function createDialog(lines: string[]) {
 export function printWelcomeMessage(
 	version: string,
 	telemetryEnabled: boolean,
+	args: Partial<C3Args>,
 ) {
 	const lines = [
 		`👋 Welcome to create-cloudflare v${version}!`,
 		`🧡 Let's get started.`,
 	];
 
+	if (args.experimental) {
+		lines.push("", blue`🧪 Running in experimental mode`);
+	}
+
 	if (telemetryEnabled) {
+		if (args.experimental) {
+			lines.push("");
+		}
+
 		const telemetryDocsUrl = `https://github.com/cloudflare/workers-sdk/blob/main/packages/create-cloudflare/telemetry.md`;
 
 		lines.push(
 			`📊 Cloudflare collects telemetry about your usage of Create-Cloudflare.`,
-			``,
+			"",
 			`Learn more at: ${blue.underline(hyperlink(telemetryDocsUrl))}`,
 		);
 	}


### PR DESCRIPTION
This is just to fix that usually bothers me, when I run C3 in experimental mode there is no indication wether it is running or not in such mode, having this confirmation seems quite nice to me since, besides the final output, there is no way for me to double check/confirm that I didn't I mess up (like a simple typo etc..) inputting the `--experimental` flag

Result:
![Screenshot 2024-12-10 at 11 59 06](https://github.com/user-attachments/assets/48e821bb-e55b-4d53-9d3f-46910f073009)


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required (just to make sure that this is not breaking some e2es that check the welcome banner or something like that)
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this simply adds some extra info in the C3 banner

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
