### PR TITLE
chore: pin `@opennextjs/cloudflare` to 0.2.x

### DIFF
--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -18,7 +18,10 @@ const generate = async (ctx: C3Context) => {
 };
 
 const configure = async () => {
-	const packages = ["@opennextjs/cloudflare", "@cloudflare/workers-types"];
+	const packages = [
+		"@opennextjs/cloudflare@0.2.x",
+		"@cloudflare/workers-types",
+	];
 	await installPackages(packages, {
 		dev: true,
 		startText: "Adding the Cloudflare adapter",


### PR DESCRIPTION
The template matches the 0.2.x release 

It will be updated later for 0.3

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: already tested (was failing)
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [X] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
