### PR TITLE
Support service bindings from Pages projects to workers in a single `workerd` instance

### DIFF
--- a/.changeset/gentle-sloths-eat.md
+++ b/.changeset/gentle-sloths-eat.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Support service bindings from Pages projects to workers in a single `workerd` instance. To try it out, pass multiple `-c` flags to Wrangler: i.e. `wrangler pages dev -c wrangler.toml -c ../other-worker/wrangler.toml`. The first `-c` flag must point to your Pages config file, and the rest should point to Workers that are bound to your Pages project.

--- a/.changeset/gentle-sloths-eat.md
+++ b/.changeset/gentle-sloths-eat.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
-Support service bindings from Pages projects to workers in a single `workerd` instance. To try it out, pass multiple `-c` flags to Wrangler: i.e. `wrangler pages dev -c wrangler.toml -c ../other-worker/wrangler.toml`. The first `-c` flag must point to your Pages config file, and the rest should point to Workers that are bound to your Pages project.
+Support service bindings from Pages projects to Workers in a single `workerd` instance. To try it out, pass multiple `-c` flags to Wrangler: i.e. `wrangler pages dev -c wrangler.toml -c ../other-worker/wrangler.toml`. The first `-c` flag must point to your Pages config file, and the rest should point to Workers that are bound to your Pages project.

--- a/packages/wrangler/e2e/multiworker-dev.test.ts
+++ b/packages/wrangler/e2e/multiworker-dev.test.ts
@@ -435,5 +435,15 @@ describe("multiworker", () => {
 				{ interval: 1000, timeout: 10_000 }
 			);
 		});
+
+		it("should error if multiple pages configs are provided", async () => {
+			const pages = helper.runLongLived(
+				`wrangler pages dev -c wrangler.toml -c wrangler.toml`,
+				{ cwd: a }
+			);
+			await pages.readUntil(
+				/You cannot use a Pages project as a service binding target/
+			);
+		});
 	});
 });

--- a/packages/wrangler/e2e/multiworker-dev.test.ts
+++ b/packages/wrangler/e2e/multiworker-dev.test.ts
@@ -361,4 +361,79 @@ describe("multiworker", () => {
 			);
 		});
 	});
