### PR TITLE
On KV 404, re-insert with 60s TTL to avoid long 404 cache HITs

### DIFF
--- a/.changeset/lovely-years-wash.md
+++ b/.changeset/lovely-years-wash.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+fix: on a 404 from KV, we do not want the asset to stay in cache for the normal 1 year TTL. Instead we want to re-insert with a 60s TTL to revalidate and prevent a bad 404 from persisting.

--- a/packages/workers-shared/asset-worker/src/utils/kv.ts
+++ b/packages/workers-shared/asset-worker/src/utils/kv.ts
@@ -1,3 +1,5 @@
+import type { Toucan } from "toucan-js";
+
 export type AssetMetadata = {
 	contentType: string;
 };
@@ -5,16 +7,40 @@ export type AssetMetadata = {
 export async function getAssetWithMetadataFromKV(
 	assetsKVNamespace: KVNamespace,
 	assetKey: string,
+	sentry?: Toucan,
 	retries = 1
 ) {
 	let attempts = 0;
 
 	while (attempts <= retries) {
 		try {
-			return await assetsKVNamespace.getWithMetadata<AssetMetadata>(assetKey, {
-				type: "stream",
-				cacheTtl: 31536000, // 1 year
-			});
+			const asset = await assetsKVNamespace.getWithMetadata<AssetMetadata>(
+				assetKey,
+				{
+					type: "stream",
+					cacheTtl: 31536000, // 1 year
+				}
+			);
+
+			if (asset.value === null) {
+				// Don't cache a 404 for a year by re-requesting with a minimum cacheTtl
+				const retriedAsset =
+					await assetsKVNamespace.getWithMetadata<AssetMetadata>(assetKey, {
+						type: "stream",
+						cacheTtl: 60, // Minimum value allowed
+					});
+
+				if (retriedAsset.value !== null && sentry) {
+					sentry.captureException(
+						new Error(
+							`Initial request for asset ${assetKey} failed, but subsequent request succeeded.`
+						)
+					);
+				}
+
+				return retriedAsset;
+			}
+			return asset;
 		} catch (err) {
 			if (attempts >= retries) {
 				throw new Error(


### PR DESCRIPTION
Fixes N/A

On a 404 from KV, we do not want the asset to stay in cache for the normal 1 year TTL. Instead we want to re-insert with a 30s TTL to revalidate and prevent a bad 404 from persisting.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not needed here
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only
