### PR TITLE
Reduce C3 CI runs

### DIFF
--- a/.github/pr-labeler.config.yml
+++ b/.github/pr-labeler.config.yml
@@ -4,6 +4,11 @@ e2e:
       - changed-files:
           - any-glob-to-any-file: "packages/wrangler/e2e/**/*"
 
+c3-e2e:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: "packages/create-cloudflare/e2e-tests/**/*"
+
 # add 'skip-pr-description-validation' label to Version Packages PRs
 skip-pr-description-validation:
   - all:

--- a/.github/pr-labeler.config.yml
+++ b/.github/pr-labeler.config.yml
@@ -7,7 +7,7 @@ e2e:
 c3-e2e:
   - all:
       - changed-files:
-          - any-glob-to-any-file: "packages/create-cloudflare/e2e-tests/**/*"
+          - any-glob-to-any-file: "packages/create-cloudflare/**/*"
 
 # add 'skip-pr-description-validation' label to Version Packages PRs
 skip-pr-description-validation:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -114,16 +114,15 @@ See below for a summary of this repo's Actions
 ### C3 E2E Tests (c3-e2e.yml)
 
 - Triggers
-  - Commits merged to the `main` branch, on the Cloudflare fork, which touch files in the `packages/create-cloudflare` directory.
-  - Updates to PRs, on the Cloudflare fork, which touch files in the `packages/create-cloudflare` directory.
+  - Commits merged to the `changeset-release/main` branch (i.e. on "Version Packages" PRs).
+  - Updates to PRs, on the Cloudflare fork, with the `c3-e2e` label applied.
 - Actions
   - Runs the E2E tests for C3.
 
 ### C3 E2E (Quarantine) (c3-e2e-quarantine.yml) ⚠️
 
 - Triggers
-  - Commits merged to the `main` branch, on the Cloudflare fork, which touch files in the `packages/create-cloudflare` directory.
-  - Updates to PRs, on the Cloudflare fork, which touch files in the `packages/create-cloudflare` directory.
+  - 3AM every day
 - Actions
   - Runs the _quarantined_ E2E tests for C3. It is expected to sometimes fail.
 

--- a/.github/workflows/c3-e2e-quarantine.yml
+++ b/.github/workflows/c3-e2e-quarantine.yml
@@ -1,12 +1,8 @@
-# Runs c3 e2e tests for quarantined frameworks on merges to main
-
 name: C3 E2E (Quarantine)
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - packages/create-cloudflare/**
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
 
 jobs:
   e2e:

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -1,11 +1,14 @@
-# Runs c3 e2e tests on pull requests with c3 changes
-
 name: C3 E2E Tests
 on:
+  push:
+    branches:
+      - changeset-release/main
   pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
 
 jobs:
   turbo-ignore:
+    if: (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains(github.event.*.labels.*.name, 'c3-e2e' ) && github.event.pull_request.head.repo.owner.login == 'cloudflare'))
     outputs:
       skip: ${{ steps.skip.outcome }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
To address CI queuing issues (C3 E2E is the most expensive job across the entire Cloudflare org), reduce C3 E2E CI runs to:
* Run normal C3 E2E on VP and PRs with the `c3-e2e` label
* Run C3 E2E quarantine at 3AM every day, when no other jobs are usually running (additionally, this can be manually run on a specific branch if needed)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: change to CI setup
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: change to CI setup
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: added in the README

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
