### PR TITLE
chore(workers-shared): Dummy `workers-shared` version bump

### DIFF
--- a/.changeset/sharp-crabs-beg.md
+++ b/.changeset/sharp-crabs-beg.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Dummy workers-shared version bump
+
+The Router Worker and Asset Worker of `workers-shared` are currently in a weird state that prevents us to redeploy them. The current versions of these workers are developer modified due to adding secrets. We want a CI controlled version to safely use these secrets.
+
+This commit performs a dummy `workers-shared` version bump to unlock us from this blocked state.


### PR DESCRIPTION
The Router Worker and Asset Worker of `workers-shared` are currently in a weird state that prevents us to redeploy them. The current versions of these workers are developer modified due to adding secrets. We want a CI controlled version to safely use these secrets.

This PR performs a dummy `workers-shared` version bump to unlock us from this blocked state.

Fixes #000

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: dummy version bump
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: dummy version bump
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: dummy version bump

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
