### PR TITLE
Render correct config format from `wrangler d1 create`

### DIFF
--- a/.changeset/tidy-keys-sin.md
+++ b/.changeset/tidy-keys-sin.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Output correct config format from `wrangler d1 create`. Previously, this command would always output TOML, regardless of the config file format

--- a/packages/wrangler/src/__tests__/d1/create.test.ts
+++ b/packages/wrangler/src/__tests__/d1/create.test.ts
@@ -61,14 +61,18 @@ describe("create", () => {
 		);
 		await runWrangler("d1 create test --location oc");
 		expect(std.out).toMatchInlineSnapshot(`
-		"✅ Successfully created DB 'test' in region OC
-		Created your new D1 database.
+			"✅ Successfully created DB 'test' in region OC
+			Created your new D1 database.
 
-		[[d1_databases]]
-		binding = \\"DB\\"
-		database_name = \\"test\\"
-		database_id = \\"51e7c314-456e-4167-b6c3-869ad188fc23\\"
-		"
-	`);
+			{
+			  \\"d1_databases\\": [
+			    {
+			      \\"binding\\": \\"DB\\",
+			      \\"database_name\\": \\"test\\",
+			      \\"database_id\\": \\"51e7c314-456e-4167-b6c3-869ad188fc23\\"
+			    }
+			  ]
+			}"
+		`);
 	});
 });

--- a/packages/wrangler/src/d1/create.ts
+++ b/packages/wrangler/src/d1/create.ts
@@ -1,6 +1,6 @@
 import TOML from "@iarna/toml";
 import { fetchResult } from "../cfetch";
-import { withConfig } from "../config";
+import { formatConfigSnippet, withConfig } from "../config";
 import { UserError } from "../errors";
 import { logger } from "../logger";
 import { requireAuth } from "../user";
@@ -83,11 +83,14 @@ export const Handler = withConfig<HandlerOptions>(
 		);
 		logger.log("Created your new D1 database.\n");
 		logger.log(
-			TOML.stringify({
-				d1_databases: [
-					{ binding: "DB", database_name: db.name, database_id: db.uuid },
-				],
-			})
+			formatConfigSnippet(
+				{
+					d1_databases: [
+						{ binding: "DB", database_name: db.name, database_id: db.uuid },
+					],
+				},
+				config.configPath
+			)
 		);
 	}
 );

--- a/packages/wrangler/src/d1/create.ts
+++ b/packages/wrangler/src/d1/create.ts
@@ -1,4 +1,3 @@
-import TOML from "@iarna/toml";
 import { fetchResult } from "../cfetch";
 import { formatConfigSnippet, withConfig } from "../config";
 import { UserError } from "../errors";


### PR DESCRIPTION
Output correct config format from `wrangler d1 create`. Previously, this command would always output TOML, regardless of the config file format

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
