### PR TITLE
Add warning for smart placement w/assets

### DIFF
--- a/.changeset/tidy-kiwis-arrive.md
+++ b/.changeset/tidy-kiwis-arrive.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Warn users when using smart placement with Workers + Assets and `serve_directly` is set to `false`

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4687,7 +4687,7 @@ addEventListener('fetch', event => {});`
 			`);
 		});
 
-		it("should warn when using smart placement with assets-first", async () => {
+		it("should warn when using smart placement with Worker first", async () => {
 			const assets = [
 				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
 				{ filePath: "file-1.txt", content: "Content of file-1" },
@@ -4697,10 +4697,13 @@ addEventListener('fetch', event => {});`
 				{ filePath: "sub-dir/file-5.txt", content: "Content of file-5" },
 			];
 			writeAssets(assets, "assets");
+			writeWorkerSource({ format: "js" });
 			writeWranglerConfig({
+				main: "index.js",
 				assets: {
 					directory: "assets",
-					experimental_serve_directly: true,
+					experimental_serve_directly: false,
+					binding: "ASSETS",
 				},
 				placement: {
 					mode: "smart",
@@ -4713,57 +4716,21 @@ addEventListener('fetch', event => {});`
 				expectedAssets: {
 					jwt: "<<aus-completion-token>>",
 					config: {
-						serve_directly: true,
+						serve_directly: false,
 					},
 				},
-				expectedType: "none",
+				expectedMainModule: "index.js",
+				expectedBindings: [{ name: "ASSETS", type: "assets" }],
 			});
 
 			await runWrangler("deploy");
 
 			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing assets with smart placement turned on may result in poor performance.[0m
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mTurning on Smart Placement in a Worker that is using assets and serve_directly set to false means that your entire Worker could be moved to run closer to your data source, and all requests will go to that Worker before serving assets.[0m
 
-				"
-			`);
-		});
+				  This could result in poor performance as round trip times could increase when serving assets.
 
-		it("should warn when using smart placement with assets-first", async () => {
-			const assets = [
-				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
-				{ filePath: "file-1.txt", content: "Content of file-1" },
-				{ filePath: "file-2.bak", content: "Content of file-2" },
-				{ filePath: "file-3.txt", content: "Content of file-3" },
-				{ filePath: "sub-dir/file-4.bak", content: "Content of file-4" },
-				{ filePath: "sub-dir/file-5.txt", content: "Content of file-5" },
-			];
-			writeAssets(assets, "assets");
-			writeWranglerConfig({
-				assets: {
-					directory: "assets",
-					experimental_serve_directly: true,
-				},
-				placement: {
-					mode: "smart",
-				},
-			});
-			const bodies: AssetManifest[] = [];
-			await mockAUSRequest(bodies);
-			mockSubDomainRequest();
-			mockUploadWorkerRequest({
-				expectedAssets: {
-					jwt: "<<aus-completion-token>>",
-					config: {
-						serve_directly: true,
-					},
-				},
-				expectedType: "none",
-			});
-
-			await runWrangler("deploy");
-
-			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing assets with smart placement turned on may result in poor performance.[0m
+				  Read more: [4mhttps://developers.cloudflare.com/workers/static-assets/binding/#smart-placement[0m
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4687,6 +4687,88 @@ addEventListener('fetch', event => {});`
 			`);
 		});
 
+		it("should warn when using smart placement with assets-first", async () => {
+			const assets = [
+				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "file-2.bak", content: "Content of file-2" },
+				{ filePath: "file-3.txt", content: "Content of file-3" },
+				{ filePath: "sub-dir/file-4.bak", content: "Content of file-4" },
+				{ filePath: "sub-dir/file-5.txt", content: "Content of file-5" },
+			];
+			writeAssets(assets, "assets");
+			writeWranglerConfig({
+				assets: {
+					directory: "assets",
+					experimental_serve_directly: true,
+				},
+				placement: {
+					mode: "smart",
+				},
+			});
+			const bodies: AssetManifest[] = [];
+			await mockAUSRequest(bodies);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAssets: {
+					jwt: "<<aus-completion-token>>",
+					config: {
+						serve_directly: true,
+					},
+				},
+				expectedType: "none",
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing assets with smart placement turned on may result in poor performance.[0m
+
+				"
+			`);
+		});
+
+		it("should warn when using smart placement with assets-first", async () => {
+			const assets = [
+				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
+				{ filePath: "file-1.txt", content: "Content of file-1" },
+				{ filePath: "file-2.bak", content: "Content of file-2" },
+				{ filePath: "file-3.txt", content: "Content of file-3" },
+				{ filePath: "sub-dir/file-4.bak", content: "Content of file-4" },
+				{ filePath: "sub-dir/file-5.txt", content: "Content of file-5" },
+			];
+			writeAssets(assets, "assets");
+			writeWranglerConfig({
+				assets: {
+					directory: "assets",
+					experimental_serve_directly: true,
+				},
+				placement: {
+					mode: "smart",
+				},
+			});
+			const bodies: AssetManifest[] = [];
+			await mockAUSRequest(bodies);
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				expectedAssets: {
+					jwt: "<<aus-completion-token>>",
+					config: {
+						serve_directly: true,
+					},
+				},
+				expectedType: "none",
+			});
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing assets with smart placement turned on may result in poor performance.[0m
+
+				"
+			`);
+		});
+
 		it("should warn if experimental_serve_directly=false but no binding is provided", async () => {
 			const assets = [
 				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -444,7 +444,17 @@ export function validateAssetsArgsAndConfig(
 		);
 	}
 
-	// User Worker ahead of assets, but no assets binding provided
+	// Smart placement turned on when using assets
+	if (
+		config?.placement?.mode === "smart" &&
+		config?.assets?.experimental_serve_directly
+	) {
+		logger.warn(
+			"Using assets with smart placement turned on may result in poor performance."
+		);
+	}
+
+	// User worker ahead of assets, but no assets binding provided
 	if (
 		"legacy" in args
 			? args.assets?.assetConfig?.serve_directly === false &&

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -447,14 +447,16 @@ export function validateAssetsArgsAndConfig(
 	// Smart placement turned on when using assets
 	if (
 		config?.placement?.mode === "smart" &&
-		config?.assets?.experimental_serve_directly
+		config?.assets?.experimental_serve_directly === false
 	) {
 		logger.warn(
-			"Using assets with smart placement turned on may result in poor performance."
+			"Turning on Smart Placement in a Worker that is using assets and serve_directly set to false means that your entire Worker could be moved to run closer to your data source, and all requests will go to that Worker before serving assets.\n" +
+				"This could result in poor performance as round trip times could increase when serving assets.\n\n" +
+				"Read more: https://developers.cloudflare.com/workers/static-assets/binding/#smart-placement"
 		);
 	}
 
-	// User worker ahead of assets, but no assets binding provided
+	// User Worker ahead of assets, but no assets binding provided
 	if (
 		"legacy" in args
 			? args.assets?.assetConfig?.serve_directly === false &&


### PR DESCRIPTION
Fixes #0000

Provides a warning if using smart placement. Internal discussions still ongoing on whether to hard block on this instead of warn.

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18780/files
  - [ ] Documentation not necessary because:
