### PR TITLE
Refactor pipelines commands into separate files, rename some options

### DIFF
--- a/.changeset/plenty-birds-melt.md
+++ b/.changeset/plenty-birds-melt.md
@@ -2,7 +2,7 @@
 "wrangler": patch
 ---
 
-Adds the following new option for `create` and `update` commands:
+Adds the following new option for `wrangler pipelines create` and `wrangler pipelines update` commands:
 
 ```
 --cors-origins           CORS origin allowlist for HTTP endpoint (use * for any origin)  [array]

--- a/.changeset/plenty-birds-melt.md
+++ b/.changeset/plenty-birds-melt.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Adds the following new option for `create` and `update` commands:
+
+```
+--cors-origins           CORS origin allowlist for HTTP endpoint (use * for any origin)  [array]
+```

--- a/.changeset/short-kids-hunt.md
+++ b/.changeset/short-kids-hunt.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
 Rename wrangler pipelines <create|update> flags

--- a/.changeset/short-kids-hunt.md
+++ b/.changeset/short-kids-hunt.md
@@ -1,0 +1,26 @@
+---
+"wrangler": minor
+---
+
+Rename wrangler pipelines <create|update> flags, add `--cors-origins` flag
+
+The following parameters have been renamed:
+
+| Previous Name     | New Name              |
+| ----------------- | --------------------- |
+| access-key-id     | r2-access-key-id      |
+| secret-access-key | r2-secret-access-key  |
+| transform         | transform-worker      |
+| r2                | r2-bucket             |
+| prefix            | r2-prefix             |
+| binding           | enable-worker-binding |
+| http              | enable-http           |
+| authentication    | require-http-auth     |
+| filename          | file-template         |
+| filepath          | partition-template    |
+
+Adds the following new option for `create` and `update` commands:
+
+```
+--cors-origins           CORS origin allowlist for HTTP endpoint (use * for any origin)  [array]
+```

--- a/.changeset/short-kids-hunt.md
+++ b/.changeset/short-kids-hunt.md
@@ -2,7 +2,7 @@
 "wrangler": minor
 ---
 
-Rename wrangler pipelines <create|update> flags, add `--cors-origins` flag
+Rename wrangler pipelines <create|update> flags
 
 The following parameters have been renamed:
 
@@ -18,9 +18,3 @@ The following parameters have been renamed:
 | authentication    | require-http-auth     |
 | filename          | file-template         |
 | filepath          | partition-template    |
-
-Adds the following new option for `create` and `update` commands:
-
-```
---cors-origins           CORS origin allowlist for HTTP endpoint (use * for any origin)  [array]
-```

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -256,11 +256,11 @@ describe("pipelines", () => {
 			"wrangler pipelines
 
 			COMMANDS
-			  wrangler pipelines create <pipeline>  Create a new pipeline
-			  wrangler pipelines list               List current pipelines
-			  wrangler pipelines show <pipeline>    Show a pipeline configuration
-			  wrangler pipelines update <pipeline>  Update a pipeline
-			  wrangler pipelines delete <pipeline>  Delete a pipeline
+			  wrangler pipelines create <pipeline>  Create a new Pipeline
+			  wrangler pipelines list               List current Pipelines
+			  wrangler pipelines show <pipeline>    Show a Pipeline configuration
+			  wrangler pipelines update <pipeline>  Update a Pipeline
+			  wrangler pipelines delete <pipeline>  Delete a Pipeline
 
 			GLOBAL FLAGS
 			  -c, --config   Path to Wrangler configuration file  [string]
@@ -279,7 +279,7 @@ describe("pipelines", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"wrangler pipelines create <pipeline>
 
-				Create a new pipeline
+				Create a new Pipeline
 
 				POSITIONALS
 				  pipeline  The name of the new pipeline  [string] [required]
@@ -296,7 +296,7 @@ describe("pipelines", () => {
 				      --batch-max-seconds  Maximum age of batch in seconds before flushing  [number]
 
 				Transformations:
-				      --transform-worker  PipelineTransform worker and entrypoint (<worker>.<entrypoint>)  [string]
+				      --transform-worker  Pipeline transform Worker and entrypoint (<worker>.<entrypoint>)  [string]
 
 				Destination settings:
 				      --r2-bucket             Destination R2 bucket name  [string] [required]
@@ -322,9 +322,9 @@ describe("pipelines", () => {
 			);
 			expect(requests.count).toEqual(1);
 			expect(std.out).toMatchInlineSnapshot(`
-				"🌀 Creating pipeline named \\"my-pipeline\\"
-				✅ Successfully created pipeline \\"my-pipeline\\" with id 0001
-				🎉 You can now send data to your pipeline!
+				"🌀 Creating Pipeline named \\"my-pipeline\\"
+				✅ Successfully created Pipeline \\"my-pipeline\\" with id 0001
+				🎉 You can now send data to your Pipeline!
 
 				To start interacting with this Pipeline from a Worker, open your Worker’s config file and add the following binding configuration:
 
@@ -337,7 +337,7 @@ describe("pipelines", () => {
 				  ]
 				}
 
-				Send data to your pipelines HTTP endpoint:
+				Send data to your Pipeline's HTTP endpoint:
 
 					curl \\"foo\\" -d '[{\\"foo\\": \\"bar\\"}]'
 				"
