### PR TITLE
fix(vitest-pool-workers): responses from `fetchMock` should have immutable headers

### DIFF
--- a/.changeset/vast-trains-joke.md
+++ b/.changeset/vast-trains-joke.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix: responses from `fetchMock` should have immutable headers

--- a/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
+++ b/fixtures/vitest-pool-workers-examples/misc/test/fetch-mock.test.ts
@@ -61,6 +61,19 @@ it("intercepts URLs with query parameters with repeated keys", async () => {
 	expect(await response3.text()).toBe("baz");
 });
 
+it("throws if you try to mutate the headers", async () => {
+	fetchMock
+		.get("https://example.com")
+		.intercept({ path: "/" })
+		.reply(200, "body");
+
+	let response = await fetch("https://example.com");
+
+	expect(() => response.headers.set("foo", "bar")).toThrowError();
+	expect(() => response.headers.append("foo", "baz")).toThrowError();
+	expect(() => response.headers.delete("foo")).toThrowError();
+});
+
 describe("AbortSignal", () => {
 	let abortSignalTimeoutMock: MockInstance;
 

--- a/packages/vitest-pool-workers/src/worker/fetch-mock.ts
+++ b/packages/vitest-pool-workers/src/worker/fetch-mock.ts
@@ -170,18 +170,14 @@ globalThis.fetch = async (input, init) => {
 					statusText: responseStatusText,
 					headers: responseHeaders,
 				});
-				const throwImmutableHeaderError = () => {
+				const throwImmutableHeadersError = () => {
 					throw new TypeError("Can't modify immutable headers");
 				};
 				Object.defineProperty(response, "url", { value: url.href });
-				Object.defineProperty(response.headers, "set", {
-					value: throwImmutableHeaderError,
-				});
-				Object.defineProperty(response.headers, "append", {
-					value: throwImmutableHeaderError,
-				});
-				Object.defineProperty(response.headers, "delete", {
-					value: throwImmutableHeaderError,
+				Object.defineProperties(response.headers, {
+					set: { value: throwImmutableHeadersError },
+					append: { value: throwImmutableHeadersError },
+					delete: { value: throwImmutableHeadersError },
 				});
 				responseResolve(response);
 			} else {

--- a/packages/vitest-pool-workers/src/worker/fetch-mock.ts
+++ b/packages/vitest-pool-workers/src/worker/fetch-mock.ts
@@ -170,7 +170,19 @@ globalThis.fetch = async (input, init) => {
 					statusText: responseStatusText,
 					headers: responseHeaders,
 				});
+				const throwImmutableHeaderError = () => {
+					throw new TypeError("Can't modify immutable headers");
+				};
 				Object.defineProperty(response, "url", { value: url.href });
+				Object.defineProperty(response.headers, "set", {
+					value: throwImmutableHeaderError,
+				});
+				Object.defineProperty(response.headers, "append", {
+					value: throwImmutableHeaderError,
+				});
+				Object.defineProperty(response.headers, "delete", {
+					value: throwImmutableHeaderError,
+				});
 				responseResolve(response);
 			} else {
 				responseResolve(maybeResponse);


### PR DESCRIPTION
Fixes #7468.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact outside of vitest-pool-workers
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
