### PR TITLE
fix(vitest-pool-workers): reset module graphs to ensure module mock works in watch mode

### DIFF
--- a/.changeset/quick-shoes-jump.md
+++ b/.changeset/quick-shoes-jump.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix mock modules not re-evaluated in watch mode

--- a/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-runner.ts
+++ b/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-runner.ts
@@ -230,7 +230,7 @@ export default class WorkersTestRunner extends VitestTestRunner {
 			await scheduler.wait(100);
 		}
 
-		// Unlike the official threads and forks pool, we do not recycle the miniflare instances to maintains the module cache.
+		// Unlike the official threads and forks pool, we do not recycle the miniflare instances to maintain the module cache.
 		// However, this creates a side effect where the module mock will not be re-evaluated on watch mode.
 		// This fixes https://github.com/cloudflare/workers-sdk/issues/6844 by resetting the module graph.
 		vi.resetModules();

--- a/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-runner.ts
+++ b/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-runner.ts
@@ -8,7 +8,7 @@ import {
 	registerHandlerAndGlobalWaitUntil,
 	waitForGlobalWaitUntil,
 } from "cloudflare:test-internal";
-// import { vi } from "vitest";
+import { vi } from "vitest";
 import { VitestTestRunner } from "vitest/runners";
 import workerdUnsafe from "workerd:unsafe";
 import type { CancelReason, Suite, Test } from "@vitest/runner";
@@ -233,7 +233,7 @@ export default class WorkersTestRunner extends VitestTestRunner {
 		// Unlike the official threads and forks pool, we do not recycle the miniflare instances to maintains the module cache.
 		// However, this creates a side effect where the module mock will not be re-evaluated on watch mode.
 		// This fixes https://github.com/cloudflare/workers-sdk/issues/6844 by resetting the module graph.
-		// vi.resetModules();
+		vi.resetModules();
 
 		// Ensure all `ctx.waitUntil()` calls complete before disposing the runtime
 		// (if using `vitest run`) and aborting all objects. `ctx.waitUntil()`s may

--- a/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-runner.ts
+++ b/packages/vitest-pool-workers/src/worker/lib/cloudflare/test-runner.ts
@@ -8,6 +8,7 @@ import {
 	registerHandlerAndGlobalWaitUntil,
 	waitForGlobalWaitUntil,
 } from "cloudflare:test-internal";
+// import { vi } from "vitest";
 import { VitestTestRunner } from "vitest/runners";
 import workerdUnsafe from "workerd:unsafe";
 import type { CancelReason, Suite, Test } from "@vitest/runner";
@@ -228,6 +229,11 @@ export default class WorkersTestRunner extends VitestTestRunner {
 			__console.log("onAfterRunFiles");
 			await scheduler.wait(100);
 		}
+
+		// Unlike the official threads and forks pool, we do not recycle the miniflare instances to maintains the module cache.
+		// However, this creates a side effect where the module mock will not be re-evaluated on watch mode.
+		// This fixes https://github.com/cloudflare/workers-sdk/issues/6844 by resetting the module graph.
+		// vi.resetModules();
 
 		// Ensure all `ctx.waitUntil()` calls complete before disposing the runtime
 		// (if using `vitest run`) and aborting all objects. `ctx.waitUntil()`s may


### PR DESCRIPTION
Fixes #6844.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact to wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
