### PR TITLE
ci: add package name to the PR artifacts

### DIFF
--- a/.github/prereleases/3-comment.mjs
+++ b/.github/prereleases/3-comment.mjs
@@ -47,13 +47,25 @@ function buildAdditionalArtifactReport(pkg) {
 	const name = pkg.json.name;
 	const type = pkg.json["workers-sdk"].type;
 	const url = getPrereleaseArtifactUrl(name);
-	if (type === "cli") {
-		return `\`\`\`sh\nnpx ${url} --no-auto-update\n\`\`\``;
-	} else if (type === "extension") {
-		return `\`\`\`sh\nwget ${url} -O ./${name}.${pkg.json.version}.vsix && code --install-extension ./${name}.${pkg.json.version}.vsix\n\`\`\``;
-	} else {
-		return `\`\`\`sh\nnpm install ${url}\n\`\`\``;
+	let command;
+
+	switch (type) {
+		case "cli":
+			command = `npx ${url} --no-auto-update`;
+			break;
+		case "extension":
+			command = `wget ${url} -O ./${name}.${pkg.json.version}.vsix && code --install-extension ./${name}.${pkg.json.version}.vsix`;
+			break;
+		default:
+			command = `npm install ${url}`;
 	}
+
+	return `
+${name}:
+\`\`\`sh
+${command}
+\`\`\`
+`;
 }
 
 /**


### PR DESCRIPTION
Make it easier to find the artifact.

It can be hard to figure out the command without the name:

<img width="950" alt="image" src="https://github.com/user-attachments/assets/f50f8d87-e32e-4b75-8bd6-176b6bec8310" />

Compare with the comment on this PR

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ci
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: ci
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
