### PR TITLE
update the astro experimental template not to unnecessarily specify `v2` for `nodejs_compat`

### DIFF
--- a/.changeset/stale-bananas-sort.md
+++ b/.changeset/stale-bananas-sort.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+update the astro experimental template not to unnecessarily specify `v2` for `nodejs_compat`

--- a/packages/create-cloudflare/templates-experimental/astro/templates/ts/wrangler.toml
+++ b/packages/create-cloudflare/templates-experimental/astro/templates/ts/wrangler.toml
@@ -1,7 +1,7 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "<TBD>"
 compatibility_date = "<TBD>"
-compatibility_flags = ["nodejs_compat_v2"]
+compatibility_flags = ["nodejs_compat"]
 main = "./dist/_worker.js/index.js"
 assets = { directory = "./dist", binding = "ASSETS" }
 


### PR DESCRIPTION
This PR simply removes the extra `_v2` that is not really needed in the Astro C3 experimental template

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this is already tested
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functional change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
