### PR TITLE
Fix interpolation search for extreme manifests

### DIFF
--- a/.changeset/orange-rockets-leave.md
+++ b/.changeset/orange-rockets-leave.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+fix: Handles a divide by zero error that could occur when searching large manifests

--- a/packages/workers-shared/asset-worker/src/assets-manifest.ts
+++ b/packages/workers-shared/asset-worker/src/assets-manifest.ts
@@ -116,14 +116,22 @@ export const interpolationSearch = (
 			arr.byteOffset + high * ENTRY_SIZE,
 			PATH_HASH_SIZE
 		);
+		const lowValueNumber = uint8ArrayToNumber(lowValue);
+		const highValueNumber = uint8ArrayToNumber(highValue);
+		const denominator = highValueNumber - lowValueNumber;
+		if (denominator < 0n) {
+			return false;
+		}
+		const numerator = searchValueNumber - lowValueNumber;
+		if (numerator < 0n) {
+			return false;
+		}
 		const mid = Math.floor(
-			Number(
-				BigInt(low) +
-					(BigInt(high - low) *
-						(searchValueNumber - uint8ArrayToNumber(lowValue))) /
-						(uint8ArrayToNumber(highValue) - uint8ArrayToNumber(lowValue))
-			)
+			Number(BigInt(low) + (BigInt(high - low) * numerator) / denominator)
 		);
+		if (mid < low || mid > high) {
+			return false;
+		}
 		const current = new Uint8Array(
 			arr.buffer,
 			arr.byteOffset + mid * ENTRY_SIZE,

--- a/packages/workers-shared/asset-worker/tests/assets-manifest.test.ts
+++ b/packages/workers-shared/asset-worker/tests/assets-manifest.test.ts
@@ -221,6 +221,21 @@ describe("search methods", async () => {
 				).toEqual(hexToBytes(searchEntry.contentHash));
 			}
 		});
+
+		it("returns false for non-existent paths", async () => {
+			const { manifest } = await makeManifestOfLength(10);
+			for (const searchEntry of [
+				new Uint8Array(PATH_HASH_SIZE),
+				new Uint8Array(PATH_HASH_SIZE).fill(127),
+				new Uint8Array(PATH_HASH_SIZE).fill(255),
+			]) {
+				const foundEntry = binarySearch(
+					new Uint8Array(manifest, HEADER_SIZE),
+					searchEntry
+				);
+				expect(foundEntry).toBe(false);
+			}
+		});
 	});
 
 	describe("interpolation search", () => {
@@ -306,6 +321,89 @@ describe("search methods", async () => {
 						CONTENT_HASH_SIZE
 					)
 				).toEqual(hexToBytes(searchEntry.contentHash));
+			}
+		});
+
+		it("returns false for non-existent paths", async () => {
+			const { manifest } = await makeManifestOfLength(10);
+			for (const searchEntry of [
+				new Uint8Array(PATH_HASH_SIZE),
+				new Uint8Array(PATH_HASH_SIZE).fill(127),
+				new Uint8Array(PATH_HASH_SIZE).fill(255),
+			]) {
+				const foundEntry = interpolationSearch(
+					new Uint8Array(manifest, HEADER_SIZE),
+					searchEntry
+				);
+				expect(foundEntry).toBe(false);
+			}
+		});
+
+		it("doesn't throw 'RangeError: Division by zero' with extreme manifests", async () => {
+			const smallEntry = {
+				path: "/small",
+				pathHashBytes: new Uint8Array(PATH_HASH_SIZE),
+				contentHash: "00000000000000000000000000000000",
+			};
+			const largeEntry = {
+				path: "/large",
+				pathHashBytes: new Uint8Array(PATH_HASH_SIZE).fill(255),
+				contentHash: "ffffffffffffffffffffffffffffffff",
+			};
+			const entries = [smallEntry, largeEntry];
+			entries.sort((a, b) => compare(a.pathHashBytes, b.pathHashBytes));
+
+			const assetManifestBytes = new Uint8Array(
+				HEADER_SIZE + entries.length * ENTRY_SIZE
+			);
+
+			for (const [i, { pathHashBytes, contentHash }] of entries.entries()) {
+				const contentHashBytes = hexToBytes(contentHash);
+				const entryOffset = HEADER_SIZE + i * ENTRY_SIZE;
+
+				assetManifestBytes.set(pathHashBytes, entryOffset + PATH_HASH_OFFSET);
+				assetManifestBytes.set(
+					contentHashBytes,
+					entryOffset + CONTENT_HASH_OFFSET
+				);
+			}
+
+			const foundSmallEntry = interpolationSearch(
+				new Uint8Array(assetManifestBytes.buffer, HEADER_SIZE),
+				smallEntry.pathHashBytes
+			) as Uint8Array;
+			expect(foundSmallEntry).not.toBe(false);
+			expect(
+				new Uint8Array(
+					foundSmallEntry.buffer,
+					CONTENT_HASH_OFFSET + foundSmallEntry.byteOffset,
+					CONTENT_HASH_SIZE
+				)
+			).toEqual(hexToBytes(smallEntry.contentHash));
+
+			const foundLargeEntry = interpolationSearch(
+				new Uint8Array(assetManifestBytes.buffer, HEADER_SIZE),
+				largeEntry.pathHashBytes
+			) as Uint8Array;
+			expect(foundLargeEntry).not.toBe(false);
+			expect(
+				new Uint8Array(
+					foundLargeEntry.buffer,
+					CONTENT_HASH_OFFSET + foundLargeEntry.byteOffset,
+					CONTENT_HASH_SIZE
+				)
+			).toEqual(hexToBytes(largeEntry.contentHash));
+
+			for (const searchEntry of [
+				new Uint8Array(PATH_HASH_SIZE).fill(1),
+				new Uint8Array(PATH_HASH_SIZE).fill(127),
+				new Uint8Array(PATH_HASH_SIZE).fill(254),
+			]) {
+				const foundEntry = interpolationSearch(
+					new Uint8Array(assetManifestBytes.buffer, HEADER_SIZE),
+					searchEntry
+				);
+				expect(foundEntry).toBe(false);
 			}
 		});
 	});


### PR DESCRIPTION
WC-3184.

There's a case that when comparing extreme manifests, (very high highs and very low lows), we'd encounter a divide by zero error. This fixes that issue by adding early checks before the calculation against what would otherwise be out-of-bounds search operations.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
