### PR TITLE
[vite-plugin-cloudflare] simplify playground playwright install

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/package.json
+++ b/packages/vite-plugin-cloudflare/playground/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"check:types": "tsc --build",
 		"test:build": "cross-env VITE_TEST_BUILD=1 vitest run -c vitest.config.e2e.ts",
-		"pretest:ci": "pnpm exec playwright install-deps && pnpm exec playwright install",
+		"pretest:ci": "pnpm playwright install chromium",
 		"test:ci": "pnpm test:serve && pnpm test:build",
 		"test:serve": "vitest run -c vitest.config.e2e.ts"
 	},


### PR DESCRIPTION
This PR simplified the vite-plugin-cloudflare playground playwright installation by only installing the chromium browser and nothing else.

This should unblock: https://github.com/vitejs/vite-ecosystem-ci/pull/361

<details><summary>Details</summary>
 
[`playwright install-deps`](https://playwright.dev/docs/browsers#install-system-dependencies) doesn't work great everywhere, for example [it doesn't work on arch linux](https://www.reddit.com/r/linux4noobs/comments/rp76h1/how_can_i_do_playwright_installdeps_on_arch_linux/), the playwright docs are a bit vague on what it installs but it sounds like it might not be generally necessary (as you can also see from the successful CI runs in this PR).

Besides that we only use the chromium browser so only that needs to actually be installed.

</details> 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: infra change
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: unrelated to wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: infra change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
