### PR TITLE
Update unenv preset

### DIFF
--- a/.changeset/chilled-mugs-fail.md
+++ b/.changeset/chilled-mugs-fail.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+chore(wrangler): update unenv dependency version
+
+unenv now uses the workerd implementation on node:dns
+See the [unjs/unenv#376](https://github.com/unjs/unenv/pull/376)

--- a/fixtures/nodejs-hybrid-app/src/index.ts
+++ b/fixtures/nodejs-hybrid-app/src/index.ts
@@ -6,6 +6,7 @@ import { Stream } from "node:stream";
 import { Context } from "vm";
 import { Client } from "pg";
 import { s } from "./dep.cjs";
+import { testUnenvPreset } from "./unenv-preset";
 
 testBasicNodejsProperties();
 
@@ -28,14 +29,18 @@ export default {
 				return testX509Certificate();
 			case "/test-require-alias":
 				return testRequireUenvAliasedPackages();
+			case "/test-unenv-preset":
+				return await testUnenvPreset();
 		}
 
 		return new Response(
-			'<a href="query">Postgres query</a> | ' +
-				'<a href="test-process">Test process global</a> | ' +
-				'<a href="test-random">Test getRandomValues()</a> | ' +
-				'<a href="test-x509-certificate">Test X509Certificate</a>' +
-				'<a href="test-require-alias">Test require unenv aliased packages</a>',
+			`<a href="query">Postgres query</a>
+<a href="test-process">Test process global</a>
+<a href="test-random">Test getRandomValues()</a>
+<a href="test-x509-certificate">Test X509Certificate</a>
+<a href="test-require-alias">Test require unenv aliased packages</a>
+<a href="test-unenv-preset">Test unenv preset</a>
+`,
 			{ headers: { "Content-Type": "text/html; charset=utf-8" } }
 		);
 	},

--- a/fixtures/nodejs-hybrid-app/src/unenv-preset.ts
+++ b/fixtures/nodejs-hybrid-app/src/unenv-preset.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert";
+
+// TODO: move to `@cloudflare/unenv-preset`
+// See: https://github.com/cloudflare/workers-sdk/issues/7579
+export async function testUnenvPreset() {
+	try {
+		await testCryptoGetRandomValues();
+		await testWorkerdImplementsBuffer();
+		await testWorkerdModules();
+		await testUtilImplements();
+		await testWorkerdPath();
+		await testWorkerdDns();
+	} catch (e) {
+		return new Response(String(e));
+	}
+
+	return new Response("OK!");
+}
+
+async function testCryptoGetRandomValues() {
+	const crypto = await import("node:crypto");
+
+	const array = new Uint32Array(10);
+	crypto.getRandomValues(array);
+	assert.strictEqual(array.length, 10);
+	assert(array.every((v) => v >= 0 && v <= 0xff_ff_ff_ff));
+}
+
+async function testWorkerdImplementsBuffer() {
+	const encoder = new TextEncoder();
+	const buffer = await import("node:buffer");
+	const Buffer = buffer.Buffer;
+	assert.strictEqual(buffer.isAscii(encoder.encode("hello world")), true);
+	assert.strictEqual(buffer.isUtf8(encoder.encode("Yağız")), true);
+	assert.strictEqual(buffer.btoa("hello"), "aGVsbG8=");
+	assert.strictEqual(buffer.atob("aGVsbG8="), "hello");
+	{
+		const dest = buffer.transcode(
+			Buffer.from([
+				0x74, 0x00, 0x1b, 0x01, 0x73, 0x00, 0x74, 0x00, 0x20, 0x00, 0x15, 0x26,
+			]),
+			"ucs2",
+			"utf8"
+		);
+		assert.strictEqual(
+			dest.toString(),
+			Buffer.from("těst ☕", "utf8").toString()
+		);
+	}
+	assert.ok(new buffer.File([], "file"));
+	assert.ok(new buffer.Blob([]));
+	assert.strictEqual(typeof buffer.INSPECT_MAX_BYTES, "number");
+	assert.strictEqual(typeof buffer.resolveObjectURL, "function");
+}
+
+async function testWorkerdModules() {
+	const module = await import("node:module");
+	// @ts-expect-error exposed by workerd
+	const require = module.createRequire("/");
+	const modules = [
+		"assert",
+		"assert/strict",
+		"buffer",
+		"diagnostics_channel",
+		"dns",
+		"dns/promises",
+		"events",
+		"path",
+		"path/posix",
+		"path/win32",
+		"querystring",
+		"stream",
+		"stream/consumers",
+		"stream/promises",
+		"stream/web",
+		"string_decoder",
+		"url",
+		"util/types",
+		"zlib",
+	];
+	for (const m of modules) {
+		assert.strictEqual(await import(m), require(m));
+	}
+}
+
+async function testUtilImplements() {
+	const { types } = await import("node:util");
+	assert.strictEqual(types.isExternal("hello world"), false);
+	assert.strictEqual(types.isAnyArrayBuffer(new ArrayBuffer(0)), true);
+}
+
+async function testWorkerdPath() {
+	const pathWin32 = await import("node:path/win32");
+	assert.strictEqual(pathWin32.sep, "\\");
+	assert.strictEqual(pathWin32.delimiter, ";");
+	const pathPosix = await import("node:path/posix");
+	assert.strictEqual(pathPosix.sep, "/");
+	assert.strictEqual(pathPosix.delimiter, ":");
+}
+
+async function testWorkerdDns() {
+	const dns = await import("node:dns");
+	await new Promise((resolve, reject) => {
+		dns.resolveTxt("nodejs.org", (error, results) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			assert.ok(Array.isArray(results[0]));
+			assert.strictEqual(results.length, 1);
+			assert.ok(results[0][0].startsWith("v=spf1"));
+			resolve(null);
+		});
+	});
+
+	const dnsPromises = await import("node:dns/promises");
+	const results = await dnsPromises.resolveCaa("google.com");
+	assert.ok(Array.isArray(results));
+	assert.strictEqual(results.length, 1);
+	assert.strictEqual(typeof results[0].critical, "number");
+	assert.strictEqual(results[0].critical, 0);
+	assert.strictEqual(results[0].issue, "pki.goog");
+}

--- a/fixtures/nodejs-hybrid-app/tests/index.test.ts
+++ b/fixtures/nodejs-hybrid-app/tests/index.test.ts
@@ -76,4 +76,17 @@ describe("nodejs compat", () => {
 			await stop();
 		}
 	});
+
+	test("unenv preset", async ({ expect }) => {
+		const { ip, port, stop } = await runWranglerDev(
+			resolve(__dirname, "../src"),
+			["--port=0", "--inspector-port=0"]
+		);
+		try {
+			const response = await fetch(`http://${ip}:${port}/test-unenv-preset`);
+			await expect(response.text()).resolves.toBe("OK!");
+		} finally {
+			await stop();
+		}
+	});
 });

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -47,8 +47,7 @@
 	"devDependencies": {
 		"@types/node": "*",
 		"typescript": "catalog:default",
-		"unbuild": "^2.0.0",
-		"wrangler": "3.95.0"
+		"unbuild": "^2.0.0"
 	},
 	"peerDependencies": {
 		"unenv": "npm:unenv-nightly@*",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -83,7 +83,7 @@
 		"resolve": "^1.22.8",
 		"selfsigned": "^2.0.1",
 		"source-map": "^0.6.1",
-		"unenv": "npm:unenv-nightly@2.0.0-20241204-140205-a5d5190",
+		"unenv": "npm:unenv-nightly@2.0.0-20241216-144314-7e05819",
 		"workerd": "1.20241218.0",
 		"xxhash-wasm": "^1.0.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1633,9 +1633,6 @@ importers:
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.6.3)(vue-tsc@2.0.29(typescript@5.6.3))
-      wrangler:
-        specifier: 3.95.0
-        version: 3.95.0(@cloudflare/workers-types@4.20241218.0)
 
   packages/vitest-pool-workers:
     dependencies:
