### PR TITLE
fix(unenv-preset): define __filename

### DIFF
--- a/packages/unenv-preset/build.config.ts
+++ b/packages/unenv-preset/build.config.ts
@@ -2,6 +2,9 @@ import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig({
 	declaration: true,
+	rollup: {
+		cjsBridge: true,
+	},
 	entries: [
 		"src/index",
 		{ input: "src/runtime/", outDir: "dist/runtime", format: "esm" },


### PR DESCRIPTION
This PR adds `__filename` which was not defined before:
(The whole `// -- Unbuild CommonJS Shims --` section is added by this PR)

```ts
// -- Unbuild CommonJS Shims --
import __cjs_url__ from 'url';
import __cjs_path__ from 'path';
import __cjs_mod__ from 'module';
const __filename = __cjs_url__.fileURLToPath(import.meta.url);
const __dirname = __cjs_path__.dirname(__filename);
const require = __cjs_mod__.createRequire(import.meta.url);

// [...] 
const cloudflare = {
  meta: {
    name: "unenv:cloudflare",
    version,
    url: __filename
  },
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: it will work ;)
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
