### PR TITLE
test: add missing await

### DIFF
--- a/fixtures/pages-workerjs-with-config-file-app/tests/index.test.ts
+++ b/fixtures/pages-workerjs-with-config-file-app/tests/index.test.ts
@@ -66,7 +66,7 @@ describe("Pages Advanced Mode with wrangler.toml", () => {
 	it("has version_metadata binding", async ({ expect }) => {
 		const response = await fetch(`http://${ip}:${port}/version_metadata`);
 
-		expect(response.json()).resolves.toMatchObject({
+		await expect(response.json()).resolves.toMatchObject({
 			id: expect.any(String),
 			tag: expect.any(String),
 		});


### PR DESCRIPTION
Fixes a warning in CI logs.

The warning warns that this will not work with Vitest3


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: fixtures 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test onlu

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
