### PR TITLE
test: fix c3 integration test

### DIFF
--- a/packages/wrangler/e2e/c3-integration.test.ts
+++ b/packages/wrangler/e2e/c3-integration.test.ts
@@ -41,7 +41,7 @@ describe.runIf(process.platform !== "win32")("c3 integration", () => {
 
 		expect(
 			readFileSync(
-				path.join(helper.tmpPath, workerName, "wrangler.toml"),
+				path.join(helper.tmpPath, workerName, "wrangler.json"),
 				"utf8"
 			)
 		).not.toContain("<TBD>");


### PR DESCRIPTION
Now that C3 generates wrangler.json files, we need to update the wranger <-> c3 integration tests

Fixes #0000
---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: test fix
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
