### PR TITLE
feat: :sparkles: introduce json output for cf pages deployment list

### DIFF
--- a/packages/wrangler/src/pages/deployments.ts
+++ b/packages/wrangler/src/pages/deployments.ts
@@ -28,10 +28,19 @@ export function ListOptions(yargs: CommonYargsArgv) {
 			choices: ["production", "preview"],
 			description: "Environment type to list deployments for",
 		},
+		json: {
+			type: "boolean",
+			description: "Return output as clean JSON",
+			default: false,
+		},
 	});
 }
 
-export async function ListHandler({ projectName, environment }: ListArgs) {
+export async function ListHandler({
+	projectName,
+	environment,
+	json,
+}: ListArgs) {
 	const config = getConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME);
 	const accountId = await requireAuth(config);
 
@@ -72,6 +81,7 @@ export async function ListHandler({ projectName, environment }: ListArgs) {
 
 	const data = deployments.map((deployment) => {
 		return {
+			Id: deployment.id,
 			Environment: titleCase(deployment.environment),
 			Branch: deployment.deployment_trigger.metadata.branch,
 			Source: shortSha(deployment.deployment_trigger.metadata.commit_hash),
@@ -86,6 +96,10 @@ export async function ListHandler({ projectName, environment }: ListArgs) {
 		account_id: accountId,
 	});
 
-	logger.table(data);
+	if (json) {
+		logger.log(JSON.stringify(data, null, 2));
+	} else {
+		logger.table(data);
+	}
 	metrics.sendMetricsEvent("list pages deployments");
 }


### PR DESCRIPTION
…as it enables other tools like jq to parse the data, also fixes [#2437]
It also introduces Id of the deployment to the output

Fixes #2437 .

added `--json` flag to the `wrangler pages deployment list` 

This enables scripts like this to work:

```bash
#!/bin/bash

# List all deployments and get their IDs
deployments=$(npx wrangler pages deployment list --json | jq -r '.[].Id')

# Get the last deployment ID
last_deployment=$(echo "$deployments" | head -n 1)

# Loop through all deployments and delete each one except the last
for deployment in $deployments; do
  if [ "$deployment" != "$last_deployment" ]; then
    echo "Deleting deployment $deployment ..."
    npx wrangler pages deployment delete $deployment
  fi
done
```


---

- Tests
  - [x] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
