### PR TITLE
Prepare to omit Content-Type header for files of unknown extension in Workers Assets

### DIFF
--- a/.changeset/beige-crews-wash.md
+++ b/.changeset/beige-crews-wash.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/workers-shared": minor
+"miniflare": minor
+"wrangler": minor
+---
+
+feat: Omits Content-Type header for files of an unknown extension in Workers Assets

--- a/fixtures/workers-with-assets/public/totallyinvalidextension.greg
+++ b/fixtures/workers-with-assets/public/totallyinvalidextension.greg
@@ -1,0 +1,1 @@
+I'm a narcissist.

--- a/fixtures/workers-with-assets/tests/index.test.ts
+++ b/fixtures/workers-with-assets/tests/index.test.ts
@@ -76,6 +76,10 @@ describe("[Workers + Assets] dynamic site", () => {
 		response = await fetch(`http://${ip}:${port}/lava-lamps.jpg`);
 		expect(response.status).toBe(200);
 		expect(response.headers.get("Content-Type")).toBe("image/jpeg");
+
+		response = await fetch(`http://${ip}:${port}/totallyinvalidextension.greg`);
+		expect(response.status).toBe(200);
+		expect(response.headers.has("Content-Type")).toBeFalsy();
 	});
 
 	it("should return 405 for non-GET or HEAD requests on routes where assets exist", async ({

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -181,7 +181,7 @@ export type ManifestEntry = {
 };
 
 export type AssetReverseMap = {
-	[pathHash: string]: { filePath: string; contentType: string };
+	[pathHash: string]: { filePath: string; contentType: string | null };
 };
 
 /**

--- a/packages/miniflare/src/workers/assets/assets-kv.worker.ts
+++ b/packages/miniflare/src/workers/assets/assets-kv.worker.ts
@@ -37,10 +37,12 @@ export default <ExportedHandler<Env>>{
 		);
 		const newResponse = new Response(response.body, response);
 		// ensure the runtime will return the metadata we need
-		newResponse.headers.append(
-			"cf-kv-metadata",
-			`{"contentType": "${contentType}"}`
-		);
+		if (contentType !== null) {
+			newResponse.headers.append(
+				"cf-kv-metadata",
+				`{"contentType": "${contentType}"}`
+			);
+		}
 		return newResponse;
 	},
 };

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -187,9 +187,10 @@ export default class extends WorkerEntrypoint<Env> {
 		return true;
 	}
 
-	async unstable_getByETag(
-		eTag: string
-	): Promise<{ readableStream: ReadableStream; contentType: string }> {
+	async unstable_getByETag(eTag: string): Promise<{
+		readableStream: ReadableStream;
+		contentType: string | undefined;
+	}> {
 		const asset = await getAssetWithMetadataFromKV(
 			this.env.ASSETS_KV_NAMESPACE,
 			eTag
@@ -203,13 +204,14 @@ export default class extends WorkerEntrypoint<Env> {
 
 		return {
 			readableStream: asset.value,
-			contentType: asset.metadata?.contentType ?? "application/octet-stream",
+			contentType: asset.metadata?.contentType,
 		};
 	}
 
-	async unstable_getByPathname(
-		pathname: string
-	): Promise<{ readableStream: ReadableStream; contentType: string } | null> {
+	async unstable_getByPathname(pathname: string): Promise<{
+		readableStream: ReadableStream;
+		contentType: string | undefined;
+	} | null> {
 		const eTag = await this.unstable_exists(pathname);
 		if (!eTag) {
 			return null;

--- a/packages/workers-shared/asset-worker/src/utils/headers.ts
+++ b/packages/workers-shared/asset-worker/src/utils/headers.ts
@@ -8,13 +8,16 @@ import { CACHE_CONTROL_BROWSER } from "../constants";
  */
 export function getHeaders(
 	eTag: string,
-	contentType: string,
+	contentType: string | undefined,
 	request: Request
 ) {
 	const headers = new Headers({
-		"Content-Type": contentType,
 		ETag: `"${eTag}"`,
 	});
+
+	if (contentType !== undefined) {
+		headers.append("Content-Type", contentType);
+	}
 
 	if (isCacheable(request)) {
 		headers.append("Cache-Control", CACHE_CONTROL_BROWSER);

--- a/packages/workers-shared/utils/helpers.ts
+++ b/packages/workers-shared/utils/helpers.ts
@@ -10,8 +10,12 @@ export const normalizeFilePath = (relativeFilepath: string) => {
 };
 
 export const getContentType = (absFilePath: string) => {
-	let contentType = getType(absFilePath) || "application/octet-stream";
-	if (contentType.startsWith("text/") && !contentType.includes("charset")) {
+	let contentType = getType(absFilePath);
+	if (
+		contentType &&
+		contentType.startsWith("text/") &&
+		!contentType.includes("charset")
+	) {
 		contentType = `${contentType}; charset=utf-8`;
 	}
 	return contentType;

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -138,7 +138,7 @@ export const syncAssets = async (
 						[(await readFile(absFilePath)).toString("base64")],
 						manifestEntry[1].hash,
 						{
-							type: getContentType(absFilePath),
+							type: getContentType(absFilePath) || "application/octet-stream",
 						}
 					),
 					manifestEntry[1].hash


### PR DESCRIPTION
Fixes WC-3028.

This isn't quite everything. This makes it work in `wrangler dev` and prepares the asset-worker in production to be able to handle missing contentType metadata. We'll need to land this, then API support, and then follow up with the final piece here.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not live yet

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
