### PR TITLE
fix: refactor Node.js compat support to ensure all polyfills are pre-bundled before the first request

### DIFF
--- a/.changeset/ninety-phones-tell.md
+++ b/.changeset/ninety-phones-tell.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+fix: refactor Node.js compat support to ensure all polyfills are pre-bundled before the first request

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import * as vite from "vite";
 import { INIT_PATH, UNKNOWN_HOST } from "./shared";
-import { getOutputDirectory, nodeBuiltInModules } from "./utils";
+import { getOutputDirectory } from "./utils";
 import type { ResolvedPluginConfig, WorkerConfig } from "./plugin-config";
 import type { Fetcher } from "@cloudflare/workers-types/experimental";
 import type {
@@ -134,8 +134,6 @@ export function createCloudflareEnvironmentOptions(
 			conditions: [...defaultConditions, "development|production"],
 			// The Cloudflare ones are proper builtins in the environment
 			builtins: [...cloudflareBuiltInModules],
-			// The Node.js ones are no proper builtins in the environment since we also polyfill them using unenv
-			external: [...nodeBuiltInModules],
 		},
 		dev: {
 			createEnvironment(name, config) {
@@ -164,10 +162,6 @@ export function createCloudflareEnvironmentOptions(
 			// Note: ssr pre-bundling is opt-in and we need to enable it by setting `noDiscovery` to false
 			noDiscovery: false,
 			entries: workerConfig.main,
-			exclude: [
-				// we have to exclude all node modules to work in dev-mode not just the unenv externals...
-				...nodeBuiltInModules,
-			],
 			esbuildOptions: {
 				platform: "neutral",
 				conditions: [...defaultConditions, "development"],

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -16,7 +16,6 @@ import {
 } from "./constants";
 import { getWorkerConfigPaths } from "./deploy-config";
 import { MODULE_PATTERN } from "./shared";
-import { nodeBuiltInModules } from "./utils";
 import type { CloudflareDevEnvironment } from "./cloudflare-environment";
 import type {
 	PersistState,
@@ -331,9 +330,7 @@ export function getDevMiniflareOptions(
 
 									const shouldExternalize =
 										// Worker modules (CompiledWasm, Text, Data)
-										moduleRE.test(moduleId) ||
-										// Node.js builtin node modules (they will be resolved to unenv aliases)
-										nodeBuiltInModules.has(moduleId);
+										moduleRE.test(moduleId);
 
 									if (shouldExternalize) {
 										const result = {

--- a/packages/vite-plugin-cloudflare/src/node-js-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/node-js-compat.ts
@@ -45,15 +45,15 @@ export function isNodeCompat(
  */
 export function getNodeCompatEntries() {
 	const entries = new Set<string>(Object.values(env.alias));
-	for (const globInject of Object.values(env.inject)) {
-		if (typeof globInject === "string") {
-			entries.add(globInject);
+	for (const globalInject of Object.values(env.inject)) {
+		if (typeof globalInject === "string") {
+			entries.add(globalInject);
 		} else {
 			assert(
-				globInject[0] !== undefined,
-				"Expected first element of globInject to be defined"
+				globalInject[0] !== undefined,
+				"Expected first element of globalInject to be defined"
 			);
-			entries.add(globInject[0]);
+			entries.add(globalInject[0]);
 		}
 	}
 	for (const external of env.external) {

--- a/packages/vite-plugin-cloudflare/src/node-js-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/node-js-compat.ts
@@ -76,6 +76,11 @@ export function injectGlobalCode(id: string, code: string) {
 
 			// the mapping is a 2 item tuple, indicating a named export, made up of a module specifier and an export name.
 			const [moduleSpecifier, exportName] = globalInject;
+			assert(
+				moduleSpecifier !== undefined,
+				"Expected moduleSpecifier to be defined"
+			);
+			assert(exportName !== undefined, "Expected exportName to be defined");
 			return `import var_${globalName} from "${moduleSpecifier}";\nglobalThis.${globalName} = var_${globalName}.${exportName};\n`;
 		})
 		.join("\n");

--- a/packages/vite-plugin-cloudflare/src/node-js-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/node-js-compat.ts
@@ -11,8 +11,6 @@ const { env } = defineEnv({
 	presets: [cloudflare],
 });
 
-const CLOUDFLARE_VIRTUAL_PREFIX = "\0__CLOUDFLARE_NODEJS_COMPAT__";
-
 /**
  * Returns true if the given combination of compat dates and flags means that we need Node.js compatibility.
  */
@@ -43,8 +41,25 @@ export function isNodeCompat(
 }
 
 /**
- * If the current environment needs Node.js compatibility,
- * then inject the necessary global polyfills into the code.
+ * Get a set of module specifiers for all possible Node.js compat polyfill entry-points
+ */
+export function getNodeCompatEntries() {
+	const entries = new Set<string>(Object.values(env.alias));
+	for (const globInject of Object.values(env.inject)) {
+		if (typeof globInject === "string") {
+			entries.add(globInject);
+		} else {
+			entries.add(globInject[0] as string);
+		}
+	}
+	for (const external of env.external) {
+		entries.delete(external);
+	}
+	return entries;
+}
+
+/**
+ * Get the necessary global polyfills to inject into the entry-point of the user's code.
  */
 export function injectGlobalCode(id: string, code: string) {
 	const injectedCode = Object.entries(env.inject)
@@ -52,12 +67,12 @@ export function injectGlobalCode(id: string, code: string) {
 			if (typeof globalInject === "string") {
 				const moduleSpecifier = globalInject;
 				// the mapping is a simple string, indicating a default export, so the string is just the module specifier.
-				return `import var_${globalName} from "${CLOUDFLARE_VIRTUAL_PREFIX}${moduleSpecifier}";\nglobalThis.${globalName} = var_${globalName};\n`;
+				return `import var_${globalName} from "${moduleSpecifier}";\nglobalThis.${globalName} = var_${globalName};\n`;
 			}
 
 			// the mapping is a 2 item tuple, indicating a named export, made up of a module specifier and an export name.
 			const [moduleSpecifier, exportName] = globalInject;
-			return `import var_${globalName} from "${CLOUDFLARE_VIRTUAL_PREFIX}${moduleSpecifier}";\nglobalThis.${globalName} = var_${globalName}.${exportName};\n`;
+			return `import var_${globalName} from "${moduleSpecifier}";\nglobalThis.${globalName} = var_${globalName}.${exportName};\n`;
 		})
 		.join("\n");
 
@@ -70,22 +85,6 @@ export function injectGlobalCode(id: string, code: string) {
 }
 
 /**
- * We only want to alias Node.js built-ins if the environment has Node.js compatibility turned on.
- * But Vite only allows us to configure aliases at the shared options level, not per environment.
- * So instead we alias these to a virtual module, which are then handled with environment specific code in the `resolveId` handler
- */
-export function getNodeCompatAliases() {
-	const aliases: Record<string, string> = {};
-	Object.keys(env.alias).forEach((key) => {
-		// Don't create aliases for modules that are already marked as external
-		if (!env.external.includes(key)) {
-			aliases[key] = CLOUDFLARE_VIRTUAL_PREFIX + key;
-		}
-	});
-	return aliases;
-}
-
-/**
  * Get an array of modules that should be considered external.
  */
 export function getNodeCompatExternals(): string[] {
@@ -93,40 +92,22 @@ export function getNodeCompatExternals(): string[] {
 }
 
 /**
- * If the `source` module id starts with the virtual prefix then strip it and return the rest of the id.
- * Otherwise return undefined.
- */
-export function maybeStripNodeJsVirtualPrefix(
-	source: string
-): string | undefined {
-	return source.startsWith(CLOUDFLARE_VIRTUAL_PREFIX)
-		? source.slice(CLOUDFLARE_VIRTUAL_PREFIX.length)
-		: undefined;
-}
-
-/**
- * Resolve the source import to an absolute path, potentially via its alias.
+ * Resolve the `source` to a Node.js compat alias if possible.
+ *
+ * If there is an alias, the return value is an object with:
+ * - `unresolved`: a bare import path to the polyfill (e.g. `unenv/runtime/node/crypto`)
+ * - `resolved` an absolute path to the polyfill (e.g. `/path/to/project/node_modules/unenv/runtime/node/child_process/index.mjs`)
  */
 export function resolveNodeJSImport(source: string) {
 	const alias = env.alias[source];
-	if (alias) {
-		// If `alias` is `undefined` then `source` was injected in the `transform` hook and we can resolve it directly.
-		// Else we resolve the `alias` instead of the `source`.
-		assert(
-			!env.external.includes(alias),
-			`Unexpected unenv alias to external module: ${source} -> ${alias}`
-		);
-		source = alias;
-	}
-	// Resolve to an absolute path using the path to this file as the resolution starting point.
-	// This is essential so that we can find the `@cloudflare/unenv-preset` and `unenv` packages,
-	// which are dependencies of this package but may not be direct dependencies of the user's project.
-	const resolved = resolvePathSync(source, {
-		url: import.meta.url,
-	});
 
-	return {
-		unresolved: source,
-		resolved,
-	};
+	// These aliases must be resolved from the context of this plugin since the alias will refer to one of the
+	// `@cloudflare/unenv-preset` or the `unenv` packages, which are direct dependencies of this package,
+	// and not the user's project.
+	if (alias) {
+		return {
+			unresolved: alias,
+			resolved: resolvePathSync(alias, { url: import.meta.url }),
+		};
+	}
 }

--- a/packages/vite-plugin-cloudflare/src/node-js-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/node-js-compat.ts
@@ -41,7 +41,7 @@ export function isNodeCompat(
 }
 
 /**
- * Get a set of module specifiers for all possible Node.js compat polyfill entry-points
+ * Gets a set of module specifiers for all possible Node.js compat polyfill entry-points
  */
 export function getNodeCompatEntries() {
 	const entries = new Set<string>(Object.values(env.alias));
@@ -49,7 +49,11 @@ export function getNodeCompatEntries() {
 		if (typeof globInject === "string") {
 			entries.add(globInject);
 		} else {
-			entries.add(globInject[0] as string);
+			assert(
+				globInject[0] !== undefined,
+				"Expected first element of globInject to be defined"
+			);
+			entries.add(globInject[0]);
 		}
 	}
 	for (const external of env.external) {
@@ -59,7 +63,7 @@ export function getNodeCompatEntries() {
 }
 
 /**
- * Get the necessary global polyfills to inject into the entry-point of the user's code.
+ * Gets the necessary global polyfills to inject into the entry-point of the user's code.
  */
 export function injectGlobalCode(id: string, code: string) {
 	const injectedCode = Object.entries(env.inject)
@@ -85,18 +89,18 @@ export function injectGlobalCode(id: string, code: string) {
 }
 
 /**
- * Get an array of modules that should be considered external.
+ * Gets an array of modules that should be considered external.
  */
 export function getNodeCompatExternals(): string[] {
 	return env.external;
 }
 
 /**
- * Resolve the `source` to a Node.js compat alias if possible.
+ * Resolves the `source` to a Node.js compat alias if possible.
  *
  * If there is an alias, the return value is an object with:
  * - `unresolved`: a bare import path to the polyfill (e.g. `unenv/runtime/node/crypto`)
- * - `resolved` an absolute path to the polyfill (e.g. `/path/to/project/node_modules/unenv/runtime/node/child_process/index.mjs`)
+ * - `resolved`: an absolute path to the polyfill (e.g. `/path/to/project/node_modules/unenv/runtime/node/child_process/index.mjs`)
  */
 export function resolveNodeJSImport(source: string) {
 	const alias = env.alias[source];

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -1,12 +1,7 @@
-import { builtinModules } from "node:module";
 import * as path from "node:path";
 import { Request as MiniflareRequest } from "miniflare";
 import * as vite from "vite";
 import type { IncomingHttpHeaders } from "node:http";
-
-export const nodeBuiltInModules = new Set(
-	builtinModules.concat(builtinModules.map((m) => `node:${m}`))
-);
 
 export function getOutputDirectory(
 	userConfig: vite.UserConfig,


### PR DESCRIPTION
Fixes #0000.

This is not fixing a bug per-se, except that prior to this change some of the Node.js polyfills would only be processed by the dependency optimizer during/after the first request was made. This meant there was a danger of the dependencies that had been prebundled already becoming stale and the app being in a bad state.

- makes use of the new custom builtin support that @dario-piotrowicz added to Vite recently
- proactively pre-bundles all the Node.js compat polyfill entry-points
- removes the need to use the Vite aliasing mechanism (which is not configurable per environment) and so the problematic virtual modules
- dramatically simplifies the Node.js compat plugin code base

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: the current tests cover the refactoring
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Not Wrangler related
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactoring

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
