### PR TITLE
No longer call `next` in server middleware.

### DIFF
--- a/.changeset/stale-zoos-drop.md
+++ b/.changeset/stale-zoos-drop.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+No longer call `next` in server middleware.

--- a/.changeset/stale-zoos-drop.md
+++ b/.changeset/stale-zoos-drop.md
@@ -3,3 +3,5 @@
 ---
 
 No longer call `next` in server middleware.
+
+This is so that the Cloudflare plugin can override subsequent dev middleware for framework integrations.

--- a/packages/vite-plugin-cloudflare/playground/hot-channel/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/hot-channel/vite.config.ts
@@ -4,7 +4,6 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
 	plugins: [
-		cloudflare({ persistState: false }),
 		{
 			name: "test-plugin",
 			configureServer(viteDevServer) {
@@ -22,5 +21,6 @@ export default defineConfig({
 				};
 			},
 		},
+		cloudflare({ persistState: false }),
 	],
 });

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -161,6 +161,7 @@ export function createCloudflareEnvironmentOptions(
 		optimizeDeps: {
 			// Note: ssr pre-bundling is opt-in and we need to enable it by setting `noDiscovery` to false
 			noDiscovery: false,
+			entries: workerConfig.main,
 			exclude: [
 				...cloudflareBuiltInModules,
 				// we have to exclude all node modules to work in dev-mode not just the unenv externals...

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -267,11 +267,14 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					miniflare
 				);
 
-				const middleware = createMiddleware(({ request }) => {
-					return entryWorker.fetch(toMiniflareRequest(request), {
-						redirect: "manual",
-					}) as any;
-				});
+				const middleware = createMiddleware(
+					({ request }) => {
+						return entryWorker.fetch(toMiniflareRequest(request), {
+							redirect: "manual",
+						}) as any;
+					},
+					{ alwaysCallNext: false }
+				);
 
 				handleWebSocket(
 					viteDevServer.httpServer,
@@ -293,11 +296,14 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					)
 				);
 
-				const middleware = createMiddleware(({ request }) => {
-					return miniflare.dispatchFetch(toMiniflareRequest(request), {
-						redirect: "manual",
-					}) as any;
-				});
+				const middleware = createMiddleware(
+					({ request }) => {
+						return miniflare.dispatchFetch(toMiniflareRequest(request), {
+							redirect: "manual",
+						}) as any;
+					},
+					{ alwaysCallNext: false }
+				);
 
 				handleWebSocket(
 					vitePreviewServer.httpServer,


### PR DESCRIPTION
Fixes #000.

This prevents `next` from being called in the dev and preview server middleware. This is for framework compatibility so that we can override middleware provided by the framework.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included:
  - [x] Tests not necessary because: compatible with existing tests
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: only affects Vite plugin
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
