### PR TITLE
[vite-plugin-cloudflare] make sure that runner initialization is properly validated

### DIFF
--- a/.changeset/smart-mice-appear.md
+++ b/.changeset/smart-mice-appear.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+fix: make sure that runner initialization is properly validated

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -99,7 +99,10 @@ export class CloudflareDevEnvironment extends vite.DevEnvironment {
 			}
 		);
 
-		assert(response.ok, "Failed to initialize module runner");
+		assert(
+			response.ok,
+			`Failed to initialize module runner, error: ${await response.text()}`
+		);
 
 		const webSocket = response.webSocket;
 		assert(webSocket, "Failed to establish WebSocket");

--- a/packages/vite-plugin-cloudflare/src/runner-worker/index.ts
+++ b/packages/vite-plugin-cloudflare/src/runner-worker/index.ts
@@ -177,9 +177,7 @@ export function createWorkerEntrypointWrapper(
 						await createModuleRunner(this.env, server);
 					} catch (e) {
 						return new Response(
-							JSON.stringify(
-								e instanceof Error ? e.message : JSON.stringify(e)
-							),
+							e instanceof Error ? e.message : JSON.stringify(e),
 							{ status: 500 }
 						);
 					}

--- a/packages/vite-plugin-cloudflare/src/runner-worker/index.ts
+++ b/packages/vite-plugin-cloudflare/src/runner-worker/index.ts
@@ -173,7 +173,16 @@ export function createWorkerEntrypointWrapper(
 
 				if (url.pathname === INIT_PATH) {
 					const { 0: client, 1: server } = new WebSocketPair();
-					createModuleRunner(this.env, server);
+					try {
+						await createModuleRunner(this.env, server);
+					} catch (e) {
+						return new Response(
+							JSON.stringify(
+								e instanceof Error ? e.message : JSON.stringify(e)
+							),
+							{ status: 500 }
+						);
+					}
 
 					return new Response(null, { status: 101, webSocket: client });
 				}


### PR DESCRIPTION
Fixes https://github.com/flarelabs-net/vite-plugin-cloudflare/issues/59

The plugin validation around the module runner initialization is not properly propagated, the changes here make sure
that it is and that a (hopefully) helpful error message is shown to the user

An easy way to see the different behavior here is to make the `createModuleRunner` function always throw:
![Screenshot 2025-01-21 at 15 30 14](https://github.com/user-attachments/assets/17a5c4ac-8707-4768-9955-106dee87940a)
and run a playground application, without the changes here it's not clear/surfaced that the runner failed initialization

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this is an extra check that, it is just in case, we don't expect the error to be triggered and testing this would require some potentially hacking tweaks in the runner initialization code (so that it can throw with no proper reason), so it's most likely not worth it, I am happy to have a look if we do strongly believe that this needs testing though
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no wrangler changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just better error handling

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
