### PR TITLE
Better messaging in dev console

### DIFF
--- a/.changeset/light-taxis-move.md
+++ b/.changeset/light-taxis-move.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+docs: clarifies that local resources are "simulated locally" or "connected to remote resource", and adds console messages to help explain local dev

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -7,6 +7,8 @@ exports[`Pages 'wrangler pages dev' > should merge (with override) \`wrangler.to
   Remote Durable Objects that are affected:
   - {"name":"DO_BINDING_1_TOML","class_name":"DO_1_TOML","script_name":"DO_SCRIPT_1_TOML"}
   - {"name":"DO_BINDING_2_TOML","class_name":"DO_2_TOML","script_name":"DO_SCRIPT_2_TOML"}
+Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+
 Your worker has access to the following bindings:
 - Durable Objects:
   - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 [not connected])
@@ -35,6 +37,7 @@ Your worker has access to the following bindings:
   - VAR2: "VAR_2_TOML"
   - VAR3: "(hidden)"
 Service bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
+Use "wrangler dev --remote" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
 ▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
 "
 `;

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -9,27 +9,27 @@ exports[`Pages 'wrangler pages dev' > should merge (with override) \`wrangler.to
   - {"name":"DO_BINDING_2_TOML","class_name":"DO_2_TOML","script_name":"DO_SCRIPT_2_TOML"}
 Your worker has access to the following bindings:
 - Durable Objects:
-  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 [not connected]) (local)
-  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML [not connected]) (local)
-  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS [not connected]) (local)
+  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 [not connected])
+  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML [not connected])
+  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS [not connected])
 - KV Namespaces:
-  - KV_BINDING_1_TOML: NEW_KV_ID_1 (local)
-  - KV_BINDING_2_TOML: KV_ID_2_TOML (local)
-  - KV_BINDING_3_ARGS: KV_ID_3_ARGS (local)
+  - KV_BINDING_1_TOML: NEW_KV_ID_1 [simulated locally]
+  - KV_BINDING_2_TOML: KV_ID_2_TOML [simulated locally]
+  - KV_BINDING_3_ARGS: KV_ID_3_ARGS [simulated locally]
 - D1 Databases:
-  - D1_BINDING_1_TOML: local-D1_BINDING_1_TOML=NEW_D1_NAME_1 (NEW_D1_NAME_1) (local)
-  - D1_BINDING_2_TOML: D1_NAME_2_TOML (D1_ID_2_TOML) (local)
-  - D1_BINDING_3_ARGS: local-D1_BINDING_3_ARGS=D1_NAME_3_ARGS (D1_NAME_3_ARGS) (local)
+  - D1_BINDING_1_TOML: local-D1_BINDING_1_TOML=NEW_D1_NAME_1 (NEW_D1_NAME_1) [simulated locally]
+  - D1_BINDING_2_TOML: D1_NAME_2_TOML (D1_ID_2_TOML) [simulated locally]
+  - D1_BINDING_3_ARGS: local-D1_BINDING_3_ARGS=D1_NAME_3_ARGS (D1_NAME_3_ARGS) [simulated locally]
 - R2 Buckets:
-  - R2_BINDING_1_TOML: NEW_R2_BUCKET_1 (local)
-  - R2_BINDING_2_TOML: R2_BUCKET_2_TOML (local)
-  - R2_BINDING_3_TOML: R2_BUCKET_3_ARGS (local)
+  - R2_BINDING_1_TOML: NEW_R2_BUCKET_1 [simulated locally]
+  - R2_BINDING_2_TOML: R2_BUCKET_2_TOML [simulated locally]
+  - R2_BINDING_3_TOML: R2_BUCKET_3_ARGS [simulated locally]
 - Services:
   - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1 [not connected]
   - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML [not connected]
   - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS [not connected]
 - AI:
-  - Name: AI_BINDING_2_TOML
+  - Name: AI_BINDING_2_TOML [connected to remote resource]
 - Vars:
   - VAR1: "(hidden)"
   - VAR2: "VAR_2_TOML"

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -8,7 +8,6 @@ exports[`Pages 'wrangler pages dev' > should merge (with override) \`wrangler.to
   - {"name":"DO_BINDING_1_TOML","class_name":"DO_1_TOML","script_name":"DO_SCRIPT_1_TOML"}
   - {"name":"DO_BINDING_2_TOML","class_name":"DO_2_TOML","script_name":"DO_SCRIPT_2_TOML"}
 Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
-
 Your worker has access to the following bindings:
 - Durable Objects:
   - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 [not connected])
@@ -37,7 +36,6 @@ Your worker has access to the following bindings:
   - VAR2: "VAR_2_TOML"
   - VAR3: "(hidden)"
 Service bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
-Use "wrangler dev --remote" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
 ▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
 "
 `;

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -327,7 +327,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 			expect(normalizeOutput(worker.currentOutput)).toContain(
 				dedent`Your worker has access to the following bindings:
 					- KV Namespaces:
-					  - KV_BINDING_TOML: KV_ID_TOML (local)
+					  - KV_BINDING_TOML: KV_ID_TOML [simulated locally]
 					- Vars:
 					  - PAGES: "⚡️ Pages ⚡️"
 				`

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -121,13 +121,13 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 			expect(normalizeOutput(worker.currentOutput)).toContain(
 				dedent`Your worker has access to the following bindings:
 					- Durable Objects:
-					  - TEST_DO: TestDurableObject (defined in a [not connected]) (local)
+					  - TEST_DO: TestDurableObject (defined in a [not connected])
 					- KV Namespaces:
-					  - TEST_KV: TEST_KV (local)
+					  - TEST_KV: TEST_KV [simulated locally]
 					- D1 Databases:
-					  - TEST_D1: local-TEST_D1 (TEST_D1) (local)
+					  - TEST_D1: local-TEST_D1 (TEST_D1) [simulated locally]
 					- R2 Buckets:
-					  - TEST_R2: TEST_R2 (local)
+					  - TEST_R2: TEST_R2 [simulated locally]
 					- Services:
 					  - TEST_SERVICE: test-worker [not connected]
 		`

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -12140,8 +12140,8 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your worker has access to the following bindings:
-        - Images:
-          - Name: IMAGES_BIND
+				- Images:
+				  - Name: IMAGES_BIND
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -12140,8 +12140,8 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your worker has access to the following bindings:
-				- Images:
-				  - Name: IMAGES_BIND
+        - Images:
+          - Name: IMAGES_BIND
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -11,6 +11,7 @@ import registerDevHotKeys from "../dev/hotkeys";
 import { getWorkerAccountAndContext } from "../dev/remote";
 import { FatalError } from "../errors";
 import { CI } from "../is-ci";
+import { logger } from "../logger";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
@@ -129,6 +130,7 @@ describe.sequential("wrangler dev", () => {
 			...mswSuccessOauthHandlers,
 			...mswSuccessUserHandlers
 		);
+		logger.clearHistory();
 	});
 
 	runInTempDir();
@@ -1212,13 +1214,10 @@ describe.sequential("wrangler dev", () => {
 				
 				Your worker has access to the following bindings:
 				- Durable Objects:
-				  - NAME_1: CLASS_1 [simulated locally]
+				  - NAME_1: CLASS_1
 				  - NAME_2: CLASS_2 (defined in SCRIPT_A [not connected])
-				  - NAME_3: CLASS_3 [simulated locally]
+				  - NAME_3: CLASS_3
 				  - NAME_4: CLASS_4 (defined in SCRIPT_B [not connected])
-
-				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
-				
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -1315,9 +1314,6 @@ describe.sequential("wrangler dev", () => {
 				  - VAR_MULTI_LINE_2: \\"(hidden)\\"
 				  - EMPTY: \\"(hidden)\\"
 				  - UNQUOTED: \\"(hidden)\\"
-				
-				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
-				
 				"
 			`);
 		});
@@ -1348,9 +1344,6 @@ describe.sequential("wrangler dev", () => {
 				Your worker has access to the following bindings:
 				- Vars:
 				  - CUSTOM_VAR: \\"(hidden)\\"
-				
-				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
-				
 				"
 			`);
 		});
@@ -1874,9 +1867,6 @@ describe.sequential("wrangler dev", () => {
 				- Services:
 				  - WorkerA: A [not connected]
 				  - WorkerB: B [not connected]
-				
-				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
-				
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -1900,9 +1890,6 @@ describe.sequential("wrangler dev", () => {
 				- Services:
 				  - WorkerA: A [not connected]
 				  - WorkerB: B [not connected]
-				
-				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
-				
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -1933,9 +1920,6 @@ describe.sequential("wrangler dev", () => {
 				  - variable: 123
 				  - overriden: \\"(hidden)\\"
 				  - SECRET: \\"(hidden)\\"
-
-				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
-				
 				"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1208,12 +1208,17 @@ describe.sequential("wrangler dev", () => {
 				process.platform === "win32" ? "127.0.0.1" : "localhost"
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-				"Your worker has access to the following bindings:
+				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				
+				Your worker has access to the following bindings:
 				- Durable Objects:
-				  - NAME_1: CLASS_1 (local)
-				  - NAME_2: CLASS_2 (defined in SCRIPT_A [not connected]) (local)
-				  - NAME_3: CLASS_3 (local)
-				  - NAME_4: CLASS_4 (defined in SCRIPT_B [not connected]) (local)
+				  - NAME_1: CLASS_1 [simulated locally]
+				  - NAME_2: CLASS_2 (defined in SCRIPT_A [not connected])
+				  - NAME_3: CLASS_3 [simulated locally]
+				  - NAME_4: CLASS_4 (defined in SCRIPT_B [not connected])
+
+				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
+				
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -1299,6 +1304,8 @@ describe.sequential("wrangler dev", () => {
 			});
 			expect(std.out).toMatchInlineSnapshot(`
 				"Using vars defined in .dev.vars
+				Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				
 				Your worker has access to the following bindings:
 				- Vars:
 				  - VAR_1: \\"(hidden)\\"
@@ -1308,6 +1315,9 @@ describe.sequential("wrangler dev", () => {
 				  - VAR_MULTI_LINE_2: \\"(hidden)\\"
 				  - EMPTY: \\"(hidden)\\"
 				  - UNQUOTED: \\"(hidden)\\"
+				
+				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
+				
 				"
 			`);
 		});
@@ -1333,9 +1343,14 @@ describe.sequential("wrangler dev", () => {
 			expect(varBindings).toEqual({ CUSTOM_VAR: "custom" });
 			expect(std.out).toMatchInlineSnapshot(`
 				"Using vars defined in .dev.vars.custom
+				Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				
 				Your worker has access to the following bindings:
 				- Vars:
 				  - CUSTOM_VAR: \\"(hidden)\\"
+				
+				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
+				
 				"
 			`);
 		});
@@ -1853,10 +1868,15 @@ describe.sequential("wrangler dev", () => {
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-				"Your worker has access to the following bindings:
+				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				
+				Your worker has access to the following bindings:
 				- Services:
 				  - WorkerA: A [not connected]
 				  - WorkerB: B [not connected]
+				
+				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
+				
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -1874,10 +1894,15 @@ describe.sequential("wrangler dev", () => {
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-				"Your worker has access to the following bindings:
+				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				
+				Your worker has access to the following bindings:
 				- Services:
 				  - WorkerA: A [not connected]
 				  - WorkerB: B [not connected]
+				
+				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
+				
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -1901,11 +1926,16 @@ describe.sequential("wrangler dev", () => {
 			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`
 				"Using vars defined in .dev.vars
+				Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				
 				Your worker has access to the following bindings:
 				- Vars:
 				  - variable: 123
 				  - overriden: \\"(hidden)\\"
 				  - SECRET: \\"(hidden)\\"
+
+				Use \\"wrangler dev --remote\\" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).
+				
 				"
 			`);
 		});

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -55,6 +55,7 @@ export class Logger {
 	constructor() {}
 
 	private overrideLoggerLevel?: LoggerLevel;
+	private onceHistory = new Set<string>();
 
 	get loggerLevel() {
 		return this.overrideLoggerLevel ?? getLoggerLevel();
@@ -107,7 +108,6 @@ export class Logger {
 		Logger.#afterLogHook?.();
 	}
 
-	static onceHistory = new Set();
 	get once() {
 		return {
 			info: (...args: unknown[]) => this.doLogOnce("info", args),
@@ -116,14 +116,16 @@ export class Logger {
 			error: (...args: unknown[]) => this.doLogOnce("error", args),
 		};
 	}
-	doLogOnce(messageLevel: Exclude<LoggerLevel, "none">, args: unknown[]) {
-		// using this.constructor.onceHistory, instead of hard-coding Logger.onceHistory, allows for subclassing
-		const { onceHistory } = this.constructor as typeof Logger;
 
+	clearHistory() {
+		this.onceHistory.clear();
+	}
+
+	doLogOnce(messageLevel: Exclude<LoggerLevel, "none">, args: unknown[]) {
 		const cacheKey = `${messageLevel}: ${args.join(" ")}`;
 
-		if (!onceHistory.has(cacheKey)) {
-			onceHistory.add(cacheKey);
+		if (!this.onceHistory.has(cacheKey)) {
+			this.onceHistory.add(cacheKey);
 			this.doLog(messageLevel, args);
 		}
 	}

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -4,17 +4,6 @@ import { logger } from "../logger";
 import type { CfWorkerInit } from "../deployment-bundle/worker";
 import type { WorkerRegistry } from "../dev-registry";
 
-function addLocalSuffix(
-	id: string | symbol | undefined,
-	local: boolean = false
-) {
-	if (!id || typeof id === "symbol") {
-		id = "";
-	}
-
-	return `${id}${local ? " (local)" : ""}`;
-}
-
 export const friendlyBindingNames: Record<
 	keyof CfWorkerInit["bindings"],
 	string
@@ -60,6 +49,10 @@ export function printBindings(
 	} = {}
 ) {
 	let hasConnectionStatus = false;
+	const addSuffix = createAddSuffix({
+		isProvisioning: context.provisioning,
+		isLocalDev: context.local,
+	});
 	const truncate = (item: string | Record<string, unknown>) => {
 		const s = typeof item === "string" ? item : JSON.stringify(item);
 		const maxLength = 40;
@@ -140,7 +133,11 @@ export function printBindings(
 
 					return {
 						key: name,
-						value: addLocalSuffix(value, context.local),
+						value: script_name
+							? value
+							: addSuffix(value, {
+									isSimulatedLocally: true,
+								}),
 					};
 				}
 			),
@@ -158,7 +155,7 @@ export function printBindings(
 
 				return {
 					key: binding,
-					value,
+					value: script_name ? value : addSuffix(value),
 				};
 			}),
 		});
@@ -170,7 +167,9 @@ export function printBindings(
 			entries: kv_namespaces.map(({ binding, id }) => {
 				return {
 					key: binding,
-					value: addLocalSuffix(id, context.local),
+					value: addSuffix(id, {
+						isSimulatedLocally: true,
+					}),
 				};
 			}),
 		});
@@ -183,10 +182,11 @@ export function printBindings(
 				({ name, destination_address, allowed_destination_addresses }) => {
 					return {
 						key: name,
-						value:
+						value: addSuffix(
 							destination_address ||
-							allowed_destination_addresses?.join(", ") ||
-							"unrestricted",
+								allowed_destination_addresses?.join(", ") ||
+								"unrestricted"
+						),
 					};
 				}
 			),
@@ -199,7 +199,9 @@ export function printBindings(
 			entries: queues.map(({ binding, queue_name }) => {
 				return {
 					key: binding,
-					value: addLocalSuffix(queue_name, context.local),
+					value: addSuffix(queue_name, {
+						isSimulatedLocally: true,
+					}),
 				};
 			}),
 		});
@@ -223,7 +225,9 @@ export function printBindings(
 					}
 					return {
 						key: binding,
-						value: addLocalSuffix(databaseValue, context.local),
+						value: addSuffix(databaseValue, {
+							isSimulatedLocally: true,
+						}),
 					};
 				}
 			),
@@ -236,7 +240,7 @@ export function printBindings(
 			entries: vectorize.map(({ binding, index_name }) => {
 				return {
 					key: binding,
-					value: index_name,
+					value: addSuffix(index_name),
 				};
 			}),
 		});
@@ -248,7 +252,9 @@ export function printBindings(
 			entries: hyperdrive.map(({ binding, id }) => {
 				return {
 					key: binding,
-					value: addLocalSuffix(id, context.local),
+					value: addSuffix(id, {
+						isSimulatedLocally: true,
+					}),
 				};
 			}),
 		});
@@ -266,7 +272,9 @@ export function printBindings(
 
 				return {
 					key: binding,
-					value: addLocalSuffix(name, context.local),
+					value: addSuffix(name, {
+						isSimulatedLocally: true,
+					}),
 				};
 			}),
 		});
@@ -278,7 +286,7 @@ export function printBindings(
 			entries: logfwdr.bindings.map((binding) => {
 				return {
 					key: binding.name,
-					value: binding.destination,
+					value: addSuffix(binding.destination),
 				};
 			}),
 		});
@@ -324,7 +332,7 @@ export function printBindings(
 			entries: analytics_engine_datasets.map(({ binding, dataset }) => {
 				return {
 					key: binding,
-					value: dataset ?? binding,
+					value: addSuffix(dataset ?? binding),
 				};
 			}),
 		});
@@ -335,7 +343,7 @@ export function printBindings(
 			name: friendlyBindingNames.text_blobs,
 			entries: Object.entries(text_blobs).map(([key, value]) => ({
 				key,
-				value: truncate(value),
+				value: addSuffix(truncate(value)),
 			})),
 		});
 	}
