### PR TITLE
add support for assets bindings to `getPlatformProxy`

### DIFF
--- a/.changeset/thick-dots-sit.md
+++ b/.changeset/thick-dots-sit.md
@@ -1,0 +1,39 @@
+---
+"wrangler": patch
+---
+
+add support for assets bindings to `getPlatformProxy`
+
+this change makes sure that that `getPlatformProxy`, when the input configuration
+file contains an assets field, correctly returns the appropriate asset binding proxy
+
+example:
+
+```json
+// wrangler.json
+{
+	"name": "my-worker",
+	"assets": {
+		"directory": "./public/",
+		"binding": "ASSETS"
+	},
+	"vars": {
+		"MY_VAR": "my-var"
+	}
+}
+```
+
+```js
+import { getPlatformProxy } from "wrangler";
+
+const { env } = await getPlatformProxy();
+
+if (env.ASSETS) {
+	const text = await (
+		await p.env.ASSETS.fetch("http://0.0.0.0/file.txt")
+	).text();
+	console.log(text); // logs the content of file.txt
+}
+
+p.dispose();
+```

--- a/fixtures/get-platform-proxy/public/test.txt
+++ b/fixtures/get-platform-proxy/public/test.txt
@@ -1,0 +1,1 @@
+this is a test text file!

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.env.test.ts
@@ -2,7 +2,11 @@ import path from "path";
 import { D1Database, R2Bucket } from "@cloudflare/workers-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getPlatformProxy } from "./shared";
-import type { Hyperdrive, KVNamespace } from "@cloudflare/workers-types";
+import type {
+	Fetcher,
+	Hyperdrive,
+	KVNamespace,
+} from "@cloudflare/workers-types";
 import type { Unstable_DevWorker } from "wrangler";
 
 type Env = {
@@ -15,6 +19,7 @@ type Env = {
 	MY_BUCKET: R2Bucket;
 	MY_D1: D1Database;
 	MY_HYPERDRIVE: Hyperdrive;
+	ASSETS: Fetcher;
 };
 
 const wranglerTomlFilePath = path.join(__dirname, "..", "wrangler.toml");
@@ -113,6 +118,17 @@ describe("getPlatformProxy - env", () => {
 		} finally {
 			await dispose();
 		}
+	});
+
+	it("correctly obtains functioning ASSETS bindings", async () => {
+		const { env, dispose } = await getPlatformProxy<Env>({
+			configPath: wranglerTomlFilePath,
+		});
+		const { ASSETS } = env;
+		const res = await ASSETS.fetch("https://0.0.0.0/test.txt");
+		const text = await res.text();
+		expect(text).toEqual("this is a test text file!\n");
+		await dispose();
 	});
 
 	it("correctly obtains functioning KV bindings", async () => {

--- a/fixtures/get-platform-proxy/wrangler.toml
+++ b/fixtures/get-platform-proxy/wrangler.toml
@@ -7,6 +7,12 @@ MY_VAR = "my-var-value"
 MY_VAR_A = "my-var-a"
 MY_JSON_VAR = { test = true }
 
+[assets]
+directory = "./public"
+binding = "ASSETS"
+html_handling = "auto-trailing-slash"
+not_found_handling = "none"
+
 [[kv_namespaces]]
 binding = "MY_KV"
 id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -158,6 +158,14 @@ async function getMiniflareOptionsFromConfig(
 		migrations: rawConfig.migrations,
 	});
 
+	const processedAssetOptions = getAssetsOptions(
+		{ assets: undefined },
+		rawConfig
+	);
+	const assetOptions = processedAssetOptions
+		? buildAssetOptions({ assets: processedAssetOptions })
+		: {};
+
 	const persistOptions = getMiniflarePersistOptions(options.persist);
 
 	const serviceBindings = await getServiceBindings(bindings.services);
@@ -172,6 +180,7 @@ async function getMiniflareOptionsFromConfig(
 					...serviceBindings,
 					...bindingOptions.serviceBindings,
 				},
+				...assetOptions,
 			},
 			...externalWorkers,
 		],


### PR DESCRIPTION
Fixes #7812

this change makes sure that that `getPlatformProxy`, when the input configuration
file contains an assets field, correctly returns the appropriate asset binding proxy

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/19300
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
