### PR TITLE
Remove CF-Connecting-IP for requests to the edge preview

### DIFF
--- a/.changeset/honest-pillows-tease.md
+++ b/.changeset/honest-pillows-tease.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Remove CF-Connecting-IP for requests to the edge preview

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -267,6 +267,9 @@ export class RemoteRuntimeController extends RuntimeController {
 						...(accessToken
 							? { Cookie: `CF_Authorization=${accessToken}` }
 							: {}),
+						// Make sure we don't pass on CF-Connecting-IP to the remote edgeworker instance
+						// Without this line, remote previews will fail with `DNS points to prohibited IP`
+						"cf-connecting-ip": "",
 					},
 					liveReload: config.dev.liveReload,
 					proxyLogsToController: true,


### PR DESCRIPTION
Make sure we don't pass on the `CF-Connecting-IP` header to the remote edge preview instance. Without this line, remote previews will fail with `DNS points to prohibited IP`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
