### PR TITLE
fix(vitest-pool-workers): stop bundling chai in module fallback

### DIFF
--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -6,7 +6,6 @@ import posixPath from "node:path/posix";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import util from "node:util";
 import * as cjsModuleLexer from "cjs-module-lexer";
-import { buildSync } from "esbuild";
 import { ModuleRuleTypeSchema, Response } from "miniflare";
 import { isFileNotFoundError } from "./helpers";
 import type { ModuleRuleType, Request, Worker_Module } from "miniflare";
@@ -59,10 +58,6 @@ export const workerdBuiltinModules = new Set([
 	...VITEST_POOL_WORKERS_DEFINE_BUILTIN_MODULES,
 	"__STATIC_CONTENT_MANIFEST",
 ]);
-
-// `chai` contains circular `require()`s which aren't supported by `workerd`
-// TODO(someday): support circular `require()` in `workerd`
-const bundleDependencies = ["chai"];
 
 function isFile(filePath: string): boolean {
 	try {
@@ -195,30 +190,6 @@ function withSourceUrl(contents: string, url: string | URL): string {
 function withImportMetaUrl(contents: string, url: string | URL): string {
 	// TODO(soon): this isn't perfect, ideally need `workerd` support
 	return contents.replaceAll("import.meta.url", JSON.stringify(url.toString()));
-}
-
-const bundleCache = new Map<string, string>();
-function bundleDependency(entryPath: string): string {
-	let output = bundleCache.get(entryPath);
-	if (output !== undefined) {
-		return output;
-	}
-	debuglog(`Bundling ${entryPath}...`);
-	const result = buildSync({
-		platform: "node",
-		target: "esnext",
-		format: "cjs",
-		bundle: true,
-		packages: "external",
-		sourcemap: "inline",
-		sourcesContent: false,
-		entryPoints: [entryPath],
-		write: false,
-	});
-	assert(result.outputFiles.length === 1);
-	output = result.outputFiles[0].text;
-	bundleCache.set(entryPath, output);
-	return output;
 }
 
 const jsExtensions = [".js", ".mjs", ".cjs"];
@@ -476,18 +447,11 @@ async function load(
 		filePath = trimSuffix(disableCjsEsmShimSuffix, filePath);
 	}
 
-	let isEsm =
+	const isEsm =
 		filePath.endsWith(".mjs") ||
 		(filePath.endsWith(".js") && isWithinTypeModuleContext(filePath));
 
-	let contents: string;
-	const maybeBundled = bundleCache.get(filePath);
-	if (maybeBundled !== undefined) {
-		contents = maybeBundled;
-		isEsm = false;
-	} else {
-		contents = fs.readFileSync(filePath, "utf8");
-	}
+	let contents = fs.readFileSync(filePath, "utf8");
 	const targetUrl = pathToFileURL(target);
 	contents = withSourceUrl(contents, targetUrl);
 
@@ -559,9 +523,7 @@ export async function handleModuleFallbackRequest(
 
 	try {
 		const filePath = await resolve(vite, method, target, specifier, referrer);
-		if (bundleDependencies.includes(specifier)) {
-			bundleDependency(filePath);
-		}
+
 		return await load(vite, logBase, method, target, specifier, filePath);
 	} catch (e) {
 		debuglog(logBase, "error:", e);


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

We were bundling chai to get around an issue with related to circular `require()`. This has now been fixed and could be cleaned up.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
