### PR TITLE
add hint when no permission to show membership info

### DIFF
--- a/.changeset/sharp-bottles-agree.md
+++ b/.changeset/sharp-bottles-agree.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Improve error message when request to obtain membership info fails
+
+Wrangler now informs user that specific permission might be not granted when fails to obtain membership info. The same information is provided when Wrangler is unable to fetch user's email.

--- a/packages/wrangler/src/__tests__/whoami.test.ts
+++ b/packages/wrangler/src/__tests__/whoami.test.ts
@@ -231,7 +231,7 @@ describe("whoami", () => {
 			└───────────────┴────────────┘
 			🔓 Token Permissions: If scopes are missing, you may need to logout and re-login.
 			Scope (Access)
-			🎢 Unable to get membership roles. Make sure you have permissions to read the account."
+			🎢 Unable to get membership roles. Make sure you have permissions to read the account. Are you missing the \`User->Memberships->Read\` permission?"
 		`);
 	});
 });

--- a/packages/wrangler/src/user/whoami.ts
+++ b/packages/wrangler/src/user/whoami.ts
@@ -86,7 +86,7 @@ async function printMembershipInfo(user: UserInfo, accountFilter?: string) {
 	} catch (e) {
 		if (isAuthenticationError(e)) {
 			logger.log(
-				`🎢 Unable to get membership roles. Make sure you have permissions to read the account.`
+				`🎢 Unable to get membership roles. Make sure you have permissions to read the account. Are you missing the \`User->Memberships->Read\` permission?`
 			);
 			return;
 		} else {


### PR DESCRIPTION
This pull request adds a hint to let users know that specific API token permissions might not be granted when Wrangler can't retrieve membership roles. This is similar to the behavior in a case where Wrangler is unable to fetch a user's email.

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [X] Required (https://github.com/cloudflare/workers-sdk/pull/8784)
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: The change is adding a hint to the localization.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR:
  - [ ] Not necessary because: minor change