### PR TITLE
Always use labels for E2E

### DIFF
--- a/.github/pr-labeler.config.yml
+++ b/.github/pr-labeler.config.yml
@@ -1,15 +1,11 @@
-# add 'e2e' label to any changes within the 'packages/wrangler/e2e' directory
 e2e:
-  - all:
+  - any:
       - changed-files:
           - any-glob-to-any-file: "packages/wrangler/e2e/**/*"
+      - head-branch: "changeset-release/main"
 
 c3-e2e:
-  - all:
+  - any:
       - changed-files:
           - any-glob-to-any-file: "packages/create-cloudflare/**/*"
-
-# add 'skip-pr-description-validation' label to Version Packages PRs
-skip-pr-description-validation:
-  - all:
       - head-branch: "changeset-release/main"

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -1,14 +1,11 @@
 name: C3 E2E Tests
 on:
-  push:
-    branches:
-      - changeset-release/main
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
 jobs:
   turbo-ignore:
-    if: (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains(github.event.*.labels.*.name, 'c3-e2e' ) && github.event.pull_request.head.repo.owner.login == 'cloudflare'))
+    if: contains(github.event.*.labels.*.name, 'c3-e2e' ) && github.event.pull_request.head.repo.owner.login == 'cloudflare'
     outputs:
       skip: ${{ steps.skip.outcome }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,6 @@
 name: E2E tests
 
 on:
-  push:
-    branches:
-      - changeset-release/main
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
   repository_dispatch:
@@ -14,7 +11,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.node }}
       cancel-in-progress: true
     timeout-minutes: 40
-    if: (github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains(github.event.*.labels.*.name, 'e2e' ) && github.event.pull_request.head.repo.owner.login == 'cloudflare'))
+    if: github.event_name == 'pull_request' && contains(github.event.*.labels.*.name, 'e2e' ) && github.event.pull_request.head.repo.owner.login == 'cloudflare'
     name: "E2E Test"
     strategy:
       fail-fast: false


### PR DESCRIPTION
Simplifies the E2E setup by only running C3 E2E and Wrangler E2E when the relevant label is applied, and then automatically applying that label to Version Packages. Previously, in some cases E2E tests were running _twice_ on Version Packages (because of the automatic label, and then the override to always run on Version Packages)

Additionally, remove the `skip-pr-description` label from Version Packages, since PR description validation is already skipped on that branch.