### PR TITLE
chore: tweak a couple of error messages in the vite plugin

### DIFF
--- a/.changeset/all-sloths-fly.md
+++ b/.changeset/all-sloths-fly.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+chore: tweak a couple of error messages in the vite plugin
+
+I was seeing an error like this: `Unexpected error: no match for module path.`. But it wasn't telling me what the path was. On debugging I noticed that it was telling me about the module "path"! Which meant I needed to enable node_compat. This patch just makes the messaging a little clearer.
+
+(Ideally we'd spot that it was a node builtin and recommend turning on node_compat, but I'll leave that to you folks.)

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -422,7 +422,7 @@ export function getDevMiniflareOptions(
 					workerToWorkflowEntrypointClassNamesMap.get(workerOptions.name);
 				assert(
 					workflowEntrypointClassNames,
-					`WorkflowEntrypoint class names not found for worker ${workerOptions.name}`
+					`WorkflowEntrypoint class names not found for worker: ${workerOptions.name}`
 				);
 
 				for (const className of [...workflowEntrypointClassNames].sort()) {
@@ -461,11 +461,11 @@ export function getDevMiniflareOptions(
 
 			const moduleRE = new RegExp(MODULE_PATTERN);
 			const match = moduleRE.exec(rawSpecifier);
-			assert(match, `Unexpected error: no match for module ${rawSpecifier}.`);
+			assert(match, `Unexpected error: no match for module: ${rawSpecifier}.`);
 			const [full, moduleType, modulePath] = match;
 			assert(
 				modulePath,
-				`Unexpected error: module path not found in reference ${full}.`
+				`Unexpected error: module path not found in reference: ${full}.`
 			);
 
 			let source: Buffer;
@@ -473,7 +473,9 @@ export function getDevMiniflareOptions(
 			try {
 				source = fs.readFileSync(modulePath);
 			} catch (error) {
-				throw new Error(`Import ${modulePath} not found. Does the file exist?`);
+				throw new Error(
+					`Import "${modulePath}" not found. Does the file exist?`
+				);
 			}
 
 			return MiniflareResponse.json({


### PR DESCRIPTION
I was seeing an error like this: `Unexpected error: no match for module path.`. But it wasn't telling me what the path was. On debugging I noticed that it was telling me about the module "path"! Which meant I needed to enable node_compat. This patch just makes the messaging a little clearer.

(Ideally we'd spot that it was a node builtin and recommend turning on node_compat, but I'll leave that to you folks.)

Fixes #0000


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: non functional change
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: non functional change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: non functional change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