@@ -414,7 +414,7 @@ describe("pipelines", () => {
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
-				"Retrieving config for pipeline \\"foo\\".
+				"Retrieving config for Pipeline \\"foo\\".
 				{
 				  \\"id\\": \\"0001\\",
 				  \\"version\\": 1,
@@ -462,7 +462,7 @@ describe("pipelines", () => {
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-				"Retrieving config for pipeline \\"bad-pipeline\\".
+				"Retrieving config for Pipeline \\"bad-pipeline\\".
 				X [ERROR] A request to the Cloudflare API (/accounts/some-account-id/pipelines/bad-pipeline) failed.
 				  Pipeline does not exist [code: 1000]
 				  If you think this is a bug, please open an issue at:
@@ -608,8 +608,8 @@ describe("pipelines", () => {
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
-				"Deleting pipeline foo.
-				Deleted pipeline foo."
+				"Deleting Pipeline foo.
+				Deleted Pipeline foo."
 			`);
 			expect(requests.count).toEqual(1);
 		});
@@ -627,7 +627,7 @@ describe("pipelines", () => {
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
-				"Deleting pipeline bad-pipeline.
+				"Deleting Pipeline bad-pipeline.
 				X [ERROR] A request to the Cloudflare API (/accounts/some-account-id/pipelines/bad-pipeline) failed.
 				  Pipeline does not exist [code: 1000]
 				  If you think this is a bug, please open an issue at:

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -551,6 +551,32 @@ describe("pipelines", () => {
 			);
 		});
 
+		it("should update a pipeline cors headers", async () => {
+			const pipeline: Pipeline = samplePipeline;
+			mockShowRequest(pipeline.name, pipeline);
+
+			const update = JSON.parse(JSON.stringify(pipeline));
+			update.source = [
+				{
+					type: "http",
+					format: "json",
+					authenticated: true,
+				},
+			];
+			const updateReq = mockUpdateRequest(update.name, update);
+
+			await runWrangler(
+				"pipelines update my-pipeline --enable-worker-binding=false --enable-http --cors-origins http://localhost:8787"
+			);
+
+			expect(updateReq.count).toEqual(1);
+			expect(updateReq.body?.source.length).toEqual(1);
+			expect(updateReq.body?.source[0].type).toEqual("http");
+			expect((updateReq.body?.source[0] as HttpSource).cors?.origins).toEqual([
+				"http://localhost:8787",
+			]);
+		});
+
 		it("should fail a missing pipeline", async () => {
 			const requests = mockShowRequest("bad-pipeline", null, 404, {
 				code: 1000,

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -304,8 +304,8 @@ describe("pipelines", () => {
 				      --r2-secret-access-key  R2 service Secret Access Key for authentication. Leave empty for OAuth confirmation.  [string]
 				      --r2-prefix             Prefix for storing files in the destination bucket  [string] [default: \\"\\"]
 				      --compression           Compression format for output files  [string] [choices: \\"none\\", \\"gzip\\", \\"deflate\\"] [default: \\"gzip\\"]
-				      --file-template         Template for individual file names (must include \${slug})  [string] [default: \\"\${slug}\${extension}\\"]
-				      --partition-template    Path template for partitioned files in the bucket  [string] [default: \\"event_date=\${date}/hr=\${hr}\\"]
+				      --file-template         Template for individual file names (must include \${slug})  [string]
+				      --partition-template    Path template for partitioned files in the bucket. If not specified, the default will be used  [string]
 
 				GLOBAL FLAGS
 				  -c, --config   Path to Wrangler configuration file  [string]

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -284,21 +284,21 @@ describe("pipelines", () => {
 				POSITIONALS
 				  pipeline  The name of the new pipeline  [string] [required]
 
-				Source settings:
+				Source settings
 				      --enable-worker-binding  Send data from a Worker to a Pipeline using a Binding  [boolean] [default: true]
 				      --enable-http            Generate an endpoint to ingest data via HTTP  [boolean] [default: true]
 				      --require-http-auth      Require Cloudflare API Token for HTTPS endpoint authentication  [boolean] [default: false]
 				      --cors-origins           CORS origin allowlist for HTTP endpoint (use * for any origin)  [array]
 
-				Batch hints:
+				Batch hints
 				      --batch-max-mb       Maximum batch size in megabytes before flushing  [number]
 				      --batch-max-rows     Maximum number of rows per batch before flushing  [number]
 				      --batch-max-seconds  Maximum age of batch in seconds before flushing  [number]
 
-				Transformations:
+				Transformations
 				      --transform-worker  Pipeline transform Worker and entrypoint (<worker>.<entrypoint>)  [string]
 
-				Destination settings:
+				Destination settings
 				      --r2-bucket             Destination R2 bucket name  [string] [required]
 				      --r2-access-key-id      R2 service Access Key ID for authentication. Leave empty for OAuth confirmation.  [string]
 				      --r2-secret-access-key  R2 service Secret Access Key for authentication. Leave empty for OAuth confirmation.  [string]

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
 import { normalizeOutput } from "../../e2e/helpers/normalize";
 import { __testSkipDelays } from "../pipelines";
 import { endEventLoop } from "./helpers/end-event-loop";
@@ -320,6 +321,27 @@ describe("pipelines", () => {
 				"pipelines create my-pipeline --r2-bucket test-bucket --r2-access-key-id my-key --r2-secret-access-key my-secret"
 			);
 			expect(requests.count).toEqual(1);
+			expect(std.out).toMatchInlineSnapshot(`
+				"🌀 Creating pipeline named \\"my-pipeline\\"
+				✅ Successfully created pipeline \\"my-pipeline\\" with id 0001
+				🎉 You can now send data to your pipeline!
+
+				To start interacting with this Pipeline from a Worker, open your Worker’s config file and add the following binding configuration:
+
+				{
+				  \\"pipelines\\": [
+				    {
+				      \\"pipeline\\": \\"my-pipeline\\",
+				      \\"binding\\": \\"PIPELINE\\"
+				    }
+				  ]
+				}
+
+				Send data to your pipelines HTTP endpoint:
+
+					curl \\"foo\\" -d '[{\\"foo\\": \\"bar\\"}]'
+				"
+			`);
 		});
 
 		it("should fail a missing bucket", async () => {

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -1,7 +1,7 @@
+import chalk from "chalk";
 import { formatConfigSnippet, readConfig } from "../../config";
 import { FatalError, UserError } from "../../errors";
 import { logger } from "../../logger";
-import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
 import { getValidBindingName } from "../../utils/getValidBindingName";
 import { printWranglerBanner } from "../../wrangler-banner";
@@ -136,7 +136,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 					(argv["r2-access-key-id"] && !argv["r2-secret-access-key"]) ||
 					(!argv["r2-access-key-id"] && argv["r2-secret-access-key"])
 				) {
-					throw new Error(
+					throw new UserError(
 						"--r2-access-key-id and --r2-secret-access-key must be provided together"
 					);
 				}
@@ -167,7 +167,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 				demandOption: false,
 				coerce: (val) => {
 					if (!val.includes("${slug}")) {
-						throw new Error("filename must contain ${slug}");
+						throw new UserError("filename must contain ${slug}");
 					}
 					return val;
 				},
@@ -283,9 +283,6 @@ export async function createPipelineHandler(
 
 	logger.log(`🌀 Creating Pipeline named "${name}"`);
 	const pipeline = await createPipeline(accountId, pipelineConfig);
-	metrics.sendMetricsEvent("create pipeline", {
-		sendMetrics: config.send_metrics,
-	});
 
 	logger.log(
 		`✅ Successfully created Pipeline "${pipeline.name}" with id ${pipeline.id}`

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -158,7 +158,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			.option("partition-template", {
 				type: "string",
 				describe: "Path template for partitioned files in the bucket",
-				default: "event_date=${date}/hr=${hr}",
+				default: "event_date=${date}/hr=${hour}",
 				demandOption: false,
 			})
 			.option("file-template", {

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -36,7 +36,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 					"require-http-auth",
 					"cors-origins",
 				],
-				"Source settings:"
+				`${chalk.bold("Source settings")}`
 			)
 			.option("enable-worker-binding", {
 				type: "boolean",
@@ -68,7 +68,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			// Batching
 			.group(
 				["batch-max-mb", "batch-max-rows", "batch-max-seconds"],
-				"Batch hints:"
+				`${chalk.bold("Batch hints")}`
 			)
 			.option("batch-max-mb", {
 				type: "number",
@@ -90,7 +90,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			})
 
 			// Transform options
-			.group(["transform-worker"], "Transformations:")
+			.group(["transform-worker"], `${chalk.bold("Transformations")}`)
 			.option("transform-worker", {
 				type: "string",
 				describe:
@@ -109,7 +109,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 					"file-template",
 					"partition-template",
 				],
-				"Destination settings:"
+				`${chalk.bold("Destination settings")}`
 			)
 			.option("r2-bucket", {
 				type: "string",

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -1,0 +1,321 @@
+import dedent from "ts-dedent";
+import { formatConfigSnippet, readConfig } from "../../config";
+import { FatalError, UserError } from "../../errors";
+import { logger } from "../../logger";
+import * as metrics from "../../metrics";
+import { requireAuth } from "../../user";
+import { getValidBindingName } from "../../utils/getValidBindingName";
+import { printWranglerBanner } from "../../wrangler-banner";
+import { createPipeline } from "../client";
+import {
+	authorizeR2Bucket,
+	BYTES_PER_MB,
+	getAccountR2Endpoint,
+	parseTransform,
+} from "../index";
+import { validateCorsOrigins, validateInRange } from "../validate";
+import type {
+	CommonYargsOptions,
+	StrictYargsOptionsToInterface,
+} from "../../yargs-types";
+import type { BindingSource, HttpSource, PipelineUserConfig } from "../client";
+import type { Argv } from "yargs";
+
+export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
+	return (
+		yargs
+			.positional("pipeline", {
+				describe: "The name of the new pipeline",
+				type: "string",
+				demandOption: true,
+			})
+			// Sources
+			.group(
+				[
+					"enable-worker-binding",
+					"enable-http",
+					"require-http-auth",
+					"cors-origins",
+				],
+				"Source settings:"
+			)
+			.option("enable-worker-binding", {
+				type: "boolean",
+				describe: "Send data from a Worker to a Pipeline using a Binding",
+				default: true,
+				demandOption: false,
+			})
+			.option("enable-http", {
+				type: "boolean",
+				describe: "Generate an endpoint to ingest data via HTTP",
+				default: true,
+				demandOption: false,
+			})
+			.option("require-http-auth", {
+				type: "boolean",
+				describe:
+					"Require Cloudflare API Token for HTTPS endpoint authentication",
+				default: false,
+				demandOption: false,
+			})
+			.option("cors-origins", {
+				type: "array",
+				describe:
+					"CORS origin allowlist for HTTP endpoint (use * for any origin)",
+				demandOption: false,
+				coerce: validateCorsOrigins,
+			})
+
+			// Batching
+			.group(
+				["batch-max-mb", "batch-max-rows", "batch-max-seconds"],
+				"Batch hints:"
+			)
+			.option("batch-max-mb", {
+				type: "number",
+				describe: "Maximum batch size in megabytes before flushing",
+				demandOption: false,
+				coerce: validateInRange("batch-max-mb", 1, 100),
+			})
+			.option("batch-max-rows", {
+				type: "number",
+				describe: "Maximum number of rows per batch before flushing",
+				demandOption: false,
+				coerce: validateInRange("batch-max-rows", 100, 1000000),
+			})
+			.option("batch-max-seconds", {
+				type: "number",
+				describe: "Maximum age of batch in seconds before flushing",
+				demandOption: false,
+				coerce: validateInRange("batch-max-seconds", 1, 300),
+			})
+
+			// Transform options
+			.group(["transform-worker"], "Transformations:")
+			.option("transform-worker", {
+				type: "string",
+				describe:
+					"PipelineTransform worker and entrypoint (<worker>.<entrypoint>)",
+				demandOption: false,
+			})
+
+			// Destination options
+			.group(
+				[
+					"r2-bucket",
+					"r2-access-key-id",
+					"r2-secret-access-key",
+					"r2-prefix",
+					"compression",
+					"file-template",
+					"partition-template",
+				],
+				"Destination settings:"
+			)
+			.option("r2-bucket", {
+				type: "string",
+				describe: "Destination R2 bucket name",
+				demandOption: true,
+			})
+			.option("r2-access-key-id", {
+				type: "string",
+				describe:
+					"R2 service Access Key ID for authentication. Leave empty for OAuth confirmation.",
+				demandOption: false,
+			})
+			.option("r2-secret-access-key", {
+				type: "string",
+				describe:
+					"R2 service Secret Access Key for authentication. Leave empty for OAuth confirmation.",
+				demandOption: false,
+			})
+			// Require these flags to be provided together
+			.implies("r2-access-key-id", "r2-secret-access-key")
+			.implies("r2-secret-access-key", "r2-access-key-id")
+			.check((argv) => {
+				if (
+					(argv["r2-access-key-id"] && !argv["r2-secret-access-key"]) ||
+					(!argv["r2-access-key-id"] && argv["r2-secret-access-key"])
+				) {
+					throw new Error(
+						"--r2-access-key-id and --r2-secret-access-key must be provided together"
+					);
+				}
+				return true;
+			})
+			.option("r2-prefix", {
+				type: "string",
+				describe: "Prefix for storing files in the destination bucket",
+				default: "",
+				demandOption: false,
+			})
+			.option("compression", {
+				type: "string",
+				describe: "Compression format for output files",
+				choices: ["none", "gzip", "deflate"],
+				default: "gzip",
+				demandOption: false,
+			})
+			.option("partition-template", {
+				type: "string",
+				describe: "Path template for partitioned files in the bucket",
+				default: "event_date=${date}/hr=${hr}",
+				demandOption: false,
+			})
+			.option("file-template", {
+				type: "string",
+				describe: "Template for individual file names (must include ${slug})",
+				default: "${slug}${extension}",
+				demandOption: false,
+				coerce: (val: string) => {
+					if (!val.includes("${slug}")) {
+						throw new Error("filename must contain ${slug}");
+					}
+					return val;
+				},
+			})
+	);
+}
+
+export async function createPipelineHandler(
+	args: StrictYargsOptionsToInterface<typeof addCreateOptions>
+) {
+	await printWranglerBanner();
+
+	const config = readConfig(args);
+	const bucket = args.r2Bucket;
+	const name = args.pipeline;
+	const compression = args.compression;
+
+	const batch = {
+		max_bytes: args.batchMaxMb
+			? args.batchMaxMb * BYTES_PER_MB // convert to bytes for the API
+			: undefined,
+		max_duration_s: args.batchMaxSeconds,
+		max_rows: args.batchMaxRows,
+	};
+
+	const accountId = await requireAuth(config);
+	const pipelineConfig: PipelineUserConfig = {
+		name: name,
+		metadata: {},
+		source: [],
+		transforms: [],
+		destination: {
+			type: "r2",
+			format: "json",
+			compression: {
+				type: compression,
+			},
+			batch: batch,
+			path: {
+				bucket: bucket,
+			},
+			credentials: {
+				endpoint: getAccountR2Endpoint(accountId),
+				access_key_id: args.r2AccessKeyId || "",
+				secret_access_key: args.r2SecretAccessKey || "",
+			},
+		},
+	};
+	const destination = pipelineConfig.destination;
+	if (
+		!destination.credentials.access_key_id &&
+		!destination.credentials.secret_access_key
+	) {
+		// auto-generate a service token
+		const auth = await authorizeR2Bucket(
+			name,
+			accountId,
+			pipelineConfig.destination.path.bucket
+		);
+		destination.credentials.access_key_id = auth.accessKeyId;
+		destination.credentials.secret_access_key = auth.secretAccessKey;
+	}
+
+	if (!destination.credentials.access_key_id) {
+		throw new FatalError("Requires a r2 access key id");
+	}
+
+	if (!destination.credentials.secret_access_key) {
+		throw new FatalError("Requires a r2 secret access key");
+	}
+
+	// add binding source (default to add)
+	if (args.enableWorkerBinding) {
+		pipelineConfig.source.push({
+			type: "binding",
+			format: "json",
+		} satisfies BindingSource);
+	}
+
+	// add http source (possibly authenticated), default to add
+	if (args.enableHttp) {
+		const source: HttpSource = {
+			type: "http",
+			format: "json",
+			authentication: args.requireHttpAuth,
+		};
+
+		if (args.corsOrigins && args.corsOrigins.length > 0) {
+			source.cors = { origins: args.corsOrigins };
+		}
+		pipelineConfig.source.push(source);
+	}
+
+	if (pipelineConfig.source.length === 0) {
+		throw new UserError(
+			"No sources have been enabled. At least one source (HTTP or Worker Binding) should be enabled"
+		);
+	}
+
+	if (args.transformWorker) {
+		pipelineConfig.transforms.push(parseTransform(args.transformWorker));
+	}
+
+	if (args.r2Prefix) {
+		pipelineConfig.destination.path.prefix = args.r2Prefix;
+	}
+	if (args.partitionTemplate) {
+		pipelineConfig.destination.path.filepath = args.partitionTemplate;
+	}
+	if (args.fileTemplate) {
+		pipelineConfig.destination.path.filename = args.fileTemplate;
+	}
+
+	logger.log(`🌀 Creating pipeline named "${name}"`);
+	const pipeline = await createPipeline(accountId, pipelineConfig);
+	metrics.sendMetricsEvent("create pipeline", {
+		sendMetrics: config.send_metrics,
+	});
+
+	logger.log(
+		`✅ Successfully created pipeline "${pipeline.name}" with id ${pipeline.id}`
+	);
+	logger.log("🎉 You can now send data to your pipeline!");
+	if (args.enableWorkerBinding) {
+		logger.log(dedent`
+		
+			To start interacting with this Pipeline from a Worker, open your Worker’s config file and add the following binding configuration:
+	
+			${formatConfigSnippet(
+				{
+					pipelines: [
+						{
+							pipeline: pipeline.name,
+							binding: getValidBindingName("PIPELINE", "PIPELINE"),
+						},
+					],
+				},
+				config.configPath
+			)}
+		`);
+	}
+	if (args.enableHttp) {
+		logger.log(dedent`
+			Send data to your pipelines HTTP endpoint:
+					
+				curl "${pipeline.endpoint}" -d '[{"foo": "bar"}]'
+		`);
+	}
+}

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -157,16 +157,15 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			})
 			.option("partition-template", {
 				type: "string",
-				describe: "Path template for partitioned files in the bucket",
-				default: "event_date=${date}/hr=${hour}",
+				describe:
+					"Path template for partitioned files in the bucket. If not specified, the default will be used",
 				demandOption: false,
 			})
 			.option("file-template", {
 				type: "string",
 				describe: "Template for individual file names (must include ${slug})",
-				default: "${slug}${extension}",
 				demandOption: false,
-				coerce: (val: string) => {
+				coerce: (val) => {
 					if (!val.includes("${slug}")) {
 						throw new Error("filename must contain ${slug}");
 					}

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -1,4 +1,3 @@
-import dedent from "ts-dedent";
 import { formatConfigSnippet, readConfig } from "../../config";
 import { FatalError, UserError } from "../../errors";
 import { logger } from "../../logger";
@@ -294,11 +293,11 @@ export async function createPipelineHandler(
 	);
 	logger.log("🎉 You can now send data to your pipeline!");
 	if (args.enableWorkerBinding) {
-		logger.log(dedent`
-		
-			To start interacting with this Pipeline from a Worker, open your Worker’s config file and add the following binding configuration:
-	
-			${formatConfigSnippet(
+		logger.log(
+			`\nTo start interacting with this Pipeline from a Worker, open your Worker’s config file and add the following binding configuration:\n`
+		);
+		logger.log(
+			formatConfigSnippet(
 				{
 					pipelines: [
 						{
@@ -308,14 +307,11 @@ export async function createPipelineHandler(
 					],
 				},
 				config.configPath
-			)}
-		`);
+			)
+		);
 	}
 	if (args.enableHttp) {
-		logger.log(dedent`
-			Send data to your pipelines HTTP endpoint:
-					
-				curl "${pipeline.endpoint}" -d '[{"foo": "bar"}]'
-		`);
+		logger.log(`\nSend data to your pipelines HTTP endpoint:\n`);
+		logger.log(`	curl "${pipeline.endpoint}" -d '[{"foo": "bar"}]'\n`);
 	}
 }

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -94,7 +94,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			.option("transform-worker", {
 				type: "string",
 				describe:
-					"PipelineTransform worker and entrypoint (<worker>.<entrypoint>)",
+					"Pipeline transform Worker and entrypoint (<worker>.<entrypoint>)",
 				demandOption: false,
 			})
 
@@ -281,16 +281,16 @@ export async function createPipelineHandler(
 		pipelineConfig.destination.path.filename = args.fileTemplate;
 	}
 
-	logger.log(`🌀 Creating pipeline named "${name}"`);
+	logger.log(`🌀 Creating Pipeline named "${name}"`);
 	const pipeline = await createPipeline(accountId, pipelineConfig);
 	metrics.sendMetricsEvent("create pipeline", {
 		sendMetrics: config.send_metrics,
 	});
 
 	logger.log(
-		`✅ Successfully created pipeline "${pipeline.name}" with id ${pipeline.id}`
+		`✅ Successfully created Pipeline "${pipeline.name}" with id ${pipeline.id}`
 	);
-	logger.log("🎉 You can now send data to your pipeline!");
+	logger.log("🎉 You can now send data to your Pipeline!");
 	if (args.enableWorkerBinding) {
 		logger.log(
 			`\nTo start interacting with this Pipeline from a Worker, open your Worker’s config file and add the following binding configuration:\n`
@@ -310,7 +310,7 @@ export async function createPipelineHandler(
 		);
 	}
 	if (args.enableHttp) {
-		logger.log(`\nSend data to your pipelines HTTP endpoint:\n`);
+		logger.log(`\nSend data to your Pipeline's HTTP endpoint:\n`);
 		logger.log(`	curl "${pipeline.endpoint}" -d '[{"foo": "bar"}]'\n`);
 	}
 }

--- a/packages/wrangler/src/pipelines/cli/delete.ts
+++ b/packages/wrangler/src/pipelines/cli/delete.ts
@@ -1,0 +1,38 @@
+import { readConfig } from "../../config";
+import { logger } from "../../logger";
+import * as metrics from "../../metrics";
+import { requireAuth } from "../../user";
+import { printWranglerBanner } from "../../wrangler-banner";
+import { deletePipeline } from "../client";
+import { validateName } from "../validate";
+import type {
+	CommonYargsOptions,
+	StrictYargsOptionsToInterface,
+} from "../../yargs-types";
+import type { Argv } from "yargs";
+
+export function addDeleteOptions(yargs: Argv<CommonYargsOptions>) {
+	return yargs.positional("pipeline", {
+		type: "string",
+		describe: "The name of the pipeline to show",
+		demandOption: true,
+	});
+}
+
+export async function deletePipelineHandler(
+	args: StrictYargsOptionsToInterface<typeof addDeleteOptions>
+) {
+	await printWranglerBanner();
+	const config = readConfig(args);
+	const accountId = await requireAuth(config);
+	const name = args.pipeline;
+
+	validateName("pipeline name", name);
+
+	logger.log(`Deleting pipeline ${name}.`);
+	await deletePipeline(accountId, name);
+	logger.log(`Deleted pipeline ${name}.`);
+	metrics.sendMetricsEvent("delete pipeline", {
+		sendMetrics: config.send_metrics,
+	});
+}

--- a/packages/wrangler/src/pipelines/cli/delete.ts
+++ b/packages/wrangler/src/pipelines/cli/delete.ts
@@ -14,7 +14,7 @@ import type { Argv } from "yargs";
 export function addDeleteOptions(yargs: Argv<CommonYargsOptions>) {
 	return yargs.positional("pipeline", {
 		type: "string",
-		describe: "The name of the pipeline to show",
+		describe: "The name of the Pipeline to show",
 		demandOption: true,
 	});
 }
@@ -29,9 +29,9 @@ export async function deletePipelineHandler(
 
 	validateName("pipeline name", name);
 
-	logger.log(`Deleting pipeline ${name}.`);
+	logger.log(`Deleting Pipeline ${name}.`);
 	await deletePipeline(accountId, name);
-	logger.log(`Deleted pipeline ${name}.`);
+	logger.log(`Deleted Pipeline ${name}.`);
 	metrics.sendMetricsEvent("delete pipeline", {
 		sendMetrics: config.send_metrics,
 	});

--- a/packages/wrangler/src/pipelines/cli/delete.ts
+++ b/packages/wrangler/src/pipelines/cli/delete.ts
@@ -1,6 +1,5 @@
 import { readConfig } from "../../config";
 import { logger } from "../../logger";
-import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
 import { printWranglerBanner } from "../../wrangler-banner";
 import { deletePipeline } from "../client";
@@ -31,8 +30,6 @@ export async function deletePipelineHandler(
 
 	logger.log(`Deleting Pipeline ${name}.`);
 	await deletePipeline(accountId, name);
+
 	logger.log(`Deleted Pipeline ${name}.`);
-	metrics.sendMetricsEvent("delete pipeline", {
-		sendMetrics: config.send_metrics,
-	});
 }

--- a/packages/wrangler/src/pipelines/cli/list.ts
+++ b/packages/wrangler/src/pipelines/cli/list.ts
@@ -1,0 +1,28 @@
+import { readConfig } from "../../config";
+import { logger } from "../../logger";
+import * as metrics from "../../metrics";
+import { requireAuth } from "../../user";
+import { listPipelines } from "../client";
+import type { CommonYargsOptions } from "../../yargs-types";
+import type { ArgumentsCamelCase } from "yargs";
+
+export async function listPipelinesHandler(
+	args: ArgumentsCamelCase<CommonYargsOptions>
+) {
+	const config = readConfig(args);
+	const accountId = await requireAuth(config);
+
+	// TODO: we should show bindings & transforms if they exist for given ids
+	const list = await listPipelines(accountId);
+	metrics.sendMetricsEvent("list pipelines", {
+		sendMetrics: config.send_metrics,
+	});
+
+	logger.table(
+		list.map((pipeline) => ({
+			name: pipeline.name,
+			id: pipeline.id,
+			endpoint: pipeline.endpoint,
+		}))
+	);
+}

--- a/packages/wrangler/src/pipelines/cli/list.ts
+++ b/packages/wrangler/src/pipelines/cli/list.ts
@@ -1,6 +1,5 @@
 import { readConfig } from "../../config";
 import { logger } from "../../logger";
-import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
 import { printWranglerBanner } from "../../wrangler-banner";
 import { listPipelines } from "../client";
@@ -16,9 +15,6 @@ export async function listPipelinesHandler(
 
 	// TODO: we should show bindings & transforms if they exist for given ids
 	const list = await listPipelines(accountId);
-	metrics.sendMetricsEvent("list pipelines", {
-		sendMetrics: config.send_metrics,
-	});
 
 	logger.table(
 		list.map((pipeline) => ({

--- a/packages/wrangler/src/pipelines/cli/list.ts
+++ b/packages/wrangler/src/pipelines/cli/list.ts
@@ -2,6 +2,7 @@ import { readConfig } from "../../config";
 import { logger } from "../../logger";
 import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
+import { printWranglerBanner } from "../../wrangler-banner";
 import { listPipelines } from "../client";
 import type { CommonYargsOptions } from "../../yargs-types";
 import type { ArgumentsCamelCase } from "yargs";
@@ -9,6 +10,7 @@ import type { ArgumentsCamelCase } from "yargs";
 export async function listPipelinesHandler(
 	args: ArgumentsCamelCase<CommonYargsOptions>
 ) {
+	await printWranglerBanner();
 	const config = readConfig(args);
 	const accountId = await requireAuth(config);
 

--- a/packages/wrangler/src/pipelines/cli/show.ts
+++ b/packages/wrangler/src/pipelines/cli/show.ts
@@ -1,6 +1,5 @@
 import { readConfig } from "../../config";
 import { logger } from "../../logger";
-import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
 import { printWranglerBanner } from "../../wrangler-banner";
 import { getPipeline } from "../client";
@@ -31,9 +30,6 @@ export async function showPipelineHandler(
 
 	logger.log(`Retrieving config for Pipeline "${name}".`);
 	const pipeline = await getPipeline(accountId, name);
-	metrics.sendMetricsEvent("show pipeline", {
-		sendMetrics: config.send_metrics,
-	});
 
 	logger.log(JSON.stringify(pipeline, null, 2));
 }

--- a/packages/wrangler/src/pipelines/cli/show.ts
+++ b/packages/wrangler/src/pipelines/cli/show.ts
@@ -14,7 +14,7 @@ import type { Argv } from "yargs";
 export function addShowOptions(yargs: Argv<CommonYargsOptions>) {
 	return yargs.positional("pipeline", {
 		type: "string",
-		describe: "The name of the pipeline to show",
+		describe: "The name of the Pipeline to show",
 		demandOption: true,
 	});
 }
@@ -29,7 +29,7 @@ export async function showPipelineHandler(
 
 	validateName("pipeline name", name);
 
-	logger.log(`Retrieving config for pipeline "${name}".`);
+	logger.log(`Retrieving config for Pipeline "${name}".`);
 	const pipeline = await getPipeline(accountId, name);
 	metrics.sendMetricsEvent("show pipeline", {
 		sendMetrics: config.send_metrics,

--- a/packages/wrangler/src/pipelines/cli/show.ts
+++ b/packages/wrangler/src/pipelines/cli/show.ts
@@ -1,0 +1,39 @@
+import { readConfig } from "../../config";
+import { logger } from "../../logger";
+import * as metrics from "../../metrics";
+import { requireAuth } from "../../user";
+import { printWranglerBanner } from "../../wrangler-banner";
+import { getPipeline } from "../client";
+import { validateName } from "../validate";
+import type {
+	CommonYargsOptions,
+	StrictYargsOptionsToInterface,
+} from "../../yargs-types";
+import type { Argv } from "yargs";
+
+export function addShowOptions(yargs: Argv<CommonYargsOptions>) {
+	return yargs.positional("pipeline", {
+		type: "string",
+		describe: "The name of the pipeline to show",
+		demandOption: true,
+	});
+}
+
+export async function showPipelineHandler(
+	args: StrictYargsOptionsToInterface<typeof addShowOptions>
+) {
+	await printWranglerBanner();
+	const config = readConfig(args);
+	const accountId = await requireAuth(config);
+	const name = args.pipeline;
+
+	validateName("pipeline name", name);
+
+	logger.log(`Retrieving config for pipeline "${name}".`);
+	const pipeline = await getPipeline(accountId, name);
+	metrics.sendMetricsEvent("show pipeline", {
+		sendMetrics: config.send_metrics,
+	});
+
+	logger.log(JSON.stringify(pipeline, null, 2));
+}

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -1,0 +1,300 @@
+import { readConfig } from "../../config";
+import { FatalError } from "../../errors";
+import { logger } from "../../logger";
+import * as metrics from "../../metrics";
+import { requireAuth } from "../../user";
+import { printWranglerBanner } from "../../wrangler-banner";
+import { getPipeline, updatePipeline } from "../client";
+import {
+	authorizeR2Bucket,
+	BYTES_PER_MB,
+	getAccountR2Endpoint,
+	parseTransform,
+} from "../index";
+import { validateCorsOrigins, validateInRange } from "../validate";
+import type {
+	CommonYargsOptions,
+	StrictYargsOptionsToInterface,
+} from "../../yargs-types";
+import type { HttpSource, Source } from "../client";
+import type { Argv } from "yargs";
+
+/**
+ * Add all the positional and optional flags for the `wrangler pipelines update` command.
+ *
+ * @param yargs
+ */
+export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
+	/* These arguments are nearly identical to the option used for creating a pipeline, with some notable differences.
+		 Particularly, not all options are available for updating, and the default values have been removed. In this case, 
+		 `undefined` is used to determine if the user provided that flag at all with the intent to change the value.
+	 */
+	return (
+		yargs
+			.positional("pipeline", {
+				describe: "The name of the pipeline to update",
+				type: "string",
+				demandOption: true,
+			})
+			.option("r2-bucket", {
+				type: "string",
+				describe: "Destination R2 bucket name",
+				demandOption: false, // Not required for updates.
+			})
+			// Sources
+			.group(
+				[
+					"enable-worker-binding",
+					"enable-http",
+					"require-http-auth",
+					"cors-origins",
+				],
+				"Source settings:"
+			)
+			.option("enable-worker-binding", {
+				type: "boolean",
+				describe: "Send data from a Worker to a Pipeline using a Binding",
+				demandOption: false,
+			})
+			.option("enable-http", {
+				type: "boolean",
+				describe: "Generate an endpoint to ingest data via HTTP",
+				demandOption: false,
+			})
+			.option("require-http-auth", {
+				type: "boolean",
+				describe:
+					"Require Cloudflare API Token for HTTPS endpoint authentication",
+				demandOption: false,
+			})
+			.option("cors-origins", {
+				type: "array",
+				describe:
+					"CORS origin allowlist for HTTP endpoint (use * for any origin)",
+				demandOption: false,
+				coerce: validateCorsOrigins,
+			})
+
+			// Batching
+			.group(
+				["batch-max-mb", "batch-max-rows", "batch-max-seconds"],
+				"Batch definition:"
+			)
+			.option("batch-max-mb", {
+				type: "number",
+				describe: "Maximum batch size in megabytes before flushing",
+				demandOption: false,
+				coerce: validateInRange("batch-max-mb", 1, 100),
+			})
+			.option("batch-max-rows", {
+				type: "number",
+				describe: "Maximum number of rows per batch before flushing",
+				demandOption: false,
+				coerce: validateInRange("batch-max-rows", 100, 1000000),
+			})
+			.option("batch-max-seconds", {
+				type: "number",
+				describe: "Maximum age of batch in seconds before flushing",
+				demandOption: false,
+				coerce: validateInRange("batch-max-seconds", 1, 300),
+			})
+
+			// Transform options
+			.group(["transform-worker"], "Transformations:")
+			.option("transform-worker", {
+				type: "string",
+				describe:
+					"PipelineTransform worker and entrypoint (<worker>.<entrypoint>)",
+				default: undefined,
+				demandOption: false,
+			})
+
+			// Destination options
+			.group(
+				[
+					"r2-bucket",
+					"r2-access-key-id",
+					"r2-secret-access-key",
+					"r2-prefix",
+					"compression",
+					"file-template",
+					"partition-template",
+				],
+				"Destination settings:"
+			)
+			.option("r2-access-key-id", {
+				type: "string",
+				describe:
+					"R2 service Access Key ID for authentication. Leave empty for OAuth confirmation.",
+				demandOption: false,
+			})
+			.option("r2-secret-access-key", {
+				type: "string",
+				describe:
+					"R2 service Secret Access Key for authentication. Leave empty for OAuth confirmation.",
+				demandOption: false,
+			})
+			// Require these flags to be provided together
+			.implies("r2-access-key-id", "r2-secret-access-key")
+			.implies("r2-secret-access-key", "r2-access-key-id")
+			.check((argv) => {
+				if (
+					(argv["r2-access-key-id"] && !argv["r2-secret-access-key"]) ||
+					(!argv["r2-access-key-id"] && argv["r2-secret-access-key"])
+				) {
+					throw new Error(
+						"--r2-access-key-id and --r2-secret-access-key must be provided together"
+					);
+				}
+				return true;
+			})
+			.option("r2-prefix", {
+				type: "string",
+				describe: "Prefix for storing files in the destination bucket",
+				demandOption: false,
+			})
+			.option("compression", {
+				type: "string",
+				describe: "Compression format for output files",
+				choices: ["none", "gzip", "deflate"],
+				demandOption: false,
+			})
+			.option("partition-template", {
+				type: "string",
+				describe: "Path template for partitioned files in the bucket",
+				demandOption: false,
+			})
+			.option("file-template", {
+				type: "string",
+				describe: "Template for individual file names (must include ${slug})",
+				demandOption: false,
+				coerce: (val: string) => {
+					if (!val.includes("${slug}")) {
+						throw new Error("filename must contain ${slug}");
+					}
+					return val;
+				},
+			})
+	);
+}
+
+export async function updatePipelineHandler(
+	args: StrictYargsOptionsToInterface<typeof addUpdateOptions>
+) {
+	await printWranglerBanner();
+
+	const name = args.pipeline;
+	// only the fields set will be updated - other fields will use the existing config
+	const config = readConfig(args);
+	const accountId = await requireAuth(config);
+
+	const pipelineConfig = await getPipeline(accountId, name);
+
+	if (args.compression) {
+		pipelineConfig.destination.compression.type = args.compression;
+	}
+	if (args.batchMaxMb) {
+		pipelineConfig.destination.batch.max_bytes = args.batchMaxMb * BYTES_PER_MB; // convert to bytes for the API
+	}
+	if (args.batchMaxSeconds) {
+		pipelineConfig.destination.batch.max_duration_s = args.batchMaxSeconds;
+	}
+	if (args.batchMaxRows) {
+		pipelineConfig.destination.batch.max_rows = args.batchMaxRows;
+	}
+
+	const bucket = args.r2Bucket;
+	const accessKeyId = args.r2AccessKeyId;
+	const secretAccessKey = args.r2SecretAccessKey;
+	if (bucket || accessKeyId || secretAccessKey) {
+		const destination = pipelineConfig.destination;
+		if (bucket) {
+			pipelineConfig.destination.path.bucket = bucket;
+		}
+		destination.credentials = {
+			endpoint: getAccountR2Endpoint(accountId),
+			access_key_id: accessKeyId || "",
+			secret_access_key: secretAccessKey || "",
+		};
+		if (!accessKeyId && !secretAccessKey) {
+			const auth = await authorizeR2Bucket(
+				name,
+				accountId,
+				destination.path.bucket
+			);
+			destination.credentials.access_key_id = auth.accessKeyId;
+			destination.credentials.secret_access_key = auth.secretAccessKey;
+		}
+		if (!destination.credentials.access_key_id) {
+			throw new FatalError("Requires a r2 access key id");
+		}
+
+		if (!destination.credentials.secret_access_key) {
+			throw new FatalError("Requires a r2 secret access key");
+		}
+	}
+
+	if (args.enableWorkerBinding !== undefined) {
+		// strip off old source & keep if necessary
+		const source = pipelineConfig.source.find(
+			(s: Source) => s.type === "binding"
+		);
+		pipelineConfig.source = pipelineConfig.source.filter(
+			(s: Source) => s.type !== "binding"
+		);
+		// add back only if specified
+		if (args.enableWorkerBinding) {
+			pipelineConfig.source.push({
+				...source,
+				type: "binding",
+				format: "json",
+			});
+		}
+	}
+
+	if (args.enableHttp !== undefined) {
+		// strip off old source & keep if necessary
+		const source = pipelineConfig.source.find((s: Source) => s.type === "http");
+		pipelineConfig.source = pipelineConfig.source.filter(
+			(s: Source) => s.type !== "http"
+		);
+		// add back if specified
+		if (args.enableHttp) {
+			pipelineConfig.source.push({
+				type: "http",
+				format: "json",
+				...source,
+				authentication:
+					args.requireHttpAuth !== undefined
+						? // if auth specified, use it
+							args.requireHttpAuth
+						: // if auth not specified, use previous value or default(false)
+							source?.authentication,
+			} satisfies HttpSource);
+		}
+	}
+
+	if (args.transformWorker) {
+		pipelineConfig.transforms.push(parseTransform(args.transformWorker));
+	}
+
+	if (args.r2Prefix) {
+		pipelineConfig.destination.path.prefix = args.r2Prefix;
+	}
+	if (args.partitionTemplate) {
+		pipelineConfig.destination.path.filepath = args.partitionTemplate;
+	}
+	if (args.fileTemplate) {
+		pipelineConfig.destination.path.filename = args.fileTemplate;
+	}
+
+	logger.log(`🌀 Updating pipeline "${name}"`);
+	const pipeline = await updatePipeline(accountId, name, pipelineConfig);
+	metrics.sendMetricsEvent("update pipeline", {
+		sendMetrics: config.send_metrics,
+	});
+
+	logger.log(
+		`✅ Successfully updated pipeline "${pipeline.name}" with ID ${pipeline.id}\n`
+	);
+}

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -32,7 +32,7 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 	return (
 		yargs
 			.positional("pipeline", {
-				describe: "The name of the pipeline to update",
+				describe: "The name of the Pipeline to update",
 				type: "string",
 				demandOption: true,
 			})
@@ -104,7 +104,7 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 			.option("transform-worker", {
 				type: "string",
 				describe:
-					"PipelineTransform worker and entrypoint (<worker>.<entrypoint>)",
+					"Pipeline transform Worker and entrypoint (<worker>.<entrypoint>)",
 				demandOption: false,
 			})
 
@@ -295,13 +295,13 @@ export async function updatePipelineHandler(
 		pipelineConfig.destination.path.filename = args.fileTemplate;
 	}
 
-	logger.log(`🌀 Updating pipeline "${name}"`);
+	logger.log(`🌀 Updating Pipeline "${name}"`);
 	const pipeline = await updatePipeline(accountId, name, pipelineConfig);
 	metrics.sendMetricsEvent("update pipeline", {
 		sendMetrics: config.send_metrics,
 	});
 
 	logger.log(
-		`✅ Successfully updated pipeline "${pipeline.name}" with ID ${pipeline.id}\n`
+		`✅ Successfully updated Pipeline "${pipeline.name}" with ID ${pipeline.id}\n`
 	);
 }

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -260,17 +260,25 @@ export async function updatePipelineHandler(
 		);
 		// add back if specified
 		if (args.enableHttp) {
-			pipelineConfig.source.push({
+			const update = {
 				type: "http",
 				format: "json",
 				...source,
-				authentication:
-					args.requireHttpAuth !== undefined
-						? // if auth specified, use it
-							args.requireHttpAuth
-						: // if auth not specified, use previous value or default(false)
-							source?.authentication,
-			} satisfies HttpSource);
+			} satisfies HttpSource;
+
+			pipelineConfig.source.push(update);
+		}
+	}
+
+	const httpSource = pipelineConfig.source.find(
+		(s: Source) => s.type === "http"
+	);
+	if (httpSource) {
+		if (args.requireHttpAuth) {
+			httpSource.authentication = args.requireHttpAuth;
+		}
+		if (args.corsOrigins && args.corsOrigins.length > 0) {
+			httpSource.cors = { origins: args.corsOrigins };
 		}
 	}
 

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -1,7 +1,7 @@
+import chalk from "chalk";
 import { readConfig } from "../../config";
 import { FatalError } from "../../errors";
 import { logger } from "../../logger";
-import * as metrics from "../../metrics";
 import { requireAuth } from "../../user";
 import { printWranglerBanner } from "../../wrangler-banner";
 import { getPipeline, updatePipeline } from "../client";
@@ -49,7 +49,7 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 					"require-http-auth",
 					"cors-origins",
 				],
-				"Source settings:"
+				`${chalk.bold("Source settings")}`
 			)
 			.option("enable-worker-binding", {
 				type: "boolean",
@@ -78,7 +78,7 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 			// Batching
 			.group(
 				["batch-max-mb", "batch-max-rows", "batch-max-seconds"],
-				"Batch definition:"
+				`${chalk.bold("Batch hints")}`
 			)
 			.option("batch-max-mb", {
 				type: "number",
@@ -100,7 +100,7 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 			})
 
 			// Transform options
-			.group(["transform-worker"], "Transformations:")
+			.group(["transform-worker"], `${chalk.bold("Transformations")}`)
 			.option("transform-worker", {
 				type: "string",
 				describe:
@@ -119,7 +119,7 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 					"file-template",
 					"partition-template",
 				],
-				"Destination settings:"
+				`${chalk.bold("Destination settings")}`
 			)
 			.option("r2-access-key-id", {
 				type: "string",
@@ -297,9 +297,6 @@ export async function updatePipelineHandler(
 
 	logger.log(`🌀 Updating Pipeline "${name}"`);
 	const pipeline = await updatePipeline(accountId, name, pipelineConfig);
-	metrics.sendMetricsEvent("update pipeline", {
-		sendMetrics: config.send_metrics,
-	});
 
 	logger.log(
 		`✅ Successfully updated Pipeline "${pipeline.name}" with ID ${pipeline.id}\n`

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -105,7 +105,6 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 				type: "string",
 				describe:
 					"PipelineTransform worker and entrypoint (<worker>.<entrypoint>)",
-				default: undefined,
 				demandOption: false,
 			})
 

--- a/packages/wrangler/src/pipelines/client.ts
+++ b/packages/wrangler/src/pipelines/client.ts
@@ -99,14 +99,7 @@ export function sha256(s: string): string {
 	return createHash("sha256").update(s).digest("hex");
 }
 
-export type PermissionGroup = {
-	id: string;
-	name: string;
-	description: string;
-	scopes: string[];
-};
-
-interface S3AccessKey {
+export interface S3AccessKey {
 	accessKeyId: string;
 	secretAccessKey: string;
 }

--- a/packages/wrangler/src/pipelines/client.ts
+++ b/packages/wrangler/src/pipelines/client.ts
@@ -26,6 +26,9 @@ export type HttpSource = {
 	format: string;
 	schema?: string;
 	authentication?: boolean;
+	cors?: {
+		origins: ["*"] | string[];
+	};
 };
 export type BindingSource = {
 	type: "binding";

--- a/packages/wrangler/src/pipelines/index.ts
+++ b/packages/wrangler/src/pipelines/index.ts
@@ -1,4 +1,5 @@
 import { HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import { getCloudflareApiEnvironmentFromEnv } from "../environment-variables/misc-variables";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
 import { APIError } from "../parse";
@@ -49,7 +50,7 @@ export async function authorizeR2Bucket(
 		endpoint: getAccountR2Endpoint(accountId),
 	});
 
-	// Wait for token to settle/propagate, retry up to 10 times, with 1s waits in-between errors
+	// Wait for token to settle/propagate, retry up to 10 times, with 2s waits in-between errors
 	!__testSkipDelaysFlag &&
 		(await retryOnAPIFailure(
 			async () => {
@@ -59,7 +60,7 @@ export async function authorizeR2Bucket(
 					})
 				);
 			},
-			1000,
+			2000,
 			10
 		));
 
@@ -67,6 +68,10 @@ export async function authorizeR2Bucket(
 }
 
 export function getAccountR2Endpoint(accountId: string) {
+	const env = getCloudflareApiEnvironmentFromEnv();
+	if (env === "staging") {
+		return `https://${accountId}.r2-staging.cloudflarestorage.com`;
+	}
 	return `https://${accountId}.r2.cloudflarestorage.com`;
 }
 

--- a/packages/wrangler/src/pipelines/index.ts
+++ b/packages/wrangler/src/pipelines/index.ts
@@ -1,34 +1,22 @@
 import { HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
-import { readConfig } from "../config";
-import { FatalError, UserError } from "../errors";
+import { FatalError } from "../errors";
 import { logger } from "../logger";
-import * as metrics from "../metrics";
 import { APIError } from "../parse";
-import { requireAuth } from "../user";
 import { retryOnAPIFailure } from "../utils/retry";
-import { printWranglerBanner } from "../wrangler-banner";
-import {
-	createPipeline,
-	deletePipeline,
-	generateR2ServiceToken,
-	getPipeline,
-	getR2Bucket,
-	listPipelines,
-	updatePipeline,
-} from "./client";
-import type { CommonYargsArgv, CommonYargsOptions } from "../yargs-types";
-import type {
-	BindingSource,
-	HttpSource,
-	PipelineUserConfig,
-	Source,
-} from "./client";
-import type { Argv } from "yargs";
+import { addCreateOptions, createPipelineHandler } from "./cli/create";
+import { addDeleteOptions, deletePipelineHandler } from "./cli/delete";
+import { listPipelinesHandler } from "./cli/list";
+import { addShowOptions, showPipelineHandler } from "./cli/show";
+import { addUpdateOptions, updatePipelineHandler } from "./cli/update";
+import { generateR2ServiceToken, getR2Bucket } from "./client";
+import type { CommonYargsArgv } from "../yargs-types";
+
+export const BYTES_PER_MB = 1000 * 1000;
 
 // flag to skip delays for tests
 let __testSkipDelaysFlag = false;
 
-async function authorizeR2Bucket(
+export async function authorizeR2Bucket(
 	pipelineName: string,
 	accountId: string,
 	bucketName: string
@@ -65,21 +53,11 @@ async function authorizeR2Bucket(
 	!__testSkipDelaysFlag &&
 		(await retryOnAPIFailure(
 			async () => {
-				try {
-					await r2.send(
-						new HeadBucketCommand({
-							Bucket: bucketName,
-						})
-					);
-				} catch (err) {
-					if (err instanceof Error && err.name === "401") {
-						throw new AuthAPIError({
-							status: 401,
-							text: "R2 HeadBucket request failed with status: 401",
-						});
-					}
-					throw err;
-				}
+				await r2.send(
+					new HeadBucketCommand({
+						Bucket: bucketName,
+					})
+				);
 			},
 			1000,
 			10
@@ -88,29 +66,12 @@ async function authorizeR2Bucket(
 	return serviceToken;
 }
 
-/**
- * AuthAPIError always retries errors so that
- * we always retry auth errors while waiting for an
- * API token to propegate and start working.
- */
-class AuthAPIError extends APIError {
-	override isRetryable(): boolean {
-		return true;
-	}
-}
-
-function getAccountR2Endpoint(accountId: string) {
+export function getAccountR2Endpoint(accountId: string) {
 	return `https://${accountId}.r2.cloudflarestorage.com`;
 }
 
-function validateName(label: string, name: string) {
-	if (!name.match(/^[a-zA-Z0-9-]+$/)) {
-		throw new Error(`Must provide a valid ${label}`);
-	}
-}
-
 // Parse out a transform of the form: <script>[.<entrypoint>]
-function parseTransform(spec: string) {
+export function parseTransform(spec: string) {
 	const [script, entrypoint, ...rest] = spec.split(".");
 	if (!script || rest.length > 0) {
 		throw new Error(
@@ -123,441 +84,37 @@ function parseTransform(spec: string) {
 	};
 }
 
-function addCreateAndUpdateOptions(yargs: Argv<CommonYargsOptions>) {
-	return yargs
-		.option("secret-access-key", {
-			describe: "The R2 service token Access Key to write data",
-			type: "string",
-			demandOption: false,
-		})
-		.option("access-key-id", {
-			describe: "The R2 service token Secret Key to write data",
-			type: "string",
-			demandOption: false,
-		})
-		.option("batch-max-mb", {
-			describe:
-				"The approximate maximum size (in megabytes) for each batch before flushing (range: 1 - 100)",
-			type: "number",
-			demandOption: false,
-		})
-		.option("batch-max-rows", {
-			describe:
-				"The approximate maximum number of rows in a batch before flushing (range: 100 - 1000000)",
-			type: "number",
-			demandOption: false,
-		})
-		.option("batch-max-seconds", {
-			describe:
-				"The approximate maximum age (in seconds) of a batch before flushing (range: 1 - 300)",
-			type: "number",
-			demandOption: false,
-		})
-		.option("transform", {
-			describe:
-				'The worker and entrypoint of the PipelineTransform implementation in the format "worker.entrypoint" \nDefault: No transformation worker',
-			type: "string",
-			demandOption: false,
-		})
-		.option("compression", {
-			describe: "Sets the compression format of output files \nDefault: gzip",
-			type: "string",
-			choices: ["none", "gzip", "deflate"],
-			demandOption: false,
-		})
-		.option("prefix", {
-			describe:
-				"Optional base path to store files in the destination bucket \nDefault: (none)",
-			type: "string",
-			demandOption: false,
-		})
-		.option("filepath", {
-			describe:
-				"The path to store partitioned files in the destination bucket \nDefault: event_date=${date}/hr=${hr}",
-			type: "string",
-			demandOption: false,
-		})
-		.option("filename", {
-			describe:
-				'The name of each unique file in the bucket. Must contain "${slug}". File extension is optional \nDefault: ${slug}${extension}',
-			type: "string",
-			demandOption: false,
-		})
-		.option("binding", {
-			describe: "Enable Worker binding to this pipeline",
-			type: "boolean",
-			default: true,
-			demandOption: false,
-		})
-		.option("http", {
-			describe: "Enable HTTPS endpoint to send data to this pipeline",
-			type: "boolean",
-			default: true,
-			demandOption: false,
-		})
-		.option("authentication", {
-			describe:
-				"Require authentication (Cloudflare API Token) to send data to the HTTPS endpoint",
-			type: "boolean",
-			default: false,
-			demandOption: false,
-		});
-}
-
 export function pipelines(pipelineYargs: CommonYargsArgv) {
 	return pipelineYargs
 		.command(
 			"create <pipeline>",
 			"Create a new pipeline",
-			(yargs) => {
-				return addCreateAndUpdateOptions(yargs)
-					.positional("pipeline", {
-						describe: "The name of the new pipeline",
-						type: "string",
-						demandOption: true,
-					})
-					.option("r2", {
-						type: "string",
-						describe: "Destination R2 bucket name",
-						demandOption: true,
-					});
-			},
-			async (args) => {
-				await printWranglerBanner();
-
-				const config = readConfig(args);
-				const bucket = args.r2;
-				const name = args.pipeline;
-				const compression =
-					args.compression === undefined ? "gzip" : args.compression;
-
-				const batch = {
-					max_bytes: args["batch-max-mb"]
-						? args["batch-max-mb"] * 1000 * 1000 // convert to bytes for the API
-						: undefined,
-					max_duration_s: args["batch-max-seconds"],
-					max_rows: args["batch-max-rows"],
-				};
-
-				if (!bucket) {
-					throw new FatalError("Requires a r2 bucket");
-				}
-
-				const accountId = await requireAuth(config);
-
-				const pipelineConfig: PipelineUserConfig = {
-					name: name,
-					metadata: {},
-					source: [],
-					transforms: [],
-					destination: {
-						type: "r2",
-						format: "json",
-						compression: {
-							type: compression,
-						},
-						batch: batch,
-						path: {
-							bucket: bucket,
-						},
-						credentials: {
-							endpoint: getAccountR2Endpoint(accountId),
-							access_key_id: args["access-key-id"] || "",
-							secret_access_key: args["secret-access-key"] || "",
-						},
-					},
-				};
-				const destination = pipelineConfig.destination;
-				if (
-					!destination.credentials.access_key_id &&
-					!destination.credentials.secret_access_key
-				) {
-					// auto-generate a service token
-					const auth = await authorizeR2Bucket(
-						name,
-						accountId,
-						pipelineConfig.destination.path.bucket
-					);
-					destination.credentials.access_key_id = auth.accessKeyId;
-					destination.credentials.secret_access_key = auth.secretAccessKey;
-				}
-
-				if (!destination.credentials.access_key_id) {
-					throw new FatalError("Requires a r2 access key id");
-				}
-
-				if (!destination.credentials.secret_access_key) {
-					throw new FatalError("Requires a r2 secret access key");
-				}
-
-				// add binding source (default to add)
-				if (args.binding === undefined || args.binding) {
-					pipelineConfig.source.push({
-						type: "binding",
-						format: "json",
-					} satisfies BindingSource);
-				}
-
-				// add http source (possibly authenticated), default to add
-				if (args.http === undefined || args.http) {
-					const source: HttpSource = {
-						type: "http",
-						format: "json",
-					};
-					if (args.authentication !== undefined) {
-						source.authentication = args.authentication;
-					}
-					pipelineConfig.source.push(source);
-				}
-				if (pipelineConfig.source.length < 1) {
-					throw new UserError(
-						"Too many sources have been disabled.  At least one source (http or binding) should be enabled"
-					);
-				}
-
-				if (args.transform !== undefined) {
-					pipelineConfig.transforms.push(parseTransform(args.transform));
-				}
-
-				if (args.prefix) {
-					pipelineConfig.destination.path.prefix = args.prefix;
-				}
-				if (args.filepath) {
-					pipelineConfig.destination.path.filepath = args.filepath;
-				}
-				if (args.filename) {
-					pipelineConfig.destination.path.filename = args.filename;
-				}
-
-				logger.log(`🌀 Creating pipeline named "${name}"`);
-				const pipeline = await createPipeline(accountId, pipelineConfig);
-				metrics.sendMetricsEvent("create pipeline", {
-					sendMetrics: config.send_metrics,
-				});
-
-				logger.log(
-					`✅ Successfully created pipeline "${pipeline.name}" with id ${pipeline.id}`
-				);
-				logger.log("🎉 You can now send data to your pipeline!");
-				logger.log(
-					`Example: curl "${pipeline.endpoint}" -d '[{"foo": "bar"}]'`
-				);
-			}
+			addCreateOptions,
+			createPipelineHandler
 		)
 		.command(
 			"list",
 			"List current pipelines",
 			(yargs) => yargs,
-			async (args) => {
-				const config = readConfig(args);
-				const accountId = await requireAuth(config);
-
-				// TODO: we should show bindings & transforms if they exist for given ids
-				const list = await listPipelines(accountId);
-				metrics.sendMetricsEvent("list pipelines", {
-					sendMetrics: config.send_metrics,
-				});
-
-				logger.table(
-					list.map((pipeline) => ({
-						name: pipeline.name,
-						id: pipeline.id,
-						endpoint: pipeline.endpoint,
-					}))
-				);
-			}
+			listPipelinesHandler
 		)
 		.command(
 			"show <pipeline>",
 			"Show a pipeline configuration",
-			(yargs) => {
-				return yargs.positional("pipeline", {
-					type: "string",
-					describe: "The name of the pipeline to show",
-					demandOption: true,
-				});
-			},
-			async (args) => {
-				await printWranglerBanner();
-				const config = readConfig(args);
-				const accountId = await requireAuth(config);
-				const name = args.pipeline;
-
-				validateName("pipeline name", name);
-
-				logger.log(`Retrieving config for pipeline "${name}".`);
-				const pipeline = await getPipeline(accountId, name);
-				metrics.sendMetricsEvent("show pipeline", {
-					sendMetrics: config.send_metrics,
-				});
-
-				logger.log(JSON.stringify(pipeline, null, 2));
-			}
+			addShowOptions,
+			showPipelineHandler
 		)
 		.command(
 			"update <pipeline>",
 			"Update a pipeline",
-			(yargs) => {
-				return addCreateAndUpdateOptions(yargs)
-					.positional("pipeline", {
-						describe: "The name of the pipeline to update",
-						type: "string",
-						demandOption: true,
-					})
-					.option("r2", {
-						type: "string",
-						describe: "Destination R2 bucket name",
-						demandOption: false,
-					});
-			},
-			async (args) => {
-				await printWranglerBanner();
-
-				const name = args.pipeline;
-				// only the fields set will be updated - other fields will use the existing config
-				const config = readConfig(args);
-				const accountId = await requireAuth(config);
-
-				const pipelineConfig = await getPipeline(accountId, name);
-
-				if (args.compression) {
-					pipelineConfig.destination.compression.type = args.compression;
-				}
-				if (args["batch-max-mb"]) {
-					pipelineConfig.destination.batch.max_bytes =
-						args["batch-max-mb"] * 1000 * 1000; // convert to bytes for the API
-				}
-				if (args["batch-max-seconds"]) {
-					pipelineConfig.destination.batch.max_duration_s =
-						args["batch-max-seconds"];
-				}
-				if (args["batch-max-rows"]) {
-					pipelineConfig.destination.batch.max_rows = args["batch-max-rows"];
-				}
-
-				const bucket = args.r2;
-				const accessKeyId = args["access-key-id"];
-				const secretAccessKey = args["secret-access-key"];
-				if (bucket || accessKeyId || secretAccessKey) {
-					const destination = pipelineConfig.destination;
-					if (bucket) {
-						pipelineConfig.destination.path.bucket = bucket;
-					}
-					destination.credentials = {
-						endpoint: getAccountR2Endpoint(accountId),
-						access_key_id: accessKeyId || "",
-						secret_access_key: secretAccessKey || "",
-					};
-					if (!accessKeyId && !secretAccessKey) {
-						const auth = await authorizeR2Bucket(
-							name,
-							accountId,
-							destination.path.bucket
-						);
-						destination.credentials.access_key_id = auth.accessKeyId;
-						destination.credentials.secret_access_key = auth.secretAccessKey;
-					}
-					if (!destination.credentials.access_key_id) {
-						throw new FatalError("Requires a r2 access key id");
-					}
-
-					if (!destination.credentials.secret_access_key) {
-						throw new FatalError("Requires a r2 secret access key");
-					}
-				}
-
-				if (args.binding !== undefined) {
-					// strip off old source & keep if necessary
-					const source = pipelineConfig.source.find(
-						(s: Source) => s.type == "binding"
-					);
-					pipelineConfig.source = pipelineConfig.source.filter(
-						(s: Source) => s.type != "binding"
-					);
-					if (args.binding) {
-						// add back only if specified
-						pipelineConfig.source.push({
-							type: "binding",
-							format: "json",
-							...source,
-						});
-					}
-				}
-
-				if (args.http !== undefined) {
-					// strip off old source & keep if necessary
-					const source = pipelineConfig.source.find(
-						(s: Source) => s.type == "http"
-					);
-					pipelineConfig.source = pipelineConfig.source.filter(
-						(s: Source) => s.type != "http"
-					);
-					if (args.http) {
-						// add back if specified
-						pipelineConfig.source.push({
-							type: "http",
-							format: "json",
-							...source,
-							authentication:
-								args.authentication !== undefined
-									? // if auth specified, use it
-										args.authentication
-									: // if auth not specified, use previous value or default(false)
-										source?.authentication,
-						} satisfies HttpSource);
-					}
-				}
-
-				if (args.transform !== undefined) {
-					pipelineConfig.transforms.push(parseTransform(args.transform));
-				}
-
-				if (args.prefix) {
-					pipelineConfig.destination.path.prefix = args.prefix;
-				}
-				if (args.filepath) {
-					pipelineConfig.destination.path.filepath = args.filepath;
-				}
-				if (args.filename) {
-					pipelineConfig.destination.path.filename = args.filename;
-				}
-
-				logger.log(`🌀 Updating pipeline "${name}"`);
-				const pipeline = await updatePipeline(accountId, name, pipelineConfig);
-				metrics.sendMetricsEvent("update pipeline", {
-					sendMetrics: config.send_metrics,
-				});
-
-				logger.log(
-					`✅ Successfully updated pipeline "${pipeline.name}" with ID ${pipeline.id}\n`
-				);
-			}
+			addUpdateOptions,
+			updatePipelineHandler
 		)
 		.command(
 			"delete <pipeline>",
 			"Delete a pipeline",
-			(yargs) => {
-				return yargs.positional("pipeline", {
-					type: "string",
-					describe: "The name of the pipeline to delete",
-					demandOption: true,
-				});
-			},
-			async (args) => {
-				await printWranglerBanner();
-				const config = readConfig(args);
-				const accountId = await requireAuth(config);
-				const name = args.pipeline;
-
-				validateName("pipeline name", name);
-
-				logger.log(`Deleting pipeline ${name}.`);
-				await deletePipeline(accountId, name);
-				logger.log(`Deleted pipeline ${name}.`);
-				metrics.sendMetricsEvent("delete pipeline", {
-					sendMetrics: config.send_metrics,
-				});
-			}
+			addDeleteOptions,
+			deletePipelineHandler
 		);
 }
 

--- a/packages/wrangler/src/pipelines/index.ts
+++ b/packages/wrangler/src/pipelines/index.ts
@@ -122,31 +122,31 @@ export function pipelines(pipelineYargs: CommonYargsArgv) {
 	return pipelineYargs
 		.command(
 			"create <pipeline>",
-			"Create a new pipeline",
+			"Create a new Pipeline",
 			addCreateOptions,
 			createPipelineHandler
 		)
 		.command(
 			"list",
-			"List current pipelines",
+			"List current Pipelines",
 			(yargs) => yargs,
 			listPipelinesHandler
 		)
 		.command(
 			"show <pipeline>",
-			"Show a pipeline configuration",
+			"Show a Pipeline configuration",
 			addShowOptions,
 			showPipelineHandler
 		)
 		.command(
 			"update <pipeline>",
-			"Update a pipeline",
+			"Update a Pipeline",
 			addUpdateOptions,
 			updatePipelineHandler
 		)
 		.command(
 			"delete <pipeline>",
-			"Delete a pipeline",
+			"Delete a Pipeline",
 			addDeleteOptions,
 			deletePipelineHandler
 		);

--- a/packages/wrangler/src/pipelines/validate.ts
+++ b/packages/wrangler/src/pipelines/validate.ts
@@ -1,0 +1,36 @@
+export function validateName(label: string, name: string) {
+	if (!name.match(/^[a-zA-Z0-9-]+$/)) {
+		throw new Error(`Must provide a valid ${label}`);
+	}
+}
+
+export function validateCorsOrigins(values: string[] | undefined) {
+	if (!values || !values.length) {
+		return values;
+	}
+
+	// If wildcard provided, ignore other options
+	if (values.includes("*")) {
+		if (values.length > 1) {
+			throw new Error("When specifying '*', only one value is permitted.");
+		}
+		return values;
+	}
+
+	// Ensure any value matches the format for a CORS origin
+	for (const value of values) {
+		if (!value.match(/^https?:\/\/[^/]+$/i)) {
+			throw new Error(`Provided value ${value} is not a valid CORS origin.`);
+		}
+	}
+	return values;
+}
+
+export function validateInRange(name: string, min: number, max: number) {
+	return (val: number) => {
+		if (val < min || val > max) {
+			throw new Error(`${name} must be between ${min} and ${max}`);
+		}
+		return val;
+	};
+}

--- a/packages/wrangler/src/pipelines/validate.ts
+++ b/packages/wrangler/src/pipelines/validate.ts
@@ -1,6 +1,8 @@
+import { UserError } from "../errors";
+
 export function validateName(label: string, name: string) {
 	if (!name.match(/^[a-zA-Z0-9-]+$/)) {
-		throw new Error(`Must provide a valid ${label}`);
+		throw new UserError(`Must provide a valid ${label}`);
 	}
 }
 
@@ -12,7 +14,7 @@ export function validateCorsOrigins(values: string[] | undefined) {
 	// If wildcard provided, ignore other options
 	if (values.includes("*")) {
 		if (values.length > 1) {
-			throw new Error("When specifying '*', only one value is permitted.");
+			throw new UserError("When specifying '*', only one value is permitted.");
 		}
 		return values;
 	}
@@ -20,7 +22,9 @@ export function validateCorsOrigins(values: string[] | undefined) {
 	// Ensure any value matches the format for a CORS origin
 	for (const value of values) {
 		if (!value.match(/^https?:\/\/[^/]+$/i)) {
-			throw new Error(`Provided value ${value} is not a valid CORS origin.`);
+			throw new UserError(
+				`Provided value ${value} is not a valid CORS origin.`
+			);
 		}
 	}
 	return values;
@@ -29,7 +33,7 @@ export function validateCorsOrigins(values: string[] | undefined) {
 export function validateInRange(name: string, min: number, max: number) {
 	return (val: number) => {
 		if (val < min || val > max) {
-			throw new Error(`${name} must be between ${min} and ${max}`);
+			throw new UserError(`${name} must be between ${min} and ${max}`);
 		}
 		return val;
 	};


### PR DESCRIPTION
**Pipelines is currently in closed beta, renaming these without providing aliases _should_ have limited to zero impact**

Moving each of the subcommand handlers and options for each subcommand into its own file. This also renames many of the parameters to be more specific.

The following parameters have been renamed:

| Previous Name | New Name |
| ---- | ---- |
| access-key-id | r2-access-key-id |
| secret-access-key | r2-secret-access-key |
| transform | transform-worker |
| r2 | r2-bucket |
| prefix | r2-prefix |
| binding | enable-worker-binding |
| http | enable-http |
| authentication | require-http-auth |
| filename | file-template |
| filepath | partition-template |

Adds the following new option for `create` and `update` commands:

```
--cors-origins           CORS origin allowlist for HTTP endpoint (use * for any origin)  [array]
```

Closes https://jira.cfdata.org/browse/PIPE-160.

---

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: Unit tests cover the change
- Public documentation
  - [ ] TODO (before merge)
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18595
  - [ ] Documentation not necessary because:

