### PR TITLE
chore: cleanup e2e hyperdrive configs

### DIFF
--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -142,7 +142,7 @@ export class WranglerE2ETestHelper {
 		const id = match[1];
 
 		onTestFinished(async () => {
-			await this.run(`wrangler hyperdrive delete ${name}`);
+			await this.run(`wrangler hyperdrive delete ${id}`);
 		});
 
 		return { id, name };

--- a/tools/e2e/e2eCleanup.ts
+++ b/tools/e2e/e2eCleanup.ts
@@ -3,6 +3,7 @@ import {
 	deleteKVNamespace,
 	deleteProject,
 	deleteWorker,
+	listHyperdriveConfigs,
 	listTmpDatabases,
 	listTmpE2EProjects,
 	listTmpE2EWorkers,
@@ -78,6 +79,19 @@ async function run() {
 	} else {
 		console.log(
 			`Successfully deleted ${d1DatabasesToDelete.length} D1 databases`
+		);
+	}
+
+	const hyperdriveConfigsToDelete = await listHyperdriveConfigs();
+	for (const config of hyperdriveConfigsToDelete) {
+		console.log("Deleting Hyperdrive configs: " + config.id);
+		await deleteDatabase(config.id);
+	}
+	if (hyperdriveConfigsToDelete.length === 0) {
+		console.log(`No Hyperdrive configs to delete.`);
+	} else {
+		console.log(
+			`Successfully deleted ${hyperdriveConfigsToDelete.length} hyperdrive configs`
 		);
 	}
 }


### PR DESCRIPTION
Fixes [DEVX-1624](https://jira.cfdata.org/browse/DEVX-1624)

the e2e tests were trying to delete using the config _name_ not _id_
so now we have 1000 configs

this adds hyperdrive configs to the nightly cleanup

and also fixes that original problem

<img width="600" alt="Screenshot 2025-02-28 at 15 52 58" src="https://github.com/user-attachments/assets/093a36a7-901b-4fd7-9ed1-85b80079b622" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: e2e cleanup job? we should see the hyperdrive configs actually deleting in the e2e test now though
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: n/a

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
