### PR TITLE
docs: clarify difference between external contributors and Cloudflare employees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ Wrangler is built and run on the Node.js JavaScript runtime.
 
 ### Fork and clone this repository
 
+#### For External Contributors
+
 Any contributions you make will be via [Pull Requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) on [GitHub](https://github.com/) developed in a local git repository and pushed to your own fork of the repository.
 
 - Ensure you have [created an account](https://docs.github.com/en/get-started/onboarding/getting-started-with-your-github-account) on GitHub.
@@ -56,6 +58,21 @@ Any contributions you make will be via [Pull Requests](https://docs.github.com/e
   * branch            main       -> FETCH_HEAD
   Already up to date.
   ```
+
+#### For Cloudflare Employees
+
+If you are a Cloudflare employee, you do not need to fork the repository. Instead, you can clone the main repository directly. This allows you to push branches directly to the upstream repository.
+
+Clone the main repository:
+```sh
+git clone https://github.com/cloudflare/workers-sdk.git
+cd workers-sdk
+```
+Create new branches directly in the cloned repository and push them to the main repository:
+```sh
+git checkout -b <new-branch-name>
+git push origin <new-branch-name>
+```
 
 ### Install dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,9 @@ Any contributions you make will be via [Pull Requests](https://docs.github.com/e
 
 #### For Cloudflare Employees
 
-If you are a Cloudflare employee, you do not need to fork the repository. Instead, you can clone the main repository directly. This allows you to push branches directly to the upstream repository.
+If you are a Cloudflare employee, you do not need to fork the repository - instead, you can clone the main repository directly. This allows you to push branches directly to the upstream repository.
+
+If you find that you don't have write access, please reach out to your manager or the Wrangler team internally.
 
 Clone the main repository:
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,11 +66,14 @@ If you are a Cloudflare employee, you do not need to fork the repository - inste
 If you find that you don't have write access, please reach out to your manager or the Wrangler team internally.
 
 Clone the main repository:
+
 ```sh
 git clone https://github.com/cloudflare/workers-sdk.git
 cd workers-sdk
 ```
+
 Create new branches directly in the cloned repository and push them to the main repository:
+
 ```sh
 git checkout -b <new-branch-name>
 git push origin <new-branch-name>


### PR DESCRIPTION
Fixes #000.

We sometimes get PRs from Cloudflare employees via a forked repo, which makes it difficult to contribute to that PR (we can't push directly to their fork like we can with PRs created from a branch on this repo). 

This PR clarifies the difference in the CONTRIBUTING.md guide to try to avoid the above situation.


- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: docs change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: docs change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only
