### PR TITLE
Add cloudchamber images list/delete commands

### DIFF
--- a/.changeset/silly-dragons-doubt.md
+++ b/.changeset/silly-dragons-doubt.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add cloudchamber images {list,delete} commands to list and delete images stored in cloudchamber managed registry.

--- a/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
@@ -159,3 +159,392 @@ describe("cloudchamber image", () => {
 		`);
 	});
 });
+
+describe("cloudchamber image list", () => {
+	const std = mockConsoleMethods();
+	const { setIsTTY } = useMockIsTTY();
+
+	mockAccountId();
+	mockApiToken();
+	beforeEach(mockAccount);
+	runInTempDir();
+	afterEach(() => {
+		patchConsole(() => {});
+		msw.resetHandlers();
+	});
+
+	it("should help", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		await runWrangler("cloudchamber images list --help");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"wrangler cloudchamber images list
+
+			perform operations on images in your cloudchamber registry
+
+			GLOBAL FLAGS
+			  -c, --config   Path to Wrangler configuration file  [string]
+			      --cwd      Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+			  -e, --env      Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+			  -h, --help     Show help  [boolean]
+			  -v, --version  Show version number  [boolean]
+
+			OPTIONS
+			      --json    Return output as clean JSON  [boolean] [default: false]
+			      --filter  Regex to filter results  [string]"
+		`);
+	});
+	it("should list images", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		const tags: Map<string, string[]> = new Map([
+			["one", ["hundred", "ten", "sha256:239a0dfhasdfui235"]],
+			["two", ["thousand", "twenty", "sha256:badfga4mag0vhjakf"]],
+			["three", ["million", "thirty", "sha256:23f0adfgbja0f0jf0"]],
+		]);
+
+		msw.use(
+			http.post("*/registries/:domain/credentials", async ({ params }) => {
+				const domain = String(params["domain"]);
+				expect(domain === "docker.io");
+				return HttpResponse.json({
+					account_id: "1234",
+					registry_host: "docker.io",
+					username: "foo",
+					password: "bar",
+				});
+			}),
+			http.get("*/v2/_catalog", async () => {
+				return HttpResponse.json({ repositories: ["one", "two", "three"] });
+			}),
+			http.get("*/v2/:repo/tags/list", async ({ params }) => {
+				const repo = String(params["repo"]);
+				const t = tags.get(repo);
+				return HttpResponse.json({
+					name: `${repo}`,
+					tags: t,
+				});
+			})
+		);
+		await runWrangler("cloudchamber images list");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"┌────────────┬─────────────────┐
+			│ REPOSITORY │ TAG             │
+			├────────────┼─────────────────┤
+			│ one        │ hundred ten     │
+			├────────────┼─────────────────┤
+			│ two        │ thousand twenty │
+			├────────────┼─────────────────┤
+			│ three      │ million thirty  │
+			└────────────┴─────────────────┘"
+		`);
+	});
+	it("should list images with a filter", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		const tags: Map<string, string[]> = new Map([
+			["one", ["hundred", "ten", "sha256:239a0dfhasdfui235"]],
+			["two", ["thousand", "twenty", "sha256:badfga4mag0vhjakf"]],
+			["three", ["million", "thirty", "sha256:23f0adfgbja0f0jf0"]],
+		]);
+
+		msw.use(
+			http.post("*/registries/:domain/credentials", async ({ params }) => {
+				const domain = String(params["domain"]);
+				expect(domain === "docker.io");
+				return HttpResponse.json({
+					account_id: "1234",
+					registry_host: "docker.io",
+					username: "foo",
+					password: "bar",
+				});
+			}),
+			http.get("*/v2/_catalog", async () => {
+				return HttpResponse.json({ repositories: ["one", "two", "three"] });
+			}),
+			http.get("*/v2/:repo/tags/list", async ({ params }) => {
+				const repo = String(params["repo"]);
+				const t = tags.get(repo);
+				return HttpResponse.json({
+					name: `${repo}`,
+					tags: t,
+				});
+			})
+		);
+		await runWrangler("cloudchamber images list --filter '^two$'");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"┌────────────┬─────────────────┐
+			│ REPOSITORY │ TAG             │
+			├────────────┼─────────────────┤
+			│ two        │ thousand twenty │
+			└────────────┴─────────────────┘"
+		`);
+	});
+	it("should filter out repos with no non-sha tags", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		const tags: Map<string, string[]> = new Map([
+			["one", ["hundred", "ten", "sha256:239a0dfhasdfui235"]],
+			["two", ["thousand", "twenty", "sha256:badfga4mag0vhjakf"]],
+			["three", ["million", "thirty", "sha256:23f0adfgbja0f0jf0"]],
+			["empty", []],
+			["shaonly", ["sha256:23f0adfgbja0f0jf0"]],
+		]);
+
+		msw.use(
+			http.post("*/registries/:domain/credentials", async ({ params }) => {
+				const domain = String(params["domain"]);
+				expect(domain === "docker.io");
+				return HttpResponse.json({
+					account_id: "1234",
+					registry_host: "docker.io",
+					username: "foo",
+					password: "bar",
+				});
+			}),
+			http.get("*/v2/_catalog", async () => {
+				return HttpResponse.json({ repositories: ["one", "two", "three"] });
+			}),
+			http.get("*/v2/:repo/tags/list", async ({ params }) => {
+				const repo = String(params["repo"]);
+				const t = tags.get(repo);
+				return HttpResponse.json({
+					name: `${repo}`,
+					tags: t,
+				});
+			})
+		);
+		await runWrangler("cloudchamber images list");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"┌────────────┬─────────────────┐
+			│ REPOSITORY │ TAG             │
+			├────────────┼─────────────────┤
+			│ one        │ hundred ten     │
+			├────────────┼─────────────────┤
+			│ two        │ thousand twenty │
+			├────────────┼─────────────────┤
+			│ three      │ million thirty  │
+			└────────────┴─────────────────┘"
+		`);
+	});
+	it("should list repos with json flag set", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		const tags: Map<string, string[]> = new Map([
+			["one", ["hundred", "ten", "sha256:239a0dfhasdfui235"]],
+			["two", ["thousand", "twenty", "sha256:badfga4mag0vhjakf"]],
+			["three", ["million", "thirty", "sha256:23f0adfgbja0f0jf0"]],
+		]);
+
+		msw.use(
+			http.post("*/registries/:domain/credentials", async ({ params }) => {
+				const domain = String(params["domain"]);
+				expect(domain === "docker.io");
+				return HttpResponse.json({
+					account_id: "1234",
+					registry_host: "docker.io",
+					username: "foo",
+					password: "bar",
+				});
+			}),
+			http.get("*/v2/_catalog", async () => {
+				return HttpResponse.json({ repositories: ["one", "two", "three"] });
+			}),
+			http.get("*/v2/:repo/tags/list", async ({ params }) => {
+				const repo = String(params["repo"]);
+				const t = tags.get(repo);
+				return HttpResponse.json({
+					name: `${repo}`,
+					tags: t,
+				});
+			})
+		);
+		await runWrangler("cloudchamber images list --json");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"[
+			  {
+			    \\"name\\": \\"one\\",
+			    \\"tags\\": [
+			      \\"hundred\\",
+			      \\"ten\\"
+			    ]
+			  },
+			  {
+			    \\"name\\": \\"two\\",
+			    \\"tags\\": [
+			      \\"thousand\\",
+			      \\"twenty\\"
+			    ]
+			  },
+			  {
+			    \\"name\\": \\"three\\",
+			    \\"tags\\": [
+			      \\"million\\",
+			      \\"thirty\\"
+			    ]
+			  }
+			]"
+		`);
+	});
+	it("should filter out repos with no non-sha tags in json output", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		const tags: Map<string, string[]> = new Map([
+			["one", ["hundred", "ten", "sha256:239a0dfhasdfui235"]],
+			["two", ["thousand", "twenty", "sha256:badfga4mag0vhjakf"]],
+			["three", ["million", "thirty", "sha256:23f0adfgbja0f0jf0"]],
+			["empty", []],
+			["shaonly", ["sha256:23f0adfgbja0f0jf0"]],
+		]);
+
+		msw.use(
+			http.post("*/registries/:domain/credentials", async ({ params }) => {
+				const domain = String(params["domain"]);
+				expect(domain === "docker.io");
+				return HttpResponse.json({
+					account_id: "1234",
+					registry_host: "docker.io",
+					username: "foo",
+					password: "bar",
+				});
+			}),
+			http.get("*/v2/_catalog", async () => {
+				return HttpResponse.json({ repositories: ["one", "two", "three"] });
+			}),
+			http.get("*/v2/:repo/tags/list", async ({ params }) => {
+				const repo = String(params["repo"]);
+				const t = tags.get(repo);
+				return HttpResponse.json({
+					name: `${repo}`,
+					tags: t,
+				});
+			})
+		);
+		await runWrangler("cloudchamber images list --json");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"[
+			  {
+			    \\"name\\": \\"one\\",
+			    \\"tags\\": [
+			      \\"hundred\\",
+			      \\"ten\\"
+			    ]
+			  },
+			  {
+			    \\"name\\": \\"two\\",
+			    \\"tags\\": [
+			      \\"thousand\\",
+			      \\"twenty\\"
+			    ]
+			  },
+			  {
+			    \\"name\\": \\"three\\",
+			    \\"tags\\": [
+			      \\"million\\",
+			      \\"thirty\\"
+			    ]
+			  }
+			]"
+		`);
+	});
+	it("should delete images", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		const tags: Map<string, string[]> = new Map([
+			["one", ["hundred", "ten", "sha256:239a0dfhasdfui235"]],
+			["two", ["thousand", "twenty", "sha256:badfga4mag0vhjakf"]],
+			["three", ["million", "thirty", "sha256:23f0adfgbja0f0jf0"]],
+		]);
+
+		msw.use(
+			http.post("*/registries/:domain/credentials", async ({ params }) => {
+				const domain = String(params["domain"]);
+				expect(domain === "docker.io");
+				return HttpResponse.json({
+					account_id: "1234",
+					registry_host: "docker.io",
+					username: "foo",
+					password: "bar",
+				});
+			}),
+			http.get("*/v2/_catalog", async () => {
+				return HttpResponse.json({ repositories: ["one", "two", "three"] });
+			}),
+			http.get("*/v2/:repo/tags/list", async ({ params }) => {
+				const repo = String(params["repo"]);
+				const t = tags.get(repo);
+				return HttpResponse.json({
+					name: `${repo}`,
+					tags: t,
+				});
+			}),
+			http.head("*/v2/:image/manifests/:tag", async ({ params }) => {
+				const image = String(params["image"]);
+				expect(image === "one");
+				const tag = String(params["tag"]);
+				expect(tag === "hundred");
+				return new HttpResponse("", {
+					status: 200,
+					headers: { "Docker-Content-Digest": "some-digest" },
+				});
+			}),
+			http.delete("*/v2/:image/manifests/:tag", async ({ params }) => {
+				const image = String(params["image"]);
+				expect(image === "one");
+				const tag = String(params["tag"]);
+				expect(tag === "hundred");
+				return new HttpResponse("", { status: 200 });
+			}),
+			http.put("*/v2/gc/layers", async () => {
+				return new HttpResponse("", { status: 200 });
+			})
+		);
+		await runWrangler("cloudchamber images delete one:hundred");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`"Deleted tag: one:hundred"`);
+	});
+	it("should error when provided a repo without a tag", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		const tags: Map<string, string[]> = new Map([
+			["one", ["hundred", "ten", "sha256:239a0dfhasdfui235"]],
+			["two", ["thousand", "twenty", "sha256:badfga4mag0vhjakf"]],
+			["three", ["million", "thirty", "sha256:23f0adfgbja0f0jf0"]],
+		]);
+
+		msw.use(
+			http.post("*/registries/:domain/credentials", async ({ params }) => {
+				const domain = String(params["domain"]);
+				expect(domain === "docker.io");
+				return HttpResponse.json({
+					account_id: "1234",
+					registry_host: "docker.io",
+					username: "foo",
+					password: "bar",
+				});
+			}),
+			http.get("*/v2/_catalog", async () => {
+				return HttpResponse.json({ repositories: ["one", "two", "three"] });
+			}),
+			http.get("*/v2/:repo/tags/list", async ({ params }) => {
+				const repo = String(params["repo"]);
+				const t = tags.get(repo);
+				return HttpResponse.json({
+					name: `${repo}`,
+					tags: t,
+				});
+			})
+		);
+		await runWrangler("cloudchamber images delete one");
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(
+			`"Error when removing image: Error: Must provide a tag to delete"`
+		);
+	});
+});

--- a/packages/wrangler/src/cloudchamber/images/list.ts
+++ b/packages/wrangler/src/cloudchamber/images/list.ts
@@ -1,0 +1,248 @@
+import { logger } from "../../logger";
+import { ImageRegistriesService } from "../client";
+import { handleFailure, promiseSpinner } from "../common";
+import type { Config } from "../../config";
+import type {
+	CommonYargsArgvJSON,
+	CommonYargsArgvSanitizedJSON,
+	StrictYargsOptionsToInterfaceJSON,
+} from "../../yargs-types";
+import type { ImageRegistryPermissions } from "../client";
+
+// cloudflare managed registry
+const domain = "registry.cloudchamber.cfdata.org";
+
+interface CatalogResponse {
+	repositories: string[];
+}
+
+interface TagsResponse {
+	name: string;
+	tags: string[];
+}
+
+export const imagesCommand = (yargs: CommonYargsArgvJSON) => {
+	return yargs
+		.command(
+			"list",
+			"perform operations on images in your cloudchamber registry",
+			(args) => listImagesYargs(args),
+			(args) =>
+				handleFailure(async (_args: CommonYargsArgvSanitizedJSON, config) => {
+					await handleListImagesCommand(args, config);
+				})(args)
+		)
+		.command(
+			"delete [image]",
+			"remove an image from your cloudchamber registry",
+			(args) => deleteImageYargs(args),
+			(args) =>
+				handleFailure(async (_args: CommonYargsArgvSanitizedJSON, config) => {
+					await handleDeleteImageCommand(args, config);
+				})(args)
+		);
+};
+
+function deleteImageYargs(yargs: CommonYargsArgvJSON) {
+	return yargs.positional("image", {
+		type: "string",
+		description: "image to delete",
+		demandOption: true,
+	});
+}
+
+function listImagesYargs(yargs: CommonYargsArgvJSON) {
+	return yargs.option("filter", {
+		type: "string",
+		description: "Regex to filter results",
+	});
+}
+
+async function handleDeleteImageCommand(
+	args: StrictYargsOptionsToInterfaceJSON<typeof deleteImageYargs>,
+	_config: Config
+) {
+	try {
+		if (!args.image.includes(":")) {
+			throw new Error(`Must provide a tag to delete`);
+		}
+		return await promiseSpinner(
+			getCreds().then(async (creds) => {
+				const url = new URL(`https://${domain}`);
+				const baseUrl = `${url.protocol}//${url.host}`;
+				const [image, tag] = args.image.split(":");
+				await deleteTag(baseUrl, image, tag, creds);
+
+				// trigger gc
+				const gcUrl = `${baseUrl}/v2/gc/layers`;
+				const gcResponse = await fetch(gcUrl, {
+					method: "PUT",
+					headers: {
+						Authorization: `Basic ${creds}`,
+						"Content-Type": "application/json",
+					},
+				});
+				if (!gcResponse.ok) {
+					throw new Error(
+						`Failed to delete image ${args.image}: ${gcResponse.status} ${gcResponse.statusText}`
+					);
+				}
+				await logger.log(`Deleted tag: ${args.image}`);
+			}),
+			{ message: "Deleting", json: args.json }
+		);
+	} catch (error) {
+		logger.log(`Error when removing image: ${error}`);
+	}
+}
+
+async function handleListImagesCommand(
+	args: StrictYargsOptionsToInterfaceJSON<typeof listImagesYargs>,
+	_config: Config
+) {
+	try {
+		return await promiseSpinner(
+			getCreds().then(async (creds) => {
+				const repos = await listRepos(creds);
+				const tags: TagsResponse[] = [];
+				for (const repo of repos) {
+					const stripped = repo.replace(/^\/+/, "");
+					const regex = new RegExp(args.filter ?? "");
+					if (regex.test(stripped)) {
+						// get all tags for repo
+						const repoTags = await listTags(stripped, creds);
+						tags.push({ name: stripped, tags: repoTags });
+					}
+				}
+
+				await ListTags(tags, false, args.json);
+			}),
+			{ message: "Listing", json: args.json }
+		);
+	} catch (error) {
+		logger.log(`Error listing images: ${error}`);
+	}
+}
+
+async function ListTags(
+	responses: TagsResponse[],
+	digests: boolean = false,
+	json: boolean = false
+) {
+	if (!digests) {
+		responses = responses.map((resp) => {
+			return {
+				name: resp.name,
+				tags: resp.tags.filter((t) => !t.startsWith("sha256")),
+			};
+		});
+	}
+	// Remove any repos with no tags
+	responses = responses.filter((resp) => {
+		return resp.tags !== undefined && resp.tags.length != 0;
+	});
+	if (json) {
+		logger.log(JSON.stringify(responses, null, 2));
+	} else {
+		const rows = responses
+			.map((resp) => {
+				return {
+					REPOSITORY: resp.name,
+					TAG: resp.tags.join(" "),
+				};
+			})
+			.flat();
+		logger.table(rows);
+	}
+}
+
+async function listTags(repo: string, creds: string): Promise<string[]> {
+	const url = new URL(`https://${domain}`);
+	const baseUrl = `${url.protocol}//${url.host}`;
+	const tagsUrl = `${baseUrl}/v2/${repo}/tags/list`;
+
+	const tagsResponse = await fetch(tagsUrl, {
+		method: "GET",
+		headers: {
+			Authorization: `Basic ${creds}`,
+		},
+	});
+	const tagsData = (await tagsResponse.json()) as TagsResponse;
+	return tagsData.tags || [];
+}
+
+async function listRepos(creds: string): Promise<string[]> {
+	const url = new URL(`https://${domain}`);
+
+	const catalogUrl = `${url.protocol}//${url.host}/v2/_catalog`;
+
+	const response = await fetch(catalogUrl, {
+		method: "GET",
+		headers: {
+			Authorization: `Basic ${creds}`,
+		},
+	});
+	if (!response.ok) {
+		console.log(JSON.stringify(response));
+		throw new Error(
+			`Failed to fetch repository catalog: ${response.status} ${response.statusText}`
+		);
+	}
+
+	const data = (await response.json()) as CatalogResponse;
+
+	return data.repositories || [];
+}
+
+async function deleteTag(
+	baseUrl: string,
+	image: string,
+	tag: string,
+	creds: string
+) {
+	const manifestAcceptHeader =
+		"application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json";
+	const manifestUrl = `${baseUrl}/v2/${image}/manifests/${tag}`;
+	// grab the digest for this tag
+	const headResponse = await fetch(manifestUrl, {
+		method: "HEAD",
+		headers: {
+			Authorization: `Basic ${creds}`,
+			Accept: manifestAcceptHeader,
+		},
+	});
+	if (!headResponse.ok) {
+		throw new Error(
+			`failed to retrieve tag info for ${tag}: ${headResponse.status} ${headResponse.statusText}`
+		);
+	}
+
+	const digest = headResponse.headers.get("Docker-Content-Digest");
+	if (!digest) {
+		throw new Error(`Digest not found for tag "${tag}".`);
+	}
+
+	const deleteUrl = `${baseUrl}/v2/${image}/manifests/${tag}`;
+	const deleteResponse = await fetch(deleteUrl, {
+		method: "DELETE",
+		headers: {
+			Authorization: `Basic ${creds}`,
+			Accept: manifestAcceptHeader,
+		},
+	});
+
+	if (!deleteResponse.ok) {
+		throw new Error(
+			`Failed to delete tag "${tag}" (digest: ${digest}): ${deleteResponse.status} ${deleteResponse.statusText}`
+		);
+	}
+}
+
+async function getCreds(): Promise<string> {
+	return await ImageRegistriesService.generateImageRegistryCredentials(domain, {
+		expiration_minutes: 5,
+		permissions: ["pull", "push"] as ImageRegistryPermissions[],
+	}).then(async (credentials) => {
+		return Buffer.from(`v1:${credentials.password}`).toString("base64");
+	});
+}

