### PR TITLE
feat: pull resource names for provisioning from config if provided 

### DIFF
--- a/.changeset/smart-lions-suffer.md
+++ b/.changeset/smart-lions-suffer.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+feat: pull resource names for provisioning from config if provided
+
+Uses `database_name` and `bucket_name` for provisioning if specified. For R2, this only happens if there is not a bucket with that name already. Also respects R2 `jurisdiction` if provided.

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -91,7 +91,6 @@ describe("--x-provision", () => {
 			],
 		});
 
-		mockGetD1Database("d1-id");
 		await runWrangler("deploy --x-provision");
 		expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB

--- a/packages/wrangler/src/d1/list.ts
+++ b/packages/wrangler/src/d1/list.ts
@@ -56,7 +56,7 @@ export const listDatabases = async (
 		);
 		page++;
 		results.push(...json);
-		if (limitCalls) {
+		if (limitCalls && page > 3) {
 			break;
 		}
 		if (json.length < pageSize) {

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -28,6 +28,7 @@ import { loadSourceMaps } from "../deployment-bundle/source-maps";
 import { confirm } from "../dialogs";
 import { getMigrationsToUpload } from "../durable";
 import { UserError } from "../errors";
+import { getFlag } from "../experimental-flags";
 import { logger } from "../logger";
 import { getMetricsUsageHeaders } from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
@@ -799,13 +800,15 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		} else {
 			assert(accountId, "Missing accountId");
 
-			await provisionBindings(
-				bindings,
-				accountId,
-				scriptName,
-				props.experimentalAutoCreate,
-				props.config
-			);
+			getFlag("RESOURCES_PROVISION")
+				? await provisionBindings(
+						bindings,
+						accountId,
+						scriptName,
+						props.experimentalAutoCreate,
+						props.config
+					)
+				: null;
 			await ensureQueuesExistByConfig(config);
 			let bindingsPrinted = false;
 

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -359,7 +359,9 @@ async function runProvisioningFlow(
 					selected = await select(
 						`Would you like to connect an existing ${friendlyBindingName} or create a new one?`,
 						{
-							choices: options.concat([{ title: "Create new", value: "new" }]),
+							choices: options.concat([
+								{ title: "Create new", value: NEW_OPTION_VALUE },
+							]),
 							defaultOption: options.length,
 						}
 					);

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -3,7 +3,6 @@ import chalk from "chalk";
 import { fetchResult } from "../cfetch";
 import { createD1Database } from "../d1/create";
 import { listDatabases } from "../d1/list";
-import { DatabaseInfo } from "../d1/types";
 import { getDatabaseInfoFromId } from "../d1/utils";
 import { confirm, prompt, select } from "../dialogs";
 import { UserError } from "../errors";


### PR DESCRIPTION
Fixes DEVX-1556

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: still experimental

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
