### PR TITLE
Add Worker Pipelines Binding to Miniflare

### DIFF
--- a/.changeset/slimy-otters-rush.md
+++ b/.changeset/slimy-otters-rush.md
@@ -1,5 +1,6 @@
 ---
-"miniflare": minor
+"miniflare": patch
+"wrangler": patch
 ---
 
 Add local binding support for Worker Pipelines

--- a/.changeset/slimy-otters-rush.md
+++ b/.changeset/slimy-otters-rush.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+Add local binding support for Worker Pipelines

--- a/fixtures/vitest-pool-workers-examples/README.md
+++ b/fixtures/vitest-pool-workers-examples/README.md
@@ -11,6 +11,7 @@ This directory contains example projects tested with `@cloudflare/vitest-pool-wo
 | [📚 d1](d1)                                                                        | Isolated tests using D1 with migrations                   |
 | [📌 durable-objects](durable-objects)                                              | Isolated tests using Durable Objects with direct access   |
 | [🚥 queues](queues)                                                                | Tests using Queue producers and consumers                 |
+| [🚰 pipelines](pipelines)                                                          | Tests using Pipelines                                     |
 | [🚀 hyperdrive](hyperdrive)                                                        | Tests using Hyperdrive with a Vitest managed TCP server   |
 | [🤹 request-mocking](request-mocking)                                              | Tests using declarative/imperative outbound request mocks |
 | [🔌 multiple-workers](multiple-workers)                                            | Tests using multiple auxiliary workers and request mocks  |

--- a/fixtures/vitest-pool-workers-examples/pipelines/README.md
+++ b/fixtures/vitest-pool-workers-examples/pipelines/README.md
@@ -1,0 +1,8 @@
+# 🚰 pipelines
+
+This Worker implements endpoint that send details of the incoming HTTP request to a Pipeline.
+
+| Test                                                                                  | Overview                                                          |
+| ------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [pipeline-send-integration-self.test.ts](test/pipeline-send-integration-self.test.ts) | Integration tests for endpoints using `SELF`                      |
+| [pipeline-send-unit.test.ts](test/pipeline-send-unit.test.ts)                         | Unit tests calling `worker.fetch()` directly mocking the Pipeline |

--- a/fixtures/vitest-pool-workers-examples/pipelines/src/env.d.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/src/env.d.ts
@@ -1,0 +1,3 @@
+interface Env {
+	PIPELINE: Pipeline;
+}

--- a/fixtures/vitest-pool-workers-examples/pipelines/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/src/index.ts
@@ -1,0 +1,11 @@
+export default {
+	async fetch(request, env, ctx) {
+		await env.PIPELINE.send([
+			{
+				method: request.method.toUpperCase(),
+				url: request.url,
+			},
+		]);
+		return new Response("Accepted", { status: 202 });
+	},
+} satisfies ExportedHandler<Env>;

--- a/fixtures/vitest-pool-workers-examples/pipelines/src/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/pipelines/src/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.workerd.json",
+	"include": ["./**/*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/pipelines/test/env.d.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/test/env.d.ts
@@ -1,0 +1,4 @@
+declare module "cloudflare:test" {
+	// Controls the type of `import("cloudflare:test").env`
+	interface ProvidedEnv extends Env {}
+}

--- a/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-integration-self.test.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-integration-self.test.ts
@@ -1,0 +1,20 @@
+import { SELF } from "cloudflare:test";
+import { expect, it, vi } from "vitest";
+
+it("produces and consumers queue message", async () => {
+	// Send data to the Pipeline
+	let response = await SELF.fetch("https://example.com/ingest", {
+		method: "POST",
+		body: "value",
+	});
+	expect(response.status).toBe(202);
+	expect(await response.text()).toBe("Accepted");
+
+	// Wait until data is sent to the pipeline
+	const result = await vi.waitUntil(async () => {
+		const response = await SELF.fetch("https://example.com/ingest");
+		const text = await response.text();
+		if (response.ok) return text;
+	});
+	expect(result).toBe("Accepted");
+});

--- a/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-integration-self.test.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-integration-self.test.ts
@@ -1,7 +1,7 @@
 import { SELF } from "cloudflare:test";
-import { expect, it, vi } from "vitest";
+import { expect, it } from "vitest";
 
-it("produces and consumers queue message", async () => {
+it("sends message to pipeline", async () => {
 	// Send data to the Pipeline
 	let response = await SELF.fetch("https://example.com/ingest", {
 		method: "POST",
@@ -9,12 +9,4 @@ it("produces and consumers queue message", async () => {
 	});
 	expect(response.status).toBe(202);
 	expect(await response.text()).toBe("Accepted");
-
-	// Wait until data is sent to the pipeline
-	const result = await vi.waitUntil(async () => {
-		const response = await SELF.fetch("https://example.com/ingest");
-		const text = await response.text();
-		if (response.ok) return text;
-	});
-	expect(result).toBe("Accepted");
 });

--- a/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-unit.test.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/test/pipeline-send-unit.test.ts
@@ -1,0 +1,45 @@
+import {
+	createExecutionContext,
+	env,
+	waitOnExecutionContext,
+} from "cloudflare:test";
+import { afterEach, expect, it, vi } from "vitest";
+import worker from "../src/index";
+
+// This will improve in the next major version of `@cloudflare/workers-types`,
+// but for now you'll need to do something like this to get a correctly-typed
+// `Request` to pass to `worker.fetch()`.
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+it("produces message to pipeline", async () => {
+	const mockPipeline = {
+		send: vi.fn().mockResolvedValue(undefined),
+	};
+
+	const testEnv = {
+		...env,
+		PIPELINE: mockPipeline,
+	};
+
+	// Send data to pipeline
+	const request = new IncomingRequest("https://example.com/ingest", {
+		method: "POST",
+		body: "value",
+	});
+	const ctx = createExecutionContext();
+	const response = await worker.fetch(request, testEnv, ctx);
+	await waitOnExecutionContext(ctx);
+
+	expect(response.status).toBe(202);
+	expect(await response.text()).toBe("Accepted");
+
+	// Check `PIPELINE.send()` was called
+	expect(mockPipeline.send).toBeCalledTimes(1);
+	expect(mockPipeline.send).toBeCalledWith([
+		{ method: "POST", url: "https://example.com/ingest" },
+	]);
+});

--- a/fixtures/vitest-pool-workers-examples/pipelines/test/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/pipelines/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.workerd-test.json",
+	"include": ["./**/*.ts", "../src/env.d.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/pipelines/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/pipelines/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.node.json",
+	"include": ["./*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/pipelines/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineWorkersProject } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersProject({
+	test: {
+		poolOptions: {
+			workers: {
+				singleWorker: true,
+				miniflare: {
+					pipelines: ["PIPELINE"],
+				},
+				wrangler: {
+					configPath: "./wrangler.toml",
+				},
+			},
+		},
+	},
+});

--- a/fixtures/vitest-pool-workers-examples/pipelines/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/pipelines/vitest.config.ts
@@ -5,9 +5,6 @@ export default defineWorkersProject({
 		poolOptions: {
 			workers: {
 				singleWorker: true,
-				miniflare: {
-					pipelines: ["PIPELINE"],
-				},
 				wrangler: {
 					configPath: "./wrangler.toml",
 				},

--- a/fixtures/vitest-pool-workers-examples/pipelines/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/pipelines/wrangler.toml
@@ -1,0 +1,7 @@
+name = "pipelines"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+
+[[pipelines]]
+binding = "PIPELINE"
+pipeline = "my-pipeline"

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -599,6 +599,13 @@ parameter in module format Workers.
 - `assetOptions?: { html_handling?: HTMLHandlingOptions, not_found_handling?: NotFoundHandlingOptions}`
   Configuration for file-based asset routing - see [docs](https://developers.cloudflare.com/workers/static-assets/routing/#routing-configuration) for options
 
+#### Pipelines
+
+- `pipelines?: Record<string, PipelineOptions> | string[]`
+
+  Record mapping binding name to a Pipeline. Different workers may bind to the same Pipeline with different bindings
+  names. If a `string[]` of pipeline names, the binding and Pipeline name are assumed to be the same.
+
 #### Workflows
 
 - `workflows?: WorkflowOptions[]`

--- a/packages/miniflare/src/plugins/index.ts
+++ b/packages/miniflare/src/plugins/index.ts
@@ -8,6 +8,7 @@ import { D1_PLUGIN, D1_PLUGIN_NAME } from "./d1";
 import { DURABLE_OBJECTS_PLUGIN, DURABLE_OBJECTS_PLUGIN_NAME } from "./do";
 import { HYPERDRIVE_PLUGIN, HYPERDRIVE_PLUGIN_NAME } from "./hyperdrive";
 import { KV_PLUGIN, KV_PLUGIN_NAME } from "./kv";
+import { PIPELINE_PLUGIN, PIPELINES_PLUGIN_NAME } from "./pipelines";
 import { QUEUES_PLUGIN, QUEUES_PLUGIN_NAME } from "./queues";
 import { R2_PLUGIN, R2_PLUGIN_NAME } from "./r2";
 import { RATELIMIT_PLUGIN, RATELIMIT_PLUGIN_NAME } from "./ratelimit";
@@ -25,6 +26,7 @@ export const PLUGINS = {
 	[RATELIMIT_PLUGIN_NAME]: RATELIMIT_PLUGIN,
 	[ASSETS_PLUGIN_NAME]: ASSETS_PLUGIN,
 	[WORKFLOWS_PLUGIN_NAME]: WORKFLOWS_PLUGIN,
+	[PIPELINES_PLUGIN_NAME]: PIPELINE_PLUGIN,
 };
 export type Plugins = typeof PLUGINS;
 
@@ -73,7 +75,9 @@ export type WorkerOptions = z.input<typeof CORE_PLUGIN.options> &
 	z.input<typeof HYPERDRIVE_PLUGIN.options> &
 	z.input<typeof RATELIMIT_PLUGIN.options> &
 	z.input<typeof ASSETS_PLUGIN.options> &
-	z.input<typeof WORKFLOWS_PLUGIN.options>;
+	z.input<typeof WORKFLOWS_PLUGIN.options> &
+	z.input<typeof PIPELINE_PLUGIN.options>;
+
 export type SharedOptions = z.input<typeof CORE_PLUGIN.sharedOptions> &
 	z.input<typeof CACHE_PLUGIN.sharedOptions> &
 	z.input<typeof D1_PLUGIN.sharedOptions> &
@@ -129,3 +133,4 @@ export * from "./ratelimit";
 export * from "./assets";
 export * from "./assets/schema";
 export * from "./workflows";
+export * from "./pipelines";

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -1,0 +1,104 @@
+import { SharedBindings } from "miniflare:shared";
+import SCRIPT_PIPELINE_OBJECT from "worker:pipelines/pipeline";
+import { z } from "zod";
+import {
+	kVoid,
+	Service,
+	Worker_Binding_DurableObjectNamespaceDesignator,
+} from "../../runtime";
+import {
+	getMiniflareObjectBindings,
+	namespaceKeys,
+	objectEntryWorker,
+	Plugin,
+	ProxyNodeBinding,
+	SERVICE_LOOPBACK,
+} from "../shared";
+
+export const PipelineOptionsSchema = z.object({
+	pipelines: z.union([z.record(z.string()), z.string().array()]).optional(),
+});
+
+export const PIPELINES_PLUGIN_NAME = "pipelines";
+const SERVICE_PIPELINE_PREFIX = `${PIPELINES_PLUGIN_NAME}:pipeline`;
+const PIPELINE_OBJECT_CLASS_NAME = "Pipeline";
+const PIPELINE_OBJECT: Worker_Binding_DurableObjectNamespaceDesignator = {
+	serviceName: SERVICE_PIPELINE_PREFIX,
+	className: PIPELINE_OBJECT_CLASS_NAME,
+};
+
+export const PIPELINE_PLUGIN: Plugin<typeof PipelineOptionsSchema> = {
+	options: PipelineOptionsSchema,
+	getBindings(options) {
+		const pipelines = bindingEntries(options.pipelines);
+		return pipelines.map<Service>(([name]) => ({
+			name,
+			service: { name: SERVICE_PIPELINE_PREFIX },
+		}));
+	},
+	getNodeBindings(options) {
+		const buckets = namespaceKeys(options.pipelines);
+		return Object.fromEntries(
+			buckets.map((name) => [name, new ProxyNodeBinding()])
+		);
+	},
+	async getServices({ options, unsafeStickyBlobs }) {
+		const pipelines = bindingEntries(options.pipelines);
+		const services = pipelines.map<Service>(([_, id]) => ({
+			name: `${SERVICE_PIPELINE_PREFIX}:${id}`,
+			worker: objectEntryWorker(PIPELINE_OBJECT, id),
+		}));
+
+		if (pipelines.length > 0) {
+			const uniqueKey = `miniflare-${PIPELINE_OBJECT_CLASS_NAME}`;
+			const pipelineService: Service = {
+				name: SERVICE_PIPELINE_PREFIX,
+				worker: {
+					compatibilityDate: "2024-12-30",
+					compatibilityFlags: ["nodejs_compat"],
+					modules: [
+						{
+							name: "pipeline.worker.js",
+							esModule: SCRIPT_PIPELINE_OBJECT(),
+						},
+					],
+					durableObjectNamespaces: [
+						{
+							className: PIPELINE_OBJECT_CLASS_NAME,
+							uniqueKey,
+						},
+					],
+					durableObjectStorage: { inMemory: kVoid },
+					bindings: [
+						{
+							name: SharedBindings.MAYBE_SERVICE_LOOPBACK,
+							service: { name: SERVICE_LOOPBACK },
+						},
+						...getMiniflareObjectBindings(unsafeStickyBlobs),
+					],
+				},
+			};
+			services.push(pipelineService);
+		}
+
+		return services;
+	},
+};
+
+function bindingEntries(
+	namespaces?:
+		| Record<string, { pipelineName: string }>
+		| string[]
+		| Record<string, string>
+): [bindingName: string, id: string][] {
+	if (Array.isArray(namespaces)) {
+		return namespaces.map((bindingName) => [bindingName, bindingName]);
+	} else if (namespaces !== undefined) {
+		return Object.entries(namespaces).map(([name, opts]) => [
+			name,
+			typeof opts === "string" ? opts : opts.pipelineName,
+		]);
+	} else {
+		return [];
+	}
+}

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -33,7 +33,7 @@ export const PIPELINE_PLUGIN: Plugin<typeof PipelineOptionsSchema> = {
 		const pipelines = bindingEntries(options.pipelines);
 		return pipelines.map<Service>(([name, id]) => ({
 			name,
-			service: { name: `SERVICE_PIPELINE_PREFIX:${id}` },
+			service: { name: `${SERVICE_PIPELINE_PREFIX}:${id}` },
 		}));
 	},
 	getNodeBindings(options) {

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -34,7 +34,6 @@ export const PIPELINE_PLUGIN: Plugin<typeof PipelineOptionsSchema> = {
 				name: `${SERVICE_PIPELINE_PREFIX}:${pipeline[1]}`,
 				worker: {
 					compatibilityDate: "2024-12-30",
-					compatibilityFlags: ["nodejs_compat"],
 					modules: [
 						{
 							name: "pipeline.worker.js",

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -31,9 +31,9 @@ export const PIPELINE_PLUGIN: Plugin<typeof PipelineOptionsSchema> = {
 	options: PipelineOptionsSchema,
 	getBindings(options) {
 		const pipelines = bindingEntries(options.pipelines);
-		return pipelines.map<Service>(([name]) => ({
+		return pipelines.map<Service>(([name, id]) => ({
 			name,
-			service: { name: SERVICE_PIPELINE_PREFIX },
+			service: { name: `SERVICE_PIPELINE_PREFIX:${id}` },
 		}));
 	},
 	getNodeBindings(options) {

--- a/packages/miniflare/src/plugins/pipelines/index.ts
+++ b/packages/miniflare/src/plugins/pipelines/index.ts
@@ -1,19 +1,7 @@
-import { SharedBindings } from "miniflare:shared";
 import SCRIPT_PIPELINE_OBJECT from "worker:pipelines/pipeline";
 import { z } from "zod";
-import {
-	kVoid,
-	Service,
-	Worker_Binding_DurableObjectNamespaceDesignator,
-} from "../../runtime";
-import {
-	getMiniflareObjectBindings,
-	namespaceKeys,
-	objectEntryWorker,
-	Plugin,
-	ProxyNodeBinding,
-	SERVICE_LOOPBACK,
-} from "../shared";
+import { Service } from "../../runtime";
+import { namespaceKeys, Plugin, ProxyNodeBinding } from "../shared";
 
 export const PipelineOptionsSchema = z.object({
 	pipelines: z.union([z.record(z.string()), z.string().array()]).optional(),
@@ -21,11 +9,6 @@ export const PipelineOptionsSchema = z.object({
 
 export const PIPELINES_PLUGIN_NAME = "pipelines";
 const SERVICE_PIPELINE_PREFIX = `${PIPELINES_PLUGIN_NAME}:pipeline`;
-const PIPELINE_OBJECT_CLASS_NAME = "Pipeline";
-const PIPELINE_OBJECT: Worker_Binding_DurableObjectNamespaceDesignator = {
-	serviceName: SERVICE_PIPELINE_PREFIX,
-	className: PIPELINE_OBJECT_CLASS_NAME,
-};
 
 export const PIPELINE_PLUGIN: Plugin<typeof PipelineOptionsSchema> = {
 	options: PipelineOptionsSchema,
@@ -42,17 +25,13 @@ export const PIPELINE_PLUGIN: Plugin<typeof PipelineOptionsSchema> = {
 			buckets.map((name) => [name, new ProxyNodeBinding()])
 		);
 	},
-	async getServices({ options, unsafeStickyBlobs }) {
+	async getServices({ options }) {
 		const pipelines = bindingEntries(options.pipelines);
-		const services = pipelines.map<Service>(([_, id]) => ({
-			name: `${SERVICE_PIPELINE_PREFIX}:${id}`,
-			worker: objectEntryWorker(PIPELINE_OBJECT, id),
-		}));
 
-		if (pipelines.length > 0) {
-			const uniqueKey = `miniflare-${PIPELINE_OBJECT_CLASS_NAME}`;
-			const pipelineService: Service = {
-				name: SERVICE_PIPELINE_PREFIX,
+		const services = [];
+		for (const pipeline of pipelines) {
+			services.push({
+				name: `${SERVICE_PIPELINE_PREFIX}:${pipeline[1]}`,
 				worker: {
 					compatibilityDate: "2024-12-30",
 					compatibilityFlags: ["nodejs_compat"],
@@ -62,23 +41,8 @@ export const PIPELINE_PLUGIN: Plugin<typeof PipelineOptionsSchema> = {
 							esModule: SCRIPT_PIPELINE_OBJECT(),
 						},
 					],
-					durableObjectNamespaces: [
-						{
-							className: PIPELINE_OBJECT_CLASS_NAME,
-							uniqueKey,
-						},
-					],
-					durableObjectStorage: { inMemory: kVoid },
-					bindings: [
-						{
-							name: SharedBindings.MAYBE_SERVICE_LOOPBACK,
-							service: { name: SERVICE_LOOPBACK },
-						},
-						...getMiniflareObjectBindings(unsafeStickyBlobs),
-					],
 				},
-			};
-			services.push(pipelineService);
+			});
 		}
 
 		return services;

--- a/packages/miniflare/src/workers/pipelines/pipeline.worker.ts
+++ b/packages/miniflare/src/workers/pipelines/pipeline.worker.ts
@@ -1,0 +1,7 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+export default class Pipeline extends WorkerEntrypoint {
+	async send(data: object[]): Promise<void> {
+		console.log("Request received", data);
+	}
+}

--- a/packages/miniflare/test/plugins/pipelines/index.spec.ts
+++ b/packages/miniflare/test/plugins/pipelines/index.spec.ts
@@ -1,0 +1,21 @@
+import test from "ava";
+import { Miniflare } from "miniflare";
+
+test("supports declaring pipelines", async (t) => {
+	const mf = new Miniflare({
+		verbose: true,
+		compatibilityDate: "2024-12-30",
+		pipelines: ["PIPELINE"],
+		modules: true,
+		script: `export default {
+        async fetch(request, env, ctx) {
+			await env.PIPELINE.send([{message: "hello"}]);
+            return new Response(null, { status: 204 });
+        },
+    }`,
+	});
+	t.teardown(() => mf.dispose());
+
+	await mf.dispatchFetch("http://localhost");
+	t.assert(true);
+});

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -609,7 +609,7 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 		await fetch(`${url}/connect`);
 	});
 
-	it("exposes Pipelines bindings", async () => {
+	it.skipIf(!isLocal)("exposes Pipelines bindings", async () => {
 		await helper.seed({
 			"wrangler.toml": dedent`
 				name = "${workerName}"

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -609,7 +609,7 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 		await fetch(`${url}/connect`);
 	});
 
