### PR TITLE
feat(vitest-pool-workers): pre bundle chai with vite instead of esbuild

### DIFF
--- a/.changeset/shy-cooks-flow.md
+++ b/.changeset/shy-cooks-flow.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+feat: pre-bundle chai with vite instead of esbuild

--- a/packages/vitest-pool-workers/package.json
+++ b/packages/vitest-pool-workers/package.json
@@ -55,7 +55,6 @@
 		"birpc": "0.2.14",
 		"cjs-module-lexer": "^1.2.3",
 		"devalue": "^4.3.0",
-		"esbuild": "catalog:default",
 		"miniflare": "workspace:*",
 		"semver": "^7.7.1",
 		"wrangler": "workspace:*",

--- a/packages/vitest-pool-workers/src/config/index.ts
+++ b/packages/vitest-pool-workers/src/config/index.ts
@@ -154,6 +154,8 @@ function createConfigPlugin(): Plugin<WorkersConfigPluginAPI> {
 			config.test.deps.optimizer ??= {};
 			config.test.deps.optimizer.ssr ??= {};
 			config.test.deps.optimizer.ssr.enabled ??= true;
+			config.test.deps.optimizer.ssr.include ??= [];
+			ensureArrayIncludes(config.test.deps.optimizer.ssr.include, ["chai"]);
 			config.test.deps.optimizer.ssr.exclude ??= [];
 			ensureArrayIncludes(config.test.deps.optimizer.ssr.exclude, [
 				...workerdBuiltinModules,

--- a/packages/vitest-pool-workers/src/pool/module-fallback.ts
+++ b/packages/vitest-pool-workers/src/pool/module-fallback.ts
@@ -6,7 +6,6 @@ import posixPath from "node:path/posix";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import util from "node:util";
 import * as cjsModuleLexer from "cjs-module-lexer";
-import { buildSync } from "esbuild";
 import { ModuleRuleTypeSchema, Response } from "miniflare";
 import { workerdBuiltinModules } from "../shared/builtin-modules";
 import { isFileNotFoundError } from "./helpers";
@@ -67,10 +66,6 @@ function trimViteVersionHash(filePath: string) {
 const forceModuleTypeRegexp = new RegExp(
 	`\\?mf_vitest_force=(${ModuleRuleTypeSchema.options.join("|")})$`
 );
-
-// `chai` contains circular `require()`s which aren't supported by `workerd`
-// TODO(someday): support circular `require()` in `workerd`
-const bundleDependencies = ["chai"];
 
 function isFile(filePath: string): boolean {
 	try {
@@ -203,30 +198,6 @@ function withSourceUrl(contents: string, url: string | URL): string {
 function withImportMetaUrl(contents: string, url: string | URL): string {
 	// TODO(soon): this isn't perfect, ideally need `workerd` support
 	return contents.replaceAll("import.meta.url", JSON.stringify(url.toString()));
-}
-
-const bundleCache = new Map<string, string>();
-function bundleDependency(entryPath: string): string {
-	let output = bundleCache.get(entryPath);
-	if (output !== undefined) {
-		return output;
-	}
-	debuglog(`Bundling ${entryPath}...`);
-	const result = buildSync({
-		platform: "node",
-		target: "esnext",
-		format: "cjs",
-		bundle: true,
-		packages: "external",
-		sourcemap: "inline",
-		sourcesContent: false,
-		entryPoints: [entryPath],
-		write: false,
-	});
-	assert(result.outputFiles.length === 1);
-	output = result.outputFiles[0].text;
-	bundleCache.set(entryPath, output);
-	return output;
 }
 
 const jsExtensions = [".js", ".mjs", ".cjs"];
@@ -483,18 +454,11 @@ async function load(
 		filePath = trimSuffix(disableCjsEsmShimSuffix, filePath);
 	}
 
-	let isEsm =
+	const isEsm =
 		filePath.endsWith(".mjs") ||
 		(filePath.endsWith(".js") && isWithinTypeModuleContext(filePath));
 
-	let contents: string;
-	const maybeBundled = bundleCache.get(filePath);
-	if (maybeBundled !== undefined) {
-		contents = maybeBundled;
-		isEsm = false;
-	} else {
-		contents = fs.readFileSync(filePath, "utf8");
-	}
+	let contents = fs.readFileSync(filePath, "utf8");
 	const targetUrl = pathToFileURL(target);
 	contents = withSourceUrl(contents, targetUrl);
 
@@ -566,9 +530,7 @@ export async function handleModuleFallbackRequest(
 
 	try {
 		const filePath = await resolve(vite, method, target, specifier, referrer);
-		if (bundleDependencies.includes(specifier)) {
-			bundleDependency(filePath);
-		}
+
 		return await load(vite, logBase, method, target, specifier, filePath);
 	} catch (e) {
 		debuglog(logBase, "error:", e);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2699,9 +2699,6 @@ importers:
       devalue:
         specifier: ^4.3.0
         version: 4.3.2
-      esbuild:
-        specifier: catalog:default
-        version: 0.25.2
       miniflare:
         specifier: workspace:*
         version: link:../miniflare
@@ -16509,7 +16506,7 @@ snapshots:
   '@vitest/utils@2.1.8':
     dependencies:
       '@vitest/pretty-format': 2.1.8
-      loupe: 3.1.2
+      loupe: 3.1.3
       tinyrainbow: 1.2.0
 
   '@vitest/utils@2.1.9':


### PR DESCRIPTION
Fixes n/a

We were pre-bundling `chai` with esbuild to get around an issue with circular `require()`. This is now [fixed](https://github.com/cloudflare/workers-sdk/issues/5367) and so we can drop `esbuild` from the dependencies. Instead, we now pre-bundle `chai` with vite to reduce the number of modules workerd must parse at runtime as an optimization.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact to wrangler / vite
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: no impact to wrangler

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

