### PR TITLE
chore: don't fail the PR description check for draft PRs

### DIFF
--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -2,10 +2,21 @@ name: Validate PR Description
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+    types:
+      [
+        opened,
+        synchronize,
+        reopened,
+        labeled,
+        unlabeled,
+        edited,
+        ready_for_review,
+        converted_to_draft,
+      ]
 
 jobs:
   check:
+    # Don't check the Version Packages PR
     if: github.head_ref != 'changeset-release/main'
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-add-pr
@@ -47,3 +58,4 @@ jobs:
           BODY: ${{ github.event.pull_request.body }}
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
           FILES: ${{ steps.files.outputs.all }}
+          DRAFT: ${{ github.event.pull_request.draft }}

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -11,7 +11,14 @@ if (require.main === module) {
 		for (const error of errors) {
 			console.error("- ", error);
 		}
-		process.exit(1);
+		if (process.env.DRAFT !== "true") {
+			process.exit(1);
+		} else {
+			console.error("These errors must be fixed before you can merge this PR.");
+			console.error(
+				"When you mark this PR as ready for review the CI check will start failing."
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #0000

Changes the PR description validation so that it only "fails" the CI check if the PR is "ready for review" (i.e. not in draft).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: it is a change to a test
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not applicable
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not a documented feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
