### PR TITLE
chore: fix broken e2e tests from merge error

### DIFF
--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -315,12 +315,6 @@ async function resolveConfig(
 		);
 	}
 
-	if (resolved.assets && resolved.dev.remote) {
-		throw new UserError(
-			"Cannot use assets in remote mode. Workers with assets are only supported in local mode. Please use `wrangler dev`."
-		);
-	}
-
 	if (
 		extractBindingsOfType("browser", resolved.bindings).length &&
 		!resolved.dev.remote


### PR DESCRIPTION
An old warning about remote dev with assets snuck in via #7533  and broke e2e tests.
(#7533 didn't need an e2e run, so it wasn't caught there)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: test fix
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
