### PR TITLE
fix(wrangler): handling of `process.env.NODE_ENV` in bundling mode

### DIFF
--- a/.changeset/lucky-jeans-relax.md
+++ b/.changeset/lucky-jeans-relax.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix(wrangler): handling of `process.env.NODE_ENV` in bundling mode

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -393,6 +393,11 @@ export async function bundleWorker(
 
 	const unenvResolvePaths = getUnenvResolvePathsFromEnv()?.split(",");
 
+	// Use `process.env["NODE_ENV" + ""]` to get the runtime value when wranler is executed.
+	// Esbuild would replace `process.env.NODE_ENV` with the value it has when wrangler gets bundled.
+	// See: https://github.com/cloudflare/workers-sdk/issues/1477)
+	const runtimeProcessEnv = process.env["NODE_ENV" + ""];
+
 	const buildOptions = {
 		// Don't use entryFile here as the file may have been changed when applying the middleware
 		entryPoints: [entry.file],
@@ -422,18 +427,16 @@ export async function bundleWorker(
 		metafile: true,
 		conditions: getBuildConditions(),
 		platform: getBuildPlatform(),
-		...(process.env.NODE_ENV && {
-			define: {
-				...(defineNavigatorUserAgent
-					? { "navigator.userAgent": `"Cloudflare-Workers"` }
-					: {}),
-				// use process.env["NODE_ENV" + ""] so that esbuild doesn't replace it
-				// when we do a build of wrangler. (re: https://github.com/cloudflare/workers-sdk/issues/1477)
-				"process.env.NODE_ENV": `"${process.env["NODE_ENV" + ""]}"`,
-				...(nodejsCompatMode === "legacy" ? { global: "globalThis" } : {}),
-				...define,
-			},
-		}),
+		define: {
+			...(defineNavigatorUserAgent
+				? { "navigator.userAgent": `"Cloudflare-Workers"` }
+				: {}),
+			...(runtimeProcessEnv
+				? { "process.env.NODE_ENV": `"${runtimeProcessEnv}"` }
+				: {}),
+			...(nodejsCompatMode === "legacy" ? { global: "globalThis" } : {}),
+			...define,
+		},
 		loader: COMMON_ESBUILD_OPTIONS.loader,
 		plugins: [
 			aliasPlugin,


### PR DESCRIPTION
Relates to #7886.

Before this PR:

- The first check `process.env.NODE_ENV` should have checked the runtime value (as done a few lines below)
- This check should only (de)activate `define["process.env.NODE_ENV"]` and not `define` as a whole.

This fix a few points from the linked issue, not all.

Notably there is still an issue when process is imported (`import process from "node:process";`) as "process" will be renamed by the hybrid plugin and not imported!

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
