### PR TITLE
Call `writeDeployConfig` in `writeBundle` rather than `builder.buildApp`

### DIFF
--- a/.changeset/modern-cycles-build.md
+++ b/.changeset/modern-cycles-build.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+The deploy config file is now written in the `writeBundle` hook rather than `builder.buildApp`. This ensures that the file is still written if other plugins override `builder` in the Vite config.

--- a/.changeset/modern-cycles-build.md
+++ b/.changeset/modern-cycles-build.md
@@ -2,4 +2,6 @@
 "@cloudflare/vite-plugin": patch
 ---
 
+Call `writeDeployConfig` in `writeBundle` rather than `builder.buildApp`.
+
 The deploy config file is now written in the `writeBundle` hook rather than `builder.buildApp`. This ensures that the file is still written if other plugins override `builder` in the Vite config.

--- a/packages/vite-plugin-cloudflare/src/deploy-config.ts
+++ b/packages/vite-plugin-cloudflare/src/deploy-config.ts
@@ -94,7 +94,7 @@ export function writeDeployConfig(
 
 		assert(
 			entryWorkerConfigPath,
-			`Unexpected error: ${resolvedPluginConfig.entryWorkerEnvironmentName} environment output directory is undefined`
+			`Unexpected error: entryWorkerConfigPath is undefined`
 		);
 
 		const deployConfig: DeployConfig = {

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -229,6 +229,8 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				});
 			},
 			writeBundle() {
+				// These conditions ensure the deploy config is emitted once per application build as `writeBundle` is called for each environment.
+				// If Vite introduces an additional hook that runs after the application has built then we could use that instead.
 				if (
 					this.environment.name ===
 					(resolvedPluginConfig.type === "assets-only"

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -134,8 +134,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 									)
 								);
 							}
-
-							writeDeployConfig(resolvedPluginConfig, resolvedViteConfig);
 						},
 					},
 				};
@@ -229,6 +227,16 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					fileName: "wrangler.json",
 					source: JSON.stringify(config),
 				});
+			},
+			writeBundle() {
+				if (
+					this.environment.name ===
+					(resolvedPluginConfig.type === "assets-only"
+						? "client"
+						: resolvedPluginConfig.entryWorkerEnvironmentName)
+				) {
+					writeDeployConfig(resolvedPluginConfig, resolvedViteConfig);
+				}
 			},
 			handleHotUpdate(options) {
 				if (resolvedPluginConfig.configPaths.has(options.file)) {


### PR DESCRIPTION
Fixes #000.

The deploy config file is now written in the `writeBundle` hook rather than `builder.buildApp`. This ensures that the file is still written if other plugins override `builder` in the Vite config.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included: already covered by tests
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: only affects Vite plugin
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
