### PR TITLE
chore: configure pnpm to use the version specified in package.json engines field

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,5 @@
 git-checks=false
+# Ref: https://pnpm.io/npmrc#manage-package-manager-versions
+# When enabled, pnpm will automatically download and run the version of pnpm
+# specified in the packageManager field of package.json.
+manage-package-manager-versions = true


### PR DESCRIPTION
Fixes #0000

This change is useful because it means that you don't have to automatically update your pnpm version as you move from one project to another. This is similar to our Volta configuration.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: chore
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: chore
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: chore

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
