### PR TITLE
update experimental Next.js template to work on `@opennextjs/cloudflare@0.4.x`

### DIFF
--- a/.changeset/cyan-suits-move.md
+++ b/.changeset/cyan-suits-move.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+update experimental Next.js template to work on `@opennextjs/cloudflare@0.4.x`


### PR DESCRIPTION
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: The experimental Next.js c3 template already has e2es
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: This is a C3 only change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: OpenNext docs updated instead https://github.com/opennextjs/docs/pull/57

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
