### PR TITLE
Collapse CI jobs into one

### DIFF
--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -102,7 +102,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13]
         filter:
-          - '--filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground"',
+          - '--filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground"'
         # Things in the tools folder are for running in CI, and so only need to run on linux
         include:
           - os: ubuntu-latest

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -102,15 +102,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13]
         filter:
-          [
-            "./packages/*",
-            "./fixtures/*",
-            "./packages/vite-plugin-cloudflare/playground",
-          ]
+          - '--filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground"',
         # Things in the tools folder are for running in CI, and so only need to run on linux
         include:
           - os: ubuntu-latest
-            filter: "./tools"
+            filter: '--filter="./tools"'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
@@ -136,7 +132,7 @@ jobs:
 
       - name: Run tests
         if: steps.changes.outputs.everything_but_markdown == 'true'
-        run: pnpm run test:ci --concurrency 1 --filter=${{ matrix.filter }}
+        run: pnpm run test:ci --concurrency 1 ${{ matrix.filter }}
         env:
           TMP_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TMP_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Previously we run packages and fixtures as different CI jobs. This meant that we were wasting on average 30s-1m30s building and setting up runners (in particular, `pnpm install` takes a long time even with a warm cache). 

This PR changes it to make packages and fixtures run in the same job, reducing wasted setup time.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tooling change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: tooling change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tooling change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
