### PR TITLE
fix(wrangler): fix schema defaults

### DIFF
--- a/.changeset/dry-snakes-deliver.md
+++ b/.changeset/dry-snakes-deliver.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix(wrangler): fix wrangler config schema defaults

--- a/packages/wrangler/src/__tests__/config/configSchema.test.ts
+++ b/packages/wrangler/src/__tests__/config/configSchema.test.ts
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+
+describe("src/config/environment.ts", () => {
+	// `@default` values must not be escaped in order to generate a valid schema.
+	test("default values are not escaped", () => {
+		const srcFile = path.join(__dirname, "../../config/environment.ts");
+		const srcLines = fs.readFileSync(srcFile, "utf-8").split("\n");
+		const hasEscapedDefaultRegex = /@default\s+`/;
+		srcLines.forEach((line, lineNumber) => {
+			const hasEscapedDefault = hasEscapedDefaultRegex.test(line);
+			expect
+				.soft(hasEscapedDefault, `On line ${lineNumber + 1}: "${line}"`)
+				.toEqual(false);
+		});
+	});
+});

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -119,11 +119,11 @@ interface EnvironmentInheritable {
 
 	/**
 	 * A list of flags that enable features from upcoming features of
-	 * the Workers runtime, usually used together with compatibility_flags.
+	 * the Workers runtime, usually used together with compatibility_date.
 	 *
-	 * More details at https://developers.cloudflare.com/workers/platform/compatibility-dates
+	 * More details at https://developers.cloudflare.com/workers/platform/compatibility-flags
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @inheritable
 	 */
 	compatibility_flags: string[];
@@ -162,23 +162,27 @@ interface EnvironmentInheritable {
 	 */
 	base_dir: string | undefined;
 
+	// Carmen according to our tests the default is undefined
+	// warning: you must force "workers_dev: true" in tests to match expected behavior
 	/**
 	 * Whether we use <name>.<subdomain>.workers.dev to
 	 * test and deploy your Worker.
 	 *
-	 * // Carmen according to our tests the default is undefined
-	 * // warning: you must force "workers_dev: true" in tests to match expected behavior
-	 * @default `true` (This is a breaking change from Wrangler v1)
+	 *
+	 * NOTE: (This is a breaking change from Wrangler v1)
+	 *
+	 * @default true
 	 * @breaking
 	 * @inheritable
 	 */
+
 	workers_dev: boolean | undefined;
 
 	/**
 	 * Whether we use <version>-<name>.<subdomain>.workers.dev to
 	 * serve Preview URLs for your Worker.
 	 *
-	 * @default `true`
+	 * @default true
 	 * @inheritable
 	 */
 	preview_urls: boolean | undefined;
@@ -214,7 +218,7 @@ interface EnvironmentInheritable {
 	/**
 	 * The function to use to replace jsx syntax.
 	 *
-	 * @default `"React.createElement"`
+	 * @default "React.createElement"
 	 * @inheritable
 	 */
 	jsx_factory: string;
@@ -222,7 +226,7 @@ interface EnvironmentInheritable {
 	/**
 	 * The function to use to replace jsx fragment syntax.
 	 *
-	 * @default `"React.Fragment"`
+	 * @default "React.Fragment"
 	 * @inheritable
 	 */
 	jsx_fragment: string;
@@ -246,7 +250,7 @@ interface EnvironmentInheritable {
 	 *
 	 * More details here https://developers.cloudflare.com/workers/platform/cron-triggers
 	 *
-	 * @default `{crons:[]}`
+	 * @default {crons:[]}
 	 * @inheritable
 	 */
 	triggers: { crons: string[] };
@@ -340,7 +344,7 @@ interface EnvironmentInheritable {
 	/**
 	 * List of bindings that you will send to logfwdr
 	 *
-	 * @default `{bindings:[]}`
+	 * @default {bindings:[]}
 	 * @inheritable
 	 */
 	logfwdr: {
@@ -432,7 +436,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `{}`
+	 * @default {}
 	 * @nonInheritable
 	 */
 	define: Record<string, string>;
@@ -442,7 +446,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `{}`
+	 * @default {}
 	 * @nonInheritable
 	 */
 	vars: Record<string, string | Json>;
@@ -456,7 +460,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `{bindings:[]}`
+	 * @default {bindings:[]}
 	 * @nonInheritable
 	 */
 	durable_objects: {
@@ -469,7 +473,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	workflows: WorkflowBinding[];
@@ -480,7 +484,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `{}`
+	 * @default {}
 	 * @nonInheritable
 	 */
 	cloudchamber: CloudchamberConfig;
@@ -495,7 +499,7 @@ export interface EnvironmentNonInheritable {
 		 * NOTE: This field is not automatically inherited from the top level environment,
 		 * and so must be specified in every named environment.
 		 *
-		 * @default `{}`
+		 * @default {}
 		 * @nonInheritable
 		 */
 		app: ContainerApp[];
@@ -511,7 +515,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	kv_namespaces: {
@@ -529,7 +533,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	send_email: {
@@ -547,7 +551,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `{consumers:[],producers:[]}`
+	 * @default {consumers:[],producers:[]}
 	 * @nonInheritable
 	 */
 	queues: {
@@ -600,7 +604,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	r2_buckets: {
@@ -620,7 +624,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	d1_databases: {
@@ -646,7 +650,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	vectorize: {
@@ -662,7 +666,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	hyperdrive: {
@@ -680,7 +684,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	services:
@@ -702,7 +706,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	analytics_engine_datasets: {
@@ -718,7 +722,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `{}`
+	 * @default {}
 	 * @nonInheritable
 	 */
 	browser:
@@ -733,7 +737,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `{}`
+	 * @default {}
 	 * @nonInheritable
 	 */
 	ai:
@@ -758,7 +762,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `{}`
+	 * @default {}
 	 * @nonInheritable
 	 */
 	unsafe: {
@@ -803,7 +807,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	mtls_certificates: {
@@ -819,7 +823,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	tail_consumers?: TailConsumer[];
@@ -830,7 +834,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	dispatch_namespaces: {
@@ -848,7 +852,7 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @nonInheritable
 	 */
 	pipelines: {
@@ -882,7 +886,7 @@ interface EnvironmentDeprecated {
 	/**
 	 * A list of services that your Worker should be bound to.
 	 *
-	 * @default `[]`
+	 * @default []
 	 * @deprecated DO NOT USE. We'd added this to test the new service binding system, but the proper way to test experimental features is to use `unsafe.bindings` configuration.
 	 */
 	experimental_services?: {

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -169,8 +169,6 @@ interface EnvironmentInheritable {
 	 * test and deploy your Worker.
 	 *
 	 *
-	 * NOTE: (This is a breaking change from Wrangler v1)
-	 *
 	 * @default true
 	 * @breaking
 	 * @inheritable


### PR DESCRIPTION
Fixes #7820

Prior to this PR, the default for i.e. `compatibility_flags` was ``"`[]`"`` while it should be `[]` only. It made the autocomplete of `wrangler.json` and `wrangler.toml` in VSCode wrong (tested with the "Even Better TOML" extension)

On top of removing the backquotes, the PR also remove some comments that were not meant to be displayed.

Note that the formatting of the default value, i.e. `{consumers:[],producers:[]}` does not use the usual formatting because it breaks VSCode syntax highlithing.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
