### PR TITLE
Bump interpolation search for asset manifest reads to 50%

### DIFF
--- a/.changeset/rotten-eyes-boil.md
+++ b/.changeset/rotten-eyes-boil.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+chore: Bump interpoplation search method for asset manifest reads to 50%

--- a/.changeset/rotten-eyes-boil.md
+++ b/.changeset/rotten-eyes-boil.md
@@ -1,5 +1,5 @@
 ---
-"@cloudflare/workers-shared": minor
+"@cloudflare/workers-shared": patch
 ---
 
 chore: Bump interpoplation search method for asset manifest reads to 50%

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -218,7 +218,7 @@ export default class extends WorkerEntrypoint<Env> {
 		const analytics = new ExperimentAnalytics(this.env.EXPERIMENT_ANALYTICS);
 		const performance = new PerformanceTimer(this.env.UNSAFE_PERFORMANCE);
 
-		const INTERPOLATION_EXPERIMENT_SAMPLE_RATE = 1 / 100; // 0.01 = 1%
+		const INTERPOLATION_EXPERIMENT_SAMPLE_RATE = 0.5;
 		let searchMethod: "binary" | "interpolation" = "binary";
 		if (Math.random() < INTERPOLATION_EXPERIMENT_SAMPLE_RATE) {
 			searchMethod = "interpolation";


### PR DESCRIPTION
WC-3184

Bumps interpolation search method for reading asset manifests to 50%, up from 1%.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no coverage
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
