### PR TITLE
fix: make vitest-pool-workers not crash with scripts that have Workflows

### DIFF
--- a/.changeset/vast-stars-dig.md
+++ b/.changeset/vast-stars-dig.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Make vitest-pool-workers not crash when a workflow is defined

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Run tests
         if: steps.changes.outputs.everything_but_markdown == 'true'
-        run: pnpm run test:ci --concurrency 1 ${{ matrix.filter }}
+        run: pnpm run test:ci --concurrency 1 --log-order=stream ${{ matrix.filter }}
         env:
           TMP_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TMP_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Run tests
         if: steps.changes.outputs.everything_but_markdown == 'true'
-        run: pnpm run test:ci --concurrency 1 --log-order=stream ${{ matrix.filter }}
+        run: pnpm run test:ci --concurrency 1 ${{ matrix.filter }}
         env:
           TMP_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TMP_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/fixtures/vitest-pool-workers-examples/workflows/README.md
+++ b/fixtures/vitest-pool-workers-examples/workflows/README.md
@@ -1,0 +1,8 @@
+# 🤯 rpc
+
+This Worker defines `WorkerEntrypoint` default and named exports. It also defines Durable Objects subclassing `DurableObject`. All of these classes define properties and methods that can be called over RPC. Integration tests dispatch events, access properties and call methods using the `SELF` helper from the `cloudflare:test` module.
+
+| Test                                                      | Overview                                     |
+| --------------------------------------------------------- | -------------------------------------------- |
+| [integration-self.test.ts](test/integration-self.test.ts) | Integration test using `SELF`                |
+| [unit.test.ts](test/unit.test.ts)                         | Unit tests calling exported classes directly |

--- a/fixtures/vitest-pool-workers-examples/workflows/README.md
+++ b/fixtures/vitest-pool-workers-examples/workflows/README.md
@@ -1,8 +1,4 @@
-# 🤯 rpc
+# 🔁 workflows
 
-This Worker defines `WorkerEntrypoint` default and named exports. It also defines Durable Objects subclassing `DurableObject`. All of these classes define properties and methods that can be called over RPC. Integration tests dispatch events, access properties and call methods using the `SELF` helper from the `cloudflare:test` module.
-
-| Test                                                      | Overview                                     |
-| --------------------------------------------------------- | -------------------------------------------- |
-| [integration-self.test.ts](test/integration-self.test.ts) | Integration test using `SELF`                |
-| [unit.test.ts](test/unit.test.ts)                         | Unit tests calling exported classes directly |
+Unit testing of workflows themselves is not possible yet - but you can still
+trigger them in unit tests.

--- a/fixtures/vitest-pool-workers-examples/workflows/src/env.d.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/src/env.d.ts
@@ -1,0 +1,3 @@
+interface Env {
+	TEST_WORKFLOW: Workflow;
+}

--- a/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
@@ -1,0 +1,25 @@
+import {
+	WorkerEntrypoint,
+	WorkflowEntrypoint,
+	WorkflowEvent,
+	WorkflowStep,
+} from "cloudflare:workers";
+
+export class TestWorkflow extends WorkflowEntrypoint<Env> {
+	constructor(ctx: ExecutionContext, env: Env) {
+		super(ctx, env);
+	}
+
+	async run(_event: Readonly<WorkflowEvent<unknown>>, step: WorkflowStep) {
+		console.log("ola");
+		return "test-workflow";
+	}
+}
+
+export default class TestNamedEntrypoint extends WorkerEntrypoint<Env> {
+	async fetch(_request: Request) {
+		const workflow = await this.env.TEST_WORKFLOW.create();
+
+		return new Response(JSON.stringify({ id: workflow.id }));
+	}
+}

--- a/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
@@ -6,12 +6,7 @@ import {
 } from "cloudflare:workers";
 
 export class TestWorkflow extends WorkflowEntrypoint<Env> {
-	constructor(ctx: ExecutionContext, env: Env) {
-		super(ctx, env);
-	}
-
 	async run(_event: Readonly<WorkflowEvent<unknown>>, step: WorkflowStep) {
-		console.log("ola");
 		return "test-workflow";
 	}
 }

