### PR TITLE
SQC-354 add mtls fields to hyperdrive

### DIFF
--- a/.changeset/wise-points-love.md
+++ b/.changeset/wise-points-love.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add mTLS configuration fields to Hyperdrive command
+
+hyperdrive create test123 ... --ca-certificate-uuid=CA_CERT_UUID --mtls-certificate-uuid=MTLS_CERT_UUID

--- a/packages/wrangler/src/__tests__/hyperdrive.test.ts
+++ b/packages/wrangler/src/__tests__/hyperdrive.test.ts
@@ -540,18 +540,58 @@ describe("hyperdrive commands", () => {
 		`);
 	});
 
+	it("should create a hyperdrive with mtls config", async () => {
+		const reqProm = mockHyperdriveCreate();
+		await runWrangler(
+			"hyperdrive create test123 --host=example.com --database=neondb --user=test --password=password --port=1234 --ca-certificate-uuid=12345 --mtls-certificate-uuid=1234"
+		);
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			Object {
+			  "mtls": Object {
+			    "ca_certificate_uuid": "12345",
+			    "mtls_certificate_uuid": "1234",
+			  },
+			  "name": "test123",
+			  "origin": Object {
+			    "database": "neondb",
+			    "host": "example.com",
+			    "password": "password",
+			    "port": 1234,
+			    "scheme": "postgresql",
+			    "user": "test",
+			  },
+			}
+		`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"🚧 Creating 'test123'
+			✅ Created new Hyperdrive config: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			📋 To start using your config from a Worker, add the following binding configuration to your Wrangler configuration file:
+
+			{
+			  \\"hyperdrive\\": [
+			    {
+			      \\"binding\\": \\"HYPERDRIVE\\",
+			      \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\"
+			    }
+			  ]
+			}"
+		`);
+	});
+
 	it("should handle listing configs", async () => {
 		mockHyperdriveGetListOrDelete();
 		await runWrangler("hyperdrive list");
 		expect(std.out).toMatchInlineSnapshot(`
 			"📋 Listing Hyperdrive configs
-			┌──────────────────────────────────────┬─────────┬────────┬────────────────┬──────┬──────────┬───────────────────┐
-			│ id                                   │ name    │ user   │ host           │ port │ database │ caching           │
-			├──────────────────────────────────────┼─────────┼────────┼────────────────┼──────┼──────────┼───────────────────┤
-			│ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx │ test123 │ test   │ example.com    │ 5432 │ neondb   │                   │
-			├──────────────────────────────────────┼─────────┼────────┼────────────────┼──────┼──────────┼───────────────────┤
-			│ yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy │ new-db  │ dbuser │ www.google.com │ 3211 │ mydb     │ {\\"disabled\\":true} │
-			└──────────────────────────────────────┴─────────┴────────┴────────────────┴──────┴──────────┴───────────────────┘"
+			┌──────────────────────────────────────┬─────────────┬─────────┬────────────────┬──────┬───────────┬───────────────────┬───────────────────────────────────────────────────────────────┐
+			│ id                                   │ name        │ user    │ host           │ port │ database  │ caching           │ mtls                                                          │
+			├──────────────────────────────────────┼─────────────┼─────────┼────────────────┼──────┼───────────┼───────────────────┼───────────────────────────────────────────────────────────────┤
+			│ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx │ test123     │ test    │ example.com    │ 5432 │ neondb    │                   │                                                               │
+			├──────────────────────────────────────┼─────────────┼─────────┼────────────────┼──────┼───────────┼───────────────────┼───────────────────────────────────────────────────────────────┤
+			│ yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy │ new-db      │ dbuser  │ www.google.com │ 3211 │ mydb      │ {\\"disabled\\":true} │                                                               │
+			├──────────────────────────────────────┼─────────────┼─────────┼────────────────┼──────┼───────────┼───────────────────┼───────────────────────────────────────────────────────────────┤
+			│ zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz │ new-db-mtls │ pg-mtls │ www.mtls.com   │ 3212 │ mydb-mtls │                   │ {\\"ca_certificate_uuid\\":\\"1234\\",\\"mtls_certificate_uuid\\":\\"1234\\"} │
+			└──────────────────────────────────────┴─────────────┴─────────┴────────────────┴──────┴───────────┴───────────────────┴───────────────────────────────────────────────────────────────┘"
 		`);
 	});
 
@@ -856,6 +896,40 @@ describe("hyperdrive commands", () => {
 			"
 		`);
 	});
