### PR TITLE
chore: Ensure that C3 e2e tests are running against local wrangler

### DIFF
--- a/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/packages.test.ts
@@ -18,7 +18,9 @@ describe("Package Helpers", () => {
 		vi.mocked(existsSync).mockImplementation(() => false);
 	});
 
-	afterEach(() => {});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
 
 	describe("npmInstall", () => {
 		test("npm", async () => {
@@ -87,12 +89,25 @@ describe("Package Helpers", () => {
 		);
 	});
 
-	test("installWrangler", async () => {
-		await installWrangler();
+	describe("installWrangler", async () => {
+		test("install wrangler@beta if in CI", async () => {
+			vi.stubEnv("CI", "true");
+			await installWrangler();
 
-		expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
-			["npm", "install", "--save-dev", "wrangler@latest"],
-			expect.anything(),
-		);
+			expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
+				["npm", "install", "--save-dev", "wrangler@beta"],
+				expect.anything(),
+			);
+		});
+
+		test("install wrangler@latest if not in CI", async () => {
+			vi.stubEnv("CI", undefined);
+			await installWrangler();
+
+			expect(vi.mocked(runCommand)).toHaveBeenCalledWith(
+				["npm", "install", "--save-dev", "wrangler@latest"],
+				expect.anything(),
+			);
+		});
 	});
 });

--- a/packages/create-cloudflare/src/helpers/packages.ts
+++ b/packages/create-cloudflare/src/helpers/packages.ts
@@ -88,9 +88,13 @@ export async function getLatestPackageVersion(packageSpecifier: string) {
  */
 export const installWrangler = async () => {
 	const { npm } = detectPackageManager();
+	// force `wrangler@beta` in case peer deps are deined that
+	// conflict with the version we want
+	// (see remix experimental tests)
+	const wrangler = process.env.CI ? `wrangler@beta` : "wrangler@latest";
 
 	// Even if Wrangler is already installed, make sure we install the latest version, as some framework CLIs are pinned to an older version
-	await installPackages([`wrangler@latest`], {
+	await installPackages([`${wrangler}`], {
 		dev: true,
 		startText: `Installing wrangler ${dim(
 			"A command line tool for building Cloudflare Workers",


### PR DESCRIPTION
Ensure that C3 e2e tests are running against `wrangler@beta` in CI

This is one smol incremental step towards fixing #7800.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
