### PR TITLE
cleanup(fixtures): add missing dependencies to packages.json

### DIFF
--- a/fixtures/additional-modules/package.json
+++ b/fixtures/additional-modules/package.json
@@ -13,7 +13,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/ai-app/package.json
+++ b/fixtures/ai-app/package.json
@@ -13,7 +13,9 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/asset-config/package.json
+++ b/fixtures/asset-config/package.json
@@ -2,7 +2,7 @@
 	"name": "workers-assets-config-test",
 	"private": true,
 	"scripts": {
-		"dev": "npx wrangler dev",
+		"dev": "wrangler dev",
 		"test:ci": "run-script-os",
 		"test:ci:default": "true",
 		"test:ci:nix": "vitest run",
@@ -14,6 +14,7 @@
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
 		"run-script-os": "^1.1.6",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",
 		"wrangler": "workspace:*"

--- a/fixtures/durable-objects-app/package.json
+++ b/fixtures/durable-objects-app/package.json
@@ -7,13 +7,14 @@
 	"main": "src/index.js",
 	"scripts": {
 		"dev": "wrangler deploy --dry-run",
-		"test": "npx vitest run",
-		"test:ci": "npx vitest run",
-		"test:watch": "npx vitest"
+		"test": "vitest run",
+		"test:ci": "vitest run",
+		"test:watch": "vitest"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/entrypoints-rpc-tests/package.json
+++ b/fixtures/entrypoints-rpc-tests/package.json
@@ -9,6 +9,7 @@
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"ts-dedent": "^2.2.0",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/get-platform-proxy/package.json
+++ b/fixtures/get-platform-proxy/package.json
@@ -10,7 +10,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/import-wasm-example/package.json
+++ b/fixtures/import-wasm-example/package.json
@@ -15,7 +15,9 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/interactive-dev-tests/package.json
+++ b/fixtures/interactive-dev-tests/package.json
@@ -8,7 +8,8 @@
 	"devDependencies": {
 		"fixtures-shared": "workspace:*",
 		"strip-ansi": "^7.1.0",
-		"undici": "catalog:default"
+		"undici": "catalog:default",
+		"vitest": "catalog:default"
 	},
 	"optionalDependencies": {
 		"@cdktf/node-pty-prebuilt-multiarch": "0.10.1-pre.11"

--- a/fixtures/local-mode-tests/package.json
+++ b/fixtures/local-mode-tests/package.json
@@ -17,6 +17,8 @@
 		"@cloudflare/workers-types": "^4.20241205.0",
 		"@types/node": "catalog:default",
 		"buffer": "^6.0.3",
+		"typescript": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/no-bundle-import/package.json
+++ b/fixtures/no-bundle-import/package.json
@@ -9,6 +9,7 @@
 	},
 	"devDependencies": {
 		"get-port": "^7.0.0",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/node-app-pages/package.json
+++ b/fixtures/node-app-pages/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/worker.js",
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --port 12345 --node-compat",
+		"dev": "wrangler pages dev public --port 12345 --node-compat",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
@@ -16,7 +16,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/nodejs-als-app/package.json
+++ b/fixtures/nodejs-als-app/package.json
@@ -11,6 +11,7 @@
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	}
 }

--- a/fixtures/nodejs-hybrid-app/package.json
+++ b/fixtures/nodejs-hybrid-app/package.json
@@ -14,6 +14,7 @@
 		"pg": "8.11.3",
 		"pg-cloudflare": "^1.1.1",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	}
 }

