### PR TITLE
Add default empty router config for assets in Miniflare

### DIFF
--- a/.changeset/purple-taxis-call.md
+++ b/.changeset/purple-taxis-call.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: Add default empty router config for assets in Miniflare

--- a/packages/create-cloudflare/e2e-tests/frameworks.test.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks.test.ts
@@ -241,6 +241,7 @@ function getFrameworkTests(opts: {
 			nuxt: {
 				testCommitMessage: true,
 				timeout: LONG_TIMEOUT,
+				unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
 				unsupportedOSs: ["win32"],
 				verifyDeploy: {
 					route: "/",
@@ -542,6 +543,7 @@ function getFrameworkTests(opts: {
 			nuxt: {
 				testCommitMessage: true,
 				timeout: LONG_TIMEOUT,
+				unsupportedPms: ["yarn"], // Currently nitro requires youch which expects Node 20+, and yarn will fail hard since we run on Node 18
 				unsupportedOSs: ["win32"],
 				verifyDeploy: {
 					route: "/",

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -154,7 +154,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 					},
 					{
 						name: "CONFIG",
-						json: JSON.stringify(options.assets.routerConfig),
+						json: JSON.stringify(options.assets.routerConfig ?? {}),
 					},
 				],
 			},


### PR DESCRIPTION
I think this might be all we need to fix the failing E2E tests in the Version Packages PR. The asset-worker has a similar default being set: https://github.com/cloudflare/workers-sdk/pull/8355/files#diff-7ff83250c22d1ffda26334752afe5b193eb685e491960f8ab94adbfe5d608dadR126

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ????
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: C3 e2e???
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
