### PR TITLE
Relax the Wrangler peer dependency for the Vite plugin

### DIFF
--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -59,7 +59,7 @@
 	},
 	"peerDependencies": {
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:^"
+		"wrangler": "catalog:vite-plugin"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/vite-plugin-cloudflare/playground/cloudflare-env/package.json
+++ b/packages/vite-plugin-cloudflare/playground/cloudflare-env/package.json
@@ -17,6 +17,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/durable-objects/package.json
+++ b/packages/vite-plugin-cloudflare/playground/durable-objects/package.json
@@ -14,6 +14,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/external-durable-objects/package.json
+++ b/packages/vite-plugin-cloudflare/playground/external-durable-objects/package.json
@@ -14,6 +14,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/external-workflows/package.json
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/package.json
@@ -14,6 +14,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/hot-channel/package.json
+++ b/packages/vite-plugin-cloudflare/playground/hot-channel/package.json
@@ -13,6 +13,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/package.json
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/package.json
@@ -24,6 +24,6 @@
 		"slash-create": "6.2.1",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/package.json
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/package.json
@@ -19,6 +19,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/node-compat/package.json
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/package.json
@@ -42,6 +42,6 @@
 		"pg-cloudflare": "^1.1.1",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/react-spa/package.json
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/package.json
@@ -21,6 +21,6 @@
 		"@vitejs/plugin-react": "^4.3.4",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
@@ -23,6 +23,6 @@
 		"@vitejs/plugin-react": "^4.3.4",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/static-mpa/package.json
+++ b/packages/vite-plugin-cloudflare/playground/static-mpa/package.json
@@ -17,6 +17,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/virtual-modules/package.json
+++ b/packages/vite-plugin-cloudflare/playground/virtual-modules/package.json
@@ -14,6 +14,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/websockets/package.json
+++ b/packages/vite-plugin-cloudflare/playground/websockets/package.json
@@ -14,6 +14,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/worker/package.json
+++ b/packages/vite-plugin-cloudflare/playground/worker/package.json
@@ -14,6 +14,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/packages/vite-plugin-cloudflare/playground/workflows/package.json
+++ b/packages/vite-plugin-cloudflare/playground/workflows/package.json
@@ -14,6 +14,6 @@
 		"@cloudflare/workers-types": "^4.20241230.0",
 		"typescript": "catalog:vite-plugin",
 		"vite": "catalog:vite-plugin",
-		"wrangler": "workspace:*"
+		"wrangler": "catalog:vite-plugin"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ catalogs:
     vite:
       specifier: ^6.0.7
       version: 6.0.7
+    wrangler:
+      specifier: ^3.101.0
+      version: 3.103.2
 
 overrides:
   '@types/react-dom@18>@types/react': ^18
@@ -1770,8 +1773,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/durable-objects:
     devDependencies:
@@ -1791,8 +1794,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/external-durable-objects:
     devDependencies:
@@ -1812,8 +1815,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/external-workflows:
     devDependencies:
@@ -1833,8 +1836,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/hot-channel:
     devDependencies:
@@ -1854,8 +1857,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/module-resolution:
     devDependencies:
@@ -1896,8 +1899,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/multi-worker:
     devDependencies:
@@ -1917,8 +1920,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/node-compat:
     devDependencies:
@@ -1953,8 +1956,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/react-spa:
     dependencies:
@@ -1990,8 +1993,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/spa-with-api:
     dependencies:
@@ -2027,8 +2030,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/static-mpa:
     devDependencies:
@@ -2048,8 +2051,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/virtual-modules:
     devDependencies:
@@ -2069,8 +2072,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/websockets:
     devDependencies:
@@ -2090,8 +2093,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/worker:
     devDependencies:
@@ -2111,8 +2114,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vite-plugin-cloudflare/playground/workflows:
     devDependencies:
@@ -2132,8 +2135,8 @@ importers:
         specifier: catalog:vite-plugin
         version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
       wrangler:
-        specifier: workspace:*
-        version: link:../../../wrangler
+        specifier: catalog:vite-plugin
+        version: 3.103.2(@cloudflare/workers-types@4.20241230.0)
 
   packages/vitest-pool-workers:
     dependencies:
@@ -8224,6 +8227,11 @@ packages:
     engines: {node: '>=16.13'}
     hasBin: true
 
+  miniflare@3.20241230.2:
+    resolution: {integrity: sha512-gFC3IaUKrLGdtA6y6PLpC/QE5YAjB5ITCfBZHkosRyFZ9ApaCHKcHRvrEFMc/R19QxxtHD+G3tExEHp7MmtsYQ==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
 
@@ -10366,6 +10374,9 @@ packages:
   unenv-nightly@2.0.0-20241218-183400-5d6aec3:
     resolution: {integrity: sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==}
 
+  unenv-nightly@2.0.0-20250109-100802-88ad671:
+    resolution: {integrity: sha512-Uij6gODNNNNsNBoDlnaMvZI99I6YlVJLRfYH8AOLMlbFrW7k2w872v9VLuIdch2vF8QBeSC4EftIh5sG4ibzdA==}
+
   unenv@2.0.0-rc.0:
     resolution: {integrity: sha512-H0kl2w8jFL/FAk0xvjVing4bS3jd//mbg1QChDnn58l9Sc5RtduaKmLAL8n+eBw5jJo8ZjYV7CrEGage5LAOZQ==}
 
@@ -10707,6 +10718,16 @@ packages:
 
   workerpool@6.5.1:
     resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+
+  wrangler@3.103.2:
+    resolution: {integrity: sha512-eYcnubPhPBU1QMZYTam+vfCLpaQx+x1EWA6nFbLhid1eqNDAk1dNwNlbo+ZryrOHDEX3XlOxn2Z3Fx8vVv3hKw==}
+    engines: {node: '>=16.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20241230.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
 
   wrangler@3.90.0:
     resolution: {integrity: sha512-E/6E9ORAl987+3kP8wDiE3L1lj9r4vQ32/dl5toIxIkSMssmPRQVdxqwgMxbxJrytbFNo8Eo6swgjd4y4nUaLg==}
@@ -17380,6 +17401,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  miniflare@3.20241230.2:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.14.0
+      acorn-walk: 8.3.2
+      capnp-ts: 0.7.0(patch_hash=l4yimnxyvkiyj6alnps2ec3sii)
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      stoppable: 1.1.0
+      undici: 5.28.4
+      workerd: 1.20241230.0
+      ws: 8.18.0
+      youch: 3.2.3
+      zod: 3.22.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   minimatch@3.0.8:
     dependencies:
       brace-expansion: 1.1.11
@@ -19659,6 +19699,14 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.5.4
 
+  unenv-nightly@2.0.0-20250109-100802-88ad671:
+    dependencies:
+      defu: 6.1.4
+      mlly: 1.7.4
+      ohash: 1.1.4
+      pathe: 1.1.2
+      ufo: 1.5.4
+
   unenv@2.0.0-rc.0:
     dependencies:
       defu: 6.1.4
@@ -20043,6 +20091,25 @@ snapshots:
       '@cloudflare/workerd-windows-64': 1.20241230.0
 
   workerpool@6.5.1: {}
+
+  wrangler@3.103.2(@cloudflare/workers-types@4.20241230.0):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.3.4
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      esbuild: 0.17.19
+      miniflare: 3.20241230.2
+      path-to-regexp: 6.3.0
+      unenv: unenv-nightly@2.0.0-20250109-100802-88ad671
+      workerd: 1.20241230.0
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20241230.0
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   wrangler@3.90.0(@cloudflare/workers-types@4.20241230.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,5 @@ catalogs:
     "vite": "^6.0.7"
     "@types/node": "^22.10.1"
     "unenv": "npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3"
+    # This is the minimum Wrangler peer dependency for Vite
+    "wrangler": "^3.101.0"


### PR DESCRIPTION
We only need the Wrangler peer dependency to be at least 3.101.0,
which is when we added support for the redirected config.

By using the peer dependency range version in the playgrounds, we ensure that
we are testing against what will be used in practice. It will also ensure that this
dependency gets bumped when needed, since the playgrounds might start to fail otherwise.

Fixes #000.

(No changeset required because this is covered by the current changeset for the first release of the plugin)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Vite plugin not covered by e2e tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no documentation facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
