### PR TITLE
Strip CF-Connecting-IP header from all outbound requests

### DIFF
--- a/.changeset/cyan-years-relate.md
+++ b/.changeset/cyan-years-relate.md
@@ -1,0 +1,6 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+fix(miniflare): strip CF-Connecting-IP header from all outbound requests

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -784,7 +784,7 @@ export const CORE_PLUGIN: Plugin<
 							esModule: STRIP_CF_CONNECTING_IP(),
 						},
 					],
-					compatibilityDate: "2025-04-28",
+					compatibilityDate: "2025-02-01",
 					globalOutbound: getGlobalOutbound(workerIndex, options),
 				},
 			});

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -8,6 +8,7 @@ import { TextEncoder } from "util";
 import { bold } from "kleur/colors";
 import { MockAgent } from "undici";
 import SCRIPT_ENTRY from "worker:core/entry";
+import STRIP_CF_CONNECTING_IP from "worker:core/strip-cf-connecting-ip";
 import { z } from "zod";
 import { fetch } from "../../http";
 import {
@@ -160,6 +161,9 @@ const CoreOptionsSchemaInput = z.intersection(
 		hasAssetsAndIsVitest: z.boolean().optional(),
 
 		tails: z.array(ServiceDesignatorSchema).optional(),
+
+		// Strip the CF-Connecting-IP header from outbound fetches
+		stripCfConnectingIp: z.boolean().default(true),
 	})
 );
 export const CoreOptionsSchema = CoreOptionsSchemaInput.transform((value) => {
@@ -388,6 +392,26 @@ export function maybeWrappedModuleToWorkerName(
 	if (name.startsWith(WRAPPED_MODULE_PREFIX)) {
 		return name.substring(WRAPPED_MODULE_PREFIX.length);
 	}
+}
+
+function getStripCfConnectingIpName(workerIndex: number) {
+	return `strip-cf-connecting-ip:${workerIndex}`;
+}
+
+function getGlobalOutbound(
+	workerIndex: number,
+	options: z.infer<typeof CORE_PLUGIN.options>
+) {
+	return options.outboundService === undefined
+		? undefined
+		: getCustomServiceDesignator(
+				/* referrer */ options.name,
+				workerIndex,
+				CustomServiceKind.KNOWN,
+				CUSTOM_SERVICE_KNOWN_OUTBOUND,
+				options.outboundService,
+				options.hasAssetsAndIsVitest
+			);
 }
 
 export const CORE_PLUGIN: Plugin<
@@ -689,17 +713,9 @@ export const CORE_PLUGIN: Plugin<
 							: options.unsafeEphemeralDurableObjects
 								? { inMemory: kVoid }
 								: { localDisk: DURABLE_OBJECTS_STORAGE_SERVICE_NAME },
-					globalOutbound:
-						options.outboundService === undefined
-							? undefined
-							: getCustomServiceDesignator(
-									/* referrer */ options.name,
-									workerIndex,
-									CustomServiceKind.KNOWN,
-									CUSTOM_SERVICE_KNOWN_OUTBOUND,
-									options.outboundService,
-									options.hasAssetsAndIsVitest
-								),
+					globalOutbound: options.stripCfConnectingIp
+						? { name: getStripCfConnectingIpName(workerIndex) }
+						: getGlobalOutbound(workerIndex, options),
 					cacheApiOutbound: { name: getCacheServiceName(workerIndex) },
 					moduleFallback:
 						options.unsafeUseModuleFallbackService &&
@@ -747,6 +763,7 @@ export const CORE_PLUGIN: Plugin<
 				if (maybeService !== undefined) services.push(maybeService);
 			}
 		}
+
 		if (options.outboundService !== undefined) {
 			const maybeService = maybeGetCustomServiceService(
 				workerIndex,
@@ -755,6 +772,22 @@ export const CORE_PLUGIN: Plugin<
 				options.outboundService
 			);
 			if (maybeService !== undefined) services.push(maybeService);
+		}
+
+		if (options.stripCfConnectingIp) {
+			services.push({
+				name: getStripCfConnectingIpName(workerIndex),
+				worker: {
+					modules: [
+						{
+							name: "index.js",
+							esModule: STRIP_CF_CONNECTING_IP(),
+						},
+					],
+					compatibilityDate: "2025-04-28",
+					globalOutbound: getGlobalOutbound(workerIndex, options),
+				},
+			});
 		}
 
 		return { services, extensions };

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -784,7 +784,7 @@ export const CORE_PLUGIN: Plugin<
 							esModule: STRIP_CF_CONNECTING_IP(),
 						},
 					],
-					compatibilityDate: "2025-02-01",
+					compatibilityDate: "2025-01-01",
 					globalOutbound: getGlobalOutbound(workerIndex, options),
 				},
 			});

--- a/packages/miniflare/src/workers/core/strip-cf-connecting-ip.worker.ts
+++ b/packages/miniflare/src/workers/core/strip-cf-connecting-ip.worker.ts
@@ -1,0 +1,7 @@
+export default {
+	fetch(request) {
+		const headers = new Headers(request.headers);
+		headers.delete("CF-Connecting-IP");
+		return fetch(request, { headers });
+	},
+} satisfies ExportedHandler;

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2995,20 +2995,6 @@ test("Miniflare: CF-Connecting-IP is preserved when present", async (t) => {
 	t.deepEqual(await ip.text(), "128.0.0.1");
 });
 
-// regression test for https://github.com/cloudflare/workers-sdk/issues/7924
-test("Miniflare: can fetch origins behind Cloudflare", async (t) => {
-	const mf = new Miniflare({
-		script:
-			"export default { fetch(request) { return fetch('https://dash.cloudflare.com') } }",
-		modules: true,
-	});
-	t.teardown(() => mf.dispose());
-
-	const landingPage = await mf.dispatchFetch("http://example.com/");
-	await landingPage.text();
-	t.assert(landingPage.status === 200);
-});
-
 test("Miniflare: can use module fallback service", async (t) => {
 	const modulesRoot = "/";
 	const modules: Record<string, Omit<Worker_Module, "name">> = {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2995,6 +2995,23 @@ test("Miniflare: CF-Connecting-IP is preserved when present", async (t) => {
 	t.deepEqual(await ip.text(), "128.0.0.1");
 });
 
+// regression test for https://github.com/cloudflare/workers-sdk/issues/7924
+test("Miniflare: can fetch origins behind Cloudflare", async (t) => {
+	const mf = new Miniflare({
+		script:
+			"export default { fetch(request) { return fetch('https://shopify.com') } }",
+		modules: true,
+	});
+	t.teardown(() => mf.dispose());
+
+	const landingPage = await mf.dispatchFetch("http://example.com/");
+	t.assert(
+		!(await landingPage.text()).includes(
+			"Unfortunately, it is resolving to an IP address that is creating a conflict within Cloudflare's system"
+		)
+	);
+});
+
 test("Miniflare: can use module fallback service", async (t) => {
 	const modulesRoot = "/";
 	const modules: Record<string, Omit<Worker_Module, "name">> = {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2999,17 +2999,14 @@ test("Miniflare: CF-Connecting-IP is preserved when present", async (t) => {
 test("Miniflare: can fetch origins behind Cloudflare", async (t) => {
 	const mf = new Miniflare({
 		script:
-			"export default { fetch(request) { return fetch('https://shopify.com') } }",
+			"export default { fetch(request) { return fetch('https://dash.cloudflare.com') } }",
 		modules: true,
 	});
 	t.teardown(() => mf.dispose());
 
 	const landingPage = await mf.dispatchFetch("http://example.com/");
-	t.assert(
-		!(await landingPage.text()).includes(
-			"Unfortunately, it is resolving to an IP address that is creating a conflict within Cloudflare's system"
-		)
-	);
+	await landingPage.text();
+	t.assert(landingPage.status === 200);
 });
 
 test("Miniflare: can use module fallback service", async (t) => {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2996,16 +2996,19 @@ test("Miniflare: CF-Connecting-IP is preserved when present", async (t) => {
 });
 
 // regression test for https://github.com/cloudflare/workers-sdk/issues/7924
+// The "server" service just returns the value of the CF-Connecting-IP header which would normally be added by Miniflare. If you send a request to with no such header, Miniflare will add one.
+// The "client" service makes an outbound request with a fake CF-Connecting-IP header to the "server" service. If the outbound stripping happens then this header will not make it to the "server" service
+// so its response will contain the header added by Miniflare. If the stripping is turned off then the response from the "server" service will contain the fake header.
 test("Miniflare: strips CF-Connecting-IP", async (t) => {
 	const server = new Miniflare({
 		script:
 			"export default { fetch(request) { return new Response(request.headers.get(`CF-Connecting-IP`)) } }",
 		modules: true,
 	});
-	const url = await server.ready;
+	const serverUrl = await server.ready;
 
 	const client = new Miniflare({
-		script: `export default { fetch(request) { return fetch('${url.href}', {headers: {"CF-Connecting-IP":"fake-value"}}) } }`,
+		script: `export default { fetch(request) { return fetch('${serverUrl.href}', {headers: {"CF-Connecting-IP":"fake-value"}}) } }`,
 		modules: true,
 	});
 	t.teardown(() => client.dispose());
@@ -3015,16 +3018,17 @@ test("Miniflare: strips CF-Connecting-IP", async (t) => {
 	// The CF-Connecting-IP header value of "fake-value" should be stripped by Miniflare, and should be replaced with a generic 127.0.0.1
 	t.notDeepEqual(await landingPage.text(), "fake-value");
 });
+
 test("Miniflare: does not strip CF-Connecting-IP when configured", async (t) => {
 	const server = new Miniflare({
 		script:
 			"export default { fetch(request) { return new Response(request.headers.get(`CF-Connecting-IP`)) } }",
 		modules: true,
 	});
-	const url = await server.ready;
+	const serverUrl = await server.ready;
 
 	const client = new Miniflare({
-		script: `export default { fetch(request) { return fetch('${url.href}', {headers: {"CF-Connecting-IP":"fake-value"}}) } }`,
+		script: `export default { fetch(request) { return fetch('${serverUrl.href}', {headers: {"CF-Connecting-IP":"fake-value"}}) } }`,
 		modules: true,
 		stripCfConnectingIp: false,
 	});

--- a/packages/miniflare/turbo.json
+++ b/packages/miniflare/turbo.json
@@ -3,7 +3,6 @@
 	"extends": ["//"],
 	"tasks": {
 		"build": {
-			"inputs": ["$TURBO_DEFAULT$", "!test/**", "!ava.config.mjs"],
 			"outputs": ["dist/**", "bootstrap.js", "worker-metafiles/**"],
 			"env": ["CI_OS"]
 		},

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -94,6 +94,7 @@ export class ProxyController extends Controller<ProxyControllerEventMap> {
 							unsafePreventEviction: true,
 						},
 					},
+					stripCfConnectingIp: false,
 					serviceBindings: {
 						PROXY_CONTROLLER: async (req): Promise<Response> => {
 							const message =

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -94,6 +94,8 @@ export class ProxyController extends Controller<ProxyControllerEventMap> {
 							unsafePreventEviction: true,
 						},
 					},
+					// Miniflare will strip CF-Connecting-IP from outgoing fetches from a Worker (to fix https://github.com/cloudflare/workers-sdk/issues/7924)
+					// However, the proxy worker only makes outgoing requests to the user Worker Miniflare instance, which _should_ receive CF-Connecting-IP
 					stripCfConnectingIp: false,
 					serviceBindings: {
 						PROXY_CONTROLLER: async (req): Promise<Response> => {

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -1116,7 +1116,6 @@ export async function buildMiniflareOptions(
 				name: getName(config),
 				compatibilityDate: config.compatibilityDate,
 				compatibilityFlags: config.compatibilityFlags,
-				stripCfConnectingIp: false,
 
 				...sourceOptions,
 				...bindingOptions,

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -1116,6 +1116,7 @@ export async function buildMiniflareOptions(
 				name: getName(config),
 				compatibilityDate: config.compatibilityDate,
 				compatibilityFlags: config.compatibilityFlags,
+				stripCfConnectingIp: false,
 
 				...sourceOptions,
 				...bindingOptions,


### PR DESCRIPTION
Fixes #7835, #7924

Strip the CF-Connecting-IP header from outbound requests.

~This cannot be effectively tested in CI because it interacts badly and in strange ways with bot management and various other protections.~ To test manually:
- Create a hello world worker (or use `fixtures/worker-ts`)
- Add `return fetch("https://www.cloudflare.com", request)` to the Worker
- Run `wrangler dev`
- With this PR, validate that the Cloudflare landing page is returned
- _Without_ this PR (`pnpx wrangler@latest dev`), validate that an error page is returned

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/8681
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

