### PR TITLE
Fix R2 bucket name validation error

### DIFF
--- a/.changeset/late-gorillas-walk.md
+++ b/.changeset/late-gorillas-walk.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: validation for R2 bucket names, the regex was wrongly rejecting buckets starting with a number and the message wasn't as clear as it could be on what was going wrong.

--- a/packages/wrangler/src/__tests__/__snapshots__/r2.test.ts.snap
+++ b/packages/wrangler/src/__tests__/__snapshots__/r2.test.ts.snap
@@ -1,113 +1,113 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket & check request inputs 1`] = `
-"Creating bucket 'testBucket'...
-✅ Created bucket 'testBucket' with default storage class of Standard.
+"Creating bucket 'test-bucket'...
+✅ Created bucket 'test-bucket' with default storage class of Standard.
 
 Configure your Worker to write objects to this bucket:
 
 {
   \\"r2_buckets\\": [
     {
-      \\"bucket_name\\": \\"testBucket\\",
-      \\"binding\\": \\"testBucket\\"
+      \\"bucket_name\\": \\"test-bucket\\",
+      \\"binding\\": \\"test_bucket\\"
     }
   ]
 }"
 `;
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket with the expected default storage class 1`] = `
-"Creating bucket 'testBucket'...
-✅ Created bucket 'testBucket' with default storage class of InfrequentAccess.
+"Creating bucket 'test-bucket'...
+✅ Created bucket 'test-bucket' with default storage class of InfrequentAccess.
 
 Configure your Worker to write objects to this bucket:
 
 {
   \\"r2_buckets\\": [
     {
-      \\"bucket_name\\": \\"testBucket\\",
-      \\"binding\\": \\"testBucket\\"
+      \\"bucket_name\\": \\"test-bucket\\",
+      \\"binding\\": \\"test_bucket\\"
     }
   ]
 }"
 `;
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket with the expected jurisdiction 1`] = `
-"Creating bucket 'testBucket (eu)'...
-✅ Created bucket 'testBucket (eu)' with default storage class of Standard.
+"Creating bucket 'test-bucket (eu)'...
+✅ Created bucket 'test-bucket (eu)' with default storage class of Standard.
 
 Configure your Worker to write objects to this bucket:
 
 {
   \\"r2_buckets\\": [
     {
-      \\"bucket_name\\": \\"testBucket\\",
-      \\"binding\\": \\"testBucket\\"
+      \\"bucket_name\\": \\"test-bucket\\",
+      \\"binding\\": \\"test_bucket\\"
     }
   ]
 }"
 `;
 
 exports[`r2 > bucket > create > wrangler.json > should create a bucket with the expected location hint 1`] = `
-"Creating bucket 'testBucket'...
-✅ Created bucket 'testBucket' with location hint weur and default storage class of Standard.
+"Creating bucket 'test-bucket'...
+✅ Created bucket 'test-bucket' with location hint weur and default storage class of Standard.
 
 Configure your Worker to write objects to this bucket:
 
 {
   \\"r2_buckets\\": [
     {
-      \\"bucket_name\\": \\"testBucket\\",
-      \\"binding\\": \\"testBucket\\"
+      \\"bucket_name\\": \\"test-bucket\\",
+      \\"binding\\": \\"test_bucket\\"
     }
   ]
 }"
 `;
 
 exports[`r2 > bucket > create > wrangler.toml > should create a bucket & check request inputs 1`] = `
-"Creating bucket 'testBucket'...
-✅ Created bucket 'testBucket' with default storage class of Standard.
+"Creating bucket 'test-bucket'...
+✅ Created bucket 'test-bucket' with default storage class of Standard.
 
 Configure your Worker to write objects to this bucket:
 
 [[r2_buckets]]
-bucket_name = \\"testBucket\\"
-binding = \\"testBucket\\"
+bucket_name = \\"test-bucket\\"
+binding = \\"test_bucket\\"
 "
 `;
 
 exports[`r2 > bucket > create > wrangler.toml > should create a bucket with the expected default storage class 1`] = `
-"Creating bucket 'testBucket'...
-✅ Created bucket 'testBucket' with default storage class of InfrequentAccess.
+"Creating bucket 'test-bucket'...
+✅ Created bucket 'test-bucket' with default storage class of InfrequentAccess.
 
 Configure your Worker to write objects to this bucket:
 
 [[r2_buckets]]
-bucket_name = \\"testBucket\\"
-binding = \\"testBucket\\"
+bucket_name = \\"test-bucket\\"
+binding = \\"test_bucket\\"
 "
 `;
 
 exports[`r2 > bucket > create > wrangler.toml > should create a bucket with the expected jurisdiction 1`] = `
-"Creating bucket 'testBucket (eu)'...
-✅ Created bucket 'testBucket (eu)' with default storage class of Standard.
+"Creating bucket 'test-bucket (eu)'...
+✅ Created bucket 'test-bucket (eu)' with default storage class of Standard.
 
 Configure your Worker to write objects to this bucket:
 
 [[r2_buckets]]
-bucket_name = \\"testBucket\\"
-binding = \\"testBucket\\"
+bucket_name = \\"test-bucket\\"
+binding = \\"test_bucket\\"
 "
 `;
 
 exports[`r2 > bucket > create > wrangler.toml > should create a bucket with the expected location hint 1`] = `
-"Creating bucket 'testBucket'...
-✅ Created bucket 'testBucket' with location hint weur and default storage class of Standard.
+"Creating bucket 'test-bucket'...
+✅ Created bucket 'test-bucket' with location hint weur and default storage class of Standard.
 
 Configure your Worker to write objects to this bucket:
 
 [[r2_buckets]]
-bucket_name = \\"testBucket\\"
-binding = \\"testBucket\\"
+bucket_name = \\"test-bucket\\"
+binding = \\"test_bucket\\"
 "
 `;

--- a/packages/wrangler/src/r2/bucket.ts
+++ b/packages/wrangler/src/r2/bucket.ts
@@ -66,7 +66,8 @@ export const r2BucketCreateCommand = createCommand({
 
 		if (!isValidR2BucketName(name)) {
 			throw new UserError(
-				`The bucket name "${name}" is invalid. Bucket names can only have alphanumeric and - characters.`
+				`The bucket name "${name}" is invalid. ` +
+					"Bucket names must begin and end with an alphanumeric and can only contain letters (a-z), numbers (0-9), and hyphens (-)."
 			);
 		}
 

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -1196,7 +1196,9 @@ export async function deleteCORSPolicy(
  * R2 bucket names must only contain alphanumeric and - characters.
  */
 export function isValidR2BucketName(name: string | undefined): name is string {
-	return typeof name === "string" && /^[a-zA-Z][a-zA-Z0-9-]*$/.test(name);
+	return (
+		typeof name === "string" && /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/.test(name)
+	);
 }
 
 const CHUNK_SIZE = 1024;


### PR DESCRIPTION
Fixes CUSTESC-48328

Fixes validation for R2 bucket names, the regex was wrongly rejecting buckets starting with a number and the message wasn't as clear as it could be on what was going wrong.


---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fixing validation