@@ -361,10 +369,13 @@ export function printBindings(
 
 	if (ai !== undefined) {
 		const entries: [{ key: string; value: string | boolean }] = [
-			{ key: "Name", value: ai.binding },
+			{ key: "Name", value: addSuffix(ai.binding) },
 		];
 		if (ai.staging) {
-			entries.push({ key: "Staging", value: ai.staging });
+			entries.push({
+				key: "Staging",
+				value: addSuffix(ai.staging.toString()),
+			});
 		}
 
 		output.push({
@@ -378,7 +389,7 @@ export function printBindings(
 			name: friendlyBindingNames.pipelines,
 			entries: pipelines.map(({ binding, pipeline }) => ({
 				key: binding,
-				value: pipeline,
+				value: addSuffix(pipeline),
 			})),
 		});
 	}
@@ -386,7 +397,7 @@ export function printBindings(
 	if (version_metadata !== undefined) {
 		output.push({
 			name: friendlyBindingNames.version_metadata,
-			entries: [{ key: "Name", value: version_metadata.binding }],
+			entries: [{ key: "Name", value: addSuffix(version_metadata.binding) }],
 		});
 	}
 
@@ -395,7 +406,7 @@ export function printBindings(
 			name: friendlyBindingNames.unsafe,
 			entries: unsafe.bindings.map(({ name, type }) => ({
 				key: type,
-				value: name,
+				value: addSuffix(name),
 			})),
 		});
 	}
@@ -425,7 +436,9 @@ export function printBindings(
 			name: friendlyBindingNames.wasm_modules,
 			entries: Object.entries(wasm_modules).map(([key, value]) => ({
 				key,
-				value: typeof value === "string" ? truncate(value) : "<Wasm>",
+				value: addSuffix(
+					typeof value === "string" ? truncate(value) : "<Wasm>"
+				),
 			})),
 		});
 	}
