### PR TITLE
Check for a single match in every iteration of interpolation search

### DIFF
--- a/.changeset/gorgeous-papayas-trade.md
+++ b/.changeset/gorgeous-papayas-trade.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+fix: interpolation search method now checks for a single match at the beginning of every iteration

--- a/packages/workers-shared/asset-worker/src/assets-manifest.ts
+++ b/packages/workers-shared/asset-worker/src/assets-manifest.ts
@@ -88,24 +88,36 @@ export const interpolationSearch = (
 	if (arr.byteLength === 0) {
 		return false;
 	}
+	// top and tail the search space
 	let low = 0;
 	let high = arr.byteLength / ENTRY_SIZE - 1;
-	if (high === low) {
-		const current = new Uint8Array(arr.buffer, arr.byteOffset, PATH_HASH_SIZE);
-		if (current.byteLength !== searchValue.byteLength) {
-			throw new TypeError(
-				"Search value and current value are of different lengths"
-			);
-		}
-		const cmp = compare(current, searchValue);
-		if (cmp === 0) {
-			return new Uint8Array(arr.buffer, arr.byteOffset, ENTRY_SIZE);
-		} else {
-			return false;
-		}
-	}
 	const searchValueNumber = uint8ArrayToNumber(searchValue);
 	while (low <= high) {
+		if (low === high) {
+			// search space has been reduced to a single element
+			const current = new Uint8Array(
+				arr.buffer,
+				arr.byteOffset + low * ENTRY_SIZE,
+				PATH_HASH_SIZE
+			);
+			if (current.byteLength !== searchValue.byteLength) {
+				throw new TypeError(
+					"Search value and current value are of different lengths"
+				);
+			}
+			const cmp = compare(current, searchValue);
+			if (cmp === 0) {
+				// and it's a match!
+				return new Uint8Array(
+					arr.buffer,
+					arr.byteOffset + low * ENTRY_SIZE,
+					ENTRY_SIZE
+				);
+			} else {
+				// and it's not a match!
+				return false;
+			}
+		}
 		const lowValue = new Uint8Array(
 			arr.buffer,
 			arr.byteOffset + low * ENTRY_SIZE,
@@ -119,17 +131,19 @@ export const interpolationSearch = (
 		const lowValueNumber = uint8ArrayToNumber(lowValue);
 		const highValueNumber = uint8ArrayToNumber(highValue);
 		const denominator = highValueNumber - lowValueNumber;
-		if (denominator < 0n) {
-			return false;
+		if (denominator <= 0n) {
+			throw new TypeError("Search space is unordered");
 		}
 		const numerator = searchValueNumber - lowValueNumber;
 		if (numerator < 0n) {
+			// the lowest value in our search space is smaller than the search value (so it can't be in the search space)
 			return false;
 		}
 		const mid = Math.floor(
 			Number(BigInt(low) + (BigInt(high - low) * numerator) / denominator)
 		);
 		if (mid < low || mid > high) {
+			// our next guess is either entirely out of range of the search space or we've already searched it
 			return false;
 		}
 		const current = new Uint8Array(
@@ -150,8 +164,10 @@ export const interpolationSearch = (
 				ENTRY_SIZE
 			);
 		} else if (cmp < 0) {
+			// our estimate was too low so our search space now becomes mid+1 -> high
 			low = mid + 1;
 		} else {
+			// our estimate was too high so our search space now becomes low -> mid-1
 			high = mid - 1;
 		}
 	}


### PR DESCRIPTION
WC-3184

We previously only checked this condition at the start of the search. But it's possible to whittle down the search space to a single element, in which case, we'd previously cause a divide by zero error. Now, with this additional check, we won't.

Also added some comments because I was getting a bit lost in the weeds. Can't imagine what it was like for someone without the context in their head! Sorry earlier reviewers!

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
