### PR TITLE
chore: refactor wrangler tail to use createCommand

### DIFF
--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -138,7 +138,7 @@ import {
 	closeSentry,
 	setupSentry,
 } from "./sentry";
-import { tailHandler, tailOptions } from "./tail";
+import { tailCommand } from "./tail";
 import registerTriggersSubcommands from "./triggers";
 import { typesHandler, typesOptions } from "./type-generation";
 import { getAuthFromEnv } from "./user";
@@ -460,12 +460,8 @@ export function createCLIParser(argv: string[]) {
 	);
 
 	// tail
-	wrangler.command(
-		"tail [worker]",
-		"🦚 Start a log tailing session for a Worker",
-		tailOptions,
-		tailHandler
-	);
+	registry.define([{ command: "wrangler tail", definition: tailCommand }]);
+	registry.registerNamespace("tail");
 
 	// secret
 	wrangler.command(

--- a/packages/wrangler/src/tail/index.ts
+++ b/packages/wrangler/src/tail/index.ts
@@ -1,6 +1,7 @@
 import { setTimeout } from "node:timers/promises";
 import onExit from "signal-exit";
-import { configFileName, readConfig } from "../config";
+import { configFileName } from "../config";
+import { createCommand } from "../core/create-command";
 import { createFatalError, UserError } from "../errors";
 import { logger } from "../logger";
 import * as metrics from "../metrics";
@@ -15,228 +16,233 @@ import {
 	prettyPrintLogs,
 	translateCLICommandToFilterMessage,
 } from "./createTail";
-import type {
-	CommonYargsArgv,
-	StrictYargsOptionsToInterface,
-} from "../yargs-types";
 import type { TailCLIFilters } from "./createTail";
 import type WebSocket from "ws";
 
-export function tailOptions(yargs: CommonYargsArgv) {
-	return yargs
-		.positional("worker", {
+export const tailCommand = createCommand({
+	metadata: {
+		description: "🦚 Start a log tailing session for a Worker",
+		status: "stable",
+		owner: "Workers: Workers Observability",
+	},
+	positionalArgs: ["worker"],
+	args: {
+		worker: {
 			describe: "Name or route of the worker to tail",
 			type: "string",
-		})
-		.option("format", {
-			default: process.stdout.isTTY ? "pretty" : "json",
+		},
+		format: {
 			choices: ["json", "pretty"],
 			describe: "The format of log entries",
-		})
-		.option("status", {
+		},
+		status: {
 			choices: ["ok", "error", "canceled"],
 			describe: "Filter by invocation status",
 			array: true,
-		})
-		.option("header", {
+		},
+		header: {
 			type: "string",
 			requiresArg: true,
 			describe: "Filter by HTTP header",
-		})
-		.option("method", {
+		},
+		method: {
 			type: "string",
 			requiresArg: true,
 			describe: "Filter by HTTP method",
 			array: true,
-		})
-		.option("sampling-rate", {
+		},
+		"sampling-rate": {
 			type: "number",
 			describe: "Adds a percentage of requests to log sampling rate",
-		})
-		.option("search", {
+		},
+		search: {
 			type: "string",
 			requiresArg: true,
 			describe: "Filter by a text match in console.log messages",
-		})
-		.option("ip", {
+		},
+		ip: {
 			type: "string",
 			requiresArg: true,
 			describe:
 				'Filter by the IP address the request originates from. Use "self" to filter for your own IP',
 			array: true,
-		})
-		.option("version-id", {
+		},
+		"version-id": {
 			type: "string",
 			requiresArg: true,
 			describe: "Filter by Worker version",
-		})
-		.option("debug", {
+		},
+		debug: {
 			type: "boolean",
 			hidden: true,
 			default: false,
 			describe:
 				"If a log would have been filtered out, send it through anyway alongside the filter which would have blocked it.",
-		})
-		.option("legacy-env", {
+		},
+		"legacy-env": {
 			type: "boolean",
 			describe: "Use legacy environments",
 			hidden: true,
-		});
-}
-
-type TailArgs = StrictYargsOptionsToInterface<typeof tailOptions>;
-
-export async function tailHandler(args: TailArgs) {
-	if (args.format === "pretty") {
-		await printWranglerBanner();
-	}
-	const config = readConfig(args);
-	if (config.pages_build_output_dir) {
-		throw new UserError(
-			"It looks like you've run a Workers-specific command in a Pages project.\n" +
-				"For Pages, please run `wrangler pages deployment tail` instead."
-		);
-	}
-	metrics.sendMetricsEvent("begin log stream", {
-		sendMetrics: config.send_metrics,
-	});
-
-	let scriptName;
-
-	const accountId = await requireAuth(config);
-
-	// Worker names can't contain "." (and most routes should), so use that as a discriminator
-	if (args.worker?.includes(".")) {
-		scriptName = await getWorkerForZone(
-			{
-				worker: args.worker,
-				accountId,
-			},
-			config.configPath
-		);
+		},
+	},
+	behaviour: {
+		printBanner: false,
+	},
+	async handler(args, { config }) {
+		args.format ??= process.stdout.isTTY ? "pretty" : "json";
 		if (args.format === "pretty") {
-			logger.log(`Connecting to worker ${scriptName} at route ${args.worker}`);
+			await printWranglerBanner();
 		}
-	} else {
-		scriptName = getLegacyScriptName({ name: args.worker, ...args }, config);
-	}
 
-	if (!scriptName) {
-		throw new UserError(
-			`Required Worker name missing. Please specify the Worker name in your ${configFileName(config.configPath)} file, or pass it as an argument with \`wrangler tail <worker-name>\``
-		);
-	}
-
-	const cliFilters: TailCLIFilters = {
-		status: args.status as ("ok" | "error" | "canceled")[] | undefined,
-		header: args.header,
-		method: args.method,
-		samplingRate: args.samplingRate,
-		search: args.search,
-		clientIp: args.ip,
-		versionId: args.versionId,
-	};
-
-	const filters = translateCLICommandToFilterMessage(cliFilters);
-
-	const { tail, expiration, deleteTail } = await createTail(
-		accountId,
-		scriptName,
-		filters,
-		args.debug,
-		!isLegacyEnv(config) ? args.env : undefined
-	);
-
-	const scriptDisplayName = `${scriptName}${
-		args.env && !isLegacyEnv(config) ? ` (${args.env})` : ""
-	}`;
-
-	if (args.format === "pretty") {
-		logger.log(
-			`Successfully created tail, expires at ${expiration.toLocaleString()}`
-		);
-	}
-
-	const printLog: (data: WebSocket.RawData) => void =
-		args.format === "pretty" ? prettyPrintLogs : jsonPrintLogs;
-
-	tail.on("message", printLog);
-
-	while (tail.readyState !== tail.OPEN) {
-		switch (tail.readyState) {
-			case tail.CONNECTING:
-				await setTimeout(100);
-				break;
-			case tail.CLOSING:
-				await setTimeout(100);
-				break;
-			case tail.CLOSED:
-				metrics.sendMetricsEvent("end log stream", {
-					sendMetrics: config.send_metrics,
-				});
-				throw new Error(
-					`Connection to ${scriptDisplayName} closed unexpectedly.`
-				);
+		if (config.pages_build_output_dir) {
+			throw new UserError(
+				"It looks like you've run a Workers-specific command in a Pages project.\n" +
+					"For Pages, please run `wrangler pages deployment tail` instead."
+			);
 		}
-	}
-
-	if (args.format === "pretty") {
-		logger.log(`Connected to ${scriptDisplayName}, waiting for logs...`);
-	}
-
-	const cancelPing = startWebSocketPing();
-	tail.on("close", exit);
-	onExit(exit);
-
-	async function exit() {
-		cancelPing();
-		tail.terminate();
-		await deleteTail();
-		metrics.sendMetricsEvent("end log stream", {
+		metrics.sendMetricsEvent("begin log stream", {
 			sendMetrics: config.send_metrics,
 		});
-	}
 
-	/**
-	 * Start pinging the websocket to see if it is still connected.
-	 *
-	 * We need to know if the connection to the tail drops.
-	 * To do this we send a ping message to the backend every few seconds.
-	 * If we don't get a matching pong message back before the next ping is due
-	 * then we have probably lost the connect.
-	 */
-	function startWebSocketPing() {
-		/** The corelation message to send to tail when pinging. */
-		const PING_MESSAGE = Buffer.from("wrangler tail ping");
-		/** How long to wait between pings. */
-		const PING_INTERVAL = 10000;
+		let scriptName;
 
-		let waitingForPong = false;
+		const accountId = await requireAuth(config);
 
-		const pingInterval = setInterval(() => {
-			if (waitingForPong) {
-				// We didn't get a pong back quickly enough so assume the connection died and exit.
-				// This approach relies on the fact that throwing an error inside a `setInterval()` callback
-				// causes the process to exit.
-				// This is a bit nasty but otherwise we have to make wholesale changes to how the `tail` command
-				// works, since currently all the tests assume that `runWrangler()` will return immediately.
-				console.log(args.format);
-				throw createFatalError(
-					"Tail disconnected, exiting.",
-					args.format === "json",
-					1
+		// Worker names can't contain "." (and most routes should), so use that as a discriminator
+		if (args.worker?.includes(".")) {
+			scriptName = await getWorkerForZone(
+				{
+					worker: args.worker,
+					accountId,
+				},
+				config.configPath
+			);
+			if (args.format === "pretty") {
+				logger.log(
+					`Connecting to worker ${scriptName} at route ${args.worker}`
 				);
 			}
-			waitingForPong = true;
-			tail.ping(PING_MESSAGE);
-		}, PING_INTERVAL);
+		} else {
+			scriptName = getLegacyScriptName({ name: args.worker, ...args }, config);
+		}
 
-		tail.on("pong", (data) => {
-			if (data.equals(PING_MESSAGE)) {
-				waitingForPong = false;
+		if (!scriptName) {
+			throw new UserError(
+				`Required Worker name missing. Please specify the Worker name in your ${configFileName(config.configPath)} file, or pass it as an argument with \`wrangler tail <worker-name>\``
+			);
+		}
+
+		const cliFilters: TailCLIFilters = {
+			status: args.status as ("ok" | "error" | "canceled")[] | undefined,
+			header: args.header,
+			method: args.method,
+			samplingRate: args.samplingRate,
+			search: args.search,
+			clientIp: args.ip,
+			versionId: args.versionId,
+		};
+
+		const filters = translateCLICommandToFilterMessage(cliFilters);
+
+		const { tail, expiration, deleteTail } = await createTail(
+			accountId,
+			scriptName,
+			filters,
+			args.debug,
+			!isLegacyEnv(config) ? args.env : undefined
+		);
+
+		const scriptDisplayName = `${scriptName}${
+			args.env && !isLegacyEnv(config) ? ` (${args.env})` : ""
+		}`;
+
+		if (args.format === "pretty") {
+			logger.log(
+				`Successfully created tail, expires at ${expiration.toLocaleString()}`
+			);
+		}
+
+		const printLog: (data: WebSocket.RawData) => void =
+			args.format === "pretty" ? prettyPrintLogs : jsonPrintLogs;
+
+		tail.on("message", printLog);
+
+		while (tail.readyState !== tail.OPEN) {
+			switch (tail.readyState) {
+				case tail.CONNECTING:
+					await setTimeout(100);
+					break;
+				case tail.CLOSING:
+					await setTimeout(100);
+					break;
+				case tail.CLOSED:
+					metrics.sendMetricsEvent("end log stream", {
+						sendMetrics: config.send_metrics,
+					});
+					throw new Error(
+						`Connection to ${scriptDisplayName} closed unexpectedly.`
+					);
 			}
-		});
+		}
 
-		return () => clearInterval(pingInterval);
-	}
-}
+		if (args.format === "pretty") {
+			logger.log(`Connected to ${scriptDisplayName}, waiting for logs...`);
+		}
+
+		const cancelPing = startWebSocketPing();
+		tail.on("close", exit);
+		onExit(exit);
+
+		async function exit() {
+			cancelPing();
+			tail.terminate();
+			await deleteTail();
+			metrics.sendMetricsEvent("end log stream", {
+				sendMetrics: config.send_metrics,
+			});
+		}
+
+		/**
+		 * Start pinging the websocket to see if it is still connected.
+		 *
+		 * We need to know if the connection to the tail drops.
+		 * To do this we send a ping message to the backend every few seconds.
+		 * If we don't get a matching pong message back before the next ping is due
+		 * then we have probably lost the connect.
+		 */
+		function startWebSocketPing() {
+			/** The corelation message to send to tail when pinging. */
+			const PING_MESSAGE = Buffer.from("wrangler tail ping");
+			/** How long to wait between pings. */
+			const PING_INTERVAL = 10000;
+
+			let waitingForPong = false;
+
+			const pingInterval = setInterval(() => {
+				if (waitingForPong) {
+					// We didn't get a pong back quickly enough so assume the connection died and exit.
+					// This approach relies on the fact that throwing an error inside a `setInterval()` callback
+					// causes the process to exit.
+					// This is a bit nasty but otherwise we have to make wholesale changes to how the `tail` command
+					// works, since currently all the tests assume that `runWrangler()` will return immediately.
+					console.log(args.format);
+					throw createFatalError(
+						"Tail disconnected, exiting.",
+						args.format === "json",
+						1
+					);
+				}
+				waitingForPong = true;
+				tail.ping(PING_MESSAGE);
+			}, PING_INTERVAL);
+
+			tail.on("pong", (data) => {
+				if (data.equals(PING_MESSAGE)) {
+					waitingForPong = false;
+				}
+			});
+
+			return () => clearInterval(pingInterval);
+		}
+	},
+});


### PR DESCRIPTION
refactors `wrangler tail` to use the createCommand interface

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: should just continue to pass existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: tail has no e2e tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactor

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
