### PR TITLE
fix: make services.environment config work with wrangler dev

### DIFF
--- a/packages/wrangler/src/dev-registry/index.ts
+++ b/packages/wrangler/src/dev-registry/index.ts
@@ -69,7 +69,7 @@ export async function getBoundRegisteredWorkers(
 	existingWorkerDefinitions?: WorkerRegistry | undefined
 ): Promise<WorkerRegistry | undefined> {
 	const serviceNames = (services || []).map(
-		(serviceBinding) => serviceBinding.service
+		(serviceBinding) => serviceBinding.environment ? `${serviceBinding.service}-${serviceBinding.environment}` : serviceBinding.service
 	);
 	const durableObjectServices = (
 		durableObjects || { bindings: [] }


### PR DESCRIPTION
Fix an trivial issue where environment settings in the services array of wrangler.jsonc were not being properly applied when running `wrangler dev` command.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because: 
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
