### PR TITLE
Revert "chore(wrangler): use the unenv preset from `@cloudflare/unenv-preset`"

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -70,7 +70,6 @@
 	},
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "workspace:*",
-		"@cloudflare/unenv-preset": "1.x",
 		"@esbuild-plugins/node-globals-polyfill": "0.2.3",
 		"@esbuild-plugins/node-modules-polyfill": "0.2.2",
 		"blake3-wasm": "2.1.5",

--- a/packages/wrangler/scripts/deps.ts
+++ b/packages/wrangler/scripts/deps.ts
@@ -21,9 +21,9 @@ export const EXTERNAL_DEPENDENCIES = [
 	// @cloudflare/workers-types is an optional peer dependency of wrangler, so users can
 	// get the types by installing the package (to what version they prefer) themselves
 	"@cloudflare/workers-types",
-	// `@cloudflare/unenv-preset` and  `unenv` must be external because they contain code
-	// which needs to be resolved and read when we are bundling the worker application
-	"@cloudflare/unenv-preset",
+
+	// unenv must be external because it contains unenv/runtime code which needs to be resolved
+	// and read when we are bundling the worker application
 	"unenv",
 
 	// path-to-regexp must be external because it contains runtime code which needs to be resolved

--- a/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
+++ b/packages/wrangler/src/deployment-bundle/esbuild-plugins/hybrid-nodejs-compat.ts
@@ -1,8 +1,7 @@
 import { builtinModules } from "node:module";
 import nodePath from "node:path";
-import { cloudflare } from "@cloudflare/unenv-preset";
 import dedent from "ts-dedent";
-import { defineEnv } from "unenv";
+import { cloudflare, defineEnv } from "unenv";
 import { getBasePath } from "../../paths";
 import type { Plugin, PluginBuild } from "esbuild";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2015,9 +2015,6 @@ importers:
       '@cloudflare/kv-asset-handler':
         specifier: workspace:*
         version: link:../kv-asset-handler
-      '@cloudflare/unenv-preset':
-        specifier: 1.x
-        version: 1.0.0(unenv-nightly@2.0.0-20250109-100802-88ad671)(workerd@1.20241230.0)
       '@esbuild-plugins/node-globals-polyfill':
         specifier: 0.2.3
         version: 0.2.3(esbuild@0.17.19)
@@ -2845,15 +2842,6 @@ packages:
     resolution: {integrity: sha512-4JbJv5cbtGeo7Vpg2Sx3LXAhkvDJeJV/9FLFm2u3MkyxXb9SXdjxoanO5bOripQThTrzB1a8Ctw/ghweSA91Cw==}
     peerDependencies:
       react: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
-
-  '@cloudflare/unenv-preset@1.0.0':
-    resolution: {integrity: sha512-rnihjY4xUsBmlqp0eM2tQXm+40aj3C7WhdH4eGHkLaoBKr3+LwuENByYm5mf65WEeA5NE6BolTnjkiJUts3RuA==}
-    peerDependencies:
-      unenv: npm:unenv-nightly@*
-      workerd: ^1.20241230.0
-    peerDependenciesMeta:
-      workerd:
-        optional: true
 
   '@cloudflare/util-en-garde@8.0.10':
     resolution: {integrity: sha512-qdCFf90hoZzT4o4xEmxOKUf9+bEJNGh4ANnRYApo6BMyVnHoHEHAQ3nWmGSHBmo+W9hOk2Ik7r1oHLbI0O/RRg==}
@@ -11243,12 +11231,6 @@ snapshots:
       '@cloudflare/intl-types': 1.5.1(react@18.3.1)
       '@cloudflare/util-en-garde': 8.0.10
       react: 18.3.1
-
-  '@cloudflare/unenv-preset@1.0.0(unenv-nightly@2.0.0-20250109-100802-88ad671)(workerd@1.20241230.0)':
-    dependencies:
-      unenv: unenv-nightly@2.0.0-20250109-100802-88ad671
-    optionalDependencies:
-      workerd: 1.20241230.0
 
   '@cloudflare/util-en-garde@8.0.10':
     dependencies:


### PR DESCRIPTION
Reverts cloudflare/workers-sdk#7720 as it introduced breakage in some of the C3 templates (eg. Nuxt)

**How was this tested**

- create a Nuxt project via `npm create cloudflare@latest` (`2.36.0` at the time of this writing)
- change the wrangler version in the generated project's `package.json` to the wrangler pre-release version of this PR
- `npm i` again
- `npm run preview` - which previously failed
- 🎉  👇 

<img width="703" alt="Screenshot 2025-01-16 at 17 14 07" src="https://github.com/user-attachments/assets/c8fbaa11-4335-4a95-8ea6-c871dc66f0e1" />



**Why was this not caught by our C3 e2e tests?**

When our C3 e2e tests run, they (in a nutshell) build C3 out of the `main` branch, and create a starter project (via that previously built executable) for each framework under test. Once the starter project is created, certain assertions are made on it.

A starter project will come with a list of predefined dependencies, necessary for the project to run and be deployed, defined in `package.json`. All (I think) C3 starter projects will have a dependency on `wrangler`, specifically, on the **latest released version** of wrangler. This is crucial to note here, because while the e2e tests are running in the "context" of a wrangler built off of `main` (let's call this version `N`), they are in fact making assertions against starter projects that were built with wrangler version `N-1` (`wrangler@latest`).

In our case this resulted in a false positive CI run, where C3 e2e tests were successful, when they should have instead failed