### PR TITLE
fix: better handler malformed paths

### DIFF
--- a/.changeset/empty-cars-provide.md
+++ b/.changeset/empty-cars-provide.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+fix: resolves an issue where a malformed path such as `https://example.com/%A0` would cause an unhandled error

--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -18,12 +18,7 @@ export const handleRequest = async (
 ) => {
 	const { pathname, search } = new URL(request.url);
 
-	let decodedPathname;
-	try {
-		decodedPathname = decodePath(pathname);
-	} catch (err) {
-		return new NotFoundResponse();
-	}
+	let decodedPathname = decodePath(pathname);
 	// normalize the path; remove multiple slashes which could lead to same-schema redirects
 	decodedPathname = decodedPathname.replace(/\/+/g, "/");
 
@@ -687,7 +682,14 @@ const safeRedirect = async (
 export const decodePath = (pathname: string) => {
 	return pathname
 		.split("/")
-		.map((x) => decodeURIComponent(x))
+		.map((x) => {
+			try {
+				const decoded = decodeURIComponent(x);
+				return decoded;
+			} catch {
+				return x;
+			}
+		})
 		.join("/");
 };
 /**
@@ -697,6 +699,13 @@ export const decodePath = (pathname: string) => {
 const encodePath = (pathname: string) => {
 	return pathname
 		.split("/")
-		.map((x) => encodeURIComponent(x))
+		.map((x) => {
+			try {
+				const encoded = encodeURIComponent(x);
+				return encoded;
+			} catch {
+				return x;
+			}
+		})
 		.join("/");
 };

--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -18,7 +18,12 @@ export const handleRequest = async (
 ) => {
 	const { pathname, search } = new URL(request.url);
 
-	let decodedPathname = decodePath(pathname);
+	let decodedPathname;
+	try {
+		decodedPathname = decodePath(pathname);
+	} catch (err) {
+		return new NotFoundResponse();
+	}
 	// normalize the path; remove multiple slashes which could lead to same-schema redirects
 	decodedPathname = decodedPathname.replace(/\/+/g, "/");
 

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -151,28 +151,41 @@ describe("[Asset Worker] `handleRequest`", () => {
 		expect(response.status).toBe(404);
 	});
 
-	it("returns 404 Not Found responses for malformed path", async () => {
+	it("returns expected responses for malformed path", async () => {
 		const assets: Record<string, string> = {
 			"/index.html": "aaaaaaaaaa",
+			"/%A0%A0.html": "bbbbbbbbbb",
 		};
 		const configuration: Required<AssetConfig> = {
-			html_handling: "none",
+			html_handling: "drop-trailing-slash",
 			not_found_handling: "none",
 			serve_directly: true,
 		};
 
+		const exists = async (pathname: string) => {
+			return assets[pathname] ?? null;
+		};
+		const getByEtag = async (_: string) => ({
+			readableStream: new ReadableStream(),
+			contentType: "text/html",
+		});
+
+		// first malformed URL should return 404 as no match above
 		const response = await handleRequest(
 			new Request("https://example.com/%A0"),
 			configuration,
-			async (pathname: string) => {
-				return assets[pathname] ?? null;
-			},
-			async (_: string) => ({
-				readableStream: new ReadableStream(),
-				contentType: "text/html",
-			})
+			exists,
+			getByEtag
 		);
-
 		expect(response.status).toBe(404);
+
+		// but second malformed URL should return 307 as it matches and then redirects
+		const response2 = await handleRequest(
+			new Request("https://example.com/%A0%A0"),
+			configuration,
+			exists,
+			getByEtag
+		);
+		expect(response2.status).toBe(307);
 	});
 });

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -150,4 +150,29 @@ describe("[Asset Worker] `handleRequest`", () => {
 
 		expect(response.status).toBe(404);
 	});
+
+	it("returns 404 Not Found responses for malformed path", async () => {
+		const assets: Record<string, string> = {
+			"/index.html": "aaaaaaaaaa",
+		};
+		const configuration: Required<AssetConfig> = {
+			html_handling: "none",
+			not_found_handling: "none",
+			serve_directly: true,
+		};
+
+		const response = await handleRequest(
+			new Request("https://example.com/%AO"),
+			configuration,
+			async (pathname: string) => {
+				return assets[pathname] ?? null;
+			},
+			async (_: string) => ({
+				readableStream: new ReadableStream(),
+				contentType: "text/html",
+			})
+		);
+
+		expect(response.status).toBe(404);
+	});
 });

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -162,7 +162,7 @@ describe("[Asset Worker] `handleRequest`", () => {
 		};
 
 		const response = await handleRequest(
-			new Request("https://example.com/%AO"),
+			new Request("https://example.com/%A0"),
 			configuration,
 			async (pathname: string) => {
 				return assets[pathname] ?? null;


### PR DESCRIPTION
Fixes #7611

This more gracefully handles malformed URLs and simply throws a 404 on them instead of the entire Worker throwing an exception.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no e2e tests for this
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user-facing changes

