### PR TITLE
refactor: add package manager info to C3Context

### DIFF
--- a/packages/create-cloudflare/src/__tests__/dialog.test.ts
+++ b/packages/create-cloudflare/src/__tests__/dialog.test.ts
@@ -1,3 +1,4 @@
+import { detectPackageManager } from "helpers/packageManagers";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
 import { collectCLIOutput, normalizeOutput } from "../../../cli/test-util";
 import { printSummary, printWelcomeMessage } from "../dialog";
@@ -101,6 +102,7 @@ describe("dialog helpers", () => {
 			},
 			originalCWD: "./workspace",
 			gitRepoAlreadyExisted: false,
+			packageManager: detectPackageManager(),
 		};
 
 		let originalStdoutColumns: number;

--- a/packages/create-cloudflare/src/__tests__/helpers.ts
+++ b/packages/create-cloudflare/src/__tests__/helpers.ts
@@ -1,4 +1,5 @@
 import { C3_DEFAULTS } from "helpers/cli";
+import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../templates";
 import type { C3Args, C3Context } from "types";
 
@@ -18,6 +19,7 @@ export const createTestContext = (name = "test", args?: C3Args): C3Context => {
 		gitRepoAlreadyExisted: false,
 		template: createTestTemplate(),
 		deployment: {},
+		packageManager: detectPackageManager(),
 	};
 };
 

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -132,13 +132,9 @@ export const setupProjectDirectory = (ctx: C3Context) => {
 };
 
 const create = async (ctx: C3Context) => {
-	const { template } = ctx;
-
 	setupProjectDirectory(ctx);
 
-	if (template.generate) {
-		await template.generate(ctx);
-	}
+	await ctx.template.generate?.({ ...ctx });
 
 	await copyTemplateFiles(ctx);
 	await updatePackageName(ctx);
@@ -160,10 +156,7 @@ const configure = async (ctx: C3Context) => {
 	//       pre-existing workers assume its presence in their configure phase
 	await updateWranglerConfig(ctx);
 
-	const { template } = ctx;
-	if (template.configure) {
-		await template.configure({ ...ctx });
-	}
+	await ctx.template.configure?.({ ...ctx });
 
 	addWranglerToGitIgnore(ctx);
 

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -38,8 +38,6 @@ import { installWorkersTypes } from "./workers";
 import { updateWranglerConfig } from "./wrangler/config";
 import type { C3Args, C3Context } from "types";
 
-const { npm } = detectPackageManager();
-
 export const main = async (argv: string[]) => {
 	const result = await parseArgs(argv);
 
@@ -90,6 +88,7 @@ export const main = async (argv: string[]) => {
 // Spawn a separate process running the most recent version of c3
 export const runLatest = async () => {
 	const args = process.argv.slice(2);
+	const { npm } = detectPackageManager();
 
 	// the parsing logic of `npm create` requires `--` to be supplied
 	// before any flags intended for the target command.

--- a/packages/create-cloudflare/src/deploy.ts
+++ b/packages/create-cloudflare/src/deploy.ts
@@ -8,7 +8,6 @@ import { processArgument } from "helpers/args";
 import { C3_DEFAULTS, openInBrowser } from "helpers/cli";
 import { quoteShellArgs, runCommand } from "helpers/command";
 import { readFile } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { poll } from "helpers/poll";
 import { parse as jsoncParse } from "jsonc-parser";
 import { isInsideGitRepo } from "./git";
@@ -21,7 +20,7 @@ import {
 import type { C3Context } from "types";
 
 export const offerToDeploy = async (ctx: C3Context) => {
-	const { npm } = detectPackageManager();
+	const { npm } = ctx.packageManager;
 
 	startSection(`Deploy with Cloudflare`, `Step 3 of 3`);
 
@@ -91,7 +90,7 @@ const readWranglerConfig = (ctx: C3Context) => {
 };
 
 export const runDeploy = async (ctx: C3Context) => {
-	const { npm, name: pm } = detectPackageManager();
+	const { npm, name: pm } = ctx.packageManager;
 
 	if (!ctx.account?.id) {
 		throw new Error("Failed to read Cloudflare account.");

--- a/packages/create-cloudflare/src/dialog.ts
+++ b/packages/create-cloudflare/src/dialog.ts
@@ -2,7 +2,6 @@ import { relative } from "path";
 import { hyperlink, logRaw, shapes, stripAnsi } from "@cloudflare/cli";
 import { bgGreen, blue, gray } from "@cloudflare/cli/colors";
 import { quoteShellArgs } from "helpers/command";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { C3Args, C3Context } from "types";
 
 /**
@@ -64,7 +63,7 @@ export const printSummary = (ctx: C3Context) => {
 		: null;
 	const relativePath = relative(ctx.originalCWD, ctx.project.path);
 	const cdCommand = relativePath ? `cd ${relativePath}` : null;
-	const { npm } = detectPackageManager();
+	const { npm } = ctx.packageManager;
 	const devServerCommand = quoteShellArgs([
 		npm,
 		"run",

--- a/packages/create-cloudflare/src/frameworks/index.ts
+++ b/packages/create-cloudflare/src/frameworks/index.ts
@@ -1,7 +1,6 @@
 import { logRaw, updateStatus } from "@cloudflare/cli";
 import { dim } from "@cloudflare/cli/colors";
 import { quoteShellArgs, runCommand } from "helpers/command";
-import { detectPackageManager } from "helpers/packageManagers";
 import frameworksPackageJson from "./package.json";
 import type { C3Context } from "types";
 
@@ -27,7 +26,7 @@ export const getFrameworkCli = (ctx: C3Context, withVersion = true) => {
  */
 export const runFrameworkGenerator = async (ctx: C3Context, args: string[]) => {
 	const cli = getFrameworkCli(ctx, true);
-	const { npm, dlx } = detectPackageManager();
+	const { npm, dlx } = ctx.packageManager;
 	// yarn cannot `yarn create@some-version` and doesn't have an npx equivalent
 	// So to retain the ability to lock versions we run it with `npx` and spoof
 	// the user agent so scaffolding tools treat the invocation like yarn

--- a/packages/create-cloudflare/src/git.ts
+++ b/packages/create-cloudflare/src/git.ts
@@ -5,7 +5,6 @@ import { getFrameworkCli } from "frameworks/index";
 import { processArgument } from "helpers/args";
 import { C3_DEFAULTS } from "helpers/cli";
 import { runCommand } from "helpers/command";
-import { detectPackageManager } from "helpers/packageManagers";
 import { version as wranglerVersion } from "wrangler/package.json";
 import { version } from "../package.json";
 import type { C3Context } from "types";
@@ -104,7 +103,7 @@ const createCommitMessage = async (ctx: C3Context) => {
 		? "Initialize web application via create-cloudflare CLI"
 		: "Initial commit (by create-cloudflare CLI)";
 
-	const packageManager = detectPackageManager();
+	const { packageManager } = ctx;
 
 	const gitVersion = await getGitVersion();
 	const insideRepo = await isInsideGitRepo(ctx.project.path);

--- a/packages/create-cloudflare/src/helpers/command.ts
+++ b/packages/create-cloudflare/src/helpers/command.ts
@@ -58,8 +58,10 @@ export const runCommand = async (
 			if (args[0] === "wrangler") {
 				const metrics = readMetricsConfig();
 				if (metrics.c3permission?.enabled === false) {
-					opts.env ??= {};
-					opts.env["WRANGLER_SEND_METRICS"] = "false";
+					opts.env = {
+						...opts.env,
+						WRANGLER_SEND_METRICS: "false",
+					};
 				}
 			}
 			const abortController = new AbortController();

--- a/packages/create-cloudflare/src/helpers/packageManagers.ts
+++ b/packages/create-cloudflare/src/helpers/packageManagers.ts
@@ -95,7 +95,7 @@ export const detectPackageManager = () => {
  *
  */
 export const rectifyPmMismatch = async (ctx: C3Context) => {
-	const { npm } = detectPackageManager();
+	const { npm } = ctx.packageManager;
 
 	if (!detectPmMismatch(ctx)) {
 		return;

--- a/packages/create-cloudflare/src/helpers/packages.ts
+++ b/packages/create-cloudflare/src/helpers/packages.ts
@@ -61,7 +61,7 @@ export const npmInstall = async (ctx: C3Context) => {
 		return;
 	}
 
-	const { npm } = detectPackageManager();
+	const { npm } = ctx.packageManager;
 
 	await runCommand([npm, "install"], {
 		silent: true,

--- a/packages/create-cloudflare/src/pages.ts
+++ b/packages/create-cloudflare/src/pages.ts
@@ -1,6 +1,5 @@
 import { brandColor, dim } from "@cloudflare/cli/colors";
 import { quoteShellArgs, runCommand } from "helpers/command";
-import { detectPackageManager } from "helpers/packageManagers";
 import { retry } from "helpers/retry";
 import { getProductionBranch } from "./git";
 import type { C3Context } from "types";
@@ -11,8 +10,6 @@ const CREATE_PROJECT_RETRIES = 3;
 /** How many times to verify the project creation before failing. */
 const VERIFY_PROJECT_RETRIES = 3;
 
-const { npx } = detectPackageManager();
-
 export const createProject = async (ctx: C3Context) => {
 	if (ctx.template.platform === "workers") {
 		return;
@@ -21,6 +18,8 @@ export const createProject = async (ctx: C3Context) => {
 		throw new Error("Failed to read Cloudflare account.");
 	}
 	const CLOUDFLARE_ACCOUNT_ID = ctx.account.id;
+
+	const { npx } = ctx.packageManager;
 
 	try {
 		const compatFlags = ctx.template.compatibilityFlags ?? [];

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -115,12 +115,12 @@ export type TemplateConfig = {
 	/** A function invoked as the first step of project creation.
 	 * Used to invoke framework creation cli in the internal web framework templates.
 	 */
-	generate?: (ctx: C3Context) => Promise<void>;
+	generate?: (ctx: Readonly<C3Context>) => Promise<void>;
 	/** A function invoked after project creation but before deployment.
 	 * Used when a template needs to run additional install steps or wrangler commands before
 	 * finalizing the project.
 	 */
-	configure?: (ctx: C3Context) => Promise<void>;
+	configure?: (ctx: Readonly<C3Context>) => Promise<void>;
 
 	/**
 	 * A transformer that is run on the project's `package.json` during the creation step.

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -18,6 +18,7 @@ import {
 	writeFile,
 	writeJSON,
 } from "helpers/files";
+import { detectPackageManager } from "helpers/packageManagers";
 import angularTemplateExperimental from "templates-experimental/angular/c3";
 import astroTemplateExperimental from "templates-experimental/astro/c3";
 import docusaurusTemplateExperimental from "templates-experimental/docusaurus/c3";
@@ -532,6 +533,7 @@ export const createContext = async (
 		originalCWD,
 		gitRepoAlreadyExisted: await isInsideGitRepo(directory),
 		deployment: {},
+		packageManager: detectPackageManager(),
 	};
 };
 

--- a/packages/create-cloudflare/src/types.ts
+++ b/packages/create-cloudflare/src/types.ts
@@ -1,3 +1,4 @@
+import { type detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "./templates";
 
 export type C3Args = {
@@ -38,6 +39,8 @@ export type C3Context = {
 	commitMessage?: string;
 	originalCWD: string;
 	gitRepoAlreadyExisted: boolean;
+	// Information about the detected package manager.
+	packageManager: Readonly<ReturnType<typeof detectPackageManager>>;
 };
 
 type DeploymentInfo = {

--- a/packages/create-cloudflare/src/workers.ts
+++ b/packages/create-cloudflare/src/workers.ts
@@ -5,7 +5,6 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
 import { getLatestTypesEntrypoint } from "helpers/compatDate";
 import { readFile, usesTypescript, writeFile } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import * as jsonc from "jsonc-parser";
 import type { C3Context } from "types";
@@ -15,7 +14,7 @@ import type { C3Context } from "types";
  * and updates the .tsconfig file to use the latest entrypoint version.
  */
 export async function installWorkersTypes(ctx: C3Context) {
-	const { npm } = detectPackageManager();
+	const { npm } = ctx.packageManager;
 
 	if (!usesTypescript(ctx)) {
 		return;

--- a/packages/create-cloudflare/src/wrangler/accounts.ts
+++ b/packages/create-cloudflare/src/wrangler/accounts.ts
@@ -54,7 +54,7 @@ export const wranglerLogin = async (ctx: C3Context) => {
 			args: ctx.args,
 		},
 		async promise() {
-			const { npx } = detectPackageManager();
+			const { npx } = ctx.packageManager;
 
 			const s = spinner();
 			s.start(

--- a/packages/create-cloudflare/templates-experimental/angular/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/angular/c3.ts
@@ -4,12 +4,9 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
 import { readFile, readJSON, writeFile } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
@@ -23,14 +20,14 @@ const generate = async (ctx: C3Context) => {
 const configure = async (ctx: C3Context) => {
 	updateAngularJson(ctx);
 	await updateAppCode();
-	await installCFWorker();
+	await installCFWorker(ctx);
 };
 
-async function installCFWorker() {
+async function installCFWorker(ctx: C3Context) {
 	await installPackages(["xhr2"], {
 		dev: true,
 		startText: "Installing additional dependencies",
-		doneText: `${brandColor("installed")} ${dim(`via \`${npm} install\``)}`,
+		doneText: `${brandColor("installed")} ${dim(`via \`${ctx.packageManager.npm} install\``)}`,
 	});
 }
 async function updateAppCode() {
@@ -101,11 +98,11 @@ const config: TemplateConfig = {
 	previewScript: "start",
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			start: `${npm} run build && wrangler dev`,
+			start: `${ctx.packageManager.npm} run build && wrangler dev`,
 			build: `ng build`,
-			deploy: `${npm} run build && wrangler deploy`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler deploy`,
 		},
 	}),
 };

--- a/packages/create-cloudflare/templates-experimental/astro/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/astro/c3.ts
@@ -4,12 +4,9 @@ import { runFrameworkGenerator } from "frameworks/index";
 import { transformFile } from "helpers/codemod";
 import { runCommand } from "helpers/command";
 import { usesTypescript } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context, PackageJson } from "types";
-
-const { npx } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [ctx.project.name, "--no-install"]);
@@ -17,7 +14,8 @@ const generate = async (ctx: C3Context) => {
 	logRaw(""); // newline
 };
 
-const configure = async () => {
+const configure = async (ctx: C3Context) => {
+	const { npx } = ctx.packageManager;
 	await runCommand([npx, "astro", "add", "cloudflare", "-y"], {
 		silent: true,
 		startText: "Installing adapter",

--- a/packages/create-cloudflare/templates-experimental/docusaurus/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/docusaurus/c3.ts
@@ -1,9 +1,6 @@
 import { runFrameworkGenerator } from "frameworks/index";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [ctx.project.name, "classic"]);
@@ -20,10 +17,10 @@ const config: TemplateConfig = {
 	},
 	path: "templates-experimental/docusaurus",
 	generate,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler deploy`,
-			preview: `${npm} run build && wrangler dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler dev`,
 		},
 	}),
 	devScript: "start",

--- a/packages/create-cloudflare/templates-experimental/gatsby/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/gatsby/c3.ts
@@ -1,10 +1,7 @@
 import { inputPrompt } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	const defaultTemplate = "https://github.com/gatsbyjs/gatsby-starter-blog";
@@ -40,10 +37,10 @@ const config: TemplateConfig = {
 	},
 	path: "templates-experimental/gatsby",
 	generate,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler deploy`,
-			preview: `${npm} run build && wrangler dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler dev`,
 		},
 	}),
 	devScript: "develop",

--- a/packages/create-cloudflare/templates-experimental/hono/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/hono/c3.ts
@@ -1,11 +1,10 @@
 import { logRaw } from "@cloudflare/cli";
 import { runFrameworkGenerator } from "frameworks/index";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
 
 const generate = async (ctx: C3Context) => {
-	const { name: pm } = detectPackageManager();
+	const { name: pm } = ctx.packageManager;
 
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,

--- a/packages/create-cloudflare/templates-experimental/nuxt/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/nuxt/c3.ts
@@ -5,13 +5,10 @@ import { runFrameworkGenerator } from "frameworks/index";
 import { mergeObjectProperties, transformFile } from "helpers/codemod";
 import { getLatestTypesEntrypoint } from "helpers/compatDate";
 import { readFile, writeFile } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm, name: pm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	const gitFlag = ctx.args.git ? `--gitInit` : `--no-gitInit`;
@@ -20,7 +17,7 @@ const generate = async (ctx: C3Context) => {
 		"init",
 		ctx.project.name,
 		"--packageManager",
-		npm,
+		ctx.packageManager.npm,
 		gitFlag,
 	]);
 
@@ -31,6 +28,7 @@ const generate = async (ctx: C3Context) => {
 
 const configure = async (ctx: C3Context) => {
 	const packages = ["nitro-cloudflare-dev", "nitropack"];
+	const { npm, name: pm } = ctx.packageManager;
 
 	// When using pnpm, explicitly add h3 package so the H3Event type declaration can be updated.
 	// Package managers other than pnpm will hoist the dependency, as will pnpm with `--shamefully-hoist`
@@ -121,10 +119,10 @@ const config: TemplateConfig = {
 	path: "templates-experimental/nuxt",
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler deploy`,
-			preview: `${npm} run build && wrangler dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler dev`,
 			"cf-typegen": `wrangler types`,
 		},
 	}),

--- a/packages/create-cloudflare/templates-experimental/qwik/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/qwik/c3.ts
@@ -5,12 +5,9 @@ import { runFrameworkGenerator } from "frameworks/index";
 import { loadTemplateSnippets, transformFile } from "helpers/codemod";
 import { quoteShellArgs, runCommand } from "helpers/command";
 import { removeFile, usesTypescript } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm, npx } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, ["playground", ctx.project.name]);
@@ -18,7 +15,7 @@ const generate = async (ctx: C3Context) => {
 
 const configure = async (ctx: C3Context) => {
 	// Add the pages integration
-	const cmd = [npx, "qwik", "add", "cloudflare-pages"];
+	const cmd = [ctx.packageManager.npx, "qwik", "add", "cloudflare-pages"];
 	endSection(`Running ${quoteShellArgs(cmd)}`);
 	await runCommand(cmd);
 
@@ -139,10 +136,10 @@ const config: TemplateConfig = {
 	path: "templates-experimental/qwik",
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler deploy`,
-			preview: `${npm} run build && wrangler dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler dev`,
 			"cf-typegen": `wrangler types`,
 		},
 	}),

--- a/packages/create-cloudflare/templates-experimental/remix/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/remix/c3.ts
@@ -1,12 +1,9 @@
 import { logRaw } from "@cloudflare/cli";
 import { brandColor, dim } from "@cloudflare/cli/colors";
 import { runFrameworkGenerator } from "frameworks/index";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
@@ -38,10 +35,10 @@ const config: TemplateConfig = {
 	path: "templates-experimental/remix",
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler deploy`,
-			preview: `${npm} run build && wrangler dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler dev`,
 			"cf-typegen": `wrangler types`,
 		},
 	}),

--- a/packages/create-cloudflare/templates-experimental/solid/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/solid/c3.ts
@@ -4,13 +4,10 @@ import { runFrameworkGenerator } from "frameworks/index";
 import { mergeObjectProperties, transformFile } from "helpers/codemod";
 import { getWorkerdCompatibilityDate } from "helpers/compatDate";
 import { usesTypescript } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	// Run the create-solid command
@@ -25,7 +22,7 @@ const configure = async (ctx: C3Context) => {
 	await installPackages(packages, {
 		dev: true,
 		startText: "Installing nitro module `nitropack`",
-		doneText: `${brandColor("installed")} ${dim(`via \`${npm} install\``)}`,
+		doneText: `${brandColor("installed")} ${dim(`via \`${ctx.packageManager.npm} install\``)}`,
 	});
 
 	usesTypescript(ctx);
@@ -80,10 +77,10 @@ const config: TemplateConfig = {
 	path: "templates-experimental/solid",
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			preview: `${npm} run build && npx wrangler dev`,
-			deploy: `${npm} run build && wrangler deploy`,
+			preview: `${ctx.packageManager.npm} run build && npx wrangler dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler deploy`,
 		},
 	}),
 	compatibilityFlags: ["nodejs_compat"],

--- a/packages/create-cloudflare/templates-experimental/svelte/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/svelte/c3.ts
@@ -4,13 +4,10 @@ import { blue, brandColor, dim } from "@cloudflare/cli/colors";
 import { runFrameworkGenerator } from "frameworks/index";
 import { transformFile } from "helpers/codemod";
 import { usesTypescript } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context, PackageJson } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, ["create", ctx.project.name]);
@@ -108,8 +105,8 @@ const config: TemplateConfig = {
 	configure,
 	transformPackageJson: async (original: PackageJson, ctx: C3Context) => {
 		let scripts: Record<string, string> = {
-			preview: `${npm} run build && wrangler dev`,
-			deploy: `${npm} run build && wrangler deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler deploy`,
 		};
 
 		if (usesTypescript(ctx)) {

--- a/packages/create-cloudflare/templates-experimental/vue/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/vue/c3.ts
@@ -1,9 +1,6 @@
 import { runFrameworkGenerator } from "frameworks/index";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [ctx.project.name]);
@@ -20,10 +17,10 @@ const config: TemplateConfig = {
 	},
 	path: "templates-experimental/vue",
 	generate,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler deploy`,
-			preview: `${npm} run build && wrangler dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler dev`,
 		},
 	}),
 	devScript: "dev",

--- a/packages/create-cloudflare/templates/analog/c3.ts
+++ b/packages/create-cloudflare/templates/analog/c3.ts
@@ -5,13 +5,10 @@ import { runFrameworkGenerator } from "frameworks/index";
 import { loadTemplateSnippets, transformFile } from "helpers/codemod";
 import { getLatestTypesEntrypoint } from "helpers/compatDate";
 import { readFile, writeFile } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm, name: pm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
@@ -24,6 +21,7 @@ const generate = async (ctx: C3Context) => {
 };
 
 const configure = async (ctx: C3Context) => {
+	const { npm, name: pm } = ctx.packageManager;
 	// Fix hoisting issues with pnpm, yarn and bun
 	if (pm === "pnpm" || pm === "yarn" || pm === "bun") {
 		const packages = [];
@@ -121,10 +119,10 @@ const config: TemplateConfig = {
 	},
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			preview: `${npm} run build && wrangler pages dev`,
-			deploy: `${npm} run build && wrangler pages deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler pages dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy`,
 			"cf-typegen": `wrangler types`,
 		},
 	}),

--- a/packages/create-cloudflare/templates/astro/c3.ts
+++ b/packages/create-cloudflare/templates/astro/c3.ts
@@ -4,12 +4,9 @@ import { runFrameworkGenerator } from "frameworks/index";
 import { transformFile } from "helpers/codemod";
 import { runCommand } from "helpers/command";
 import { usesTypescript } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context, PackageJson } from "types";
-
-const { npx } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [ctx.project.name, "--no-install"]);
@@ -17,7 +14,9 @@ const generate = async (ctx: C3Context) => {
 	logRaw(""); // newline
 };
 
-const configure = async () => {
+const configure = async (ctx: C3Context) => {
+	const { npx } = ctx.packageManager;
+
 	await runCommand([npx, "astro", "add", "cloudflare", "-y"], {
 		silent: true,
 		startText: "Installing adapter",

--- a/packages/create-cloudflare/templates/docusaurus/c3.ts
+++ b/packages/create-cloudflare/templates/docusaurus/c3.ts
@@ -1,9 +1,6 @@
 import { runFrameworkGenerator } from "frameworks/index";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [ctx.project.name, "classic"]);
@@ -16,10 +13,10 @@ const config: TemplateConfig = {
 	platform: "pages",
 	displayName: "Docusaurus",
 	generate,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			preview: `${npm} run build && wrangler pages dev ./build`,
-			deploy: `${npm} run build && wrangler pages deploy ./build`,
+			preview: `${ctx.packageManager.npm} run build && wrangler pages dev ./build`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy ./build`,
 		},
 	}),
 	devScript: "preview",

--- a/packages/create-cloudflare/templates/gatsby/c3.ts
+++ b/packages/create-cloudflare/templates/gatsby/c3.ts
@@ -1,10 +1,7 @@
 import { inputPrompt } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	const defaultTemplate = "https://github.com/gatsbyjs/gatsby-starter-blog";
@@ -36,10 +33,10 @@ const config: TemplateConfig = {
 	platform: "pages",
 	displayName: "Gatsby",
 	generate,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler pages deploy ./public`,
-			preview: `${npm} run build && wrangler pages dev ./public`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy ./public`,
+			preview: `${ctx.packageManager.npm} run build && wrangler pages dev ./public`,
 		},
 	}),
 	devScript: "develop",

--- a/packages/create-cloudflare/templates/hono/c3.ts
+++ b/packages/create-cloudflare/templates/hono/c3.ts
@@ -3,13 +3,12 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
 import { loadTemplateSnippets, transformFile } from "helpers/codemod";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type * as recast from "recast";
 import type { C3Context } from "types";
 
 const generate = async (ctx: C3Context) => {
-	const { name: pm } = detectPackageManager();
+	const { name: pm } = ctx.packageManager;
 
 	await runFrameworkGenerator(ctx, [
 		ctx.project.name,

--- a/packages/create-cloudflare/templates/next/c3.ts
+++ b/packages/create-cloudflare/templates/next/c3.ts
@@ -13,13 +13,10 @@ import {
 	writeFile,
 	writeJSON,
 } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import { getTemplatePath } from "../../src/templates";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm, npx } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	const projectName = ctx.project.name;
@@ -211,6 +208,8 @@ export default {
 		},
 	},
 	transformPackageJson: async (_, ctx) => {
+		const { npm, npx } = ctx.packageManager;
+
 		const isNpm = npm === "npm";
 		const isBun = npm === "bun";
 		const isNpmOrBun = isNpm || isBun;

--- a/packages/create-cloudflare/templates/nuxt/c3.ts
+++ b/packages/create-cloudflare/templates/nuxt/c3.ts
@@ -5,13 +5,10 @@ import { runFrameworkGenerator } from "frameworks/index";
 import { mergeObjectProperties, transformFile } from "helpers/codemod";
 import { getLatestTypesEntrypoint } from "helpers/compatDate";
 import { readFile, writeFile } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm, name: pm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	const gitFlag = ctx.args.git ? `--gitInit` : `--no-gitInit`;
@@ -20,7 +17,7 @@ const generate = async (ctx: C3Context) => {
 		"init",
 		ctx.project.name,
 		"--packageManager",
-		npm,
+		ctx.packageManager.npm,
 		gitFlag,
 	]);
 
@@ -120,10 +117,10 @@ const config: TemplateConfig = {
 	},
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler pages deploy`,
-			preview: `${npm} run build && wrangler pages dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler pages dev`,
 			"cf-typegen": `wrangler types`,
 		},
 	}),

--- a/packages/create-cloudflare/templates/pre-existing/c3.ts
+++ b/packages/create-cloudflare/templates/pre-existing/c3.ts
@@ -4,12 +4,11 @@ import { join } from "path";
 import { brandColor, dim } from "@cloudflare/cli/colors";
 import { processArgument } from "helpers/args";
 import { runCommand } from "helpers/command";
-import { detectPackageManager } from "helpers/packageManagers";
 import { chooseAccount, wranglerLogin } from "../../src/wrangler/accounts";
 import type { C3Context } from "types";
 
 export async function copyExistingWorkerFiles(ctx: C3Context) {
-	const { dlx } = detectPackageManager();
+	const { dlx } = ctx.packageManager;
 
 	if (ctx.args.existingScript === undefined) {
 		ctx.args.existingScript = await processArgument(

--- a/packages/create-cloudflare/templates/qwik/c3.ts
+++ b/packages/create-cloudflare/templates/qwik/c3.ts
@@ -5,12 +5,9 @@ import { runFrameworkGenerator } from "frameworks/index";
 import { loadTemplateSnippets, transformFile } from "helpers/codemod";
 import { quoteShellArgs, runCommand } from "helpers/command";
 import { usesTypescript } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm, npx } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, ["playground", ctx.project.name]);
@@ -18,7 +15,7 @@ const generate = async (ctx: C3Context) => {
 
 const configure = async (ctx: C3Context) => {
 	// Add the pages integration
-	const cmd = [npx, "qwik", "add", "cloudflare-pages"];
+	const cmd = [ctx.packageManager.npx, "qwik", "add", "cloudflare-pages"];
 	endSection(`Running ${quoteShellArgs(cmd)}`);
 	await runCommand(cmd);
 
@@ -133,10 +130,10 @@ const config: TemplateConfig = {
 	},
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler pages deploy`,
-			preview: `${npm} run build && wrangler pages dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler pages dev`,
 			"cf-typegen": `wrangler types`,
 		},
 	}),

--- a/packages/create-cloudflare/templates/react/c3.ts
+++ b/packages/create-cloudflare/templates/react/c3.ts
@@ -1,11 +1,8 @@
 import { logRaw } from "@cloudflare/cli";
 import { inputPrompt } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	const variant = await inputPrompt({
@@ -48,10 +45,10 @@ const config: TemplateConfig = {
 	displayName: "React",
 	platform: "pages",
 	generate,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler pages deploy ./dist`,
-			preview: `${npm} run build && wrangler pages dev ./dist`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy ./dist`,
+			preview: `${ctx.packageManager.npm} run build && wrangler pages dev ./dist`,
 		},
 	}),
 	devScript: "dev",

--- a/packages/create-cloudflare/templates/remix/c3.ts
+++ b/packages/create-cloudflare/templates/remix/c3.ts
@@ -3,11 +3,8 @@ import { brandColor, dim } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
 import { transformFile } from "helpers/codemod";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [
@@ -53,10 +50,10 @@ const config: TemplateConfig = {
 	},
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler pages deploy`,
-			preview: `${npm} run build && wrangler pages dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler pages dev`,
 			"cf-typegen": `wrangler types`,
 		},
 	}),

--- a/packages/create-cloudflare/templates/solid/c3.ts
+++ b/packages/create-cloudflare/templates/solid/c3.ts
@@ -3,12 +3,9 @@ import { blue } from "@cloudflare/cli/colors";
 import { runFrameworkGenerator } from "frameworks/index";
 import { mergeObjectProperties, transformFile } from "helpers/codemod";
 import { usesTypescript } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	// Run the create-solid command
@@ -73,10 +70,10 @@ const config: TemplateConfig = {
 	},
 	generate,
 	configure,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			preview: `${npm} run build && npx wrangler pages dev`,
-			deploy: `${npm} run build && wrangler pages deploy`,
+			preview: `${ctx.packageManager.npm} run build && npx wrangler pages dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy`,
 		},
 	}),
 	compatibilityFlags: ["nodejs_compat"],

--- a/packages/create-cloudflare/templates/svelte/c3.ts
+++ b/packages/create-cloudflare/templates/svelte/c3.ts
@@ -5,13 +5,10 @@ import { blue, brandColor, dim } from "@cloudflare/cli/colors";
 import { runFrameworkGenerator } from "frameworks/index";
 import { transformFile } from "helpers/codemod";
 import { usesTypescript } from "helpers/files";
-import { detectPackageManager } from "helpers/packageManagers";
 import { installPackages } from "helpers/packages";
 import * as recast from "recast";
 import type { TemplateConfig } from "../../src/templates";
-import type { C3Context, PackageJson } from "types";
-
-const { npm } = detectPackageManager();
+import type { C3Context } from "types";
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, ["create", ctx.project.name]);
@@ -135,10 +132,10 @@ const config: TemplateConfig = {
 	},
 	generate,
 	configure,
-	transformPackageJson: async (original: PackageJson, ctx: C3Context) => {
+	transformPackageJson: async (_, ctx: C3Context) => {
 		let scripts: Record<string, string> = {
-			preview: `${npm} run build && wrangler pages dev`,
-			deploy: `${npm} run build && wrangler pages deploy`,
+			preview: `${ctx.packageManager.npm} run build && wrangler pages dev`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy`,
 		};
 
 		if (usesTypescript(ctx)) {

--- a/packages/create-cloudflare/templates/vue/c3.ts
+++ b/packages/create-cloudflare/templates/vue/c3.ts
@@ -1,9 +1,6 @@
 import { runFrameworkGenerator } from "frameworks/index";
-import { detectPackageManager } from "helpers/packageManagers";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
-
-const { npm } = detectPackageManager();
 
 const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [ctx.project.name]);
@@ -16,10 +13,10 @@ const config: TemplateConfig = {
 	displayName: "Vue",
 	platform: "pages",
 	generate,
-	transformPackageJson: async () => ({
+	transformPackageJson: async (_, ctx) => ({
 		scripts: {
-			deploy: `${npm} run build && wrangler pages deploy ./dist`,
-			preview: `${npm} run build && wrangler pages dev ./dist`,
+			deploy: `${ctx.packageManager.npm} run build && wrangler pages deploy ./dist`,
+			preview: `${ctx.packageManager.npm} run build && wrangler pages dev ./dist`,
 		},
 	}),
 	devScript: "dev",


### PR DESCRIPTION
The package manager is used many times and initialized many times.

Adding it to the context.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No usert facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
