### PR TITLE
Make `builder.buildApp` overridable

### DIFF
--- a/.changeset/good-rooms-sneeze.md
+++ b/.changeset/good-rooms-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Make it possible to override `builder.buildApp` in the user config or prior plugins

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/__tests__/custom-build-app.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/__tests__/custom-build-app.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "vitest";
+import { getTextResponse, isBuild, serverLogs } from "../../__test-utils__";
+
+test("returns the correct response", async () => {
+	expect(await getTextResponse()).toEqual("Hello World!");
+});
+
+test.runIf(isBuild)("runs a custom buildApp function", async () => {
+	expect(serverLogs.info.join()).toContain("__before-build__");
+	expect(serverLogs.info.join()).toContain("__after-build__");
+});

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/package.json
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@playground/worker",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build --app",
+		"check:types": "tsc --build",
+		"dev": "vite dev",
+		"preview": "vite preview"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "workspace:*",
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "^4.20250214.0",
+		"typescript": "catalog:default",
+		"vite": "catalog:vite-plugin",
+		"wrangler": "catalog:vite-plugin"
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/package.json
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@playground/worker",
+	"name": "@playground/custom-build-app",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/src/index.ts
@@ -1,0 +1,5 @@
+export default {
+	async fetch() {
+		return new Response("Hello World!");
+	},
+} satisfies ExportedHandler;

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/tsconfig.json
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/tsconfig.node.json
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/tsconfig.node.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/base.json"],
+	"include": ["vite.config.ts", "__tests__"]
+}

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/tsconfig.worker.json
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/tsconfig.worker.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/worker.json"],
+	"include": ["src"]
+}

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/turbo.json
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://turbo.build/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["dist/**"]
+		}
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/vite.config.ts
@@ -1,0 +1,17 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	builder: {
+		async buildApp(builder) {
+			const workerEnvironment = builder.environments.worker;
+
+			if (workerEnvironment) {
+				builder.config.logger.info("__before-build__");
+				await builder.build(workerEnvironment);
+				builder.config.logger.info("__after-build__");
+			}
+		},
+	},
+	plugins: [cloudflare({ persistState: false })],
+});

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/wrangler.toml
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/wrangler.toml
@@ -1,0 +1,3 @@
+name = "worker"
+main = "./src/index.ts"
+compatibility_date = "2024-12-30"

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -98,42 +98,44 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 								}
 							: undefined,
 					builder: {
-						async buildApp(builder) {
-							const clientEnvironment = builder.environments.client;
-							const defaultHtmlPath = path.resolve(
-								builder.config.root,
-								"index.html"
-							);
-
-							if (
-								clientEnvironment &&
-								(clientEnvironment.config.build.rollupOptions.input ||
-									fs.existsSync(defaultHtmlPath))
-							) {
-								await builder.build(clientEnvironment);
-							}
-
-							if (resolvedPluginConfig.type === "workers") {
-								const workerEnvironments = Object.keys(
-									resolvedPluginConfig.workers
-								).map((environmentName) => {
-									const environment = builder.environments[environmentName];
-
-									assert(
-										environment,
-										`${environmentName} environment not found`
-									);
-
-									return environment;
-								});
-
-								await Promise.all(
-									workerEnvironments.map((environment) =>
-										builder.build(environment)
-									)
+						buildApp:
+							userConfig.builder?.buildApp ??
+							(async (builder) => {
+								const clientEnvironment = builder.environments.client;
+								const defaultHtmlPath = path.resolve(
+									builder.config.root,
+									"index.html"
 								);
-							}
-						},
+
+								if (
+									clientEnvironment &&
+									(clientEnvironment.config.build.rollupOptions.input ||
+										fs.existsSync(defaultHtmlPath))
+								) {
+									await builder.build(clientEnvironment);
+								}
+
+								if (resolvedPluginConfig.type === "workers") {
+									const workerEnvironments = Object.keys(
+										resolvedPluginConfig.workers
+									).map((environmentName) => {
+										const environment = builder.environments[environmentName];
+
+										assert(
+											environment,
+											`${environmentName} environment not found`
+										);
+
+										return environment;
+									});
+
+									await Promise.all(
+										workerEnvironments.map((environment) =>
+											builder.build(environment)
+										)
+									);
+								}
+							}),
 					},
 				};
 			},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1849,6 +1849,27 @@ importers:
         specifier: catalog:vite-plugin
         version: 3.109.1(@cloudflare/workers-types@4.20250214.0)
 
+  packages/vite-plugin-cloudflare/playground/custom-build-app:
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: workspace:*
+        version: link:../..
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../../workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20250214.0
+        version: 4.20250214.0
+      typescript:
+        specifier: catalog:default
+        version: 5.7.3
+      vite:
+        specifier: catalog:vite-plugin
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+      wrangler:
+        specifier: catalog:vite-plugin
+        version: 3.109.1(@cloudflare/workers-types@4.20250214.0)
+
   packages/vite-plugin-cloudflare/playground/dev-vars:
     devDependencies:
       '@cloudflare/vite-plugin':


### PR DESCRIPTION
Fixes #000.

Make it possible to override `builder.buildApp` in the user config or prior plugins. As well as allowing users to provide their own `buildApp` function, this also makes framework integrations less dependent on plugin order.

I haven't added a specific playground to test this as it is likely the `buildApp` API might change soon.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
