### PR TITLE
chore: fix lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,19 +826,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/kv-asset-handler
 
-  fixtures/t:
-    dependencies:
-      hono:
-        specifier: ^4.6.19
-        version: 4.6.19
-    devDependencies:
-      '@cloudflare/workers-types':
-        specifier: ^4.20250109.0
-        version: 4.20250121.0
-      wrangler:
-        specifier: ^3.101.0
-        version: 3.103.2(@cloudflare/workers-types@4.20250121.0)
-
   fixtures/type-generation:
     devDependencies:
       vitest:
@@ -7760,10 +7747,6 @@ packages:
   hono@3.12.11:
     resolution: {integrity: sha512-LSpxVgIMR3UzyFiXZaPvqBUGqyOKG0LMZqgMn2RXz9f+YAdkHSfFQQX0dtU72fPm5GnEMh5AYXs0ek5NYgMOmA==}
     engines: {node: '>=16.0.0'}
-
-  hono@4.6.19:
-    resolution: {integrity: sha512-Xw5DwU2cewEsQ1DkDCdy6aBJkEBARl5loovoL1gL3/gw81RdaPbXrNJYp3LoQpzpJ7ECC/1OFi/vn3UZTLHFEw==}
-    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -17185,8 +17168,6 @@ snapshots:
   heap-js@2.5.0: {}
 
   hono@3.12.11: {}
-
-  hono@4.6.19: {}
 
   hookable@5.5.3: {}
 


### PR DESCRIPTION
Fixes n/a.

There are some issue type-checking the vite-plugin codebase in the CI (See [this example](https://github.com/cloudflare/workers-sdk/actions/runs/13055701126/job/36428906143?pr=7933)) which might be caused by #7967 or #7972. Updating the lockfile seems to resolve the issue. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: lockfile
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: lockfile
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: lockfile

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
