### PR TITLE
feat(wrangler): Capture Workers with static assets in the telemetry data

### DIFF
--- a/.changeset/long-houses-mate.md
+++ b/.changeset/long-houses-mate.md
@@ -1,0 +1,11 @@
+---
+"wrangler": minor
+---
+
+feat: Capture Workers with static assets in the telemetry data
+
+We want to measure accurately what this number of Workers + Assets projects running in remote mode is, as this number will be a very helpful data point down the road, when more decisions around remote mode will have to be taken.
+
+These changes add this kind of insight to our telemetry data, by capturing whether the command running is in the context of a Workers + Assets project.
+
+N.B. With these changes in place we will be capturing the Workers + Assets context for all commands, not just wrangler dev --remote.

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { http, HttpResponse } from "msw";
 import { vi } from "vitest";
 import { CI } from "../is-ci";
@@ -189,6 +190,7 @@ describe("metrics", () => {
 				isPagesCI: false,
 				isWorkersCI: false,
 				isInteractive: true,
+				hasAssets: false,
 				argsUsed: [],
 				argsCombination: "",
 				command: "wrangler docs",
@@ -357,6 +359,58 @@ describe("metrics", () => {
 
 				expect(requests.count).toBe(2);
 				expect(std.debug).toContain('isWorkersCI":true');
+			});
+
+			it("should capture Workers + Assets projects", async () => {
+				writeWranglerConfig({ assets: { directory: "./public" } });
+
+				// set up empty static assets directory
+				fs.mkdirSync("./public");
+
+				const requests = mockMetricRequest();
+
+				await runWrangler("docs arg");
+				expect(requests.count).toBe(2);
+
+				// command started
+				const expectedStartReq = {
+					deviceId: "f82b1f46-eb7b-4154-aa9f-ce95f23b2288",
+					event: "wrangler command started",
+					timestamp: 1733961600000,
+					properties: {
+						amplitude_session_id: 1733961600000,
+						amplitude_event_id: 0,
+						...{ ...reused, hasAssets: true },
+					},
+				};
+				expect(std.debug).toContain(
+					`Posting data ${JSON.stringify(expectedStartReq)}`
+				);
+
+				// command completed
+				const expectedCompleteReq = {
+					deviceId: "f82b1f46-eb7b-4154-aa9f-ce95f23b2288",
+					event: "wrangler command completed",
+					timestamp: 1733961606000,
+					properties: {
+						amplitude_session_id: 1733961600000,
+						amplitude_event_id: 1,
+						...{ ...reused, hasAssets: true },
+						durationMs: 6000,
+						durationSeconds: 6,
+						durationMinutes: 0.1,
+					},
+				};
+				expect(std.debug).toContain(
+					`Posting data ${JSON.stringify(expectedCompleteReq)}`
+				);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					Cloudflare collects anonymous telemetry about your usage of Wrangler. Learn more at https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md
+					Opening a link in your default browser: FAKE_DOCS_URL:{\\"params\\":\\"query=arg&hitsPerPage=1&getRankingInfo=0\\"}"
+				`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
 
 			it("should not send arguments with wrangler login", async () => {

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -1155,6 +1155,7 @@ export async function main(argv: string[]): Promise<void> {
 			const { rawConfig, configPath } = experimental_readRawConfig(args);
 			dispatcher = getMetricsDispatcher({
 				sendMetrics: rawConfig.send_metrics,
+				hasAssets: !!rawConfig.assets?.directory,
 				configPath,
 			});
 		} catch (e) {

--- a/packages/wrangler/src/metrics/metrics-config.ts
+++ b/packages/wrangler/src/metrics/metrics-config.ts
@@ -24,6 +24,10 @@ export interface MetricsConfigOptions {
 	 */
 	sendMetrics?: boolean;
 	/**
+	 * Captures whether this is a Worker with static assets
+	 */
+	hasAssets?: boolean;
+	/**
 	 * Path to wrangler configuration file, if it exists. Used for configFileType property
 	 */
 	configPath?: string | undefined;

--- a/packages/wrangler/src/metrics/metrics-dispatcher.ts
+++ b/packages/wrangler/src/metrics/metrics-dispatcher.ts
@@ -111,6 +111,7 @@ export function getMetricsDispatcher(options: MetricsConfigOptions) {
 					isPagesCI: isPagesCI(),
 					isWorkersCI: isWorkersCI(),
 					isInteractive: isInteractive(),
+					hasAssets: options.hasAssets ?? false,
 					argsUsed,
 					argsCombination,
 				};

--- a/packages/wrangler/src/metrics/types.ts
+++ b/packages/wrangler/src/metrics/types.ts
@@ -53,6 +53,10 @@ export type CommonEventProperties = {
 	 */
 	isInteractive: boolean;
 	/**
+	 * Whether this is a Worker with static assets
+	 */
+	hasAssets: boolean;
+	/**
 	 * A list of normalised argument names/flags that were passed in or are set by default.
 	 * Excludes boolean flags set to false.
 	 */


### PR DESCRIPTION
Fixes DEVX-1525

During many Workers+Assets conversations, folks have mentioned that we expect usage for assets in remote mode to be fairly small. We should measure accurately what this number is, as it will be a very helpful data point down the road, when more decisions around remote mode will have to be taken.

This PR adds this kind of insight to our telemetry data, by capturing whether the command running is in the context of a Workers + Assets project. 

N.B. With these changes in place we will be capturing the Workers + Assets context for all commands, not just `wrangler dev --remote`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
