### PR TITLE
fix(vite-plugin): use ESM exports of ws for vite dev server

### DIFF
--- a/.changeset/free-tables-kneel.md
+++ b/.changeset/free-tables-kneel.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Fix bug where under some ESM environments the dev server would fail to start.

--- a/packages/vite-plugin-cloudflare/src/websockets.ts
+++ b/packages/vite-plugin-cloudflare/src/websockets.ts
@@ -1,4 +1,4 @@
-import ws from "ws";
+import { WebSocketServer } from "ws";
 import { UNKNOWN_HOST } from "./shared";
 import { nodeHeadersToWebHeaders } from "./utils";
 import type { Fetcher } from "@cloudflare/workers-types/experimental";
@@ -15,7 +15,7 @@ export function handleWebSocket(
 	fetcher: ReplaceWorkersTypes<Fetcher>["fetch"],
 	logger: vite.Logger
 ) {
-	const nodeWebSocket = new ws.Server({ noServer: true });
+	const nodeWebSocket = new WebSocketServer({ noServer: true });
 
 	httpServer.on(
 		"upgrade",


### PR DESCRIPTION
Fixes #8222

Uses the ESM export `WebSocketServer` of `ws` since `Server` isn't present in `ws`'s ESM package as described by [this comment by a ws maintainer](https://github.com/websockets/ws/issues/1538#issuecomment-944859160), which was causing the vite plugin to crash when starting the dev server in some ESM environments.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix to match documented behavior

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
