### PR TITLE
chore: include banner in output of tests for commands with json/pretty mode

### DIFF
--- a/packages/wrangler/src/__tests__/d1/execute.test.ts
+++ b/packages/wrangler/src/__tests__/d1/execute.test.ts
@@ -6,6 +6,10 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWranglerConfig } from "../helpers/write-wrangler-config";
 
+// we want to include the banner to make sure it doesn't show up in the output
+// when --json=true
+vi.unmock("../../wrangler-banner");
+
 describe("execute", () => {
 	const std = mockConsoleMethods();
 	runInTempDir();
@@ -136,6 +140,29 @@ describe("execute", () => {
 				2
 			)
 		);
+	});
+
+	it("should show banner by default", async () => {
+		setIsTTY(false);
+		writeWranglerConfig({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+
+		await runWrangler("d1 execute db --command 'select 1;'");
+		expect(std.out).toContain("⛅️ wrangler x.x.x");
+	});
+	it("should not show banner if --json=true", async () => {
+		setIsTTY(false);
+		writeWranglerConfig({
+			d1_databases: [
+				{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+			],
+		});
+
+		await runWrangler("d1 execute db --command 'select 1;' --json");
+		expect(std.out).not.toContain("⛅️ wrangler x.x.x");
 	});
 });
 

--- a/packages/wrangler/src/__tests__/d1/info.test.ts
+++ b/packages/wrangler/src/__tests__/d1/info.test.ts
@@ -8,6 +8,9 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWranglerConfig } from "../helpers/write-wrangler-config";
 
