### PR TITLE
Use global fetch in the `import-npm` fixture tests

### DIFF
--- a/fixtures/import-npm/packages/import-example/package.json
+++ b/fixtures/import-npm/packages/import-example/package.json
@@ -15,7 +15,6 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "../../../../packages/workers-tsconfig",
-		"undici": "^5.28.4",
 		"wrangler": "../../../../packages/wrangler"
 	}
 }

--- a/fixtures/import-npm/packages/import-example/tests/index.test.ts
+++ b/fixtures/import-npm/packages/import-example/tests/index.test.ts
@@ -1,5 +1,4 @@
 import { resolve } from "path";
-import { fetch } from "undici";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { runWranglerDev } from "../../../../shared/src/run-wrangler-long-lived";
 


### PR DESCRIPTION
Attempt to fix CI issues with the `import-npm` fixture by using global fetch instead of undici fetch in tests, since the tests were failing to resolve undici.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: change to a fixture
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
