### PR TITLE
refactor(wrangler): runWranglerDev always log error

### DIFF
--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -87,9 +87,7 @@ async function runLongLivedWrangler(
 		chunks.push(chunk);
 	});
 	wranglerProcess.stderr?.on("data", (chunk) => {
-		if (process.env.WRANGLER_LOG === "debug") {
-			console.log(`[${command}]`, chunk.toString());
-		}
+		console.log(`[${command}]`, chunk.toString());
 		chunks.push(chunk);
 	});
 	const getOutput = () => Buffer.concat(chunks).toString();


### PR DESCRIPTION
@petebacondarwin this is reverting [one change](https://github.com/cloudflare/workers-sdk/commit/e4716cc87893a0633bd2d00543b351e83e228970) you made a couple weeks ago.

I had CI (and local) that were impossible to debug without this.

I see that you mention that the logs would be printed on timeout anyway... but that's unless your test timeout is less than the timeout in `runLongLivedWrangler` - it is the case with the failures I had (30 vs 50s in updated file).

Adding `stderr` only should hopefully not be too spammy?

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tested locally
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
