### PR TITLE
Add worker_url to OutputEntryDeployment

### DIFF
--- a/.changeset/tricky-ears-clean.md
+++ b/.changeset/tricky-ears-clean.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add worker_url to OutputEntryDeployment from wrangler deploy

--- a/packages/wrangler/src/__tests__/output.test.ts
+++ b/packages/wrangler/src/__tests__/output.test.ts
@@ -88,6 +88,7 @@ describe("writeOutput()", () => {
 			targets: undefined,
 			worker_name_overridden: false,
 			wrangler_environment: undefined,
+			worker_url: "mock-worker-url",
 		});
 
 		const outputFile = readFileSync(WRANGLER_OUTPUT_FILE_PATH, "utf8");
@@ -108,6 +109,7 @@ describe("writeOutput()", () => {
 				targets: undefined,
 				worker_name_overridden: false,
 				wrangler_environment: undefined,
+				worker_url: "mock-worker-url",
 			},
 		]);
 	});
@@ -157,6 +159,7 @@ describe("writeOutput()", () => {
 			targets: undefined,
 			worker_name_overridden: false,
 			wrangler_environment: undefined,
+			worker_url: "mock-worker-url",
 		});
 
 		const outputFilePaths = readdirSync("output");
@@ -180,6 +183,7 @@ describe("writeOutput()", () => {
 				targets: undefined,
 				worker_name_overridden: false,
 				wrangler_environment: undefined,
+				worker_url: "mock-worker-url",
 			},
 		]);
 	});

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -383,6 +383,7 @@ export default async function deploy(props: Props): Promise<{
 	versionId: string | null;
 	workerTag: string | null;
 	targets?: string[];
+	workerUrl?: string;
 }> {
 	// TODO: warn if git/hg has uncommitted changes
 	const { config, accountId, name } = props;
@@ -516,7 +517,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		const yes = await confirmLatestDeploymentOverwrite(accountId, scriptName);
 		if (!yes) {
 			cancel("Aborting deploy...");
-			return { versionId, workerTag };
+			return { versionId, workerTag, workerUrl };
 		}
 	}
 
@@ -977,7 +978,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 	if (props.dryRun) {
 		logger.log(`--dry-run: exiting now.`);
-		return { versionId, workerTag };
+		return { versionId, workerTag, workerUrl };
 	}
 
 	const uploadMs = Date.now() - start;
@@ -987,7 +988,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 	// Early exit for WfP since it doesn't need the below code
 	if (props.dispatchNamespace !== undefined) {
 		deployWfpUserWorker(props.dispatchNamespace, versionId);
-		return { versionId, workerTag };
+		return { versionId, workerTag, workerUrl };
 	}
 
 	// deploy triggers
@@ -1000,6 +1001,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		versionId,
 		workerTag,
 		targets: targets ?? [],
+		workerUrl,
 	};
 }
 

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -358,42 +358,43 @@ async function deployWorker(args: DeployArgs) {
 		assert(accountId, "Missing account ID");
 		await verifyWorkerMatchesCITag(accountId, name, config.configPath);
 	}
-	const { sourceMapSize, versionId, workerTag, targets } = await deploy({
-		config,
-		accountId,
-		name,
-		rules: getRules(config),
-		entry,
-		env: args.env,
-		compatibilityDate: args.latest
-			? new Date().toISOString().substring(0, 10)
-			: args.compatibilityDate,
-		compatibilityFlags: args.compatibilityFlags,
-		vars: cliVars,
-		defines: cliDefines,
-		alias: cliAlias,
-		triggers: args.triggers,
-		jsxFactory: args.jsxFactory,
-		jsxFragment: args.jsxFragment,
-		tsconfig: args.tsconfig,
-		routes: args.routes,
-		assetsOptions,
-		legacyAssetPaths,
-		legacyEnv: isLegacyEnv(config),
-		minify: args.minify,
-		nodeCompat: args.nodeCompat,
-		isWorkersSite: Boolean(args.site || config.site),
-		outDir: args.outdir,
-		dryRun: args.dryRun,
-		noBundle: !(args.bundle ?? !config.no_bundle),
-		keepVars: args.keepVars,
-		logpush: args.logpush,
-		uploadSourceMaps: args.uploadSourceMaps,
-		oldAssetTtl: args.oldAssetTtl,
-		projectRoot,
-		dispatchNamespace: args.dispatchNamespace,
-		experimentalAutoCreate: args.experimentalAutoCreate,
-	});
+	const { sourceMapSize, versionId, workerTag, targets, workerUrl } =
+		await deploy({
+			config,
+			accountId,
+			name,
+			rules: getRules(config),
+			entry,
+			env: args.env,
+			compatibilityDate: args.latest
+				? new Date().toISOString().substring(0, 10)
+				: args.compatibilityDate,
+			compatibilityFlags: args.compatibilityFlags,
+			vars: cliVars,
+			defines: cliDefines,
+			alias: cliAlias,
+			triggers: args.triggers,
+			jsxFactory: args.jsxFactory,
+			jsxFragment: args.jsxFragment,
+			tsconfig: args.tsconfig,
+			routes: args.routes,
+			assetsOptions,
+			legacyAssetPaths,
+			legacyEnv: isLegacyEnv(config),
+			minify: args.minify,
+			nodeCompat: args.nodeCompat,
+			isWorkersSite: Boolean(args.site || config.site),
+			outDir: args.outdir,
+			dryRun: args.dryRun,
+			noBundle: !(args.bundle ?? !config.no_bundle),
+			keepVars: args.keepVars,
+			logpush: args.logpush,
+			uploadSourceMaps: args.uploadSourceMaps,
+			oldAssetTtl: args.oldAssetTtl,
+			projectRoot,
+			dispatchNamespace: args.dispatchNamespace,
+			experimentalAutoCreate: args.experimentalAutoCreate,
+		});
 
 	writeOutput({
 		type: "deploy",
@@ -404,6 +405,7 @@ async function deployWorker(args: DeployArgs) {
 		targets,
 		wrangler_environment: args.env,
 		worker_name_overridden: workerNameOverridden,
+		worker_url: workerUrl,
 	});
 
 	metrics.sendMetricsEvent(

--- a/packages/wrangler/src/output.ts
+++ b/packages/wrangler/src/output.ts
@@ -97,6 +97,8 @@ interface OutputEntryDeployment extends OutputEntryBase<"deploy"> {
 	worker_name_overridden: boolean;
 	/** wrangler environment used */
 	wrangler_environment: string | undefined;
+	/** The worker URL associated with this deploy */
+	worker_url: string | undefined;
 }
 
 interface OutputEntryPagesDeployment extends OutputEntryBase<"pages-deploy"> {


### PR DESCRIPTION
Fixes #8041

Add worker_url to OutputEntryDeployment from wrangler deploy
---
- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Wrangler's output file is not currently documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
