### PR TITLE
chore: refactor `wrangler types` to use createCommand

### DIFF
--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -140,7 +140,7 @@ import {
 } from "./sentry";
 import { tailHandler, tailOptions } from "./tail";
 import registerTriggersSubcommands from "./triggers";
-import { typesHandler, typesOptions } from "./type-generation";
+import { typesCommand } from "./type-generation";
 import { getAuthFromEnv } from "./user";
 import { loginCommand, logoutCommand, whoamiCommand } from "./user/commands";
 import { whoami } from "./user/whoami";
@@ -477,12 +477,8 @@ export function createCLIParser(argv: string[]) {
 	);
 
 	// types
-	wrangler.command(
-		"types [path]",
-		"📝 Generate types from bindings and module rules in configuration\n",
-		typesOptions,
-		typesHandler
-	);
+	registry.define([{ command: "wrangler types", definition: typesCommand }]);
+	registry.registerNamespace("types");
 
 	/******************** CMD GROUP ***********************/
 	registry.define([


### PR DESCRIPTION
refactors `wrangler types` to use the createCommand interface

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: should continue to pass existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactor

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
