### PR TITLE
Fix D1 exports to properly pad HEX strings for binary values

### DIFF
--- a/.changeset/green-dodos-push.md
+++ b/.changeset/green-dodos-push.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Fix D1 exports to properly pad HEX strings for binary values.

--- a/packages/miniflare/src/workers/d1/dumpSql.ts
+++ b/packages/miniflare/src/workers/d1/dumpSql.ts
@@ -71,7 +71,7 @@ export function* dumpSql(
 					return outputQuotedEscapedString(cell);
 				} else if (cell instanceof ArrayBuffer) {
 					return `X'${Array.prototype.map
-						.call(new Uint8Array(cell), (b) => b.toString(16))
+						.call(new Uint8Array(cell), (b) => b.toString(16).padStart(2, "0"))
 						.join("")}'`;
 				} else {
 					console.log({ colType, cellType, cell, column: columns[i] });


### PR DESCRIPTION
Fixes #6452

The export logic was corrupting data when a binary value was being converted into HEX strings, and one of the bytes had a leading zero.

Also fixed in the internal version used in production (CFSQL-1166).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: same fix applied and tested internally.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: same fix applied and tested internally.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no API change, this is a bugfix.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