--- a/fixtures/pages-d1-shim/package.json
+++ b/fixtures/pages-d1-shim/package.json
@@ -4,14 +4,16 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev ./public --d1 foobar --port 8777",
+		"dev": "wrangler pages dev ./public --d1 foobar --port 8777",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-dev-proxy-with-script/package.json
+++ b/fixtures/pages-dev-proxy-with-script/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"sideEffects": false,
 	"scripts": {
-		"dev": "npx wrangler pages dev public",
+		"dev": "wrangler pages dev public",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
@@ -11,7 +11,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -17,7 +17,9 @@
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
 		"pages-plugin-example": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-functions-wasm-app/package.json
+++ b/fixtures/pages-functions-wasm-app/package.json
@@ -4,15 +4,17 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --port 8776",
-		"publish": "npx wrangler pages deploy public",
+		"dev": "wrangler pages dev public --port 8776",
+		"publish": "wrangler pages deploy public",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-functions-with-config-file-app/package.json
+++ b/fixtures/pages-functions-with-config-file-app/package.json
@@ -4,14 +4,16 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev",
+		"dev": "wrangler pages dev",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-functions-with-routes-app/package.json
+++ b/fixtures/pages-functions-with-routes-app/package.json
@@ -4,7 +4,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --port 8776",
+		"dev": "wrangler pages dev public --port 8776",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
@@ -12,7 +12,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-nodejs-v2-compat/package.json
+++ b/fixtures/pages-nodejs-v2-compat/package.json
@@ -4,16 +4,18 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev:functions-app": "npx wrangler pages dev ./apps/functions --port 8792",
-		"dev:workerjs-directory": "npx wrangler pages dev ./apps/workerjs-directory --port 8792",
-		"dev:workerjs-file": "npx wrangler pages dev ./apps/workerjs-file --port 8792",
+		"dev:functions-app": "wrangler pages dev ./apps/functions --port 8792",
+		"dev:workerjs-directory": "wrangler pages dev ./apps/workerjs-directory --port 8792",
+		"dev:workerjs-file": "wrangler pages dev ./apps/workerjs-file --port 8792",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-plugin-mounted-on-root-app/package.json
+++ b/fixtures/pages-plugin-mounted-on-root-app/package.json
@@ -17,7 +17,9 @@
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
 		"pages-plugin-example": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-proxy-app/package.json
+++ b/fixtures/pages-proxy-app/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "esbuild --bundle --platform=node server/index.ts --outfile=dist/index.js",
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev --compatibility-date=2024-01-17 --port 8790 --proxy 8791 -- pnpm run server",
+		"dev": "wrangler pages dev --compatibility-date=2024-01-17 --port 8790 --proxy 8791 -- pnpm run server",
 		"server": "node dist/index.js",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
@@ -15,7 +15,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"miniflare": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-simple-assets/package.json
+++ b/fixtures/pages-simple-assets/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/worker.js",
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public",
+		"dev": "wrangler pages dev public",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
@@ -13,7 +13,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-workerjs-and-functions-app/package.json
+++ b/fixtures/pages-workerjs-and-functions-app/package.json
@@ -4,14 +4,16 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --port 8955",
+		"dev": "wrangler pages dev public --port 8955",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-workerjs-app/package.json
+++ b/fixtures/pages-workerjs-app/package.json
@@ -4,14 +4,16 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev ./workerjs-test --port 8792",
+		"dev": "wrangler pages dev ./workerjs-test --port 8792",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-workerjs-directory/package.json
+++ b/fixtures/pages-workerjs-directory/package.json
@@ -4,13 +4,15 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --d1=D1 --d1=PUT=elsewhere --kv KV --kv KV_REF=other_kv --r2 R2 --r2=R2_REF=other_r2 --port 8794",
+		"dev": "wrangler pages dev public --d1=D1 --d1=PUT=elsewhere --kv KV --kv KV_REF=other_kv --r2 R2 --r2=R2_REF=other_r2 --port 8794",
 		"test:ci": "vitest run",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-workerjs-wasm-app/package.json
+++ b/fixtures/pages-workerjs-wasm-app/package.json
@@ -4,15 +4,17 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --port 8776",
-		"publish": "npx wrangler pages deploy public",
+		"dev": "wrangler pages dev public --port 8776",
+		"publish": "wrangler pages deploy public",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-workerjs-with-config-file-app/package.json
+++ b/fixtures/pages-workerjs-with-config-file-app/package.json
@@ -4,14 +4,16 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev",
+		"dev": "wrangler pages dev",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-workerjs-with-routes-app/package.json
+++ b/fixtures/pages-workerjs-with-routes-app/package.json
@@ -4,14 +4,16 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev public --port 8751",
+		"dev": "wrangler pages dev public --port 8751",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"engines": {

--- a/fixtures/pages-ws-app/package.json
+++ b/fixtures/pages-ws-app/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "esbuild --bundle --platform=node server/index.ts --outfile=dist/index.js",
 		"check:type": "tsc",
-		"dev": "npx wrangler pages dev --port 8790 --proxy 8791 -- pnpm run server",
+		"dev": "wrangler pages dev --port 8790 --proxy 8791 -- pnpm run server",
 		"server": "node dist/index.js",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
@@ -15,6 +15,8 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"miniflare": "workspace:*",
+		"typescript": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*",
 		"ws": "^8.18.0"
 	},

--- a/fixtures/ratelimit-app/package.json
+++ b/fixtures/ratelimit-app/package.json
@@ -13,7 +13,9 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/type-generation/package.json
+++ b/fixtures/type-generation/package.json
@@ -7,6 +7,7 @@
 		"test:watch": "vitest"
 	},
 	"devDependencies": {
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/worker-app/package.json
+++ b/fixtures/worker-app/package.json
@@ -17,7 +17,9 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:^",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/workers-with-assets-only/package.json
+++ b/fixtures/workers-with-assets-only/package.json
@@ -2,7 +2,7 @@
 	"name": "workers-assets-only",
 	"private": true,
 	"scripts": {
-		"dev": "npx wrangler dev",
+		"dev": "wrangler dev",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
@@ -10,7 +10,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/workers-with-assets-serve-directly/package.json
+++ b/fixtures/workers-with-assets-serve-directly/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler dev",
+		"dev": "wrangler dev",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
@@ -11,7 +11,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/workers-with-assets/package.json
+++ b/fixtures/workers-with-assets/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "npx wrangler dev",
+		"dev": "wrangler dev",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
@@ -11,7 +11,9 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/workflow-multiple/package.json
+++ b/fixtures/workflow-multiple/package.json
@@ -8,7 +8,9 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/fixtures/workflow/package.json
+++ b/fixtures/workflow/package.json
@@ -8,7 +8,9 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20241205.0",
+		"typescript": "catalog:default",
 		"undici": "catalog:default",
+		"vitest": "catalog:default",
 		"wrangler": "workspace:*"
 	},
 	"volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,9 +130,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -142,9 +148,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:^
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -163,6 +175,9 @@ importers:
       run-script-os:
         specifier: ^1.1.6
         version: 1.1.6
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
@@ -187,6 +202,9 @@ importers:
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -202,6 +220,9 @@ importers:
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -214,9 +235,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -232,9 +259,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:^
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -256,6 +289,9 @@ importers:
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
 
   fixtures/isomorphic-random-example: {}
 
@@ -275,6 +311,12 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -284,6 +326,9 @@ importers:
       get-port:
         specifier: ^7.0.0
         version: 7.0.0
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -300,9 +345,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -318,6 +369,9 @@ importers:
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -342,6 +396,9 @@ importers:
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -351,9 +408,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -366,9 +429,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -388,9 +457,15 @@ importers:
       pages-plugin-example:
         specifier: workspace:*
         version: link:../pages-plugin-example
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -400,9 +475,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -412,9 +493,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -427,9 +514,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -439,9 +532,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:^
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -470,9 +569,15 @@ importers:
       pages-plugin-example:
         specifier: workspace:*
         version: link:../pages-plugin-example
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -485,9 +590,15 @@ importers:
       miniflare:
         specifier: workspace:*
         version: link:../../packages/miniflare
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -500,9 +611,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -512,9 +629,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -524,9 +647,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:^
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -536,9 +665,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -548,9 +683,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -560,9 +701,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -572,9 +719,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -587,6 +740,12 @@ importers:
       miniflare:
         specifier: workspace:*
         version: link:../../packages/miniflare
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -599,9 +758,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:^
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -624,6 +789,9 @@ importers:
 
   fixtures/type-generation:
     devDependencies:
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -684,9 +852,15 @@ importers:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:^
         version: link:../../packages/workers-tsconfig
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -710,9 +884,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -725,9 +905,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -740,9 +926,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -752,9 +944,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -764,9 +962,15 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20241205.0
+      typescript:
+        specifier: catalog:default
+        version: 5.6.3
       undici:
         specifier: catalog:default
         version: 5.28.4
+      vitest:
+        specifier: catalog:default
+        version: 2.1.8(@types/node@18.19.59)(@vitest/ui@2.1.8)(msw@2.4.3(typescript@5.6.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -13441,7 +13645,7 @@ snapshots:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.1
+      loupe: 3.1.2
       pathval: 2.0.0
 
   chainsaw@0.1.0:


### PR DESCRIPTION
Cleanup `package.json` in the fixtures directory

- Add explicit vitest, typescript when they are used by the scripts
- Removed `npx` - unneeded and for consistency 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: already tested
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
