### PR TITLE
chore: do not build the world when publishing Wrangler and C3

### DIFF
--- a/packages/create-cloudflare/package.json
+++ b/packages/create-cloudflare/package.json
@@ -31,7 +31,7 @@
 		"dev:codemod": "node -r esbuild-register scripts/codemodDev.ts",
 		"check:lint": "eslint . --max-warnings=0",
 		"check:type": "tsc",
-		"prepublishOnly": "pnpm -w run build",
+		"prepublishOnly": "pnpm exec turbo build -F create-cloudflare",
 		"test:e2e": "vitest run --config ./vitest-e2e.config.mts",
 		"test:e2e:npm": "pnpm run build && cross-env TEST_PM=npm vitest run --config ./vitest-e2e.config.mts",
 		"test:e2e:pnpm": "pnpm run build && cross-env TEST_PM=pnpm vitest run --config ./vitest-e2e.config.mts",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -59,7 +59,7 @@
 		"dev": "pnpm run clean && concurrently -c black,blue --kill-others-on-fail false \"pnpm run bundle --watch\" \"pnpm run check:type --watch --preserveWatchOutput\"",
 		"emit-types": "tsc -p tsconfig.emit.json && node -r esbuild-register scripts/emit-types.ts",
 		"generate-json-schema": "pnpm exec ts-json-schema-generator --no-type-check --path src/config/config.ts --type RawConfig --out config-schema.json",
-		"prepublishOnly": "SOURCEMAPS=false pnpm run -w build",
+		"prepublishOnly": "SOURCEMAPS=false pnpm exec turbo build -F wrangler",
 		"start": "pnpm run bundle && cross-env NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
 		"test": "dotenv -- pnpm run assert-git-version && dotenv -- vitest",
 		"test:ci": "pnpm run test run",


### PR DESCRIPTION
Fixes #0000

This is a simple change to the prepublish scripts for Wrangler and create-cloudflare to avoid building unnecessary packages when deploying.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: CI change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: doesn't affect e2e flows
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal chore change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
