### PR TITLE
Relax the messaging when Wrangler uses redirected configuration

### DIFF
--- a/.changeset/green-mice-carry.md
+++ b/.changeset/green-mice-carry.md
@@ -1,0 +1,8 @@
+---
+"wrangler": patch
+---
+
+Relax the messaging when Wrangler uses redirected configuration
+
+Previously the messaging was rendered as a warning, which implied that the user
+had done something wrong. Now it is just a regular info message.

--- a/packages/wrangler/src/__tests__/config/findWranglerConfig.test.ts
+++ b/packages/wrangler/src/__tests__/config/findWranglerConfig.test.ts
@@ -105,22 +105,16 @@ describe("config findWranglerConfig()", () => {
 				Object {
 				  "debug": "",
 				  "err": "",
-				  "info": "",
+				  "info": "Using redirected Wrangler configuration.
+				 - Configuration being used: \\"dist/wrangler.json\\"
+				 - Original user's configuration: \\"<no user config found>\\"
+				 - Deploy configuration file: \\".wrangler/deploy/config.json\\"
+				Using redirected Wrangler configuration.
+				 - Configuration being used: \\"dist/wrangler.json\\"
+				 - Original user's configuration: \\"<no user config found>\\"
+				 - Deploy configuration file: \\".wrangler/deploy/config.json\\"",
 				  "out": "",
-				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing redirected Wrangler configuration.[0m
-
-				  Configuration being used: \\"dist/wrangler.json\\"
-				  Original user's configuration: \\"<no user config found>\\"
-				  Deploy configuration file: \\".wrangler/deploy/config.json\\"
-
-
-				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing redirected Wrangler configuration.[0m
-
-				  Configuration being used: \\"dist/wrangler.json\\"
-				  Original user's configuration: \\"<no user config found>\\"
-				  Deploy configuration file: \\".wrangler/deploy/config.json\\"
-
-				",
+				  "warn": "",
 				}
 			`);
 		});
@@ -148,22 +142,16 @@ describe("config findWranglerConfig()", () => {
 				Object {
 				  "debug": "",
 				  "err": "",
-				  "info": "",
+				  "info": "Using redirected Wrangler configuration.
+				 - Configuration being used: \\"dist/wrangler.json\\"
+				 - Original user's configuration: \\"wrangler.toml\\"
+				 - Deploy configuration file: \\".wrangler/deploy/config.json\\"
+				Using redirected Wrangler configuration.
+				 - Configuration being used: \\"dist/wrangler.json\\"
+				 - Original user's configuration: \\"wrangler.toml\\"
+				 - Deploy configuration file: \\".wrangler/deploy/config.json\\"",
 				  "out": "",
-				  "warn": "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing redirected Wrangler configuration.[0m
-
-				  Configuration being used: \\"dist/wrangler.json\\"
-				  Original user's configuration: \\"wrangler.toml\\"
-				  Deploy configuration file: \\".wrangler/deploy/config.json\\"
-
-
-				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUsing redirected Wrangler configuration.[0m
-
-				  Configuration being used: \\"dist/wrangler.json\\"
-				  Original user's configuration: \\"wrangler.toml\\"
-				  Deploy configuration file: \\".wrangler/deploy/config.json\\"
-
-				",
+				  "warn": "",
 				}
 			`);
 		});

--- a/packages/wrangler/src/config/config-helpers.ts
+++ b/packages/wrangler/src/config/config-helpers.ts
@@ -128,11 +128,11 @@ function findRedirectedWranglerConfig(
 			}
 		}
 
-		logger.warn(dedent`
+		logger.info(dedent`
 			Using redirected Wrangler configuration.
-			Configuration being used: "${path.relative(".", redirectedConfigPath)}"
-			Original user's configuration: "${userConfigPath ? path.relative(".", userConfigPath) : "<no user config found>"}"
-			Deploy configuration file: "${path.relative(".", deployConfigPath)}"
+			 - Configuration being used: "${path.relative(".", redirectedConfigPath)}"
+			 - Original user's configuration: "${userConfigPath ? path.relative(".", userConfigPath) : "<no user config found>"}"
+			 - Deploy configuration file: "${path.relative(".", deployConfigPath)}"
 		`);
 		return redirectedConfigPath;
 	}


### PR DESCRIPTION
Previously the messaging was rendered as a warning, which implied that the user had done something wrong. Now it is just a regular info message.

Fixes #0000

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor change that doesn't affect docs

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
