### PR TITLE
Use TEXT bindings for plain text values in Miniflare

### DIFF
--- a/.changeset/dry-numbers-doubt.md
+++ b/.changeset/dry-numbers-doubt.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+Use TEXT bindings for plain text values in Miniflare. This is an internal detail that should have no user facing impact.

--- a/.changeset/dry-numbers-doubt.md
+++ b/.changeset/dry-numbers-doubt.md
@@ -1,5 +1,5 @@
 ---
-"miniflare": minor
+"miniflare": patch
 ---
 
 Use TEXT bindings for plain text values in Miniflare. This is an internal detail that should have no user facing impact.

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -339,11 +339,20 @@ function validateCompatibilityDate(log: Log, compatibilityDate: string) {
 	return compatibilityDate;
 }
 
-function buildJsonBindings(bindings: Record<string, Json>): Worker_Binding[] {
-	return Object.entries(bindings).map(([name, value]) => ({
-		name,
-		json: JSON.stringify(value),
-	}));
+function buildBindings(bindings: Record<string, Json>): Worker_Binding[] {
+	return Object.entries(bindings).map(([name, value]) => {
+		if (typeof value === "string") {
+			return {
+				name,
+				text: value,
+			};
+		} else {
+			return {
+				name,
+				json: JSON.stringify(value),
+			};
+		}
+	});
 }
 
 const WRAPPED_MODULE_PREFIX = "miniflare-internal:wrapped:";
@@ -368,7 +377,7 @@ export const CORE_PLUGIN: Plugin<
 		const bindings: Awaitable<Worker_Binding>[] = [];
 
 		if (options.bindings !== undefined) {
-			bindings.push(...buildJsonBindings(options.bindings));
+			bindings.push(...buildBindings(options.bindings));
 		}
 		if (options.wasmBindings !== undefined) {
 			bindings.push(
@@ -424,7 +433,7 @@ export const CORE_PLUGIN: Plugin<
 					// Build binding
 					const moduleName = workerNameToWrappedModule(scriptName);
 					const innerBindings =
-						bindings === undefined ? [] : buildJsonBindings(bindings);
+						bindings === undefined ? [] : buildBindings(bindings);
 					// `scriptName`'s bindings will be added to `innerBindings` when
 					// assembling the config
 					return {


### PR DESCRIPTION
Use `text` bindings for text values when passing to Miniflare. This gives parity with deployed behaviour.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactor

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
