### PR TITLE
refactor(wrangler): make JSON parsing independent of Node

### DIFF
--- a/.changeset/thick-bikes-teach.md
+++ b/.changeset/thick-bikes-teach.md
@@ -1,0 +1,10 @@
+---
+"wrangler": patch
+---
+
+refactor(wrangler): make JSON parsing independent of Node
+
+Switch `jsonc-parser` to parse json:
+
+- `JSON.parse()` exception messages are not stable across Node versions
+- While `jsonc-parser` is used, JSONC specific syntax is disabled

--- a/packages/wrangler/src/__tests__/parse.test.ts
+++ b/packages/wrangler/src/__tests__/parse.test.ts
@@ -225,17 +225,15 @@ describe("parseJSON", () => {
 				kind: "error",
 				location: {
 					line: 3,
-					column: 9,
+					column: 10,
+					length: 2,
 					lineText: '"version" "1',
 					file: undefined,
 					fileText: `\n{\n"version" "1\n}\n`,
 				},
 				notes: [],
 			});
-			expect(text).oneOf([
-				/* Node.js v16/v18 */ "Unexpected string",
-				/* Node.js v20+ */ "Expected ':' after property name",
-			]);
+			expect(text).toEqual("UnexpectedEndOfString");
 		}
 	});
 
