### PR TITLE
feat: allowlist some types defaults

### DIFF
--- a/.changeset/wet-starfishes-drum.md
+++ b/.changeset/wet-starfishes-drum.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Include default values for wrangler types --path and --x-include-runtime in telemetry
+
+User provided strings are still left redacted as always.

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -582,15 +582,22 @@ describe("metrics", () => {
 				const args = {
 					default: false,
 					array: ["beep", "boop"],
-					secretArray: ["beep", "boop"],
-					// Note how
+					// Note how this is normalised
 					"secret-array": ["beep", "boop"],
 					number: 42,
 					string: "secret",
 					secretString: "secret",
+					flagOne: "default",
+					// Note how this is normalised
+					experimentalIncludeRuntime: "",
 				};
 
-				const redacted = redactArgValues(args, ["string", "array"]);
+				const redacted = redactArgValues(args, {
+					string: "*",
+					array: "*",
+					flagOne: ["default"],
+					xIncludeRuntime: [".wrangler/types/runtime.d.ts"],
+				});
 				expect(redacted).toEqual({
 					default: false,
 					array: ["beep", "boop"],
@@ -598,6 +605,8 @@ describe("metrics", () => {
 					number: 42,
 					string: "secret",
 					secretString: "<REDACTED>",
+					flagOne: "default",
+					xIncludeRuntime: ".wrangler/types/runtime.d.ts",
 				});
 			});
 		});

--- a/packages/wrangler/src/metrics/metrics-dispatcher.ts
+++ b/packages/wrangler/src/metrics/metrics-dispatcher.ts
@@ -261,10 +261,7 @@ const getAllowedArgs = (
 	allowList: Record<string, AllowedValues> & { "*": AllowedValues },
 	key: string
 ) => {
-	logger.debug(allowList);
 	const commandSpecific = allowList[key] ?? [];
-	logger.debug("key", key);
-	logger.debug({ ...commandSpecific, ...allowList["*"] });
 	return { ...commandSpecific, ...allowList["*"] };
 };
 export const redactArgValues = (
@@ -275,13 +272,11 @@ export const redactArgValues = (
 
 	for (let [key, value] of Object.entries(args)) {
 		key = normalise(key);
-		logger.debug(key, value);
 		// the default is not set by yargs :/
 		if (key === "xIncludeRuntime" && value === "") {
 			value = ".wrangler/types/runtime.d.ts";
 		}
 		const allowedValuesForArg = allowedValues[key] ?? [];
-		logger.debug(allowedValuesForArg);
 		if (exclude.has(key)) {
 			continue;
 		}

--- a/packages/wrangler/src/metrics/metrics-dispatcher.ts
+++ b/packages/wrangler/src/metrics/metrics-dispatcher.ts
@@ -272,7 +272,6 @@ export const redactArgValues = (
 
 	for (let [key, value] of Object.entries(args)) {
 		key = normalise(key);
-		// the default is not set by yargs :/
 		if (key === "xIncludeRuntime" && value === "") {
 			value = ".wrangler/types/runtime.d.ts";
 		}
@@ -283,16 +282,20 @@ export const redactArgValues = (
 		if (
 			typeof value === "number" ||
 			typeof value === "boolean" ||
-			allowedValuesForArg.includes(normalise(key))
+			allowedValuesForArg.includes(key)
 		) {
 			result[key] = value;
 		} else if (
+			// redact if its a string, unless the value is in the allow list
+			// * is a special value that allows all values for that arg
 			typeof value === "string" &&
 			!(allowedValuesForArg === "*" || allowedValuesForArg.includes(value))
 		) {
 			result[key] = "<REDACTED>";
 		} else if (Array.isArray(value)) {
 			result[key] = value.map((v) =>
+				// redact if its a string, unless the value is in the allow list
+				// * is a special value that allows all values for that arg
 				typeof v === "string" &&
 				!(allowedValuesForArg === "*" || allowedValuesForArg.includes(v))
 					? "<REDACTED>"


### PR DESCRIPTION
Include default values for wrangler types --path and --x-include-runtime in telemetry

User provided strings are still left redacted as always.

Note i've also tested this manually for wrangler types

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: metrics
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: expanding documented behaviour

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
