### PR TITLE
Fix RPC method invocations showing up as unknown events

### DIFF
--- a/.changeset/fifty-pots-nail.md
+++ b/.changeset/fifty-pots-nail.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix RPC method invocations showing up as unknown events

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -15,9 +15,8 @@ import type {
 	QueueEvent,
 	RequestEvent,
 	ScheduledEvent,
-	TailEvent,
 	TailEventMessage,
-	TailInfo,
+	TailEventMessageType,
 } from "../../tail/createTail";
 import type { RequestInit } from "undici";
 import type WebSocket from "ws";
@@ -807,18 +806,7 @@ function serialize(message: TailEventMessage): WebSocket.RawData {
  * @param event A TailEvent
  * @returns true if `event` is a RequestEvent
  */
-function isRequest(
-	event:
-		| ScheduledEvent
-		| RequestEvent
-		| AlarmEvent
-		| EmailEvent
-		| TailEvent
-		| TailInfo
-		| QueueEvent
-		| undefined
-		| null
-): event is RequestEvent {
+function isRequest(event: TailEventMessageType): event is RequestEvent {
 	return Boolean(event && "request" in event);
 }
 

--- a/packages/wrangler/src/tail/createTail.ts
+++ b/packages/wrangler/src/tail/createTail.ts
@@ -198,6 +198,18 @@ export async function createTail(
 	return { tail, expiration, deleteTail };
 }
 
+export type TailEventMessageType =
+	| RequestEvent
+	| ScheduledEvent
+	| AlarmEvent
+	| EmailEvent
+	| TailEvent
+	| TailInfo
+	| QueueEvent
+	| RpcEvent
+	| undefined
+	| null;
+
 /**
  * Everything captured by the trace worker and sent to us via
  * `wrangler tail` is structured JSON that deserializes to this type.
@@ -212,6 +224,11 @@ export type TailEventMessage = {
 	 * The name of the script we're tailing
 	 */
 	scriptName?: string;
+
+	/**
+	 * The name of the entrypoint invoked by the Worker
+	 */
+	entrypoint?: string;
 
 	/**
 	 * Any exceptions raised by the worker
@@ -250,29 +267,19 @@ export type TailEventMessage = {
 	/**
 	 * The event that triggered the worker. In the case of an HTTP request,
 	 * this will be a RequestEvent. If it's a cron trigger, it'll be a
-	 * ScheduledEvent. If it's a durable object alarm, it's an AlarmEvent.
+	 * ScheduledEvent. If it's a Durable Object alarm, it's an AlarmEvent.
 	 * If it's a email, it'a an EmailEvent. If it's a Queue consumer event,
 	 * it's a QueueEvent.
 	 *
 	 * Until workers-types exposes individual types for export, we'll have
 	 * to just re-define these types ourselves.
 	 */
-	event:
-		| RequestEvent
-		| ScheduledEvent
-		| AlarmEvent
-		| EmailEvent
-		| TailEvent
-		| TailInfo
-		| QueueEvent
-		| undefined
-		| null;
+	event: TailEventMessageType;
 };
 
 /**
  * A request that triggered worker execution
  */
-
 export type RequestEvent = {
 	request: Pick<Request, "url" | "method" | "headers"> & {
 		/**
@@ -386,7 +393,7 @@ export type ScheduledEvent = {
 };
 
 /**
- * A event that was triggered from a durable object alarm
+ * An event that was triggered from a Durable Object alarm
  */
 export type AlarmEvent = {
 	/**
@@ -442,8 +449,8 @@ export type TailInfo = {
 	type: string;
 };
 
-/*
- * A event that was triggered by receiving a batch of messages from a Queue for consumption.
+/**
+ * An event that was triggered by receiving a batch of messages from a Queue for consumption.
  */
 export type QueueEvent = {
 	/**
@@ -455,4 +462,14 @@ export type QueueEvent = {
 	 * The number of messages in the batch.
 	 */
 	batchSize: number;
+};
+
+/**
+ * An RPC method that was invoked
+ */
+export type RpcEvent = {
+	/**
+	 * The name of the RPC method that was invoked
+	 */
+	rpcMethod: string;
 };

--- a/packages/wrangler/src/tail/printing.ts
+++ b/packages/wrangler/src/tail/printing.ts
@@ -5,6 +5,7 @@ import type {
 	EmailEvent,
 	QueueEvent,
 	RequestEvent,
+	RpcEvent,
 	ScheduledEvent,
 	TailEvent,
 	TailEventMessage,
@@ -82,6 +83,13 @@ export function prettyPrintLogs(data: WebSocket.RawData): void {
 		logger.log(
 			`Queue ${queueName} (${batchSizeMsg}) - ${outcome} @ ${datetime}`
 		);
+	} else if (isRpcEvent(eventMessage.event)) {
+		const outcome = prettifyOutcome(eventMessage.outcome);
+		const datetime = new Date(eventMessage.eventTimestamp).toLocaleString();
+
+		logger.log(
+			`${eventMessage.entrypoint}.${eventMessage.event.rpcMethod} - ${outcome} @ ${datetime}`
+		);
 	} else {
 		// Unknown event type
 		const outcome = prettifyOutcome(eventMessage.outcome);
@@ -125,6 +133,10 @@ function isEmailEvent(event: TailEventMessage["event"]): event is EmailEvent {
 
 function isQueueEvent(event: TailEventMessage["event"]): event is QueueEvent {
 	return Boolean(event && "queue" in event);
+}
+
+function isRpcEvent(event: TailEventMessage["event"]): event is RpcEvent {
+	return Boolean(event && "rpcMethod" in event);
 }
 
 /**


### PR DESCRIPTION
Fix RPC method invocations showing up as unknown events. Users will now see the following in the case of either a `Service<MyWorkerEntrypoint>` or a DurableObjectNamespace<MyDurableObject>` when invoking either from a worker:
```
MyWorkerEntrypoint.add - Ok @ 1/17/2025, 4:14:15 PM
MyDurableObject.add - Ok @ 1/17/2025, 4:14:16 PM
```

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: No easy way to test this other than manually testing
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: I don't think that e2e tests cover this.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: This should have been expected to work previously.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
