### PR TITLE
add node:timers and node:net to unenv-preset

### DIFF
--- a/.changeset/nine-rocks-appear.md
+++ b/.changeset/nine-rocks-appear.md
@@ -1,5 +1,0 @@
----
-"@cloudflare/unenv-preset": patch
----
-
-Update unenv to 2.0.0-rc.1

--- a/.changeset/nine-rocks-appear.md
+++ b/.changeset/nine-rocks-appear.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Update unenv to 2.0.0-rc.1

--- a/.changeset/popular-pigs-glow.md
+++ b/.changeset/popular-pigs-glow.md
@@ -2,4 +2,4 @@
 "@cloudflare/unenv-preset": patch
 ---
 
-Removes node:net and node:timers from polyfills
+Removes `node:net`, `node:timers` and `node:timers/promises` from polyfills

--- a/.changeset/popular-pigs-glow.md
+++ b/.changeset/popular-pigs-glow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Removes node:net and node:timers from polyfills

--- a/.changeset/popular-pigs-glow.md
+++ b/.changeset/popular-pigs-glow.md
@@ -1,5 +1,8 @@
 ---
-"@cloudflare/unenv-preset": patch
+"@cloudflare/unenv-preset": minor
 ---
 
-Removes `node:net`, `node:timers` and `node:timers/promises` from polyfills
+Use the workerd implementation for Node `net`, `timers`, and `timers/promises` modules
+
+- drop the polyfills
+- update `unenv` to 2.0.0-rc.1

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -54,7 +54,7 @@
 		"wrangler": "workspace:*"
 	},
 	"peerDependencies": {
-		"unenv": "2.0.0-rc.0",
+		"unenv": "2.0.0-rc.1",
 		"workerd": "^1.20250124.0"
 	},
 	"peerDependenciesMeta": {

--- a/packages/unenv-preset/package.json
+++ b/packages/unenv-preset/package.json
@@ -55,7 +55,7 @@
 	},
 	"peerDependencies": {
 		"unenv": "2.0.0-rc.0",
-		"workerd": "^1.20241230.0"
+		"workerd": "^1.20250124.0"
 	},
 	"peerDependenciesMeta": {
 		"workerd": {

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -4,7 +4,7 @@ import type { Preset } from "unenv";
 // Built-in APIs provided by workerd.
 // https://developers.cloudflare.com/workers/runtime-apis/nodejs/
 // https://github.com/cloudflare/workerd/tree/main/src/node
-// Last checked: 2024-10-22
+// Last checked: 2025-01-24
 const cloudflareNodeCompatModules = [
 	"_stream_duplex",
 	"_stream_passthrough",
@@ -18,6 +18,7 @@ const cloudflareNodeCompatModules = [
 	"dns",
 	"dns/promises",
 	"events",
+	"net",
 	"path",
 	"path/posix",
 	"path/win32",
@@ -27,6 +28,8 @@ const cloudflareNodeCompatModules = [
 	"stream/promises",
 	"stream/web",
 	"string_decoder",
+	"timers",
+	"timers/promises",
 	"url",
 	"util/types",
 	"zlib",
@@ -39,7 +42,6 @@ const hybridNodeCompatModules = [
 	"crypto",
 	"module",
 	"process",
-	"timers",
 	"util",
 ];
 

--- a/packages/unenv-preset/src/preset.ts
+++ b/packages/unenv-preset/src/preset.ts
@@ -2,10 +2,14 @@ import { version } from "../package.json";
 import type { Preset } from "unenv";
 
 // Built-in APIs provided by workerd.
+//
 // https://developers.cloudflare.com/workers/runtime-apis/nodejs/
 // https://github.com/cloudflare/workerd/tree/main/src/node
+//
 // Last checked: 2025-01-24
-const cloudflareNodeCompatModules = [
+//
+// NOTE: Please sync any changes to `testNodeCompatModules`.
+const nodeCompatModules = [
 	"_stream_duplex",
 	"_stream_passthrough",
 	"_stream_readable",
@@ -53,7 +57,7 @@ export const cloudflare: Preset = {
 	},
 	alias: {
 		...Object.fromEntries(
-			cloudflareNodeCompatModules.flatMap((p) => [
+			nodeCompatModules.flatMap((p) => [
 				[p, p],
 				[`node:${p}`, `node:${p}`],
 			])
@@ -92,5 +96,5 @@ export const cloudflare: Preset = {
 		],
 	},
 	polyfill: [],
-	external: cloudflareNodeCompatModules.flatMap((p) => [p, `node:${p}`]),
+	external: nodeCompatModules.flatMap((p) => [p, `node:${p}`]),
 };

--- a/packages/unenv-preset/tests/worker/index.ts
+++ b/packages/unenv-preset/tests/worker/index.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert";
 
-
 // List all the test functions.
 // The test can be executing by fetching the `/${testName}` url.
 export const TESTS = {

--- a/packages/unenv-preset/tests/worker/index.ts
+++ b/packages/unenv-preset/tests/worker/index.ts
@@ -10,6 +10,7 @@ export const TESTS = {
 	testPath,
 	testDns,
 	testTimers,
+	testNet,
 };
 
 export default {
@@ -86,6 +87,7 @@ async function testModules() {
 		"dns",
 		"dns/promises",
 		"events",
+		"net",
 		"path",
 		"path/posix",
 		"path/win32",
@@ -95,6 +97,8 @@ async function testModules() {
 		"stream/promises",
 		"stream/web",
 		"string_decoder",
+		"timers",
+		"timers/promises",
 		"url",
 		"util/types",
 		"zlib",
@@ -149,4 +153,11 @@ async function testTimers() {
 	// active is deprecated and no more in the type
 	(timers as any).active(timeout);
 	timers.clearTimeout(timeout);
+}
+
+export async function testNet() {
+	const net = await import("node:net");
+	assert.strictEqual(typeof net, "object");
+	assert.strictEqual(typeof net.createConnection, "function");
+	assert.throws(() => net.createServer(), /not implemented/);
 }

--- a/packages/unenv-preset/tests/worker/index.ts
+++ b/packages/unenv-preset/tests/worker/index.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 
+
 // List all the test functions.
 // The test can be executing by fetching the `/${testName}` url.
 export const TESTS = {
@@ -153,6 +154,9 @@ async function testTimers() {
 	// active is deprecated and no more in the type
 	(timers as any).active(timeout);
 	timers.clearTimeout(timeout);
+
+	const timersPromises = await import("node:timers/promises");
+	assert.strictEqual(await timersPromises.setTimeout(1, "timeout"), "timeout");
 }
 
 export async function testNet() {

--- a/packages/unenv-preset/tests/worker/index.ts
+++ b/packages/unenv-preset/tests/worker/index.ts
@@ -5,7 +5,7 @@ import assert from "node:assert";
 export const TESTS = {
 	testCryptoGetRandomValues,
 	testImplementsBuffer,
-	testModules,
+	testNodeCompatModules,
 	testUtilImplements,
 	testPath,
 	testDns,
@@ -75,7 +75,7 @@ async function testImplementsBuffer() {
 	assert.strictEqual(typeof buffer.resolveObjectURL, "function");
 }
 
-async function testModules() {
+async function testNodeCompatModules() {
 	const module = await import("node:module");
 	// @ts-expect-error exposed by workerd
 	const require = module.createRequire("/");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1669,8 +1669,8 @@ importers:
   packages/unenv-preset:
     dependencies:
       unenv:
-        specifier: 2.0.0-rc.0
-        version: 2.0.0-rc.0
+        specifier: 2.0.0-rc.1
+        version: 2.0.0-rc.1
       workerd:
         specifier: ^1.20250124.0
         version: 1.20250124.0
@@ -10571,6 +10571,9 @@ packages:
 
   unenv@2.0.0-rc.0:
     resolution: {integrity: sha512-H0kl2w8jFL/FAk0xvjVing4bS3jd//mbg1QChDnn58l9Sc5RtduaKmLAL8n+eBw5jJo8ZjYV7CrEGage5LAOZQ==}
+
+  unenv@2.0.0-rc.1:
+    resolution: {integrity: sha512-PU5fb40H8X149s117aB4ytbORcCvlASdtF97tfls4BPIyj4PeVxvpSuy1jAptqYHqB0vb2w2sHvzM0XWcp2OKg==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -20025,6 +20028,14 @@ snapshots:
       ufo: 1.5.4
 
   unenv@2.0.0-rc.0:
+    dependencies:
+      defu: 6.1.4
+      mlly: 1.7.4
+      ohash: 1.1.4
+      pathe: 1.1.2
+      ufo: 1.5.4
+
+  unenv@2.0.0-rc.1:
     dependencies:
       defu: 6.1.4
       mlly: 1.7.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1672,8 +1672,8 @@ importers:
         specifier: 2.0.0-rc.0
         version: 2.0.0-rc.0
       workerd:
-        specifier: ^1.20241230.0
-        version: 1.20241230.0
+        specifier: ^1.20250124.0
+        version: 1.20250124.0
     devDependencies:
       '@types/node-unenv':
         specifier: npm:@types/node@^22.10.5


### PR DESCRIPTION
We currently implement node:timers and node:net in cloudflare workers. I've opened a similar PR to unenv as well: https://github.com/unjs/unenv/pull/396

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: we already have ones that cover it through E2E
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/19341
  - [ ] Documentation not necessary

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
