### PR TITLE
Add support for binding to named entrypoints in the same Worker

### DIFF
--- a/.changeset/bitter-teeth-think.md
+++ b/.changeset/bitter-teeth-think.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Add support for binding to named entrypoints in the same worker

--- a/packages/vite-plugin-cloudflare/playground/node-compat/worker-basic/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/worker-basic/index.ts
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import { join } from "path";
 // Check that we can actually import unenv polyfilled modules in user source.
 import "perf_hooks";
+// Check that `cloudflare:worker` imports work when `nodejs_compat` is enabled
+import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
+
+export class MyWorkerEntrypoint extends WorkerEntrypoint {}
+export class MyDurableObject extends DurableObject {}
 
 export default {
 	async fetch() {

--- a/packages/vite-plugin-cloudflare/playground/node-compat/worker-basic/wrangler.toml
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/worker-basic/wrangler.toml
@@ -2,3 +2,14 @@ name = "worker"
 main = "./index.ts"
 compatibility_date = "2024-12-30"
 compatibility_flags = ["nodejs_compat"]
+
+services = [
+	{ binding = "MY_SERVICE", service = "worker", entrypoint = "MyWorkerEntrypoint" },
+]
+
+[durable_objects]
+bindings = [{ name = "MY_DO", class_name = "MyDurableObject" }]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["MyDurableObject"]

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/__tests__/same-worker-service-bindings.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/__tests__/same-worker-service-bindings.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "vitest";
+import { getJsonResponse } from "../../__test-utils__";
+
+test("calls an RPC method on a named entrypoint in the same worker", async () => {
+	const result = await getJsonResponse();
+	expect(result).toEqual({ result: 20 });
+});

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/package.json
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@playground/same-worker-service-bindings",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build --app",
+		"check:types": "tsc --build",
+		"dev": "vite dev",
+		"preview": "vite preview"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "workspace:*",
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "^4.20250214.0",
+		"typescript": "catalog:default",
+		"vite": "catalog:vite-plugin",
+		"wrangler": "catalog:vite-plugin"
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/src/index.ts
@@ -1,0 +1,18 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+interface Env {
+	NAMED_ENTRYPOINT: Fetcher<NamedEntrypoint>;
+}
+
+export class NamedEntrypoint extends WorkerEntrypoint {
+	multiply(a: number, b: number) {
+		return a * b;
+	}
+}
+
+export default {
+	async fetch(request, env) {
+		const result = await env.NAMED_ENTRYPOINT.multiply(4, 5);
+		return Response.json({ result });
+	},
+} satisfies ExportedHandler<Env>;

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/tsconfig.json
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/tsconfig.node.json
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/tsconfig.node.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/base.json"],
+	"include": ["vite.config.ts", "__tests__"]
+}

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/tsconfig.worker.json
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/tsconfig.worker.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/worker.json"],
+	"include": ["src"]
+}

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/turbo.json
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://turbo.build/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["dist/**"]
+		}
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/vite.config.ts
@@ -1,0 +1,6 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [cloudflare({ persistState: false })],
+});

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/wrangler.toml
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/wrangler.toml
@@ -1,0 +1,7 @@
+name = "worker"
+main = "./src/index.ts"
+compatibility_date = "2024-12-30"
+
+services = [
+	{ binding = "NAMED_ENTRYPOINT", service = "worker", entrypoint = "NamedEntrypoint" },
+]

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -3,7 +3,12 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { Log, LogLevel, Response as MiniflareResponse } from "miniflare";
+import {
+	kCurrentWorker,
+	Log,
+	LogLevel,
+	Response as MiniflareResponse,
+} from "miniflare";
 import * as vite from "vite";
 import {
 	unstable_getMiniflareWorkerOptions,
@@ -76,14 +81,14 @@ function getWorkerToWorkerEntrypointNamesMap(
 			if (
 				typeof value === "object" &&
 				"name" in value &&
-				typeof value.name === "string" &&
 				value.entrypoint !== undefined &&
 				value.entrypoint !== "default"
 			) {
-				const entrypointNames = workerToWorkerEntrypointNamesMap.get(
-					value.name
-				);
-				assert(entrypointNames, missingWorkerErrorMessage(value.name));
+				const targetWorkerName =
+					value.name === kCurrentWorker ? worker.name : value.name;
+				const entrypointNames =
+					workerToWorkerEntrypointNamesMap.get(targetWorkerName);
+				assert(entrypointNames, missingWorkerErrorMessage(targetWorkerName));
 
 				entrypointNames.add(value.entrypoint);
 			}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2163,6 +2163,27 @@ importers:
         specifier: catalog:vite-plugin
         version: 3.109.1(@cloudflare/workers-types@4.20250214.0)
 
+  packages/vite-plugin-cloudflare/playground/same-worker-service-bindings:
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: workspace:*
+        version: link:../..
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../../workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20250214.0
+        version: 4.20250214.0
+      typescript:
+        specifier: catalog:default
+        version: 5.7.3
+      vite:
+        specifier: catalog:vite-plugin
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+      wrangler:
+        specifier: catalog:vite-plugin
+        version: 3.109.1(@cloudflare/workers-types@4.20250214.0)
+
   packages/vite-plugin-cloudflare/playground/spa-with-api:
     dependencies:
       react:


### PR DESCRIPTION
Fixes #000

This adds support for binding to named entrypoints in the same Worker.

Additionally, this adds `cloudflare:workers` imports to the `node-compat/worker-basic` playground so that we have tests to confirm that Cloudflare builtins can be used when `nodejs_compat` is enabled.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