@@ -436,9 +449,11 @@ export function printBindings(
 			entries: dispatch_namespaces.map(({ binding, namespace, outbound }) => {
 				return {
 					key: binding,
-					value: outbound
-						? `${namespace} (outbound -> ${outbound.service})`
-						: namespace,
+					value: addSuffix(
+						outbound
+							? `${namespace} (outbound -> ${outbound.service})`
+							: namespace
+					),
 				};
 			}),
 		});
@@ -450,7 +465,7 @@ export function printBindings(
 			entries: mtls_certificates.map(({ binding, certificate_id }) => {
 				return {
 					key: binding,
-					value: certificate_id,
+					value: addSuffix(certificate_id),
 				};
 			}),
 		});
@@ -461,7 +476,7 @@ export function printBindings(
 			name: friendlyBindingNames.unsafe,
 			entries: Object.entries(unsafe.metadata).map(([key, value]) => ({
 				key,
-				value: JSON.stringify(value),
+				value: addSuffix(JSON.stringify(value)),
 			})),
 		});
 	}
@@ -469,6 +484,12 @@ export function printBindings(
 	if (output.length === 0) {
 		logger.log("No bindings found.");
 		return;
+	}
+
+	if (context.local) {
+		logger.log(
+			`Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.\n`
+		);
 	}
 
 	let title: string;
@@ -501,4 +522,53 @@ export function printBindings(
 			`\nService bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by ${chalk.green("[connected]")} or ${chalk.red("[not connected]")}. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development\n`
 		);
 	}
