### PR TITLE
fix(vitest-pool-workers): improve error message with isolated storage

### DIFF
--- a/.changeset/red-rockets-lie.md
+++ b/.changeset/red-rockets-lie.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+improve error message with isolated storage

--- a/packages/vitest-pool-workers/src/pool/loopback.ts
+++ b/packages/vitest-pool-workers/src/pool/loopback.ts
@@ -328,7 +328,8 @@ function checkAllStorageOperationsResolved(
 			`Failed to ${action} isolated storage stack frame in ${source}.`,
 			`In particular, we were unable to ${action} ${LIST_FORMAT.format(failedProducts)} storage.`,
 			"This usually means your Worker tried to access storage outside of a test, or some resources have not been disposed of properly.",
-			"See https://developers.cloudflare.com/workers/testing/vitest-integration/known-issues/#isolated-storage for common causes and suggested solution.",
+			`Ensure you "await" all Promises that read or write to these services, and make sure you use the "using" keyword when passing data across JSRPC.`,
+			`See https://developers.cloudflare.com/workers/testing/vitest-integration/known-issues/#isolated-storage for more details.`,
 			"\x1b[2m"
 		);
 		lines.push("\x1b[22m" + separator, "");

--- a/packages/vitest-pool-workers/src/pool/loopback.ts
+++ b/packages/vitest-pool-workers/src/pool/loopback.ts
@@ -327,7 +327,7 @@ function checkAllStorageOperationsResolved(
 			separator,
 			`Failed to ${action} isolated storage stack frame in ${source}.`,
 			`In particular, we were unable to ${action} ${LIST_FORMAT.format(failedProducts)} storage.`,
-			"This usually means your Worker access storage outside of a test, or some resources have not been disposed of properly.",
+			"This usually means your Worker tried to access storage outside of a test, or some resources have not been disposed of properly.",
 			"See https://developers.cloudflare.com/workers/testing/vitest-integration/known-issues/#isolated-storage for common causes and suggested solution.",
 			"\x1b[2m"
 		);

--- a/packages/vitest-pool-workers/src/pool/loopback.ts
+++ b/packages/vitest-pool-workers/src/pool/loopback.ts
@@ -326,11 +326,9 @@ function checkAllStorageOperationsResolved(
 			"",
 			separator,
 			`Failed to ${action} isolated storage stack frame in ${source}.`,
-			"This usually means your Worker tried to access storage outside of a test, or failed to cleanup storage passed across an RPC boundary.",
-			`In particular, we were unable to ${action} ${LIST_FORMAT.format(
-				failedProducts
-			)} storage.`,
-			"Ensure you `await` all `Promise`s that read or write to these services, and make sure you use the `using` keyword when passing data across JSRPC. See https://developers.cloudflare.com/workers/runtime-apis/rpc/lifecycle#explicit-resource-management for more details.",
+			`In particular, we were unable to ${action} ${LIST_FORMAT.format(failedProducts)} storage.`,
+			"This usually means your Worker access storage outside of a test, or some resources have not been disposed of properly.",
+			"See https://developers.cloudflare.com/workers/testing/vitest-integration/known-issues/#isolated-storage for common causes and suggested solution.",
 			"\x1b[2m"
 		);
 		lines.push("\x1b[22m" + separator, "");


### PR DESCRIPTION
Fixes #5629

This PRs updated the error message with isolated storage with a link to known issues documented in https://github.com/cloudflare/cloudflare-docs/pull/20033

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: updated error message only
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact to wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/20033
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
