### PR TITLE
chore(wrangler): update unenv dependency version

### DIFF
--- a/.changeset/nice-pandas-wait.md
+++ b/.changeset/nice-pandas-wait.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+chore(wrangler): update unenv dependency version
+
+The updated unenv contains a fix for the module resolution,
+see <https://github.com/unjs/unenv/pull/378>.
+That bug prevented us from using unenv module resolution,
+see <https://github.com/cloudflare/workers-sdk/pull/7583>.

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -83,7 +83,7 @@
 		"resolve": "^1.22.8",
 		"selfsigned": "^2.0.1",
 		"source-map": "^0.6.1",
-		"unenv": "npm:unenv-nightly@2.0.0-20241216-144314-7e05819",
+		"unenv": "npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3",
 		"workerd": "1.20241218.0",
 		"xxhash-wasm": "^1.0.1"
 	},

--- a/packages/wrangler/src/__tests__/unenv/unenv.test.ts
+++ b/packages/wrangler/src/__tests__/unenv/unenv.test.ts
@@ -1,0 +1,22 @@
+import { cloudflare, defineEnv } from "unenv";
+
+describe("unenv", () => {
+	test("module resolution does not throw", async () => {
+		const env = {
+			alias: {},
+			...cloudflare,
+		};
+
+		env.alias["should/no/throw"] = "if/this/is/not/valid";
+
+		// Throws "Error: ENOTDIR: not a directory, open '.../node_modules/.pnpm/unenv-nightly@2.0.0-20241216-144314-7e05819/node_modules/unenv-nightly/dist/index.mjs/package.json'"
+		// before https://github.com/unjs/unenv/pull/378 is integrated via 2.0.0-20241218-183400-5d6aec3
+		expect(() => {
+			defineEnv({
+				nodeCompat: true,
+				presets: [env],
+				resolve: true,
+			});
+		}).not.toThrow();
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2019,8 +2019,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       unenv:
-        specifier: npm:unenv-nightly@2.0.0-20241216-144314-7e05819
-        version: unenv-nightly@2.0.0-20241216-144314-7e05819
+        specifier: npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3
+        version: unenv-nightly@2.0.0-20241218-183400-5d6aec3
       workerd:
         specifier: 1.20241218.0
         version: 1.20241218.0
@@ -9735,6 +9735,9 @@ packages:
 
   unenv-nightly@2.0.0-20241216-144314-7e05819:
     resolution: {integrity: sha512-HpRspwDDxEwb6f9jOJYdL8iuZ054GIJ61LWHui7FPcgSVUPIXjZ3Nf0bh0qVIEqSGb3bNU/C1Zcw6fKHVl4lDg==}
+
+  unenv-nightly@2.0.0-20241218-183400-5d6aec3:
+    resolution: {integrity: sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -18548,6 +18551,14 @@ snapshots:
       ufo: 1.5.4
 
   unenv-nightly@2.0.0-20241216-144314-7e05819:
+    dependencies:
+      defu: 6.1.4
+      mlly: 1.7.3
+      ohash: 1.1.4
+      pathe: 1.1.2
+      ufo: 1.5.4
+
+  unenv-nightly@2.0.0-20241218-183400-5d6aec3:
     dependencies:
       defu: 6.1.4
       mlly: 1.7.3


### PR DESCRIPTION

This is testing the fix in unenv for module resolution.
The bug made use revert using the unenv module resolution in the nodejs hybrid plugin last week.

Note that module resolution has not been plugged in again in this PR. We are only pulling the fix and testing it. The module resolution PRs will be re-integrated as follow up PRs.

/cc @pi0

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
