### PR TITLE
Prevent infinite `console.log()`/`console.info()` loops with Wrangler E2E tests

### DIFF
--- a/packages/wrangler/e2e/startWorker.test.ts
+++ b/packages/wrangler/e2e/startWorker.test.ts
@@ -10,7 +10,7 @@ import WebSocket from "ws";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import type { DevToolsEvent } from "../src/api";
 
-const OPTIONS = [{ remote: false }, { remote: true }] as const;
+const OPTIONS = [{ remote: true }, { remote: false }] as const;
 
 type Wrangler = Awaited<ReturnType<WranglerE2ETestHelper["importWrangler"]>>;
 
@@ -201,18 +201,16 @@ describe.each(OPTIONS)("DevEnv (remote: $remote)", ({ remote }) => {
 	// through a worker (InspectorProxyWorker) which hits the limit (without the fix, compatibilityFlags:["increase_websocket_message_size"])
 	// By logging a large string we can verify that the inspector messages are being proxied successfully.
 	it("InspectorProxyWorker can proxy messages > 1MB", async (t) => {
-		t.onTestFinished(() => worker?.dispose());
+		const consoleInfoSpy = vi
+			.spyOn(console, "info")
+			.mockImplementation(() => {});
+		const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-		const originalConsoleLog = console.log;
-		const mockConsoleLogImpl = (message: unknown, ...args: unknown[]) => {
-			if (typeof message === "string" && /z+/.test(message)) {
-				return; // don't log chunks of the large string
-			}
-
-			originalConsoleLog(message, ...args);
-		};
-		vi.spyOn(console, "info").mockImplementation(mockConsoleLogImpl);
-		vi.spyOn(console, "log").mockImplementation(mockConsoleLogImpl);
+		t.onTestFinished(() => {
+			worker?.dispose();
+			consoleInfoSpy.mockRestore();
+			consoleLogSpy.mockRestore();
+		});
 
 		const LARGE_STRING = "This is a large string" + "z".repeat(2 ** 20);
 
@@ -250,9 +248,7 @@ describe.each(OPTIONS)("DevEnv (remote: $remote)", ({ remote }) => {
 				expect(consoleApiMessages).toContainMatchingObject({
 					method: "Runtime.consoleAPICalled",
 					params: expect.objectContaining({
-						args: [
-							{ type: "string", value: expect.stringContaining("zzzzzzzzz") },
-						],
+						args: [{ type: "string", value: LARGE_STRING }],
 					}),
 				});
 			},


### PR DESCRIPTION
One of the Wrangler E2E tests is checking to see if inspector messages >1MB can be succesfully sent (a regression test for a bug introduced during phase 1 of the start dev worker work). However, since we don't really want to _actually_ log a 1MB message during tests, we had been mocking the output of `console.log()`/`console.info()`. In Vitest v3, the way we'd done this seems to have been causing an infinite loop, so instead I've replaced the mock implementation with an empty function. We don't really care about _any_ console output in the specific test, so that shouldn't cause any issues.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal testing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
