### PR TITLE
Allow unsafe param to pass through vite build

### DIFF
--- a/.changeset/old-bees-design.md
+++ b/.changeset/old-bees-design.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Support unsafe params

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -218,8 +218,10 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 
 			config.no_bundle = true;
 			config.rules = [{ type: "ESModule", globs: ["**/*.js"] }];
-			// Setting this to `undefined` for now because `readConfig` will error when reading the output file if it's set to an empty object. This needs to be fixed in Wrangler.
-			config.unsafe = undefined;
+			// Set to `undefined` if it's an empty object because `readConfig` will error when reading the output file if it's set to an empty object. This needs to be fixed in Wrangler.
+			if (config.unsafe && Object.keys(config.unsafe).length === 0) {
+				config.unsafe = undefined;
+			}
 
 			this.emitFile({
 				type: "asset",

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -218,7 +218,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 
 			config.no_bundle = true;
 			config.rules = [{ type: "ESModule", globs: ["**/*.js"] }];
-			// Set to `undefined` if it's an empty object because `readConfig` will error when reading the output file if it's set to an empty object. This needs to be fixed in Wrangler.
+			// Set to `undefined` if it's an empty object so that the user doesn't see a warning about using `unsafe` fields when deploying their Worker.
 			if (config.unsafe && Object.keys(config.unsafe).length === 0) {
 				config.unsafe = undefined;
 			}


### PR DESCRIPTION
@jamesopstad this allows unsafe params to pass through the wrangler.json file while using vite as long as unsafe isn't set to an empty object. At least according to the comment, this was done for a reason to prevent empty objects from passing through, but seemed to do it unconditionally (even if not empty).

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tested locally
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: don't apply to the vite plugin
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: small bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
