### PR TITLE
chore(wrangler): use the unenv preset from `@cloudflare/unenv-preset`

### DIFF
--- a/.changeset/cuddly-pets-smell.md
+++ b/.changeset/cuddly-pets-smell.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+chore(wrangler): use the unenv preset from `@cloudflare/unenv-preset`

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -70,6 +70,7 @@
 	},
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "workspace:*",
+		"@cloudflare/unenv-preset": "1.x",
 		"@esbuild-plugins/node-globals-polyfill": "0.2.3",
 		"@esbuild-plugins/node-modules-polyfill": "0.2.2",
 		"blake3-wasm": "2.1.5",

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -21,9 +21,9 @@ export const EXTERNAL_DEPENDENCIES = [
 	// @cloudflare/workers-types is an optional peer dependency of wrangler, so users can
 	// get the types by installing the package (to what version they prefer) themselves
 	"@cloudflare/workers-types",
-
-	// unenv must be external because it contains unenv/runtime code which needs to be resolved
-	// and read when we are bundling the worker application
+	// `@cloudflare/unenv-preset` and  `unenv` must be external because they contain code
+	// which needs to be resolved and read when we are bundling the worker application
+	"@cloudflare/unenv-preset",
 	"unenv",
 
 	// path-to-regexp must be external because it contains runtime code which needs to be resolved

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -1,7 +1,8 @@
 import { builtinModules } from "node:module";
 import nodePath from "node:path";
+import { cloudflare } from "@cloudflare/unenv-preset";
 import dedent from "ts-dedent";
-import { cloudflare, defineEnv } from "unenv";
+import { defineEnv } from "unenv";
 import { getBasePath } from "../../paths";
 import type { Plugin, PluginBuild } from "esbuild";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2015,6 +2015,9 @@ importers:
       '@cloudflare/kv-asset-handler':
         specifier: workspace:*
         version: link:../kv-asset-handler
+      '@cloudflare/unenv-preset':
+        specifier: 1.x
+        version: 1.0.0(unenv-nightly@2.0.0-20250109-100802-88ad671)(workerd@1.20241230.0)
       '@esbuild-plugins/node-globals-polyfill':
         specifier: 0.2.3
         version: 0.2.3(esbuild@0.17.19)
@@ -2842,6 +2845,15 @@ packages:
     resolution: {integrity: sha512-4JbJv5cbtGeo7Vpg2Sx3LXAhkvDJeJV/9FLFm2u3MkyxXb9SXdjxoanO5bOripQThTrzB1a8Ctw/ghweSA91Cw==}
     peerDependencies:
       react: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
+
+  '@cloudflare/unenv-preset@1.0.0':
+    resolution: {integrity: sha512-rnihjY4xUsBmlqp0eM2tQXm+40aj3C7WhdH4eGHkLaoBKr3+LwuENByYm5mf65WEeA5NE6BolTnjkiJUts3RuA==}
+    peerDependencies:
+      unenv: npm:unenv-nightly@*
+      workerd: ^1.20241230.0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
 
   '@cloudflare/util-en-garde@8.0.10':
     resolution: {integrity: sha512-qdCFf90hoZzT4o4xEmxOKUf9+bEJNGh4ANnRYApo6BMyVnHoHEHAQ3nWmGSHBmo+W9hOk2Ik7r1oHLbI0O/RRg==}
@@ -11231,6 +11243,12 @@ snapshots:
       '@cloudflare/intl-types': 1.5.1(react@18.3.1)
       '@cloudflare/util-en-garde': 8.0.10
       react: 18.3.1
+
+  '@cloudflare/unenv-preset@1.0.0(unenv-nightly@2.0.0-20250109-100802-88ad671)(workerd@1.20241230.0)':
+    dependencies:
+      unenv: unenv-nightly@2.0.0-20250109-100802-88ad671
+    optionalDependencies:
+      workerd: 1.20241230.0
 
   '@cloudflare/util-en-garde@8.0.10':
     dependencies:


### PR DESCRIPTION
The cloudflare preset was migrated to this mono-repo (`@cloudflare/unenv-preset`)

This PR is switching to using this version

To do before merging:
- [x] diff the output of a wrangler build before/after
- [x] test the pre-release version of wrangler
- [ ] make sure the Vite plugin works with `@cloudflare/unenv-preset`
- [x] publish `@cloudflare/unenv-preset@1.0.0` and use that version

/cc @petebacondarwin @pi0 @dario-piotrowicz 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: preset is tested, will do a diff test
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
