### PR TITLE
add telemetry to auto provisioning

### DIFF
--- a/.changeset/bright-islands-sleep.md
+++ b/.changeset/bright-islands-sleep.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: add telemetry to experimental auto-provisioning

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from "msw";
+import { logger } from "../logger";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { clearDialogs, mockPrompt, mockSelect } from "./helpers/mock-dialogs";
@@ -30,6 +31,7 @@ describe("--x-provision", () => {
 	const { setIsTTY } = useMockIsTTY();
 
 	beforeEach(() => {
+		logger.loggerLevel = "debug";
 		setIsTTY(true);
 		msw.use(
 			...mswSuccessDeploymentScriptMetadata,
@@ -103,6 +105,18 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+
+		expect(std.debug).toContain(
+			JSON.stringify(
+				{
+					"kv_namespace inherited": 1,
+					"d1 inherited": 1,
+					"r2_bucket inherited": 1,
+				},
+				undefined,
+				2
+			)
+		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 	});
@@ -208,6 +222,17 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).toContain(
+				JSON.stringify(
+					{
+						"kv_namespace connected": 1,
+						"d1 connected": 1,
+						"r2_bucket connected": 1,
+					},
+					undefined,
+					2
+				)
+			);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -327,6 +352,17 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).toContain(
+				JSON.stringify(
+					{
+						"kv_namespace connected": 1,
+						"d1 connected": 1,
+						"r2_bucket connected": 1,
+					},
+					undefined,
+					2
+				)
+			);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -459,6 +495,17 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).toContain(
+				JSON.stringify(
+					{
+						"kv_namespace created": 1,
+						"d1 created": 1,
+						"r2_bucket created": 1,
+					},
+					undefined,
+					2
+				)
+			);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -524,6 +571,9 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).toContain(
+				JSON.stringify({ "d1 created": 1 }, undefined, 2)
+			);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -566,6 +616,9 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).toContain(
+				JSON.stringify({ "d1 inherited": 1 }, undefined, 2)
+			);
 		});
 
 		it("will not inherit d1 binding when the database name is provided but has changed", async () => {
@@ -643,6 +696,9 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).toContain(
+				JSON.stringify({ "d1 created": 1 }, undefined, 2)
+			);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -716,6 +772,9 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).toContain(
+				JSON.stringify({ "r2_bucket created": 1 }, undefined, 2)
+			);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -770,6 +829,7 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).not.toContain("Provisioning summary");
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -814,6 +874,9 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).toContain(
+				JSON.stringify({ "d1 connected": 1 }, undefined, 2)
+			);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
@@ -898,6 +961,9 @@ describe("--x-provision", () => {
 				  https://test-name.test-sub-domain.workers.dev
 				Current Version ID: Galaxy-Class"
 			`);
+			expect(std.debug).toContain(
+				JSON.stringify({ "r2_bucket created": 1 }, undefined, 2)
+			);
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -369,6 +369,7 @@ async function collectPendingResources(
 	summary: Record<string, number>;
 }> {
 	let settings: Settings | undefined;
+	// summarises what happens to the resources to send as one telemetry event
 	const summary: Record<string, number> = {};
 
 	try {
@@ -457,9 +458,12 @@ export async function provisionBindings(
 
 		logger.log(`🎉 All resources provisioned, continuing with deployment...\n`);
 	}
-	metrics.sendMetricsEvent("provision resources", summary, {
-		sendMetrics: config.send_metrics,
-	});
+	if (Object.keys(summary).length) {
+		metrics.sendMetricsEvent("provision resources", summary, {
+			sendMetrics: config.send_metrics,
+		});
+		logger.debug("Provisioning summary:", JSON.stringify(summary, null, 2));
+	}
 }
 
 function getSettings(accountId: string, scriptName: string) {

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -81,7 +81,8 @@ export type EventNames =
 	| "list pipelines"
 	| "delete pipeline"
 	| "update pipeline"
-	| "show pipeline";
+	| "show pipeline"
+	| "provision resources";
 
 /**
  * Send a metrics event, with no extra properties, to Cloudflare, if usage tracking is enabled.


### PR DESCRIPTION
Fixes [DEVX-1618]
Sends a new adhoc telemetry event since the dispatcher cannot (currently) be used in command handlers.
draft amplitude dash: https://app.amplitude.com/analytics/cloudflare/dashboard/4h1lunzd

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unreleased

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
