### PR TITLE
update experimental Next.js template to work on `@opennextjs/cloudflare@0.5.x`

### DIFF
--- a/.changeset/fluffy-fans-bake.md
+++ b/.changeset/fluffy-fans-bake.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+update experimental Next.js template to work on `@opennextjs/cloudflare@0.5.x`

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -21,7 +21,7 @@ const generate = async (ctx: C3Context) => {
 
 const configure = async () => {
 	const packages = [
-		"@opennextjs/cloudflare@0.4.x",
+		"@opennextjs/cloudflare@0.5.x",
 		"@cloudflare/workers-types",
 	];
 	await installPackages(packages, {


### PR DESCRIPTION
We've recently bumped the `@opennextjs/cloudflare` package to `0.5` without any breaking change, so we can just
bump the dependency in the C3 Next.js experimental template

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: the C3 Next.js experimental template already has e2e tests
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not related with wrangler
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
