### PR TITLE
feat(vitest-pool-workers): step-through debugging

### DIFF
--- a/.changeset/small-news-kneel.md
+++ b/.changeset/small-news-kneel.md
@@ -4,6 +4,10 @@
 
 Added step-through debugging support with Vitest.
 
-You can now debug your workers tests by running `vitest --inspect --no-file-parallelism`. This opens an inspector on port 9229 by default, allowing you to step through your code with a `debugger` statement when a debugger is attached.
+To start debugging, run Vitest with the following command and attach a debugger to port 9229:
+
+```sh
+vitest --inspect=9229 --no-file-parallelism
+```
 
 For more details, check out our [Vitest Debugging guide](https://developers.cloudflare.com/workers/testing/vitest-integration/debugging).

--- a/.changeset/small-news-kneel.md
+++ b/.changeset/small-news-kneel.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Added step-through debugging support with Vitest.
+
+You can now debug your workers tests by running `vitest --inspect --no-file-parallelism`. This opens an inspector on port 9229 by default, allowing you to step through your code with a `debugger` statement when a debugger is attached.
+
+For more details, check out our [Vitest Debugging guide](https://developers.cloudflare.com/workers/testing/vitest-integration/debugging).

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -561,7 +561,7 @@ function buildProjectMiniflareOptions(
 		: undefined;
 
 	if (inspectorPort !== undefined && !project.options.singleWorker) {
-		log.warn(`Tests run in a single worker when the inspector is open.`);
+		log.warn(`Tests run in singleWorker mode when the inspector is open.`);
 
 		project.options.singleWorker = true;
 	}

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -892,7 +892,7 @@ function validateInspectorConfig(config: SerializedConfig) {
 	if (config.inspector.enabled && !warnedUnsupportedInspectorOptions) {
 		if (config.inspectBrk) {
 			log.warn(
-				`The "--inspect-brk" flag is not supported. Fallback to "--inspect".`
+				`The "--inspect-brk" flag is not supported. Use "--inspect" instead.`
 			);
 		} else if (config.inspector.waitForDebugger) {
 			log.warn(

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -560,7 +560,6 @@ function buildProjectMiniflareOptions(
 		? ctx.config.inspector.port ?? 9229
 		: undefined;
 
-	// If the inspectorPort is not set, check if the Node inspector is running
 	if (inspectorPort !== undefined && !project.options.singleWorker) {
 		log.warn(`Tests run in a single worker when the inspector is open.`);
 

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -556,6 +556,17 @@ function buildProjectMiniflareOptions(
 	assert(runnerWorker.name !== undefined);
 	assert(runnerWorker.name.startsWith(WORKER_NAME_PREFIX));
 
+	const inspectorPort = ctx.config.inspector.enabled
+		? ctx.config.inspector.port ?? 9229
+		: undefined;
+
+	// If the inspectorPort is not set, check if the Node inspector is running
+	if (inspectorPort !== undefined && !project.options.singleWorker) {
+		log.warn(`Tests run in a single worker when the inspector is open.`);
+
+		project.options.singleWorker = true;
+	}
+
 	if (project.options.singleWorker || project.options.isolatedStorage) {
 		// Single Worker, Isolated or Shared Storage
 		//  --> single instance with single runner worker
@@ -563,6 +574,7 @@ function buildProjectMiniflareOptions(
 		//  --> multiple instances each with single runner worker
 		return {
 			...SHARED_MINIFLARE_OPTIONS,
+			inspectorPort,
 			unsafeModuleFallbackService: moduleFallbackService,
 			workers: [runnerWorker, ABORT_ALL_WORKER, ...auxiliaryWorkers],
 		};
@@ -610,7 +622,11 @@ async function getProjectMiniflare(
 	if (project.mf === undefined) {
 		// If `mf` is now `undefined`, create new instances
 		if (singleInstance) {
-			log.info(`Starting single runtime for ${project.relativePath}...`);
+			log.info(
+				`Starting single runtime for ${project.relativePath}` +
+					`${mfOptions.inspectorPort !== undefined ? ` with inspector on port ${mfOptions.inspectorPort}` : ""}` +
+					`...`
+			);
 			project.mf = new Miniflare(mfOptions);
 		} else {
 			log.info(`Starting isolated runtimes for ${project.relativePath}...`);
@@ -864,6 +880,31 @@ function assertCompatibleVitestVersion(ctx: Vitest) {
 		log.warn(message);
 	}
 }
+
+let warnedUnsupportedInspectorOptions = false;
+
+function validateInspectorConfig(config: SerializedConfig) {
+	if (config.inspector.host) {
+		throw new TypeError(
+			"Customizing inspector host is not supported with vitest-pool-workers."
+		);
+	}
+
+	if (config.inspector.enabled && !warnedUnsupportedInspectorOptions) {
+		if (config.inspectBrk) {
+			log.warn(
+				`The "--inspect-brk" flag is not supported. Fallback to "--inspect".`
+			);
+		} else if (config.inspector.waitForDebugger) {
+			log.warn(
+				`The "inspector.waitForDebugger" option is not supported. Insert a debugger statement if you need to pause execution.`
+			);
+		}
+
+		warnedUnsupportedInspectorOptions = true;
+	}
+}
+
 async function executeMethod(
 	ctx: Vitest,
 	specs: TestSpecification[],
@@ -931,6 +972,13 @@ async function executeMethod(
 			(timerMethod) =>
 				timerMethod !== "setImmediate" && timerMethod !== "clearImmediate"
 		);
+
+		validateInspectorConfig(config);
+
+		// We don't want it to call `node:inspector` inside Workerd
+		config.inspector = {
+			enabled: false,
+		};
 
 		// We don't need all pool options from the config at runtime.
 		// Additionally, users may set symbols in the config which aren't

--- a/packages/vitest-pool-workers/test/inspector.test.ts
+++ b/packages/vitest-pool-workers/test/inspector.test.ts
@@ -1,0 +1,113 @@
+import dedent from "ts-dedent";
+import { test, waitFor } from "./helpers";
+
+test("opens an inspector with the `--inspect` argument", async ({
+	expect,
+	seed,
+	vitestDev,
+}) => {
+	await seed({
+		"vitest.config.mts": dedent`
+			import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+			export default defineWorkersConfig({
+				test: {
+					poolOptions: {
+						workers: {
+							main: "./index.ts",
+							singleWorker: true,
+							miniflare: {
+								compatibilityDate: "2024-01-01",
+								compatibilityFlags: ["nodejs_compat"],
+							},
+						},
+					},
+				}
+			});
+		`,
+		"index.ts": dedent`
+			export default {
+				async fetch(request, env, ctx) {
+					return new Response("hello world");
+				}
+			}
+		`,
+		"index.test.ts": dedent`
+			import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+			import { it, expect } from "vitest";
+			import worker from "./index";
+			it("sends request", async () => {
+				const request = new Request("https://example.com");
+				const ctx = createExecutionContext();
+				const response = await worker.fetch(request, env, ctx);
+				await waitOnExecutionContext(ctx);
+				expect(await response.text()).toBe("hello world");
+			});
+		`,
+	});
+	const result = vitestDev({
+		flags: ["--inspect", "--no-file-parallelism"],
+	});
+
+	await waitFor(() => {
+		expect(result.stdout).toMatch("inspector on port 9229");
+	});
+});
+
+test("customize inspector config", async ({ expect, seed, vitestDev }) => {
+	await seed({
+		"vitest.config.mts": dedent`
+			import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+			export default defineWorkersConfig({
+				test: {
+					inspector: {
+						// Test if this overrides the inspector port
+						port: 3456,
+					},
+					poolOptions: {
+						workers: {
+							main: "./index.ts",
+							// Test if we warn and override the singleWorker option when the inspector is open
+							singleWorker: false,
+							miniflare: {
+								compatibilityDate: "2024-01-01",
+								compatibilityFlags: ["nodejs_compat"],
+							},
+						},
+					},
+				}
+			});
+		`,
+		"index.ts": dedent`
+			export default {
+				async fetch(request, env, ctx) {
+					return new Response("hello world");
+				}
+			}
+		`,
+		"index.test.ts": dedent`
+			import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+			import { it, expect } from "vitest";
+			import worker from "./index";
+			it("sends request", async () => {
+				const request = new Request("https://example.com");
+				const ctx = createExecutionContext();
+				const response = await worker.fetch(request, env, ctx);
+				await waitOnExecutionContext(ctx);
+				expect(await response.text()).toBe("hello world");
+			});
+		`,
+	});
+	const result = vitestDev({
+		// Test if we warn and ignore the `waitForDebugger` option
+		flags: ["--inspect-brk", "--no-file-parallelism"],
+	});
+
+	await waitFor(() => {
+		expect(result.stdout).toMatch(
+			"Tests run in a single worker when the inspector is open."
+		);
+		expect(result.stdout).toMatch(`The "--inspect-brk" flag is not supported.`);
+		expect(result.stdout).toMatch("Starting single runtime");
+		expect(result.stdout).toMatch("inspector on port 3456");
+	});
+});

--- a/packages/vitest-pool-workers/test/inspector.test.ts
+++ b/packages/vitest-pool-workers/test/inspector.test.ts
@@ -104,7 +104,7 @@ test("customize inspector config", async ({ expect, seed, vitestDev }) => {
 
 	await waitFor(() => {
 		expect(result.stdout).toMatch(
-			"Tests run in a single worker when the inspector is open."
+			"Tests run in singleWorker mode when the inspector is open."
 		);
 		expect(result.stdout).toMatch(`The "--inspect-brk" flag is not supported.`);
 		expect(result.stdout).toMatch("Starting single runtime");


### PR DESCRIPTION
Fixes #5391

Added step-through debugging support with Vitest.

You can now debug your workers tests by running `vitest --inspect --no-file-parallelism` which opens an inspector on port 9229 by default.

If you are using vscode, you can creates a `.vscode/launch.json` file that contains the following:

```json
{
    "configurations": [
        {
            "type": "node",
            "request": "launch",
            "name": "Open inspector with Vitest",
            "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
            "console": "integratedTerminal",
            "args": ["--inspect=9229", "--no-file-parallelism"]
        },
        {
            "name": "Attach to Workers Runtime",
            "type": "node",
            "request": "attach",
            "port": 9229,
            "cwd": "/",
            "resolveSourceMapLocations": null,
            "attachExistingChildren": false,
            "autoAttachChildProcesses": false,
        }
    ],
    "compounds": [
        {
            "name": "Debug Workers tests",
            "configurations": ["Open inspector with Vitest", "Attach to Workers Runtime"],
            "stopAll": true
        }
    ]
}
```


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact to wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/20360
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
