### PR TITLE
Workflows: fix getting a workflow when such workflow was not yet created

### DIFF
--- a/.changeset/lovely-fireants-roll.md
+++ b/.changeset/lovely-fireants-roll.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workflows-shared": patch
+---
+
+Fix getting a workflow when such workflow was not yet created

--- a/.changeset/lovely-fireants-roll.md
+++ b/.changeset/lovely-fireants-roll.md
@@ -2,4 +2,4 @@
 "@cloudflare/workflows-shared": patch
 ---
 
-Fixed a bug in local development where fetching a Workflow instance by ID would return a Workflow status, even if that instance did not exist. This only impacted the `get()` method on the Worker bindings. 
+Fixed a bug in local development where fetching a Workflow instance by ID would return a Workflow status, even if that instance did not exist. This only impacted the `get()` method on the Worker bindings.

--- a/.changeset/lovely-fireants-roll.md
+++ b/.changeset/lovely-fireants-roll.md
@@ -2,4 +2,4 @@
 "@cloudflare/workflows-shared": patch
 ---
 
-Fix getting a workflow when such workflow was not yet created
+Fixed a bug in local development where fetching a Workflow instance by ID would return a Workflow status, even if that instance did not exist. This only impacted the `get()` method on the Worker bindings. 

--- a/fixtures/import-npm/package-lock.json
+++ b/fixtures/import-npm/package-lock.json
@@ -15,7 +15,7 @@
 			"dev": true
 		},
 		"../../packages/wrangler": {
-			"version": "3.92.0",
+			"version": "3.95.0",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {

--- a/fixtures/workflow/tests/index.test.ts
+++ b/fixtures/workflow/tests/index.test.ts
@@ -83,4 +83,15 @@ describe("Workflows", () => {
 			output: [],
 		});
 	});
+
+	it("fails getting a workflow without creating it first", async ({
+		expect,
+	}) => {
+		await expect(
+			fetchJson(`http://${ip}:${port}/status?workflowName=anotherTest`)
+		).resolves.toMatchObject({
+			message: "instance.not_found",
+			name: "Error",
+		});
+	});
 });

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -142,6 +142,11 @@ export class Engine extends DurableObject<Env> {
 		_accountId: number,
 		_instanceId: string
 	): Promise<InstanceStatus> {
+		// NOTE(dferreira): we need to verify if the engine was initialized or not
+		if (this.accountId === undefined) {
+			throw new Error("stub not initialized");
+		}
+
 		const res = await this.ctx.storage.get<InstanceStatus>(ENGINE_STATUS_KEY);
 
 		// NOTE(lduarte): if status don't exist, means that engine is running for the first time, so we assume queued

--- a/packages/workflows-shared/src/engine.ts
+++ b/packages/workflows-shared/src/engine.ts
@@ -142,7 +142,6 @@ export class Engine extends DurableObject<Env> {
 		_accountId: number,
 		_instanceId: string
 	): Promise<InstanceStatus> {
-		// NOTE(dferreira): we need to verify if the engine was initialized or not
 		if (this.accountId === undefined) {
 			throw new Error("stub not initialized");
 		}


### PR DESCRIPTION
Fixes WOR-440.

Fixed a bug in local development where fetching a Workflow instance by ID would return a Workflow status, even if that instance did not exist. This only impacted the `get()` method on the Worker bindings. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: workflows does not have them
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
