### PR TITLE
feat: add Waku to C3

### DIFF
--- a/.changeset/moody-hands-sort.md
+++ b/.changeset/moody-hands-sort.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+feat(create-cloudflare): Add Waku workers template

--- a/.changeset/moody-hands-sort.md
+++ b/.changeset/moody-hands-sort.md
@@ -1,5 +1,5 @@
 ---
-"create-cloudflare": patch
+"create-cloudflare": minor
 ---
 
-feat(create-cloudflare): Add Waku workers template
+feat(create-cloudflare): Add Waku Workers template

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -579,12 +579,12 @@ describe("Create Cloudflare CLI", () => {
 					        Fetch a Worker initialized from the Cloudflare dashboard.
 					  --framework=<value>, -f
 					    The type of framework to use to create a web application (when using this option "--category" is coerced to "web-framework")
-					    When using the --framework option, C3 will dispatch to the official creation tool used by the framework (e.g. "create-astro" is used for Astro).
+					    When using the --framework option, C3 will dispatch to the official creation tool used by the framework (ex. "create-remix" is used for Remix).
 					    You may specify additional arguments to be passed directly to these underlying tools by adding them after a "--" argument, like so:
 					    npm create cloudflare -- --framework next -- --ts
 					    pnpm create cloudflare --framework next -- --ts
 					    Allowed Values:
-					      analog, angular, astro, docusaurus, gatsby, hono, next, nuxt, qwik, react, react-router, solid, svelte, vue
+					      analog, angular, astro, docusaurus, gatsby, hono, next, nuxt, qwik, react, react-router, remix, solid, svelte, vue, waku
 					  --platform=<value>
 					    Whether the application should be deployed to Pages or Workers. This is only applicable for Frameworks templates that support both Pages and Workers.
 					    Allowed Values:

--- a/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
+++ b/packages/create-cloudflare/e2e/tests/cli/cli.test.ts
@@ -579,12 +579,12 @@ describe("Create Cloudflare CLI", () => {
 					        Fetch a Worker initialized from the Cloudflare dashboard.
 					  --framework=<value>, -f
 					    The type of framework to use to create a web application (when using this option "--category" is coerced to "web-framework")
-					    When using the --framework option, C3 will dispatch to the official creation tool used by the framework (ex. "create-remix" is used for Remix).
+					    When using the --framework option, C3 will dispatch to the official creation tool used by the framework (e.g. "create-astro" is used for Astro).
 					    You may specify additional arguments to be passed directly to these underlying tools by adding them after a "--" argument, like so:
 					    npm create cloudflare -- --framework next -- --ts
 					    pnpm create cloudflare --framework next -- --ts
 					    Allowed Values:
-					      analog, angular, astro, docusaurus, gatsby, hono, next, nuxt, qwik, react, react-router, remix, solid, svelte, vue, waku
+					      analog, angular, astro, docusaurus, gatsby, hono, next, nuxt, qwik, react, react-router, solid, svelte, vue, waku
 					  --platform=<value>
 					    Whether the application should be deployed to Pages or Workers. This is only applicable for Frameworks templates that support both Pages and Workers.
 					    Allowed Values:

--- a/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
+++ b/packages/create-cloudflare/e2e/tests/frameworks/test-config.ts
@@ -567,6 +567,21 @@ function getFrameworkTestConfig(pm: string): NamedFrameworkTestConfig[] {
 			},
 			nodeCompat: false,
 		},
+		{
+			name: "waku",
+			testCommitMessage: true,
+			timeout: LONG_TIMEOUT,
+			unsupportedOSs: ["win32"],
+			verifyDeploy: {
+				route: "/",
+				expectedText: "Waku",
+			},
+			verifyPreview: {
+				route: "/",
+				expectedText: "Waku",
+			},
+			nodeCompat: false,
+		},
 	];
 }
 

--- a/packages/create-cloudflare/src/frameworks/package.json
+++ b/packages/create-cloudflare/src/frameworks/package.json
@@ -16,7 +16,7 @@
 		"create-react-router": "7.8.2",
 		"create-solid": "0.6.7",
 		"create-vue": "3.18.0",
-		"create-waku": "0.12.3-0.24.0-0",
+		"create-waku": "0.12.5-0.26.1-0",
 		"gatsby": "5.15.0",
 		"sv": "0.9.6",
 		"nuxi": "3.28.0"

--- a/packages/create-cloudflare/src/frameworks/package.json
+++ b/packages/create-cloudflare/src/frameworks/package.json
@@ -16,6 +16,7 @@
 		"create-react-router": "7.8.2",
 		"create-solid": "0.6.7",
 		"create-vue": "3.18.0",
+		"create-waku": "0.12.3-0.24.0-0",
 		"gatsby": "5.15.0",
 		"sv": "0.9.6",
 		"nuxi": "3.28.0"

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -43,6 +43,7 @@ import scheduledTemplate from "templates/scheduled/c3";
 import solidTemplate from "templates/solid/c3";
 import svelteTemplate from "templates/svelte/c3";
 import vueTemplate from "templates/vue/c3";
+import wakuTemplate from "templates/waku/c3";
 import { isInsideGitRepo } from "./git";
 import { validateProjectDirectory, validateTemplateUrl } from "./validators";
 import type { Option } from "@cloudflare/cli/interactive";
@@ -204,6 +205,7 @@ export function getFrameworkMap({ experimental = false }): TemplateMap {
 			solid: solidTemplate,
 			svelte: svelteTemplate,
 			vue: vueTemplate,
+			waku: wakuTemplate,
 		};
 	}
 }

