### PR TITLE
Fix wrangler config detection with json and toml formats

### DIFF
--- a/.changeset/red-mice-divide.md
+++ b/.changeset/red-mice-divide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Fix wrangler config file detection edge case. Previously, a folder containing wrangler.json, and a subfolder containing wrangler.toml would actually detect the top-level wrangler.json due to the order they were checked.

--- a/packages/wrangler/src/config/config-helpers.ts
+++ b/packages/wrangler/src/config/config-helpers.ts
@@ -50,8 +50,10 @@ export function findWranglerConfig(
 	referencePath: string = process.cwd(),
 	{ useRedirectIfAvailable = false } = {}
 ): ConfigPaths {
-	const userConfigPath =
-		findUpSync([`wrangler.json`, `wrangler.jsonc`, `wrangler.toml`], { cwd: referencePath });
+	const userConfigPath = findUpSync(
+		[`wrangler.json`, `wrangler.jsonc`, `wrangler.toml`],
+		{ cwd: referencePath }
+	);
 
 	return {
 		userConfigPath,

--- a/packages/wrangler/src/config/config-helpers.ts
+++ b/packages/wrangler/src/config/config-helpers.ts
@@ -51,9 +51,7 @@ export function findWranglerConfig(
 	{ useRedirectIfAvailable = false } = {}
 ): ConfigPaths {
 	const userConfigPath =
-		findUpSync(`wrangler.json`, { cwd: referencePath }) ??
-		findUpSync(`wrangler.jsonc`, { cwd: referencePath }) ??
-		findUpSync(`wrangler.toml`, { cwd: referencePath });
+		findUpSync([`wrangler.json`, `wrangler.jsonc`, `wrangler.toml`], { cwd: referencePath });
 
 	return {
 		userConfigPath,


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

_Describe your change..._
Assume this (admittedly suboptimal) folder layout:
```
- my-fancy-worker/
  - worker.ts
  - wrangler.json
  - some-feature
    - some-worker.ts
    - wrangler.toml
```

Wrangler, without this change, would pick up the outer config file due to the order `findUpSync` was run in. While it is an edge case, we did run into it with a worker where some functionality has been extracted to a separate one for use with jsrpc, and I was migrating them to use `.json` instead of `.toml`.

Fortunately, findUpSync supports an array of strings as input, and even the priority of json > jsonc > toml is kept, if all three are present at the same level.
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: it's such an edge case
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
