### PR TITLE
feat(wrangler): use unenv bulitin dependency resolution

### DIFF
--- a/.changeset/chilled-needles-notice.md
+++ b/.changeset/chilled-needles-notice.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat(wrangler): use unenv bulitin dependency resolution

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -10420,7 +10420,7 @@ export default{
 			fs.writeFileSync(
 				"index.js",
 				`
-      import path from 'path';
+      import path from 'node:path';
       console.log(path);
       export default {}
       `
@@ -10441,7 +10441,7 @@ export default{
 			}
 		`);
 			expect(fs.readFileSync("dist/index.js", { encoding: "utf-8" })).toContain(
-				`import path from "path";`
+				`import path from "node:path";`
 			);
 		});
 


### PR DESCRIPTION
Reapply of #7541

The initial PR was reverted by https://github.com/cloudflare/workers-sdk/pull/7583

The root caused was fixed in https://github.com/cloudflare/workers-sdk/pull/7614 (via https://github.com/unjs/unenv/pull/378)

/cc @pi0

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: already tested in https://github.com/cloudflare/workers-sdk/pull/7614/files#diff-dc9521e48f13c8af9737ee8c555eb22b138b148285e843ce1b4b9bdb3b2e3dd7R1
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
