### PR TITLE
Fix regression in retryOnAPIFailure preventing any requests from being retried

### DIFF
--- a/.changeset/neat-needles-brush.md
+++ b/.changeset/neat-needles-brush.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Fix regression in retryOnAPIFailure preventing any requests from being retried
+
+Also fixes a regression in pipelines that prevented 401 errors from being retried when waiting for an API token to become active.

--- a/packages/wrangler/src/__tests__/utils/retry.test.ts
+++ b/packages/wrangler/src/__tests__/utils/retry.test.ts
@@ -38,7 +38,7 @@ describe("retryOnAPIFailure", () => {
 		expect(attempts).toBe(1);
 	});
 
-	it("should not retry TypeError", async () => {
+	it("should retry TypeError", async () => {
 		let attempts = 0;
 
 		await expect(() =>
@@ -47,7 +47,7 @@ describe("retryOnAPIFailure", () => {
 				throw new TypeError("type error");
 			})
 		).rejects.toMatchInlineSnapshot(`[TypeError: type error]`);
-		expect(attempts).toBe(1);
+		expect(attempts).toBe(3);
 	});
 
 	it("should retry custom APIError implementation with non-5xx error", async () => {

--- a/packages/wrangler/src/__tests__/utils/retry.test.ts
+++ b/packages/wrangler/src/__tests__/utils/retry.test.ts
@@ -1,0 +1,73 @@
+import { APIError } from "../../parse";
+import { retryOnAPIFailure } from "../../utils/retry";
+
+describe("retryOnAPIFailure", () => {
+	it("should retry 5xx errors and succeed if the 3rd try succeeds", async () => {
+		let attempts = 0;
+
+		await retryOnAPIFailure(() => {
+			attempts++;
+			if (attempts < 3) {
+				throw new APIError({ status: 500, text: "500 error" });
+			}
+		});
+		expect(attempts).toBe(3);
+	});
+
+	it("should throw 5xx error after all retries fail", async () => {
+		let attempts = 0;
+
+		await expect(() =>
+			retryOnAPIFailure(() => {
+				attempts++;
+				throw new APIError({ status: 500, text: "500 error" });
+			})
+		).rejects.toMatchInlineSnapshot(`[APIError: 500 error]`);
+		expect(attempts).toBe(3);
+	});
+
+	it("should not retry non-5xx errors", async () => {
+		let attempts = 0;
+
+		await expect(() =>
+			retryOnAPIFailure(() => {
+				attempts++;
+				throw new APIError({ status: 401, text: "401 error" });
+			})
+		).rejects.toMatchInlineSnapshot(`[APIError: 401 error]`);
+		expect(attempts).toBe(1);
+	});
+
+	it("should not retry TypeError", async () => {
+		let attempts = 0;
+
+		await expect(() =>
+			retryOnAPIFailure(() => {
+				attempts++;
+				throw new TypeError("type error");
+			})
+		).rejects.toMatchInlineSnapshot(`[TypeError: type error]`);
+		expect(attempts).toBe(1);
+	});
+
+	it("should retry custom APIError implementation with non-5xx error", async () => {
+		let checkedCustomIsRetryable = false;
+		class CustomAPIError extends APIError {
+			isRetryable(): boolean {
+				checkedCustomIsRetryable = true;
+				return true;
+			}
+		}
+
+		let attempts = 0;
+
+		await expect(() =>
+			retryOnAPIFailure(() => {
+				attempts++;
+				throw new CustomAPIError({ status: 401, text: "401 error" });
+			})
+		).rejects.toMatchInlineSnapshot(`[CustomAPIError: 401 error]`);
+		expect(attempts).toBe(3);
+		expect(checkedCustomIsRetryable).toBe(true);
+	});
+});

--- a/packages/wrangler/src/__tests__/utils/retry.test.ts
+++ b/packages/wrangler/src/__tests__/utils/retry.test.ts
@@ -50,6 +50,18 @@ describe("retryOnAPIFailure", () => {
 		expect(attempts).toBe(3);
 	});
 
+	it("should not retry other errors", async () => {
+		let attempts = 0;
+
+		await expect(() =>
+			retryOnAPIFailure(() => {
+				attempts++;
+				throw new Error("some error");
+			})
+		).rejects.toMatchInlineSnapshot(`[Error: some error]`);
+		expect(attempts).toBe(1);
+	});
+
 	it("should retry custom APIError implementation with non-5xx error", async () => {
 		let checkedCustomIsRetryable = false;
 		class CustomAPIError extends APIError {

--- a/packages/wrangler/src/utils/retry.ts
+++ b/packages/wrangler/src/utils/retry.ts
@@ -21,11 +21,11 @@ export async function retryOnAPIFailure<T>(
 	try {
 		return await action();
 	} catch (err) {
-		if (
-			err instanceof APIError &&
-			!err.isRetryable() &&
-			!(err instanceof TypeError)
-		) {
+		if (err instanceof APIError) {
+			if (!err.isRetryable()) {
+				throw err;
+			}
+		} else if (!(err instanceof TypeError)) {
 			throw err;
 		}
 

--- a/packages/wrangler/src/utils/retry.ts
+++ b/packages/wrangler/src/utils/retry.ts
@@ -23,7 +23,7 @@ export async function retryOnAPIFailure<T>(
 	} catch (err) {
 		if (
 			(err instanceof APIError && !err.isRetryable()) ||
-			!(err instanceof TypeError)
+			err instanceof TypeError
 		) {
 			throw err;
 		}

--- a/packages/wrangler/src/utils/retry.ts
+++ b/packages/wrangler/src/utils/retry.ts
@@ -22,8 +22,9 @@ export async function retryOnAPIFailure<T>(
 		return await action();
 	} catch (err) {
 		if (
-			(err instanceof APIError && !err.isRetryable()) ||
-			err instanceof TypeError
+			err instanceof APIError &&
+			!err.isRetryable() &&
+			!(err instanceof TypeError)
 		) {
 			throw err;
 		}


### PR DESCRIPTION
Also fixes a regression in pipelines that prevented 401 errors from being retried when waiting for an API token to become active.

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: decent enough unit testing? idk
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
