### PR TITLE
Add purge queue command

### DIFF
--- a/.changeset/lemon-areas-tap.md
+++ b/.changeset/lemon-areas-tap.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+Add new command to purge a Queue
+
+This new command can be used to delete all existing messages in a Queue

--- a/packages/wrangler/src/queues/cli/commands/index.ts
+++ b/packages/wrangler/src/queues/cli/commands/index.ts
@@ -9,6 +9,7 @@ import {
 	options as pauseResumeOptions,
 	resumeHandler,
 } from "./pause-resume";
+import { handler as purgeHandler, options as purgeOptions } from "./purge";
 import { handler as updateHandler, options as updateOptions } from "./update";
 import type { CommonYargsArgv } from "../../../yargs-types";
 
@@ -63,6 +64,13 @@ export function queues(yargs: CommonYargsArgv) {
 		"Resume message delivery for a Queue",
 		pauseResumeOptions,
 		resumeHandler
+	);
+
+	yargs.command(
+		"purge <name>",
+		"Purge messages from a Queue",
+		purgeOptions,
+		purgeHandler
 	);
 
 	yargs.fail(HandleUnauthorizedError);

--- a/packages/wrangler/src/queues/cli/commands/purge.ts
+++ b/packages/wrangler/src/queues/cli/commands/purge.ts
@@ -1,0 +1,39 @@
+import { readConfig } from "../../../config";
+import { prompt } from "../../../dialogs";
+import { FatalError } from "../../../errors";
+import isInteractive from "../../../is-interactive";
+import { logger } from "../../../logger";
+import { purgeQueue } from "../../client";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../../../yargs-types";
+
+export function options(yargs: CommonYargsArgv) {
+	return yargs.positional("name", {
+		type: "string",
+		demandOption: true,
+		description: "The name of the queue",
+	});
+}
+
+export async function handler(
+	args: StrictYargsOptionsToInterface<typeof options>
+) {
+	const config = readConfig(args);
+
+	if (isInteractive()) {
+		const result = await prompt(
+			`This operation will permanently delete all the messages in Queue ${args.name}. Type ${args.name} to proceed.`
+		);
+		if (result !== args.name) {
+			throw new FatalError(
+				"Incorrect queue name provided. Skipping purge operation"
+			);
+		}
+	}
+
+	await purgeQueue(config, args.name);
+
+	logger.log(`Started a purge operation for Queue '${args.name}'`);
+}

--- a/packages/wrangler/src/queues/client.ts
+++ b/packages/wrangler/src/queues/client.ts
@@ -85,6 +85,15 @@ export interface ConsumerSettings {
 	retry_delay?: number;
 }
 
+export interface PurgeQueueBody {
+	delete_messages_permanently: boolean;
+}
+
+export interface PurgeQueueResponse {
+	started_at: string;
+	complete: boolean;
+}
+
 const queuesUrl = (accountId: string, queueId?: string): string => {
 	let url = `/accounts/${accountId}/queues`;
 	if (queueId) {
@@ -405,4 +414,18 @@ export async function deleteWorkerConsumer(
 		queue
 	);
 	return deleteConsumerById(config, queue.queue_id, targetConsumer.consumer_id);
+}
+
+export async function purgeQueue(
+	config: Config,
+	queueName: string
+): Promise<void> {
+	const accountId = await requireAuth(config);
+	const queue = await getQueue(config, queueName);
+	const purgeURL = `${queuesUrl(accountId, queue.queue_id)}/purge`;
+	const body: PurgeQueueBody = { delete_messages_permanently: true };
+	return fetchResult(purgeURL, {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
 }


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/MQ-851

Adds a new `purge` command to delete all messages in a Queue.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/20284
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
