### PR TITLE
Provide unsafe metadata for wrangler versions secret put

### DIFF
--- a/.changeset/wise-pants-raise.md
+++ b/.changeset/wise-pants-raise.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Provides unsafe.metadata configurations when using wrangler versions secret put.

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -6,6 +6,7 @@ import { mockConsoleMethods } from "../../helpers/mock-console";
 import { clearDialogs } from "../../helpers/mock-dialogs";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { runWrangler } from "../../helpers/run-wrangler";
+import { writeWranglerConfig } from "../../helpers/write-wrangler-config";
 import { mockPostVersion, mockSetupApiCalls } from "./utils";
 import type { Interface } from "node:readline";
 
@@ -183,5 +184,94 @@ describe("versions secret bulk", () => {
 
 			"
 		`);
+	});
+
+	test("unsafe metadata is provided", async () => {
+		writeWranglerConfig({
+			name: "script-name",
+			unsafe: { metadata: { build_options: { stable_id: "foo/bar" } } },
+		});
+
+		await writeFile(
+			"secrets.json",
+			JSON.stringify({
+				SECRET_1: "secret-1",
+				SECRET_2: "secret-2",
+				SECRET_3: "secret-3",
+			}),
+			{ encoding: "utf8" }
+		);
+
+		mockSetupApiCalls();
+		mockPostVersion((metadata) => {
+			expect(metadata.bindings).toStrictEqual([
+				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
+				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
+				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
+			]);
+			expect(metadata.keep_bindings).toStrictEqual([
+				"secret_key",
+				"secret_text",
+			]);
+			expect(metadata.keep_assets).toBeTruthy();
+			expect(metadata["build_options"]).toStrictEqual({ stable_id: "foo/bar" });
+		});
+
+		await runWrangler(`versions secret bulk secrets.json --name script-name`);
+		expect(std.out).toMatchInlineSnapshot(
+			`
+			"🌀 Creating the secrets for the Worker \\"script-name\\"
+			✨ Successfully created secret for key: SECRET_1
+			✨ Successfully created secret for key: SECRET_2
+			✨ Successfully created secret for key: SECRET_3
+			✨ Success! Created version id with 3 secrets.
+			➡️  To deploy this version to production traffic use the command \\"wrangler versions deploy\\"."
+		`
+		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	test("unsafe metadata not included if not in wrangler.toml", async () => {
+		writeWranglerConfig({
+			name: "script-name",
+		});
+
+		await writeFile(
+			"secrets.json",
+			JSON.stringify({
+				SECRET_1: "secret-1",
+				SECRET_2: "secret-2",
+				SECRET_3: "secret-3",
+			}),
+			{ encoding: "utf8" }
+		);
+
+		mockSetupApiCalls();
+		mockPostVersion((metadata) => {
+			expect(metadata.bindings).toStrictEqual([
+				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
+				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
+				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
+			]);
+			expect(metadata.keep_bindings).toStrictEqual([
+				"secret_key",
+				"secret_text",
+			]);
+			expect(metadata.keep_assets).toBeTruthy();
+			expect(metadata["build_options"]).toBeUndefined();
+		});
+
+		await runWrangler(`versions secret bulk secrets.json --name script-name`);
+		expect(std.out).toMatchInlineSnapshot(
+			`
+			"🌀 Creating the secrets for the Worker \\"script-name\\"
+			✨ Successfully created secret for key: SECRET_1
+			✨ Successfully created secret for key: SECRET_2
+			✨ Successfully created secret for key: SECRET_3
+			✨ Success! Created version id with 3 secrets.
+			➡️  To deploy this version to production traffic use the command \\"wrangler versions deploy\\"."
+		`
+		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 });

--- a/packages/wrangler/src/versions/secrets/bulk.ts
+++ b/packages/wrangler/src/versions/secrets/bulk.ts
@@ -86,6 +86,7 @@ export const versionsSecretBulkCommand = createCommand({
 			versionMessage: args.message ?? `Bulk updated ${secrets.length} secrets`,
 			versionTag: args.tag,
 			sendMetrics: config.send_metrics,
+			unsafeMetadata: config.unsafe.metadata,
 		});
 
 		for (const secret of secrets) {

--- a/packages/wrangler/src/versions/secrets/index.ts
+++ b/packages/wrangler/src/versions/secrets/index.ts
@@ -78,6 +78,8 @@ interface ScriptSettings {
 	observability: Observability;
 }
 
+type CfUnsafeMetadata = Record<string, unknown>;
+
 interface CopyLatestWorkerVersionArgs {
 	accountId: string;
 	scriptName: string;
@@ -87,6 +89,7 @@ interface CopyLatestWorkerVersionArgs {
 	versionTag?: string;
 	sendMetrics?: boolean;
 	overrideAllSecrets?: boolean; // Used for delete - this will make sure we do not inherit any
+	unsafeMetadata?: CfUnsafeMetadata | undefined;
 }
 
 // TODO: This is a naive implementation, replace later
@@ -98,6 +101,7 @@ export async function copyWorkerVersionWithNewSecrets({
 	versionMessage,
 	versionTag,
 	sendMetrics,
+	unsafeMetadata,
 	overrideAllSecrets,
 }: CopyLatestWorkerVersionArgs) {
 	// Grab the specific version info
@@ -157,7 +161,9 @@ export async function copyWorkerVersionWithNewSecrets({
 	const worker: CfWorkerInit = {
 		name: scriptName,
 		main: mainModule,
-		bindings: {} as CfWorkerInit["bindings"], // handled in rawBindings
+		bindings: {
+			unsafe: { metadata: unsafeMetadata }, // pass along unsafe metadata
+		} as CfWorkerInit["bindings"], // handled in rawBindings
 		rawBindings: bindings,
 		modules,
 		sourceMaps: sourceMaps,

--- a/packages/wrangler/src/versions/secrets/put.ts
+++ b/packages/wrangler/src/versions/secrets/put.ts
@@ -90,6 +90,7 @@ export const versionsSecretPutCommand = createCommand({
 			versionMessage: args.message ?? `Updated secret "${args.key}"`,
 			versionTag: args.tag,
 			sendMetrics: config.send_metrics,
+			unsafeMetadata: config.unsafe.metadata,
 		});
 
 		logger.log(


### PR DESCRIPTION
In cases of `wrangler versions secret put`, we were losing the stable name on asset-worker and router-worker. This passes along the unsafe metadata during these deploys.

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: n/a
