### PR TITLE
Fix asset-worker not logging analytics for successful requests

### DIFF
--- a/.changeset/heavy-parents-switch.md
+++ b/.changeset/heavy-parents-switch.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+fix: fix analytics not being logged for `asset-worker` in the case of a successful request.

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -106,6 +106,7 @@ export default class extends WorkerEntrypoint<Env> {
 					hostname: url.hostname,
 					eyeballPath: url.pathname,
 					env: this.env.ENVIRONMENT,
+					version: this.env.VERSION_METADATA?.id,
 				});
 
 				return handleRequest(

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -115,21 +115,17 @@ export default class extends WorkerEntrypoint<Env> {
 					this.unstable_exists.bind(this),
 					this.unstable_getByETag.bind(this)
 				);
-			}).catch((err) =>
-				this.handleError(sentry, analytics, performance, startTimeMs, err)
-			);
+			})
+				.catch((err) => this.handleError(sentry, analytics, err))
+				.finally(() => this.submitMetrics(analytics, performance, startTimeMs));
 		} catch (err) {
-			return this.handleError(sentry, analytics, performance, startTimeMs, err);
+			const errorResponse = this.handleError(sentry, analytics, err);
+			this.submitMetrics(analytics, performance, startTimeMs);
+			return errorResponse;
 		}
 	}
 
-	handleError(
-		sentry: Toucan | undefined,
-		analytics: Analytics,
-		performance: PerformanceTimer,
-		startTimeMs: number,
-		err: unknown
-	) {
+	handleError(sentry: Toucan | undefined, analytics: Analytics, err: unknown) {
 		try {
 			const response = new InternalServerErrorResponse(err as Error);
 
@@ -143,9 +139,22 @@ export default class extends WorkerEntrypoint<Env> {
 			}
 
 			return response;
-		} finally {
+		} catch (e) {
+			console.error("Error handling error", e);
+			return new InternalServerErrorResponse(e as Error);
+		}
+	}
+
+	submitMetrics(
+		analytics: Analytics,
+		performance: PerformanceTimer,
+		startTimeMs: number
+	) {
+		try {
 			analytics.setData({ requestTime: performance.now() - startTimeMs });
 			analytics.write();
+		} catch (e) {
+			console.error("Error submitting metrics", e);
 		}
 	}
 

--- a/packages/workers-shared/asset-worker/wrangler.toml
+++ b/packages/workers-shared/asset-worker/wrangler.toml
@@ -15,6 +15,16 @@ compatibility_date = "2024-07-31"
 # nodejs_compat required when using @cloudflare/vitest-pool-workers
 compatibility_flags = ["nodejs_compat"]
 
+[unsafe.metadata.build_options]
+stable_id = "cloudflare/cf_asset_worker"
+networks = ["cf","jdc"]
+
+[vars]
+ENVIRONMENT = "production"
+
+[version_metadata]
+binding = "VERSION_METADATA"
+
 [[unsafe.bindings]]
 name = "CONFIG"
 type = "param"
@@ -29,13 +39,6 @@ data_ref = true
 [[unsafe.bindings]]
 name = "ASSETS_KV_NAMESPACE"
 type = "internal_assets"
-
-[unsafe.metadata.build_options]
-stable_id = "cloudflare/cf_asset_worker"
-networks = ["cf","jdc"]
-
-[version_metadata]
-binding = "VERSION_METADATA"
 
 [[unsafe.bindings]]
 name = "workers-asset-worker"


### PR DESCRIPTION
Fixes N/A

Fix analytics not being logged for `asset-worker` in the case of a successful request.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: analytics change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: analytics change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: analytics change

