### PR TITLE
chore: update workflow default node version

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -3,7 +3,7 @@ description: "Install dependencies, fetching from cache when possible"
 inputs:
   node-version:
     description: the version of Node.js to install
-    default: 18.20.2
+    default: 18.20.5
   turbo-api:
     description: the api URL for connecting to the turbo remote cache
   turbo-team:


### PR DESCRIPTION
Fixes #7648

This updates the default node version to the latest patch version of node 18, which is required by our Nuxt c3 tests.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ci update
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
