### PR TITLE
fix(vitest-pool-workers): support running in directories containing spaces

### DIFF
--- a/.changeset/twenty-chefs-lick.md
+++ b/.changeset/twenty-chefs-lick.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: support running in directories that contain spaces

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import events from "node:events";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import util from "node:util";
 import { createBirpc } from "birpc";
 import * as devalue from "devalue";
@@ -667,7 +667,7 @@ async function runTests(
 	ctx.state.clearFiles(project.project, files);
 	const data: WorkerContext = {
 		pool: "threads",
-		worker: threadsWorkerPath,
+		worker: pathToFileURL(threadsWorkerPath).href,
 		port: undefined as unknown as MessagePort,
 		config,
 		files,

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -39,10 +39,7 @@ import {
 	scheduleStorageReset,
 	waitForStorageReset,
 } from "./loopback";
-import {
-	ensurePosixLikePath,
-	handleModuleFallbackRequest,
-} from "./module-fallback";
+import { handleModuleFallbackRequest } from "./module-fallback";
 import type {
 	SourcelessWorkerOptions,
 	WorkersConfigPluginAPI,
@@ -657,12 +654,8 @@ async function runTests(
 	invalidates: string[] = [],
 	method: "run" | "collect"
 ) {
-	let workerPath = path.join(ctx.distPath, "worker.js");
-	let threadsWorkerPath = path.join(ctx.distPath, "workers", "threads.js");
-	if (process.platform === "win32") {
-		workerPath = `/${ensurePosixLikePath(workerPath)}`;
-		threadsWorkerPath = `/${ensurePosixLikePath(threadsWorkerPath)}`;
-	}
+	const workerPath = path.join(ctx.distPath, "worker.js");
+	const threadsWorkerPath = path.join(ctx.distPath, "workers", "threads.js");
 
 	ctx.state.clearFiles(project.project, files);
 	const data: WorkerContext = {
@@ -705,7 +698,7 @@ async function runTests(
 		headers: {
 			Upgrade: "websocket",
 			"MF-Vitest-Worker-Data": structuredSerializableStringify({
-				filePath: workerPath,
+				filePath: pathToFileURL(workerPath).href,
 				name: method,
 				data,
 				cwd: process.cwd(),

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -549,7 +549,7 @@ export async function handleModuleFallbackRequest(
 	// currently passes `import("file:///a/index.mjs")` through like this.
 	// TODO(soon): remove this code once the new modules refactor lands
 	if (specifier.startsWith("file:")) {
-		specifier = specifier.substring(5);
+		specifier = fileURLToPath(specifier);
 	}
 
 	if (isWindows) {

--- a/packages/vitest-pool-workers/test/global-setup.ts
+++ b/packages/vitest-pool-workers/test/global-setup.ts
@@ -37,8 +37,10 @@ export default async function ({ provide }: GlobalSetupContext) {
  * Create a temporary package that contains vitest-pool-workers and vitest.
  */
 async function createTestProject() {
+	// Create temporary directory containing a space to avoid regressing on
+	// https://github.com/cloudflare/workers-sdk/issues/5268
 	const projectPath = await fs.realpath(
-		await fs.mkdtemp(path.join(os.tmpdir(), "vitest-pool-workers-"))
+		await fs.mkdtemp(path.join(os.tmpdir(), "vitest-pool-workers temp-"))
 	);
 	const packageJsonPath = path.join(projectPath, "package.json");
 	const packageJson = {


### PR DESCRIPTION
Fixes #5268, #8064. Close #5913.

Just made a minor tweak from #5913 to fix window support.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Made the test project path to include a space. So this should be covered by existing tests. 
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact to wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