+
+	describe("pages", () => {
+		beforeEach(async () => {
+			await baseSeed(a, {
+				"wrangler.toml": dedent`
+					name = "${workerName}"
+					pages_build_output_dir = "./public"
+					compatibility_date = "2024-11-01"
+
+                    [[services]]
+					binding = "CEE"
+					service = '${workerName3}'
+
+					[[services]]
+					binding = "BEE"
+					service = '${workerName2}'
+				`,
+				"functions/cee.ts": dedent/* javascript */ `
+				export async function onRequest(context) {
+					return context.env.CEE.fetch("https://example.com");
+				}`,
+				"functions/bee.ts": dedent/* javascript */ `
+				export async function onRequest(context) {
+					return context.env.BEE.fetch("https://example.com");
+				}`,
+				"public/index.html": `<h1>hello pages assets</h1>`,
+			});
+		});
+
+		it("pages project assets", async () => {
+			const pages = helper.runLongLived(
+				`wrangler pages dev -c wrangler.toml -c ${b}/wrangler.toml -c ${c}/wrangler.toml`,
+				{ cwd: a }
+			);
+			const { url } = await pages.waitForReady(5_000);
+
+			await vi.waitFor(
+				async () =>
+					await expect(fetchText(`${url}`)).resolves.toBe(
+						"<h1>hello pages assets</h1>"
+					),
+				{ interval: 1000, timeout: 10_000 }
+			);
+		});
+
+		it("pages project fetching service worker", async () => {
+			const pages = helper.runLongLived(
+				`wrangler pages dev -c wrangler.toml -c ${b}/wrangler.toml -c ${c}/wrangler.toml`,
+				{ cwd: a }
+			);
+			const { url } = await pages.waitForReady(5_000);
+
+			await vi.waitFor(
+				async () =>
+					await expect(fetchText(`${url}/cee`)).resolves.toBe(
+						"Hello from service worker"
+					),
+				{ interval: 1000, timeout: 10_000 }
+			);
+		});
+
+		it("pages project fetching module worker", async () => {
+			const pages = helper.runLongLived(
+				`wrangler pages dev -c wrangler.toml -c ${b}/wrangler.toml -c ${c}/wrangler.toml`,
+				{ cwd: a }
+			);
+			const { url } = await pages.waitForReady(5_000);
+
+			await vi.waitFor(
+				async () =>
+					await expect(fetchText(`${url}/bee`)).resolves.toBe("hello world"),
+				{ interval: 1000, timeout: 10_000 }
+			);
+		});
+	});
 });

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -232,7 +232,7 @@ async function resolveConfig(
 		input.dev?.multiworkerPrimary === false
 	) {
 		throw new UserError(
-			`You cannot use a Pages project as a service binding target`
+			`You cannot use a Pages project as a service binding target.\nIf you are trying to develop Pages and Workers together, please use \`wrangler pages dev\`. Note the first config file specified must be for the Pages project`
 		);
 	}
 	const legacySite = unwrapHook(input.legacy?.site, config);

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -227,6 +227,14 @@ async function resolveConfig(
 	config: Config,
 	input: StartDevWorkerInput
 ): Promise<StartDevWorkerOptions> {
+	if (
+		config.pages_build_output_dir &&
+		input.dev?.multiworkerPrimary === false
+	) {
+		throw new UserError(
+			`You cannot use a Pages project as a service binding target`
+		);
+	}
 	const legacySite = unwrapHook(input.legacy?.site, config);
 
 	const legacyAssets = unwrapHook(input.legacy?.legacyAssets, config);

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -301,7 +301,12 @@ export function createCLIParser(argv: string[]) {
 			requiresArg: true,
 		})
 		.check(
-			demandSingleValue("config", (configArgv) => configArgv["_"][0] === "dev")
+			demandSingleValue(
+				"config",
+				(configArgv) =>
+					configArgv["_"][0] === "dev" ||
+					(configArgv["_"][0] === "pages" && configArgv["_"][1] === "dev")
+			)
 		)
 		.option("env", {
 			alias: "e",

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -292,7 +292,7 @@ export const Handler = async (args: PagesDevArguments) => {
 		path.resolve(process.cwd(), args.config[0]) !== config.configPath
 	) {
 		throw new FatalError(
-			"The first `--config` argument must point to your pages config file: " +
+			"The first `--config` argument must point to your Pages configuration file: " +
 				path.relative(process.cwd(), config.configPath)
 		);
 	}

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -872,8 +872,7 @@ export const Handler = async (args: PagesDevArguments) => {
 
 	const devServer = await run(
 		{
-			// TODO: can we make this work?
-			MULTIWORKER: false,
+			MULTIWORKER: Array.isArray(args.config),
 			RESOURCES_PROVISION: false,
 		},
 		() =>


### PR DESCRIPTION
Fixes #5918

As of #7251, Wrangler has supported configuring multiple Workers to run in the same `workerd` instance (with service bindings between them) using multiple `-c` flags. However, this didn't work for Pages.

This PR adds support for Pages, using the same API as for regular Workers: `wrangler pages dev -c wrangler.toml ../other-worker/wrangler.toml`. However, a slight difference with Pages (compared to regular Workers) is that you can't customise the location of the Pages config file. As such, the first `-c` argument _must_ point to the config file for the Pages project, and _must_ be located in the project root. We could've omitted this entirely, but it felt like it would be more confusing to implicitly read a config file that wasn't mentioned—open to dissenting opinions here!

This PR also shifts `wrangler pages dev` to use `startDev()` directly rather than going through `unstable_dev()`, opening the door to removing `unstable_dev()` entirely in the future.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/19175
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
