### PR TITLE
cloudchamber/create: always print deployment and placement ID

### DIFF
--- a/packages/wrangler/src/cloudchamber/cli/deployments.ts
+++ b/packages/wrangler/src/cloudchamber/cli/deployments.ts
@@ -1,5 +1,5 @@
 import { exit } from "process";
-import { cancel, crash, endSection, log } from "@cloudflare/cli";
+import { cancel, crash, endSection, log, newline } from "@cloudflare/cli";
 import { processArgument } from "@cloudflare/cli/args";
 import { brandColor, dim, yellow } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
@@ -172,11 +172,10 @@ export async function pickDeployment(deploymentIdPrefix?: string) {
 }
 
 export function logDeployment(deployment: DeploymentV2) {
+	log(`${brandColor("image")} ${dim(deployment.image)}`);
 	log(
-		`${brandColor("Image")} ${dim(deployment.image)}\n${brandColor(
-			"Location"
-		)} ${dim(idToLocationName(deployment.location.name))}\n${brandColor(
-			"Version"
-		)} ${dim(`${deployment.version}`)}\n`
+		`${brandColor("location")} ${dim(idToLocationName(deployment.location.name))}`
 	);
+	log(`${brandColor("version")} ${dim(`${deployment.version}`)}`);
+	newline();
 }

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -344,17 +344,15 @@ export function renderDeploymentConfiguration(
 	}
 
 	const containerInformation = [
-		["Image", image],
-		["Location", idToLocationName(location)],
-		["VCPU", `${vcpu}`],
-		["Memory", memory],
-		["Environment variables", environmentVariablesText],
-		["Labels", labelsText],
+		["image", image],
+		["location", idToLocationName(location)],
+		["vCPU", `${vcpu}`],
+		["memory", memory],
+		["environment variables", environmentVariablesText],
+		["labels", labelsText],
 		...(network === undefined
 			? []
-			: [
-					["Include IPv4", network.assign_ipv4 === "predefined" ? "yes" : "no"],
-				]),
+			: [["IPv4", network.assign_ipv4 === "predefined" ? "yes" : "no"]]),
 	] as const;
 
 	updateStatus(

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -3,10 +3,10 @@ import {
 	endSection,
 	log,
 	startSection,
-	status,
 	updateStatus,
 } from "@cloudflare/cli";
 import { processArgument } from "@cloudflare/cli/args";
+import { brandColor, dim } from "@cloudflare/cli/colors";
 import { inputPrompt, spinner } from "@cloudflare/cli/interactive";
 import { pollSSHKeysUntilCondition, waitForPlacement } from "./cli";
 import { getLocation } from "./cli/locations";
@@ -171,9 +171,9 @@ async function askWhichSSHKeysDoTheyWantToAdd(
 
 	if (keys.length === 1) {
 		const yes = await inputPrompt({
-			question: `Do you want to add the ssh key ${keyItems[0].name}?`,
+			question: `Do you want to add the SSH key ${keyItems[0].name}?`,
 			type: "confirm",
-			helpText: "You need this to ssh into the VM",
+			helpText: "You need this to SSH into the VM",
 			defaultValue: false,
 			label: "",
 		});
@@ -190,15 +190,15 @@ async function askWhichSSHKeysDoTheyWantToAdd(
 
 	const res = await inputPrompt({
 		question:
-			"You have multiple ssh keys in your account, what do you want to do for this new deployment?",
-		label: "",
+			"You have multiple SSH keys in your account, what do you want to do for this new deployment?",
+		label: "ssh",
 		defaultValue: false,
 		helpText: "",
 		type: "select",
 		options: [
 			{ label: "Add all of them", value: "all" },
 			{ label: "Select the keys", value: "select" },
-			{ label: "Don't add any ssh keys", value: "none" },
+			{ label: "Don't add any SSH keys", value: "none" },
 		],
 	});
 	if (res === "all") {
@@ -294,7 +294,7 @@ async function handleCreateCommand(
 
 	const yes = await inputPrompt({
 		type: "confirm",
-		question: "Do you want to go ahead and create your container?",
+		question: "Proceed?",
 		label: "",
 	});
 	if (!yes) {
@@ -323,10 +323,8 @@ async function handleCreateCommand(
 	}
 
 	stop();
-	updateStatus(`${status.success} Created deployment!`);
-	if (deployment.network?.ipv4) {
-		log(`${deployment.id}\nIP: ${deployment.network.ipv4}`);
-	}
+	updateStatus("Created deployment", false);
+	log(`${brandColor("id")} ${dim(deployment.id)}\n`);
 
 	endSection("Creating a placement for your container");
 	startSection("Create a Cloudflare container", "Step 2 of 2");


### PR DESCRIPTION
We currently only print the full deployment ID when the deployment has an IPv4 address. This commit makes the deployment ID always print, as well as the placement ID. We also move the printing of the IPv4 address (if one exists) to the same place as the IPv6 address so that they are printed together.

There are a few other nit-picky changes as well. I've tried to make capitalization of labels more consistent (there doesn't appear to be a rule on when someone should be capitalized and when it shouldn't be, but I've at least made it more consistent within the subcommands themselves). I also changed the green "SUCCESS" message to only print once at the very end of the `cloudchamber create` command. This is consistent with the flow for creating a Worker.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: minor UI changes only
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] Required
  - [x] Not required because: minor UI changes only
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor UI changes only
