### PR TITLE
Provide unique sentry tag+release for asset-worker and routr-worker

### DIFF
--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -33,9 +33,9 @@
 		"check:type:tests": "tsc -p ./asset-worker/tests/tsconfig.json && tsc -p ./router-worker/tests/tsconfig.json",
 		"clean": "rimraf dist",
 		"deploy": "pnpm run generate-sourcemaps && pnpm run deploy:router-worker && pnpm run deploy:asset-worker && pnpm run upload-sourcemaps",
-		"deploy:asset-worker": "CLOUDFLARE_API_TOKEN=$WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN pnpx wrangler versions upload -c asset-worker/wrangler.toml --tag $(node -r esbuild-register ./scripts/get-version-tag.ts)",
+		"deploy:asset-worker": "CLOUDFLARE_API_TOKEN=$WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN pnpx wrangler versions upload -c asset-worker/wrangler.toml --tag aw-$(node -r esbuild-register ./scripts/get-version-tag.ts)",
 		"deploy:asset-worker-staging": "CLOUDFLARE_API_TOKEN=$WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN pnpx wrangler deploy -c asset-worker/wrangler.toml -e staging",
-		"deploy:router-worker": "CLOUDFLARE_API_TOKEN=$WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN pnpx wrangler versions upload -c router-worker/wrangler.toml --tag $(node -r esbuild-register ./scripts/get-version-tag.ts)",
+		"deploy:router-worker": "CLOUDFLARE_API_TOKEN=$WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN pnpx wrangler versions upload -c router-worker/wrangler.toml --tag rw-$(node -r esbuild-register ./scripts/get-version-tag.ts)",
 		"deploy:router-worker-staging": "CLOUDFLARE_API_TOKEN=$WORKERS_DEPLOY_AND_CONFIG_CLOUDFLARE_API_TOKEN pnpx wrangler deploy -c router-worker/wrangler.toml -e staging",
 		"deploy:staging": "pnpm run deploy:router-worker-staging && pnpm run deploy:asset-worker-staging",
 		"dev": "pnpm run clean && concurrently -n bundle:asset-worker,bundle:router-worker -c blue,magenta \"pnpm run bundle:asset-worker --watch\" \"pnpm run bundle:router-worker --watch\"",
@@ -48,8 +48,8 @@
 		"test:router-worker": "vitest -c router-worker/vitest.config.mts --dir router-worker",
 		"types:emit": "tsc index.ts --declaration --emitDeclarationOnly --declarationDir ./dist",
 		"upload-sourcemaps": "pnpm run upload-sourcemaps:asset-worker && pnpm run upload-sourcemaps:router-worker",
-		"upload-sourcemaps:asset-worker": "node -r esbuild-register ./scripts/upload-sourcemaps.ts --worker asset-worker --tag $(node -r esbuild-register ./scripts/get-version-tag.ts)",
-		"upload-sourcemaps:router-worker": "node -r esbuild-register ./scripts/upload-sourcemaps.ts --worker router-worker --tag $(node -r esbuild-register ./scripts/get-version-tag.ts)"
+		"upload-sourcemaps:asset-worker": "node -r esbuild-register ./scripts/upload-sourcemaps.ts --worker asset-worker --tag aw-$(node -r esbuild-register ./scripts/get-version-tag.ts)",
+		"upload-sourcemaps:router-worker": "node -r esbuild-register ./scripts/upload-sourcemaps.ts --worker router-worker --tag rw-$(node -r esbuild-register ./scripts/get-version-tag.ts)"
 	},
 	"dependencies": {
 		"mime": "^3.0.0",


### PR DESCRIPTION
Presently, the tags collide, which will cause issues since the workers do not share the same code.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: n/a
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: n/a
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: n/a

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