-	it.skipIf(!isLocal).fails("exposes Pipelines bindings", async () => {
+	it("exposes Pipelines bindings", async () => {
 		await helper.seed({
 			"wrangler.toml": dedent`
 				name = "${workerName}"

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -640,7 +640,9 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 		const res = await fetch(url);
 
 		await expect(res.text()).resolves.toBe("env.PIPELINE is available");
-		expect(worker.currentOutput).toMatchInlineSnapshot(`Request received`);
+		// worker.currentOutput is sometimes racey, worker.output will hang
+		const match = await worker.readUntil(/Request received/);
+		expect(match[0]).not.toBeNull();
 	});
 
 	it.skipIf(!isLocal)("exposes queue producer/consumer bindings", async () => {

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -626,7 +626,7 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 						if (env.PIPELINE === undefined) {
 							return new Response("env.PIPELINE is undefined");
 						}
-
+						env.PIPELINE.send([{hello: "world"}]);
 						return new Response("env.PIPELINE is available");
 					}
 				}
@@ -640,6 +640,7 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 		const res = await fetch(url);
 
 		await expect(res.text()).resolves.toBe("env.PIPELINE is available");
+		expect(worker.currentOutput).toMatchInlineSnapshot(`Request received`);
 	});
 
 	it.skipIf(!isLocal)("exposes queue producer/consumer bindings", async () => {

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -33,6 +33,7 @@ import type {
 	CfDurableObject,
 	CfHyperdrive,
 	CfKvNamespace,
+	CfPipeline,
 	CfQueue,
 	CfR2Bucket,
 	CfScriptFormat,
@@ -334,6 +335,9 @@ function queueProducerEntry(
 		{ queueName: queue.queue_name, deliveryDelay: queue.delivery_delay },
 	];
 }
+function pipelineEntry(pipeline: CfPipeline): [string, string] {
+	return [pipeline.binding, pipeline.pipeline];
+}
 function hyperdriveEntry(hyperdrive: CfHyperdrive): [string, string] {
 	return [hyperdrive.binding, hyperdrive.localConnectionString ?? ""];
 }
@@ -375,6 +379,7 @@ type WorkerOptionsBindings = Pick<
 	| "d1Databases"
 	| "queueProducers"
 	| "queueConsumers"
+	| "pipelines"
 	| "hyperdrives"
 	| "durableObjects"
 	| "serviceBindings"
@@ -694,6 +699,7 @@ export function buildMiniflareBindingOptions(config: MiniflareBindingsConfig): {
 		queueConsumers: Object.fromEntries(
 			config.queueConsumers?.map(queueConsumerEntry) ?? []
 		),
+		pipelines: Object.fromEntries(bindings.pipelines?.map(pipelineEntry) ?? []),
 		hyperdrives: Object.fromEntries(
 			bindings.hyperdrive?.map(hyperdriveEntry) ?? []
 		),


### PR DESCRIPTION
Adding support to Miniflare to reference bindings during `wrangler dev` or during tests via vitest.

This binding uses newer JSRPC method instead of propagating changes through `workerd.capnp`.

Fixes https://jira.cfdata.org/browse/PIPE-166

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: no e2e test needed
- Public documentation
  - [ ] TODO (before merge)
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18595
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
