### PR TITLE
feat: add options to readConfig() to specify control how we deal with missing environment definitions

### DIFF
--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -80,6 +80,13 @@ export type ReadConfigOptions = {
 	 * unless the requested environment is listed in the `optionalEnvironments` below.
 	 */
 	hideWarningForEnvironmentWhenOnlyTopLevel?: boolean;
+	/**
+	 * Any environments in this list do not need to have a named environment defined, even if there are other named environments.
+	 *
+	 * Normally in that case Wrangler would exit with an error.
+	 * Now such environments will just use the top-level environment and there will also be no warning.
+	 */
+	optionalEnvironments?: string[];
 };
 /**
  * Get the Wrangler configuration; read it from the give `configPath` if available.

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -67,26 +67,41 @@ type ReadConfigCommandArgs = NormalizeAndValidateConfigArgs & {
 	script?: string;
 };
 
+export type ReadConfigOptions = {
+	/**
+	 * If this option is true then no warnings are displayed to the user.
+	 */
+	hideWarnings?: boolean;
+	/**
+	 * If this option is true then no warning is displayed when the user asks for an environment
+	 * and there are no named environments defined in the Wrangler configuration.
+	 *
+	 * If there are named environments defined then that would still be an error condition -
+	 * unless the requested environment is listed in the `optionalEnvironments` below.
+	 */
+	hideWarningForEnvironmentWhenOnlyTopLevel?: boolean;
+};
 /**
  * Get the Wrangler configuration; read it from the give `configPath` if available.
  */
 export function readConfig(
 	args: ReadConfigCommandArgs,
-	options?: { hideWarnings?: boolean }
+	options?: ReadConfigOptions
 ): Config;
 export function readConfig(
 	args: ReadConfigCommandArgs,
-	{ hideWarnings = false }: { hideWarnings?: boolean } = {}
+	options: ReadConfigOptions = {}
 ): Config {
 	const { rawConfig, configPath } = experimental_readRawConfig(args);
 
 	const { config, diagnostics } = normalizeAndValidateConfig(
 		rawConfig,
 		configPath,
-		args
+		args,
+		options
 	);
 
-	if (diagnostics.hasWarnings() && !hideWarnings) {
+	if (diagnostics.hasWarnings() && !options.hideWarnings) {
 		logger.warn(diagnostics.renderWarnings());
 	}
 	if (diagnostics.hasErrors()) {
@@ -98,7 +113,7 @@ export function readConfig(
 
 export function readPagesConfig(
 	args: ReadConfigCommandArgs,
-	{ hideWarnings = false }: { hideWarnings?: boolean } = {}
+	options: ReadConfigOptions = {}
 ): Omit<Config, "pages_build_output_dir"> & { pages_build_output_dir: string } {
 	let rawConfig: RawConfig;
 	let configPath: string | undefined;
@@ -122,10 +137,11 @@ export function readPagesConfig(
 	const { config, diagnostics } = normalizeAndValidateConfig(
 		rawConfig,
 		configPath,
-		args
+		args,
+		options
 	);
 
-	if (diagnostics.hasWarnings() && !hideWarnings) {
+	if (diagnostics.hasWarnings() && !options.hideWarnings) {
 		logger.warn(diagnostics.renderWarnings());
 	}
 	if (diagnostics.hasErrors()) {

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -34,6 +34,7 @@ import {
 	validateTypedArray,
 } from "./validation-helpers";
 import { configFileName, formatConfigSnippet } from ".";
+import type { ReadConfigOptions } from ".";
 import type {
 	CreateApplicationRequest,
 	UserDeploymentConfiguration,
@@ -80,7 +81,8 @@ export function isPagesConfig(rawConfig: RawConfig): boolean {
 export function normalizeAndValidateConfig(
 	rawConfig: RawConfig,
 	configPath: string | undefined,
-	args: NormalizeAndValidateConfigArgs
+	args: NormalizeAndValidateConfigArgs,
+	options: ReadConfigOptions = {}
 ): {
 	config: Config;
 	diagnostics: Diagnostics;
@@ -232,6 +234,7 @@ export function normalizeAndValidateConfig(
 				isLegacyEnv,
 				rawConfig
 			);
+
 			const envNames = rawConfig.env
 				? `The available configured environment names are: ${JSON.stringify(
 						Object.keys(rawConfig.env)
@@ -248,7 +251,7 @@ export function normalizeAndValidateConfig(
 
 			if (envNames.length > 0) {
 				diagnostics.errors.push(message);
-			} else {
+			} else if (!options.hideWarningForEnvironmentWhenOnlyTopLevel) {
 				// Only warn (rather than error) if there are not actually any environments configured in the Wrangler configuration file.
 				diagnostics.warnings.push(message);
 			}


### PR DESCRIPTION
Fixes #0000

This will be used by the Vite plugin, since `vite dev` command will always set the environment
to "development", and we don't want the user to have to define this explicitly if they don't want to.
In such cases there is no need for the user to define this environment explicitly,
even if there are other environments defined.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal API only

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
