### PR TITLE
chore: consolidate to a single rimraf version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
 		"jsonc-parser": "^3.2.0",
 		"prettier": "^3.2.5",
 		"prettier-plugin-packagejson": "^2.2.18",
-		"rimraf": "^5.0.1",
 		"tree-kill": "^1.2.2",
 		"turbo": "^2.2.3",
 		"typescript": "catalog:default",

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -68,7 +68,6 @@
 		"@types/http-cache-semantics": "^4.0.1",
 		"@types/mime": "^3.0.4",
 		"@types/node": "catalog:default",
-		"@types/rimraf": "^4.0.5",
 		"@types/stoppable": "^1.1.1",
 		"@types/which": "^2.0.1",
 		"@types/ws": "^8.5.7",
@@ -91,7 +90,7 @@
 		"kleur": "^4.1.5",
 		"mime": "^3.0.0",
 		"pretty-bytes": "^6.0.0",
-		"rimraf": "^5.0.1",
+		"rimraf": "catalog:default",
 		"source-map": "^0.6.1",
 		"which": "^2.0.2"
 	},

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -54,7 +54,7 @@
 		"@types/mime": "^3.0.4",
 		"concurrently": "^8.2.2",
 		"esbuild": "0.17.19",
-		"rimraf": "^6.0.1",
+		"rimraf": "catalog:default",
 		"toucan-js": "^3.3.1",
 		"typescript": "catalog:default",
 		"vitest": "catalog:default"

--- a/packages/workflows-shared/package.json
+++ b/packages/workflows-shared/package.json
@@ -44,7 +44,7 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"@types/mime": "^3.0.4",
 		"esbuild": "0.17.19",
-		"rimraf": "^6.0.1",
+		"rimraf": "catalog:default",
 		"typescript": "catalog:default",
 		"vitest": "catalog:default"
 	},

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -142,6 +142,7 @@
 		"patch-console": "^1.0.0",
 		"pretty-bytes": "^6.0.0",
 		"prompts": "^2.4.2",
+		"rimraf": "catalog:default",
 		"semiver": "^1.1.0",
 		"shell-quote": "^1.8.1",
 		"signal-exit": "^3.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@vitest/ui':
       specifier: ~2.1.8
       version: 2.1.8
+    rimraf:
+      specifier: ^5.0.10
+      version: 5.0.10
     typescript:
       specifier: ~5.6.3
       version: 5.6.3
@@ -103,9 +106,6 @@ importers:
       prettier-plugin-packagejson:
         specifier: ^2.2.18
         version: 2.2.18(prettier@3.2.5)
-      rimraf:
-        specifier: ^5.0.1
-        version: 5.0.1
       tree-kill:
         specifier: ^1.2.2
         version: 1.2.2
@@ -1424,9 +1424,6 @@ importers:
       '@types/node':
         specifier: ^18.19.59
         version: 18.19.59
-      '@types/rimraf':
-        specifier: ^4.0.5
-        version: 4.0.5
       '@types/stoppable':
         specifier: ^1.1.1
         version: 1.1.3
@@ -1494,8 +1491,8 @@ importers:
         specifier: ^6.0.0
         version: 6.1.1
       rimraf:
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: catalog:default
+        version: 5.0.10
       source-map:
         specifier: ^0.6.1
         version: 0.6.1
@@ -1935,8 +1932,8 @@ importers:
         specifier: 0.17.19
         version: 0.17.19
       rimraf:
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: catalog:default
+        version: 5.0.10
       toucan-js:
         specifier: ^3.3.1
         version: 3.3.1(patch_hash=b5gffumfuckaq3c77sda2gdfuq)
@@ -2004,8 +2001,8 @@ importers:
         specifier: 0.17.19
         version: 0.17.19
       rimraf:
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: catalog:default
+        version: 5.0.10
       typescript:
         specifier: catalog:default
         version: 5.6.3
@@ -2233,6 +2230,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      rimraf:
+        specifier: catalog:default
+        version: 5.0.10
       semiver:
         specifier: ^1.1.0
         version: 1.1.0
