### PR TITLE
fix(create-cloudflare): make DNS poling copy more user friendly

### DIFF
--- a/.changeset/large-hotels-create.md
+++ b/.changeset/large-hotels-create.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+This change makes the user facing message C3 displays while waiting for DNS propagation, more friendly/informative. The idea is to inform users that DNS propagation might sometimes take even up to 2 minutes. This will hopefully prevent confusion around whether how long the process will take, or whether the process is stuck, etc.

--- a/packages/create-cloudflare/src/helpers/poll.ts
+++ b/packages/create-cloudflare/src/helpers/poll.ts
@@ -22,7 +22,7 @@ export const poll = async (url: string): Promise<boolean> => {
 	const domain = new URL(url).host;
 	const s = spinner();
 
-	s.start("Waiting for DNS to propagate. This might take up to two minutes.");
+	s.start("Waiting for DNS to propagate. This might take a few minutes.");
 
 	// Start out by sleeping for 10 seconds since it's unlikely DNS changes will
 	// have propogated before then

--- a/packages/create-cloudflare/src/helpers/poll.ts
+++ b/packages/create-cloudflare/src/helpers/poll.ts
@@ -22,7 +22,7 @@ export const poll = async (url: string): Promise<boolean> => {
 	const domain = new URL(url).host;
 	const s = spinner();
 
-	s.start("Waiting for DNS to propagate");
+	s.start("Waiting for DNS to propagate. This might take up to two minutes.");
 
 	// Start out by sleeping for 10 seconds since it's unlikely DNS changes will
 	// have propogated before then
@@ -47,7 +47,9 @@ const pollDns = async (
 	s: ReturnType<typeof spinner>,
 ) => {
 	while (Date.now() - start < TIMEOUT) {
-		s.update(`Waiting for DNS to propagate (${secondsSince(start)}s)`);
+		s.update(
+			`Waiting for DNS to propagate. This might take up to two minutes. (${secondsSince(start)}s)`,
+		);
 		if (await isDomainResolvable(domain)) {
 			s.stop(`${brandColor("DNS propagation")} ${dim("complete")}.`);
 			return;

--- a/packages/create-cloudflare/src/helpers/poll.ts
+++ b/packages/create-cloudflare/src/helpers/poll.ts
@@ -48,7 +48,7 @@ const pollDns = async (
 ) => {
 	while (Date.now() - start < TIMEOUT) {
 		s.update(
-			`Waiting for DNS to propagate. This might take up to two minutes. (${secondsSince(start)}s)`,
+			`Waiting for DNS to propagate. This might take a few minutes. (${secondsSince(start)}s)`,
 		);
 		if (await isDomainResolvable(domain)) {
 			s.stop(`${brandColor("DNS propagation")} ${dim("complete")}.`);


### PR DESCRIPTION
This change makes the user facing message C3 displays while waiting for DNS propagation, more friendly/informative. The idea is to inform users that DNS propagation might sometimes take even up to 2 minutes. This will hopefully prevent confusion around whether how long the process will take, or whether the process is stuck, etc.

See https://github.com/cloudflare/workers-sdk/issues/8187

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: just copy change. Also the fn that contains this message is not covered by tests
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: just copy change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just copy change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
