### PR TITLE
Add additional error messaging for errors from KV

### DIFF
--- a/.changeset/cuddly-bees-allow.md
+++ b/.changeset/cuddly-bees-allow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Adds additional error messaging for errors from KV.

--- a/packages/workers-shared/asset-worker/src/utils/kv.ts
+++ b/packages/workers-shared/asset-worker/src/utils/kv.ts
@@ -43,9 +43,11 @@ export async function getAssetWithMetadataFromKV(
 			return asset;
 		} catch (err) {
 			if (attempts >= retries) {
-				throw new Error(
-					`Requested asset ${assetKey} could not be fetched from KV namespace.`
-				);
+				let message = `Requested asset ${assetKey} could not be fetched from KV namespace.`;
+				if (err instanceof Error) {
+					message = `Requested asset ${assetKey} could not be fetched from KV namespace: ${err.message}`;
+				}
+				throw new Error(message);
 			}
 
 			// Exponential backoff, 1 second first time, then 2 second, then 4 second etc.


### PR DESCRIPTION
We're not logging enough information in the error message we're sending to sentry, to understand why the KV get failed. This commit adds the error message.


- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: n/a
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: n/a

