### PR TITLE
CI: compute the name for artifacts correctly

### DIFF
--- a/.github/actions/run-c3-e2e/action.yml
+++ b/.github/actions/run-c3-e2e/action.yml
@@ -39,7 +39,7 @@ runs:
         git config --global user.email wrangler@cloudflare.com
         git config --global user.name 'Wrangler automated PR updater'
 
-    - name: E2E Tests ${{inputs.experimental && '(experimental)' || ''}}
+    - name: E2E Tests ${{inputs.experimental == 'true' && '(experimental)' || ''}}
       id: run-e2e
       shell: bash
       run: pnpm run test:e2e --filter create-cloudflare
@@ -57,8 +57,8 @@ runs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: e2e-logs${{inputs.quarantine && '-quarantine' || ''}}${{inputs.experimental && '-experimental' || ''}}-${{runner.os}}-${{inputs.packageManager}}
-        path: packages/create-cloudflare/.e2e-logs${{inputs.experimental && '-experimental' || ''}}
+        name: e2e-logs${{inputs.quarantine == 'true' && '-quarantine' || ''}}${{inputs.experimental == 'true' && '-experimental' || ''}}-${{runner.os}}-${{inputs.packageManager}}
+        path: packages/create-cloudflare/.e2e-logs${{inputs.experimental == 'true' && '-experimental' || ''}}
         include-hidden-files: true
 
     - name: Fail if errors detected


### PR DESCRIPTION
In the `run-c3-e2e` GH Action we compute various things from the inputs. In particular using `experimental` and `quarantine`.

But it seems that these are converted to strings rather than booleans, so we cannot simple check the truthy state of `inputs.quarantine`, for example since this might have the value `"false"`, which is truthy.

