### PR TITLE
fix wrong catalog used for typescrint in dev-vars vite-plugin-cloudflare playground app

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/dev-vars/package.json
+++ b/packages/vite-plugin-cloudflare/playground/dev-vars/package.json
@@ -12,7 +12,7 @@
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20241230.0",
-		"typescript": "catalog:vite-plugin",
+		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "catalog:vite-plugin"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1782,11 +1782,11 @@ importers:
         specifier: ^4.20241230.0
         version: 4.20250121.0
       typescript:
-        specifier: catalog:vite-plugin
+        specifier: catalog:default
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.0.7(@types/node@18.19.59)(jiti@2.4.2)
+        version: 6.0.7(@types/node@18.19.74)(jiti@2.4.2)
       wrangler:
         specifier: catalog:vite-plugin
         version: 3.103.2(@cloudflare/workers-types@4.20250121.0)
@@ -10604,9 +10604,6 @@ packages:
 
   unenv-nightly@2.0.0-20250109-100802-88ad671:
     resolution: {integrity: sha512-Uij6gODNNNNsNBoDlnaMvZI99I6YlVJLRfYH8AOLMlbFrW7k2w872v9VLuIdch2vF8QBeSC4EftIh5sG4ibzdA==}
-
-  unenv@2.0.0-rc.0:
-    resolution: {integrity: sha512-H0kl2w8jFL/FAk0xvjVing4bS3jd//mbg1QChDnn58l9Sc5RtduaKmLAL8n+eBw5jJo8ZjYV7CrEGage5LAOZQ==}
 
   unenv@2.0.0-rc.1:
     resolution: {integrity: sha512-PU5fb40H8X149s117aB4ytbORcCvlASdtF97tfls4BPIyj4PeVxvpSuy1jAptqYHqB0vb2w2sHvzM0XWcp2OKg==}
@@ -20008,14 +20005,6 @@ snapshots:
       ufo: 1.5.4
 
   unenv-nightly@2.0.0-20250109-100802-88ad671:
-    dependencies:
-      defu: 6.1.4
-      mlly: 1.7.4
-      ohash: 1.1.4
-      pathe: 1.1.2
-      ufo: 1.5.4
-
-  unenv@2.0.0-rc.0:
     dependencies:
       defu: 6.1.4
       mlly: 1.7.4


### PR DESCRIPTION
In https://github.com/cloudflare/workers-sdk/pull/7864 I've used the incorrect catalog for the `typescript` dependency ([the `vite-plugin` catalog doesn't include the `typescript` dependency](https://github.com/cloudflare/workers-sdk/blob/471cc748bf8257892a0026668db64efee912b447/pnpm-workspace.yaml#L22-L26)), that breaks `pnpm i` (in CI and locally), this PR is fixing that

I am not sure how that wasn't detected in #7864 😕 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: infra change
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: infra change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: infra change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
