### PR TITLE
chore: change some `asserts` to UserErrors so they don't get reported to sentry

### DIFF
--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -272,7 +272,8 @@ async function deployWorker(args: DeployArgs) {
 	if (config.pages_build_output_dir) {
 		throw new UserError(
 			"It looks like you've run a Workers-specific command in a Pages project.\n" +
-				"For Pages, please run `wrangler pages deploy` instead."
+				"For Pages, please run `wrangler pages deploy` instead.",
+			{ telemetryMessage: true }
 		);
 	}
 	// We use the `userConfigPath` to compute the root of a project,
@@ -284,12 +285,14 @@ async function deployWorker(args: DeployArgs) {
 
 	if (args.public) {
 		throw new UserError(
-			"The --public field has been deprecated, try --legacy-assets instead."
+			"The --public field has been deprecated, try --legacy-assets instead.",
+			{ telemetryMessage: true }
 		);
 	}
 	if (args.experimentalPublic) {
 		throw new UserError(
-			"The --experimental-public field has been deprecated, try --legacy-assets instead."
+			"The --experimental-public field has been deprecated, try --legacy-assets instead.",
+			{ telemetryMessage: true }
 		);
 	}
 
@@ -298,7 +301,8 @@ async function deployWorker(args: DeployArgs) {
 		(args.site || config.site)
 	) {
 		throw new UserError(
-			"Cannot use legacy assets and Workers Sites in the same Worker."
+			"Cannot use legacy assets and Workers Sites in the same Worker.",
+			{ telemetryMessage: true }
 		);
 	}
 

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -349,10 +349,12 @@ async function deployWorker(args: DeployArgs) {
 		workerNameOverridden = true;
 	}
 
-	assert(
-		name,
-		'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
-	);
+	if (!name) {
+		throw new UserError(
+			'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+			{ telemetryMessage: true }
+		);
+	}
 
 	if (!args.dryRun) {
 		assert(accountId, "Missing account ID");

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -55,7 +55,8 @@ export default async function triggersDeploy(
 
 	if (!scriptName) {
 		throw new UserError(
-			'You need to provide a name when uploading a Worker Version. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+			'You need to provide a name when uploading a Worker Version. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+			{ telemetryMessage: true }
 		);
 	}
 
@@ -86,7 +87,7 @@ export default async function triggersDeploy(
 	}
 
 	if (!accountId) {
-		throw new UserError("Missing accountId");
+		throw new UserError("Missing accountId", { telemetryMessage: true });
 	}
 
 	const uploadMs = Date.now() - start;

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -114,7 +114,8 @@ export const versionsDeployCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+				{ telemetryMessage: true }
 			);
 		}
 
@@ -144,13 +145,16 @@ export const versionsDeployCommand = createCommand({
 
 		// validate we have at least 1 version
 		if (confirmedVersionsToDeploy.length === 0) {
-			throw new UserError("You must select at least 1 version to deploy.");
+			throw new UserError("You must select at least 1 version to deploy.", {
+				telemetryMessage: true,
+			});
 		}
 
 		// validate we have at most experimentalMaxVersions (default: 2)
 		if (confirmedVersionsToDeploy.length > args.maxVersions) {
 			throw new UserError(
-				`You must select at most ${args.maxVersions} versions to deploy.`
+				`You must select at most ${args.maxVersions} versions to deploy.`,
+				{ telemetryMessage: "You must select at most 2 versions to deploy.`" }
 			);
 		}
 

--- a/packages/wrangler/src/versions/deployments/list.ts
+++ b/packages/wrangler/src/versions/deployments/list.ts
@@ -47,7 +47,8 @@ export const deploymentsListCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name for your Worker. Either pass it as a cli arg with `--name <name>` or in your configuration file as `name = "<name>"`'
+				'You need to provide a name for your Worker. Either pass it as a cli arg with `--name <name>` or in your configuration file as `name = "<name>"`',
+				{ telemetryMessage: true }
 			);
 		}
 

--- a/packages/wrangler/src/versions/deployments/status.ts
+++ b/packages/wrangler/src/versions/deployments/status.ts
@@ -52,14 +52,17 @@ export const deploymentsStatusCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name for your Worker. Either pass it as a cli arg with `--name <name>` or in your configuration file as `name = "<name>"`'
+				'You need to provide a name for your Worker. Either pass it as a cli arg with `--name <name>` or in your configuration file as `name = "<name>"`',
+				{ telemetryMessage: true }
 			);
 		}
 
 		const latestDeployment = await fetchLatestDeployment(accountId, workerName);
 
 		if (!latestDeployment) {
-			throw new UserError(`The Worker ${workerName} has no deployments.`);
+			throw new UserError(`The Worker ${workerName} has no deployments.`, {
+				telemetryMessage: "The Worker has no deployments",
+			});
 		}
 
 		if (args.json) {

--- a/packages/wrangler/src/versions/list.ts
+++ b/packages/wrangler/src/versions/list.ts
@@ -44,7 +44,8 @@ export const versionsListCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+				{ telemetryMessage: true }
 			);
 		}
 

--- a/packages/wrangler/src/versions/rollback/index.ts
+++ b/packages/wrangler/src/versions/rollback/index.ts
@@ -48,7 +48,8 @@ export const versionsRollbackCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name for your Worker. Either pass it as a cli arg with `--name <name>` or in your configuration file as `name = "<name>"`'
+				'You need to provide a name for your Worker. Either pass it as a cli arg with `--name <name>` or in your configuration file as `name = "<name>"`',
+				{ telemetryMessage: true }
 			);
 		}
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -314,12 +314,14 @@ export const versionsUploadCommand = createCommand({
 
 		if (args.site || config.site) {
 			throw new UserError(
-				"Workers Sites does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead."
+				"Workers Sites does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead.",
+				{ telemetryMessage: true }
 			);
 		}
 		if (args.legacyAssets || config.legacy_assets) {
 			throw new UserError(
-				"Legacy assets does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead."
+				"Legacy assets does not support uploading versions through `wrangler versions upload`. You must use `wrangler deploy` instead.",
+				{ telemetryMessage: true }
 			);
 		}
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -365,10 +365,12 @@ export const versionsUploadCommand = createCommand({
 			workerNameOverridden = true;
 		}
 
-		assert(
-			name,
-			'You need to provide a name when publishing a worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
-		);
+		if (!name) {
+			throw new UserError(
+				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+				{ telemetryMessage: true }
+			);
+		}
 
 		if (!args.dryRun) {
 			assert(accountId, "Missing account ID");

--- a/packages/wrangler/src/versions/view.ts
+++ b/packages/wrangler/src/versions/view.ts
@@ -52,7 +52,8 @@ export const versionsViewCommand = createCommand({
 
 		if (workerName === undefined) {
 			throw new UserError(
-				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`'
+				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
+				{ telemetryMessage: true }
 			);
 		}
 


### PR DESCRIPTION
A couple of worker name not found errors were showing up in sentry.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: just needs to pass existing
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: just needs to pass existing
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
