### PR TITLE
fix(create-cloudflare): Ensure we exit the process on "SIGINT" and "SIGTERM"

### DIFF
--- a/.changeset/ripe-socks-stay.md
+++ b/.changeset/ripe-socks-stay.md
@@ -1,0 +1,10 @@
+---
+"create-cloudflare": patch
+---
+
+fix: Ensure we exit the process on "SIGINT" and "SIGTERM"
+
+Currently C3 does not explicitly exit the process if an error is thrown, or if a "SIGINT" or "SIGTERM" signal is received. This leads to situations when, if `ctrl+C` is pressed while there are still tasks in the stack/microtask queues (think in flight async xhr calls, or polling, or long running
+`while` loops), the current process will continue running until all those tasks are run to completion, and the queues are empty.
+
+This commit fixes this by explicitly calling `process.exit()` when an error is thrown (our internal "SIGINT"/"SIGTERM" handlers will throw a `CancelError`), thus ensuring we always exit the process.

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -201,4 +201,9 @@ main(process.argv)
 	})
 	.finally(async () => {
 		await reporter.waitForAllEventsSettled();
+
+		// ensure we explicitly exit the process, otherwise any ongoing async
+		// calls or leftover tasks in the stack queue will keep running until
+		// completed
+		process.exit();
 	});

--- a/packages/create-cloudflare/src/metrics.ts
+++ b/packages/create-cloudflare/src/metrics.ts
@@ -188,7 +188,7 @@ export function createReporter() {
 		// Create a new promise that will reject when the user interrupts the process
 		const cancelDeferred = promiseWithResolvers<never>();
 		const cancel = async (signal?: NodeJS.Signals) => {
-			// Let subtasks handles the signals first with a short timeout
+			// Let subtasks handle the signals first with a short timeout
 			await setTimeout(10);
 
 			cancelDeferred.reject(new CancelError(`Operation cancelled`, signal));


### PR DESCRIPTION
Currently C3 does not explicitly exit the process if an error is thrown, or if a "SIGINT" or "SIGTERM" signal is received. This leads to situations when, if `ctrl+C` is pressed while there are still tasks in the stack/microtask queues (think in flight async xhr calls, or polling, or long running
`while` loops), the current process will continue running until all those tasks are run to completion, and the queues are empty.

This commit fixes this by explicitly calling `process.exit()` when an error is thrown (our internal "SIGINT"/"SIGTERM" handlers will throw a `CancelError`), thus ensuring we always exit the process.

Fixes https://github.com/cloudflare/workers-sdk/issues/8187

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not covered by e2e tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
