### PR TITLE
Revert "fix(workers-playground): sends raw request method through the `X-CF-HTTP-Method` header"

### DIFF
--- a/.changeset/heavy-gorillas-punch.md
+++ b/.changeset/heavy-gorillas-punch.md
@@ -1,0 +1,7 @@
+---
+"workers-playground": patch
+---
+
+Reverts #7639
+
+Seems like our prev release of the workers-playground broke things. We are seeing a spike of related errors. We are therefore reverting the changes

--- a/packages/workers-playground/src/QuickEditor/HTTPTab/fetchWorker.ts
+++ b/packages/workers-playground/src/QuickEditor/HTTPTab/fetchWorker.ts
@@ -10,14 +10,12 @@ export function fetchWorker(
 
 	return fetch(`${proxyUrl.origin}${init}`, {
 		...input,
-		method: "POST",
 		headers: [
 			...(input?.headers ?? [])
 				.filter(([name]) => name)
 				.map<[string, string]>(([n, v]) => [`cf-ew-raw-${n}`, v]),
 			["X-CF-Token", token],
 			["cf-raw-http", "true"],
-			["X-CF-HTTP-Method", input.method ?? "GET"],
 		],
 	});
 }


### PR DESCRIPTION
Reverts cloudflare/workers-sdk#7639

Seems like our prev release of the workers-playground broke things. We are seeing a spike of related errors. We are therefore reverting to undo the breakage, and will handle fixing forward later on