### PR TITLE
Write fetch handler so that `npm run start` works

### DIFF
--- a/.changeset/tall-donkeys-pull.md
+++ b/.changeset/tall-donkeys-pull.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix scheduled TS template to include a fetch handler like the JS one

--- a/packages/create-cloudflare/templates/scheduled/ts/src/index.ts
+++ b/packages/create-cloudflare/templates/scheduled/ts/src/index.ts
@@ -16,6 +16,13 @@
  */
 
 export default {
+	async fetch(req) {
+		const url = new URL(req.url);
+		url.pathname = '/__scheduled';
+		url.searchParams.append('cron', '* * * * *');
+		return new Response(`To test the scheduled handler, ensure you have used the "--test-scheduled" then try running "curl ${url.href}".`);
+	},
+
 	// The scheduled handler is invoked at the interval set in our wrangler.jsonc's
 	// [[triggers]] configuration.
 	async scheduled(event, env, ctx): Promise<void> {


### PR DESCRIPTION
Write a default fetch handler like the JS example: https://github.com/cloudflare/workers-sdk/edit/main/packages/create-cloudflare/templates/scheduled/js/src/index.js

Without it, `npm run start / dev` will point to a browser location that does not exist.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: c3 change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: change does not affect documentation
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR:
  - [x] Not necessary because: c3 is not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
