### PR TITLE
fix(vitest-pool-workers): fetchMock support on auxiliary worker

### DIFF
--- a/.changeset/huge-pears-tickle.md
+++ b/.changeset/huge-pears-tickle.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: allow the `fetchMock` option to be parsed upfront before passing it to Miniflare

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -163,6 +163,11 @@ export const CoreOptionsSchema = CoreOptionsSchemaInput.transform((value) => {
 				"Only one of `outboundService` or `fetchMock` may be specified per worker"
 			);
 		}
+
+		// The `fetchMock` option is used to construct the `outboundService` only
+		// Removing it from the output allows us to re-parse the options later
+		// This allows us to validate the options and then feed them into Miniflare without issue.
+		value.fetchMock = undefined;
 		value.outboundService = (req) => fetch(req, { dispatcher: fetchMock });
 	}
 	return value;

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -167,7 +167,7 @@ export const CoreOptionsSchema = CoreOptionsSchemaInput.transform((value) => {
 		// The `fetchMock` option is used to construct the `outboundService` only
 		// Removing it from the output allows us to re-parse the options later
 		// This allows us to validate the options and then feed them into Miniflare without issue.
-		value.fetchMock = undefined;
+		// value.fetchMock = undefined;
 		value.outboundService = (req) => fetch(req, { dispatcher: fetchMock });
 	}
 	return value;

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -167,7 +167,7 @@ export const CoreOptionsSchema = CoreOptionsSchemaInput.transform((value) => {
 		// The `fetchMock` option is used to construct the `outboundService` only
 		// Removing it from the output allows us to re-parse the options later
 		// This allows us to validate the options and then feed them into Miniflare without issue.
-		// value.fetchMock = undefined;
+		value.fetchMock = undefined;
 		value.outboundService = (req) => fetch(req, { dispatcher: fetchMock });
 	}
 	return value;


### PR DESCRIPTION
Fixes #5486.

In `vitest-pool-workers`, we parse the Miniflare options from `poolOptions` upfront before instantiating a Miniflare instance. This creates an issue with `fetchMock`: the Zod schema sets an `outboundService` based on the `fetchMock` option during the initial parse, and then runs again when a Miniflare instance is created. This results in an error because Miniflare does not accept having both `fetchMock` and `outboundService` simultaneously.

This fix removes the `fetchMock` option during the initial parse so that Miniflare only receives the `outboundService`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
