### PR TITLE
fix(playground-preview-worker,edge-preview-authenticated-proxy): ensure no body is passed when constructing a GET or HEAD request to the preview worker

### DIFF
--- a/.changeset/clean-sheep-promise.md
+++ b/.changeset/clean-sheep-promise.md
@@ -1,0 +1,6 @@
+---
+"edge-preview-authenticated-proxy": patch
+"playground-preview-worker": patch
+---
+
+fix: ensure no body is passed when constructing a GET or HEAD request to the preview worker

--- a/packages/edge-preview-authenticated-proxy/src/index.ts
+++ b/packages/edge-preview-authenticated-proxy/src/index.ts
@@ -230,14 +230,12 @@ async function handleRawHttp(request: Request, url: URL) {
 		}
 	}
 
-	const workerResponse = await fetch(
-		switchRemote(url, remote),
-		new Request(request, {
-			method,
-			headers: requestHeaders,
-			redirect: "manual",
-		})
-	);
+	const workerResponse = await fetch(switchRemote(url, remote), {
+		method,
+		headers: requestHeaders,
+		body: method === "GET" || method === "HEAD" ? null : request.body,
+		redirect: "manual",
+	});
 
 	const responseHeaders = new Headers(workerResponse.headers);
 

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -48,9 +48,7 @@ describe("Preview Worker", () => {
 							return Response.redirect("https://example.com", 302)
 						}
 						if(url.pathname === "/method") {
-							return new Response(request.method, {
-								headers: { "X-Test-Http-Method": request.method },
-							});
+							return new Response(request.method)
 						}
 						if(url.pathname === "/status") {
 							return new Response(407)
@@ -337,7 +335,9 @@ describe("Raw HTTP preview", () => {
 							return Response.redirect("https://example.com", 302)
 						}
 						if(url.pathname === "/method") {
-							return new Response(request.method)
+							return new Response(request.method, {
+								headers: { "Test-Http-Method": request.method },
+							})
 						}
 						if(url.pathname === "/status") {
 							return new Response(407)
@@ -508,7 +508,8 @@ compatibility_date = "2023-01-01"
 
 			// HEAD request does not return any body. So we will confirm by asserting the response header
 			expect(await resp.text()).toEqual(method === "HEAD" ? "" : method);
-			expect(resp.headers.get("X-Test-Http-Method")).toEqual(method);
+			// Header from the client response will be prefixed with "cf-ew-raw-"
+			expect(resp.headers.get("cf-ew-raw-Test-Http-Method")).toEqual(method);
 		}
 	);
 

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -48,7 +48,9 @@ describe("Preview Worker", () => {
 							return Response.redirect("https://example.com", 302)
 						}
 						if(url.pathname === "/method") {
-							return new Response(request.method)
+							return new Response(request.method, {
+								headers: { "X-Test-Http-Method": request.method },
+							});
 						}
 						if(url.pathname === "/status") {
 							return new Response(407)
@@ -504,7 +506,9 @@ compatibility_date = "2023-01-01"
 				}
 			);
 
-			expect(await resp.text()).toEqual(method);
+			// HEAD request does not return any body. So we will confirm by asserting the response header
+			expect(await resp.text()).toEqual(method === "HEAD" ? "" : method);
+			expect(resp.headers.get("X-Test-Http-Method")).toEqual(method);
 		}
 	);
 

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -487,23 +487,26 @@ compatibility_date = "2023-01-01"
 		expect(await resp.text()).toEqual("PUT");
 	});
 
-	it("should support GET method specified on the X-CF-Http-Method header", async () => {
-		const token = randomBytes(4096).toString("hex");
-		const resp = await worker.fetch(
-			`https://0000.rawhttp.devprod.cloudflare.dev/method`,
-			{
-				method: "POST",
-				headers: {
-					origin: "https://cloudflare.dev",
-					"X-CF-Token": token,
-					"X-CF-Remote": `http://127.0.0.1:${remote.port}`,
-					"X-CF-Http-Method": "GET",
-				},
-			}
-		);
+	it.each(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])(
+		"should support %s method specified on the X-CF-Http-Method header",
+		async (method) => {
+			const token = randomBytes(4096).toString("hex");
+			const resp = await worker.fetch(
+				`https://0000.rawhttp.devprod.cloudflare.dev/method`,
+				{
+					method: "POST",
+					headers: {
+						origin: "https://cloudflare.dev",
+						"X-CF-Token": token,
+						"X-CF-Remote": `http://127.0.0.1:${remote.port}`,
+						"X-CF-Http-Method": method,
+					},
+				}
+			);
 
-		expect(await resp.text()).toEqual("GET");
-	});
+			expect(await resp.text()).toEqual(method);
+		}
+	);
 
 	it("should fallback to the request method if the X-CF-Http-Method header is missing", async () => {
 		const token = randomBytes(4096).toString("hex");

--- a/packages/edge-preview-authenticated-proxy/tests/index.test.ts
+++ b/packages/edge-preview-authenticated-proxy/tests/index.test.ts
@@ -487,6 +487,24 @@ compatibility_date = "2023-01-01"
 		expect(await resp.text()).toEqual("PUT");
 	});
 
