### PR TITLE
bump node.js to v.20 for all C3 workflows

### DIFF
--- a/.github/workflows/c3-dependabot-versioning-prs.yml
+++ b/.github/workflows/c3-dependabot-versioning-prs.yml
@@ -18,6 +18,9 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
+        with:
+          node-version: 20
+
       - name: Configure Git
         run: |
           git config --global user.email wrangler@cloudflare.com

--- a/.github/workflows/c3-e2e-experimental.yml
+++ b/.github/workflows/c3-e2e-experimental.yml
@@ -50,6 +50,7 @@ jobs:
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          node-version: 20
 
       - name: E2E Tests
         if: steps.changes.outputs.everything_but_markdown == 'true'

--- a/.github/workflows/c3-e2e-quarantine.yml
+++ b/.github/workflows/c3-e2e-quarantine.yml
@@ -39,6 +39,7 @@ jobs:
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          node-version: 20
 
       - name: E2E Tests
         uses: ./.github/actions/run-c3-e2e

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -50,6 +50,7 @@ jobs:
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-signature: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+          node-version: 20
 
       - name: E2E Tests
         if: steps.changes.outputs.everything_but_markdown == 'true'


### PR DESCRIPTION
The C3 e2es (both experimental and not) tests for Nuxt using yarn under ubuntu seem to be consistently failing on every PR that runs them.

By looking at the logs it looks like Nuxt is incompatible with the version of node that we're using in our workflows:
![Screenshot 2024-12-30 at 11 53 44](https://github.com/user-attachments/assets/fcb311e7-243b-4d11-81dc-ef1e27a7be6b)

So in this PR I am simply bumping the node version used by all the C3 workflows as that should be pretty safe to do I think.

I did not change the [default node version for all workflows](https://github.com/cloudflare/workers-sdk/blob/acbea32c6df82269b435e34d8c51fe8a26c973f1/.github/actions/install-dependencies/action.yml#L6) as I assume that we have a specific reason as to why we want to use `18.20.2` there (if not I am happy to change that value instead)


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this is just a CI change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this is just a CI change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
