### PR TITLE
chore: include `templates` directory in wrangler"s `check:type` script

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -54,7 +54,7 @@
 		"build": "pnpm run clean && pnpm run bundle && pnpm run emit-types && pnpm run generate-json-schema",
 		"bundle": "node -r esbuild-register scripts/bundle.ts",
 		"check:lint": "eslint . --max-warnings=0",
-		"check:type": "tsc",
+		"check:type": "tsc -p ./tsconfig.json && tsc -p ./templates/tsconfig.json",
 		"clean": "rimraf wrangler-dist miniflare-dist emitted-types",
 		"dev": "pnpm run clean && concurrently -c black,blue --kill-others-on-fail false \"pnpm run bundle --watch\" \"pnpm run check:type --watch --preserveWatchOutput\"",
 		"emit-types": "tsc -p tsconfig.emit.json && node -r esbuild-register scripts/emit-types.ts",

--- a/packages/wrangler/templates/pages-dev-pipeline.ts
+++ b/packages/wrangler/templates/pages-dev-pipeline.ts
@@ -20,10 +20,11 @@ export default <ExportedHandler<{ ASSETS: Fetcher }>>{
 
 		for (const include of routes.include) {
 			if (isRoutingRuleMatch(pathname, include)) {
-				if (worker.fetch === undefined) {
+				const workerAsHandler = worker as ExportedHandler;
+				if (workerAsHandler.fetch === undefined) {
 					throw new TypeError("Entry point missing `fetch` handler");
 				}
-				return worker.fetch(request, env, context);
+				return workerAsHandler.fetch(request, env, context);
 			}
 		}
 

--- a/packages/wrangler/templates/tsconfig.json
+++ b/packages/wrangler/templates/tsconfig.json
@@ -4,5 +4,12 @@
 		"types": ["@cloudflare/workers-types"]
 	},
 	"include": ["**/*.ts"],
-	"exclude": ["__tests__", "./init-tests/**"]
+	"exclude": [
+		"__tests__",
+		"./init-tests/**",
+		// Note: `startDevWorker` and `middleware` should also be included but some work is needed
+		//       for that first (see: https://github.com/cloudflare/workers-sdk/issues/8303)
+		"startDevWorker",
+		"middleware"
+	]
 }


### PR DESCRIPTION
I've noticed that wrangler's `check:type` script is not including the `templates` directory at all, this PR is partially addressing this, here I am still excluding the `startDevWorker` and `middleware` directories since those are quite problematic and potentially time consuming to address (I'm going to create an issue for addressing these separately)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: infra change
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: infra change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: infra change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
