### PR TITLE
chore: update unenv to 2.0.0-rc.0

### DIFF
--- a/.changeset/red-comics-sit.md
+++ b/.changeset/red-comics-sit.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/unenv-preset": patch
+"wrangler": patch
+---
+
+chore: update unenv to 2.0.0-rc.0
+
+Pull a couple changes in node:timers
+
+- unjs/unenv#384 fix function bindings in node:timer
+- unjs/unenv#385 implement active and \_unrefActive in node:timer

--- a/.changeset/red-comics-sit.md
+++ b/.changeset/red-comics-sit.md
@@ -9,3 +9,6 @@ Pull a couple changes in node:timers
 
 - unjs/unenv#384 fix function bindings in node:timer
 - unjs/unenv#385 implement active and \_unrefActive in node:timer
+
+The unenv update also includes #unjs/unenv/381 which implements
+`stdout`, `stderr` and `stdin` of `node:process` with `node:tty`

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -54,7 +54,7 @@
 		"wrangler": "workspace:*"
 	},
 	"peerDependencies": {
-		"unenv": "npm:unenv-nightly@*",
+		"unenv": ">=2.0.0-rc.0",
 		"workerd": "^1.20241230.0"
 	},
 	"peerDependenciesMeta": {

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -54,7 +54,7 @@
 		"wrangler": "workspace:*"
 	},
 	"peerDependencies": {
-		"unenv": ">=2.0.0-rc.0",
+		"unenv": "2.0.0-rc.0",
 		"workerd": "^1.20241230.0"
 	},
 	"peerDependenciesMeta": {

--- a/packages/unenv-preset/tests/worker/index.ts
+++ b/packages/unenv-preset/tests/worker/index.ts
@@ -9,6 +9,7 @@ export const TESTS = {
 	testUtilImplements,
 	testPath,
 	testDns,
+	testTimers,
 };
 
 export default {
@@ -140,4 +141,12 @@ async function testDns() {
 	assert.strictEqual(typeof results[0].critical, "number");
 	assert.strictEqual(results[0].critical, 0);
 	assert.strictEqual(results[0].issue, "pki.goog");
+}
+
+async function testTimers() {
+	const timers = await import("node:timers");
+	const timeout = timers.setTimeout(() => null, 1000);
+	// active is deprecated and no more in the type
+	(timers as any).active(timeout);
+	timers.clearTimeout(timeout);
 }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -76,7 +76,7 @@
 		"esbuild": "0.17.19",
 		"miniflare": "workspace:*",
 		"path-to-regexp": "6.3.0",
-		"unenv": "npm:unenv-nightly@2.0.0-20250109-100802-88ad671",
+		"unenv": "2.0.0-rc.0",
 		"workerd": "1.20241230.0"
 	},
 	"devDependencies": {

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -9786,7 +9786,7 @@ addEventListener('fetch', event => {});`
 					)
 				)
 			).resolves.toMatchInlineSnapshot(`
-				"X [ERROR] Unexpected external import of \\"node:stream\\" and \\"node:timers/promises\\".
+				"X [ERROR] Unexpected external import of \\"node:events\\", \\"node:net\\", \\"node:stream\\", \\"node:timers/promises\\", and \\"node:tty\\".
 				Your worker has no default export, which means it is assumed to be a Service Worker format Worker.
 				Did you mean to create a ES Module format Worker?
 				If so, try adding \`export default { ... }\` in your entry-point.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1666,8 +1666,8 @@ importers:
   packages/unenv-preset:
     dependencies:
       unenv:
-        specifier: npm:unenv-nightly@*
-        version: unenv-nightly@2.0.0-20250109-100802-88ad671
+        specifier: '>=2.0.0-rc.0'
+        version: 2.0.0-rc.0
       workerd:
         specifier: ^1.20241230.0
         version: 1.20241230.0
@@ -2502,8 +2502,8 @@ importers:
         specifier: 6.3.0
         version: 6.3.0
       unenv:
-        specifier: npm:unenv-nightly@2.0.0-20250109-100802-88ad671
-        version: unenv-nightly@2.0.0-20250109-100802-88ad671
+        specifier: 2.0.0-rc.0
+        version: 2.0.0-rc.0
       workerd:
         specifier: 1.20241230.0
         version: 1.20241230.0
@@ -10366,8 +10366,8 @@ packages:
   unenv-nightly@2.0.0-20241218-183400-5d6aec3:
     resolution: {integrity: sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==}
 
-  unenv-nightly@2.0.0-20250109-100802-88ad671:
-    resolution: {integrity: sha512-Uij6gODNNNNsNBoDlnaMvZI99I6YlVJLRfYH8AOLMlbFrW7k2w872v9VLuIdch2vF8QBeSC4EftIh5sG4ibzdA==}
+  unenv@2.0.0-rc.0:
+    resolution: {integrity: sha512-H0kl2w8jFL/FAk0xvjVing4bS3jd//mbg1QChDnn58l9Sc5RtduaKmLAL8n+eBw5jJo8ZjYV7CrEGage5LAOZQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -19659,10 +19659,10 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.5.4
 
-  unenv-nightly@2.0.0-20250109-100802-88ad671:
+  unenv@2.0.0-rc.0:
     dependencies:
       defu: 6.1.4
-      mlly: 1.7.3
+      mlly: 1.7.4
       ohash: 1.1.4
       pathe: 1.1.2
       ufo: 1.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1666,7 +1666,7 @@ importers:
   packages/unenv-preset:
     dependencies:
       unenv:
-        specifier: '>=2.0.0-rc.0'
+        specifier: 2.0.0-rc.0
         version: 2.0.0-rc.0
       workerd:
         specifier: ^1.20241230.0


### PR DESCRIPTION
unenv@2.0.0-rc.0 is out 🎉

Thanks @pi0

There are only a few changes from the latest `unenv-nightly` and 2 of them are for the `node:timer` module and required to be able to use `mysql` on `workerd`.

One more [change](https://github.com/unjs/unenv/pull/381) in unenv implements stdout, stderr and stdin with node:tty. It explains the added deps in tests.

For now `unenv-preset` pins `unenv` to `2.0.0-rc.0`, later we will switch to "2.x" but we expect backward incompatible changes in the next RCs (thanks Pooya for catching that)

/cc @anonrig

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
