### PR TITLE
fix: remove unnecessary flags passed to `create-next-app` when creating Next.js apps in experimental mode

### DIFF
--- a/.changeset/four-mammals-report.md
+++ b/.changeset/four-mammals-report.md
@@ -1,0 +1,9 @@
+---
+"create-cloudflare": patch
+---
+
+fix: remove unnecessary flags passed to `create-next-app` when creating Next.js apps in experimental mode
+
+This change removes a set of flags that get passed to `create-next-app` that force the generated Next.js
+application to have specific settings (e.g. typescript, tailwind, src directory, etc...) which are not
+actually mandatory/recommended for the use of the open-next Cloudflare adapter

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -7,16 +7,7 @@ import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
 
 const generate = async (ctx: C3Context) => {
-	await runFrameworkGenerator(ctx, [
-		ctx.project.name,
-		"--ts",
-		"--tailwind",
-		"--eslint",
-		"--app",
-		"--import-alias",
-		"@/*",
-		"--src-dir",
-	]);
+	await runFrameworkGenerator(ctx, [ctx.project.name]);
 };
 
 const configure = async () => {


### PR DESCRIPTION
This change removes a set of flags that get passed to `create-next-app` that force the generated Next.js
application to have specific settings (e.g. typescript, tailwind, src directory, etc...) which are not
actually mandatory/recommended for the use of the open-next Cloudflare adapter

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: there's already a c3 e2e test for the Next.js experimental template
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not related to wrangler in any way
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: broadens the options users have when using the C3 Next.js experimental template, not something that needs specific documentation

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
