### PR TITLE
Change type to "inherit" for all fetched bindings in versions secret put

### DIFF
--- a/.changeset/kind-sloths-speak.md
+++ b/.changeset/kind-sloths-speak.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Bugfix: Modified versions secret put to inherit all known bindings, which circumvents a limitation in the API which does not return all fields for all bindings.

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -49,6 +49,7 @@ describe("versions secret bulk", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
 				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
 				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
@@ -119,6 +120,7 @@ describe("versions secret bulk", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
 				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
 				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
@@ -164,6 +166,7 @@ describe("versions secret bulk", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
 				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
 				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
@@ -205,6 +208,7 @@ describe("versions secret bulk", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
 				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
 				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },
@@ -249,6 +253,7 @@ describe("versions secret bulk", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET_1", text: "secret-1" },
 				{ type: "secret_text", name: "SECRET_2", text: "secret-2" },
 				{ type: "secret_text", name: "SECRET_3", text: "secret-3" },

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -32,6 +32,7 @@ describe("versions secret delete", () => {
 		mockPostVersion((metadata) => {
 			// We should have all secrets except the one being deleted
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "inherit", name: "ANOTHER_SECRET" },
 				{ type: "inherit", name: "YET_ANOTHER_SECRET" },
 			]);
@@ -55,6 +56,7 @@ describe("versions secret delete", () => {
 		mockGetVersion();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "inherit", name: "ANOTHER_SECRET" },
 				{ type: "inherit", name: "YET_ANOTHER_SECRET" },
 			]);
@@ -82,6 +84,7 @@ describe("versions secret delete", () => {
 		mockGetVersion();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "inherit", name: "ANOTHER_SECRET" },
 				{ type: "inherit", name: "YET_ANOTHER_SECRET" },
 			]);

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -35,6 +35,7 @@ describe("versions secret put", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
 			]);
 			expect(metadata.keep_bindings).toStrictEqual([
@@ -97,6 +98,7 @@ describe("versions secret put", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
 			]);
 			expect(metadata.keep_bindings).toStrictEqual([
@@ -138,6 +140,7 @@ describe("versions secret put", () => {
 			mockSetupApiCalls();
 			mockPostVersion((metadata) => {
 				expect(metadata.bindings).toStrictEqual([
+					{ type: "inherit", name: "do-binding" },
 					{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
 				]);
 				expect(metadata.keep_bindings).toStrictEqual([
@@ -178,6 +181,7 @@ describe("versions secret put", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
 			]);
 			expect(metadata.keep_bindings).toStrictEqual([
@@ -208,6 +212,7 @@ describe("versions secret put", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
 			]);
 			expect(metadata.keep_bindings).toStrictEqual([
@@ -245,6 +250,7 @@ describe("versions secret put", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "NEW_SECRET", text: "the-secret" },
 			]);
 			expect(metadata.keep_bindings).toStrictEqual([
@@ -273,6 +279,38 @@ describe("versions secret put", () => {
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 
+	test("all non-secret bindings are inherited", async () => {
+		setIsTTY(true);
+
+		mockSetupApiCalls();
+
+		mockPrompt({
+			text: "Enter a secret value:",
+			options: { isSecret: true },
+			result: "the-secret",
+		});
+
+		mockPostVersion((metadata) => {
+			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
+				{ type: "secret_text", name: "SECRET", text: "the-secret" },
+			]);
+			expect(metadata.keep_bindings).toStrictEqual([
+				"secret_key",
+				"secret_text",
+			]);
+			expect(metadata.annotations).not.toBeUndefined();
+		});
+		await runWrangler("versions secret put SECRET --name script-name");
+
+		expect(std.out).toMatchInlineSnapshot(`
+			"🌀 Creating the secret for the Worker \\"script-name\\"
+			✨ Success! Created version id with secret SECRET.
+			➡️  To deploy this version with secret SECRET to production traffic use the command \\"wrangler versions deploy\\"."
+		`);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
 	test("can update an existing secret", async () => {
 		setIsTTY(true);
 
@@ -285,6 +323,7 @@ describe("versions secret put", () => {
 		mockSetupApiCalls();
 		mockPostVersion((metadata) => {
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET", text: "the-secret" },
 			]);
 			expect(metadata.keep_bindings).toStrictEqual([
@@ -361,6 +400,7 @@ describe("versions secret put", () => {
 			expect((formData.get("module.wasm") as File).size).equal(10);
 
 			expect(metadata.bindings).toStrictEqual([
+				{ type: "inherit", name: "do-binding" },
 				{ type: "secret_text", name: "SECRET", text: "the-secret" },
 			]);
 			expect(metadata.keep_bindings).toStrictEqual([

--- a/packages/wrangler/src/__tests__/versions/secrets/utils.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/utils.ts
@@ -59,6 +59,11 @@ export function mockGetVersion(versionInfo?: VersionDetails) {
 										name: "YET_ANOTHER_SECRET",
 										text: "Yet another secret shhhhh",
 									},
+									{
+										name: "do-binding",
+										type: "durable_object_namespace",
+										namespace_id: "some-namespace-id",
+									},
 								],
 								script: {
 									etag: "etag",

--- a/packages/wrangler/src/versions/secrets/index.ts
+++ b/packages/wrangler/src/versions/secrets/index.ts
@@ -122,18 +122,15 @@ export async function copyWorkerVersionWithNewSecrets({
 	);
 
 	// Filter out secrets because we're gonna inherit them
-	const bindings: WorkerMetadataBinding[] =
-		versionInfo.resources.bindings.filter(
-			(binding) => binding.type !== "secret_text"
-		);
-
-	// We cannot upload a DO with a namespace_id so remove it
-	for (const binding of bindings) {
-		if (binding.type === "durable_object_namespace") {
-			// @ts-expect-error - it doesn't exist within wrangler but does in the API
-			delete binding.namespace_id;
-		}
-	}
+	const bindings: WorkerMetadataBinding[] = versionInfo.resources.bindings
+		.filter((binding) => binding.type !== "secret_text")
+		.map((binding) => {
+			// Inherit all of the existing bindings
+			return {
+				name: binding.name,
+				type: "inherit",
+			};
+		});
 
 	// Add the new secrets
 	for (const secret of secrets) {


### PR DESCRIPTION
This commit provides a means of inheriting all known bindings, rather than attempting to rebuild them in the versions secret put call. Some bindings (like DOs and internal bindings) don't have all fields returned. Instead, we can provide a type "inherit" for each known binding-by-name, and the API will carry over the binding from the last version.

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: n/a
 
