### PR TITLE
fix(create-cloudflare): bump vitest-pool-workers version on the templates

### DIFF
--- a/.changeset/cuddly-radios-rule.md
+++ b/.changeset/cuddly-radios-rule.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+fix: bump `vitest-pool-workers` version range in templates
+
+This resolves [#7815](https://github.com/cloudflare/workers-sdk/issues/7815), where users encountered an error about missing `nodejs_compat` or `nodejs_compat_v2` compatibility flags when running Vitest on a fresh Hello World project created with `create-cloudflare`.

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -71,14 +71,23 @@ export type RunnerConfig = {
 	argv?: string[];
 	quarantine?: boolean;
 	timeout?: number;
+	/**
+	 * Specifies whether to assert the response from the specified route after deployment.
+	 */
 	verifyDeploy: null | {
 		route: string;
 		expectedText: string;
 	};
+	/**
+	 * Specifies whether to run the preview script for the project and assert the response from the specified route.
+	 */
 	verifyPreview: null | {
 		route: string;
 		expectedText: string;
 	};
+	/**
+	 * Specifies whether to run the test script for the project and verify the exit code.
+	 */
 	verifyTest?: boolean;
 };
 

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -25,7 +25,9 @@ import type {
 import type { Writable } from "stream";
 import type { RunnerTestCase, Suite, Test } from "vitest";
 
-export const C3_E2E_PREFIX = "tmp-e2e-c3";
+// Project Name prefix
+// Note: Project name can only be up to 58 characters long
+export const C3_E2E_PREFIX = "tmp-c3";
 
 export const keys = {
 	enter: "\x0d",

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -25,9 +25,7 @@ import type {
 import type { Writable } from "stream";
 import type { RunnerTestCase, Suite, Test } from "vitest";
 
-// Project Name prefix
-// Note: Project name can only be up to 58 characters long
-export const C3_E2E_PREFIX = "tmp-c3";
+export const C3_E2E_PREFIX = "tmp-e2e-c3";
 
 export const keys = {
 	enter: "\x0d",
@@ -384,9 +382,18 @@ export const testProjectDir = (suite: string, test: string) => {
 	const randomSuffix = crypto.randomBytes(4).toString("hex");
 	const baseProjectName = `${C3_E2E_PREFIX}${randomSuffix}`;
 
-	const getName = () =>
+	const getName = () => {
 		// Worker project names cannot be longer than 58 characters
-		`${baseProjectName}-${test.substring(0, 57 - baseProjectName.length)}`;
+		const projectName = `${baseProjectName}-${test.substring(0, 57 - baseProjectName.length)}`;
+
+		// Project name cannot start/end with a dash
+		if (projectName.endsWith("-")) {
+			return projectName.slice(0, -1);
+		}
+
+		return projectName;
+	};
+
 	const getPath = () => path.join(tmpDirPath, getName());
 	const clean = () => {
 		try {

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -79,6 +79,7 @@ export type RunnerConfig = {
 		route: string;
 		expectedText: string;
 	};
+	verifyTest?: boolean;
 };
 
 export const runC3 = async (

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -148,8 +148,7 @@ const workerTests = getWorkerTests({ experimental });
 
 describe
 	.skipIf(
-		experimental || // skip until we add tests for experimental workers templates
-			getFrameworkToTest({ experimental }) ||
+		getFrameworkToTest({ experimental }) ||
 			isQuarantineMode() ||
 			process.platform === "win32",
 	)

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -31,7 +31,29 @@ type WorkerTestConfig = RunnerConfig & {
 
 function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 	if (opts.experimental) {
-		return [];
+		return [
+			{
+				template: "hello-world-with-assets",
+				variants: ["TypeScript", "JavaScript"],
+				verifyDeploy: {
+					route: "/message",
+					expectedText: "Hello, World!",
+				},
+				// There is no preview script
+				verifyPreview: null,
+				verifyTest: true,
+			},
+			{
+				template: "hello-world-durable-object-with-assets",
+				variants: ["TypeScript", "JavaScript"],
+				verifyDeploy: {
+					route: "/",
+					expectedText: "Hello, World!",
+				},
+				// There is no preview script
+				verifyPreview: null,
+			},
+		];
 	} else {
 		return [
 			{
@@ -203,6 +225,7 @@ const runCli = async (
 		projectPath,
 		"--type",
 		template,
+		experimental ? "--experimental" : "",
 		"--no-open",
 		"--no-git",
 		NO_DEPLOY ? "--no-deploy" : "--deploy",

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -34,7 +34,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 		return [
 			{
 				template: "hello-world-with-assets",
-				variants: ["TypeScript", "JavaScript"],
+				variants: ["ts", "js"],
 				verifyDeploy: {
 					route: "/message",
 					expectedText: "Hello, World!",
@@ -46,7 +46,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 			},
 			{
 				template: "hello-world-with-assets",
-				variants: ["Python"],
+				variants: ["python"],
 				verifyDeploy: {
 					route: "/message",
 					expectedText: "Hello, World!",
@@ -57,7 +57,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 			},
 			{
 				template: "hello-world-durable-object-with-assets",
-				variants: ["TypeScript", "JavaScript"],
+				variants: ["ts", "js"],
 				verifyDeploy: {
 					route: "/",
 					expectedText: "Hello, World!",
@@ -82,7 +82,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 		return [
 			{
 				template: "hello-world",
-				variants: ["TypeScript", "JavaScript"],
+				variants: ["ts", "js"],
 				verifyDeploy: {
 					route: "/",
 					expectedText: "Hello World!",
@@ -95,7 +95,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 			},
 			{
 				template: "hello-world",
-				variants: ["Python"],
+				variants: ["python"],
 				verifyDeploy: {
 					route: "/",
 					expectedText: "Hello World!",
@@ -107,7 +107,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 			},
 			{
 				template: "common",
-				variants: ["TypeScript", "JavaScript"],
+				variants: ["ts", "js"],
 				verifyDeploy: {
 					route: "/",
 					expectedText: "Try making requests to:",
@@ -119,14 +119,14 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 			},
 			{
 				template: "queues",
-				variants: ["TypeScript", "JavaScript"],
+				variants: ["ts", "js"],
 				// Skipped for now, since C3 does not yet support resource creation
 				verifyDeploy: null,
 				verifyPreview: null,
 			},
 			{
 				template: "scheduled",
-				variants: ["TypeScript", "JavaScript"],
+				variants: ["ts", "js"],
 				// Skipped for now, since it's not possible to test scheduled events on deployed Workers
 				verifyDeploy: null,
 				verifyPreview: null,
@@ -168,15 +168,7 @@ describe
 							return {
 								...testConfig,
 								name: `${testConfig.name ?? testConfig.template}-${variant.toLowerCase()}`,
-								promptHandlers: [
-									{
-										matcher: /Which language do you want to use\?/,
-										input: {
-											type: "select",
-											target: variant,
-										},
-									},
-								],
+								argv: (testConfig.argv ?? []).concat("--lang", variant),
 							};
 						})
 					: [testConfig],
@@ -195,9 +187,6 @@ describe
 
 							// Relevant project files should have been created
 							expect(project.path).toExist();
-
-							const gitignorePath = join(project.path, ".gitignore");
-							expect(gitignorePath).toExist();
 
 							const pkgJsonPath = join(project.path, "package.json");
 							expect(pkgJsonPath).toExist();

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -44,8 +44,28 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 				verifyTest: true,
 			},
 			{
+				template: "hello-world-with-assets",
+				variants: ["Python"],
+				verifyDeploy: {
+					route: "/message",
+					expectedText: "Hello, World!",
+				},
+				// There is no preview script
+				verifyPreview: null,
+			},
+			{
 				template: "hello-world-durable-object-with-assets",
 				variants: ["TypeScript", "JavaScript"],
+				verifyDeploy: {
+					route: "/",
+					expectedText: "Hello, World!",
+				},
+				// There is no preview script
+				verifyPreview: null,
+			},
+			{
+				template: "hello-world-assets-only",
+				variants: [],
 				verifyDeploy: {
 					route: "/",
 					expectedText: "Hello, World!",

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -199,12 +199,16 @@ describe
 
 							try {
 								expect(jsonPath).toExist();
-								const config = readJSON(jsonPath) as { main: string };
-								expect(join(project.path, config.main)).toExist();
-							} catch {
+								const config = readJSON(jsonPath) as { main?: string };
+								if (config.main) {
+									expect(join(project.path, config.main)).toExist();
+								}
+							} catch (e) {
 								expect(tomlPath).toExist();
-								const config = readToml(tomlPath) as { main: string };
-								expect(join(project.path, config.main)).toExist();
+								const config = readToml(tomlPath) as { main?: string };
+								if (config.main) {
+									expect(join(project.path, config.main)).toExist();
+								}
 							}
 
 							const { verifyDeploy, verifyTest } = testConfig;

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -42,6 +42,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 				// There is no preview script
 				verifyPreview: null,
 				verifyTest: true,
+				argv: ["--category", "hello-world"],
 			},
 			{
 				template: "hello-world-with-assets",
@@ -52,6 +53,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 				},
 				// There is no preview script
 				verifyPreview: null,
+				argv: ["--category", "hello-world"],
 			},
 			{
 				template: "hello-world-durable-object-with-assets",
@@ -62,6 +64,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 				},
 				// There is no preview script
 				verifyPreview: null,
+				argv: ["--category", "hello-world"],
 			},
 			{
 				template: "hello-world-assets-only",
@@ -72,6 +75,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 				},
 				// There is no preview script
 				verifyPreview: null,
+				argv: ["--category", "hello-world"],
 			},
 		];
 	} else {

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -245,7 +245,7 @@ const runCli = async (
 		projectPath,
 		"--type",
 		template,
-		experimental ? "--experimental" : "",
+		...(experimental ? ["--experimental"] : []),
 		"--no-open",
 		"--no-git",
 		NO_DEPLOY ? "--no-deploy" : "--deploy",

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/package.json
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/package.json
@@ -9,7 +9,7 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.5.2",
+		"@cloudflare/vitest-pool-workers": "^0.6.4",
 		"wrangler": "^3.101.0",
 		"vitest": "2.1.8"
 	}

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/package.json
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/package.json
@@ -10,7 +10,7 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.5.2",
+		"@cloudflare/vitest-pool-workers": "^0.6.4",
 		"typescript": "^5.5.2",
 		"vitest": "2.1.8",
 		"wrangler": "^3.101.0"

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -9,7 +9,7 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.5.2",
+		"@cloudflare/vitest-pool-workers": "^0.6.4",
 		"wrangler": "^3.101.0",
 		"vitest": "2.1.8"
 	}

--- a/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
+++ b/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
@@ -14,7 +14,7 @@ describe('Hello World worker', () => {
 	});
 
 	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch(request, env, ctx); // Break the test to verify the CI pipeline
+		const response = await SELF.fetch('http://example.com');
 		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
 	});
 });

--- a/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
+++ b/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
@@ -14,7 +14,7 @@ describe('Hello World worker', () => {
 	});
 
 	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('https://example.com');
+		const response = await SELF.fetch(request, env, ctx); // Break the test to verify the CI pipeline
 		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
 	});
 });

--- a/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
+++ b/packages/create-cloudflare/templates/hello-world/js/test/index.spec.js
@@ -14,7 +14,7 @@ describe('Hello World worker', () => {
 	});
 
 	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch(request, env, ctx);
+		const response = await SELF.fetch('https://example.com');
 		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
 	});
 });

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -10,7 +10,7 @@
 		"cf-typegen": "wrangler types"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.5.2",
+		"@cloudflare/vitest-pool-workers": "^0.6.4",
 		"typescript": "^5.5.2",
 		"vitest": "2.1.8",
 		"wrangler": "^3.101.0"


### PR DESCRIPTION
Fixes #7815.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: package version bump

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
