### PR TITLE
chore: update eslint-config-turbo version

### DIFF
--- a/packages/eslint-config-worker/index.js
+++ b/packages/eslint-config-worker/index.js
@@ -19,7 +19,7 @@ module.exports = {
 		project: true,
 	},
 	plugins: ["@typescript-eslint", "import", "unused-imports", "no-only-tests"],
-	extends: ["turbo"],
+	extends: ["plugin:turbo/recommended"],
 	overrides: [
 		{
 			files: ["*.ts", "*.tsx"],
@@ -27,7 +27,7 @@ module.exports = {
 				"eslint:recommended",
 				"plugin:@typescript-eslint/recommended",
 				"plugin:import/typescript",
-				"turbo",
+				"plugin:turbo/recommended",
 			],
 
 			rules: {

--- a/packages/eslint-config-worker/package.json
+++ b/packages/eslint-config-worker/package.json
@@ -7,7 +7,7 @@
 	"dependencies": {
 		"@typescript-eslint/parser": "^6.9.0",
 		"eslint": "^8.57.1",
-		"eslint-config-turbo": "latest",
+		"eslint-config-turbo": "^2.4.4",
 		"eslint-plugin-import": "2.26.x",
 		"eslint-plugin-no-only-tests": "^3.1.0",
 		"eslint-plugin-react": "^7.33.2",

--- a/packages/eslint-config-worker/react.js
+++ b/packages/eslint-config-worker/react.js
@@ -1,6 +1,6 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
-	extends: ["turbo", "@cloudflare/eslint-config-worker"],
+	extends: ["plugin:turbo/recommended", "@cloudflare/eslint-config-worker"],
 	plugins: ["eslint-plugin-react", "eslint-plugin-react-hooks"],
 	overrides: [
 		{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1336,8 +1336,8 @@ importers:
         specifier: ^8.57.1
         version: 8.57.1
       eslint-config-turbo:
-        specifier: latest
-        version: 2.4.2(eslint@8.57.1)(turbo@2.2.3)
+        specifier: ^2.4.4
+        version: 2.4.4(eslint@8.57.1)(turbo@2.2.3)
       eslint-plugin-import:
         specifier: 2.26.x
         version: 2.26.0(@typescript-eslint/parser@6.10.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)
@@ -7500,8 +7500,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-config-turbo@2.4.2:
-    resolution: {integrity: sha512-yPiW5grffSWETp/3bVPUXWQkHfiLoOBb3wuBbM90HlKkLOhggySn9C6/yUccprqRguMgR5OzXIuzDuUnX6bulw==}
+  eslint-config-turbo@2.4.4:
+    resolution: {integrity: sha512-4w/heWywWkFw09a5MY5lCvb9suJlhBSkzNtGTwM5+zRif4rksubaMYy1pD0++5rqoDVcQax25jCrtii9ptsNDw==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -7576,8 +7576,8 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
 
-  eslint-plugin-turbo@2.4.2:
-    resolution: {integrity: sha512-67IZtvOFaWDnUmYMV3luRIE1kqL+ok5MxPEsIPUqH2vQggML7jmZFZx/P9jhXAoFH+pViEz5QEzDa2DBLHqzQg==}
+  eslint-plugin-turbo@2.4.4:
+    resolution: {integrity: sha512-myEnQTjr3FkI0j1Fu0Mqnv1z8n0JW5iFTOUNzHaEevjzl+1uzMSsFwks/x8i3rGmI3EYtC1BY8K2B2pS0Vfx6w==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -17053,10 +17053,10 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-config-turbo@2.4.2(eslint@8.57.1)(turbo@2.2.3):
+  eslint-config-turbo@2.4.4(eslint@8.57.1)(turbo@2.2.3):
     dependencies:
       eslint: 8.57.1
-      eslint-plugin-turbo: 2.4.2(eslint@8.57.1)(turbo@2.2.3)
+      eslint-plugin-turbo: 2.4.4(eslint@8.57.1)(turbo@2.2.3)
       turbo: 2.2.3
 
   eslint-import-resolver-node@0.3.9:
@@ -17141,7 +17141,7 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.8
 
-  eslint-plugin-turbo@2.4.2(eslint@8.57.1)(turbo@2.2.3):
+  eslint-plugin-turbo@2.4.4(eslint@8.57.1)(turbo@2.2.3):
     dependencies:
       dotenv: 16.0.3
       eslint: 8.57.1


### PR DESCRIPTION
Fixes n/a.

The dependabot PR on #8340 updated the `eslint-config-turbo` version and runs into an [error](https://github.com/cloudflare/workers-sdk/actions/runs/13653973927/job/38168668476?pr=8340#step:5:141) with eslint. This fix follows the suggestion on https://github.com/vercel/turborepo/pull/9978/files#r1974406494

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: package update / Fix CI error 
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: package update 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: package update 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
