### PR TITLE
Revert "Don't require Hyperdrive local connection string when using wrangler dev --remote"

### DIFF
--- a/.changeset/nervous-jeans-obey.md
+++ b/.changeset/nervous-jeans-obey.md
@@ -1,5 +1,0 @@
----
-"wrangler": patch
----
-
-Fix to not require local connection string when using Hyperdrive and wrangler dev --remote

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -1042,12 +1042,7 @@ export function getBindings(
 			process.env[
 				`WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_${hyperdrive.binding}`
 			];
-		// only require a local connection string in the wrangler file or the env if not using dev --remote
-		if (
-			local &&
-			!connectionStringFromEnv &&
-			!hyperdrive.localConnectionString
-		) {
+		if (!connectionStringFromEnv && !hyperdrive.localConnectionString) {
 			throw new UserError(
 				`When developing locally, you should use a local Postgres connection string to emulate Hyperdrive functionality. Please setup Postgres locally and set the value of the 'WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_${hyperdrive.binding}' variable or "${hyperdrive.binding}"'s "localConnectionString" to the Postgres connection string.`
 			);


### PR DESCRIPTION
Reverts cloudflare/workers-sdk#7485

Reverting this because the added e2e test fails. It is unclear to me at this moment why the e2es didn't fail on the original PR. The e2e label was correctly added but it seems that the e2es didn't run at all? I will have to investigate that.

The reason the e2e test is failing is because that hyperdrive remote resource does not exist, which is mandatory when running `wrangler dev --remote`.

I attempted to [fix forward](https://github.com/cloudflare/workers-sdk/pull/7536), but turns out that `wrangler hyperdrive create` requires us to specify a DB to connect to, and this cannot be a local db (see this err message 👉 `The database hostname or IP provided is not a publicly resolvable address. Only publicly routable addresses are currently supported.`). I also attempted to connect to a public db, but that failed with `Databases must be configured to support SSL/TLS`, so clearly we need a better strategy here. 

Since this e2e test is currently blocking our release, I decided to fix backwards, by reverting the changes