### PR TITLE
Unwrap SDW errors before sending to Sentry

### DIFF
--- a/.changeset/honest-spies-prove.md
+++ b/.changeset/honest-spies-prove.md
@@ -2,4 +2,4 @@
 "wrangler": patch
 ---
 
-Send error cause to Sentry when available
+Unwrap the error cause when available to send to Sentry

--- a/.changeset/honest-spies-prove.md
+++ b/.changeset/honest-spies-prove.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Send error cause to Sentry when available

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -1087,7 +1087,7 @@ export async function main(argv: string[]): Promise<void> {
 		cliHandlerThrew = true;
 		let mayReport = true;
 		let errorType: string | undefined;
-		let loggableException: Error | undefined = e as Error;
+		let loggableException = e;
 
 		logger.log(""); // Just adds a bit of space
 		if (e instanceof CommandLineArgsError) {

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -1087,7 +1087,7 @@ export async function main(argv: string[]): Promise<void> {
 		cliHandlerThrew = true;
 		let mayReport = true;
 		let errorType: string | undefined;
-		let loggableException: Error | undefined = undefined;
+		let loggableException: Error | undefined = e as Error;
 
 		logger.log(""); // Just adds a bit of space
 		if (e instanceof CommandLineArgsError) {
@@ -1153,7 +1153,6 @@ export async function main(argv: string[]): Promise<void> {
 			errorType = "BuildFailure";
 			logBuildFailure(e.cause.errors, e.cause.warnings);
 		} else {
-			loggableException = e as Error;
 			if (
 				// Is this a StartDevEnv error event? If so, unwrap the cause, which is usually the user-recognisable error
 				e &&
@@ -1180,17 +1179,15 @@ export async function main(argv: string[]): Promise<void> {
 			}
 		}
 
-		const reportableError = loggableException ?? e;
-
 		if (
 			// Only report the error if we didn't just handle it
 			mayReport &&
 			// ...and it's not a user error
-			!(reportableError instanceof UserError) &&
+			!(loggableException instanceof UserError) &&
 			// ...and it's not an un-reportable API error
-			!(reportableError instanceof APIError && !reportableError.reportable)
+			!(loggableException instanceof APIError && !loggableException.reportable)
 		) {
-			await captureGlobalException(reportableError);
+			await captureGlobalException(loggableException);
 		}
 		const durationMs = Date.now() - startTime;
 


### PR DESCRIPTION
This should make Sentry errors more actionable, by unwrapping error `cause` (which was causing all the `captureGlobalException` issues)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: some existing tests cover sentry, and this isn't really testable
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: n/a

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