+
+	if (context.local) {
+		logger.log(
+			`\nUse "wrangler dev --remote" to run both your Worker and all bindings remotely (https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings).\n`
+		);
+	}
+}
+
+function normalizeValue(value: string | symbol | undefined) {
+	if (!value || typeof value === "symbol") {
+		return "";
+	}
+
+	return value;
+}
+
+/**
+ * Creates a function for adding a suffix to the value of a binding in the console.
+ *
+ * The suffix is only for local dev so it can be used to determine whether a binding is
+ * simulated locally or connected to a remote resource.
+ *
+ * We don't show the suffix when provisioning because the bindings are not yet available in local dev.
+ */
+function createAddSuffix({
+	isProvisioning = false,
+	isLocalDev = false,
+}: {
+	isProvisioning?: boolean;
+	isLocalDev?: boolean;
+}) {
+	return function addSuffix(
+		value: string | symbol | undefined,
+		{
+			isSimulatedLocally = false,
+		}: {
+			isSimulatedLocally?: boolean;
+		} = {}
+	) {
+		const normalizedValue = normalizeValue(value);
+
+		if (isProvisioning || !isLocalDev) {
+			return normalizedValue;
+		}
+
+		return isSimulatedLocally
+			? `${normalizedValue} [simulated locally]`
+			: `${normalizedValue} [connected to remote resource]`;
+	};
 }


### PR DESCRIPTION
Fixes #000.

In the developer's console output:

- adds "[Simulated Locally]" to local bindings
- adds "[Connected to Remote Resource]" to remote bindings
- adds explanation after Wrangler banner explaining that the resources are simulated locally via Miniflare.
- adds link to doc
add brief explanation of --remote  flag and link to relevant doc.
e.g.

```
⛅️ wrangler 3.102.0
--------------------------------------------------------

Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development/#develop-using-remote-resources-and-bindings

Your Worker has access to the following bindings:

Durable Objects:
  - MY_DO: MyDo [Simulated locally]
KV Namespaces:
  - MY_KV: c8dsdfhh258c94d91239ed7nj6f33e163 [Simulated locally]
Vectorize Indexes:
  - MY_INDEX: my-index [Connected to Remote Resource]
Use "wrangler dev --remote" to run both your Worker and all bindings remotely
```

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This is documentation in itself.