--- a/packages/wrangler/src/cloudchamber/index.ts
+++ b/packages/wrangler/src/cloudchamber/index.ts
@@ -5,6 +5,7 @@ import { createCommand, createCommandOptionalYargs } from "./create";
 import { curlCommand, yargsCurl } from "./curl";
 import { deleteCommand, deleteCommandOptionalYargs } from "./delete";
 import { registriesCommand } from "./images/images";
+import { imagesCommand } from "./images/list";
 import { listCommand, listDeploymentsYargs } from "./list";
 import { modifyCommand, modifyCommandOptionalYargs } from "./modify";
 import { sshCommand } from "./ssh/ssh";
@@ -81,5 +82,10 @@ export const cloudchamber = (
 			"push a tagged image to a Cloudflare managed registry, which is automatically integrated with your account",
 			(args) => pushYargs(args),
 			(args) => handleFailure(pushCommand)(args)
+		)
+		.command(
+			"images",
+			"perform operations on images in your clouchamber registry",
+			(args) => imagesCommand(args).command(subHelp)
 		);
 };


### PR DESCRIPTION
Adds a cloudchamber images {list,delete} commands for operating on the cloudchamber managed registry.
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No e2e test for Cloudchamber yet
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: The cloudchamber subcommand is not documented in that repo.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
