### PR TITLE
Enable Sentry Console integration

### DIFF
--- a/.changeset/few-bobcats-brake.md
+++ b/.changeset/few-bobcats-brake.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+When reporting errors to Sentry, Wrangler will now include the console output as additional metadata

--- a/packages/wrangler/src/__tests__/sentry.test.ts
+++ b/packages/wrangler/src/__tests__/sentry.test.ts
@@ -64,7 +64,7 @@ describe("sentry", () => {
 				"Getting User settings...
 
 				[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m
-				? Would you like to report this error to Cloudflare?
+				? Would you like to report this error to Cloudflare? Wrangler's output and the error details will be shared with the Wrangler team to help us diagnose and fix the issue.
 				🤖 Using fallback value in non-interactive context: no"
 			`);
 			expect(sentryRequests?.length).toEqual(0);
@@ -103,7 +103,7 @@ describe("sentry", () => {
 				)
 			);
 			mockConfirm({
-				text: "Would you like to report this error to Cloudflare?",
+				text: "Would you like to report this error to Cloudflare? Wrangler's output and the error details will be shared with the Wrangler team to help us diagnose and fix the issue.",
 				result: false,
 			});
 			await expect(runWrangler("whoami")).rejects.toMatchInlineSnapshot(
@@ -129,7 +129,7 @@ describe("sentry", () => {
 				)
 			);
 			mockConfirm({
-				text: "Would you like to report this error to Cloudflare?",
+				text: "Would you like to report this error to Cloudflare? Wrangler's output and the error details will be shared with the Wrangler team to help us diagnose and fix the issue.",
 				result: true,
 			});
 			await expect(runWrangler("whoami")).rejects.toMatchInlineSnapshot(
@@ -381,6 +381,7 @@ describe("sentry", () => {
 				        "InboundFilters",
 				        "FunctionToString",
 				        "LinkedErrors",
+				        "Console",
 				        "OnUncaughtException",
 				        "OnUnhandledRejection",
 				        "ContextLines",

--- a/packages/wrangler/src/sentry/index.ts
+++ b/packages/wrangler/src/sentry/index.ts
@@ -18,9 +18,11 @@ const makeSentry10Transport = (options: BaseTransportOptions) => {
 	let eventQueue: [string, RequestInit][] = [];
 
 	const transportSentry10 = async (request: TransportRequest) => {
-		/* Adds helpful properties to the request body before we send it to our
-    proxy Worker. These properties can be parsed out from the NDJSON in
-    `request.body`, but it's easier and safer to just attach them here. */
+		/**
+		 * Adds helpful properties to the request body before we send it to our
+		 * proxy Worker. These properties can be parsed out from the NDJSON in
+		 * `request.body`, but it's easier and safer to just attach them here.
+		 */
 		const sentryWorkerPayload = {
 			envelope: request.body,
 			url: options.url,
@@ -84,7 +86,6 @@ const makeSentry10Transport = (options: BaseTransportOptions) => {
 };
 
 const disabledDefaultIntegrations = [
-	"Console", // Console logs may contain PII
 	"LocalVariables", // Local variables may contain tokens and PII
 	"Http", // Only captures method/URL/response status, but URL may contain PII
 	"Undici", // Same as "Http"

--- a/packages/wrangler/src/sentry/index.ts
+++ b/packages/wrangler/src/sentry/index.ts
@@ -151,7 +151,7 @@ export function addBreadcrumb(
 export async function captureGlobalException(e: unknown) {
 	if (typeof SENTRY_DSN !== "undefined") {
 		sentryReportingAllowed = await confirm(
-			"Would you like to report this error to Cloudflare?",
+			"Would you like to report this error to Cloudflare? Wrangler's output and the error details will be shared with the Wrangler team to help us diagnose and fix the issue.",
 			{ fallbackValue: false }
 		);
 


### PR DESCRIPTION
Currently, Sentry errors reported by users in Wrangler do _not_ include console output. We made this decision out of an abundance of caution to try and reduce the amount of potential data we were capturing. However, this is causing issues with being able to effectively diagnose reported errors from Wrangler (in particular `MiniflareCoreError [ERR_RUNTIME_FAILURE]` is undiagnosable without console output).

As such, I think we should turn the console integration on. Console output from Wrangler should not include PII—I believe our thinking at this time was that potentially user logs from a local Worker might accidentally include PII? However, users still have to make a active decision to report errors to Sentry, and so I think that gives sufficient opportunity for users to not send specific logs that they don't wish to share.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: doesn't cover sentry
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this isn't documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