+
+	it("should handle updating a hyperdrive config's mtls configuration", async () => {
+		const reqProm = mockHyperdriveUpdate();
+		await runWrangler(
+			"hyperdrive update xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --ca-certificate-uuid=2345 --mtls-certificate-uuid=234"
+		);
+		await expect(reqProm).resolves.toMatchInlineSnapshot(`
+			Object {
+			  "mtls": Object {
+			    "ca_certificate_uuid": "2345",
+			    "mtls_certificate_uuid": "234",
+			  },
+			}
+		`);
+		expect(std.out).toMatchInlineSnapshot(`
+			"🚧 Updating 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+			✅ Updated xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx Hyperdrive config
+			 {
+			  \\"id\\": \\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\\",
+			  \\"name\\": \\"test123\\",
+			  \\"origin\\": {
+			    \\"scheme\\": \\"postgresql\\",
+			    \\"host\\": \\"example.com\\",
+			    \\"port\\": 5432,
+			    \\"database\\": \\"neondb\\",
+			    \\"user\\": \\"test\\"
+			  },
+			  \\"mtls\\": {
+			    \\"ca_certificate_uuid\\": \\"2345\\",
+			    \\"mtls_certificate_uuid\\": \\"234\\"
+			  }
+			}"
+		`);
+	});
 });
 
 const defaultConfig: HyperdriveConfig = {
@@ -908,6 +982,21 @@ function mockHyperdriveGetListOrDelete() {
 									disabled: true,
 								},
 							},
+							{
+								id: "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
+								name: "new-db-mtls",
+								origin: {
+									host: "www.mtls.com",
+									port: 3212,
+									database: "mydb-mtls",
+									user: "pg-mtls",
+									scheme: "pg-mtls",
+								},
+								mtls: {
+									ca_certificate_uuid: "1234",
+									mtls_certificate_uuid: "1234",
+								},
+							},
 						],
 						true
 					)
@@ -955,6 +1044,11 @@ function mockHyperdriveUpdate(): Promise<PatchHyperdriveBody> {
 							delete origin.port;
 						}
 					}
+					const mtls = defaultConfig.mtls;
+					if (mtls && reqBody.mtls) {
+						mtls.ca_certificate_uuid = reqBody.mtls.ca_certificate_uuid;
+						mtls.mtls_certificate_uuid = reqBody.mtls.mtls_certificate_uuid;
+					}
 
 					return HttpResponse.json(
 						createFetchResult(
@@ -963,6 +1057,7 @@ function mockHyperdriveUpdate(): Promise<PatchHyperdriveBody> {
 								name: reqBody.name ?? defaultConfig.name,
 								origin,
 								caching: reqBody.caching ?? defaultConfig.caching,
+								mtls: reqBody.mtls,
 							},
 							true
 						)
@@ -999,6 +1094,7 @@ function mockHyperdriveCreate(): Promise<CreateUpdateHyperdriveBody> {
 									access_client_id: reqBody.origin.access_client_id,
 								},
 								caching: reqBody.caching,
+								mtls: reqBody.mtls,
 							},
 							true
 						)