--- a/packages/create-cloudflare/templates/waku/c3.ts
+++ b/packages/create-cloudflare/templates/waku/c3.ts
@@ -25,7 +25,7 @@ const config: TemplateConfig = {
 	transformPackageJson: async () => ({
 		scripts: {
 			deploy: `${npm} run build && wrangler deploy`,
-			preview: `${npm} run build && wrangler dev`,
+			preview: `NODE_ENV=production ${npm} run build && wrangler dev`,
 		},
 	}),
 	devScript: "dev",

--- a/packages/create-cloudflare/templates/waku/c3.ts
+++ b/packages/create-cloudflare/templates/waku/c3.ts
@@ -1,0 +1,35 @@
+import { runFrameworkGenerator } from "frameworks/index";
+import { detectPackageManager } from "helpers/packageManagers";
+import type { TemplateConfig } from "../../src/templates";
+import type { C3Context } from "types";
+
+const { npm } = detectPackageManager();
+
+const generate = async (ctx: C3Context) => {
+	await runFrameworkGenerator(ctx, [
+		"--project-name",
+		ctx.project.name,
+		"--template",
+		"07_cloudflare",
+	]);
+};
+
+const config: TemplateConfig = {
+	configVersion: 1,
+	id: "waku",
+	frameworkCli: "create-waku",
+	platform: "workers",
+	displayName: "Waku",
+	path: "templates/waku",
+	generate,
+	transformPackageJson: async () => ({
+		scripts: {
+			deploy: `${npm} run build && wrangler deploy`,
+			preview: `${npm} run build && wrangler dev`,
+		},
+	}),
+	devScript: "dev",
+	deployScript: "deploy",
+	previewScript: "preview",
+};
+export default config;

--- a/packages/create-cloudflare/templates/waku/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/waku/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+	"name": "<TBD>",
+	"main": "./dist/worker/serve-cloudflare.js",
+	// https://developers.cloudflare.com/workers/platform/compatibility-dates
+	"compatibility_date": "<TBD>",
+	// nodejs_als is required for Waku server-side request context
+	// It can be removed if only building static pages
+	"compatibility_flags": ["nodejs_als"],
+	// https://developers.cloudflare.com/workers/static-assets/binding/
+	"assets": {
+		"binding": "ASSETS",
+		"directory": "./dist/assets",
+		"html_handling": "drop-trailing-slash",
+		"not_found_handling": "404-page"
+	},
+	"vars": {
+		"MAX_ITEMS": 10
+	}
+}


### PR DESCRIPTION
Fixes #7594.

Adding a C3 template for Waku, a minimal React framework. https://waku.gg/

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): <https://github.com/cloudflare/cloudflare-docs/pull/20444>
  - [ ] Documentation not necessary because:

