### PR TITLE
refactor(wrangler): refine the type of buildOptions

### DIFF
--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -393,7 +393,7 @@ export async function bundleWorker(
 
 	const unenvResolvePaths = getUnenvResolvePathsFromEnv()?.split(",");
 
-	const buildOptions: esbuild.BuildOptions & { metafile: true } = {
+	const buildOptions = {
 		// Don't use entryFile here as the file may have been changed when applying the middleware
 		entryPoints: [entry.file],
 		bundle,
@@ -460,7 +460,7 @@ export async function bundleWorker(
 		// logging, we disable esbuild's default logging, and log build failures
 		// ourselves.
 		logLevel: "silent",
-	};
+	} satisfies esbuild.BuildOptions;
 
 	let result: esbuild.BuildResult<typeof buildOptions>;
 	let stop: BundleResult["stop"];


### PR DESCRIPTION
Minor change I figured out while exploring metafiles - my idea is to have an options to expose them so that users can get info about their bundle content.

The change:

Before this PR, we had:

```ts
const buildOptions: esbuild.BuildOptions & { metafile: true } = {
  // ...
  metafile: true,
  // ...
};

let result: esbuild.BuildResult<typeof buildOptions>;
```

Because the type of result depends on `typeof buildOptions`, we had to add `& { metafile: true }` so that the metafile specific props are exposed on the result.

This PR switches to:

```ts
const buildOptions = {
  // ...
  metafile: true,
  // ...
} satisfies esbuild.BuildOptions;
```

So that `typeof buildOptions` is not `esbuild.BuildOptions ` but it's actual type and then `metafile: true` is inferred from the actual value.

There are multiple other properties on `result`depending on the actual type of the options, so this minor change is a nice thing to have.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [] Required
  - [x] Not required because: type only change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