@@ -248,13 +246,14 @@ describe("parseJSON", () => {
 		} catch (err) {
 			expect({ ...(err as Error) }).toStrictEqual({
 				name: "ParseError",
-				text: "Unexpected number",
+				text: "CommaExpected",
 				kind: "error",
 				location: {
 					file,
 					fileText,
 					line: 4,
-					column: 8,
+					column: 9,
+					length: 5,
 					lineText: `\t\t\t"c":[012345]`,
 				},
 				notes: [],

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -9,7 +9,6 @@ import { runWrangler } from "../../helpers/run-wrangler";
 import { mockPostVersion, mockSetupApiCalls } from "./utils";
 import type { Interface } from "node:readline";
 
-
 describe("versions secret bulk", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -148,9 +148,7 @@ describe("versions secret bulk", () => {
 
 		await expect(
 			runWrangler(`versions secret bulk secrets.json --name script-name`)
-		).rejects.toThrowError(
-			`The contents of "secrets.json" is not valid JSON: "ParseError: Unexpected token o"`
-		);
+		).rejects.toThrowError(`The contents of "secrets.json" is not valid JSON`);
 	});
 
 	test("should error on invalid json stdin", async () => {

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -9,6 +9,7 @@ import { runWrangler } from "../../helpers/run-wrangler";
 import { mockPostVersion, mockSetupApiCalls } from "./utils";
 import type { Interface } from "node:readline";
 
+
 describe("versions secret bulk", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
@@ -148,7 +149,9 @@ describe("versions secret bulk", () => {
 
 		await expect(
 			runWrangler(`versions secret bulk secrets.json --name script-name`)
-		).rejects.toThrowError(`The contents of "secrets.json" is not valid JSON`);
+		).rejects.toThrowError(
+			`The contents of "secrets.json" is not valid JSON: "ParseError: InvalidSymbol"`
+		);
 	});
 
 	test("should error on invalid json stdin", async () => {

--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -96,11 +96,11 @@ export async function fetchInternal<ResponseType>(
 	// as otherwise parseJSON will throw an error back to the user.
 	if (!jsonText && (response.status === 204 || response.status === 205)) {
 		const emptyBody = `{"result": {}, "success": true, "errors": [], "messages": []}`;
-		return parseJSON<ResponseType>(emptyBody);
+		return parseJSON(emptyBody) as ResponseType;
 	}
 
 	try {
-		return parseJSON<ResponseType>(jsonText);
+		return parseJSON(jsonText) as ResponseType;
 	} catch (err) {
 		throw new APIError({
 			text: "Received a malformed response from the API",

--- a/packages/wrangler/src/config/config-helpers.ts
+++ b/packages/wrangler/src/config/config-helpers.ts
@@ -82,10 +82,9 @@ function findRedirectedWranglerConfig(
 	let redirectedConfigPath: string | undefined;
 	const deployConfigFile = readFileSync(deployConfigPath);
 	try {
-		const deployConfig: { configPath?: string } = parseJSONC(
-			deployConfigFile,
-			deployConfigPath
-		);
+		const deployConfig = parseJSONC(deployConfigFile, deployConfigPath) as {
+			configPath?: string;
+		};
 		redirectedConfigPath =
 			deployConfig.configPath &&
 			path.resolve(path.dirname(deployConfigPath), deployConfig.configPath);

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -180,7 +180,7 @@ export const experimental_readRawConfig = (
 	if (configPath?.endsWith("toml")) {
 		rawConfig = parseTOML(readFileSync(configPath), configPath);
 	} else if (configPath?.endsWith("json") || configPath?.endsWith("jsonc")) {
-		rawConfig = parseJSONC(readFileSync(configPath), configPath);
+		rawConfig = parseJSONC(readFileSync(configPath), configPath) as RawConfig;
 	}
 	return { rawConfig, configPath, userConfigPath };
 };

--- a/packages/wrangler/src/config/patch-config.ts
+++ b/packages/wrangler/src/config/patch-config.ts
@@ -3,6 +3,7 @@ import TOML from "@iarna/toml";
 import { applyEdits, format, modify } from "jsonc-parser";
 import { parseJSONC, parseTOML, readFileSync } from "../parse";
 import type { RawConfig } from "./config";
+import type { JsonMap } from "@iarna/toml";
 import type { JSONPath } from "jsonc-parser";
 
 export const experimental_patchConfig = (

--- a/packages/wrangler/src/config/patch-config.ts
+++ b/packages/wrangler/src/config/patch-config.ts
@@ -46,7 +46,7 @@ export const experimental_patchConfig = (
 	configString = applyEdits(configString, formatEdit);
 
 	if (configPath.endsWith(".toml")) {
-		configString = TOML.stringify(parseJSONC(configString));
+		configString = TOML.stringify(parseJSONC(configString) as JsonMap);
 	}
 	writeFileSync(configPath, configString);
 	return configString;

--- a/packages/wrangler/src/dev/create-worker-preview.ts
+++ b/packages/wrangler/src/dev/create-worker-preview.ts
@@ -190,11 +190,11 @@ export async function createPreviewSession(
 
 	logger.debug("-- END EXCHANGE API RESPONSE");
 	try {
-		const { inspector_websocket, prewarm, token } = parseJSON<{
+		const { inspector_websocket, prewarm, token } = parseJSON(bodyText) as {
 			inspector_websocket: string;
 			token: string;
 			prewarm: string;
-		}>(bodyText);
+		};
 		const inspector = new URL(inspector_websocket);
 		inspector.searchParams.append("cf_workers_preview_token", token);
 

--- a/packages/wrangler/src/parse.ts
+++ b/packages/wrangler/src/parse.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import { resolve } from "node:path";
 import TOML from "@iarna/toml";
 import { formatMessagesSync } from "esbuild";
-import { parse as jsoncParse, printParseErrorCode } from "jsonc-parser";
+import * as jsoncParser from "jsonc-parser";
 import { UserError } from "./errors";
 import { logger } from "./logger";
 import type { ParseError as JsoncParseError } from "jsonc-parser";
@@ -136,8 +136,6 @@ export function parseTOML(input: string, file?: string): TOML.JsonMap | never {
 	}
 }
 
-const JSON_ERROR_SUFFIX = " in JSON at position ";
-
 /**
  * A minimal type describing a package.json file.
  */
@@ -158,35 +156,29 @@ export function parsePackageJSON<T extends PackageJSON = PackageJSON>(
 }
 
 /**
- * A wrapper around `JSON.parse` that throws a `ParseError`.
+ * Parses JSON and throws a `ParseError`.
  */
 export function parseJSON<T>(input: string, file?: string): T {
-	try {
-		return JSON.parse(input);
-	} catch (err) {
-		const { message } = err as Error;
-		const index = message.lastIndexOf(JSON_ERROR_SUFFIX);
-		if (index < 0) {
-			throw err;
-		}
-		const text = message.substring(0, index);
-		const position = parseInt(
-			message.substring(index + JSON_ERROR_SUFFIX.length)
-		);
-		const location = indexLocation({ file, fileText: input }, position);
-		throw new ParseError({ text, location });
-	}
+	return parseJSONC<T>(input, file, {
+		allowEmptyContent: false,
+		allowTrailingComma: false,
+		disallowComments: true,
+	});
 }
 
 /**
  * A wrapper around `JSONC.parse` that throws a `ParseError`.
  */
-export function parseJSONC<T>(input: string, file?: string): T {
+export function parseJSONC<T>(
+	input: string,
+	file?: string,
+	options: jsoncParser.ParseOptions = { allowTrailingComma: true }
+): T {
 	const errors: JsoncParseError[] = [];
-	const data = jsoncParse(input, errors, { allowTrailingComma: true });
+	const data = jsoncParser.parse(input, errors, options);
 	if (errors.length) {
 		throw new ParseError({
-			text: printParseErrorCode(errors[0].error),
+			text: jsoncParser.printParseErrorCode(errors[0].error),
 			location: {
 				...indexLocation({ file, fileText: input }, errors[0].offset + 1),
 				length: errors[0].length,

--- a/packages/wrangler/src/parse.ts
+++ b/packages/wrangler/src/parse.ts
@@ -148,18 +148,15 @@ export type PackageJSON = {
 /**
  * A typed version of `parseJSON()`.
  */
-export function parsePackageJSON<T extends PackageJSON = PackageJSON>(
-	input: string,
-	file?: string
-): T {
-	return parseJSON<T>(input, file);
+export function parsePackageJSON(input: string, file?: string): PackageJSON {
+	return parseJSON(input, file) as PackageJSON;
 }
 
 /**
  * Parses JSON and throws a `ParseError`.
  */
-export function parseJSON<T>(input: string, file?: string): T {
-	return parseJSONC<T>(input, file, {
+export function parseJSON(input: string, file?: string): unknown {
+	return parseJSONC(input, file, {
 		allowEmptyContent: false,
 		allowTrailingComma: false,
 		disallowComments: true,
@@ -169,11 +166,11 @@ export function parseJSON<T>(input: string, file?: string): T {
 /**
  * A wrapper around `JSONC.parse` that throws a `ParseError`.
  */
-export function parseJSONC<T>(
+export function parseJSONC(
 	input: string,
 	file?: string,
 	options: jsoncParser.ParseOptions = { allowTrailingComma: true }
-): T {
+): unknown {
 	const errors: JsoncParseError[] = [];
 	const data = jsoncParser.parse(input, errors, options);
 	if (errors.length) {

--- a/packages/wrangler/src/r2/cors.ts
+++ b/packages/wrangler/src/r2/cors.ts
@@ -96,10 +96,9 @@ export const r2BucketCORSSetCommand = createCommand({
 
 		const jsonFilePath = path.resolve(file);
 
-		const corsConfig = parseJSON<{ rules: CORSRule[] }>(
-			readFileSync(jsonFilePath),
-			jsonFilePath
-		);
+		const corsConfig = parseJSON(readFileSync(jsonFilePath), jsonFilePath) as {
+			rules: CORSRule[];
+		};
 
 		if (!corsConfig.rules || !Array.isArray(corsConfig.rules)) {
 			throw new UserError(

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -544,7 +544,7 @@ export async function parseBulkInputToObject(input?: string) {
 		try {
 			const fileContent = readFileSync(jsonFilePath);
 			try {
-				content = parseJSON<Record<string, string>>(fileContent);
+				content = parseJSON(fileContent) as Record<string, string>;
 			} catch (e) {
 				content = dotenvParse(fileContent);
 				// dotenvParse does not error unless fileContent is undefined, no keys === error
@@ -566,7 +566,7 @@ export async function parseBulkInputToObject(input?: string) {
 				pipedInput += line;
 			}
 			try {
-				content = parseJSON<Record<string, string>>(pipedInput);
+				content = parseJSON(pipedInput) as Record<string, string>;
 			} catch (e) {
 				content = dotenvParse(pipedInput);
 				// dotenvParse does not error unless fileContent is undefined, no keys === error

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -561,9 +561,9 @@ function readTsconfigTypes(tsconfigPath: string): string[] {
 	}
 
 	try {
-		const tsconfig = parseJSONC<TSConfig>(
+		const tsconfig = parseJSONC(
 			fs.readFileSync(tsconfigPath, "utf-8")
-		);
+		) as TSConfig;
 		return tsconfig.compilerOptions?.types || [];
 	} catch (e) {
 		return [];


### PR DESCRIPTION
This first started as a PR to relax a constraint on an exception message...

It turned out to be because Node throws different exceptions when `JSON.parse`ing across different version.

So let's use `jsonc-parser` instead that will be consistent across Node versions/runtimes.

One more change is that `parseJSON(c)` are no more parametrized. They returns `unknow` because that's the truth.
Callers can change that with an explicit cast.

(Any JSONC specifics are disabled when parsing JSON).

____

Initial description:


While the test passes on the CI, it fails locally for me:

```
wrangler:test:ci:  FAIL  src/__tests__/versions/secrets/bulk.test.ts > versions secret bulk > should error on invalid json file
wrangler:test:ci: AssertionError: expected [Function] to throw error including 'The contents of "secrets.json" is not…' but got 'The contents of "secrets.json" is not…'
wrangler:test:ci: 
wrangler:test:ci: Expected: "The contents of "secrets.json" is not valid JSON: "ParseError: Unexpected token o""
wrangler:test:ci: Received: "The contents of "secrets.json" is not valid JSON: "SyntaxError: Unexpected token 'o', "not valid json :(" is not valid JSON""
wrangler:test:ci: 
```

It might be linked to the Node version?

Anyway details are not meaningful, dropping them.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix / refactor

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
