### PR TITLE
fix(create-cloudflare): use tabs for indentation in wrangler.json

### DIFF
--- a/.changeset/wild-kiwis-behave.md
+++ b/.changeset/wild-kiwis-behave.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: generated wrangler.json and wrangler.jsonc files will now be formatted with tabs, to match the rest of the generated files

--- a/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
+++ b/packages/create-cloudflare/src/wrangler/__tests__/config.test.ts
@@ -107,13 +107,13 @@ describe("update wrangler config", () => {
 			 * https://developers.cloudflare.com/workers/wrangler/configuration/
 			 */
 			{
-			  "$schema": "node_modules/wrangler/config-schema.json",
-			  "name": "test",
-			  "main": "src/index.ts",
-			  "compatibility_date": "2024-01-17",
-			  "observability": {
-			    "enabled": true
-			  }
+				"$schema": "node_modules/wrangler/config-schema.json",
+				"name": "test",
+				"main": "src/index.ts",
+				"compatibility_date": "2024-01-17",
+				"observability": {
+					"enabled": true
+				}
 			  /**
 			   * Smart Placement
 			   * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement

--- a/packages/create-cloudflare/src/wrangler/config.ts
+++ b/packages/create-cloudflare/src/wrangler/config.ts
@@ -45,12 +45,12 @@ export const updateWranglerConfig = async (ctx: C3Context) => {
 			ensureNameExists(parsed, ctx.project.name),
 		);
 
-		const comment = `/**\n * For more details on how to configure Wrangler, refer to:\n * https://developers.cloudflare.com/workers/wrangler/configuration/\n */\n{\n  "$schema": "node_modules/wrangler/config-schema.json",`;
+		const comment = `/**\n * For more details on how to configure Wrangler, refer to:\n * https://developers.cloudflare.com/workers/wrangler/configuration/\n */\n{\n\t"$schema": "node_modules/wrangler/config-schema.json",`;
 
 		if (!modified["observability"]) {
 			modified["observability"] = { enabled: true };
 		}
-		const stringified = comment + JSON.stringify(modified, null, 2).slice(1);
+		const stringified = comment + JSON.stringify(modified, null, '\t').slice(1);
 
 		writeWranglerJson(
 			ctx,

--- a/packages/create-cloudflare/src/wrangler/config.ts
+++ b/packages/create-cloudflare/src/wrangler/config.ts
@@ -50,7 +50,7 @@ export const updateWranglerConfig = async (ctx: C3Context) => {
 		if (!modified["observability"]) {
 			modified["observability"] = { enabled: true };
 		}
-		const stringified = comment + JSON.stringify(modified, null, '\t').slice(1);
+		const stringified = comment + JSON.stringify(modified, null, "\t").slice(1);
 
 		writeWranglerJson(
 			ctx,


### PR DESCRIPTION
Fixes #8151

This simply uses tabs for indentation to match the format of most common hello world, etc. templates.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no functional changes
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no functional changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functional changes
