### PR TITLE
Add status code analytics to router-worker

### DIFF
--- a/.changeset/odd-months-crash.md
+++ b/.changeset/odd-months-crash.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+chore: Add status code analytics to router-worker

--- a/packages/workers-shared/asset-worker/src/analytics.ts
+++ b/packages/workers-shared/asset-worker/src/analytics.ts
@@ -18,6 +18,8 @@ type Data = {
 	metalId?: number;
 	// double4 - Colo tier (e.g. tier 1, tier 2, tier 3)
 	coloTier?: number;
+	// double5 - Response status code
+	status?: number;
 
 	// -- Blobs --
 	// blob1 - Hostname of the request
@@ -66,6 +68,7 @@ export class Analytics {
 				this.data.coloId ?? -1, // double2
 				this.data.metalId ?? -1, // double3
 				this.data.coloTier ?? -1, // double4
+				this.data.status ?? -1, // double5
 			],
 			blobs: [
 				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -117,13 +117,17 @@ export default class extends WorkerEntrypoint<Env> {
 					version: this.env.VERSION_METADATA?.id,
 				});
 
-				return handleRequest(
+				const response = await handleRequest(
 					request,
 					this.env,
 					config,
 					this.unstable_exists.bind(this),
 					this.unstable_getByETag.bind(this)
 				);
+
+				analytics.setData({ status: response.status });
+
+				return response;
 			});
 		} catch (err) {
 			return this.handleError(sentry, analytics, err);


### PR DESCRIPTION
WC-3202

The cost of an `await` here is outweighed by the confidence we get in making stable asset-worker releases.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no coverage
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