+// we want to include the banner to make sure it doesn't show up in the output when
+// when --json=true
+vi.unmock("../../wrangler-banner");
 describe("info", () => {
 	mockAccountId({ accountId: null });
 	mockApiToken();
@@ -16,7 +19,7 @@ describe("info", () => {
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
 
-	it("should display version when alpha", async () => {
+	beforeEach(() => {
 		setIsTTY(false);
 		mockGetMemberships([
 			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
@@ -30,6 +33,8 @@ describe("info", () => {
 				},
 			],
 		});
+	});
+	it("should display version when alpha", async () => {
 		msw.use(
 			http.get("*/accounts/:accountId/d1/database/*", async () => {
 				return HttpResponse.json(
@@ -66,19 +71,6 @@ describe("info", () => {
 	});
 
 	it("should not display version when not alpha", async () => {
-		setIsTTY(false);
-		mockGetMemberships([
-			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
-		]);
-		writeWranglerConfig({
-			d1_databases: [
-				{
-					binding: "DB",
-					database_name: "northwind",
-					database_id: "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
-				},
-			],
-		});
 		msw.use(
 			http.get("*/accounts/:accountId/d1/database/*", async () => {
 				return HttpResponse.json(
@@ -128,5 +120,71 @@ describe("info", () => {
 		  \\"rows_written_24h\\": 0
 		}"
 	`);
+	});
+
+	it("should print banner in pretty mode", async () => {
+		msw.use(
+			http.get("*/accounts/:accountId/d1/database/*", async () => {
+				return HttpResponse.json(
+					{
+						result: {
+							uuid: "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
+							name: "northwind",
+							created_at: "2023-05-23T08:33:54.590Z",
+							version: "beta",
+							num_tables: 13,
+							file_size: 33067008,
+							running_in_region: "WEUR",
+						},
+						success: true,
+						errors: [],
+						messages: [],
+					},
+					{ status: 200 }
+				);
+			})
+		);
+		msw.use(
+			http.post("*/graphql", async () => {
+				return HttpResponse.json(
+					{
+						result: null,
+						success: true,
+						errors: [],
+						messages: [],
+					},
+					{ status: 200 }
+				);
+			})
+		);
+		// pretty print by default
+		await runWrangler("d1 info northwind");
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			------------------
+
+			┌───────────────────┬──────────────────────────────────────┐
+			│ DB                │ d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06 │
+			├───────────────────┼──────────────────────────────────────┤
+			│ name              │ northwind                            │
+			├───────────────────┼──────────────────────────────────────┤
+			│ created_at        │ 2023-05-23T08:33:54.590Z             │
+			├───────────────────┼──────────────────────────────────────┤
+			│ num_tables        │ 13                                   │
+			├───────────────────┼──────────────────────────────────────┤
+			│ running_in_region │ WEUR                                 │
+			├───────────────────┼──────────────────────────────────────┤
+			│ database_size     │ 33.1 MB                              │
+			├───────────────────┼──────────────────────────────────────┤
+			│ read_queries_24h  │ 0                                    │
+			├───────────────────┼──────────────────────────────────────┤
+			│ write_queries_24h │ 0                                    │
+			├───────────────────┼──────────────────────────────────────┤
+			│ rows_read_24h     │ 0                                    │
+			├───────────────────┼──────────────────────────────────────┤
+			│ rows_written_24h  │ 0                                    │
+			└───────────────────┴──────────────────────────────────────┘"
+		`);
 	});
 });

--- a/packages/wrangler/src/__tests__/d1/info.test.ts
+++ b/packages/wrangler/src/__tests__/d1/info.test.ts
@@ -122,7 +122,7 @@ describe("info", () => {
 	`);
 	});
 
-	it("should print banner in pretty mode", async () => {
+	it("should pretty print by default, incl. the wrangler banner", async () => {
 		msw.use(
 			http.get("*/accounts/:accountId/d1/database/*", async () => {
 				return HttpResponse.json(

--- a/packages/wrangler/src/__tests__/d1/list.test.ts
+++ b/packages/wrangler/src/__tests__/d1/list.test.ts
@@ -1,0 +1,85 @@
+import { http, HttpResponse } from "msw";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { useMockIsTTY } from "../helpers/mock-istty";
+import { mockGetMemberships } from "../helpers/mock-oauth-flow";
+import { msw } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+
+// we want to include the banner to make sure it doesn't show up in the output when
+// when --json=true
+vi.unmock("../../wrangler-banner");
+describe("list", () => {
+	mockAccountId({ accountId: null });
+	mockApiToken();
+	mockConsoleMethods();
+	runInTempDir();
+	const std = mockConsoleMethods();
+	const { setIsTTY } = useMockIsTTY();
+
+	beforeEach(() => {
+		setIsTTY(false);
+		mockGetMemberships([
+			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+		]);
+		msw.use(
+			http.get("*/accounts/:accountId/d1/database", async () => {
+				return HttpResponse.json(
+					{
+						result: [
+							{
+								uuid: "1",
+								name: "a",
+								binding: "A",
+							},
+							{
+								uuid: "2",
+								name: "b",
+								binding: "B",
+							},
+						],
+						success: true,
+						errors: [],
+						messages: [],
+					},
+					{ status: 200 }
+				);
+			})
+		);
+	});
+	it("should print as json if specified, without wrangler banner", async () => {
+		await runWrangler("d1 list --json");
+		expect(std.out).toMatchInlineSnapshot(`
+			"[
+			  {
+			    \\"uuid\\": \\"1\\",
+			    \\"name\\": \\"a\\",
+			    \\"binding\\": \\"A\\"
+			  },
+			  {
+			    \\"uuid\\": \\"2\\",
+			    \\"name\\": \\"b\\",
+			    \\"binding\\": \\"B\\"
+			  }
+			]"
+		`);
+	});
+
+	it("should pretty print by default", async () => {
+		await runWrangler("d1 list");
+		expect(std.out).toMatchInlineSnapshot(`
+			"
+			 ⛅️ wrangler x.x.x
+			------------------
+
+			┌──────┬──────┬─────────┐
+			│ uuid │ name │ binding │
+			├──────┼──────┼─────────┤
+			│ 1    │ a    │ A       │
+			├──────┼──────┼─────────┤
+			│ 2    │ b    │ B       │
+			└──────┴──────┴─────────┘"
+		`);
+	});
+});

--- a/packages/wrangler/src/__tests__/d1/list.test.ts
+++ b/packages/wrangler/src/__tests__/d1/list.test.ts
@@ -48,7 +48,7 @@ describe("list", () => {
 			})
 		);
 	});
-	it("should print as json if specified, without wrangler banner", async () => {
+	it("should print as json if `--json` flag is specified, without wrangler banner", async () => {
 		await runWrangler("d1 list --json");
 		expect(std.out).toMatchInlineSnapshot(`
 			"[

--- a/packages/wrangler/src/__tests__/d1/list.test.ts
+++ b/packages/wrangler/src/__tests__/d1/list.test.ts
@@ -66,7 +66,7 @@ describe("list", () => {
 		`);
 	});
 
-	it("should pretty print by default", async () => {
+	it("should pretty print by default, including the wrangler banner", async () => {
 		await runWrangler("d1 list");
 		expect(std.out).toMatchInlineSnapshot(`
 			"

--- a/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
+++ b/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
@@ -170,7 +170,7 @@ describe("time-travel", () => {
 			vi.useRealTimers();
 		});
 		describe("restore", () => {
-			it("should print as json if specified, without wrangler banner", async () => {
+			it("should print as json, without wrangler banner", async () => {
 				await runWrangler(
 					`d1 time-travel restore db --timestamp=2011-09-05T14:48:00.000Z --json`
 				);
@@ -205,7 +205,7 @@ describe("time-travel", () => {
 			});
 		});
 		describe("info", () => {
-			it("should print as json if specified, without wrangler banner", async () => {
+			it("should print as json, without wrangler banner", async () => {
 				await runWrangler(
 					`d1 time-travel info db --timestamp=2011-09-05T14:48:00.000Z --json`
 				);

--- a/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
+++ b/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
@@ -9,8 +9,12 @@ import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import { writeWranglerConfig } from "../helpers/write-wrangler-config";
 
+// we want to include the banner to make sure it doesn't show up in the output when
+// when --json=true
+vi.unmock("../../wrangler-banner");
+
 describe("time-travel", () => {
-	mockConsoleMethods();
+	const std = mockConsoleMethods();
 	mockAccountId({ accountId: null });
 	mockApiToken();
 	runInTempDir();
@@ -108,6 +112,131 @@ describe("time-travel", () => {
 			);
 			//since the function throws if the db is alpha
 			expect(result).toBeUndefined();
+		});
+	});
+
+	describe("--json", () => {
+		beforeEach(() => {
+			setIsTTY(false);
+			writeWranglerConfig({
+				d1_databases: [
+					{ binding: "DATABASE", database_name: "db", database_id: "xxxx" },
+				],
+			});
+			mockGetMemberships([
+				{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+			]);
+			msw.use(
+				http.get("*/accounts/:accountId/d1/database/*", async () => {
+					return HttpResponse.json(
+						{
+							result: {
+								uuid: "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
+								name: "db",
+								created_at: "2023-05-23T08:33:54.590Z",
+								version: "beta",
+								num_tables: 13,
+								file_size: 33067008,
+								running_in_region: "WEUR",
+							},
+							success: true,
+							errors: [],
+							messages: [],
+						},
+						{ status: 200 }
+					);
+				}),
+				http.post(
+					"*/accounts/:accountId/d1/database/*/time_travel/restore",
+					async () => {
+						return HttpResponse.json(
+							{
+								result: {
+									bookmark: "a",
+								},
+								success: true,
+								errors: [],
+								messages: [],
+							},
+							{ status: 200 }
+						);
+					}
+				)
+			);
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2011-10-05T14:48:00.000Z"));
+		});
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+		describe("restore", () => {
+			it("should print as json if specified, without wrangler banner", async () => {
+				await runWrangler(
+					`d1 time-travel restore db --timestamp=2011-09-05T14:48:00.000Z --json`
+				);
+				expect(std.out).toMatchInlineSnapshot(`
+					"{
+					  \\"bookmark\\": \\"a\\"
+					}"
+				`);
+			});
+
+			it("should pretty print by default", async () => {
+				await runWrangler(
+					`d1 time-travel restore db --timestamp=2011-09-05T14:48:00.000Z"`
+				);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					------------------
+
+					🚧 Restoring database db from bookmark undefined
+
+					⚠️ This will overwrite all data in database db.
+					In-flight queries and transactions will be cancelled.
+
+					? OK to proceed (y/N)
+					🤖 Using fallback value in non-interactive context: yes
+					⚡️ Time travel in progress...
+					✅ Database db restored back to bookmark a
+
+					↩️ To undo this operation, you can restore to the previous bookmark: undefined"
+				`);
+			});
+		});
+		describe("info", () => {
+			it("should print as json if specified, without wrangler banner", async () => {
+				await runWrangler(
+					`d1 time-travel info db --timestamp=2011-09-05T14:48:00.000Z --json`
+				);
+				expect(std.out).toMatchInlineSnapshot(`
+					"{
+					  \\"uuid\\": \\"d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06\\",
+					  \\"name\\": \\"db\\",
+					  \\"created_at\\": \\"2023-05-23T08:33:54.590Z\\",
+					  \\"version\\": \\"beta\\",
+					  \\"num_tables\\": 13,
+					  \\"file_size\\": 33067008,
+					  \\"running_in_region\\": \\"WEUR\\"
+					}"
+				`);
+			});
+			it("should pretty print by default", async () => {
+				await runWrangler(
+					`d1 time-travel info db --timestamp=2011-09-05T14:48:00.000Z"`
+				);
+				expect(std.out).toMatchInlineSnapshot(`
+					"
+					 ⛅️ wrangler x.x.x
+					------------------
+
+					🚧 Time Traveling...
+					⚠️ Timestamp '2011-09-05T14:48:00.000Z' corresponds with bookmark 'undefined'
+					⚡️ To restore to this specific bookmark, run:
+					 \`wrangler d1 time-travel restore db --bookmark=undefined\`
+					      "
+				`);
+			});
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -21,9 +21,9 @@ import type {
 import type { RequestInit } from "undici";
 import type WebSocket from "ws";
 
-// we want to include the banner to make sure it doesn't show up in
-// the output of json mode
-vi.unmock("../wrangler-banner");
+// we want to include the banner to make sure it doesn't show up in the output when
+// when --format=json
+vi.unmock("../../wrangler-banner");
 vi.mock("ws", async (importOriginal) => {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 	const realModule = await importOriginal<typeof import("ws")>();

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -21,6 +21,9 @@ import type {
 import type { RequestInit } from "undici";
 import type WebSocket from "ws";
 
+// we want to include the banner to make sure it doesn't show up in
+// the output of json mode
+vi.unmock("../wrangler-banner");
 vi.mock("ws", async (importOriginal) => {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 	const realModule = await importOriginal<typeof import("ws")>();
@@ -513,8 +516,12 @@ describe("pages deployment tail", () => {
 						"[mock expiration date]"
 					)
 			).toMatchInlineSnapshot(`
-					"Connected to deployment mock-deployment-id, waiting for logs...
-					GET https://example.org/ - Ok @ [mock event timestamp]"
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Connected to deployment mock-deployment-id, waiting for logs...
+				GET https://example.org/ - Ok @ [mock event timestamp]"
 			`);
 			await api.closeHelper();
 		});
@@ -541,8 +548,12 @@ describe("pages deployment tail", () => {
 						"[mock expiration date]"
 					)
 			).toMatchInlineSnapshot(`
-					"Connected to deployment mock-deployment-id, waiting for logs...
-					\\"* * * * *\\" @ [mock timestamp string] - Ok"
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Connected to deployment mock-deployment-id, waiting for logs...
+				\\"* * * * *\\" @ [mock timestamp string] - Ok"
 			`);
 			await api.closeHelper();
 		});
@@ -569,8 +580,12 @@ describe("pages deployment tail", () => {
 						"[mock expiration date]"
 					)
 			).toMatchInlineSnapshot(`
-					"Connected to deployment mock-deployment-id, waiting for logs...
-					Alarm @ [mock scheduled time] - Ok"
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Connected to deployment mock-deployment-id, waiting for logs...
+				Alarm @ [mock scheduled time] - Ok"
 			`);
 			await api.closeHelper();
 		});
@@ -597,8 +612,12 @@ describe("pages deployment tail", () => {
 						"[mock expiration date]"
 					)
 			).toMatchInlineSnapshot(`
-					"Connected to deployment mock-deployment-id, waiting for logs...
-					Email from:${mockEmailEventFrom} to:${mockEmailEventTo} size:${mockEmailEventSize} @ [mock event timestamp] - Ok"
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Connected to deployment mock-deployment-id, waiting for logs...
+				Email from:from@example.com to:to@example.com size:45416 @ [mock event timestamp] - Ok"
 			`);
 			await api.closeHelper();
 		});
@@ -625,8 +644,12 @@ describe("pages deployment tail", () => {
 						"[mock expiration date]"
 					)
 			).toMatchInlineSnapshot(`
-					"Connected to deployment mock-deployment-id, waiting for logs...
-					Queue my-queue123 (7 messages) - Ok @ [mock timestamp string]"
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Connected to deployment mock-deployment-id, waiting for logs...
+				Queue my-queue123 (7 messages) - Ok @ [mock timestamp string]"
 			`);
 			await api.closeHelper();
 		});
@@ -652,9 +675,13 @@ describe("pages deployment tail", () => {
 						"[mock timestamp string]"
 					)
 			).toMatchInlineSnapshot(`
-			"Connected to deployment mock-deployment-id, waiting for logs...
-			Unknown Event - Ok @ [mock timestamp string]"
-		`);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Connected to deployment mock-deployment-id, waiting for logs...
+				Unknown Event - Ok @ [mock timestamp string]"
+			`);
 			await api.closeHelper();
 		});
 
@@ -681,9 +708,13 @@ describe("pages deployment tail", () => {
 						"[mock expiration date]"
 					)
 			).toMatchInlineSnapshot(`
-			        "Connected to deployment mock-deployment-id, waiting for logs...
-			        GET https://example.org/ - Ok @ [mock event timestamp]"
-		      `);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Connected to deployment mock-deployment-id, waiting for logs...
+				GET https://example.org/ - Ok @ [mock event timestamp]"
+			`);
 			await api.closeHelper();
 		});
 
@@ -739,12 +770,16 @@ describe("pages deployment tail", () => {
 					"[mock event timestamp]"
 				)
 			).toMatchInlineSnapshot(`
-						"Connected to deployment mock-deployment-id, waiting for logs...
-						GET https://example.org/ - Ok @ [mock event timestamp]
-						  (log) some string
-						  (log) { complex: 'object' }
-						  (error) 1234"
-				`);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Connected to deployment mock-deployment-id, waiting for logs...
+				GET https://example.org/ - Ok @ [mock event timestamp]
+				  (log) some string
+				  (log) { complex: 'object' }
+				  (error) 1234"
+			`);
 			expect(std.err).toMatchInlineSnapshot(`
 					"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error[0m
 

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -52,8 +52,8 @@ vi.mock("ws", async (importOriginal) => {
 	return module;
 });
 
-// we want to include the banner to make sure it doesn't show up in
-// the output of json mode
+// we want to include the banner to make sure it doesn't show up in the output when
+// when --format=json
 vi.unmock("../wrangler-banner");
 
 describe("tail", () => {

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -51,6 +51,11 @@ vi.mock("ws", async (importOriginal) => {
 	});
 	return module;
 });
+
+// we want to include the banner to make sure it doesn't show up in
+// the output of json mode
+vi.unmock("../wrangler-banner");
+
 describe("tail", () => {
 	mockAccountId();
 	mockApiToken();
@@ -528,10 +533,14 @@ describe("tail", () => {
 					)
 					.replace(mockTailExpiration.toISOString(), "[mock expiration date]")
 			).toMatchInlineSnapshot(`
-			        "Successfully created tail, expires at [mock expiration date]
-			        Connected to test-worker, waiting for logs...
-			        GET https://example.org/ - Ok @ [mock event timestamp]"
-		      `);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				GET https://example.org/ - Ok @ [mock event timestamp]"
+			`);
 			await api.closeHelper();
 		});
 
@@ -555,10 +564,14 @@ describe("tail", () => {
 					)
 					.replace(mockTailExpiration.toISOString(), "[mock expiration date]")
 			).toMatchInlineSnapshot(`
-			        "Successfully created tail, expires at [mock expiration date]
-			        Connected to test-worker, waiting for logs...
-			        MyDurableObject.foo - Ok @ [mock event timestamp]"
-		      `);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				MyDurableObject.foo - Ok @ [mock event timestamp]"
+			`);
 			await api.closeHelper();
 		});
 
@@ -579,10 +592,14 @@ describe("tail", () => {
 					)
 					.replace(mockTailExpiration.toISOString(), "[mock expiration date]")
 			).toMatchInlineSnapshot(`
-			        "Successfully created tail, expires at [mock expiration date]
-			        Connected to test-worker, waiting for logs...
-			        \\"* * * * *\\" @ [mock timestamp string] - Ok"
-		      `);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				\\"* * * * *\\" @ [mock timestamp string] - Ok"
+			`);
 			await api.closeHelper();
 		});
 
@@ -603,10 +620,14 @@ describe("tail", () => {
 					)
 					.replace(mockTailExpiration.toISOString(), "[mock expiration date]")
 			).toMatchInlineSnapshot(`
-			        "Successfully created tail, expires at [mock expiration date]
-			        Connected to test-worker, waiting for logs...
-			        Alarm @ [mock scheduled time] - Ok"
-		      `);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				Alarm @ [mock scheduled time] - Ok"
+			`);
 			await api.closeHelper();
 		});
 
@@ -627,10 +648,14 @@ describe("tail", () => {
 					)
 					.replace(mockTailExpiration.toISOString(), "[mock expiration date]")
 			).toMatchInlineSnapshot(`
-			"Successfully created tail, expires at [mock expiration date]
-			Connected to test-worker, waiting for logs...
-			Email from:from@example.com to:to@example.com size:45416 @ [mock event timestamp] - Ok"
-		`);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				Email from:from@example.com to:to@example.com size:45416 @ [mock event timestamp] - Ok"
+			`);
 			await api.closeHelper();
 		});
 
@@ -654,10 +679,14 @@ describe("tail", () => {
 						"[mock expiration date]"
 					)
 			).toMatchInlineSnapshot(`
-			"Successfully created tail, expires at [mock expiration date]
-			Connected to test-worker, waiting for logs...
-			Tailing some-worker,other-worker - Ok @ [mock event timestamp]"
-		`);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				Tailing some-worker,other-worker - Ok @ [mock event timestamp]"
+			`);
 			await api.closeHelper();
 		});
 
@@ -680,11 +709,15 @@ describe("tail", () => {
 					"[mock expiration date]"
 				)
 			).toMatchInlineSnapshot(`
-			"Successfully created tail, expires at [mock expiration date]
-			Connected to test-worker, waiting for logs...
-			Tail is currently in sampling mode due to the high volume of messages. To prevent messages from being dropped consider adding filters.
-			Tail has exited sampling mode and is no longer dropping messages."
-		`);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				Tail is currently in sampling mode due to the high volume of messages. To prevent messages from being dropped consider adding filters.
+				Tail has exited sampling mode and is no longer dropping messages."
+			`);
 			await api.closeHelper();
 		});
 
@@ -705,10 +738,14 @@ describe("tail", () => {
 					)
 					.replace(mockTailExpiration.toISOString(), "[mock expiration date]")
 			).toMatchInlineSnapshot(`
-			        "Successfully created tail, expires at [mock expiration date]
-			        Connected to test-worker, waiting for logs...
-			        Queue my-queue123 (7 messages) - Ok @ [mock timestamp string]"
-		      `);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				Queue my-queue123 (7 messages) - Ok @ [mock timestamp string]"
+			`);
 			await api.closeHelper();
 		});
 
@@ -728,10 +765,14 @@ describe("tail", () => {
 					)
 					.replace(mockTailExpiration.toISOString(), "[mock expiration date]")
 			).toMatchInlineSnapshot(`
-			"Successfully created tail, expires at [mock expiration date]
-			Connected to test-worker, waiting for logs...
-			Unknown Event - Ok @ [mock timestamp string]"
-		`);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				Unknown Event - Ok @ [mock timestamp string]"
+			`);
 			await api.closeHelper();
 		});
 
@@ -753,10 +794,14 @@ describe("tail", () => {
 					)
 					.replace(mockTailExpiration.toISOString(), "[mock expiration date]")
 			).toMatchInlineSnapshot(`
-			        "Successfully created tail, expires at [mock expiration date]
-			        Connected to test-worker, waiting for logs...
-			        GET https://example.org/ - Ok @ [mock event timestamp]"
-		      `);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				GET https://example.org/ - Ok @ [mock event timestamp]"
+			`);
 			await api.closeHelper();
 		});
 
@@ -808,13 +853,17 @@ describe("tail", () => {
 					)
 					.replace(mockTailExpiration.toISOString(), "[mock expiration date]")
 			).toMatchInlineSnapshot(`
-			        "Successfully created tail, expires at [mock expiration date]
-			        Connected to test-worker, waiting for logs...
-			        GET https://example.org/ - Ok @ [mock event timestamp]
-			          (log) some string
-			          (log) { complex: 'object' }
-			          (error) 1234"
-		      `);
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				Successfully created tail, expires at [mock expiration date]
+				Connected to test-worker, waiting for logs...
+				GET https://example.org/ - Ok @ [mock event timestamp]
+				  (log) some string
+				  (log) { complex: 'object' }
+				  (error) 1234"
+			`);
 			expect(std.err).toMatchInlineSnapshot(`
 			        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1m  Error: some error[0m
 


### PR DESCRIPTION
The wrangler banner is normally [mocked](https://github.com/cloudflare/workers-sdk/blob/82a89371250a1ec3e56fa5a518c685d362bde0ad/packages/wrangler/src/__tests__/vitest.setup.ts#L86) in tests so it isn't included in the console output that we check. However, we do want to test for the _absence_ of the banner when a particular command has a 'json' mode where the output should be json only.

This PR adds/updates tests for d1 and tail commands that have a 'json' option.
There may be some commands that have an _implicit_ guarantee that they output json without a separate flag, but I don't have a good way of identifying those - `secret list` now has tests for it but there may be others?

This should ensure issues like #7487 and #8101 don't happen again 😅 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: change to tests
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: only change unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
