### PR TITLE
Add jaeger bindings to asset-worker

### DIFF
--- a/.changeset/tough-walls-poke.md
+++ b/.changeset/tough-walls-poke.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Adds jaeger tracing for asset-worker.

--- a/packages/workers-shared/asset-worker/src/utils/mocks.ts
+++ b/packages/workers-shared/asset-worker/src/utils/mocks.ts
@@ -1,0 +1,32 @@
+import type { JaegerTracing, Span } from "../../../utils/types";
+
+export function mockJaegerBindingSpan(): Span {
+	return {
+		addLogs: () => {},
+		setTags: () => {},
+		end: () => {},
+		isRecording: true,
+	};
+}
+
+export function mockJaegerBinding(): JaegerTracing {
+	return {
+		enterSpan: (_, span, ...args) => {
+			return span(mockJaegerBindingSpan(), ...args);
+		},
+		getSpanContext: () => ({
+			traceId: "test-trace",
+			spanId: "test-span",
+			parentSpanId: "test-parent-span",
+			traceFlags: 0,
+		}),
+		runWithSpanContext: (_, callback, ...args) => {
+			return callback(...args);
+		},
+
+		traceId: "test-trace",
+		spanId: "test-span",
+		parentSpanId: "test-parent-span",
+		cfTraceIdHeader: "test-trace:test-span:0",
+	};
+}

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import { applyConfigurationDefaults } from "../src/configuration";
 import { handleRequest } from "../src/handler";
+import { mockJaegerBinding } from "../src/utils/mocks";
 import type { AssetConfig } from "../../utils/types";
 
 describe("[Asset Worker] `handleRequest`", () => {
@@ -17,8 +18,14 @@ describe("[Asset Worker] `handleRequest`", () => {
 			contentType: "text/html",
 		});
 
+		const mockEnv = {
+			JAEGER: mockJaegerBinding(),
+		};
+
 		const response = await handleRequest(
 			new Request("https://example.com/"),
+			// @ts-expect-error Empty config default to using mocked jaeger
+			mockEnv,
 			configuration,
 			exists,
 			getByETag
@@ -40,10 +47,16 @@ describe("[Asset Worker] `handleRequest`", () => {
 			contentType: "text/html",
 		});
 
+		const mockEnv = {
+			JAEGER: mockJaegerBinding(),
+		};
+
 		const response = await handleRequest(
 			new Request("https://example.com/", {
 				headers: { "If-None-Match": `"${eTag}"` },
 			}),
+			// @ts-expect-error Empty config default to using mocked jaeger
+			mockEnv,
 			configuration,
 			exists,
 			getByETag
@@ -65,10 +78,16 @@ describe("[Asset Worker] `handleRequest`", () => {
 			contentType: "text/html",
 		});
 
+		const mockEnv = {
+			JAEGER: mockJaegerBinding(),
+		};
+
 		const response = await handleRequest(
 			new Request("https://example.com/", {
 				headers: { "If-None-Match": `W/"${eTag}"` },
 			}),
+			// @ts-expect-error Empty config default to using mocked jaeger
+			mockEnv,
 			configuration,
 			exists,
 			getByETag
@@ -90,10 +109,16 @@ describe("[Asset Worker] `handleRequest`", () => {
 			contentType: "text/html",
 		});
 
+		const mockEnv = {
+			JAEGER: mockJaegerBinding(),
+		};
+
 		const response = await handleRequest(
 			new Request("https://example.com/", {
 				headers: { "If-None-Match": "a fake etag!" },
 			}),
+			// @ts-expect-error Empty config default to using mocked jaeger
+			mockEnv,
 			configuration,
 			exists,
 			getByETag
@@ -110,9 +135,15 @@ describe("[Asset Worker] `handleRequest`", () => {
 			"/test.html": "dddddddddd",
 		};
 
+		const mockEnv = {
+			JAEGER: mockJaegerBinding(),
+		};
+
 		// Attempt to path traverse down to the root /test within asset-server
 		let response = await handleRequest(
 			new Request("https://example.com/blog/../test"),
+			// @ts-expect-error Empty config default to using mocked jaeger
+			mockEnv,
 			applyConfigurationDefaults({}),
 			async (pathname: string) => {
 				if (pathname.startsWith("/blog/")) {
@@ -133,6 +164,8 @@ describe("[Asset Worker] `handleRequest`", () => {
 		// Attempt to path traverse down to the root /test within asset-server
 		response = await handleRequest(
 			new Request("https://example.com/blog/%2E%2E/test"),
+			// @ts-expect-error Empty config default to using mocked jaeger
+			mockEnv,
 			applyConfigurationDefaults({}),
 			async (pathname: string) => {
 				if (pathname.startsWith("/blog/")) {
@@ -170,9 +203,15 @@ describe("[Asset Worker] `handleRequest`", () => {
 			contentType: "text/html",
 		});
 
+		const mockEnv = {
+			JAEGER: mockJaegerBinding(),
+		};
+
 		// first malformed URL should return 404 as no match above
 		const response = await handleRequest(
 			new Request("https://example.com/%A0"),
+			// @ts-expect-error Empty config default to using mocked jaeger
+			mockEnv,
 			configuration,
 			exists,
 			getByEtag
@@ -182,6 +221,8 @@ describe("[Asset Worker] `handleRequest`", () => {
 		// but second malformed URL should return 307 as it matches and then redirects
 		const response2 = await handleRequest(
 			new Request("https://example.com/%A0%A0"),
+			// @ts-expect-error Empty config default to using mocked jaeger
+			{},
 			configuration,
 			exists,
 			getByEtag

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -27,3 +27,40 @@ export interface UnsafePerformanceTimer {
 	readonly timeOrigin: number;
 	now: () => number;
 }
+
+export interface JaegerTracing {
+	enterSpan<T extends unknown[], R = void>(
+		name: string,
+		span: (s: Span, ...args: T) => R,
+		...args: T
+	): R;
+	getSpanContext(): SpanContext | null;
+	runWithSpanContext<T extends unknown[]>(
+		spanContext: SpanContext | null,
+		callback: (...args: T) => unknown,
+		...args: T
+	): unknown;
+
+	readonly traceId: string | null;
+	readonly spanId: string | null;
+	readonly parentSpanId: string | null;
+	readonly cfTraceIdHeader: string | null;
+}
+
+export interface Span {
+	addLogs(logs: JaegerRecord): void;
+	setTags(tags: JaegerRecord): void;
+	end(): void;
+
+	isRecording: boolean;
+}
+
+export interface SpanContext {
+	traceId: string;
+	spanId: string;
+	parentSpanId: string;
+	traceFlags: number;
+}
+
+export type JaegerValue = string | number | boolean;
+export type JaegerRecord = Record<string, JaegerValue>;


### PR DESCRIPTION
This commit adds Jaeger tracing to asset-worker, in order for us to be able to have better insight into failures from KV.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: n/a

