### PR TITLE
fix: remove extra config files that are generated by c3 with `--existing-script `

### DIFF
--- a/.changeset/sixty-spoons-unite.md
+++ b/.changeset/sixty-spoons-unite.md
@@ -2,4 +2,6 @@
 "create-cloudflare": patch
 ---
 
-fix: remove duplicate config files that are created when using --existing-script
+fix: stop c3 adding a duplicate `./wrangler.jsonc` when using --existing-script
+
+This should mean dev and deploy on projects initialised using `create-cloudflare --existing-script` start working again. Note there will still be an extraneous `./src/wrangler.toml`, which will require a separate fix in the dashboard. This file can be manually deleted in the meantime.

--- a/.changeset/sixty-spoons-unite.md
+++ b/.changeset/sixty-spoons-unite.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: remove duplicate config files that are created when using --existing-script

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -1,5 +1,5 @@
 import fs, { readFileSync } from "node:fs";
-import { basename } from "node:path";
+import { basename, join } from "node:path";
 import { detectPackageManager } from "helpers/packageManagers";
 import { beforeAll, describe, expect } from "vitest";
 import { version } from "../package.json";
@@ -438,6 +438,11 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 			);
 			expect(output).toContain("Pre-existing Worker (from Dashboard)");
 			expect(output).toContain("Application created successfully!");
+			expect(fs.existsSync(join(project.path, "wrangler.jsonc"))).toBe(false);
+			expect(fs.existsSync(join(project.path, "wrangler.json"))).toBe(false);
+			expect(
+				fs.readFileSync(join(project.path, "wrangler.toml"), "utf8"),
+			).toContain('FOO = "bar"');
 		});
 	},
 );

--- a/packages/create-cloudflare/templates/pre-existing/c3.ts
+++ b/packages/create-cloudflare/templates/pre-existing/c3.ts
@@ -1,11 +1,9 @@
-import { existsSync } from "fs";
 import { cp, mkdtemp } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { brandColor, dim } from "@cloudflare/cli/colors";
 import { processArgument } from "helpers/args";
 import { runCommand } from "helpers/command";
-import { removeFile } from "helpers/files";
 import { detectPackageManager } from "helpers/packageManagers";
 import { chooseAccount, wranglerLogin } from "../../src/wrangler/accounts";
 import type { C3Context } from "types";
@@ -50,14 +48,6 @@ export async function copyExistingWorkerFiles(ctx: C3Context) {
 			)}`,
 		},
 	);
-
-	// dash hello-world template generates unused files:
-	// we only want to remove the wrangler.toml in src/ if another one exists in the project root
-	// ./src/wrangler.toml does NOT have user configuration from the dash
-	// ./wrangler.toml DOES have user bindings.
-	if (existsSync(join(tempdir, ctx.args.existingScript, "wrangler.toml"))) {
-		removeFile(join(tempdir, ctx.args.existingScript, "./src/wrangler.toml"));
-	}
 
 	// copy src/* files from the downloaded Worker
 	await cp(

--- a/packages/create-cloudflare/templates/pre-existing/js/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/pre-existing/js/wrangler.jsonc
@@ -1,5 +1,0 @@
-{
-  "name": "<TBD>",
-  "main": "src/index.js",
-  "compatibility_date": "<TBD>"
-}


### PR DESCRIPTION
Fixes #8188

This was generating broken projects due to the fact there were three (!) separate config files.


<img width="354" alt="Screenshot 2025-02-24 at 10 54 25" src="https://github.com/user-attachments/assets/6f6e0400-2715-4ea2-bd1f-ff676c7acf84" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: i don't really know how to test this, but i have tried it manually though?
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
