### PR TITLE
[vite-plugin] add `inspectorPort` option to plugin config

### DIFF
--- a/.changeset/polite-walls-bathe.md
+++ b/.changeset/polite-walls-bathe.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+add `inspectorPort` option to plugin config
+
+add an `inspectorPort` option that allows developers to start a devTools inspector server
+that allows them to debug their workers (defaulting to `9229`)

--- a/packages/vite-plugin-cloudflare/src/constants.ts
+++ b/packages/vite-plugin-cloudflare/src/constants.ts
@@ -4,3 +4,5 @@ export const ASSET_WORKERS_COMPATIBILITY_DATE = "2024-10-04";
 // TODO: add `Text` and `Data` types (resolves https://github.com/cloudflare/workers-sdk/issues/8022)
 export const MODULE_TYPES = ["CompiledWasm"] as const;
 export type ModuleType = (typeof MODULE_TYPES)[number];
+
+export const DEFAULT_INSPECTOR_PORT = 9229;

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -293,7 +293,8 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				const miniflare = new Miniflare(
 					getPreviewMiniflareOptions(
 						vitePreviewServer,
-						pluginConfig.persistState ?? true
+						pluginConfig.persistState ?? true,
+						pluginConfig.inspectorPort
 					)
 				);
 

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -18,6 +18,7 @@ import {
 import {
 	ASSET_WORKER_NAME,
 	ASSET_WORKERS_COMPATIBILITY_DATE,
+	DEFAULT_INSPECTOR_PORT,
 	ROUTER_WORKER_NAME,
 } from "./constants";
 import { getWorkerConfigPaths } from "./deploy-config";
@@ -385,6 +386,7 @@ export function getDevMiniflareOptions(
 
 	return {
 		log: logger,
+		inspectorPort: resolvedPluginConfig.inspectorPort,
 		handleRuntimeStdio(stdout, stderr) {
 			const decoder = new TextDecoder();
 			stdout.forEach((data) => logger.info(decoder.decode(data)));
@@ -528,7 +530,8 @@ function getPreviewModules(
 
 export function getPreviewMiniflareOptions(
 	vitePreviewServer: vite.PreviewServer,
-	persistState: PersistState
+	persistState: PersistState,
+	inspectorPort = DEFAULT_INSPECTOR_PORT
 ): MiniflareOptions {
 	const resolvedViteConfig = vitePreviewServer.config;
 	const configPaths = getWorkerConfigPaths(resolvedViteConfig.root);
@@ -560,6 +563,7 @@ export function getPreviewMiniflareOptions(
 
 	return {
 		log: logger,
+		inspectorPort,
 		handleRuntimeStdio(stdout, stderr) {
 			const decoder = new TextDecoder();
 			stdout.forEach((data) => logger.info(decoder.decode(data)));

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import * as path from "node:path";
 import * as vite from "vite";
+import { DEFAULT_INSPECTOR_PORT } from "./constants";
 import { findWranglerConfig, getWorkerConfig } from "./workers-configs";
 import type {
 	AssetsOnlyWorkerResolvedConfig,
@@ -26,6 +27,7 @@ interface AuxiliaryWorkerConfig extends BaseWorkerConfig {
 export interface PluginConfig extends EntryWorkerConfig {
 	auxiliaryWorkers?: AuxiliaryWorkerConfig[];
 	persistState?: PersistState;
+	inspectorPort?: number;
 }
 
 type Defined<T> = Exclude<T, undefined>;
@@ -48,6 +50,7 @@ interface BasePluginConfig {
 	configPaths: Set<string>;
 	persistState: PersistState;
 	cloudflareEnv: string | undefined;
+	inspectorPort: number;
 }
 
 interface AssetsOnlyPluginConfig extends BasePluginConfig {
@@ -82,6 +85,7 @@ export function resolvePluginConfig(
 ): ResolvedPluginConfig {
 	const configPaths = new Set<string>();
 	const persistState = pluginConfig.persistState ?? true;
+	const inspectorPort = pluginConfig.inspectorPort ?? DEFAULT_INSPECTOR_PORT;
 	const root = userConfig.root ? path.resolve(userConfig.root) : process.cwd();
 	const { CLOUDFLARE_ENV: cloudflareEnv } = vite.loadEnv(
 		viteEnv.mode,
@@ -108,6 +112,7 @@ export function resolvePluginConfig(
 			type: "assets-only",
 			config: entryWorkerResolvedConfig.config,
 			configPaths,
+			inspectorPort,
 			persistState,
 			rawConfigs: {
 				entryWorker: entryWorkerResolvedConfig,
@@ -163,6 +168,7 @@ export function resolvePluginConfig(
 		type: "workers",
 		configPaths,
 		persistState,
+		inspectorPort,
 		workers,
 		entryWorkerEnvironmentName,
 		rawConfigs: {


### PR DESCRIPTION
add an `inspectorPort` option that allows developers to start a devTools inspector server
that allows them to debug their workers

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: I tried including a test but it doesn't seem to work reliably in CI, since this is a minor, currently undocumented feature it is probably fine to leave it untested for now and investigate properly a testing strategy (if necessary) later on 
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: unrelated to wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: proper documentation for this will be implemented as part of https://github.com/cloudflare/workers-sdk/issues/7852 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