--- a/packages/wrangler/src/hyperdrive/client.ts
+++ b/packages/wrangler/src/hyperdrive/client.ts
@@ -7,6 +7,7 @@ export type HyperdriveConfig = {
 	name: string;
 	origin: PublicOrigin;
 	caching?: CachingOptions;
+	mtls?: Mtls;
 };
 
 export type OriginDatabase = {
@@ -73,12 +74,19 @@ export type CreateUpdateHyperdriveBody = {
 	name: string;
 	origin: OriginWithSecrets;
 	caching?: CachingOptions;
+	mtls?: Mtls;
 };
 
 export type PatchHyperdriveBody = {
 	name?: string;
 	origin?: OriginWithSecretsPartial;
 	caching?: CachingOptions;
+	mtls?: Mtls;
+};
+
+export type Mtls = {
+	ca_certificate_uuid?: string;
+	mtls_certificate_uuid?: string;
 };
 
 export async function createConfig(

--- a/packages/wrangler/src/hyperdrive/create.ts
+++ b/packages/wrangler/src/hyperdrive/create.ts
@@ -1,7 +1,12 @@
 import { configFileName, formatConfigSnippet, readConfig } from "../config";
 import { logger } from "../logger";
 import { createConfig } from "./client";
-import { getCacheOptionsFromArgs, getOriginFromArgs, upsertOptions } from ".";
+import {
+	getCacheOptionsFromArgs,
+	getMtlsFromArgs,
+	getOriginFromArgs,
+	upsertOptions,
+} from ".";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -32,6 +37,7 @@ export async function handler(
 		name: args.name,
 		origin,
 		caching: getCacheOptionsFromArgs(args),
+		mtls: getMtlsFromArgs(args),
 	});
 	logger.log(`✅ Created new Hyperdrive config: ${database.id}`);
 	logger.log(

--- a/packages/wrangler/src/hyperdrive/index.ts
+++ b/packages/wrangler/src/hyperdrive/index.ts
@@ -12,6 +12,7 @@ import type {
 } from "../yargs-types";
 import type {
 	CachingOptions,
+	Mtls,
 	NetworkOriginWithSecrets,
 	OriginDatabaseWithSecrets,
 	OriginWithSecrets,
@@ -115,6 +116,16 @@ export function upsertOptions<T>(yargs: Argv<T>) {
 				type: "number",
 				describe:
 					"Indicates the number of seconds cache may serve the response after it becomes stale, cannot be set when caching is disabled",
+			},
+			"ca-certificate-uuid": {
+				type: "string",
+				describe:
+					"Sets custom CA certificate when connecting to origin database. Must be valid UUID of already uploaded CA certificate.",
+			},
+			"mtls-certificate-uuid": {
+				type: "string",
+				describe:
+					"Sets custom mTLS client certificates when connecting to origin database. Must be valid UUID of already uploaded public/private key certificates.",
 			},
 		})
 		.group(
@@ -295,5 +306,20 @@ export function getCacheOptionsFromArgs(
 		return undefined;
 	} else {
 		return caching;
+	}
+}
+
+export function getMtlsFromArgs(
+	args: StrictYargsOptionsToInterface<typeof upsertOptions>
+): Mtls | undefined {
+	const mtls = {
+		ca_certificate_uuid: args.caCertificateUuid,
+		mtls_certificate_uuid: args.mtlsCertificateUuid,
+	};
+
+	if (JSON.stringify(mtls) === "{}") {
+		return undefined;
+	} else {
+		return mtls;
 	}
 }

--- a/packages/wrangler/src/hyperdrive/list.ts
+++ b/packages/wrangler/src/hyperdrive/list.ts
@@ -26,6 +26,7 @@ export async function handler(
 			port: database.origin.port?.toString() ?? "",
 			database: database.origin.database ?? "",
 			caching: JSON.stringify(database.caching),
+			mtls: JSON.stringify(database.mtls),
 		}))
 	);
 }

--- a/packages/wrangler/src/hyperdrive/update.ts
+++ b/packages/wrangler/src/hyperdrive/update.ts
@@ -1,7 +1,12 @@
 import { readConfig } from "../config";
 import { logger } from "../logger";
 import { patchConfig } from "./client";
-import { getCacheOptionsFromArgs, getOriginFromArgs, upsertOptions } from ".";
+import {
+	getCacheOptionsFromArgs,
+	getMtlsFromArgs,
+	getOriginFromArgs,
+	upsertOptions,
+} from ".";
 import type {
 	CommonYargsArgv,
 	StrictYargsOptionsToInterface,
@@ -32,6 +37,7 @@ export async function handler(
 		name: args.name,
 		origin,
 		caching: getCacheOptionsFromArgs(args),
+		mtls: getMtlsFromArgs(args),
 	});
 	logger.log(
 		`✅ Updated ${updated.id} Hyperdrive config\n`,


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

- Add mtls fields to hyperdrive command `ca_certificate_uuid` and `mtls_certificate_uuid`

---

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: no e2e test
- Public documentation
  - [ ] TODO (before merge)
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/20523
  - [ ] Documentation not necessary because:
