### PR TITLE
Add workflow for uploading asset-worker and router-worker

### DIFF
--- a/.github/workflows/workers-shared-deploy-production.yml
+++ b/.github/workflows/workers-shared-deploy-production.yml
@@ -1,0 +1,21 @@
+name: Deploy Workers Shared Production
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-workers:
+    name: Deploy Workers Shared Production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Deploy
+        run: pnpm deploy
+        working-directory: packages/workers-shared
+        env:
+          WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN: ${{ secrets.WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Creates internal workflow to allow us to upload new versions of router-worker and asset-worker without an explicit wrangler release.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: n/a
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: internal workflow
