### PR TITLE
Provide validation around experimental_serve_directly usage

### DIFF
--- a/.changeset/swift-zebras-guess.md
+++ b/.changeset/swift-zebras-guess.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Provide validation around assets.experimental_serve_directly

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4724,7 +4724,7 @@ addEventListener('fetch', event => {});`
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false set without an assets binding[0m
 
 				  Setting experimental_serve_directly to false will always invoke your Worker script.
-				  To fetch your assets from your Worker, please set [assets.binding] in your configuration file.
+				  To fetch your assets from your Worker, please set the [assets.binding] key in your configuration file.
 
 				  Read more: [4mhttps://developers.cloudflare.com/workers/static-assets/binding/#binding[0m
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4687,6 +4687,143 @@ addEventListener('fetch', event => {});`
 			`);
 		});
 
+		it("should warn when using smart placement with assets-first", async () => {
+			const assets = [
+				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "file-2.bak", content: "Content of file-2" },
+				{ filePath: "file-3.txt", content: "Content of file-3" },
+				{ filePath: "sub-dir/file-4.bak", content: "Content of file-4" },
+				{ filePath: "sub-dir/file-5.txt", content: "Content of file-5" },
+			];
+			writeAssets(assets, "assets");
+			writeWranglerConfig({
+				assets: {
+					directory: "assets",
+					experimental_serve_directly: true,
+				},
+				placement: {
+					mode: "smart",
+				},
+			});
+			const bodies: AssetManifest[] = [];
+			await mockAUSRequest(bodies);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAssets: {
+					jwt: "<<aus-completion-token>>",
+					config: {
+						serve_directly: true,
+					},
+				},
+				expectedType: "none",
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing assets with smart placement turned on may result in poor performance.[0m
+
+				"
+			`);
+		});
+
+		it("should warn when using smart placement with assets-first", async () => {
+			const assets = [
+				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "file-2.bak", content: "Content of file-2" },
+				{ filePath: "file-3.txt", content: "Content of file-3" },
+				{ filePath: "sub-dir/file-4.bak", content: "Content of file-4" },
+				{ filePath: "sub-dir/file-5.txt", content: "Content of file-5" },
+			];
+			writeAssets(assets, "assets");
+			writeWranglerConfig({
+				assets: {
+					directory: "assets",
+					experimental_serve_directly: true,
+				},
+				placement: {
+					mode: "smart",
+				},
+			});
+			const bodies: AssetManifest[] = [];
+			await mockAUSRequest(bodies);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAssets: {
+					jwt: "<<aus-completion-token>>",
+					config: {
+						serve_directly: true,
+					},
+				},
+				expectedType: "none",
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing assets with smart placement turned on may result in poor performance.[0m
+
+				"
+			`);
+		});
+
+		it("should warn if experimental_serve_directly=false but no binding is provided", async () => {
+			const assets = [
+				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "file-2.bak", content: "Content of file-2" },
+				{ filePath: "file-3.txt", content: "Content of file-3" },
+				{ filePath: "sub-dir/file-4.bak", content: "Content of file-4" },
+				{ filePath: "sub-dir/file-5.txt", content: "Content of file-5" },
+			];
+			writeAssets(assets, "assets");
+			writeWorkerSource({ format: "js" });
+			writeWranglerConfig({
+				main: "index.js",
+				assets: {
+					directory: "assets",
+					experimental_serve_directly: false,
+				},
+			});
+			const bodies: AssetManifest[] = [];
+			await mockAUSRequest(bodies);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAssets: {
+					jwt: "<<aus-completion-token>>",
+					config: {
+						serve_directly: false,
+					},
+				},
+				expectedMainModule: "index.js",
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false but no assets.binding provided.[0m
+
+				"
+			`);
+		});
+
+		it("should error if an experimental_serve_directly is false without providing a user Worker", async () => {
+			writeWranglerConfig({
+				assets: {
+					directory: "xyz",
+					experimental_serve_directly: false,
+				},
+			});
+
+			await expect(runWrangler("deploy")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Cannot set experimental_serve_directly=false without a Worker script.
+				Please remove experimental_serve_directly from your configuration file, or provide a Worker script in your configuration file (\`main\`).]
+			`);
+		});
+
 		it("should be able to upload files with special characters in filepaths", async () => {
 			// NB windows will disallow these characters in file paths anyway < > : " / \ | ? *
 			const assets = [

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4724,7 +4724,8 @@ addEventListener('fetch', event => {});`
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false set without an assets binding[0m
 
 				  Setting experimental_serve_directly to false will always invoke your Worker script.
-				  To fetch your assets from your Worker, please set the [assets.binding] key in your configuration file.
+				  To fetch your assets from your Worker, please set the [assets.binding] key in your configuration
+				  file.
 
 				  Read more: [4mhttps://developers.cloudflare.com/workers/static-assets/binding/#binding[0m
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4687,88 +4687,6 @@ addEventListener('fetch', event => {});`
 			`);
 		});
 
-		it("should warn when using smart placement with assets-first", async () => {
-			const assets = [
-				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
-				{ filePath: "file-1.txt", content: "Content of file-1" },
-				{ filePath: "file-2.bak", content: "Content of file-2" },
-				{ filePath: "file-3.txt", content: "Content of file-3" },
-				{ filePath: "sub-dir/file-4.bak", content: "Content of file-4" },
-				{ filePath: "sub-dir/file-5.txt", content: "Content of file-5" },
-			];
-			writeAssets(assets, "assets");
-			writeWranglerConfig({
-				assets: {
-					directory: "assets",
-					experimental_serve_directly: true,
-				},
-				placement: {
-					mode: "smart",
-				},
-			});
-			const bodies: AssetManifest[] = [];
-			await mockAUSRequest(bodies);
-			mockSubDomainRequest();
-			mockUploadWorkerRequest({
-				expectedAssets: {
-					jwt: "<<aus-completion-token>>",
-					config: {
-						serve_directly: true,
-					},
-				},
-				expectedType: "none",
-			});
-
-			await runWrangler("deploy");
-
-			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing assets with smart placement turned on may result in poor performance.[0m
-
-				"
-			`);
-		});
-
-		it("should warn when using smart placement with assets-first", async () => {
-			const assets = [
-				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
-				{ filePath: "file-1.txt", content: "Content of file-1" },
-				{ filePath: "file-2.bak", content: "Content of file-2" },
-				{ filePath: "file-3.txt", content: "Content of file-3" },
-				{ filePath: "sub-dir/file-4.bak", content: "Content of file-4" },
-				{ filePath: "sub-dir/file-5.txt", content: "Content of file-5" },
-			];
-			writeAssets(assets, "assets");
-			writeWranglerConfig({
-				assets: {
-					directory: "assets",
-					experimental_serve_directly: true,
-				},
-				placement: {
-					mode: "smart",
-				},
-			});
-			const bodies: AssetManifest[] = [];
-			await mockAUSRequest(bodies);
-			mockSubDomainRequest();
-			mockUploadWorkerRequest({
-				expectedAssets: {
-					jwt: "<<aus-completion-token>>",
-					config: {
-						serve_directly: true,
-					},
-				},
-				expectedType: "none",
-			});
-
-			await runWrangler("deploy");
-
-			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing assets with smart placement turned on may result in poor performance.[0m
-
-				"
-			`);
-		});
-
 		it("should warn if experimental_serve_directly=false but no binding is provided", async () => {
 			const assets = [
 				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
@@ -4803,13 +4721,18 @@ addEventListener('fetch', event => {});`
 			await runWrangler("deploy");
 
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false but no assets.binding provided.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false set without an assets binding[0m
+
+				  Setting experimental_serve_directly to false will always invoke your Worker script.
+				  To fetch your assets from your Worker, please set [assets.binding] in your configuration file.
+
+				  Read more: [4mhttps://developers.cloudflare.com/workers/static-assets/binding/#binding[0m
 
 				"
 			`);
 		});
 
-		it("should error if an experimental_serve_directly is false without providing a user Worker", async () => {
+		it("should error if experimental_serve_directly is false and no user Worker is provided", async () => {
 			writeWranglerConfig({
 				assets: {
 					directory: "xyz",

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1696,7 +1696,8 @@ describe.sequential("wrangler dev", () => {
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false set without an assets binding[0m
 
 				  Setting experimental_serve_directly to false will always invoke your Worker script.
-				  To fetch your assets from your Worker, please set the [assets.binding] key in your configuration file.
+				  To fetch your assets from your Worker, please set the [assets.binding] key in your configuration
+				  file.
 
 				  Read more: [4mhttps://developers.cloudflare.com/workers/static-assets/binding/#binding[0m
 

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1696,7 +1696,7 @@ describe.sequential("wrangler dev", () => {
 				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false set without an assets binding[0m
 
 				  Setting experimental_serve_directly to false will always invoke your Worker script.
-				  To fetch your assets from your Worker, please set [assets.binding] in your configuration file.
+				  To fetch your assets from your Worker, please set the [assets.binding] key in your configuration file.
 
 				  Read more: [4mhttps://developers.cloudflare.com/workers/static-assets/binding/#binding[0m
 

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1693,13 +1693,18 @@ describe.sequential("wrangler dev", () => {
 			await runWranglerUntilConfig("dev");
 
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false but no assets.binding provided.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false set without an assets binding[0m
+
+				  Setting experimental_serve_directly to false will always invoke your Worker script.
+				  To fetch your assets from your Worker, please set [assets.binding] in your configuration file.
+
+				  Read more: [4mhttps://developers.cloudflare.com/workers/static-assets/binding/#binding[0m
 
 				"
 			`);
 		});
 
-		it("should error if an experimental_serve_directly is false without providing a user Worker", async () => {
+		it("should error if experimental_serve_directly is false and no user Worker is provided", async () => {
 			writeWranglerConfig({
 				assets: { directory: "assets", experimental_serve_directly: false },
 			});

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1679,6 +1679,41 @@ describe.sequential("wrangler dev", () => {
 			);
 		});
 
+		it("should warn if experimental_serve_directly=false but no binding is provided", async () => {
+			writeWranglerConfig({
+				main: "index.js",
+				assets: {
+					directory: "assets",
+					experimental_serve_directly: false,
+				},
+			});
+			fs.mkdirSync("assets");
+			fs.writeFileSync("index.js", `export default {};`);
+
+			await runWranglerUntilConfig("dev");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mexperimental_serve_directly=false but no assets.binding provided.[0m
+
+				"
+			`);
+		});
+
+		it("should error if an experimental_serve_directly is false without providing a user Worker", async () => {
+			writeWranglerConfig({
+				assets: { directory: "assets", experimental_serve_directly: false },
+			});
+			fs.mkdirSync("assets");
+			await expect(
+				runWrangler("dev")
+			).rejects.toThrowErrorMatchingInlineSnapshot(
+				`
+				[Error: Cannot set experimental_serve_directly=false without a Worker script.
+				Please remove experimental_serve_directly from your configuration file, or provide a Worker script in your configuration file (\`main\`).]
+			`
+			);
+		});
+
 		it("should error if directory specified by '--assets' command line argument does not exist", async () => {
 			writeWranglerConfig({
 				main: "./index.js",

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -443,6 +443,42 @@ export function validateAssetsArgsAndConfig(
 				"Please remove the asset binding from your configuration file, or provide a Worker script in your configuration file (`main`)."
 		);
 	}
+
+	// Smart placement turned on when using assets
+	if (
+		config?.placement?.mode === "smart" &&
+		config?.assets?.experimental_serve_directly
+	) {
+		logger.warn(
+			"Using assets with smart placement turned on may result in poor performance."
+		);
+	}
+
+	// User worker ahead of assets, but no assets binding provided
+	if (
+		"legacy" in args
+			? args.assets?.assetConfig?.serve_directly === false &&
+				!args.assets?.binding
+			: config?.assets?.experimental_serve_directly === false &&
+				!config?.assets?.binding
+	) {
+		logger.warn(
+			"experimental_serve_directly=false but no assets.binding provided."
+		);
+	}
+
+	// Using serve_directly=false, but didn't provide a Worker script
+	if (
+		"legacy" in args
+			? args.entrypoint === noOpEntrypoint &&
+				args.assets?.assetConfig?.serve_directly === false
+			: !config?.main && config?.assets?.experimental_serve_directly === false
+	) {
+		throw new UserError(
+			"Cannot set experimental_serve_directly=false without a Worker script.\n" +
+				"Please remove experimental_serve_directly from your configuration file, or provide a Worker script in your configuration file (`main`)."
+		);
+	}
 }
 
 const CF_ASSETS_IGNORE_FILENAME = ".assetsignore";

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -444,17 +444,7 @@ export function validateAssetsArgsAndConfig(
 		);
 	}
 
-	// Smart placement turned on when using assets
-	if (
-		config?.placement?.mode === "smart" &&
-		config?.assets?.experimental_serve_directly
-	) {
-		logger.warn(
-			"Using assets with smart placement turned on may result in poor performance."
-		);
-	}
-
-	// User worker ahead of assets, but no assets binding provided
+	// User Worker ahead of assets, but no assets binding provided
 	if (
 		"legacy" in args
 			? args.assets?.assetConfig?.serve_directly === false &&
@@ -463,7 +453,10 @@ export function validateAssetsArgsAndConfig(
 				!config?.assets?.binding
 	) {
 		logger.warn(
-			"experimental_serve_directly=false but no assets.binding provided."
+			"experimental_serve_directly=false set without an assets binding\n" +
+				"Setting experimental_serve_directly to false will always invoke your Worker script.\n" +
+				"To fetch your assets from your Worker, please set [assets.binding] in your configuration file.\n\n" +
+				"Read more: https://developers.cloudflare.com/workers/static-assets/binding/#binding"
 		);
 	}
 

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -455,7 +455,7 @@ export function validateAssetsArgsAndConfig(
 		logger.warn(
 			"experimental_serve_directly=false set without an assets binding\n" +
 				"Setting experimental_serve_directly to false will always invoke your Worker script.\n" +
-				"To fetch your assets from your Worker, please set [assets.binding] in your configuration file.\n\n" +
+				"To fetch your assets from your Worker, please set the [assets.binding] key in your configuration file.\n\n" +
 				"Read more: https://developers.cloudflare.com/workers/static-assets/binding/#binding"
 		);
 	}


### PR DESCRIPTION
Fixes #0000

Gives guidance on usage of serve_directly in the following cases:
- (Warning) User worker runs first but no assets binding
- (Error) User worker runs first but no user worker provided

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: n/a