--- a/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
@@ -17,7 +17,14 @@ export class TestWorkflow extends WorkflowEntrypoint<Env> {
 }
 
 export default class TestNamedEntrypoint extends WorkerEntrypoint<Env> {
-	async fetch(_request: Request) {
+	async fetch(request: Request) {
+		const maybeId = new URL(request.url).searchParams.get("id");
+		if (maybeId !== null) {
+			const instance = await this.env.TEST_WORKFLOW.get(maybeId);
+
+			return Response.json(await instance.status());
+		}
+
 		const workflow = await this.env.TEST_WORKFLOW.create();
 
 		return new Response(JSON.stringify({ id: workflow.id }));

--- a/fixtures/vitest-pool-workers-examples/workflows/src/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/workflows/src/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.workerd.json",
+	"include": ["./**/*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/workflows/test/env.d.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/test/env.d.ts
@@ -1,0 +1,6 @@
+declare module "cloudflare:test" {
+	// Controls the type of `import("cloudflare:test").env`
+	interface ProvidedEnv extends Env {
+		TEST_WORKFLOW: Workflow;
+	}
+}

--- a/fixtures/vitest-pool-workers-examples/workflows/test/integration-self.test.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/test/integration-self.test.ts
@@ -1,0 +1,10 @@
+import { createExecutionContext, env, SELF } from "cloudflare:test";
+import { expect, it, vi } from "vitest";
+
+it.skip("should be able to trigger a workflow", async () => {
+	const request = new Request("https://mock-worker.local", {});
+
+	const res = await SELF.fetch(request);
+
+	expect(res.status).toBe(200);
+});

--- a/fixtures/vitest-pool-workers-examples/workflows/test/integration-self.test.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/test/integration-self.test.ts
@@ -1,7 +1,7 @@
 import { createExecutionContext, env, SELF } from "cloudflare:test";
 import { expect, it, vi } from "vitest";
 
-it.skip("should be able to trigger a workflow", async () => {
+it("should be able to trigger a workflow", async () => {
 	const request = new Request("https://mock-worker.local", {});
 
 	const res = await SELF.fetch(request);

--- a/fixtures/vitest-pool-workers-examples/workflows/test/integration-self.test.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/test/integration-self.test.ts
@@ -1,5 +1,5 @@
 import { createExecutionContext, env, SELF } from "cloudflare:test";
-import { expect, it, vi } from "vitest";
+import { expect, it, test, vi } from "vitest";
 
 it("should be able to trigger a workflow", async () => {
 	const request = new Request("https://mock-worker.local", {});
@@ -7,4 +7,21 @@ it("should be able to trigger a workflow", async () => {
 	const res = await SELF.fetch(request);
 
 	expect(res.status).toBe(200);
+});
+
+test("workflow should reach the end and be successful", async () => {
+	const request = new Request("https://mock-worker.local", {});
+
+	const res = await SELF.fetch(request);
+
+	const json = await res.json<{ id: string }>();
+
+	await vi.waitUntil(async () => {
+		const checkReq = new Request(`https://mock-worker.local?id=${json.id}`);
+
+		const res = await SELF.fetch(checkReq);
+
+		const statusJson = await res.json<{ status: string }>();
+		return statusJson.status === "complete";
+	}, 1000);
 });

--- a/fixtures/vitest-pool-workers-examples/workflows/test/integration-self.test.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/test/integration-self.test.ts
@@ -1,27 +1,22 @@
-import { createExecutionContext, env, SELF } from "cloudflare:test";
-import { expect, it, test, vi } from "vitest";
+import { SELF } from "cloudflare:test";
+import { expect, it, vi } from "vitest";
 
 it("should be able to trigger a workflow", async () => {
-	const request = new Request("https://mock-worker.local", {});
-
-	const res = await SELF.fetch(request);
+	const res = await SELF.fetch("https://mock-worker.local");
 
 	expect(res.status).toBe(200);
 });
 
-test("workflow should reach the end and be successful", async () => {
-	const request = new Request("https://mock-worker.local", {});
-
-	const res = await SELF.fetch(request);
+it("workflow should reach the end and be successful", async () => {
+	const res = await SELF.fetch("https://mock-worker.local");
 
 	const json = await res.json<{ id: string }>();
 
 	await vi.waitUntil(async () => {
-		const checkReq = new Request(`https://mock-worker.local?id=${json.id}`);
-
-		const res = await SELF.fetch(checkReq);
+		const res = await SELF.fetch(`https://mock-worker.local?id=${json.id}`);
 
 		const statusJson = await res.json<{ status: string }>();
+		console.log(statusJson);
 		return statusJson.status === "complete";
 	}, 1000);
 });

--- a/fixtures/vitest-pool-workers-examples/workflows/test/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/workflows/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.workerd-test.json",
+	"include": ["./**/*.ts", "../src/env.d.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/workflows/tsconfig.json
+++ b/fixtures/vitest-pool-workers-examples/workflows/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.node.json",
+	"include": ["./*.ts"]
+}

--- a/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineWorkersProject } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersProject({
+	esbuild: {
+		// Required for `using` support
+		target: "ES2022",
+	},
+	test: {
+		poolOptions: {
+			workers: {
+				singleWorker: true,
+				miniflare: {
+					// Required to use `SELF.scheduled()`. This is an experimental
+					// compatibility flag, and cannot be enabled in production.
+					compatibilityFlags: ["service_binding_extra_handlers"],
+				},
+				wrangler: {
+					configPath: "./wrangler.toml",
+				},
+			},
+		},
+	},
+});

--- a/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
@@ -9,6 +9,8 @@ export default defineWorkersProject({
 		poolOptions: {
 			workers: {
 				singleWorker: true,
+				// FIXME(lduarte): currently for the workflow binding to work, isolateStorage must be disabled.
+				isolatedStorage: false,
 				miniflare: {
 					// Required to use `SELF.scheduled()`. This is an experimental
 					// compatibility flag, and cannot be enabled in production.

--- a/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/vitest.config.ts
@@ -11,11 +11,6 @@ export default defineWorkersProject({
 				singleWorker: true,
 				// FIXME(lduarte): currently for the workflow binding to work, isolateStorage must be disabled.
 				isolatedStorage: false,
-				miniflare: {
-					// Required to use `SELF.scheduled()`. This is an experimental
-					// compatibility flag, and cannot be enabled in production.
-					compatibilityFlags: ["service_binding_extra_handlers"],
-				},
 				wrangler: {
 					configPath: "./wrangler.toml",
 				},

--- a/fixtures/vitest-pool-workers-examples/workflows/wrangler.toml
+++ b/fixtures/vitest-pool-workers-examples/workflows/wrangler.toml
@@ -1,0 +1,8 @@
+name = "workflows"
+main = "src/index.ts"
+compatibility_date = "2025-02-04"
+
+[[workflows]]
+binding = "TEST_WORKFLOW"
+class_name = "TestWorkflow"
+name = "test-workflow"

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -341,12 +341,7 @@ function fixupWorkflowBindingsToSelf(
 	for (const key of Object.keys(worker.workflows)) {
 		const designator = worker.workflows[key];
 		// `designator` hasn't been validated at this point
-		if (typeof designator === "string") {
-			// Either this is a simple `string` designator to the current worker...
-			result.add(designator);
-			worker.workflows[key].className = USER_OBJECT_MODULE_NAME + designator;
-		} else if (isWorkflowDesignatorToSelf(designator, worker.name)) {
-			// ...or it's an object designator to the current worker
+		if (isWorkflowDesignatorToSelf(designator, worker.name)) {
 			result.add(designator.className);
 			// Shallow clone to avoid mutating config
 			worker.workflows[key] = {

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -209,7 +209,7 @@ function isDurableObjectDesignatorToSelf(
 function isWorkflowDesignatorToSelf(
 	value: unknown,
 	currentScriptName: string | undefined
-): value is string | { className: string } {
+): value is { className: string } {
 	return (
 		typeof value === "object" &&
 		value !== null &&

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -454,13 +454,9 @@ function buildProjectWorkerOptions(
 		workflowClassNames.length !== 0 &&
 		project.options.isolatedStorage === true
 	) {
-		const message = [
-			`Project ${project.relativePath} has Workflows defined and \`isolatedStorage\` set to true.`,
-			"Please set `isolatedStorage` to false in order to run projects with Workflows.",
-			`Workflows defined in project: ${workflowClassNames.join(", ")}`,
-		].join("\n");
-
-		throw new Error(message);
+		throw new Error(`Project ${project.relativePath} has Workflows defined and \`isolatedStorage\` set to true.
+Please set \`isolatedStorage\` to false in order to run projects with Workflows.
+Workflows defined in project: ${workflowClassNames.join(", ")}`);
 	}
 
 	const wrappers = [

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -449,6 +449,20 @@ function buildProjectWorkerOptions(
 	const workflowClassNames = Array.from(
 		fixupWorkflowBindingsToSelf(runnerWorker)
 	).sort();
+
+	if (
+		workflowClassNames.length !== 0 &&
+		project.options.isolatedStorage === true
+	) {
+		const message = [
+			`Project ${project.relativePath} has Workflows defined and \`isolatedStorage\` set to true.`,
+			"Please set `isolatedStorage` to false in order to run projects with Workflows.",
+			`Workflows defined in project: ${workflowClassNames.join(", ")}`,
+		].join("\n");
+
+		throw new Error(message);
+	}
+
 	const wrappers = [
 		'import { createWorkerEntrypointWrapper, createDurableObjectWrapper, createWorkflowEntrypointWrapper } from "cloudflare:test-internal";',
 	];

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -206,6 +206,21 @@ function isDurableObjectDesignatorToSelf(
 	);
 }
 
+function isWorkflowDesignatorToSelf(
+	value: unknown,
+	currentScriptName: string | undefined
+): value is string | { className: string } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"className" in value &&
+		typeof value.className === "string" &&
+		(!("scriptName" in value) ||
+			value.scriptName === undefined ||
+			value.scriptName === currentScriptName)
+	);
+}
+
 interface DurableObjectDesignator {
 	className: string;
 	scriptName?: string;
@@ -313,6 +328,36 @@ function fixupDurableObjectBindingsToSelf(
 	return result;
 }
 
+function fixupWorkflowBindingsToSelf(
+	worker: SourcelessWorkerOptions
+): Set<string> {
+	// TODO(someday): may need to extend this to take into account other workers
+	//  if doing multi-worker tests across workspace projects
+	// TODO(someday): may want to validate class names are valid identifiers?
+	const result = new Set<string>();
+	if (worker.workflows === undefined) {
+		return result;
+	}
+	for (const key of Object.keys(worker.workflows)) {
+		const designator = worker.workflows[key];
+		// `designator` hasn't been validated at this point
+		if (typeof designator === "string") {
+			// Either this is a simple `string` designator to the current worker...
+			result.add(designator);
+			worker.workflows[key].className = USER_OBJECT_MODULE_NAME + designator;
+		} else if (isWorkflowDesignatorToSelf(designator, worker.name)) {
+			// ...or it's an object designator to the current worker
+			result.add(designator.className);
+			// Shallow clone to avoid mutating config
+			worker.workflows[key] = {
+				...designator,
+				className: USER_OBJECT_MODULE_NAME + designator.className,
+			};
+		}
+	}
+	return result;
+}
+
 type ProjectWorkers = [
 	runnerWorker: WorkerOptions,
 	...auxiliaryWorkers: WorkerOptions[],
@@ -401,9 +446,13 @@ function buildProjectWorkerOptions(
 	const durableObjectClassNames = Array.from(
 		fixupDurableObjectBindingsToSelf(runnerWorker)
 	).sort();
+	const workflowClassNames = Array.from(
+		fixupWorkflowBindingsToSelf(runnerWorker)
+	).sort();
 	const wrappers = [
-		'import { createWorkerEntrypointWrapper, createDurableObjectWrapper } from "cloudflare:test-internal";',
+		'import { createWorkerEntrypointWrapper, createDurableObjectWrapper, createWorkflowEntrypointWrapper } from "cloudflare:test-internal";',
 	];
+
 	for (const entrypointName of serviceBindingEntrypointNames) {
 		const quotedEntrypointName = JSON.stringify(entrypointName);
 		const wrapper = `export const ${USER_OBJECT_MODULE_NAME}${entrypointName} = createWorkerEntrypointWrapper(${quotedEntrypointName});`;
@@ -412,6 +461,12 @@ function buildProjectWorkerOptions(
 	for (const className of durableObjectClassNames) {
 		const quotedClassName = JSON.stringify(className);
 		const wrapper = `export const ${USER_OBJECT_MODULE_NAME}${className} = createDurableObjectWrapper(${quotedClassName});`;
+		wrappers.push(wrapper);
+	}
+
+	for (const className of workflowClassNames) {
+		const quotedClassName = JSON.stringify(className);
+		const wrapper = `export const ${USER_OBJECT_MODULE_NAME}${className} = createWorkflowEntrypointWrapper(${quotedClassName});`;
 		wrappers.push(wrapper);
 	}
 

--- a/packages/vitest-pool-workers/src/pool/loopback.ts
+++ b/packages/vitest-pool-workers/src/pool/loopback.ts
@@ -277,7 +277,10 @@ async function popStackedStorage(fromDepth: number, persistPath: string) {
 				break;
 			}
 			const namePath = path.join(keyPath, name);
-			assert(name.endsWith(".sqlite"), `Expected .sqlite, got ${namePath}`);
+			// if we are using workflows, we don't care if the sqlite got commited or not.
+			if (!persistPath.endsWith("workflows")) {
+				assert(name.endsWith(".sqlite"), `Expected .sqlite, got ${namePath}`);
+			}
 			await fs.unlink(namePath);
 		}
 	}

--- a/packages/vitest-pool-workers/src/pool/loopback.ts
+++ b/packages/vitest-pool-workers/src/pool/loopback.ts
@@ -277,10 +277,7 @@ async function popStackedStorage(fromDepth: number, persistPath: string) {
 				break;
 			}
 			const namePath = path.join(keyPath, name);
-			// if we are using workflows, we don't care if the sqlite got commited or not.
-			if (!persistPath.endsWith("workflows")) {
-				assert(name.endsWith(".sqlite"), `Expected .sqlite, got ${namePath}`);
-			}
+
 			await fs.unlink(namePath);
 		}
 	}

--- a/packages/vitest-pool-workers/src/pool/loopback.ts
+++ b/packages/vitest-pool-workers/src/pool/loopback.ts
@@ -277,6 +277,7 @@ async function popStackedStorage(fromDepth: number, persistPath: string) {
 				break;
 			}
 			const namePath = path.join(keyPath, name);
+			assert(name.endsWith(".sqlite"), `Expected .sqlite, got ${namePath}`);
 
 			await fs.unlink(namePath);
 		}

--- a/packages/vitest-pool-workers/src/worker/entrypoints.ts
+++ b/packages/vitest-pool-workers/src/worker/entrypoints.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import {
 	DurableObject as DurableObjectClass,
 	WorkerEntrypoint,
+	WorkflowEntrypoint,
 } from "cloudflare:workers";
 import { maybeHandleRunRequest, runInRunnerObject } from "./durable-objects";
 import { getResolvedMainPath, stripInternalEnv } from "./env";
@@ -40,7 +41,10 @@ function importModule(
  * things a little trickier for us...
  */
 function createProxyPrototypeClass<
-	T extends typeof WorkerEntrypoint | typeof DurableObjectClass,
+	T extends
+		| typeof WorkerEntrypoint
+		| typeof DurableObjectClass
+		| typeof WorkflowEntrypoint,
 	ExtraPrototype = unknown,
 >(
 	superClass: T,
@@ -486,6 +490,70 @@ export function createDurableObjectWrapper(
 			}
 		};
 	}
+
+	return Wrapper;
+}
+
+// =============================================================================
+// `WorkflowEntrypoint` wrappers
+// =============================================================================
+
+type WorkflowEntrypointConstructor = {
+	new (
+		...args: ConstructorParameters<typeof WorkflowEntrypoint>
+	): WorkflowEntrypoint;
+};
+
+export function createWorkflowEntrypointWrapper(entrypoint: string) {
+	const Wrapper = createProxyPrototypeClass(
+		WorkflowEntrypoint,
+		function (this: WorkflowEntrypoint<InternalUserEnv>, key) {
+			// only Workflow `run` should be exposed over RPC
+			if (!["run"].includes(key)) {
+				return;
+			}
+
+			const property = getWorkerEntrypointRPCProperty(
+				this as unknown as WorkerEntrypoint<InternalUserEnv>,
+				entrypoint,
+				key
+			);
+			return getRPCPropertyCallableThenable(key, property);
+		}
+	);
+
+	Wrapper.prototype.run = async function (
+		this: WorkflowEntrypoint<InternalUserEnv>,
+		...args
+	) {
+		const { mainPath, entrypointValue } = await getWorkerEntrypointExport(
+			this.env,
+			entrypoint
+		);
+		const userEnv = stripInternalEnv(this.env);
+		// entrypoint value should always be an object, worker entrypoint only supports this
+		if (typeof entrypointValue === "function") {
+			// Assuming the user has defined a `WorkflowEntrypoint` subclass
+			const ctor = entrypointValue as WorkflowEntrypointConstructor;
+			const instance = new ctor(this.ctx, userEnv);
+			// noinspection SuspiciousTypeOfGuard
+			if (!(instance instanceof WorkflowEntrypoint)) {
+				const message = `Expected ${entrypoint} export of ${mainPath} to be a subclass of \`WorkerEntrypoint\``;
+				throw new TypeError(message);
+			}
+			const maybeFn = instance["run"];
+			if (typeof maybeFn === "function") {
+				return maybeFn.call(instance, ...args);
+			} else {
+				const message = `Expected ${entrypoint} export of ${mainPath} to define a \`run()\` method`;
+				throw new TypeError(message);
+			}
+		} else {
+			// Assuming the user has messed up
+			const message = `Expected ${entrypoint} export of ${mainPath}to be an object or a class, got ${entrypointValue}`;
+			throw new TypeError(message);
+		}
+	};
 
 	return Wrapper;
 }

--- a/packages/vitest-pool-workers/src/worker/entrypoints.ts
+++ b/packages/vitest-pool-workers/src/worker/entrypoints.ts
@@ -531,26 +531,26 @@ export function createWorkflowEntrypointWrapper(entrypoint: string) {
 			entrypoint
 		);
 		const userEnv = stripInternalEnv(this.env);
-		// entrypoint value should always be an object, worker entrypoint only supports this
+		// workflow entrypoint value should always be a constructor
 		if (typeof entrypointValue === "function") {
 			// Assuming the user has defined a `WorkflowEntrypoint` subclass
 			const ctor = entrypointValue as WorkflowEntrypointConstructor;
 			const instance = new ctor(this.ctx, userEnv);
 			// noinspection SuspiciousTypeOfGuard
 			if (!(instance instanceof WorkflowEntrypoint)) {
-				const message = `Expected ${entrypoint} export of ${mainPath} to be a subclass of \`WorkerEntrypoint\``;
+				const message = `Expected ${entrypoint} export of ${mainPath} to be a subclass of \`WorkflowEntrypoint\``;
 				throw new TypeError(message);
 			}
 			const maybeFn = instance["run"];
 			if (typeof maybeFn === "function") {
 				return maybeFn.call(instance, ...args);
 			} else {
-				const message = `Expected ${entrypoint} export of ${mainPath} to define a \`run()\` method`;
+				const message = `Expected ${entrypoint} export of ${mainPath} to define a \`run()\` method, but got ${typeof maybeFn}`;
 				throw new TypeError(message);
 			}
 		} else {
 			// Assuming the user has messed up
-			const message = `Expected ${entrypoint} export of ${mainPath}to be an object or a class, got ${entrypointValue}`;
+			const message = `Expected ${entrypoint} export of ${mainPath} to be a subclass of \`WorkflowEntrypoint\`, but got ${entrypointValue}`;
 			throw new TypeError(message);
 		}
 	};


### PR DESCRIPTION
Because `vitest-pool-workers` uses its runner worker as the entrypoint and not the user provided worker. The user provided worker is loaded AFAICT though eval (`vitest-pool-workers` enables eval) so we need, at startup time, to add the required entrypoints and make them dynamically call the user one.

Not only that, if you try to create a workflow instance it would throw a `isolated storage` error - I suspect that is this caused by engine still being active at the end of the test (since workflows are async, not in the request path, and might take undefinite time to complete).

In order to fix this, I've bypassed the isolated storage check for workflows internal DOs. I wonder if there might be collisions between test files if there are any concurrency regarding test files (aka `singleWorker` is false) - I think that this is fine to do, the point of this PR is not to make workflows really testable yet but to at least to make `vitest-pool-workers` **not** crash if a user includes a workflow in the worker definition.

Fixes (partially) #7414.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: doesn't add support to individually test workflows but only makes vitest not crash if they are defined
 - Wrangler V3 Backport
   - [ ] TODO (before merge)
   - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
   - [x] Not necessary because: patch for vitest-pool-workers doesn't affect wrangler


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