+	it("should support GET method specified on the X-CF-Http-Method header", async () => {
+		const token = randomBytes(4096).toString("hex");
+		const resp = await worker.fetch(
+			`https://0000.rawhttp.devprod.cloudflare.dev/method`,
+			{
+				method: "POST",
+				headers: {
+					origin: "https://cloudflare.dev",
+					"X-CF-Token": token,
+					"X-CF-Remote": `http://127.0.0.1:${remote.port}`,
+					"X-CF-Http-Method": "GET",
+				},
+			}
+		);
+
+		expect(await resp.text()).toEqual("GET");
+	});
+
 	it("should fallback to the request method if the X-CF-Http-Method header is missing", async () => {
 		const token = randomBytes(4096).toString("hex");
 		const resp = await worker.fetch(

--- a/packages/playground-preview-worker/src/index.ts
+++ b/packages/playground-preview-worker/src/index.ts
@@ -79,17 +79,14 @@ async function handleRawHttp(request: Request, url: URL, env: Env) {
 		}
 	}
 
-	const workerResponse = await userObject.fetch(
-		url,
-		new Request(request, {
-			method,
-			headers: {
-				...Object.fromEntries(headers),
-				"cf-run-user-worker": "true",
-			},
-			redirect: "manual",
-		})
-	);
+	headers.append("cf-run-user-worker", "true");
+
+	const workerResponse = await userObject.fetch(url, {
+		method,
+		headers,
+		body: method === "GET" || method === "HEAD" ? null : request.body,
+		redirect: "manual",
+	});
 
 	const responseHeaders = new Headers(workerResponse.headers);
 

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -24,7 +24,9 @@ export default {
 			return Response.redirect("https://example.com", 302)
 		}
 		if(url.pathname === "/method") {
-			return new Response(request.method)
+			return new Response(request.method, {
+				headers: { "X-Test-Http-Method": request.method },
+			})
 		}
 		if(url.pathname === "/status") {
 			return new Response(407)
@@ -270,7 +272,9 @@ describe("Preview Worker", () => {
 				redirect: "manual",
 			});
 
-			expect(await resp.text()).toEqual(method);
+			// HEAD request does not return any body. So we will confirm by asserting the response header
+			expect(await resp.text()).toEqual(method === "HEAD" ? "" : method);
+			expect(resp.headers.get("X-Test-Http-Method")).toEqual(method);
 		}
 	);
 	it("should fallback to the request method if the X-CF-Http-Method header is missing", async () => {

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -257,6 +257,19 @@ describe("Preview Worker", () => {
 
 		expect(await resp.text()).toEqual("PUT");
 	});
+	it("should handle GET method specified on the X-CF-Http-Method header", async () => {
+		const resp = await fetch(`${PREVIEW_REMOTE}/method`, {
+			method: "POST",
+			headers: {
+				"X-CF-Token": defaultUserToken,
+				"X-CF-Http-Method": "GET",
+				"CF-Raw-HTTP": "true",
+			},
+			redirect: "manual",
+		});
+
+		expect(await resp.text()).toEqual("GET");
+	});
 	it("should fallback to the request method if the X-CF-Http-Method header is missing", async () => {
 		const resp = await fetch(`${PREVIEW_REMOTE}/method`, {
 			method: "PUT",

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -25,7 +25,7 @@ export default {
 		}
 		if(url.pathname === "/method") {
 			return new Response(request.method, {
-				headers: { "X-Test-Http-Method": request.method },
+				headers: { "Test-Http-Method": request.method },
 			})
 		}
 		if(url.pathname === "/status") {
@@ -274,7 +274,8 @@ describe("Preview Worker", () => {
 
 			// HEAD request does not return any body. So we will confirm by asserting the response header
 			expect(await resp.text()).toEqual(method === "HEAD" ? "" : method);
-			expect(resp.headers.get("X-Test-Http-Method")).toEqual(method);
+			// Header from the client response will be prefixed with "cf-ew-raw-"
+			expect(resp.headers.get("cf-ew-raw-Test-Http-Method")).toEqual(method);
 		}
 	);
 	it("should fallback to the request method if the X-CF-Http-Method header is missing", async () => {

--- a/packages/playground-preview-worker/tests/index.test.ts
+++ b/packages/playground-preview-worker/tests/index.test.ts
@@ -257,19 +257,22 @@ describe("Preview Worker", () => {
 
 		expect(await resp.text()).toEqual("PUT");
 	});
-	it("should handle GET method specified on the X-CF-Http-Method header", async () => {
-		const resp = await fetch(`${PREVIEW_REMOTE}/method`, {
-			method: "POST",
-			headers: {
-				"X-CF-Token": defaultUserToken,
-				"X-CF-Http-Method": "GET",
-				"CF-Raw-HTTP": "true",
-			},
-			redirect: "manual",
-		});
+	it.each(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"])(
+		"should handle %s method specified on the X-CF-Http-Method header",
+		async (method) => {
+			const resp = await fetch(`${PREVIEW_REMOTE}/method`, {
+				method: "POST",
+				headers: {
+					"X-CF-Token": defaultUserToken,
+					"X-CF-Http-Method": method,
+					"CF-Raw-HTTP": "true",
+				},
+				redirect: "manual",
+			});
 
-		expect(await resp.text()).toEqual("GET");
-	});
+			expect(await resp.text()).toEqual(method);
+		}
+	);
 	it("should fallback to the request method if the X-CF-Http-Method header is missing", async () => {
 		const resp = await fetch(`${PREVIEW_REMOTE}/method`, {
 			method: "PUT",


### PR DESCRIPTION
Fixes #7791, #7630

This PR fixes the following error we see after releasing the change on #7639.

> Error: Request with a GET or HEAD method cannot have a body.

The implementation has been updated in both `playground-preview-worker` and `edge-preview-authenticated-proxy`, which are used by the worker playground and the dashboard.

**Note**: This change itself will not affect how playground and dashboard works as the behavior is opt-in. We will have to un-revert #7639 and we should be able to verify this on the preview playground.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
