### PR TITLE
Warn if compat date < most recent compat date supported by installed Wrangler

### DIFF
--- a/.changeset/clean-ties-study.md
+++ b/.changeset/clean-ties-study.md
@@ -1,0 +1,6 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Encourage updating compatbility date if more recent compatibility date is available

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -317,9 +317,24 @@ function validateCompatibilityDate(log: Log, compatibilityDate: string) {
 			"ERR_FUTURE_COMPATIBILITY_DATE",
 			`Compatibility date "${compatibilityDate}" is in the future and unsupported`
 		);
-	} else if (
-		numericCompare(compatibilityDate, supportedCompatibilityDate) > 0
-	) {
+	}
+
+	if (numericCompare(compatibilityDate, supportedCompatibilityDate) < 0) {
+		// Encourage people to update their compatibility date if their Worker
+		log.warn(
+			[
+			  `A more recent compatibility date is available. `,
+			  bold(`"${supportedCompatibilityDate}"`),
+			  ` is the latest compatibility date supported by the installed Cloudflare Workers Runtime.`,
+			  `Your Worker is configured to use `,
+			  bold(`${compatibilityDate}"`),
+			  `. Update the compatibility date in your wrangler.toml or wrangler.json configuration file to get the latest functionality.`,
+			  `Learn more about compatibility dates: https://developers.cloudflare.com/workers/configuration/compatibility-dates/`
+		    ].join("")
+		);
+	}
+
+	if (numericCompare(compatibilityDate, supportedCompatibilityDate) > 0) {
 		// If this compatibility date is greater than the maximum supported
 		// compatibility date of the runtime, but not in the future, warn,
 		// and use the maximum supported date instead
@@ -336,6 +351,7 @@ function validateCompatibilityDate(log: Log, compatibilityDate: string) {
 		);
 		return supportedCompatibilityDate;
 	}
+
 	return compatibilityDate;
 }
 


### PR DESCRIPTION
We don't currently warn you at all if you're using an older [compat date](https://developers.cloudflare.com/workers/configuration/compatibility-dates/) than what is supported by the version of Wrangler that you're running.

I think we should, because:

1. Most compat date updates simply mean things get better, a bug gets fixed, a new API is supported, etc.
2. There are a lot of projects out there that, unless they update their compat date to a more recent one, won't be able to use improved Node.js compat
3. Not everyone is familiar with compatibility dates, and if you gloss past them, you don't realize that being on a very old compat date is kind of like (though for important reasons not the same as) being on an old version of Node.js

If you look at an issue like https://github.com/cloudflare/next-on-pages/issues/908 — people get mixed up despite guidance. And the more that we're loud about — update your compatibility date — we make sure that this is one of the first things that people experiment when trying to get something to work. We're going to get higher signal bug reports if people report "yes I've tried this with the latest compat date" versus us asking people to do this and circle back.

Maybe this is a bit aggressive, showing this every time you run `wrangler dev`. I could see possibly:

1. Only warning if your compat date is > n months older than the currently installed version of Wrangler
2. Allowing people to suppress the warning (do we have a mechanism for this?)

Finally — we should link to the relevant docs in the warning. One of the most consistent pieces of feedback I've heard talking to people is, "I wish you linked to that docs page you just sent me in the error message I got.".