### PR TITLE
cleanup unnecessary nullish coalescing operation

### DIFF
--- a/packages/create-cloudflare/src/helpers/compatDate.ts
+++ b/packages/create-cloudflare/src/helpers/compatDate.ts
@@ -27,7 +27,7 @@ export async function getWorkerdCompatibilityDate() {
 		const match = latestWorkerdVersion.match(/\d+\.(\d{4})(\d{2})(\d{2})\.\d+/);
 
 		if (match) {
-			const [, year, month, date] = match ?? [];
+			const [, year, month, date] = match;
 			const compatDate = `${year}-${month}-${date}`;
 
 			s.stop(`${brandColor("compatibility date")} ${dim(compatDate)}`);


### PR DESCRIPTION
Extremely minimal cleanup, just removing an unnecessary nullish coalescing operation noticed by @vicb ([comment](https://github.com/opennextjs/opennextjs-cloudflare/pull/220#discussion_r1900996091)) when I copied this code over to out open-next adapter.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this functionality is already tested
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: this is tested in unit tests, it's not relevant in e2es
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's simply some minor code cleanup

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
