### PR TITLE
Plumb through account ID and Worker ID into asset-worker and router-worker

### DIFF
--- a/.changeset/eighty-penguins-complain.md
+++ b/.changeset/eighty-penguins-complain.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+chore: plumb through account ID and Worker ID into the asset-worker and router-worker for use in analytics and error reporting.

--- a/packages/workers-shared/asset-worker/src/analytics.ts
+++ b/packages/workers-shared/asset-worker/src/analytics.ts
@@ -5,6 +5,10 @@ const VERSION = 1;
 
 // When adding new columns please update the schema
 type Data = {
+	// -- Indexes --
+	accountId?: number;
+	scriptId?: number;
+
 	// -- Doubles --
 	// double1 - The time it takes for the whole request to complete in milliseconds
 	requestTime?: number;
@@ -55,8 +59,8 @@ export class Analytics {
 
 		this.readyAnalytics.logEvent({
 			version: VERSION,
-			accountId: 0, // TODO: need to plumb through
-			indexId: this.data.hostname?.substring(0, 96),
+			accountId: this.data.accountId,
+			indexId: this.data.scriptId?.toString(),
 			doubles: [
 				this.data.requestTime ?? -1, // double1
 				this.data.coloId ?? -1, // double2

--- a/packages/workers-shared/asset-worker/src/types.ts
+++ b/packages/workers-shared/asset-worker/src/types.ts
@@ -4,13 +4,6 @@ export interface ReadyAnalytics {
 	logEvent: (e: ReadyAnalyticsEvent) => void;
 }
 
-export interface ColoMetadata {
-	metalId: number;
-	coloId: number;
-	coloRegion: string;
-	coloTier: number;
-}
-
 export interface ReadyAnalyticsEvent {
 	accountId?: number;
 	indexId?: string;

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -10,6 +10,10 @@ export enum DISPATCH_TYPE {
 
 // When adding new columns please update the schema
 type Data = {
+	// -- Indexes --
+	accountId?: number;
+	scriptId?: number;
+
 	// -- Doubles --
 	// double1 - The time it takes for the whole request to complete in milliseconds
 	requestTime?: number;
@@ -58,8 +62,8 @@ export class Analytics {
 
 		this.readyAnalytics.logEvent({
 			version: VERSION,
-			accountId: 0, // TODO: need to plumb through
-			indexId: this.data.hostname?.substring(0, 96),
+			accountId: this.data.accountId,
+			indexId: this.data.scriptId?.toString(),
 			doubles: [
 				this.data.requestTime ?? -1, // double1
 				this.data.coloId ?? -1, // double2

--- a/packages/workers-shared/router-worker/src/index.ts
+++ b/packages/workers-shared/router-worker/src/index.ts
@@ -34,21 +34,23 @@ export default {
 				ctx,
 				env.SENTRY_DSN,
 				env.SENTRY_ACCESS_CLIENT_ID,
-				env.SENTRY_ACCESS_CLIENT_SECRET
+				env.SENTRY_ACCESS_CLIENT_SECRET,
+				env.COLO_METADATA,
+				env.CONFIG?.account_id,
+				env.CONFIG?.script_id
 			);
 
 			const url = new URL(request.url);
-			if (sentry) {
-				sentry.setUser({ username: url.hostname });
-				sentry.setTag("colo", env.COLO_METADATA.coloId);
-				sentry.setTag("metal", env.COLO_METADATA.metalId);
-			}
 
 			if (env.COLO_METADATA && env.VERSION_METADATA && env.CONFIG) {
 				analytics.setData({
+					accountId: env.CONFIG.account_id,
+					scriptId: env.CONFIG.script_id,
+
 					coloId: env.COLO_METADATA.coloId,
 					metalId: env.COLO_METADATA.metalId,
 					coloTier: env.COLO_METADATA.coloTier,
+
 					coloRegion: env.COLO_METADATA.coloRegion,
 					hostname: url.hostname,
 					version: env.VERSION_METADATA.id,

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 export const RoutingConfigSchema = z.object({
 	has_user_worker: z.boolean().optional(),
 	invoke_user_worker_ahead_of_assets: z.boolean().optional(),
+
+	// Used for analytics and reporting
+	account_id: z.number().optional(),
+	script_id: z.number().optional(),
 });
 
 export const AssetConfigSchema = z.object({
@@ -20,8 +24,20 @@ export const AssetConfigSchema = z.object({
 	serve_directly: z.boolean().optional(),
 });
 
+export const InternalConfigSchema = z.object({
+	// Used for analytics and reporting
+	account_id: z.number().optional(),
+	script_id: z.number().optional(),
+});
+
+export const AssetWorkerConfigShema = z.object({
+	...AssetConfigSchema.shape,
+	...InternalConfigSchema.shape,
+});
+
 export type RoutingConfig = z.infer<typeof RoutingConfigSchema>;
 export type AssetConfig = z.infer<typeof AssetConfigSchema>;
+export type AssetWorkerConfig = z.infer<typeof AssetWorkerConfigShema>;
 
 export interface UnsafePerformanceTimer {
 	readonly timeOrigin: number;
@@ -64,3 +80,10 @@ export interface SpanContext {
 
 export type JaegerValue = string | number | boolean;
 export type JaegerRecord = Record<string, JaegerValue>;
+
+export interface ColoMetadata {
+	metalId: number;
+	coloId: number;
+	coloRegion: string;
+	coloTier: number;
+}


### PR DESCRIPTION
Fixes N/A

plumb through account ID and Worker ID into the asset-worker and router-worker for use in analytics and error reporting.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: analytics/error reporting changes
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: analytics/error reporting changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: analytics/error reporting changes
