### PR TITLE
Remove debug ids from upload-sourcemaps.ts

### DIFF
--- a/packages/workers-shared/scripts/upload-sourcemaps.ts
+++ b/packages/workers-shared/scripts/upload-sourcemaps.ts
@@ -53,9 +53,6 @@ async function generateRelease(worker: string, release: string) {
 	console.log("Finalizing release");
 	await sentryCli.releases.finalize(release);
 
-	console.log("Inject debug ids");
-	await sentryCli.execute(["sourcemaps", "inject", dir], true);
-
 	console.log("Uploading sourcemaps");
 	await sentryCli.releases.uploadSourceMaps(release, {
 		include: [dir],


### PR DESCRIPTION
Debug IDs were causing a mismatch with expected release. Since we are creating our own release, we can remove this. Validated in staging:
https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: n/a
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: n/a

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
