### PR TITLE
chore(create-cloudflare): update vitest version in templates

### DIFF
--- a/.changeset/spicy-eggs-tan.md
+++ b/.changeset/spicy-eggs-tan.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+update vitest version in templates to ~2.1.9

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/package.json
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/js/package.json
@@ -11,6 +11,6 @@
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.6.4",
 		"wrangler": "^3.101.0",
-		"vitest": "2.1.8"
+		"vitest": "~2.1.9"
 	}
 }

--- a/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/package.json
+++ b/packages/create-cloudflare/templates-experimental/hello-world-with-assets/ts/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.6.4",
 		"typescript": "^5.5.2",
-		"vitest": "2.1.8",
+		"vitest": "~2.1.9",
 		"wrangler": "^3.101.0"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/js/package.json
+++ b/packages/create-cloudflare/templates/hello-world/js/package.json
@@ -11,6 +11,6 @@
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.6.4",
 		"wrangler": "^3.101.0",
-		"vitest": "2.1.8"
+		"vitest": "~2.1.9"
 	}
 }

--- a/packages/create-cloudflare/templates/hello-world/ts/package.json
+++ b/packages/create-cloudflare/templates/hello-world/ts/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.6.4",
 		"typescript": "^5.5.2",
-		"vitest": "2.1.8",
+		"vitest": "~2.1.9",
 		"wrangler": "^3.101.0"
 	}
 }


### PR DESCRIPTION
Fixes n/a.

The vitest team has released [v2.1.9](https://github.com/vitest-dev/vitest/releases/tag/v2.1.9) with critical security patches yesterday. This updates the version in our templates to use v2.1.9 or any future patches through the `~` version range.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: updated vitest version only
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: updated vitest version only
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: updated vitest version only

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
