### PR TITLE
Use fetchPagedListResult when listing Hyperdrive configs from API

### DIFF
--- a/.changeset/smooth-games-cover.md
+++ b/.changeset/smooth-games-cover.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Use fetchPagedListResult when listing Hyperdrive configs from the API
+
+This fixes an issue where only 20 configs were being listed.

--- a/packages/wrangler/src/hyperdrive/client.ts
+++ b/packages/wrangler/src/hyperdrive/client.ts
@@ -1,4 +1,4 @@
-import { fetchResult } from "../cfetch";
+import { fetchPagedListResult, fetchResult } from "../cfetch";
 import { requireAuth } from "../user";
 import type { Config } from "../config";
 
@@ -111,9 +111,12 @@ export async function getConfig(
 
 export async function listConfigs(config: Config): Promise<HyperdriveConfig[]> {
 	const accountId = await requireAuth(config);
-	return await fetchResult(`/accounts/${accountId}/hyperdrive/configs`, {
-		method: "GET",
-	});
+	return await fetchPagedListResult(
+		`/accounts/${accountId}/hyperdrive/configs`,
+		{
+			method: "GET",
+		}
+	);
 }
 
 export async function patchConfig(


### PR DESCRIPTION
Fixes SQC-394

This solved an issue for customers that have more than 20 Hyperdrive configs. The Hyperdrive backend has default settings for pagination, and in some cases this would mean that not all Hyperdrive configs would be listed by the CLI.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Will be covered by existing tests.
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Covered by unit tests.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Does not change the API surface of the Hyperdrive command.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
