### PR TITLE
Fix assets inheritance

### DIFF
--- a/.changeset/long-bulldogs-clean.md
+++ b/.changeset/long-bulldogs-clean.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fixes a regression introduced in Wrangler 3.107.0 in which `[assets]` was not being inherited from the top-level environment.

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -596,11 +596,16 @@ function normalizeAndValidateAssets(
 			`The "experimental_serve_directly" field is not longer supported. Please use run_worker_first.\nRead more: https://developers.cloudflare.com/workers/static-assets/binding/#run_worker_first`,
 			false // Leave in for the moment, to be removed in a future release
 		);
-
-		validateAssetsConfig(diagnostics, "assets", rawEnv.assets, topLevelEnv);
-		return rawEnv.assets;
 	}
-	return undefined;
+
+	return inheritable(
+		diagnostics,
+		topLevelEnv,
+		rawEnv,
+		"assets",
+		validateAssetsConfig,
+		undefined
+	);
 }
 
 /**


### PR DESCRIPTION
Fixes N/A

Fixes a regression introduced in Wrangler 3.107.0 in which `[assets]` was not being inherited from the top-level environment.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no change

