### PR TITLE
Fix Durable Objects transfer migration validation

### DIFF
--- a/.changeset/beige-lamps-leave.md
+++ b/.changeset/beige-lamps-leave.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix Durable Objects transfer migration validation

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -1923,6 +1923,18 @@ describe("normalizeAndValidateConfig()", () => {
 								},
 							],
 							deleted_classes: ["CLASS_3", "CLASS_4"],
+							new_sqlite_classes: ["CLASS_5", "CLASS_6"],
+							transferred_classes: [
+								{
+									from: "FROM_CLASS",
+									from_script: "FROM_SCRIPT",
+									to: "TO_CLASS",
+								},
+								{
+									from: "FROM_CLASS",
+									to: "TO_CLASS",
+								},
+							],
 							unrecognized_field: "FOO",
 						},
 					],
@@ -1943,7 +1955,8 @@ describe("normalizeAndValidateConfig()", () => {
 				`);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
 			          "Processing wrangler configuration:
-			            - Expected \\"migrations[0].renamed_classes\\" to be an array of \\"{from: string, to: string}\\" objects but got [{\\"from\\":\\"FROM_CLASS\\",\\"to\\":\\"TO_CLASS\\"},{\\"a\\":\\"something\\",\\"b\\":\\"someone\\"}]."
+			            - Expected \\"migrations[0].renamed_classes\\" to be an array of \\"{from: string, to: string}\\" objects but got [{\\"from\\":\\"FROM_CLASS\\",\\"to\\":\\"TO_CLASS\\"},{\\"a\\":\\"something\\",\\"b\\":\\"someone\\"}].
+			            - Expected \\"migrations[0].transferred_classes\\" to be an array of \\"{from: string, from_script: string, to: string}\\" objects but got [{\\"from\\":\\"FROM_CLASS\\",\\"from_script\\":\\"FROM_SCRIPT\\",\\"to\\":\\"TO_CLASS\\"},{\\"from\\":\\"FROM_CLASS\\",\\"to\\":\\"TO_CLASS\\"}]."
 		        `);
 			});
 		});

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -3413,6 +3413,7 @@ const validateMigrations: ValidatorFn = (diagnostics, field, value) => {
 			new_sqlite_classes,
 			renamed_classes,
 			deleted_classes,
+			transferred_classes,
 			...rest
 		} = rawMigrations[i];
 
@@ -3473,6 +3474,33 @@ const validateMigrations: ValidatorFn = (diagnostics, field, value) => {
 				valid = false;
 			}
 		}
+
+		if (transferred_classes !== undefined) {
+			if (!Array.isArray(transferred_classes)) {
+				diagnostics.errors.push(
+					`Expected "migrations[${i}].transferred_classes" to be an array of "{from: string, from_script: string, to: string}" objects but got ${JSON.stringify(
+						transferred_classes
+					)}.`
+				);
+				valid = false;
+			} else if (
+				transferred_classes.some(
+					(c) =>
+						typeof c !== "object" ||
+						!isRequiredProperty(c, "from", "string") ||
+						!isRequiredProperty(c, "from_script", "string") ||
+						!isRequiredProperty(c, "to", "string")
+				)
+			) {
+				diagnostics.errors.push(
+					`Expected "migrations[${i}].transferred_classes" to be an array of "{from: string, from_script: string, to: string}" objects but got ${JSON.stringify(
+						transferred_classes
+					)}.`
+				);
+				valid = false;
+			}
+		}
+
 		valid =
 			validateOptionalTypedArray(
 				diagnostics,


### PR DESCRIPTION
Durable Objects transfer migration validation was previously warning when transfer migrations were specified. 

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: Covered by included tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: Addresses a bug in a feature no one uses :P