### PR TITLE
Fix D1 Export error handling when presigned URLs are invalid

### DIFF
--- a/.changeset/olive-gifts-flash.md
+++ b/.changeset/olive-gifts-flash.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+D1 export will now show an error when the presigned URL is invalid

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -145,7 +145,7 @@ describe("export", () => {
 			})
 		);
 
-		expect(async () => await runWrangler("d1 export db --remote --output test-remote.sql")).toThrowError(
+		await expect(runWrangler("d1 export db --remote --output test-remote.sql")).rejects.toThrowError(
 			/There was an error while downloading from the presigned URL with status code: 403/
 		);
 	});

--- a/packages/wrangler/src/__tests__/d1/export.test.ts
+++ b/packages/wrangler/src/__tests__/d1/export.test.ts
@@ -146,7 +146,7 @@ describe("export", () => {
 		);
 
 		expect(async () => await runWrangler("d1 export db --remote --output test-remote.sql")).toThrowError(
-			/Erroneous response while downloading from the presigned URL with status code: 403/
+			/There was an error while downloading from the presigned URL with status code: 403/
 		);
 	});
 });

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -193,6 +193,9 @@ async function exportRemotely(
 		startMessage: `Downloading SQL to ${output}`,
 		async promise() {
 			const contents = await fetch(finalResponse.result.signed_url);
+			if (!contents.ok) {
+				throw new Error(`Erroneous response while downloading from the presigned URL with status code: ${contents.status}`);
+			}
 			await fs.writeFile(output, contents.body || "");
 		},
 	});

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -194,7 +194,9 @@ async function exportRemotely(
 		async promise() {
 			const contents = await fetch(finalResponse.result.signed_url);
 			if (!contents.ok) {
-				throw new Error(`There was an error while downloading from the presigned URL with status code: ${contents.status}`);
+				throw new Error(
+					`There was an error while downloading from the presigned URL with status code: ${contents.status}`
+				);
 			}
 			await fs.writeFile(output, contents.body || "");
 		},

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -194,7 +194,7 @@ async function exportRemotely(
 		async promise() {
 			const contents = await fetch(finalResponse.result.signed_url);
 			if (!contents.ok) {
-				throw new Error(`Erroneous response while downloading from the presigned URL with status code: ${contents.status}`);
+				throw new Error(`There was an error while downloading from the presigned URL with status code: ${contents.status}`);
 			}
 			await fs.writeFile(output, contents.body || "");
 		},


### PR DESCRIPTION
Fixes error handling for CFSQL-1205 (https://www.cloudflarestatus.com/incidents/x2vwc84qvwx3).

When the presigned URLs generated during export are invalid, wrangler was just outputting the broken response into the SQL file.

This change adds a validation that the request was successful before writing it to the file so that users get immediate feedback that it went wrong. Main change is in `packages/wrangler/src/d1/export.ts`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by the normal tests.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Nothing changed.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
