### PR TITLE
fix(workers-playground): send raw request method through the `X-CF-HTTP-Method` header

### DIFF
--- a/.changeset/odd-cougars-matter.md
+++ b/.changeset/odd-cougars-matter.md
@@ -1,0 +1,5 @@
+---
+"workers-playground": patch
+---
+
+fix: sends raw request method through the X-CF-HTTP-Method header

--- a/packages/workers-playground/src/QuickEditor/HTTPTab/fetchWorker.ts
+++ b/packages/workers-playground/src/QuickEditor/HTTPTab/fetchWorker.ts
@@ -10,12 +10,14 @@ export function fetchWorker(
 
 	return fetch(`${proxyUrl.origin}${init}`, {
 		...input,
+		method: "POST",
 		headers: [
 			...(input?.headers ?? [])
 				.filter(([name]) => name)
 				.map<[string, string]>(([n, v]) => [`cf-ew-raw-${n}`, v]),
 			["X-CF-Token", token],
 			["cf-raw-http", "true"],
+			["X-CF-HTTP-Method", input.method ?? "GET"],
 		],
 	});
 }


### PR DESCRIPTION
Fixes #7791.

This PR un-reverts #7791 which was made because of a bug upstream and is now fixed in #7793. ~~We should verify it on the preview playground before merging this PR.~~ I have tested this on the preview environment as described on [this comment](https://github.com/cloudflare/workers-sdk/pull/7936#issuecomment-2622163606).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Tested manually
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Tested manually.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
