### PR TITLE
Adds Python print e2e test again.

### DIFF
--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -455,6 +455,46 @@ describe.each([{ cmd: "wrangler dev" }])(
 
 			expect(text).toBe("py hello world 5");
 		});
+
+		it(`can print during ${cmd}`, async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.toml": dedent`
+					name = "${workerName}"
+					main = "index.py"
+					compatibility_date = "2023-01-01"
+					compatibility_flags = ["python_workers"]
+			`,
+				"arithmetic.py": dedent`
+					def mul(a,b):
+						return a*b`,
+				"index.py": dedent`
+					from arithmetic import mul
+
+					from js import Response, console
+					def on_fetch(request):
+						console.log(f"hello {mul(2,3)}")
+						print(f"foobar {mul(4,3)}")
+						console.log(f"end")
+						return Response.new(f"py hello world {mul(2,3)}")`,
+				"package.json": dedent`
+					{
+						"name": "worker",
+						"version": "0.0.0",
+						"private": true
+					}
+					`,
+			});
+			const worker = helper.runLongLived(cmd);
+
+			const { url } = await worker.waitForReady();
+
+			await expect(fetchText(url)).resolves.toBe("py hello world 6");
+
+			await worker.readUntil(/hello 6/);
+			await worker.readUntil(/foobar 12/);
+			await worker.readUntil(/end/);
+		});
 	}
 );
 


### PR DESCRIPTION
This was reverted in https://github.com/cloudflare/workers-sdk/pull/8252. Recreating to figure out what went wrong.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tests

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

----

### Test Plan

Tested locally by running:

```
CLOUDFLARE_ACCOUNT_ID=8d783f274e1f82dc46744c297b015a2f CLOUDFLARE_API_TOKEN="foobar" WRANGLER="node --no-warnings $PWD/packages/wrangler/bin/wrangler.js" WRANGLER_IMPORT="$PWD/packages/wrangler/wrangler-dist/cli.js" pnpm --filter wrangler run test:e2e -- packages/wrangler/e2e/dev.test.ts
```

I removed some of the other tests in dev.test.ts, thankfully the above seems to run it without getting caught on other tests that are failing so it allowed me to verify these work locally.