### PR TITLE
add `formatOnSave` option to vscode `settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,5 +87,6 @@
 		{
 			"mode": "auto"
 		}
-	]
+	],
+	"editor.formatOnSave": true
 }


### PR DESCRIPTION
Hopefully it's not too controversial, but having the `formatOnSave` option in the vscode settings could be rather convenient so that:
 - it helps new contributors using vscode making sure that their formatting is correct (avoiding them getting formatting errors in their PRs and needing to go back and fix them)
 - if I don't want to set the `formatOnSave` setting generally for my vscode (e.g. I can work with codebases without a formatter setup, etc...), it can still work for this monorepo without needing to switch back and forth between having it on and off
 
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: very minor infra change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: very minor infra change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: very minor infra change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
