### PR TITLE
Add Queues commands to pause-delivery and resume-delivery

### DIFF
--- a/.changeset/shiny-zebras-switch.md
+++ b/.changeset/shiny-zebras-switch.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add two new Queues commands: pause-delivery and resume-delivery
+
+These new commands allow users to pause and resume the delivery of messages to Queue Consumers

--- a/packages/wrangler/src/queues/cli/commands/index.ts
+++ b/packages/wrangler/src/queues/cli/commands/index.ts
@@ -4,6 +4,11 @@ import { handler as createHandler, options as createOptions } from "./create";
 import { handler as deleteHandler, options as deleteOptions } from "./delete";
 import { handler as infoHandler, options as infoOptions } from "./info";
 import { handler as listHandler, options as listOptions } from "./list";
+import {
+	pauseHandler,
+	options as pauseResumeOptions,
+	resumeHandler,
+} from "./pause-resume";
 import { handler as updateHandler, options as updateOptions } from "./update";
 import type { CommonYargsArgv } from "../../../yargs-types";
 
@@ -44,6 +49,20 @@ export function queues(yargs: CommonYargsArgv) {
 		async (consumersYargs) => {
 			await consumers(consumersYargs);
 		}
+	);
+
+	yargs.command(
+		"pause-delivery <name>",
+		"Pause message delivery for a Queue",
+		pauseResumeOptions,
+		pauseHandler
+	);
+
+	yargs.command(
+		"resume-delivery <name>",
+		"Resume message delivery for a Queue",
+		pauseResumeOptions,
+		resumeHandler
 	);
 
 	yargs.fail(HandleUnauthorizedError);

--- a/packages/wrangler/src/queues/cli/commands/pause-resume.ts
+++ b/packages/wrangler/src/queues/cli/commands/pause-resume.ts
@@ -1,0 +1,55 @@
+import { readConfig } from "../../../config";
+import { logger } from "../../../logger";
+import { getQueue, updateQueue } from "../../client";
+import { handleFetchError } from "../../utils";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../../../yargs-types";
+import type { PostQueueBody } from "../../client";
+
+export function options(yargs: CommonYargsArgv) {
+	return yargs.positional("name", {
+		type: "string",
+		demandOption: true,
+		description: "The name of the queue",
+	});
+}
+
+export async function pauseHandler(
+	args: StrictYargsOptionsToInterface<typeof options>
+) {
+	return toggleDeliveryPaused(args, true);
+}
+
+export async function resumeHandler(
+	args: StrictYargsOptionsToInterface<typeof options>
+) {
+	return toggleDeliveryPaused(args, false);
+}
+
+async function toggleDeliveryPaused(
+	args: StrictYargsOptionsToInterface<typeof options>,
+	paused: boolean
+) {
+	const config = readConfig(args);
+	const body: PostQueueBody = {
+		queue_name: args.name,
+		settings: {
+			delivery_paused: paused,
+		},
+	};
+	try {
+		const currentQueue = await getQueue(config, args.name);
+
+		let msg = paused ? "Pausing" : "Resuming";
+		logger.log(`${msg} message delivery for queue ${args.name}.`);
+
+		await updateQueue(config, body, currentQueue.queue_id);
+
+		msg = paused ? "Paused" : "Resumed";
+		logger.log(`${msg} message delivery for queue ${args.name}.`);
+	} catch (e) {
+		handleFetchError(e as { code?: number });
+	}
+}

--- a/packages/wrangler/src/queues/client.ts
+++ b/packages/wrangler/src/queues/client.ts
@@ -19,6 +19,7 @@ interface WorkerService {
 
 export interface QueueSettings {
 	delivery_delay?: number;
+	delivery_paused?: boolean;
 	message_retention_period?: number;
 }
 


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/MQ-846.

Adds new commands to pause and resume message delivery for a Queue.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: new feature
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/20284
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
