### PR TITLE
[vite-plugin-cloudflare] chore: simplify the modules externalization logic

### DIFF
--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -325,22 +325,6 @@ export function getDevMiniflareOptions(
 										`Invalid invoke event: ${invokePayloadData.name}`
 									);
 
-									const [moduleId] = invokePayloadData.data;
-									const moduleRE = new RegExp(MODULE_PATTERN);
-
-									const shouldExternalize =
-										// Worker modules (CompiledWasm, Text, Data)
-										moduleRE.test(moduleId);
-
-									if (shouldExternalize) {
-										const result = {
-											externalize: moduleId,
-											type: "module",
-										} satisfies vite.FetchResult;
-
-										return MiniflareResponse.json({ result });
-									}
-
 									const devEnvironment = viteDevServer.environments[
 										environmentName
 									] as CloudflareDevEnvironment;


### PR DESCRIPTION
The changes here remove the `shouldExternalize` logic from our `__VITE_INVOKE_MODULE__` function.

I've been looking into this so I figured I might as well just open a PR for this change, although now I'm not sure if this is really
simplifying the externalization logic or simply moving complexity from one place to another 😕 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this functionality is already tested
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not wrangler related
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: an internal refactoring, no behavioral changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
