### PR TITLE
chore(vite-plugin): skip node_compat test for now due to flakiness

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/basic.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/basic.test.ts
@@ -1,7 +1,7 @@
 import { describe } from "vitest";
 import { fetchJson, runCommand, test, waitForReady } from "./helpers.js";
 
-describe("node compatibility", () => {
+describe.skip("node compatibility", () => {
 	describe.each(["pnpm", "npm", "yarn"])("using %s", (pm) => {
 		test("can serve a Worker request", async ({ expect, seed, viteDev }) => {
 			const projectPath = await seed("basic");


### PR DESCRIPTION
Skips flaky vite-plugin test

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: skips test
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: skips test
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: skips test

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
