### PR TITLE
chore(vitest-pool-workers): test intercepting fetch with different query pattern

### DIFF
--- a/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
+++ b/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
@@ -43,6 +43,11 @@ it("intercepts URLs with query parameters with repeated keys", async () => {
 		.intercept({ path: "/bar?a=1&a=2" })
 		.reply(200, "bar");
 
+	fetchMock
+		.get("https://example.com")
+		.intercept({ path: "/baz", query: { key1: ["a", "b"], key2: "c" } })
+		.reply(200, "baz");
+
 	let response1 = await fetch("https://example.com/foo?key=value");
 	expect(response1.url).toEqual("https://example.com/foo?key=value");
 	expect(await response1.text()).toBe("foo");
@@ -50,6 +55,10 @@ it("intercepts URLs with query parameters with repeated keys", async () => {
 	let response2 = await fetch("https://example.com/bar?a=1&a=2");
 	expect(response2.url).toEqual("https://example.com/bar?a=1&a=2");
 	expect(await response2.text()).toBe("bar");
+
+	let response3 = await fetch("https://example.com/baz?key1=a&key2=c&key1=b");
+	expect(response3.url).toEqual("https://example.com/baz?key1=a&key2=c&key1=b");
+	expect(await response3.text()).toBe("baz");
 });
 
 describe("AbortSignal", () => {

--- a/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
+++ b/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
@@ -35,12 +35,21 @@ it("falls through to global fetch() if unmatched", async () => {
 it("intercepts URLs with query parameters with repeated keys", async () => {
 	fetchMock
 		.get("https://example.com")
-		.intercept({ path: "/foo/bar?a=1&a=2" })
-		.reply(200, "body");
+		.intercept({ path: "/foo", query: { key: "value" } })
+		.reply(200, "foo");
 
-	let response = await fetch("https://example.com/foo/bar?a=1&a=2");
-	expect(response.url).toEqual("https://example.com/foo/bar?a=1&a=2");
-	expect(await response.text()).toBe("body");
+	fetchMock
+		.get("https://example.com")
+		.intercept({ path: "/bar?a=1&a=2" })
+		.reply(200, "bar");
+
+	let response1 = await fetch("https://example.com/foo?key=value");
+	expect(response1.url).toEqual("https://example.com/foo?key=value");
+	expect(await response1.text()).toBe("foo");
+
+	let response2 = await fetch("https://example.com/bar?a=1&a=2");
+	expect(response2.url).toEqual("https://example.com/bar?a=1&a=2");
+	expect(await response2.text()).toBe("bar");
 });
 
 describe("AbortSignal", () => {

--- a/packages/vitest-pool-workers/src/worker/fetch-mock.ts
+++ b/packages/vitest-pool-workers/src/worker/fetch-mock.ts
@@ -93,11 +93,10 @@ globalThis.fetch = async (input, init) => {
 	const bodyText = bodyArray === null ? "" : DECODER.decode(bodyArray);
 	const dispatchOptions: Dispatcher.DispatchOptions = {
 		origin: url.origin,
-		path: url.pathname,
+		path: url.pathname + url.search,
 		method: request.method as Dispatcher.HttpMethod,
 		body: bodyText,
 		headers: requestHeaders,
-		query: Object.fromEntries(url.searchParams),
 	};
 	requests.set(dispatchOptions, { request, body: bodyArray });
 

--- a/packages/vitest-pool-workers/src/worker/fetch-mock.ts
+++ b/packages/vitest-pool-workers/src/worker/fetch-mock.ts
@@ -93,10 +93,11 @@ globalThis.fetch = async (input, init) => {
 	const bodyText = bodyArray === null ? "" : DECODER.decode(bodyArray);
 	const dispatchOptions: Dispatcher.DispatchOptions = {
 		origin: url.origin,
-		path: url.pathname + url.search,
+		path: url.pathname,
 		method: request.method as Dispatcher.HttpMethod,
 		body: bodyText,
 		headers: requestHeaders,
+		query: Object.fromEntries(url.searchParams),
 	};
 	requests.set(dispatchOptions, { request, body: bodyArray });
 


### PR DESCRIPTION
Fixes n/a.

Tested a few more cases around different query interception as suggested by @Skye-31 on https://github.com/cloudflare/workers-sdk/pull/7668#issuecomment-2574070405

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Adding extra tests only
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Adding extra tests only
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
