### PR TITLE
Add flag for Assets RPC

### DIFF
--- a/.changeset/silver-tools-promise.md
+++ b/.changeset/silver-tools-promise.md
@@ -1,0 +1,6 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Add the experimental `--x-assets-rpc` flag to gate feature work to support JSRPC with Workers + Assets projects.

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -206,6 +206,8 @@ export const CoreSharedOptionsSchema = z.object({
 	unsafeModuleFallbackService: ServiceFetchSchema.optional(),
 	// Keep blobs when deleting/overwriting keys, required for stacked storage
 	unsafeStickyBlobs: z.boolean().optional(),
+
+	unsafeEnableAssetsRpc: z.boolean().optional(),
 });
 
 export const CORE_PLUGIN_NAME = "core";

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -2616,6 +2616,7 @@ describe("normalizeAndValidateConfig()", () => {
 					{
 						RESOURCES_PROVISION: true,
 						MULTIWORKER: false,
+						ASSETS_RPC: false,
 					},
 					() =>
 						normalizeAndValidateConfig(
@@ -2771,6 +2772,7 @@ describe("normalizeAndValidateConfig()", () => {
 					{
 						RESOURCES_PROVISION: true,
 						MULTIWORKER: false,
+						ASSETS_RPC: false,
 					},
 					() =>
 						normalizeAndValidateConfig(
@@ -3100,6 +3102,7 @@ describe("normalizeAndValidateConfig()", () => {
 					{
 						RESOURCES_PROVISION: true,
 						MULTIWORKER: false,
+						ASSETS_RPC: false,
 					},
 					() =>
 						normalizeAndValidateConfig(

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -223,6 +223,7 @@ export async function unstable_dev(
 		experimentalVectorizeBindToProd: vectorizeBindToProd ?? false,
 		experimentalImagesLocalMode: imagesLocalMode ?? false,
 		enableIpc: options?.experimental?.enableIpc,
+		experimentalAssetsRpc: false,
 	};
 
 	//outside of test mode, rebuilds work fine, but only one instance of wrangler will work at a time
@@ -231,6 +232,7 @@ export async function unstable_dev(
 			// TODO: can we make this work?
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: false,
+			ASSETS_RPC: false,
 		},
 		() => startDev(devOptions)
 	);

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -105,6 +105,7 @@ export async function getPlatformProxy<
 		{
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: false,
+			ASSETS_RPC: false,
 		},
 		() => getMiniflareOptionsFromConfig(rawConfig, env, options)
 	);

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -93,9 +93,9 @@ function createHandler(def: CommandDefinition) {
 			const experimentalFlags = def.behaviour?.overrideExperimentalFlags
 				? def.behaviour?.overrideExperimentalFlags(args)
 				: {
-						FILE_BASED_REGISTRY: false,
 						MULTIWORKER: false,
 						RESOURCES_PROVISION: args.experimentalProvision ?? false,
+						ASSETS_RPC: false,
 					};
 
 			await run(experimentalFlags, () =>

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -245,6 +245,7 @@ export const deployCommand = createCommand({
 		overrideExperimentalFlags: (args) => ({
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
+			ASSETS_RPC: false,
 		}),
 	},
 	validateArgs(args) {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -20,6 +20,7 @@ import { getVarsForDev } from "./dev/dev-vars";
 import registerDevHotKeys from "./dev/hotkeys";
 import { maybeRegisterLocalWorker } from "./dev/local";
 import { UserError } from "./errors";
+import { getFlag } from "./experimental-flags";
 import isInteractive from "./is-interactive";
 import { logger } from "./logger";
 import { getLegacyAssetPaths, getSiteAssetPaths } from "./sites";
@@ -60,6 +61,7 @@ export const dev = createCommand({
 		overrideExperimentalFlags: (args) => ({
 			MULTIWORKER: Array.isArray(args.config),
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
+			ASSETS_RPC: args.experimentalAssetsRpc,
 		}),
 	},
 	metadata: {
@@ -326,6 +328,13 @@ export const dev = createCommand({
 			describe:
 				"Use a local lower-fidelity implementation of the Images binding",
 			default: false,
+		},
+		"experimental-assets-rpc": {
+			alias: "x-assets-rpc",
+			type: "boolean",
+			describe: "Support JSRPC bindings to Workers + Assets projects",
+			default: false,
+			hidden: true,
 		},
 	},
 	async validateArgs(args) {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -20,7 +20,6 @@ import { getVarsForDev } from "./dev/dev-vars";
 import registerDevHotKeys from "./dev/hotkeys";
 import { maybeRegisterLocalWorker } from "./dev/local";
 import { UserError } from "./errors";
-import { getFlag } from "./experimental-flags";
 import isInteractive from "./is-interactive";
 import { logger } from "./logger";
 import { getLegacyAssetPaths, getSiteAssetPaths } from "./sites";

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -10,6 +10,7 @@ import {
 import { ModuleTypeToRuleType } from "../deployment-bundle/module-collection";
 import { withSourceURLs } from "../deployment-bundle/source-url";
 import { createFatalError, UserError } from "../errors";
+import { getFlag } from "../experimental-flags";
 import {
 	EXTERNAL_IMAGES_WORKER_NAME,
 	EXTERNAL_IMAGES_WORKER_SCRIPT,
@@ -1026,6 +1027,8 @@ export async function buildMiniflareOptions(
 		liveReload: config.liveReload,
 		upstream,
 		unsafeProxySharedSecret: proxyToUserWorkerAuthenticationSecret,
+
+		unsafeEnableAssetsRpc: getFlag("ASSETS_RPC"),
 
 		log,
 		verbose: logger.loggerLevel === "debug",

--- a/packages/wrangler/src/experimental-flags.ts
+++ b/packages/wrangler/src/experimental-flags.ts
@@ -4,6 +4,7 @@ import { logger } from "./logger";
 export type ExperimentalFlags = {
 	MULTIWORKER: boolean;
 	RESOURCES_PROVISION: boolean;
+	ASSETS_RPC: boolean;
 };
 
 const flags = new AsyncLocalStorage<ExperimentalFlags>();

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -880,6 +880,7 @@ export const Handler = async (args: PagesDevArguments) => {
 		{
 			MULTIWORKER: Array.isArray(args.config),
 			RESOURCES_PROVISION: false,
+			ASSETS_RPC: false,
 		},
 		() =>
 			startDev({
@@ -959,6 +960,7 @@ export const Handler = async (args: PagesDevArguments) => {
 				siteInclude: undefined,
 				siteExclude: undefined,
 				inspect: undefined,
+				experimentalAssetsRpc: false,
 			})
 	);
 

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -266,6 +266,7 @@ export const versionsUploadCommand = createCommand({
 		overrideExperimentalFlags: (args) => ({
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
+			ASSETS_RPC: false,
 		}),
 	},
 	handler: async function versionsUploadHandler(args, { config }) {


### PR DESCRIPTION
Fixes [DEVX-1646](https://jira.cfdata.org/browse/DEVX-1646)

Adds a flag for Assets RPC, usable with `--x-assets-rpc`. This is passed through to Miniflare as `unsafeEnableAssetsRpc`, and is available as `sharedOpts.core.unsafeEnableAssetsRpc` within the `#assembleConfig()` function.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: This PR adds a flag but no functionality—tests will come with the PR adding functionality
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No functional changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental flag

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
