### PR TITLE
Inject `CF-Connecting-IP` from workerd `clientIp`

### DIFF
--- a/.changeset/red-lamps-obey.md
+++ b/.changeset/red-lamps-obey.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+Support the `CF-Connecting-IP` header, which will be available in your Worker to determine the IP address of the client that initiated a request.

--- a/packages/miniflare/src/http/server.ts
+++ b/packages/miniflare/src/http/server.ts
@@ -2,14 +2,8 @@ import fs from "fs/promises";
 import { z } from "zod";
 import { CORE_PLUGIN } from "../plugins";
 import { HttpOptions, Socket_Https } from "../runtime";
-import { Awaitable, CoreHeaders } from "../workers";
+import { Awaitable } from "../workers";
 import { CERT, KEY } from "./cert";
-
-export const ENTRY_SOCKET_HTTP_OPTIONS: HttpOptions = {
-	// Even though we inject a `cf` object in the entry worker, allow it to
-	// be customised via `dispatchFetch`
-	cfBlobHeader: CoreHeaders.CF_BLOB,
-};
 
 export async function getEntrySocketHttpOptions(
 	coreOpts: z.infer<typeof CORE_PLUGIN.sharedOptions>
@@ -34,7 +28,6 @@ export async function getEntrySocketHttpOptions(
 	if (privateKey && certificateChain) {
 		return {
 			https: {
-				options: ENTRY_SOCKET_HTTP_OPTIONS,
 				tlsOptions: {
 					keypair: {
 						privateKey: privateKey,
@@ -44,7 +37,7 @@ export async function getEntrySocketHttpOptions(
 			},
 		};
 	} else {
-		return { http: ENTRY_SOCKET_HTTP_OPTIONS };
+		return { http: {} };
 	}
 }
 

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -28,7 +28,6 @@ import {
 	coupleWebSocket,
 	DispatchFetch,
 	DispatchFetchDispatcher,
-	ENTRY_SOCKET_HTTP_OPTIONS,
 	fetch,
 	getAccessibleHosts,
 	getEntrySocketHttpOptions,
@@ -1117,7 +1116,7 @@ export class Miniflare {
 			sockets.push({
 				name: SOCKET_ENTRY_LOCAL,
 				service: { name: SERVICE_ENTRY },
-				http: ENTRY_SOCKET_HTTP_OPTIONS,
+				http: {},
 				address: "127.0.0.1:0",
 			});
 		}

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -349,8 +349,6 @@ export default <ExportedHandler<Env>>{
 
 		const clientIp = request.cf?.clientIp as string;
 
-		const originalCf = JSON.stringify(request.cf);
-
 		// Parse this manually (rather than using the `cfBlobHeader` config property in workerd to parse it into request.cf)
 		// This is because we want to have access to the clientIp, which workerd puts in request.cf if no cfBlobHeader is provided
 		const clientCfBlobHeader = request.headers.get(CoreHeaders.CF_BLOB);
@@ -364,8 +362,6 @@ export default <ExportedHandler<Env>>{
 					clientAcceptEncoding: request.headers.get("Accept-Encoding") ?? "",
 				};
 		request = new Request(request, { cf });
-
-		request.headers.set("MF-Raw-workerd-CF", originalCf);
 
 		// The proxy client will always specify an operation
 		const isProxy = request.headers.get(CoreHeaders.OP) !== null;

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -363,6 +363,8 @@ export default <ExportedHandler<Env>>{
 				};
 		request = new Request(request, { cf });
 
+		request.headers.set("MF-Raw-workerd-CF", JSON.stringify(request.cf));
+
 		// The proxy client will always specify an operation
 		const isProxy = request.headers.get(CoreHeaders.OP) !== null;
 		if (isProxy) return handleProxy(request, env);

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -349,6 +349,8 @@ export default <ExportedHandler<Env>>{
 
 		const clientIp = request.cf?.clientIp as string;
 
+		const originalCf = JSON.stringify(request.cf);
+
 		// Parse this manually (rather than using the `cfBlobHeader` config property in workerd to parse it into request.cf)
 		// This is because we want to have access to the clientIp, which workerd puts in request.cf if no cfBlobHeader is provided
 		const clientCfBlobHeader = request.headers.get(CoreHeaders.CF_BLOB);
@@ -363,7 +365,7 @@ export default <ExportedHandler<Env>>{
 				};
 		request = new Request(request, { cf });
 
-		request.headers.set("MF-Raw-workerd-CF", JSON.stringify(request.cf));
+		request.headers.set("MF-Raw-workerd-CF", originalCf);
 
 		// The proxy client will always specify an operation
 		const isProxy = request.headers.get(CoreHeaders.OP) !== null;

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -35,7 +35,8 @@ const encoder = new TextEncoder();
 
 function getUserRequest(
 	request: Request<unknown, IncomingRequestCfProperties>,
-	env: Env
+	env: Env,
+	clientIp: string | undefined
 ) {
 	// The ORIGINAL_URL header is added to outbound requests from Miniflare,
 	// triggered either by calling Miniflare.#dispatchFetch(request),
@@ -89,15 +90,6 @@ function getUserRequest(
 	// special handling to allow this if a `Request` instance is passed.
 	// See https://github.com/cloudflare/workerd/issues/1122 for more details.
 	request = new Request(url, request);
-	if (request.cf === undefined) {
-		const cf: IncomingRequestCfProperties = {
-			...env[CoreBindings.JSON_CF_BLOB],
-			// Defaulting to empty string to preserve undefined `Accept-Encoding`
-			// through Wrangler's proxy worker.
-			clientAcceptEncoding: request.headers.get("Accept-Encoding") ?? "",
-		};
-		request = new Request(request, { cf });
-	}
 
 	// `Accept-Encoding` is always set to "br, gzip" in Workers:
 	// https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#accept-encoding
@@ -105,6 +97,11 @@ function getUserRequest(
 
 	if (rewriteHeadersFromOriginalUrl) {
 		request.headers.set("Host", url.host);
+	}
+
+	if (clientIp) {
+		const [ip] = clientIp.split(":");
+		request.headers.set("CF-Connecting-IP", ip);
 	}
 
 	request.headers.delete(CoreHeaders.PROXY_SHARED_SECRET);
@@ -343,6 +340,22 @@ export default <ExportedHandler<Env>>{
 	async fetch(request, env, ctx) {
 		const startTime = Date.now();
 
+		const clientIp = request.cf?.clientIp;
+
+		// Parse this manually (rather than using the `cfBlobHeader` config property in workerd to parse it into request.cf)
+		// This is because we want to have access to the clientIp, which workerd puts in request.cf if no cfBlobHeader is provided
+		const clientCfBlobHeader = request.headers.get(CoreHeaders.CF_BLOB);
+
+		const cf: IncomingRequestCfProperties = clientCfBlobHeader
+			? JSON.parse(clientCfBlobHeader)
+			: {
+					...env[CoreBindings.JSON_CF_BLOB],
+					// Defaulting to empty string to preserve undefined `Accept-Encoding`
+					// through Wrangler's proxy worker.
+					clientAcceptEncoding: request.headers.get("Accept-Encoding") ?? "",
+				};
+		request = new Request(request, { cf });
+
 		// The proxy client will always specify an operation
 		const isProxy = request.headers.get(CoreHeaders.OP) !== null;
 		if (isProxy) return handleProxy(request, env);
@@ -356,7 +369,7 @@ export default <ExportedHandler<Env>>{
 		const clientAcceptEncoding = request.headers.get("Accept-Encoding");
 
 		try {
-			request = getUserRequest(request, env);
+			request = getUserRequest(request, env, clientIp);
 		} catch (e) {
 			if (e instanceof HttpError) {
 				return e.toResponse();

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2631,7 +2631,7 @@ test("Miniflare: dispatchFetch() can override cf", async (t) => {
 test("Miniflare: CF-Connecting-IP is injected", async (t) => {
 	const mf = new Miniflare({
 		script:
-			"export default { fetch(request) { return new Response(request.headers.get('MF-Raw-workerd-CF')) } }",
+			"export default { fetch(request) { return new Response(request.headers.get('CF-Connecting-IP')) } }",
 		modules: true,
 		cf: {
 			myFakeField: "test",
@@ -2640,13 +2640,18 @@ test("Miniflare: CF-Connecting-IP is injected", async (t) => {
 	t.teardown(() => mf.dispose());
 
 	const ip = await mf.dispatchFetch("http://example.com/");
-	t.deepEqual(await ip.text(), "127.0.0.1");
+	// Tracked in https://github.com/cloudflare/workerd/issues/3310
+	if (!isWindows) {
+		t.deepEqual(await ip.text(), "127.0.0.1");
+	} else {
+		t.deepEqual(await ip.text(), "");
+	}
 });
 
 test("Miniflare: CF-Connecting-IP is injected (ipv6)", async (t) => {
 	const mf = new Miniflare({
 		script:
-			"export default { fetch(request) { return new Response(request.headers.get('MF-Raw-workerd-CF')) } }",
+			"export default { fetch(request) { return new Response(request.headers.get('CF-Connecting-IP')) } }",
 		modules: true,
 		cf: {
 			myFakeField: "test",
@@ -2656,7 +2661,13 @@ test("Miniflare: CF-Connecting-IP is injected (ipv6)", async (t) => {
 	t.teardown(() => mf.dispose());
 
 	const ip = await mf.dispatchFetch("http://example.com/");
-	t.deepEqual(await ip.text(), "::1");
+
+	// Tracked in https://github.com/cloudflare/workerd/issues/3310
+	if (!isWindows) {
+		t.deepEqual(await ip.text(), "::1");
+	} else {
+		t.deepEqual(await ip.text(), "");
+	}
 });
 
 test("Miniflare: CF-Connecting-IP is preserved when present", async (t) => {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2610,6 +2610,39 @@ test("Miniflare: getCf() returns a user provided cf object", async (t) => {
 	t.deepEqual(cf, { myFakeField: "test" });
 });
 
+test("Miniflare: dispatchFetch() can override cf", async (t) => {
+	const mf = new Miniflare({
+		script:
+			"export default { fetch(request) { return Response.json(request.cf) } }",
+		modules: true,
+		cf: {
+			myFakeField: "test",
+		},
+	});
+	t.teardown(() => mf.dispose());
+
+	const cf = await mf.dispatchFetch("http://example.com/", {
+		cf: { myFakeField: "test2" },
+	});
+	const cfJson = (await cf.json()) as { myFakeField: string };
+	t.deepEqual(cfJson.myFakeField, "test2");
+});
+
+test("Miniflare: CF-Connecting-IP is injected", async (t) => {
+	const mf = new Miniflare({
+		script:
+			"export default { fetch(request) { return new Response(request.headers.get('CF-Connecting-IP')) } }",
+		modules: true,
+		cf: {
+			myFakeField: "test",
+		},
+	});
+	t.teardown(() => mf.dispose());
+
+	const ip = await mf.dispatchFetch("http://example.com/");
+	t.deepEqual(await ip.text(), "127.0.0.1");
+});
+
 test("Miniflare: can use module fallback service", async (t) => {
 	const modulesRoot = "/";
 	const modules: Record<string, Omit<Worker_Module, "name">> = {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2628,7 +2628,7 @@ test("Miniflare: dispatchFetch() can override cf", async (t) => {
 	t.deepEqual(cfJson.myFakeField, "test2");
 });
 
-test("Miniflare: CF-Connecting-IP is injected", async (t) => {
+unixSerialTest("Miniflare: CF-Connecting-IP is injected", async (t) => {
 	const mf = new Miniflare({
 		script:
 			"export default { fetch(request) { return new Response(request.headers.get('CF-Connecting-IP')) } }",
@@ -2643,7 +2643,7 @@ test("Miniflare: CF-Connecting-IP is injected", async (t) => {
 	t.deepEqual(await ip.text(), "127.0.0.1");
 });
 
-test("Miniflare: CF-Connecting-IP is injected (ipv6)", async (t) => {
+unixSerialTest("Miniflare: CF-Connecting-IP is injected (ipv6)", async (t) => {
 	const mf = new Miniflare({
 		script:
 			"export default { fetch(request) { return new Response(request.headers.get('CF-Connecting-IP')) } }",

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2628,10 +2628,10 @@ test("Miniflare: dispatchFetch() can override cf", async (t) => {
 	t.deepEqual(cfJson.myFakeField, "test2");
 });
 
-unixSerialTest("Miniflare: CF-Connecting-IP is injected", async (t) => {
+test("Miniflare: CF-Connecting-IP is injected", async (t) => {
 	const mf = new Miniflare({
 		script:
-			"export default { fetch(request) { return new Response(request.headers.get('CF-Connecting-IP')) } }",
+			"export default { fetch(request) { return new Response(request.headers.get('MF-Raw-workerd-CF')) } }",
 		modules: true,
 		cf: {
 			myFakeField: "test",
@@ -2643,10 +2643,10 @@ unixSerialTest("Miniflare: CF-Connecting-IP is injected", async (t) => {
 	t.deepEqual(await ip.text(), "127.0.0.1");
 });
 
-unixSerialTest("Miniflare: CF-Connecting-IP is injected (ipv6)", async (t) => {
+test("Miniflare: CF-Connecting-IP is injected (ipv6)", async (t) => {
 	const mf = new Miniflare({
 		script:
-			"export default { fetch(request) { return new Response(request.headers.get('CF-Connecting-IP')) } }",
+			"export default { fetch(request) { return new Response(request.headers.get('MF-Raw-workerd-CF')) } }",
 		modules: true,
 		cf: {
 			myFakeField: "test",


### PR DESCRIPTION
Fixes CUSTESC-46864, fixes https://github.com/cloudflare/workers-sdk/issues/7588

When deployed, Workers can access the IP of the client that initiated a request using the `CF-Connecting-IP` header. However, this wasn't available locally, and so there was previously no way to know the IP address of a connecting client from a `wrangler dev` session. 

As it turns out, `workerd` injects a `clientIp` (that appears to be of the form `{ip}:{port}`— @danlapid or @kentonv could you confirm the format here?) using the `request.cf` property. Previously, the `request.cf` injected by `workerd` wouldn't make it to a user worker, because Miniflare injects a more fleshed out `request.cf` value that reflects what would be seen in production. As such, this PR extracts the `clientIp` from `workerd`'s `request.cf` and puts it in the `CF-Connecting-IP` header _before_ Miniflare injects it's own `request.cf` value.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by Miniflare tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: matching (documented) production behaviour

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
