### PR TITLE
fix(vitest-pool-workers) Fix support for query params with repeated keys

### DIFF
--- a/.changeset/moody-bikes-cross.md
+++ b/.changeset/moody-bikes-cross.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: Add support interception of URLs with repeated key/name in its query params.
+
+e.g., `https://example.com/foo/bar?a=1&a=2`

--- a/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
+++ b/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
@@ -32,6 +32,17 @@ it("falls through to global fetch() if unmatched", async () => {
 	expect(await response.text()).toBe("fallthrough:GET https://example.com/bad");
 });
 
+it("intercepts URLs with query parameters with repeated keys", async () => {
+	fetchMock
+		.get("https://example.com")
+		.intercept({ path: "/foo/bar?a=1&a=2" })
+		.reply(200, "body");
+
+	let response = await fetch("https://example.com/foo/bar?a=1&a=2");
+	expect(response.url).toEqual("https://example.com/foo/bar?a=1&a=2");
+	expect(await response.text()).toBe("body");
+});
+
 describe("AbortSignal", () => {
 	let abortSignalTimeoutMock: MockInstance;
 

--- a/packages/vitest-pool-workers/src/worker/fetch-mock.ts
+++ b/packages/vitest-pool-workers/src/worker/fetch-mock.ts
@@ -93,11 +93,10 @@ globalThis.fetch = async (input, init) => {
 	const bodyText = bodyArray === null ? "" : DECODER.decode(bodyArray);
 	const dispatchOptions: Dispatcher.DispatchOptions = {
 		origin: url.origin,
-		path: url.pathname,
+		path: url.pathname + url.search,
 		method: request.method as Dispatcher.HttpMethod,
 		body: bodyText,
 		headers: requestHeaders,
-		query: Object.fromEntries(url.searchParams),
 	};
 	requests.set(dispatchOptions, { request, body: bodyArray });
 


### PR DESCRIPTION
Fixes #7667

Support interception of URLs with repeated key/name in its query params. e.g., `/index.html?a=1&a=2`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [X] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: this is a bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
