### PR TITLE
[wrangler] fix: avoid `getPlatformProxy` logging twice that it is using vars defined in `.dev.vars` files

### DIFF
--- a/.changeset/gentle-foxes-float.md
+++ b/.changeset/gentle-foxes-float.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+fix: avoid `getPlatformProxy` logging twice that it is using vars defined in `.dev.vars` files
+
+when `getPlatformProxy` is called and it retrieves values from `.dev.vars` files, it logs twice
+a message like: `Using vars defined in .dev.vars`, the changes here make sure that in such cases
+this log only appears once

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -5,7 +5,6 @@ import { DEFAULT_MODULE_RULES } from "../../../deployment-bundle/rules";
 import { getBindings } from "../../../dev";
 import { getBoundRegisteredWorkers } from "../../../dev-registry";
 import { getClassNamesWhichUseSQLite } from "../../../dev/class-names-sqlite";
-import { getVarsForDev } from "../../../dev/dev-vars";
 import {
 	buildAssetOptions,
 	buildMiniflareBindingOptions,
@@ -118,16 +117,11 @@ export async function getPlatformProxy<
 
 	const bindings: Env = await mf.getBindings();
 
-	const vars = getVarsForDev(rawConfig, env);
-
 	const cf = await mf.getCf();
 	deepFreeze(cf);
 
 	return {
-		env: {
-			...vars,
-			...bindings,
-		},
+		env: bindings,
 		cf: cf as CfProperties,
 		ctx: new ExecutionContext(),
 		caches: new CacheStorage(),


### PR DESCRIPTION
Fixes #7944

when `getPlatformProxy` is called and it retrieves values from `.dev.vars` files, it logs twice a message like: `Using vars defined in .dev.vars`, the changes here make sure that in such cases this log only appears once

(Prerequisite for fixing https://github.com/opennextjs/opennextjs-cloudflare/issues/288)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this functionality is already tested, the only noticeable change here is the removal of the extra terminal log, I am not sure if that can be reliably tested, I can look into that if we believe it beneficial but it feels not completely worth it to me
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
