### PR TITLE
test: log the C3 e2e log file to the console when a test fails

### DIFF
--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./helpers";
 import type { Suite } from "vitest";
 
-const experimental = Boolean(process.env.E2E_EXPERIMENTAL);
+const experimental = process.env.E2E_EXPERIMENTAL === "true";
 const frameworkToTest = getFrameworkToTest({ experimental: false });
 
 // Note: skipIf(frameworkToTest) makes it so that all the basic C3 functionality

--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -624,7 +624,7 @@ function getFrameworkTests(opts: {
 	}
 }
 
-const experimental = Boolean(process.env.E2E_EXPERIMENTAL);
+const experimental = process.env.E2E_EXPERIMENTAL === "true";
 const frameworkMap = getFrameworkMap({ experimental });
 const frameworkTests = getFrameworkTests({ experimental });
 

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -7,6 +7,7 @@ import {
 	rmSync,
 } from "fs";
 import crypto from "node:crypto";
+import { readFileSync } from "node:fs";
 import { tmpdir } from "os";
 import path from "path";
 import { setTimeout } from "timers/promises";
@@ -323,16 +324,21 @@ export const waitForExit = async (
 	};
 };
 
-export const createTestLogStream = (
+const createTestLogStream = (
 	opts: { experimental: boolean },
 	task: RunnerTestCase,
 ) => {
 	// The .ansi extension allows for editor extensions that format ansi terminal codes
 	const fileName = `${normalizeTestName(task)}.ansi`;
 	assert(task.suite, "Expected task.suite to be defined");
-	return createWriteStream(path.join(getLogPath(opts, task.suite), fileName), {
+	const logPath = path.join(getLogPath(opts, task.suite), fileName);
+	const logStream = createWriteStream(logPath, {
 		flags: "a",
 	});
+	return {
+		logPath,
+		logStream,
+	};
 };
 
 export const recreateLogFolder = (
@@ -374,7 +380,7 @@ const normalizeTestName = (task: Test) => {
 	return baseName + suffix;
 };
 
-export const testProjectDir = (suite: string, test: string) => {
+const testProjectDir = (suite: string, test: string) => {
 	const tmpDirPath =
 		process.env.E2E_PROJECT_PATH ??
 		realpathSync(mkdtempSync(path.join(tmpdir(), `c3-tests-${suite}`)));
@@ -496,9 +502,21 @@ export const test = (opts: { experimental: boolean }) =>
 			await use({ path: getPath(), name: getName() });
 			clean();
 		},
-		async logStream({ task }, use) {
-			const logStream = createTestLogStream(opts, task);
+		async logStream({ task, onTestFailed }, use) {
+			const { logPath, logStream } = createTestLogStream(opts, task);
+
+			onTestFailed(() => {
+				console.error("##[group]Logs from failed test:", logPath);
+				try {
+					console.error(readFileSync(logPath, "utf8"));
+				} catch {
+					console.error("Unable to read log file");
+				}
+				console.error("##[endgroup]");
+			});
+
 			await use(logStream);
+
 			logStream.close();
 		},
 	});

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -147,7 +147,7 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 	}
 }
 
-const experimental = Boolean(process.env.E2E_EXPERIMENTAL);
+const experimental = process.env.E2E_EXPERIMENTAL === "true";
 const workerTests = getWorkerTests({ experimental });
 
 describe


### PR DESCRIPTION
Hopefully this will help with debugging C3 e2e tests without having to download the log artifact files.
See https://github.com/cloudflare/workers-sdk/actions/runs/13073993617/job/36481629597?pr=7982#step:5:394

Fixes #0000

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included (it is a change to how tests are run)
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: only affects C3 e2e tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just a change to how tests are run

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
