### PR TITLE
fix: interactively list Cloudchamber deployments using labels

### DIFF
--- a/.changeset/public-groups-thank.md
+++ b/.changeset/public-groups-thank.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: interactively list Cloudchamber deployments using labels

--- a/packages/wrangler/src/cloudchamber/cli/deployments.ts
+++ b/packages/wrangler/src/cloudchamber/cli/deployments.ts
@@ -77,6 +77,7 @@ export async function loadDeployments(
 		image?: string;
 		state?: string;
 		ipv4?: string;
+		labels?: string[];
 	}
 ): Promise<DeploymentV2[]> {
 	const { start, stop } = spinner();
@@ -87,7 +88,8 @@ export async function loadDeployments(
 			deploymentsParams?.location,
 			deploymentsParams?.image,
 			deploymentsParams?.state as DeploymentPlacementState | undefined,
-			deploymentsParams?.state
+			deploymentsParams?.state,
+			deploymentsParams?.labels
 		)
 	);
 


### PR DESCRIPTION
The `--label` arguments were ignored when listing deployments interactively.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no test coverage of interactive flow
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required (triggered action https://github.com/cloudflare/workers-sdk/actions/runs/13572114935)
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not a documented aspect of the feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
