### PR TITLE
Unleash the (dependabot) floodgates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,3 @@ updates:
       - "miniflare"
       - "dependencies"
       - "skip-pr-description-validation"
-    allow:
-      - dependency-name: "workerd"
-      - dependency-name: "@cloudflare/workers-types"


### PR DESCRIPTION
Allow dependabot to update all packages, now it supports [pnpm workspace catalogs](https://github.blog/changelog/2025-02-04-dependabot-now-supports-pnpm-workspace-catalogs-ga/)
