### PR TITLE
unenv preset changeset for 2.0.0

### DIFF
--- a/.changeset/itchy-peaches-kneel.md
+++ b/.changeset/itchy-peaches-kneel.md
@@ -1,0 +1,8 @@
+---
+"@cloudflare/unenv-preset": major
+---
+
+Sync the cloudflare preset with `unenv@2.0.0-rc.8`
+
+- The preset is now delivered as ESM only
+- A polyfill is added for perf_hooks


### PR DESCRIPTION
The main changes for 2.0.0 were implemented in https://github.com/cloudflare/workers-sdk/pull/7915
There are been a few small follow-up PRs to fix minor issues.

The preset is not used yet by wrangler (or the vite plugin) - that will be the next step.

However the latest beta release is validated with wrangler in #8300.

After the preset 2.0.0 is released (hopefully on Tuesday):

- 8300 should be update to use that release, we will verify that there is no pb with Astro, ... The goal is that we use that in wrangler on Thursday release
- The Vite plugin should be update to use 2.0.0

/cc @petebacondarwin @jamesopstad 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not used by wrangler yet
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
