### PR TITLE
[C3] Consistently use full official full stack framework names

### DIFF
--- a/.changeset/quick-years-run.md
+++ b/.changeset/quick-years-run.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Consistently use full official full stack framework names
+
+Rename the `Solid` framework entry to `SolidStart` and `Next` to `Next.js` so that these alongside `SvelteKit` present the full official unshortened names of full stack frameworks

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -38,7 +38,7 @@ export default {
 	//       is not yet fully ready for Next.js 15, once it is we should remove the following
 	frameworkCliPinnedVersion: "14.2.5",
 	platform: "workers",
-	displayName: "Next (using Node.js compat + Workers Assets)",
+	displayName: "Next.js (using Node.js compat + Workers Assets)",
 	path: "templates-experimental/next",
 	copyFiles: {
 		path: "./templates",

--- a/packages/create-cloudflare/templates-experimental/solid/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/solid/c3.ts
@@ -72,7 +72,7 @@ const config: TemplateConfig = {
 	configVersion: 1,
 	id: "solid",
 	frameworkCli: "create-solid",
-	displayName: "Solid",
+	displayName: "SolidStart",
 	platform: "workers",
 	copyFiles: {
 		path: "./templates",

--- a/packages/create-cloudflare/templates/next/c3.ts
+++ b/packages/create-cloudflare/templates/next/c3.ts
@@ -176,7 +176,7 @@ export default {
 	id: "next",
 	frameworkCli: "create-next-app",
 	platform: "pages",
-	displayName: "Next",
+	displayName: "Next.js",
 	generate,
 	configure,
 	copyFiles: {

--- a/packages/create-cloudflare/templates/solid/c3.ts
+++ b/packages/create-cloudflare/templates/solid/c3.ts
@@ -66,7 +66,7 @@ const config: TemplateConfig = {
 	configVersion: 1,
 	id: "solid",
 	frameworkCli: "create-solid",
-	displayName: "Solid",
+	displayName: "SolidStart",
 	platform: "pages",
 	copyFiles: {
 		path: "./templates",


### PR DESCRIPTION
Fixes #7662

Renames the `Solid` and `Next` entries to `SolidStart` and `Next.js` respectively (for clarity and consistency)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: these values are simply displayed and not tested AFAIK
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: these values are simply displayed and not tested AFAIK
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/19007
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
