### PR TITLE
feat(miniflare): Add assets Proxy Worker skeleton in miniflare

### DIFF
--- a/.changeset/dry-ends-post.md
+++ b/.changeset/dry-ends-post.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+"miniflare": patch
+"wrangler": patch
+---
+
+feat: Add assets Proxy Worker skeleton in miniflare
+
+This commit implements a very basic Proxy Worker skeleton, and wires it in the "pipeline" miniflare creates for assets. This Worker will be incrementally worked on, but for now, the current implementation will forward all incoming requests to the Router Worker, thus leaving the current assets behaviour in local dev, the same.
+
+This is an experimental feature available under the `--x-assets-rpc` flag: `wrangler dev --x-assets-rpc`.

--- a/fixtures/workers-with-assets-only/tests/index.test.ts
+++ b/fixtures/workers-with-assets-only/tests/index.test.ts
@@ -3,176 +3,184 @@ import { fetch } from "undici";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
-describe("[Workers + Assets] static-assets only site`", () => {
-	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
+const devCmds = [{ args: [] }, { args: ["--x-assets-rpc"] }];
 
-	beforeAll(async () => {
-		({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
-			"--port=0",
-			"--inspector-port=0",
-		]));
-	});
+describe.each(devCmds)(
+	"[wrangler dev $args][Workers + Assets] static-assets only site`",
+	({ args }) => {
+		let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
-	afterAll(async () => {
-		await stop?.();
-	});
-
-	it("should respond with static asset content", async ({ expect }) => {
-		let response = await fetch(`http://${ip}:${port}/index.html`);
-		let text = await response.text();
-		expect(response.status).toBe(200);
-		expect(text).toContain(`<h1>Hello Workers + Assets World 🚀!</h1>`);
-
-		response = await fetch(`http://${ip}:${port}/about/index.html`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(text).toContain(`<p>Learn more about Workers with Assets soon!</p>`);
-	});
-
-	it("should resolve '/' to '/index.html' ", async ({ expect }) => {
-		let response = await fetch(`http://${ip}:${port}/`);
-		expect(response.status).toBe(200);
-		expect(await response.text()).toContain(
-			`<h1>Hello Workers + Assets World 🚀!</h1>`
-		);
-	});
-
-	it("should 404 if asset is not found in the asset manifest", async ({
-		expect,
-	}) => {
-		let response = await fetch(`http://${ip}:${port}/hello.html`);
-		expect(response.status).toBe(404);
-
-		response = await fetch(`http://${ip}:${port}/hello.txt`);
-		expect(response.status).toBe(404);
-	});
-
-	it("should handle content types correctly", async ({ expect }) => {
-		let response = await fetch(`http://${ip}:${port}/index.html`);
-		let text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe(
-			"text/html; charset=utf-8"
-		);
-
-		response = await fetch(`http://${ip}:${port}/README.md`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe(
-			"text/markdown; charset=utf-8"
-		);
-		expect(text).toContain(`Welcome to Workers + Assets YAY!`);
-
-		response = await fetch(`http://${ip}:${port}/yay.txt`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe(
-			"text/plain; charset=utf-8"
-		);
-		expect(text).toContain(`.----------------.`);
-
-		response = await fetch(`http://${ip}:${port}/lava-lamps.jpg`);
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe("image/jpeg");
-	});
-
-	it("should return 405 for non-GET or HEAD requests if asset route exists", async ({
-		expect,
-	}) => {
-		// as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
-		// excl. TRACE and CONNECT which are not supported
-
-		let response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "POST",
+		beforeAll(async () => {
+			({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
+				"--port=0",
+				"--inspector-port=0",
+				...args,
+			]));
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
 
-		response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "PUT",
+		afterAll(async () => {
+			await stop?.();
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
 
-		response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "DELETE",
+		it("should respond with static asset content", async ({ expect }) => {
+			let response = await fetch(`http://${ip}:${port}/index.html`);
+			let text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toContain(`<h1>Hello Workers + Assets World 🚀!</h1>`);
+
+			response = await fetch(`http://${ip}:${port}/about/index.html`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toContain(
+				`<p>Learn more about Workers with Assets soon!</p>`
+			);
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
 
-		response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "OPTIONS",
+		it("should resolve '/' to '/index.html' ", async ({ expect }) => {
+			let response = await fetch(`http://${ip}:${port}/`);
+			expect(response.status).toBe(200);
+			expect(await response.text()).toContain(
+				`<h1>Hello Workers + Assets World 🚀!</h1>`
+			);
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
 
-		response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "PATCH",
+		it("should 404 if asset is not found in the asset manifest", async ({
+			expect,
+		}) => {
+			let response = await fetch(`http://${ip}:${port}/hello.html`);
+			expect(response.status).toBe(404);
+
+			response = await fetch(`http://${ip}:${port}/hello.txt`);
+			expect(response.status).toBe(404);
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
-	});
 
-	it("should return 404 for non-GET requests if asset route does not exist", async ({
-		expect,
-	}) => {
-		// as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
-		// excl. TRACE and CONNECT which are not supported
+		it("should handle content types correctly", async ({ expect }) => {
+			let response = await fetch(`http://${ip}:${port}/index.html`);
+			let text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe(
+				"text/html; charset=utf-8"
+			);
 
-		let response = await fetch(`http://${ip}:${port}/nope.html`, {
-			method: "HEAD",
+			response = await fetch(`http://${ip}:${port}/README.md`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe(
+				"text/markdown; charset=utf-8"
+			);
+			expect(text).toContain(`Welcome to Workers + Assets YAY!`);
+
+			response = await fetch(`http://${ip}:${port}/yay.txt`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe(
+				"text/plain; charset=utf-8"
+			);
+			expect(text).toContain(`.----------------.`);
+
+			response = await fetch(`http://${ip}:${port}/lava-lamps.jpg`);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe("image/jpeg");
 		});
-		expect(response.status).toBe(404);
 
-		response = await fetch(`http://${ip}:${port}/nope.html`, {
-			method: "POST",
+		it("should return 405 for non-GET or HEAD requests if asset route exists", async ({
+			expect,
+		}) => {
+			// as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+			// excl. TRACE and CONNECT which are not supported
+
+			let response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "POST",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
+
+			response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "PUT",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
+
+			response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "DELETE",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
+
+			response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "OPTIONS",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
+
+			response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "PATCH",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
 		});
-		expect(response.status).toBe(404);
 
-		response = await fetch(`http://${ip}:${port}/nope.html`, {
-			method: "PUT",
+		it("should return 404 for non-GET requests if asset route does not exist", async ({
+			expect,
+		}) => {
+			// as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+			// excl. TRACE and CONNECT which are not supported
+
+			let response = await fetch(`http://${ip}:${port}/nope.html`, {
+				method: "HEAD",
+			});
+			expect(response.status).toBe(404);
+
+			response = await fetch(`http://${ip}:${port}/nope.html`, {
+				method: "POST",
+			});
+			expect(response.status).toBe(404);
+
+			response = await fetch(`http://${ip}:${port}/nope.html`, {
+				method: "PUT",
+			});
+			expect(response.status).toBe(404);
+
+			response = await fetch(`http://${ip}:${port}/nope.html`, {
+				method: "DELETE",
+			});
+			expect(response.status).toBe(404);
+
+			response = await fetch(`http://${ip}:${port}/nope.html`, {
+				method: "OPTIONS",
+			});
+			expect(response.status).toBe(404);
+
+			response = await fetch(`http://${ip}:${port}/nope.html`, {
+				method: "PATCH",
+			});
+			expect(response.status).toBe(404);
 		});
-		expect(response.status).toBe(404);
 
-		response = await fetch(`http://${ip}:${port}/nope.html`, {
-			method: "DELETE",
+		it("should work with encoded path names", async ({ expect }) => {
+			let response = await fetch(`http://${ip}:${port}/about/[fünky].txt`);
+			let text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.url).toBe(
+				`http://${ip}:${port}/about/%5Bf%C3%BCnky%5D.txt`
+			);
+			expect(text).toContain(`This should work.`);
+
+			response = await fetch(`http://${ip}:${port}/about/[boop]`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.url).toBe(`http://${ip}:${port}/about/%5Bboop%5D`);
+			expect(text).toContain(`[boop].html`);
+
+			response = await fetch(`http://${ip}:${port}/about/%5Bboop%5D`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toContain(`[boop].html`);
+
+			response = await fetch(`http://${ip}:${port}/about/%255Bboop%255D`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toContain(`%255Bboop%255D.html`);
 		});
-		expect(response.status).toBe(404);
-
-		response = await fetch(`http://${ip}:${port}/nope.html`, {
-			method: "OPTIONS",
-		});
-		expect(response.status).toBe(404);
-
-		response = await fetch(`http://${ip}:${port}/nope.html`, {
-			method: "PATCH",
-		});
-		expect(response.status).toBe(404);
-	});
-
-	it("should work with encoded path names", async ({ expect }) => {
-		let response = await fetch(`http://${ip}:${port}/about/[fünky].txt`);
-		let text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.url).toBe(
-			`http://${ip}:${port}/about/%5Bf%C3%BCnky%5D.txt`
-		);
-		expect(text).toContain(`This should work.`);
-
-		response = await fetch(`http://${ip}:${port}/about/[boop]`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.url).toBe(`http://${ip}:${port}/about/%5Bboop%5D`);
-		expect(text).toContain(`[boop].html`);
-
-		response = await fetch(`http://${ip}:${port}/about/%5Bboop%5D`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(text).toContain(`[boop].html`);
-
-		response = await fetch(`http://${ip}:${port}/about/%255Bboop%255D`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(text).toContain(`%255Bboop%255D.html`);
-	});
-});
+	}
+);

--- a/fixtures/workers-with-assets/tests/index.test.ts
+++ b/fixtures/workers-with-assets/tests/index.test.ts
@@ -3,211 +3,221 @@ import { fetch } from "undici";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
-describe("[Workers + Assets] dynamic site", () => {
-	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
+const devCmds = [{ args: [] }, { args: ["--x-assets-rpc"] }];
 
-	beforeAll(async () => {
-		({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
-			"--port=0",
-			"--inspector-port=0",
-		]));
-	});
+describe.each(devCmds)(
+	"[wrangler dev $args][Workers + Assets] dynamic site",
+	({ args }) => {
+		let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
-	afterAll(async () => {
-		await stop?.();
-	});
-
-	it("should respond with static asset content", async ({ expect }) => {
-		let response = await fetch(`http://${ip}:${port}/index.html`);
-		let text = await response.text();
-		expect(response.status).toBe(200);
-		expect(text).toContain(`<h1>Hello Workers + Assets World 🚀!</h1>`);
-
-		response = await fetch(`http://${ip}:${port}/about/index.html`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(text).toContain(`<p>Learn more about Workers with Assets soon!</p>`);
-	});
-
-	it("should fallback to the user Worker if there are no assets at a given path ", async ({
-		expect,
-	}) => {
-		// Requests should hit the Asset Worker *first*, then try the user Worker
-		const response = await fetch(`http://${ip}:${port}/no-assets-here`);
-		const text = await response.text();
-		expect(text).toContain(
-			"There were no assets at this route! Hello from the user Worker instead!"
-		);
-	});
-
-	// html_handling defaults to 'auto-trailing-slash'
-	it("should `/` resolve to `/index.html` ", async ({ expect }) => {
-		const response = await fetch(`http://${ip}:${port}/`);
-		const text = await response.text();
-		expect(text).toContain("<h1>Hello Workers + Assets World 🚀!</h1>");
-	});
-
-	it("should handle content types correctly on asset routes", async ({
-		expect,
-	}) => {
-		let response = await fetch(`http://${ip}:${port}/index.html`);
-		let text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe(
-			"text/html; charset=utf-8"
-		);
-
-		response = await fetch(`http://${ip}:${port}/README.md`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe(
-			"text/markdown; charset=utf-8"
-		);
-		expect(text).toContain(`Welcome to Workers + Assets YAY!`);
-
-		response = await fetch(`http://${ip}:${port}/yay.txt`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe(
-			"text/plain; charset=utf-8"
-		);
-		expect(text).toContain(`.----------------.`);
-
-		response = await fetch(`http://${ip}:${port}/lava-lamps.jpg`);
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe("image/jpeg");
-
-		response = await fetch(`http://${ip}:${port}/totallyinvalidextension.greg`);
-		expect(response.status).toBe(200);
-		expect(response.headers.has("Content-Type")).toBeFalsy();
-	});
-
-	it("should return 405 for non-GET or HEAD requests on routes where assets exist", async ({
-		expect,
-	}) => {
-		// these should return the error and NOT be forwarded onto the user Worker
-		// POST etc. request -> RW -> AW -> check manifest --405--> RW --405--> eyeball
-
-		// methods as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
-		// excl. TRACE and CONNECT which are not supported
-
-		let response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "POST",
+		beforeAll(async () => {
+			({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
+				"--port=0",
+				"--inspector-port=0",
+				...args,
+			]));
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
 
-		response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "PUT",
+		afterAll(async () => {
+			await stop?.();
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
 
-		response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "DELETE",
+		it("should respond with static asset content", async ({ expect }) => {
+			let response = await fetch(`http://${ip}:${port}/index.html`);
+			let text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toContain(`<h1>Hello Workers + Assets World 🚀!</h1>`);
+
+			response = await fetch(`http://${ip}:${port}/about/index.html`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toContain(
+				`<p>Learn more about Workers with Assets soon!</p>`
+			);
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
 
-		response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "OPTIONS",
+		it("should fallback to the user Worker if there are no assets at a given path ", async ({
+			expect,
+		}) => {
+			// Requests should hit the Asset Worker *first*, then try the user Worker
+			const response = await fetch(`http://${ip}:${port}/no-assets-here`);
+			const text = await response.text();
+			expect(text).toContain(
+				"There were no assets at this route! Hello from the user Worker instead!"
+			);
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
 
-		response = await fetch(`http://${ip}:${port}/index.html`, {
-			method: "PATCH",
+		// html_handling defaults to 'auto-trailing-slash'
+		it("should `/` resolve to `/index.html` ", async ({ expect }) => {
+			const response = await fetch(`http://${ip}:${port}/`);
+			const text = await response.text();
+			expect(text).toContain("<h1>Hello Workers + Assets World 🚀!</h1>");
 		});
-		expect(response.status).toBe(405);
-		expect(response.statusText).toBe("Method Not Allowed");
-	});
 
-	it("should work with encoded path names", async ({ expect }) => {
-		let response = await fetch(`http://${ip}:${port}/about/[fünky].txt`);
-		let text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.url).toBe(
-			`http://${ip}:${port}/about/%5Bf%C3%BCnky%5D.txt`
-		);
-		expect(text).toContain(`This should work.`);
+		it("should handle content types correctly on asset routes", async ({
+			expect,
+		}) => {
+			let response = await fetch(`http://${ip}:${port}/index.html`);
+			let text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe(
+				"text/html; charset=utf-8"
+			);
 
-		response = await fetch(`http://${ip}:${port}/about/[boop]`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.url).toBe(`http://${ip}:${port}/about/%5Bboop%5D`);
-		expect(text).toContain(`[boop].html`);
+			response = await fetch(`http://${ip}:${port}/README.md`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe(
+				"text/markdown; charset=utf-8"
+			);
+			expect(text).toContain(`Welcome to Workers + Assets YAY!`);
 
-		response = await fetch(`http://${ip}:${port}/about/%5Bboop%5D`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(text).toContain(`[boop].html`);
+			response = await fetch(`http://${ip}:${port}/yay.txt`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe(
+				"text/plain; charset=utf-8"
+			);
+			expect(text).toContain(`.----------------.`);
 
-		response = await fetch(`http://${ip}:${port}/about/%255Bboop%255D`);
-		text = await response.text();
-		expect(response.status).toBe(200);
-		expect(text).toContain(`%5Bboop%5D.html`);
-	});
+			response = await fetch(`http://${ip}:${port}/lava-lamps.jpg`);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe("image/jpeg");
 
-	it("should forward all request types to the user Worker if there are *not* assets on that route", async ({
-		expect,
-	}) => {
-		// Unlike above, if the AW does NOT find assets on a route, non-GET request should return 404s
-		// This is because all requests are first sent to the AW and only then to the UW
-		// and we don't want to 405 on a valid POST request intended for the UW
-		// POST etc. request -> RW -> AW -> checks manifest --404--> RW -> UW -> response
-
-		let response = await fetch(`http://${ip}:${port}/no-assets-here`, {
-			method: "GET",
+			response = await fetch(
+				`http://${ip}:${port}/totallyinvalidextension.greg`
+			);
+			expect(response.status).toBe(200);
+			expect(response.headers.has("Content-Type")).toBeFalsy();
 		});
-		expect(response.status).toBe(200);
 
-		response = await fetch(`http://${ip}:${port}/no-assets-here`, {
-			method: "HEAD",
+		it("should return 405 for non-GET or HEAD requests on routes where assets exist", async ({
+			expect,
+		}) => {
+			// these should return the error and NOT be forwarded onto the user Worker
+			// POST etc. request -> RW -> AW -> check manifest --405--> RW --405--> eyeball
+
+			// methods as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+			// excl. TRACE and CONNECT which are not supported
+
+			let response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "POST",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
+
+			response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "PUT",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
+
+			response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "DELETE",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
+
+			response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "OPTIONS",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
+
+			response = await fetch(`http://${ip}:${port}/index.html`, {
+				method: "PATCH",
+			});
+			expect(response.status).toBe(405);
+			expect(response.statusText).toBe("Method Not Allowed");
 		});
-		expect(response.status).toBe(200);
 
-		response = await fetch(`http://${ip}:${port}/no-assets-here`, {
-			method: "POST",
+		it("should work with encoded path names", async ({ expect }) => {
+			let response = await fetch(`http://${ip}:${port}/about/[fünky].txt`);
+			let text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.url).toBe(
+				`http://${ip}:${port}/about/%5Bf%C3%BCnky%5D.txt`
+			);
+			expect(text).toContain(`This should work.`);
+
+			response = await fetch(`http://${ip}:${port}/about/[boop]`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.url).toBe(`http://${ip}:${port}/about/%5Bboop%5D`);
+			expect(text).toContain(`[boop].html`);
+
+			response = await fetch(`http://${ip}:${port}/about/%5Bboop%5D`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toContain(`[boop].html`);
+
+			response = await fetch(`http://${ip}:${port}/about/%255Bboop%255D`);
+			text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toContain(`%5Bboop%5D.html`);
 		});
-		expect(response.status).toBe(200);
 
-		response = await fetch(`http://${ip}:${port}/no-assets-here`, {
-			method: "PUT",
+		it("should forward all request types to the user Worker if there are *not* assets on that route", async ({
+			expect,
+		}) => {
+			// Unlike above, if the AW does NOT find assets on a route, non-GET request should return 404s
+			// This is because all requests are first sent to the AW and only then to the UW
+			// and we don't want to 405 on a valid POST request intended for the UW
+			// POST etc. request -> RW -> AW -> checks manifest --404--> RW -> UW -> response
+
+			let response = await fetch(`http://${ip}:${port}/no-assets-here`, {
+				method: "GET",
+			});
+			expect(response.status).toBe(200);
+
+			response = await fetch(`http://${ip}:${port}/no-assets-here`, {
+				method: "HEAD",
+			});
+			expect(response.status).toBe(200);
+
+			response = await fetch(`http://${ip}:${port}/no-assets-here`, {
+				method: "POST",
+			});
+			expect(response.status).toBe(200);
+
+			response = await fetch(`http://${ip}:${port}/no-assets-here`, {
+				method: "PUT",
+			});
+			expect(response.status).toBe(200);
+
+			response = await fetch(`http://${ip}:${port}/no-assets-here`, {
+				method: "DELETE",
+			});
+			expect(response.status).toBe(200);
+
+			response = await fetch(`http://${ip}:${port}/no-assets-here`, {
+				method: "OPTIONS",
+			});
+			expect(response.status).toBe(200);
+
+			response = await fetch(`http://${ip}:${port}/no-assets-here`, {
+				method: "PATCH",
+			});
+			expect(response.status).toBe(200);
 		});
-		expect(response.status).toBe(200);
 
-		response = await fetch(`http://${ip}:${port}/no-assets-here`, {
-			method: "DELETE",
+		it("should be able to use an ASSETS binding", async ({ expect }) => {
+			let response = await fetch(`http://${ip}:${port}/assets-binding`);
+			let text = await response.text();
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe(
+				"text/html; charset=utf-8"
+			);
+			expect(text).toContain("<h1>✨This is from a user Worker binding✨</h1>");
 		});
-		expect(response.status).toBe(200);
 
-		response = await fetch(`http://${ip}:${port}/no-assets-here`, {
-			method: "OPTIONS",
+		it("should be able to use a binding to a named entrypoint", async ({
+			expect,
+		}) => {
+			let response = await fetch(`http://${ip}:${port}/named-entrypoint`);
+			let text = await response.text();
+			expect(response.status).toBe(200);
+			expect(text).toContain("hello from a named entrypoint");
 		});
-		expect(response.status).toBe(200);
-
-		response = await fetch(`http://${ip}:${port}/no-assets-here`, {
-			method: "PATCH",
-		});
-		expect(response.status).toBe(200);
-	});
-
-	it("should be able to use an ASSETS binding", async ({ expect }) => {
-		let response = await fetch(`http://${ip}:${port}/assets-binding`);
-		let text = await response.text();
-		expect(response.status).toBe(200);
-		expect(response.headers.get("Content-Type")).toBe(
-			"text/html; charset=utf-8"
-		);
-		expect(text).toContain("<h1>✨This is from a user Worker binding✨</h1>");
-	});
-
-	it("should be able to use a binding to a named entrypoint", async ({
-		expect,
-	}) => {
-		let response = await fetch(`http://${ip}:${port}/named-entrypoint`);
-		let text = await response.text();
-		expect(response.status).toBe(200);
-		expect(text).toContain("hello from a named entrypoint");
-	});
-});
+	}
+);

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -63,7 +63,10 @@ import {
 	WorkerOptions,
 	WrappedBindingNames,
 } from "./plugins";
-import { ROUTER_SERVICE_NAME } from "./plugins/assets/constants";
+import {
+	ROUTER_SERVICE_NAME,
+	RPC_PROXY_SERVICE_NAME,
+} from "./plugins/assets/constants";
 import {
 	CUSTOM_SERVICE_KNOWN_OUTBOUND,
 	CustomServiceKind,
@@ -1205,13 +1208,23 @@ export class Miniflare {
 								"core:user:",
 								""
 							);
+
+							/*
+							 * If we are running multiple Workers in a single dev session,
+							 * and this is a binding to a Worker with assets, we want that
+							 * binding to point to the Router Worker or the Assets Proxy
+							 * Worker, if the `unsafeEnableAssetsRpc` flag is enabled
+							 */
 							const maybeAssetTargetService = allWorkerOpts.find(
 								(worker) =>
 									worker.core.name === targetWorkerName && worker.assets.assets
 							);
 							if (maybeAssetTargetService && !binding.service?.entrypoint) {
 								assert(binding.service?.name);
-								binding.service.name = `${ROUTER_SERVICE_NAME}:${targetWorkerName}`;
+								binding.service.name = this.#sharedOpts.core
+									.unsafeEnableAssetsRpc
+									? `${RPC_PROXY_SERVICE_NAME}:${targetWorkerName}`
+									: `${ROUTER_SERVICE_NAME}:${targetWorkerName}`;
 							}
 						}
 					}
@@ -1220,6 +1233,8 @@ export class Miniflare {
 
 			// Collect all services required by this worker
 			const unsafeStickyBlobs = sharedOpts.core.unsafeStickyBlobs ?? false;
+			const unsafeEnableAssetsRpc =
+				sharedOpts.core.unsafeEnableAssetsRpc ?? false;
 			const unsafeEphemeralDurableObjects =
 				workerOpts.core.unsafeEphemeralDurableObjects ?? false;
 			const pluginServicesOptionsBase: Omit<
@@ -1239,6 +1254,7 @@ export class Miniflare {
 				unsafeEphemeralDurableObjects,
 				queueProducers,
 				queueConsumers,
+				unsafeEnableAssetsRpc,
 			};
 			for (const [key, plugin] of PLUGIN_ENTRIES) {
 				const pluginServicesExtensions = await plugin.getServices({
@@ -1310,14 +1326,21 @@ export class Miniflare {
 		const globalServices = getGlobalServices({
 			sharedOptions: sharedOpts.core,
 			allWorkerRoutes,
-			// if Workers + Assets project but NOT Vitest, point to router Worker instead
-			// if Vitest with assets, the self binding on the test runner will point to RW
+			/*
+			 * - if Workers + Assets project but NOT Vitest, point to Router Worker or
+			 *   Proxy Worker depending on whether experimental flag `unsafeEnableAssetsRpc`
+			 *   was set
+			 * - if Vitest with assets, the self binding on the test runner will point to
+			 *   Router Worker
+			 */
 			fallbackWorkerName:
 				this.#workerOpts[0].assets.assets &&
 				!this.#workerOpts[0].core.name?.startsWith(
 					"vitest-pool-workers-runner-"
 				)
-					? `${ROUTER_SERVICE_NAME}:${this.#workerOpts[0].core.name}`
+					? this.#sharedOpts.core.unsafeEnableAssetsRpc
+						? `${RPC_PROXY_SERVICE_NAME}:${this.#workerOpts[0].core.name}`
+						: `${ROUTER_SERVICE_NAME}:${this.#workerOpts[0].core.name}`
 					: getUserServiceName(this.#workerOpts[0].core.name),
 			loopbackPort,
 			log: this.#log,

--- a/packages/miniflare/src/plugins/assets/constants.ts
+++ b/packages/miniflare/src/plugins/assets/constants.ts
@@ -1,4 +1,5 @@
 export const ASSETS_PLUGIN_NAME = "assets";
 export const ASSETS_SERVICE_NAME = `${ASSETS_PLUGIN_NAME}:assets-service`;
 export const ROUTER_SERVICE_NAME = `${ASSETS_PLUGIN_NAME}:router`;
+export const RPC_PROXY_SERVICE_NAME = `${ASSETS_PLUGIN_NAME}:rpc-proxy`;
 export const ASSETS_KV_SERVICE_NAME = `${ASSETS_PLUGIN_NAME}:kv`;

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -16,6 +16,7 @@ import prettyBytes from "pretty-bytes";
 import SCRIPT_ASSETS from "worker:assets/assets";
 import SCRIPT_ASSETS_KV from "worker:assets/assets-kv";
 import SCRIPT_ROUTER from "worker:assets/router";
+import SCRIPT_RPC_PROXY from "worker:assets/rpc-proxy";
 import { z } from "zod";
 import { Service } from "../../runtime";
 import { SharedBindings } from "../../workers";
@@ -26,6 +27,7 @@ import {
 	ASSETS_PLUGIN_NAME,
 	ASSETS_SERVICE_NAME,
 	ROUTER_SERVICE_NAME,
+	RPC_PROXY_SERVICE_NAME,
 } from "./constants";
 import { AssetsOptionsSchema } from "./schema";
 
@@ -55,7 +57,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 		};
 	},
 
-	async getServices({ options }) {
+	async getServices({ options, unsafeEnableAssetsRpc }) {
 		if (!options.assets) {
 			return [];
 		}
@@ -158,7 +160,39 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 			},
 		};
 
-		return [storageService, namespaceService, assetService, routerService];
+		const services = [
+			storageService,
+			namespaceService,
+			assetService,
+			routerService,
+		];
+
+		if (unsafeEnableAssetsRpc) {
+			const assetsProxyService: Service = {
+				name: `${RPC_PROXY_SERVICE_NAME}:${id}`,
+				worker: {
+					compatibilityDate: "2024-08-01",
+					modules: [
+						{
+							name: "assets-proxy-worker.mjs",
+							esModule: SCRIPT_RPC_PROXY(),
+						},
+					],
+					bindings: [
+						{
+							name: "ROUTER_WORKER",
+							service: {
+								name: `${ROUTER_SERVICE_NAME}:${id}`,
+							},
+						},
+					],
+				},
+			};
+
+			services.push(assetsProxyService);
+		}
+
+		return services;
 	},
 };
 

--- a/packages/miniflare/src/plugins/assets/schema.ts
+++ b/packages/miniflare/src/plugins/assets/schema.ts
@@ -8,7 +8,7 @@ import { PathSchema } from "../../shared";
 export const AssetsOptionsSchema = z.object({
 	assets: z
 		.object({
-			// User worker name or vitest runner - this is only ever set inside miniflare
+			// User Worker name or vitest runner - this is only ever set inside miniflare
 			// The assets plugin needs access to the worker name to create the router worker - user worker binding
 			workerName: z.string().optional(),
 			directory: PathSchema,

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -81,6 +81,7 @@ export interface PluginServicesOptions<
 	unsafeEphemeralDurableObjects: boolean;
 	queueProducers: QueueProducers;
 	queueConsumers: QueueConsumers;
+	unsafeEnableAssetsRpc: boolean;
 }
 
 export interface ServicesExtensions {

--- a/packages/miniflare/src/workers/assets/rpc-proxy.worker.ts
+++ b/packages/miniflare/src/workers/assets/rpc-proxy.worker.ts
@@ -1,0 +1,14 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+import type RouterWorker from "@cloudflare/workers-shared/asset-worker/src/index";
+
+interface Env {
+	ROUTER_WORKER: Service<RouterWorker>;
+}
+export default class RPCProxyWorker extends WorkerEntrypoint<Env> {
+	async fetch(request: Request) {
+		// for now forward everything to the ROUTER WORKER
+		// this way we can wire this proxy Worker without
+		// changing the current assets behaviour
+		return this.env.ROUTER_WORKER.fetch(request);
+	}
+}

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -218,6 +218,7 @@ async function parseCustomPoolOptions(
 	if (options.miniflare?.assets) {
 		// (Used to set the SELF binding to point to the router worker instead)
 		options.miniflare.hasAssetsAndIsVitest = true;
+		options.miniflare.unsafeEnableAssetsRpc ??= false;
 		options.miniflare.assets.routerConfig ??= {};
 		options.miniflare.assets.routerConfig.has_user_worker = Boolean(
 			options.main


### PR DESCRIPTION
This PR implements a very basic Proxy Worker skeleton, and wires it in the "pipeline" miniflare creates for assets. This Worker will be incrementally worked on, but for now, the current implementation will forward all incoming requests to the Router Worker, thus leaving the current assets behaviour in local dev, unchanged.

TLDR 👇 

<img width="1184" alt="Screenshot 2025-02-27 at 16 44 34" src="https://github.com/user-attachments/assets/8d584ffa-4c88-4152-99a1-8a10fb611010" />

**Why are we doing this?** Because we expect the proxy Worker code to be quite involved, so we don't want to worry at that point whether the wiring works properly or not. We just want to focus on that Worker code

Fixes DEVX-1641, DEVX-1642

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because: covered by existing tests
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
