### PR TITLE
change `watch` scripts to `dev` in packages for consistency

### DIFF
--- a/packages/cloudflare-workers-bindings-extension/package.json
+++ b/packages/cloudflare-workers-bindings-extension/package.json
@@ -14,7 +14,7 @@
 	"scripts": {
 		"vscode:prepublish": "pnpm run package",
 		"compile": "pnpm run check:type && pnpm run check:lint && node esbuild.js",
-		"watch": "npm-run-all -p watch:*",
+		"dev": "npm-run-all -p watch:*",
 		"watch:esbuild": "node esbuild.js --watch",
 		"watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
 		"package": "pnpm run check:type && pnpm run check:lint && node esbuild.js --production",

--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -39,7 +39,7 @@
 		"test:e2e:yarn": "pnpm run build && cross-env TEST_PM=yarn vitest run --config ./vitest-e2e.config.mts",
 		"test:unit": "vitest run --config ./vitest.config.mts",
 		"test:unit:watch": "vitest --config ./vitest.config.mts",
-		"watch": "node -r esbuild-register scripts/build.ts --watch",
+		"dev": "node -r esbuild-register scripts/build.ts --watch",
 		"test:ci": "vitest run --config ./vitest.config.mts"
 	},
 	"devDependencies": {

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -35,9 +35,9 @@
 	"scripts": {
 		"build": "tsup",
 		"check:type": "tsc --build",
+		"dev": "tsup --watch",
 		"test": "vitest",
-		"test:ci": "vitest run",
-		"watch": "tsup --watch"
+		"test:ci": "vitest run"
 	},
 	"dependencies": {
 		"@hattip/adapter-node": "^0.0.49",


### PR DESCRIPTION
It's quite minor but I noticed that almost all packages in the monorepo have a `dev` script for building the package in watch mode with a few exceptions, so for consistency sake I'd also use that script name there

Besides the above, this type of consistency can potentially help with the turborepo setup (e.g. I want to dev multiple packages at once)

<details>

currently if I run `pnpm dev` in the monorepo root I get the following error:
![Screenshot 2025-01-21 at 14 22 02](https://github.com/user-attachments/assets/4b932f5e-95ce-401a-ad8b-38c5e4594572)

but you get the gist
</details>

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: minor infra change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: minor infra change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor infra change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
