### PR TITLE
Add `CF-Cache-Status` to Workers Assets

### DIFF
--- a/.changeset/thirty-emus-find.md
+++ b/.changeset/thirty-emus-find.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Add `CF-Cache-Status` to Workers Assets responses to indicate if we returned a cached asset or not. This will also populate zone cache analytics and Logpush logs.

--- a/packages/workers-shared/asset-worker/src/analytics.ts
+++ b/packages/workers-shared/asset-worker/src/analytics.ts
@@ -36,6 +36,8 @@ type Data = {
 	version?: string;
 	// blob7 - Region of the colo (e.g. WEUR)
 	coloRegion?: string;
+	// blob8 - The cache status of the request
+	cacheStatus?: string;
 };
 
 export class Analytics {
@@ -78,6 +80,7 @@ export class Analytics {
 				this.data.error?.substring(0, 256), // blob5 - trim to 256 bytes
 				this.data.version, // blob6
 				this.data.coloRegion, // blob7
+				this.data.cacheStatus, // blob8
 			],
 		});
 	}

--- a/packages/workers-shared/asset-worker/src/utils/final-operations.ts
+++ b/packages/workers-shared/asset-worker/src/utils/final-operations.ts
@@ -1,0 +1,41 @@
+import { InternalServerErrorResponse } from '../../../utils/responses';
+import type { Toucan } from 'toucan-js';
+import type { Analytics } from '../analytics';
+import type { PerformanceTimer } from '../../../utils/performance';
+
+export function handleError(
+	sentry: Toucan | undefined,
+	analytics: Analytics,
+	err: unknown
+) {
+	try {
+		const response = new InternalServerErrorResponse(err as Error);
+
+		// Log to Sentry if we can
+		if (sentry) {
+			sentry.captureException(err);
+		}
+
+		if (err instanceof Error) {
+			analytics.setData({ error: err.message });
+		}
+
+		return response;
+	} catch (e) {
+		console.error("Error handling error", e);
+		return new InternalServerErrorResponse(e as Error);
+	}
+}
+
+export function submitMetrics(
+	analytics: Analytics,
+	performance: PerformanceTimer,
+	startTimeMs: number
+) {
+	try {
+		analytics.setData({ requestTime: performance.now() - startTimeMs });
+		analytics.write();
+	} catch (e) {
+		console.error("Error submitting metrics", e);
+	}
+}

--- a/packages/workers-shared/asset-worker/src/utils/final-operations.ts
+++ b/packages/workers-shared/asset-worker/src/utils/final-operations.ts
@@ -1,7 +1,7 @@
-import { InternalServerErrorResponse } from '../../../utils/responses';
-import type { Toucan } from 'toucan-js';
-import type { Analytics } from '../analytics';
-import type { PerformanceTimer } from '../../../utils/performance';
+import { InternalServerErrorResponse } from "../../../utils/responses";
+import type { PerformanceTimer } from "../../../utils/performance";
+import type { Analytics } from "../analytics";
+import type { Toucan } from "toucan-js";
 
 export function handleError(
 	sentry: Toucan | undefined,

--- a/packages/workers-shared/asset-worker/src/utils/headers.ts
+++ b/packages/workers-shared/asset-worker/src/utils/headers.ts
@@ -12,6 +12,7 @@ import type { AssetConfig } from "../../../utils/types";
 export function getAssetHeaders(
 	eTag: string,
 	contentType: string | undefined,
+	cacheStatus: string,
 	request: Request
 ) {
 	const headers = new Headers({
@@ -25,6 +26,10 @@ export function getAssetHeaders(
 	if (isCacheable(request)) {
 		headers.append("Cache-Control", CACHE_CONTROL_BROWSER);
 	}
+
+	// Attach CF-Cache-Status, this will show to users that we are caching assets
+	// and it will also populate the cache fields through the logging pipeline.
+	headers.append("CF-Cache-Status", cacheStatus);
 
 	return headers;
 }


### PR DESCRIPTION
Fixes N/A

Attach a CF-Cache-Status header to asset responses. We currently do not have a way to get this status from KV so we're assuming HIT if it's <= 100 ms. This will mark ~99.5% of requests today as cache HIT which is probably about right.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no change to behaviour - though we may changelog but not a blocker
