### PR TITLE
Add test command for the extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,18 @@
 			"internalConsoleOptions": "neverOpen",
 			"skipFiles": ["<node_internals>/**"],
 			"cwd": "${workspaceFolder}/tools"
+		},
+		{
+			"name": "Run Bindings Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}/packages/cloudflare-workers-bindings-extension"
+			],
+			"outFiles": [
+				"${workspaceFolder}/packages/cloudflare-workers-bindings-extension/dist/**/*.js"
+			],
+			"preLaunchTask": "npm: vscode:prepublish - packages/cloudflare-workers-bindings-extension"
 		}
 	]
 }

--- a/packages/cloudflare-workers-bindings-extension/package.json
+++ b/packages/cloudflare-workers-bindings-extension/package.json
@@ -24,7 +24,39 @@
 		"build": "vsce package",
 		"deploy": "vsce publish --pre-release"
 	},
-	"activationEvents": [],
+	"contributes": {
+		"commands": [
+			{
+				"command": "cloudflare-workers-bindings-extension.testCommand",
+				"title": "Test command",
+				"icon": {
+					"light": "resources/light/edit.svg",
+					"dark": "resources/dark/edit.svg"
+				}
+			}
+		],
+		"views": {
+			"cloudflare-workers-bindings": [
+				{
+					"id": "cloudflare-workers-bindings-extension",
+					"name": "Bindings",
+					"icon": "resources/icons/cf-workers-logo.svg"
+				}
+			]
+		},
+		"viewsContainers": {
+			"activitybar": [
+				{
+					"id": "cloudflare-workers-bindings",
+					"title": "Cloudflare Workers",
+					"icon": "media/cf-workers-logo.svg"
+				}
+			]
+		}
+	},
+	"activationEvents": [
+		"workspaceContains:{**/wrangler.json,**/wrangler.jsonc,**/wrangler.toml}"
+	],
 	"devDependencies": {
 		"@types/mocha": "^10.0.7",
 		"@types/node": "20.x",

--- a/packages/cloudflare-workers-bindings-extension/src/extension.ts
+++ b/packages/cloudflare-workers-bindings-extension/src/extension.ts
@@ -1,5 +1,9 @@
 import * as vscode from "vscode";
 
 export async function activate(context: vscode.ExtensionContext) {
-	// ACTIVATED
+	vscode.commands.registerCommand(
+		"cloudflare-workers-bindings-extension.testCommand",
+		() =>
+			vscode.window.showInformationMessage(`Successfully called test command.`)
+	);
 }


### PR DESCRIPTION
Make sure the extension is:
- rendered in the sidebar
- has a debugging task
- has a test command to run via the command palette ("Test Command")