### PR TITLE
refactor(CI): explicitly set encoding when reading package.json

### DIFF
--- a/.github/version-script.js
+++ b/.github/version-script.js
@@ -16,7 +16,7 @@ const { execSync } = require("child_process");
 try {
 	const packageName = getArgs()[0] ?? "wrangler";
 	const packageJsonPath = `./packages/${packageName}/package.json`;
-	const pkg = JSON.parse(readFileSync(packageJsonPath));
+	const pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 	const stdout = execSync("git rev-parse --short HEAD", { encoding: "utf8" });
 	pkg.version = "0.0.0-" + stdout.trim();
 	writeFileSync(packageJsonPath, JSON.stringify(pkg, null, "\t") + "\n");


### PR DESCRIPTION
readFileSync returns a `Buffer` if the encoding is not set.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tested locally
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: CI
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
