### PR TITLE
chore(unenv-preset): Add .cjs output for the preset

### DIFF
--- a/.changeset/shy-flies-float.md
+++ b/.changeset/shy-flies-float.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+chore(unenv-preset): Add .cjs output for the preset

--- a/packages/unenv-preset/build.config.ts
+++ b/packages/unenv-preset/build.config.ts
@@ -1,7 +1,13 @@
 import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig({
+	declaration: true,
+	rollup: {
+		emitCJS: true,
+		cjsBridge: true,
+	},
 	entries: [
-		{ input: "src/", outDir: "dist/src", format: "esm", declaration: true },
+		"src/index",
+		{ input: "src/runtime/", outDir: "dist/runtime", format: "esm" },
 	],
 });

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -24,18 +24,19 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"types": "./dist/src/index.d.ts",
-			"import": "./dist/src/index.mjs"
+			"types": "./dist/index.d.ts",
+			"require": "./dist/index.cjs",
+			"import": "./dist/index.mjs"
 		},
 		"./runtime/*": {
-			"types": "./dist/src/runtime/*.d.ts",
-			"import": "./dist/src/runtime/*.mjs"
+			"types": "./dist/runtime/*.d.ts",
+			"import": "./dist/runtime/*.mjs"
 		}
 	},
-	"main": "./dist/src/index.mjs",
-	"types": "./dist/src/index.d.ts",
+	"main": "./dist/index.cjs",
+	"types": "./dist/index.d.ts",
 	"files": [
-		"dist/src"
+		"dist"
 	],
 	"scripts": {
 		"build": "unbuild",


### PR DESCRIPTION
We do not need .cjs for the runtime files but `wrangler` requires the preset so we need to have a `dist/index.cjs`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tested via #7720
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
