### PR TITLE
refactor(wrangler): max bundle size is now 3MiB

### DIFF
--- a/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
@@ -7,6 +7,7 @@ import type { Metafile } from "esbuild";
 
 const ONE_KIB_BYTES = 1024;
 // Current max is 3 MiB for free accounts, 10 MiB for paid accounts.
+// See https://developers.cloudflare.com/workers/platform/limits/#worker-size
 const MAX_GZIP_SIZE_BYTES = 3 * ONE_KIB_BYTES * ONE_KIB_BYTES;
 
 async function getSize(modules: Pick<CfModule, "content">[]) {

--- a/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle-reporter.ts
@@ -6,7 +6,8 @@ import type { CfModule } from "./worker";
 import type { Metafile } from "esbuild";
 
 const ONE_KIB_BYTES = 1024;
-const ALLOWED_INITIAL_MAX = ONE_KIB_BYTES * 1024; // Current max is 1 MiB
+// Current max is 3 MiB for free accounts, 10 MiB for paid accounts.
+const MAX_GZIP_SIZE_BYTES = 3 * ONE_KIB_BYTES * ONE_KIB_BYTES;
 
 async function getSize(modules: Pick<CfModule, "content">[]) {
 	const gzipSize = gzipSync(
@@ -30,7 +31,7 @@ export async function printBundleSize(
 		gzipSize / ONE_KIB_BYTES
 	).toFixed(2)} KiB`;
 
-	const percentage = (gzipSize / ALLOWED_INITIAL_MAX) * 100;
+	const percentage = (gzipSize / MAX_GZIP_SIZE_BYTES) * 100;
 
 	const colorizedReport =
 		percentage > 90


### PR DESCRIPTION
Minor update...
I found this while looking for something else in wrangler source code.

(And I always wondered by `Total Upload: 8916.85 KiB / gzip: 1645.88 KiB` was red when working on OpenNext)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tested locally
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented?

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
