### PR TITLE
chore: add metrics event for provisioning

### DIFF
--- a/.changeset/wet-glasses-rush.md
+++ b/.changeset/wet-glasses-rush.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+feat: add telemetry to experimental auto-provisioning

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -424,7 +424,8 @@ export async function provisionBindings(
 
 		const resourceCount = pendingResources.reduce(
 			(acc, resource) => {
-				acc[resource.resourceType] = acc[resource.resourceType] + 1 || 1;
+				acc[resource.resourceType] ??= 0;
+				acc[resource.resourceType]++;
 				return acc;
 			},
 			{} as Record<string, number>

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -7,6 +7,7 @@ import { prompt, select } from "../dialogs";
 import { UserError } from "../errors";
 import { createKVNamespace, listKVNamespaces } from "../kv/helpers";
 import { logger } from "../logger";
+import * as metrics from "../metrics";
 import { APIError } from "../parse";
 import { createR2Bucket, getR2Bucket, listR2Buckets } from "../r2/helpers";
 import { isLegacyEnv } from "../utils/isLegacyEnv";
@@ -421,7 +422,17 @@ export async function provisionBindings(
 			);
 		}
 
+		const resourceCount = pendingResources.reduce(
+			(acc, resource) => {
+				acc[resource.resourceType] = acc[resource.resourceType] + 1 || 1;
+				return acc;
+			},
+			{} as Record<string, number>
+		);
 		logger.log(`🎉 All resources provisioned, continuing with deployment...\n`);
+		metrics.sendMetricsEvent("provision resources", resourceCount, {
+			sendMetrics: config.send_metrics,
+		});
 	}
 }
 

--- a/packages/wrangler/src/metrics/send-event.ts
+++ b/packages/wrangler/src/metrics/send-event.ts
@@ -81,7 +81,8 @@ export type EventNames =
 	| "list pipelines"
 	| "delete pipeline"
 	| "update pipeline"
-	| "show pipeline";
+	| "show pipeline"
+	| "provision resources";
 
 /**
  * Send a metrics event, with no extra properties, to Cloudflare, if usage tracking is enabled.


### PR DESCRIPTION
Fixes [DEVX-1618]
Sends a new adhoc telemetry event since the dispatcher cannot (currently) be used in command handlers.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: single metrics event - these haven't been tested anywhere else and don't affect functionality
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: single metrics event - these haven't been tested anywhere else and don't affect functionality
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unreleased feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
