### PR TITLE
vite-plugin: show warning if the user has forgotten to turn on nodejs_compat 

### DIFF
--- a/.changeset/loud-worlds-ask.md
+++ b/.changeset/loud-worlds-ask.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Show warning if the user has forgotten to turn on nodejs_compat

--- a/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-warnings/warnings.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-warnings/warnings.spec.ts
@@ -4,18 +4,7 @@ import dedent from "ts-dedent";
 import { expect, test, vi } from "vitest";
 import { serverLogs } from "../../../__test-utils__";
 
-test("should display warnings if nodejs_compat is missing", async ({
-	onTestFinished,
-}) => {
-	const wranglerConfigPath = join(
-		__dirname,
-		"../../worker-warnings/wrangler.toml"
-	);
-	const originalWranglerConfig = readFileSync(wranglerConfigPath, "utf8");
-	onTestFinished(() => {
-		writeFileSync(wranglerConfigPath, originalWranglerConfig);
-	});
-
+test("should display warnings if nodejs_compat is missing", async () => {
 	await vi.waitFor(async () => {
 		expect(serverLogs.warns[0]?.replaceAll("\\", "/")).toContain(
 			dedent`

--- a/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-warnings/warnings.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-warnings/warnings.spec.ts
@@ -1,0 +1,29 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import dedent from "ts-dedent";
+import { expect, test, vi } from "vitest";
+import { serverLogs } from "../../../__test-utils__";
+
+test("should display warnings if nodejs_compat is missing", async ({
+	onTestFinished,
+}) => {
+	const wranglerConfigPath = join(
+		__dirname,
+		"../../worker-warnings/wrangler.toml"
+	);
+	const originalWranglerConfig = readFileSync(wranglerConfigPath, "utf8");
+	onTestFinished(() => {
+		writeFileSync(wranglerConfigPath, originalWranglerConfig);
+	});
+
+	await vi.waitFor(async () => {
+		expect(serverLogs.warns[0]?.replaceAll("\\", "/")).toContain(
+			dedent`
+				Unexpected Node.js imports for environment "worker". Do you need to enable the "nodejs_compat" compatibility flag?
+				Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.
+				 - "node:assert/strict" imported from "worker-warnings/index.ts"
+				 - "perf_hooks" imported from "worker-warnings/index.ts"
+				`
+		);
+	});
+});

--- a/packages/vite-plugin-cloudflare/playground/node-compat/package.json
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/package.json
@@ -33,7 +33,11 @@
 		"random:build": "vite build --app -c vite.config.worker-random.ts",
 		"random:dev": "vite dev -c vite.config.worker-random.ts",
 		"random:preview": "vite preview -c vite.config.worker-random.ts",
-		"random:test": "vitest run -c ../vitest.config.e2e.ts worker-random"
+		"random:test": "vitest run -c ../vitest.config.e2e.ts worker-random",
+		"warnings:build": "vite build --app -c vite.config.worker-warnings.ts",
+		"warnings:dev": "vite dev -c vite.config.worker-warnings.ts",
+		"warnings:preview": "vite preview -c vite.config.worker-warnings.ts",
+		"warnings:test": "vitest run -c ../vitest.config.e2e.ts worker-warnings"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",

--- a/packages/vite-plugin-cloudflare/playground/node-compat/tsconfig.worker.json
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/tsconfig.worker.json
@@ -6,6 +6,7 @@
 		"worker-crypto",
 		"worker-postgres",
 		"worker-process",
-		"worker-random"
+		"worker-random",
+		"worker-warnings"
 	]
 }

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-warnings.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-warnings.ts
@@ -1,0 +1,15 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	build: {
+		outDir: "dist/worker-warnings",
+	},
+	plugins: [
+		cloudflare({
+			configPath: "./worker-warnings/wrangler.toml",
+			inspectorPort: false,
+			persistState: false,
+		}),
+	],
+});

--- a/packages/vite-plugin-cloudflare/playground/node-compat/worker-warnings/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/worker-warnings/index.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+// Check that we can actually import unenv polyfilled modules in user source.
+import "perf_hooks";
+
+export default {
+	async fetch() {
+		assert(true, "the world is broken");
+		return new Response("OK!");
+	},
+} satisfies ExportedHandler;

--- a/packages/vite-plugin-cloudflare/playground/node-compat/worker-warnings/wrangler.toml
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/worker-warnings/wrangler.toml
@@ -1,0 +1,5 @@
+name = "worker"
+main = "./index.ts"
+compatibility_date = "2024-12-30"
+# Do not turn on Node.js compatibility to trigger the warnings
+# compatibility_flags = ["nodejs_compat"]

--- a/packages/vite-plugin-cloudflare/playground/package.json
+++ b/packages/vite-plugin-cloudflare/playground/package.json
@@ -14,6 +14,7 @@
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"playwright-chromium": "catalog:default",
+		"ts-dedent": "^2.2.0",
 		"typescript": "catalog:default"
 	}
 }

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -59,11 +59,6 @@ let workersConfigsWarningShown = false;
 
 let miniflare: Miniflare | undefined;
 
-const nodeJsCompatWarningsMap = new WeakMap<
-	WorkerConfig,
-	NodeJsCompatWarnings
->();
-
 /**
  * Vite plugin that enables a full-featured integration between Vite and the Cloudflare Workers runtime.
  *
@@ -76,6 +71,8 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 	let resolvedViteConfig: vite.ResolvedConfig;
 
 	const additionalModulePaths = new Set<string>();
+
+	const nodeJsCompatWarningsMap = new Map<WorkerConfig, NodeJsCompatWarnings>();
 
 	// This is set when the client environment is built to determine if the entry Worker should include assets
 	let hasClientBuild = false;
@@ -667,9 +664,8 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 											build.onResolve(
 												{ filter: NODEJS_MODULES_RE },
 												({ path, importer }) => {
-													// We have to delay getting this object from the map to here
-													// It has not been created at the point that the `configEnvironment()` hook is called.
-													// It only gets created in the
+													// We have to delay getting this `nodeJsCompatWarnings` from the `nodeJsCompatWarningsMap` until we are in this function.
+													// It has not been added to the map until the `configureServer()` hook is called, which is after the `configEnvironment()` hook.
 													const nodeJsCompatWarnings =
 														nodeJsCompatWarningsMap.get(workerConfig);
 													assert(

--- a/packages/vite-plugin-cloudflare/src/node-js-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/node-js-compat.ts
@@ -152,9 +152,7 @@ export class NodeJsCompatWarnings {
 	registerImport(source: string, importer = "<unknown>") {
 		const importers = this.sources.get(source) ?? new Set();
 		this.sources.set(source, importers);
-		if (!importers.has(importer)) {
-			importers.add(importer);
-		}
+		importers.add(importer);
 	}
 
 	renderWarningsOnIdle() {

--- a/packages/vite-plugin-cloudflare/src/node-js-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/node-js-compat.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert";
+import { builtinModules } from "node:module";
+import path from "node:path";
 import { cloudflare } from "@cloudflare/unenv-preset";
 import MagicString from "magic-string";
 import { getNodeCompat } from "miniflare";
 import { resolvePathSync } from "mlly";
 import { defineEnv } from "unenv";
+import * as vite from "vite";
 import type { WorkerConfig } from "./plugin-config";
 
 const { env } = defineEnv({
@@ -15,11 +18,20 @@ export const nodeCompatExternals = new Set(env.external);
 export const nodeCompatEntries = getNodeCompatEntries();
 
 /**
+ * All the Node.js modules including their `node:...` aliases.
+ */
+export const nodejsBuiltins = new Set([
+	...builtinModules,
+	...builtinModules.map((m) => `node:${m}`),
+]);
+export const NODEJS_MODULES_RE = new RegExp(
+	`^(node:)?(${builtinModules.join("|")})$`
+);
+
+/**
  * Returns true if the given combination of compat dates and flags means that we need Node.js compatibility.
  */
-export function isNodeCompat(
-	workerConfig: WorkerConfig | undefined
-): workerConfig is WorkerConfig {
+export function isNodeCompat(workerConfig: WorkerConfig | undefined) {
 	if (workerConfig === undefined) {
 		return false;
 	}
@@ -129,4 +141,46 @@ function getNodeCompatEntries() {
 	nodeCompatExternals.forEach((external) => entries.delete(external));
 
 	return entries;
+}
+
+export class NodeJsCompatWarnings {
+	private sources = new Map<string, Set<string>>();
+	private timer: NodeJS.Timeout | undefined;
+
+	constructor(private readonly environment: vite.Environment) {}
+
+	registerImport(source: string, importer = "<unknown>") {
+		const importers = this.sources.get(source) ?? new Set();
+		this.sources.set(source, importers);
+		if (!importers.has(importer)) {
+			importers.add(importer);
+		}
+	}
+
+	renderWarningsOnIdle() {
+		if (this.timer) {
+			clearTimeout(this.timer);
+		}
+		this.timer = setTimeout(() => {
+			this.renderWarnings();
+			this.timer = undefined;
+		}, 500);
+	}
+
+	renderWarnings() {
+		if (this.sources.size > 0) {
+			let message =
+				`\n\nUnexpected Node.js imports for environment "${this.environment.name}". Do you need to enable the "nodejs_compat" compatibility flag?\n` +
+				"Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.\n";
+			this.sources.forEach((importers, source) => {
+				importers.forEach((importer) => {
+					message += ` - "${source}" imported from "${path.relative(this.environment.config.root, importer)}"\n`;
+				});
+			});
+			this.environment.logger.warn(message, {
+				environment: this.environment.name,
+			});
+			this.sources.clear();
+		}
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1918,6 +1918,9 @@ importers:
       playwright-chromium:
         specifier: catalog:default
         version: 1.49.1
+      ts-dedent:
+        specifier: ^2.2.0
+        version: 2.2.0
       typescript:
         specifier: catalog:default
         version: 5.7.3


### PR DESCRIPTION
Fixes #8136 and [DEVX-1755](https://jira.cfdata.org/browse/DEVX-1755)

## example 1

If `nodejs_compat` is missing in Wrangler config:

```
> vite dev -c vite.config.worker-process.ts

Using vars defined in worker-process/.dev.vars

  VITE v6.1.0  ready in 1213 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help

Using vars defined in worker-process/.dev.vars
4:55:44 PM [vite] (worker) Re-optimizing dependencies because vite config has changed
4:55:44 PM [vite] server restarted.

Unexpected Node.js imports for environment "worker". Do you need to enable the "nodejs_compat" compatibility flag?
Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.
 - "node:assert" imported from "worker-process/index.ts"
```

and then without restarting Vite, update the Wrangler config to include the compat flag:

```
Using vars defined in worker-process/.dev.vars
4:55:54 PM [vite] (worker) Re-optimizing dependencies because vite config has changed
4:55:54 PM [vite] server restarted.
```

## example 2

If code imports a library that uses node.js APIs without the nodejs_compat flag on:

```
> vite dev -c vite.config.worker-postgres.ts

  VITE v6.1.0  ready in 1064 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help


Unexpected Node.js imports for environment "worker". Do you need to enable the "nodejs_compat" compatibility flag?
Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.
 - "events" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/connection.js"
 - "events" imported from "../../../../node_modules/.pnpm/pg-pool@3.7.0_pg@8.13.1/node_modules/pg-pool/index.js"
 - "events" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/client.js"
 - "events" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/native/client.js"
 - "events" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/query.js"
 - "events" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/native/query.js"
 - "events" imported from "../../../../node_modules/.pnpm/pg-cloudflare@1.1.1/node_modules/pg-cloudflare/dist/index.js"
 - "net" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/connection.js"
 - "net" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/stream.js"
 - "util" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/native/client.js"
 - "util" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/native/query.js"
 - "util" imported from "../../../../node_modules/.pnpm/pgpass@1.0.5/node_modules/pgpass/lib/helper.js"
 - "tls" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/stream.js"
 - "path" imported from "../../../../node_modules/.pnpm/pgpass@1.0.5/node_modules/pgpass/lib/index.js"
 - "path" imported from "../../../../node_modules/.pnpm/pgpass@1.0.5/node_modules/pgpass/lib/helper.js"
 - "dns" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/connection-parameters.js"
 - "crypto" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/crypto/utils-webcrypto.js"
 - "crypto" imported from "../../../../node_modules/.pnpm/pg@8.13.1/node_modules/pg/lib/crypto/utils-legacy.js"
 - "fs" imported from "../../../../node_modules/.pnpm/pgpass@1.0.5/node_modules/pgpass/lib/index.js"
 - "fs" imported from "../../../../node_modules/.pnpm/pg-connection-string@2.7.0/node_modules/pg-connection-string/index.js"
 - "stream" imported from "../../../../node_modules/.pnpm/pgpass@1.0.5/node_modules/pgpass/lib/helper.js"
 - "stream" imported from "../../../../node_modules/.pnpm/split2@4.2.0/node_modules/split2/index.js"
 - "string_decoder" imported from "../../../../node_modules/.pnpm/split2@4.2.0/node_modules/split2/index.js"

error running /Users/pbacondarwin/dev/cloudflare/workers-sdk/packages/vite-plugin-cloudflare/playground/node-compat/node_modules/.vite/deps_worker/pg.js?v=6cf86f3b
Error: Failed to load url events (resolved id: events) in /Users/pbacondarwin/dev/cloudflare/workers-sdk/packages/vite-plugin-cloudflare/playground/node-compat/node_modules/.vite/deps_worker/pg.js. Does the file exist?
    at loadAndTransform (file:///Users/pbacondarwin/dev/cloudflare/workers-sdk/node_modules/.pnpm/vite@6.1.0_@types+node@18.19.76_jiti@2.4.2/node_modules/vite/dist/node/chunks/dep-CfG9u7Cn.js:41295:17)
error running /Users/pbacondarwin/dev/cloudflare/workers-sdk/packages/vite-plugin-cloudflare/playground/node-compat/worker-postgres/index.ts
Error: Failed to load url events (resolved id: events) in /Users/pbacondarwin/dev/cloudflare/workers-sdk/packages/vite-plugin-cloudflare/playground/node-compat/node_modules/.vite/deps_worker/pg.js. Does the file exist?
    at loadAndTransform (file:///Users/pbacondarwin/dev/cloudflare/workers-sdk/node_modules/.pnpm/vite@6.1.0_@types+node@18.19.76_jiti@2.4.2/node_modules/vite/dist/node/chunks/dep-CfG9u7Cn.js:41295:17)

4:42:46 PM [vite] Internal server error: Failed to load url events (resolved id: events) in /Users/pbacondarwin/dev/cloudflare/workers-sdk/packages/vite-plugin-cloudflare/playground/node-compat/node_modules/.vite/deps_worker/pg.js. Does the file exist?
      at async ProxyServer.fetch (file:///Users/pbacondarwin/dev/cloudflare/workers-sdk/packages/miniflare/src/workers/core/proxy.worker.ts:173:11)
4:42:46 PM [vite] Internal server error: Failed to load url events (resolved id: events) in /Users/pbacondarwin/dev/cloudflare/workers-sdk/packages/vite-plugin-cloudflare/playground/node-compat/node_modules/.vite/deps_worker/pg.js. Does the file exist?
      at async ProxyServer.fetch (file:///Users/pbacondarwin/dev/cloudflare/workers-sdk/packages/miniflare/src/workers/core/proxy.worker.ts:173:11) (x2)


Unexpected Node.js imports for environment "worker". Do you need to enable the "nodejs_compat" compatibility flag?
Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.
 - "events" imported from "node_modules/.vite/deps_worker/pg.js?v=6cf86f3b"
```

and then when the Wrangler config is fixed:

```
4:43:20 PM [vite] (worker) Re-optimizing dependencies because vite config has changed
4:43:20 PM [vite] server restarted.
4:43:21 PM [vite] (worker) ✨ new dependencies optimized: @cloudflare/unenv-preset/polyfill/performance, @cloudflare/unenv-preset/node/process, @cloudflare/unenv-preset/node/console
4:43:21 PM [vite] (worker) ✨ optimized dependencies changed. reloading
[vite] program reload

4:43:22 PM [vite] (worker) ✨ new dependencies optimized: unenv/node/perf_hooks
4:43:22 PM [vite] (worker) ✨ optimized dependencies changed. reloading
4:43:22 PM [vite] (worker) ✨ new dependencies optimized: unenv/node/tty
4:43:22 PM [vite] (worker) ✨ optimized dependencies changed. reloading
4:43:22 PM [vite] (worker) ✨ new dependencies optimized: @cloudflare/unenv-preset/node/crypto, unenv/node/fs, @cloudflare/unenv-preset/node/tls, @cloudflare/unenv-preset/node/util
4:43:22 PM [vite] (worker) ✨ optimized dependencies changed. reloading
4:43:22 PM [vite] (worker) ✨ new dependencies optimized: unenv/node/fs/promises
4:43:22 PM [vite] (worker) ✨ optimized dependencies changed. reloading
[vite] program reload
```
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required (for Vite e2e tests)
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just warnings
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR:
  - [x] Not necessary because: Vite plugin is not backported
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