@@ -4645,10 +4645,6 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
-  '@types/rimraf@4.0.5':
-    resolution: {integrity: sha512-DTCZoIQotB2SUJnYgrEx43cQIUYOlNZz0AZPbKU4PSLYTUdML5Gox0++z4F9kQocxStrCmRNhi4x5x/UlwtKUA==}
-    deprecated: This is a stub types definition. rimraf provides its own type definitions, so you do not need this installed.
-
   '@types/semver@6.2.7':
     resolution: {integrity: sha512-blctEWbzUFzQx799RZjzzIdBJOXmE37YYEyDtKkx5Dg+V7o/zyyAxLPiI98A2jdTtDgxZleMdfV+7p8WbRJ1OQ==}
 
@@ -6579,11 +6575,6 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
-  glob@11.0.0:
-    resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -7123,10 +7114,6 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jackspeak@4.0.1:
-    resolution: {integrity: sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==}
-    engines: {node: 20 || >=22}
-
   javascript-time-ago@2.5.7:
     resolution: {integrity: sha512-EGvh6K4hpJz0S0aZinbW2EfXDqT/JBB84HfMOFDTzGg7yjpjql9feSgtlG1JQ6b6/NkIxl+PoKSUTEMsatTuTg==}
 
@@ -7392,10 +7379,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.0.0:
-    resolution: {integrity: sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==}
-    engines: {node: 20 || >=22}
-
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -7538,10 +7521,6 @@ packages:
     resolution: {integrity: sha512-dM3RBlJE8rUFxnqlPCaFCq0E7qQqEQvKbYX7W/APGCK+rLcyLmEBzC4GQR/niXdNM/oV6gdg9AA50ghnn2ALuw==}
     engines: {node: '>=16.13'}
     hasBin: true
-
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
 
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
@@ -8043,10 +8022,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -8732,14 +8707,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@5.0.1:
-    resolution: {integrity: sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==}
-    engines: {node: '>=14'}
-    hasBin: true
-
-  rimraf@6.0.1:
-    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
-    engines: {node: 20 || >=22}
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
   rollup-plugin-dts@6.1.1:
@@ -12890,10 +12859,6 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
-  '@types/rimraf@4.0.5':
-    dependencies:
-      rimraf: 6.0.1
-
   '@types/semver@6.2.7': {}
 
   '@types/semver@7.5.1': {}
@@ -15313,15 +15278,6 @@ snapshots:
       package-json-from-dist: 1.0.0
       path-scurry: 1.11.1
 
-  glob@11.0.0:
-    dependencies:
-      foreground-child: 3.1.1
-      jackspeak: 4.0.1
-      minimatch: 10.0.1
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.0
-      path-scurry: 2.0.0
-
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -15859,12 +15815,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.0.1:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-
   javascript-time-ago@2.5.7:
     dependencies:
       relative-time-format: 1.1.4
@@ -16110,8 +16060,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.0.0: {}
-
   lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -16247,10 +16195,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
 
   minimatch@3.0.8:
     dependencies:
@@ -16827,11 +16771,6 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
-
-  path-scurry@2.0.0:
-    dependencies:
-      lru-cache: 11.0.0
       minipass: 7.1.2
 
   path-to-regexp@6.3.0: {}
@@ -17503,14 +17442,9 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rimraf@5.0.1:
+  rimraf@5.0.10:
     dependencies:
       glob: 10.4.5
-
-  rimraf@6.0.1:
-    dependencies:
-      glob: 11.0.0
-      package-json-from-dist: 1.0.0
 
   rollup-plugin-dts@6.1.1(rollup@3.29.5)(typescript@5.6.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,10 +4,12 @@ packages:
   - "tools"
 
 catalog:
-  vitest: ~2.1.8
+  "@types/node": "^18.19.59"
   "@vitest/runner": ~2.1.8
   "@vitest/snapshot": ~2.1.8
   "@vitest/ui": ~2.1.8
-  undici: "^5.28.4"
+  # rimraf@6 requires node 20 or >=22
+  rimraf: "^5.0.10"
   typescript: "~5.6.3"
-  "@types/node": "^18.19.59"
+  undici: "^5.28.4"
+  vitest: ~2.1.8


### PR DESCRIPTION
Move rimraf to the default catalog.

Notes:
- Using v5 as v6 requires node 20 or >= 22
- `@types` are not needed (only ever executred from `package.json`)
- Ordered catalog alphabetically

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tested by build
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
