### PR TITLE
chore: delete more orphaned e2e resources

### DIFF
--- a/tools/e2e/__tests__/common.test.ts
+++ b/tools/e2e/__tests__/common.test.ts
@@ -122,7 +122,7 @@ describe("listTmpKVNamespaces()", () => {
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces`,
 				method: "GET",
 				query: {
-					per_page: 10,
+					per_page: 100,
 					page: 1,
 					direction: "asc",
 					order: "title",
@@ -142,6 +142,7 @@ describe("listTmpKVNamespaces()", () => {
 						{ id: "kv-8", title: "kv-8" },
 						{ id: "kv-9", title: "kv-9" },
 						{ id: "kv-10", title: "kv-10" },
+						...Array(90).fill({ id: "kv-10", title: "kv-10" }),
 					],
 				})
 			);
@@ -151,7 +152,7 @@ describe("listTmpKVNamespaces()", () => {
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces`,
 				method: "GET",
 				query: {
-					per_page: 10,
+					per_page: 100,
 					page: 2,
 					direction: "asc",
 					order: "title",
@@ -194,7 +195,7 @@ describe("listTmpDatabases()", () => {
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/d1/database`,
 				method: "GET",
 				query: {
-					per_page: 10,
+					per_page: 100,
 					page: 1,
 				},
 			})
@@ -212,6 +213,11 @@ describe("listTmpDatabases()", () => {
 						{ uuid: "8", name: "tmp-e2e-db-4", created_at: oldTimeStr },
 						{ uuid: "9", name: "db-5", created_at: nowStr },
 						{ uuid: "10", name: "db-6", created_at: oldTimeStr },
+						...Array(90).fill({
+							uuid: "10",
+							name: "db-6",
+							created_at: oldTimeStr,
+						}),
 					],
 				})
 			);
@@ -221,7 +227,7 @@ describe("listTmpDatabases()", () => {
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/d1/database`,
 				method: "GET",
 				query: {
-					per_page: 10,
+					per_page: 100,
 					page: 2,
 				},
 			})

--- a/tools/e2e/common.ts
+++ b/tools/e2e/common.ts
@@ -148,7 +148,7 @@ export const deleteWorker = async (id: string) => {
 };
 
 export const listTmpKVNamespaces = async () => {
-	const pageSize = 10;
+	const pageSize = 100;
 	let page = 1;
 	const results: KVNamespaceInfo[] = [];
 	while (results.length % pageSize === 0) {
@@ -185,7 +185,7 @@ export const deleteKVNamespace = async (id: string) => {
 };
 
 export const listTmpDatabases = async () => {
-	const pageSize = 10;
+	const pageSize = 100;
 	let page = 1;
 	const results: Database[] = [];
 	while (results.length % pageSize === 0) {


### PR DESCRIPTION
Increasing the max number of resources we could delete each time - I started off with about ~50 resources each run in case it took forever, but it hasn't broken and we have _so many_ d1 databases to delete.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: existing tests should cover it 
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not tested e2e
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal testing stuff

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
