### PR TITLE
feat: make provisioning non-interactive by default

### DIFF
--- a/.changeset/clean-carrots-draw.md
+++ b/.changeset/clean-carrots-draw.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: make experiemntal auto-provisioning non-interactive by default.

--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -67,9 +67,7 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 	});
 
 	it("can provision resources and deploy worker", async () => {
-		const worker = helper.runLongLived(
-			`wrangler deploy --x-provision --x-auto-create`
-		);
+		const worker = helper.runLongLived(`wrangler deploy --x-provision`);
 		await worker.exitCode;
 		const output = await worker.output;
 		expect(normalize(output)).toMatchInlineSnapshot(`

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -92,7 +92,7 @@ describe("--x-provision", () => {
 			],
 		});
 
-		await runWrangler("deploy --x-provision");
+		await runWrangler("deploy --x-provision --x-auto-create=false");
 		expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
@@ -176,7 +176,7 @@ describe("--x-provision", () => {
 				],
 			});
 
-			await runWrangler("deploy --x-provision");
+			await runWrangler("deploy --x-provision --x-auto-create=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
@@ -301,7 +301,7 @@ describe("--x-provision", () => {
 				],
 			});
 
-			await runWrangler("deploy --x-provision");
+			await runWrangler("deploy --x-provision --x-auto-create=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
@@ -436,7 +436,7 @@ describe("--x-provision", () => {
 				],
 			});
 
-			await runWrangler("deploy --x-provision");
+			await runWrangler("deploy --x-provision --x-auto-create=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
@@ -525,7 +525,7 @@ describe("--x-provision", () => {
 				],
 			});
 
-			await runWrangler("deploy --x-provision");
+			await runWrangler("deploy --x-provision --x-auto-create=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
@@ -583,7 +583,7 @@ describe("--x-provision", () => {
 				],
 			});
 
-			await runWrangler("deploy --x-provision");
+			await runWrangler("deploy --x-provision --x-auto-create=false");
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
@@ -650,7 +650,7 @@ describe("--x-provision", () => {
 				],
 			});
 
-			await runWrangler("deploy --x-provision");
+			await runWrangler("deploy --x-provision --x-auto-create=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
@@ -730,7 +730,7 @@ describe("--x-provision", () => {
 				],
 			});
 
-			await runWrangler("deploy --x-provision");
+			await runWrangler("deploy --x-provision --x-auto-create=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
@@ -800,7 +800,7 @@ describe("--x-provision", () => {
 				],
 			});
 
-			await runWrangler("deploy --x-provision");
+			await runWrangler("deploy --x-provision --x-auto-create=false");
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
@@ -825,7 +825,9 @@ describe("--x-provision", () => {
 			legacy_env: false,
 			kv_namespaces: [{ binding: "KV" }],
 		});
-		await expect(runWrangler("deploy --x-provision")).rejects.toThrow(
+		await expect(
+			runWrangler("deploy --x-provision --x-auto-create=false")
+		).rejects.toThrow(
 			"Provisioning resources is not supported with a service environment"
 		);
 	});

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -230,7 +230,7 @@ export function deployOptions(yargs: CommonYargsArgv) {
 			.option("experimental-auto-create", {
 				describe: "Automatically provision draft bindings with new resources",
 				type: "boolean",
-				default: false,
+				default: true,
 				hidden: true,
 				alias: "x-auto-create",
 			})


### PR DESCRIPTION
Make `--x-auto-create` default to `true`, so the flag doesn't need to be provided any more when using `--x-provision`. Interactivity can be restored by setting `--x-auto-create=false`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unreleased feat

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
