### PR TITLE
Omit files from public directory in Worker builds

### DIFF
--- a/.changeset/hip-beans-hug.md
+++ b/.changeset/hip-beans-hug.md
@@ -2,4 +2,4 @@
 "@cloudflare/vite-plugin": patch
 ---
 
-No longer copy public directory in Worker builds
+Omit files from public directory in Worker builds

--- a/.changeset/hip-beans-hug.md
+++ b/.changeset/hip-beans-hug.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+No longer copy public directory in Worker builds

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -148,6 +148,7 @@ export function createCloudflareEnvironmentOptions(
 			// We need to enable `emitAssets` in order to support additional modules defined by `rules`
 			emitAssets: true,
 			outDir: getOutputDirectory(userConfig, environmentName),
+			copyPublicDir: false,
 			ssr: true,
 			rollupOptions: {
 				// Note: vite starts dev pre-bundling crawling from either optimizeDeps.entries or rollupOptions.input


### PR DESCRIPTION
Fixes #[000].

Omit files from public directory in Worker builds

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: N/A
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
