### PR TITLE
feat: Add Cloudflare system prompt to newly created projects

### DIFF
--- a/.changeset/better-trees-admire.md
+++ b/.changeset/better-trees-admire.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": patch
+---
+
+Add Cloudflare system prompt to newly created projects
+
+AI driven editors like Cursor can use a system prompt to guide the AI in writing code. This function adds a system prompt to the project directory if it doesn't already exist. We use the cursor standard path, other editors expect the user to explicitly specify the path to the system prompt (for now)

--- a/packages/create-cloudflare/src/__tests__/templates.test.ts
+++ b/packages/create-cloudflare/src/__tests__/templates.test.ts
@@ -10,10 +10,12 @@ import {
 } from "helpers/files";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
+	addCloudflareSystemPrompt,
 	addWranglerToGitIgnore,
 	deriveCorrelatedArgs,
 	downloadRemoteTemplate,
 } from "../templates";
+import { createTestContext } from "./helpers";
 import type { PathLike } from "fs";
 import type { C3Args, C3Context } from "types";
 
@@ -316,5 +318,34 @@ describe("deriveCorrelatedArgs", () => {
 		).toThrow(
 			"The `--ts` argument cannot be specified in conjunction with the `--lang` argument",
 		);
+	});
+});
+
+describe("addCloudflareSystemPrompt", () => {
+	const writeFileResults: {
+		file: string | undefined;
+		content: string | undefined;
+	} = { file: undefined, content: undefined };
+
+	beforeEach(() => {
+		vi.mocked(writeFile).mockImplementation((file: string, content: string) => {
+			writeFileResults.file = file;
+			writeFileResults.content = content;
+		});
+	});
+
+	beforeEach(() => {
+		vi.mocked(existsSync).mockReset();
+		vi.mocked(readFile).mockReset();
+		vi.mocked(directoryExists).mockReset();
+
+		writeFileResults.file = undefined;
+		writeFileResults.content = undefined;
+	});
+	test("it should add the system prompt to the project", async () => {
+		const ctx = createTestContext();
+		await addCloudflareSystemPrompt(ctx);
+		expect(writeFileResults.file).toContain(".cursor");
+		expect(writeFileResults.content).toContain("cloudflare");
 	});
 });

--- a/packages/create-cloudflare/src/__tests__/templates.test.ts
+++ b/packages/create-cloudflare/src/__tests__/templates.test.ts
@@ -337,7 +337,6 @@ describe("addCloudflareSystemPrompt", () => {
 	beforeEach(() => {
 		vi.mocked(existsSync).mockReset();
 		vi.mocked(readFile).mockReset();
-		vi.mocked(directoryExists).mockReset();
 
 		writeFileResults.file = undefined;
 		writeFileResults.content = undefined;

--- a/packages/create-cloudflare/src/cli.ts
+++ b/packages/create-cloudflare/src/cli.ts
@@ -27,6 +27,7 @@ import { showHelp } from "./help";
 import { reporter, runTelemetryCommand } from "./metrics";
 import { createProject } from "./pages";
 import {
+	addCloudflareSystemPrompt,
 	addWranglerToGitIgnore,
 	copyTemplateFiles,
 	createContext,
@@ -141,6 +142,7 @@ const create = async (ctx: C3Context) => {
 	}
 
 	await copyTemplateFiles(ctx);
+	await addCloudflareSystemPrompt(ctx);
 	await updatePackageName(ctx);
 
 	chdir(ctx.project.path);

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync } from "fs";
 import { cp, mkdtemp, rename } from "fs/promises";
 import { tmpdir } from "os";
 import { basename, dirname, join, resolve } from "path";
@@ -600,7 +600,7 @@ export const addCloudflareSystemPrompt = async (ctx: C3Context) => {
 			"https://developers.cloudflare.com/workers/prompt.txt",
 		);
 		const systemPrompt = await systemPromptResponse.text();
-		writeFileSync(systemPromptPath, systemPrompt);
+		writeFile(systemPromptPath, systemPrompt);
 	}
 };
 

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -594,13 +594,23 @@ export const addCloudflareSystemPrompt = async (ctx: C3Context) => {
 	// and save it to .cursor/rules/cloudflare.mdc
 	const path = ctx.project.path;
 	const systemPromptPath = path + "/.cursor/rules/cloudflare.mdc";
-	mkdirSync(path + "/.cursor/rules", { recursive: true });
+
+	// recursive: true might not be available in the version of node we are using
+	mkdirSync(path + "/.cursor");
+	mkdirSync(path + "/.cursor/rules");
 	if (!existsSync(systemPromptPath)) {
-		const systemPromptResponse = await fetch(
-			"https://developers.cloudflare.com/workers/prompt.txt",
-		);
-		const systemPrompt = await systemPromptResponse.text();
-		writeFile(systemPromptPath, systemPrompt);
+		try {
+			const systemPromptResponse = await fetch(
+				"https://developers.cloudflare.com/workers/prompt.txt",
+			);
+			const systemPrompt = await systemPromptResponse.text();
+			writeFile(systemPromptPath, systemPrompt);
+		} catch (error) {
+			console.warn(
+				"Could not download system prompt from cloudflare docs",
+				error,
+			);
+		}
 	}
 };
 


### PR DESCRIPTION
AI driven editors like Cursor can use a system prompt to guide the AI in writing code. This function adds a system prompt to the project directory if it doesn't already exist. We use the cursor standard path, other editors expect the user to explicitly specify the path to the system prompt (for now)

Fixes #0000

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: non functional change 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: non functional, should happen in the background 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