@@ -2809,12 +2806,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20241205.0':
-    resolution: {integrity: sha512-TArEZkSZkHJyEwnlWWkSpCI99cF6lJ14OVeEoI9Um/+cD9CKZLM9vCmsLeKglKheJ0KcdCnkA+DbeD15t3VaWg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-64@1.20241216.0':
     resolution: {integrity: sha512-GreuUuvd1tp34i/I8rv9I6tJTGkLIdUZfPd4Gq7glRntWhZSfeJOlhFHOa/tIil1SrWi1UzXmWeW22DCcUIprA==}
     engines: {node: '>=16'}
@@ -2829,12 +2820,6 @@ packages:
 
   '@cloudflare/workerd-darwin-arm64@1.20241106.1':
     resolution: {integrity: sha512-j3dg/42D/bPgfNP3cRUBxF+4waCKO/5YKwXNj+lnVOwHxDu+ne5pFw9TIkKYcWTcwn0ZUkbNZNM5rhJqRn4xbg==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20241205.0':
-    resolution: {integrity: sha512-u5eqKa9QRdA8MugfgCoD+ADDjY6EpKbv3hSYJETmmUh17l7WXjWBzv4pUvOKIX67C0UzMUy4jZYwC53MymhX3w==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -2857,12 +2842,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20241205.0':
-    resolution: {integrity: sha512-OYA7S5zpumMamWEW+IhhBU6YojIEocyE5X/YFPiTOCrDE3dsfr9t6oqNE7hxGm1VAAu+Irtl+a/5LwmBOU681w==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-64@1.20241216.0':
     resolution: {integrity: sha512-HRkePwhnb/4r2Bd6SS3n8VWLPnczh2ApKo3j5N0YSVOz/bEJlqEbEnKAUivCb79C3zptTsbsb0tJ4b5uZsaHtw==}
     engines: {node: '>=16'}
@@ -2877,12 +2856,6 @@ packages:
 
   '@cloudflare/workerd-linux-arm64@1.20241106.1':
     resolution: {integrity: sha512-mdQFPk4+14Yywn7n1xIzI+6olWM8Ybz10R7H3h+rk0XulMumCWUCy1CzIDauOx6GyIcSgKIibYMssVHZR30ObA==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@cloudflare/workerd-linux-arm64@1.20241205.0':
-    resolution: {integrity: sha512-qAzecONjFJGIAVJZKExQ5dlbic0f3d4A+GdKa+H6SoUJtPaWiE3K6WuePo4JOT7W3/Zfh25McmX+MmpMUUcM5Q==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -2905,12 +2878,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20241205.0':
-    resolution: {integrity: sha512-BEab+HiUgCdl6GXAT7EI2yaRtDPiRJlB94XLvRvXi1ZcmQqsrq6awGo6apctFo4WUL29V7c09LxmN4HQ3X2Tvg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
   '@cloudflare/workerd-windows-64@1.20241216.0':
     resolution: {integrity: sha512-6UtbWgZNFuVyq6d3nKsp3Eb53Ghm2EYObCKTs9TSzV2ZHbovgOIU8BKIlbfJvmkEbG4Q8bbfZkb3QJpG/IwchQ==}
     engines: {node: '>=16'}
@@ -2922,10 +2889,6 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
-
-  '@cloudflare/workers-shared@0.11.0':
-    resolution: {integrity: sha512-A+lQ8xp7992qSeMmuQ0ssL6CPmm+ZmAv6Ddikan0n1jjpMAic+97l7xtVIsswSn9iLMFPYQ9uNN/8Fl0AgARIQ==}
-    engines: {node: '>=16.7.0'}
 
   '@cloudflare/workers-shared@0.8.0':
     resolution: {integrity: sha512-1OvFkNtslaMZAJsaocTmbACApgmWv55uLpNj50Pn2MGcxdAjpqykXJFQw5tKc+lGV9TDZh9oO3Rsk17IEQDzIg==}
@@ -7607,11 +7570,6 @@ packages:
     engines: {node: '>=16.13'}
     hasBin: true
 
-  miniflare@3.20241205.0:
-    resolution: {integrity: sha512-Z0cTtIf6ZrcAJ3SrOI9EUM3s4dkGhNeU6Ubl8sroYhsPVD+rtz3m5+p6McHFWCkcMff1o60X5XEKVTmkz0gbpA==}
-    engines: {node: '>=16.13'}
-    hasBin: true
-
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
     engines: {node: 20 || >=22}
@@ -9775,9 +9733,6 @@ packages:
   unenv-nightly@2.0.0-20241111-080453-894aa31:
     resolution: {integrity: sha512-0W39QQOQ9VE8kVVUpGwEG+pZcsCXk5wqNG6rDPE6Gr+fiA69LR0qERM61hW5KCOkC1/ArCFrfCGjwHyyv/bI0Q==}
 
-  unenv-nightly@2.0.0-20241204-140205-a5d5190:
-    resolution: {integrity: sha512-jpmAytLeiiW01pl5bhVn9wYJ4vtiLdhGe10oXlJBuQEX8mxjxO8BlEXGHU4vr4yEikjFP1wsomTHt/CLU8kUwg==}
-
   unenv-nightly@2.0.0-20241216-144314-7e05819:
     resolution: {integrity: sha512-HpRspwDDxEwb6f9jOJYdL8iuZ054GIJ61LWHui7FPcgSVUPIXjZ3Nf0bh0qVIEqSGb3bNU/C1Zcw6fKHVl4lDg==}
 
@@ -10092,11 +10047,6 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20241205.0:
-    resolution: {integrity: sha512-vso/2n0c5SdBDWiD+Sx5gM7unA6SiZXRVUHDqH1euoP/9mFVHZF8icoYsNLB87b/TX8zNgpae+I5N/xFpd9v0g==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   workerd@1.20241216.0:
     resolution: {integrity: sha512-q92hkfZ0ZmH6DrcQ426AqJR0KyG6NRAUNUT3Kvpzk76rLHzw6pvVeU9exATkqnwk5K3LQK6l1asuSsBDdXsPpw==}
     engines: {node: '>=16'}
@@ -10116,16 +10066,6 @@ packages:
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20241106.0
-    peerDependenciesMeta:
-      '@cloudflare/workers-types':
-        optional: true
-
-  wrangler@3.95.0:
-    resolution: {integrity: sha512-3w5852i3FNyDz421K2Qk4v5L8jjwegO5O8E1+VAQmjnm82HFNxpIRUBq0bmM7CTLvOPI/Jjcmj/eAWjQBL7QYg==}
-    engines: {node: '>=16.17.0'}
-    hasBin: true
-    peerDependencies:
-      '@cloudflare/workers-types': ^4.20241205.0
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -11168,9 +11108,6 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20241106.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20241205.0':
-    optional: true
-
   '@cloudflare/workerd-darwin-64@1.20241216.0':
     optional: true
 
@@ -11178,9 +11115,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20241106.1':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20241205.0':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20241216.0':
@@ -11192,9 +11126,6 @@ snapshots:
   '@cloudflare/workerd-linux-64@1.20241106.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20241205.0':
-    optional: true
-
   '@cloudflare/workerd-linux-64@1.20241216.0':
     optional: true
 
@@ -11202,9 +11133,6 @@ snapshots:
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20241106.1':
-    optional: true
-
-  '@cloudflare/workerd-linux-arm64@1.20241205.0':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20241216.0':
@@ -11216,19 +11144,11 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20241106.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20241205.0':
-    optional: true
-
   '@cloudflare/workerd-windows-64@1.20241216.0':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20241218.0':
     optional: true
-
-  '@cloudflare/workers-shared@0.11.0':
-    dependencies:
-      mime: 3.0.0
-      zod: 3.22.3
 
   '@cloudflare/workers-shared@0.8.0':
     dependencies:
@@ -16296,25 +16216,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  miniflare@3.20241205.0:
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      acorn: 8.14.0
-      acorn-walk: 8.3.2
-      capnp-ts: 0.7.0(patch_hash=l4yimnxyvkiyj6alnps2ec3sii)
-      exit-hook: 2.2.1
-      glob-to-regexp: 0.4.1
-      stoppable: 1.1.0
-      undici: 5.28.4
-      workerd: 1.20241205.0
-      ws: 8.18.0
-      youch: 3.2.3
-      zod: 3.22.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   minimatch@10.0.1:
     dependencies:
       brace-expansion: 2.0.1
@@ -18646,13 +18547,6 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.5.4
 
-  unenv-nightly@2.0.0-20241204-140205-a5d5190:
-    dependencies:
-      defu: 6.1.4
-      ohash: 1.1.4
-      pathe: 1.1.2
-      ufo: 1.5.4
-
   unenv-nightly@2.0.0-20241216-144314-7e05819:
     dependencies:
       defu: 6.1.4
@@ -19042,14 +18936,6 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20241106.1
       '@cloudflare/workerd-windows-64': 1.20241106.1
 
-  workerd@1.20241205.0:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20241205.0
-      '@cloudflare/workerd-darwin-arm64': 1.20241205.0
-      '@cloudflare/workerd-linux-64': 1.20241205.0
-      '@cloudflare/workerd-linux-arm64': 1.20241205.0
-      '@cloudflare/workerd-windows-64': 1.20241205.0
-
   workerd@1.20241216.0:
     optionalDependencies:
       '@cloudflare/workerd-darwin-64': 1.20241216.0
@@ -19088,34 +18974,6 @@ snapshots:
       source-map: 0.6.1
       unenv: unenv-nightly@2.0.0-20241111-080453-894aa31
       workerd: 1.20241106.1
-      xxhash-wasm: 1.0.1
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20241218.0
-      fsevents: 2.3.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  wrangler@3.95.0(@cloudflare/workers-types@4.20241218.0):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.3.4
-      '@cloudflare/workers-shared': 0.11.0
-      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
-      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
-      blake3-wasm: 2.1.5
-      chokidar: 4.0.1
-      date-fns: 4.1.0
-      esbuild: 0.17.19
-      itty-time: 1.0.6
-      miniflare: 3.20241205.0
-      nanoid: 3.3.7
-      path-to-regexp: 6.3.0
-      resolve: 1.22.8
-      selfsigned: 2.1.1
-      source-map: 0.6.1
-      unenv: unenv-nightly@2.0.0-20241204-140205-a5d5190
-      workerd: 1.20241205.0
       xxhash-wasm: 1.0.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20241218.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2022,8 +2022,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       unenv:
-        specifier: npm:unenv-nightly@2.0.0-20241204-140205-a5d5190
-        version: unenv-nightly@2.0.0-20241204-140205-a5d5190
+        specifier: npm:unenv-nightly@2.0.0-20241216-144314-7e05819
+        version: unenv-nightly@2.0.0-20241216-144314-7e05819
       workerd:
         specifier: 1.20241218.0
         version: 1.20241218.0
@@ -16299,7 +16299,7 @@ snapshots:
   miniflare@3.20241205.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      acorn: 8.11.3
+      acorn: 8.14.0
       acorn-walk: 8.3.2
       capnp-ts: 0.7.0(patch_hash=l4yimnxyvkiyj6alnps2ec3sii)
       exit-hook: 2.2.1
@@ -18610,7 +18610,7 @@ snapshots:
       mkdist: 1.6.0(typescript@5.6.3)(vue-tsc@2.0.29(typescript@5.6.3))
       mlly: 1.7.3
       pathe: 1.1.2
-      pkg-types: 1.0.3
+      pkg-types: 1.2.1
       pretty-bytes: 6.1.1
       rollup: 3.29.5
       rollup-plugin-dts: 6.1.1(rollup@3.29.5)(typescript@5.6.3)


### PR DESCRIPTION
Add tests for the unenv preset

We will need to mobve those tests to the package, see https://github.com/cloudflare/workers-sdk/issues/7579

dns is expected to fail before we upgrade to workerd 20241216

- https://github.com/cloudflare/workers-sdk/pull/7562
- https://github.com/cloudflare/workers-sdk/pull/7566

The second commit speed-up the tests by launching wrangler only once for all the tests. 

/cc @pi0 

edit: this PR does not change the resolution mechanism (which is what broke the wrangler a few days ago).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
