### PR TITLE
fix(C3): Use today's date for compat date when the latest workerd release date is in the future

### DIFF
--- a/.changeset/heavy-otters-cough.md
+++ b/.changeset/heavy-otters-cough.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+fix: Use today's date for compat date when the latest workerd release date is in the future
+
+Fixes an issue where deployments would fail when there is a workerd release on the same day due to workerd releases having a date in the future because Workers does not allow using a compat date in the future.

--- a/packages/create-cloudflare/src/helpers/compatDate.ts
+++ b/packages/create-cloudflare/src/helpers/compatDate.ts
@@ -26,16 +26,28 @@ export async function getWorkerdCompatibilityDate() {
 		// The format of the workerd version is `major.yyyymmdd.patch`.
 		const match = latestWorkerdVersion.match(/\d+\.(\d{4})(\d{2})(\d{2})\.\d+/);
 
+		// workerd releases often have a date for the following day.
+		// Unfortunately, Workers deployments will fail if they specify
+		// a compatibility date in the future. This means that most
+		// who create a new project on the same day as a workerd
+		// release will have their deployments fail until they
+		// manually adjust the compatibility date.
+		//
+		// To work around this, we must manually ensure that the compat date
+		// is not on a future UTC day when there was a recent workerd release.
 		if (match) {
 			const [, year, month, date] = match;
-			const compatDate = `${year}-${month}-${date}`;
-
-			s.stop(`${brandColor("compatibility date")} ${dim(compatDate)}`);
-			return compatDate;
+			let compatDate = new Date(`${year}-${month}-${date}`);
+			if (compatDate.getTime() > Date.now()) {
+				compatDate = new Date(Date.now());
+			}
+			const compatDateString = compatDate.toISOString().slice(0, 10);
+			s.stop(`${brandColor("compatibility date")} ${dim(compatDateString)}`);
+			return compatDateString;
 		}
 	} catch {}
 
-	const fallbackDate = "2023-05-18";
+	const fallbackDate = "2024-11-11";
 
 	s.stop(
 		`${brandColor("compatibility date")} ${dim(


### PR DESCRIPTION
Fixes an issue where deployments would fail when there is a workerd release on the same day due to workerd releases having a date in the future because Workers does not allow using a compat date in the future.

I found this really frustrating that C3 templates fail to deploy if there is a workerd release on the same day:
![image](https://github.com/user-attachments/assets/4378207f-6d44-4540-a671-2af26e8f982b)


_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: small change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
