### PR TITLE
C3: ensure that git commits are generated

### DIFF
--- a/.changeset/five-streets-act.md
+++ b/.changeset/five-streets-act.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+ensure that git commits are generated

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -440,6 +440,9 @@ const testProjectDir = (suite: string, test: string) => {
 	return { getName, getPath, clean };
 };
 
+/**
+ * Test that we pushed the commit message to the deployment correctly.
+ */
 export const testDeploymentCommitMessage = async (
 	projectName: string,
 	framework: string,
@@ -491,6 +494,9 @@ export const testDeploymentCommitMessage = async (
 	expect(projectLatestCommitMessage).toContain(`framework = ${framework}`);
 };
 
+/**
+ * Test that C3 added a git commit with the correct message.
+ */
 export async function testGitCommitMessage(
 	projectName: string,
 	framework: string,

--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -13,6 +13,7 @@ import path from "path";
 import { setTimeout } from "timers/promises";
 import { stripAnsi } from "@cloudflare/cli";
 import { spawn } from "cross-spawn";
+import { runCommand } from "helpers/command";
 import { retry } from "helpers/retry";
 import treeKill from "tree-kill";
 import { fetch } from "undici";
@@ -489,6 +490,24 @@ export const testDeploymentCommitMessage = async (
 	expect(projectLatestCommitMessage).toContain(`project name = ${projectName}`);
 	expect(projectLatestCommitMessage).toContain(`framework = ${framework}`);
 };
+
+export async function testGitCommitMessage(
+	projectName: string,
+	framework: string,
+	projectPath: string,
+) {
+	const commitMessage = await runCommand(["git", "log", "-1"], {
+		silent: true,
+		cwd: projectPath,
+	});
+
+	expect(commitMessage).toMatch(
+		/Initialize web application via create-cloudflare CLI/,
+	);
+	expect(commitMessage).toContain(`C3 = create-cloudflare@${version}`);
+	expect(commitMessage).toContain(`project name = ${projectName}`);
+	expect(commitMessage).toContain(`framework = ${framework}`);
+}
 
 export const isQuarantineMode = () => {
 	return process.env.E2E_QUARANTINE === "true";

--- a/packages/create-cloudflare/src/__tests__/git.test.ts
+++ b/packages/create-cloudflare/src/__tests__/git.test.ts
@@ -147,6 +147,9 @@ describe("git helpers", () => {
 
 	describe("offerGit", async () => {
 		test("happy path", async () => {
+			// The testCreateContext() helper sets up the ctx.args to be all the C3_DEFAULT_ARGS values, which undermines the idea that the user has not provided any command line args.
+			// By providing an args object here (and elsewhere in this file) we ensure that none of the CLI args are set so that we have control over them in the tests.
+
 			const ctx = createTestContext("test", { projectName: "test" });
 			mockGitInstalled(true);
 			mockGitConfig();

--- a/packages/create-cloudflare/src/__tests__/git.test.ts
+++ b/packages/create-cloudflare/src/__tests__/git.test.ts
@@ -169,7 +169,7 @@ describe("git helpers", () => {
 			expect(ctx.args.git).toBe(true);
 		});
 
-		test("git not installed", async () => {
+		test("git not installed will not ask the user whether to use git and will not use git", async () => {
 			const ctx = createTestContext("test", { projectName: "test" });
 			mockGitInstalled(false);
 


### PR DESCRIPTION
Fixes #8264

This fixes a small regression introduced by #8264. In that PR we wanted to avoid running `git init` if there was already a repository in place, but it also resulted in the git commit being skipped in every case.

Even if you are not in a git repo you would see:
![image](https://github.com/user-attachments/assets/2327fcfa-1e01-4bcd-865b-c69b216c0ff8)


Here we fix the regression but also tidy up the code (and unit tests) because there was a lot of unnecessary repeated commands being run, and it was not always clear when values should have been set by.

It also adds in support for testing that the git commit is actually applied in e2e tests, which was not being tested before.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: C3 only
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
