### PR TITLE
feat(wrangler): Add Secrets Store support

### DIFF
--- a/.changeset/soft-buses-sniff.md
+++ b/.changeset/soft-buses-sniff.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add Secrets Store command support to Wrangler CLI

--- a/packages/wrangler/e2e/secrets-store.test.ts
+++ b/packages/wrangler/e2e/secrets-store.test.ts
@@ -1,0 +1,153 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
+import { generateResourceName } from "./helpers/generate-resource-name";
+import { normalizeOutput } from "./helpers/normalize";
+
+describe("secrets-store", async () => {
+	let cachedStoreId = "";
+	let cachedSecretId = "";
+
+	const storeName = generateResourceName("secrets-store-store");
+	const secretName = generateResourceName("secrets-store-secret");
+	const helper = new WranglerE2ETestHelper();
+
+	const originalColumns = process.stdout.columns;
+	beforeAll(() => {
+		process.stdout.columns = 180;
+	});
+
+	afterAll(() => {
+		process.stdout.columns = originalColumns;
+	});
+
+	const normalize = (str: string) => {
+		return normalizeOutput(str, {
+			[storeName]: "tmp-e2e-secrets-store-store",
+			[secretName]: "tmp-e2e-secrets-store-secret",
+			[process.env.CLOUDFLARE_ACCOUNT_ID as string]: "CLOUDFLARE_ACCOUNT_ID",
+		});
+	};
+
+	it("creates a store", async () => {
+		const output = await helper.run(
+			`wrangler secrets-store store create ${storeName} --remote`
+		);
+
+		const regex = /ID:\s*(\w{32})/;
+		const match = output.stdout.match(regex);
+
+		if (match && match[1]) {
+			cachedStoreId = match[1];
+		} else {
+			throw new Error("No uuid for store found.");
+		}
+
+		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
+			"🔐 Creating store... (Name: tmp-e2e-secrets-store-store-00000000-0000-0000-0000-000000000000)
+✅ Created store! (Name: tmp-e2e-secrets-store-store-00000000-0000-0000-0000-000000000000, ID: 00000000000000000000000000000000)"
+		`);
+	});
+
+	it("lists stores", async () => {
+		const output = await helper.run(
+			`wrangler secrets-store store list --per-page 100 --remote`
+		);
+
+		expect(normalize(output.stdout)).toContain(
+			"tmp-e2e-secrets-store-store-00000000-0000-0000-0000-000000000000"
+		);
+	});
+
+	it("creates a secret", async () => {
+		const output = await helper.run(
+			`wrangler secrets-store secret create ${cachedStoreId} --name ${secretName} --value shh --scopes workers --comment test --remote`
+		);
+
+		const regex = /ID:\s*(\w{32})/;
+		const match = output.stdout.match(regex);
+
+		if (match && match[1]) {
+			cachedSecretId = match[1];
+		}
+
+		expect(normalize(output.stdout)).toContain(
+			"🔐 Creating secret... (Name: tmp-e2e-secrets-store-secret-00000000-0000-0000-0000-000000000000, Value: REDACTED, Scopes: workers, Comment: test"
+		);
+		expect(normalize(output.stdout)).toContain(
+			"✅ Created secret! (ID: 00000000000000000000000000000000)"
+		);
+	});
+
+	it("gets a secret", async () => {
+		const output = await helper.run(
+			`wrangler secrets-store secret get ${cachedStoreId} --secret-id ${cachedSecretId} --remote`
+		);
+
+		expect(normalize(output.stdout)).toContain(
+			"🔐 Getting secret... (ID: 00000000000000000000000000000000)"
+		);
+		expect(normalize(output.stdout)).toContain(
+			"tmp-e2e-secrets-store-secret-00000000-0000-0000-0000-000000000000"
+		);
+	});
+
+	it("updates a secret", async () => {
+		const output = await helper.run(
+			`wrangler secrets-store secret update ${cachedStoreId} --secret-id ${cachedSecretId} --value shh --remote`
+		);
+
+		expect(normalize(output.stdout)).toContain(
+			"🔐 Updating secret... (ID: 00000000000000000000000000000000)"
+		);
+		expect(normalize(output.stdout)).toContain(
+			"✅ Updated secret! (ID: 00000000000000000000000000000000)"
+		);
+		expect(normalize(output.stdout)).toContain(
+			"tmp-e2e-secrets-store-secret-00000000-0000-0000-0000-00000000000"
+		);
+	});
+
+	it("deletes a secret", async () => {
+		const output = await helper.run(
+			`wrangler secrets-store secret delete ${cachedStoreId} --secret-id ${cachedSecretId} --remote`
+		);
+
+		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
+			"🔐 Deleting secret... (ID: 00000000000000000000000000000000)
+✅ Deleted secret! (ID: 00000000000000000000000000000000)"
+		`);
+	});
+
+	it("validates a secret is deleted", async () => {
+		const output = await helper.run(
+			`wrangler secrets-store secret get ${cachedStoreId} --secret-id ${cachedSecretId} --remote`
+		);
+
+		expect(normalize(output.stdout)).toContain(
+			"🔐 Getting secret... (ID: 00000000000000000000000000000000)"
+		);
+		expect(normalize(output.stdout)).toContain("secret_not_found [code: 1001]");
+	});
+
+	it("deletes a store", async () => {
+		const output = await helper.run(
+			`wrangler secrets-store store delete ${cachedStoreId} --remote`
+		);
+
+		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
+			"🔐 Deleting store... (Name: 00000000000000000000000000000000)
+✅ Deleted store! (ID: 00000000000000000000000000000000)"
+		`);
+	});
+
+	it("validates a store is deleted", async () => {
+		const output = await helper.run(
+			`wrangler secrets-store secret get ${cachedStoreId} --secret-id ${cachedSecretId} --remote`
+		);
+
+		expect(normalize(output.stdout)).toContain(
+			"🔐 Getting secret... (ID: 00000000000000000000000000000000)"
+		);
+		expect(normalize(output.stdout)).toContain("store_not_found [code: 1001]");
+	});
+});

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -560,7 +560,7 @@ describe("deploy", () => {
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
-				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in.
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
@@ -602,7 +602,7 @@ describe("deploy", () => {
 
 				expect(std.out).toMatchInlineSnapshot(`
 					"Attempting to login via OAuth...
-					Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+					Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 					Successfully logged in.
 					Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -66,6 +66,7 @@ describe("wrangler", () => {
 				  wrangler login                  🔓 Login to Cloudflare
 				  wrangler logout                 🚪 Logout from Cloudflare
 				  wrangler whoami                 🕵️  Retrieve your user information
+				  wrangler secrets-store          🔐 Manage the Secrets Store [alpha]
 
 				GLOBAL FLAGS
 				  -c, --config   Path to Wrangler configuration file  [string]
@@ -124,6 +125,7 @@ describe("wrangler", () => {
 				  wrangler login                  🔓 Login to Cloudflare
 				  wrangler logout                 🚪 Logout from Cloudflare
 				  wrangler whoami                 🕵️  Retrieve your user information
+				  wrangler secrets-store          🔐 Manage the Secrets Store [alpha]
 
 				GLOBAL FLAGS
 				  -c, --config   Path to Wrangler configuration file  [string]

--- a/packages/wrangler/src/__tests__/secrets-store.test.ts
+++ b/packages/wrangler/src/__tests__/secrets-store.test.ts
@@ -1,0 +1,939 @@
+import { http, HttpResponse } from "msw";
+import { vi } from "vitest";
+import { endEventLoop } from "./helpers/end-event-loop";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { clearDialogs, mockConfirm, mockPrompt } from "./helpers/mock-dialogs";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { createFetchResult, msw } from "./helpers/msw";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+import type {
+	CreateSecret,
+	CreateStore,
+	UpdateSecret,
+} from "../secrets-store/client";
+
+describe("secrets-store help", () => {
+	const std = mockConsoleMethods();
+	runInTempDir();
+
+	it("shows help text when no arguments are passed", async () => {
+		await runWrangler("secrets-store");
+		await endEventLoop();
+
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		expect(std.out).toMatchInlineSnapshot(`
+		  "wrangler secrets-store
+
+🔐 Manage the Secrets Store [alpha]
+
+COMMANDS
+  wrangler secrets-store store   🔐 Manage Stores within the Secrets Store [alpha]
+  wrangler secrets-store secret  🔐 Manage Secrets within the Secrets Store [alpha]
+
+GLOBAL FLAGS
+  -c, --config   Path to Wrangler configuration file  [string]
+      --cwd      Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+  -e, --env      Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+  -h, --help     Show help  [boolean]
+  -v, --version  Show version number  [boolean]"
+		`);
+	});
+
+	it("shows help when an invalid argument is passed", async () => {
+		await expect(() => runWrangler("secrets-store qwer")).rejects.toThrow(
+			"Unknown argument: qwer"
+		);
+
+		expect(std.err).toMatchInlineSnapshot(`
+		"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mUnknown argument: qwer[0m
+
+		"
+	`);
+		expect(std.out).toMatchInlineSnapshot(`
+		  "
+wrangler secrets-store
+
+🔐 Manage the Secrets Store [alpha]
+
+COMMANDS
+  wrangler secrets-store store   🔐 Manage Stores within the Secrets Store [alpha]
+  wrangler secrets-store secret  🔐 Manage Secrets within the Secrets Store [alpha]
+
+GLOBAL FLAGS
+  -c, --config   Path to Wrangler configuration file  [string]
+      --cwd      Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
+  -e, --env      Environment to use for operations, and for selecting .env and .dev.vars files  [string]
+  -h, --help     Show help  [boolean]
+  -v, --version  Show version number  [boolean]"
+		`);
+	});
+});
+
+describe("secrets-store store commands", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+
+	const std = mockConsoleMethods();
+
+	beforeEach(() => {
+		// @ts-expect-error we're using a very simple setTimeout mock here
+		vi.spyOn(global, "setTimeout").mockImplementation((fn, _period) => {
+			setImmediate(fn);
+		});
+		setIsTTY(true);
+	});
+
+	afterEach(() => {
+		clearDialogs();
+	});
+
+	describe("secrets-store store create", () => {
+		it("creates a store", async () => {
+			const reqProm = mockStoreCreate();
+			await runWrangler("secrets-store store create test-store --remote");
+
+			await expect(reqProm).resolves.toMatchInlineSnapshot(`
+        Object {
+          "name": "test-store",
+        }
+      `);
+
+			expect(std.out).toMatchInlineSnapshot(`
+        "🔐 Creating store... (Name: test-store)
+✅ Created store! (Name: test-store, ID: 8b9199cad1954bc39add51c948767679)"
+      `);
+		});
+
+		it("errors in creating a store when no name passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler("secrets-store store create --remote");
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Not enough non-option arguments: got 0, need at least 1"
+			`);
+		});
+	});
+
+	describe("secrets-store store list", () => {
+		it("lists stores", async () => {
+			mockStoreList();
+			await runWrangler("secrets-store store list --remote");
+
+			expect(std.out).toMatchInlineSnapshot(`
+        "🔐 Listing stores...
+┌─────────────┬──────────────────────────────────┬──────────────────────────────────┬──────────────────────┬──────────────────────┐
+│ Name        │ ID                               │ AccountID                        │ Created              │ Modified             │
+├─────────────┼──────────────────────────────────┼──────────────────────────────────┼──────────────────────┼──────────────────────┤
+│ other-store │ 8686c49f762447988c02fd472f1fa82d │ 1b3ea6aa53af9903d51524c75900323a │ 3/4/2025, 8:10:35 PM │ 3/4/2025, 8:10:35 PM │
+├─────────────┼──────────────────────────────────┼──────────────────────────────────┼──────────────────────┼──────────────────────┤
+│ test-store  │ 8686c49f762447988c02fd472f1fa82c │ 1b3ea6aa53af9903d51524c75900323a │ 3/4/2025, 8:10:35 PM │ 3/4/2025, 8:10:35 PM │
+└─────────────┴──────────────────────────────────┴──────────────────────────────────┴──────────────────────┴──────────────────────┘"
+      `);
+		});
+
+		it("handles an empty response of stores", async () => {
+			mockStoreListEmpty();
+
+			let err: undefined | Error;
+			try {
+				await runWrangler("secrets-store store list --remote");
+			} catch (e) {
+				err = e as Error;
+			}
+
+			expect(err?.message).toMatchInlineSnapshot(`
+        "List request returned no stores."
+      `);
+		});
+	});
+});
+
+describe("secrets-store secret commands", () => {
+	mockAccountId();
+	mockApiToken();
+	runInTempDir();
+	const { setIsTTY } = useMockIsTTY();
+
+	const std = mockConsoleMethods();
+
+	beforeEach(() => {
+		// @ts-expect-error we're using a very simple setTimeout mock here
+		vi.spyOn(global, "setTimeout").mockImplementation((fn, _period) => {
+			setImmediate(fn);
+		});
+		setIsTTY(true);
+	});
+
+	afterEach(() => {
+		clearDialogs();
+	});
+
+	describe("secrets-store secret create", () => {
+		it("creates a secret", async () => {
+			const reqProm = mockSecretCreate();
+
+			mockPrompt({
+				text: "Enter a secret value:",
+				options: { isSecret: true },
+				result: `shhhhhhh!`,
+			});
+
+			await runWrangler(
+				"secrets-store secret create " +
+					"850e0805c1084551bb46d150b5dfe414 " +
+					"--name TEST_SECRET " +
+					"--scopes 'workers' " +
+					"--comment 'wrangler secret' " +
+					"--remote"
+			);
+
+			await expect(reqProm).resolves.toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "comment": "wrangler secret",
+            "name": "TEST_SECRET",
+            "scopes": Array [
+              "workers",
+            ],
+            "value": "shhhhhhh!",
+          },
+        ]
+      `);
+
+			expect(std.out).toMatchInlineSnapshot(`
+        "
+🔐 Creating secret... (Name: TEST_SECRET, Value: REDACTED, Scopes: workers, Comment: wrangler secret)
+✅ Created secret! (ID: 36dabbe4d01c49de82847b9a22673cbd)
+┌─────────────┬──────────────────────────────────┬──────────────────────────────────┬─────────────────┬─────────┬─────────┬──────────────────────┬──────────────────────┐
+│ Name        │ ID                               │ StoreID                          │ Comment         │ Scopes  │ Status  │ Created              │ Modified             │
+├─────────────┼──────────────────────────────────┼──────────────────────────────────┼─────────────────┼─────────┼─────────┼──────────────────────┼──────────────────────┤
+│ TEST_SECRET │ 36dabbe4d01c49de82847b9a22673cbd │ 850e0805c1084551bb46d150b5dfe414 │ wrangler secret │ workers │ pending │ 3/5/2025, 9:56:40 PM │ 3/5/2025, 9:56:40 PM │
+└─────────────┴──────────────────────────────────┴──────────────────────────────────┴─────────────────┴─────────┴─────────┴──────────────────────┴──────────────────────┘"
+      `);
+		});
+
+		it("errors in creating a secret when no store-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret create " +
+						"--name TEST_SECRET " +
+						"--value 'shhhhhhh!' " +
+						"--scopes 'workers' " +
+						"--comment 'wrangler secret' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Not enough non-option arguments: got 0, need at least 1"
+			`);
+		});
+
+		it("errors in creating a secret when no name passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret create " +
+						"850e0805c1084551bb46d150b5dfe414 " +
+						"--value 'shhhhhhh!' " +
+						"--scopes 'workers' " +
+						"--comment 'wrangler secret' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Missing required argument: name"
+			`);
+		});
+
+		it("errors in creating a secret when no value passed", async () => {
+			mockPrompt({
+				text: "Enter a secret value:",
+				options: { isSecret: true },
+				result: ``,
+			});
+
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret create " +
+						"850e0805c1084551bb46d150b5dfe414 " +
+						"--name TEST_SECRET " +
+						"--scopes 'workers' " +
+						"--comment 'wrangler secret' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Need to pass in a value when creating a secret."
+			`);
+		});
+
+		it("errors in creating a secret when no scopes passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret create " +
+						"850e0805c1084551bb46d150b5dfe414 " +
+						"--name TEST_SECRET " +
+						"--value 'shhhhhhh!' " +
+						"--comment 'wrangler secret' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Missing required argument: scopes"
+			`);
+		});
+	});
+
+	describe("secrets-store secret list", () => {
+		it("lists secrets", async () => {
+			mockSecretList();
+			await runWrangler(
+				"secrets-store secret list 850e0805c1084551bb46d150b5dfe414 --remote"
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+        "🔐 Listing secrets... (store-id: 850e0805c1084551bb46d150b5dfe414, page: 1, per-page: 10)
+┌────────────┬──────────────────────────────────┬─────────────────────────────────┬─────────┬─────────┬───────────────────────┬───────────────────────┐
+│ Name       │ ID                               │ Comment                         │ Scopes  │ Status  │ Created               │ Modified              │
+├────────────┼──────────────────────────────────┼─────────────────────────────────┼─────────┼─────────┼───────────────────────┼───────────────────────┤
+│ SECRET_KEY │ 8b108ac1cf244f91a17964f585ffa707 │ Key for Algolia search indexing │ workers │ active  │ 2/28/2025, 9:43:43 AM │ 2/28/2025, 9:43:45 AM │
+├────────────┼──────────────────────────────────┼─────────────────────────────────┼─────────┼─────────┼───────────────────────┼───────────────────────┤
+│ API_KEY    │ 2821af4e600a446f87af4e9944b693c3 │ Key for DigitalOcean droplets   │ workers │ active  │ 2/28/2025, 9:43:43 AM │ 2/28/2025, 9:43:44 AM │
+├────────────┼──────────────────────────────────┼─────────────────────────────────┼─────────┼─────────┼───────────────────────┼───────────────────────┤
+│ DB_KEY     │ df3f6eb1159a4f10ac5fe836e2b8169c │ Key for PostgreSQL database     │ workers │ active  │ 2/28/2025, 9:43:43 AM │ 2/28/2025, 9:43:45 AM │
+└────────────┴──────────────────────────────────┴─────────────────────────────────┴─────────┴─────────┴───────────────────────┴───────────────────────┘"`);
+		});
+
+		it("handles empty response of secrets", async () => {
+			mockSecretListEmpty();
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret list 850e0805c1084551bb46d150b5dfe414 --remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+
+			expect(err?.message).toMatchInlineSnapshot(
+				`"List request returned no secrets."`
+			);
+		});
+
+		it("errors in listing secrets when no store-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler("secrets-store secret list --remote");
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Not enough non-option arguments: got 0, need at least 1"
+			`);
+		});
+	});
+
+	describe("secrets-store secret get", () => {
+		it("gets a secret", async () => {
+			mockSecretGet();
+			await runWrangler(
+				"secrets-store secret get 850e0805c1084551bb46d150b5dfe414 --secret-id df3f6eb1159a4f10ac5fe836e2b8169c --remote"
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+        "🔐 Getting secret... (ID: df3f6eb1159a4f10ac5fe836e2b8169c)
+┌────────┬──────────────────────────────────┬──────────────────────────────────┬─────────────────────────────┬─────────┬─────────┬───────────────────────┬───────────────────────┐
+│ Name   │ ID                               │ StoreID                          │ Comment                     │ Scopes  │ Status  │ Created               │ Modified              │
+├────────┼──────────────────────────────────┼──────────────────────────────────┼─────────────────────────────┼─────────┼─────────┼───────────────────────┼───────────────────────┤
+│ DB_KEY │ df3f6eb1159a4f10ac5fe836e2b8169c │ 850e0805c1084551bb46d150b5dfe414 │ Key for PostgreSQL database │ workers │ active  │ 2/28/2025, 9:43:43 AM │ 2/28/2025, 9:43:45 AM │
+└────────┴──────────────────────────────────┴──────────────────────────────────┴─────────────────────────────┴─────────┴─────────┴───────────────────────┴───────────────────────┘"`);
+		});
+
+		it("errors in getting a secret when no store-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret get --secret-id df3f6eb1159a4f10ac5fe836e2b8169c --remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Not enough non-option arguments: got 0, need at least 1"
+			`);
+		});
+
+		it("errors in getting a secret when no secret-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret get 850e0805c1084551bb46d150b5dfe414 --remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Missing required argument: secret-id"
+			`);
+		});
+	});
+
+	describe("secrets-store secret delete", () => {
+		it("deletes a secret", async () => {
+			mockSecretDelete();
+			await runWrangler(
+				"secrets-store secret delete 850e0805c1084551bb46d150b5dfe414 --secret-id df3f6eb1159a4f10ac5fe836e2b8169c --remote"
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+        "🔐 Deleting secret... (ID: df3f6eb1159a4f10ac5fe836e2b8169c)
+✅ Deleted secret! (ID: df3f6eb1159a4f10ac5fe836e2b8169c)"
+      `);
+		});
+
+		it("errors in deleting a secret when no store-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret delete --secret-id df3f6eb1159a4f10ac5fe836e2b8169c --remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Not enough non-option arguments: got 0, need at least 1"
+			`);
+		});
+
+		it("errors in deleting a secret when no secret-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret delete 850e0805c1084551bb46d150b5dfe414 --remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Missing required argument: secret-id"
+			`);
+		});
+	});
+
+	describe("secrets-store secret update", () => {
+		it("updates a secret", async () => {
+			mockConfirm({
+				text: "Do you want to update the secret value?",
+				result: true,
+			});
+
+			mockPrompt({
+				text: "Enter a secret value:",
+				options: { isSecret: true },
+				result: `shhhhhhh!`,
+			});
+
+			const reqProm = mockSecretUpdate();
+
+			await runWrangler(
+				"secrets-store secret update " +
+					"850e0805c1084551bb46d150b5dfe414 " +
+					"--secret-id df3f6eb1159a4f10ac5fe836e2b8169c " +
+					"--scopes 'workers' " +
+					"--comment 'wrangler secret update' " +
+					"--remote"
+			);
+
+			await expect(reqProm).resolves.toMatchInlineSnapshot(`
+        Object {
+          "comment": "wrangler secret update",
+          "scopes": Array [
+            "workers",
+          ],
+          "value": "shhhhhhh!",
+        }
+      `);
+
+			expect(std.out).toMatchInlineSnapshot(`
+        "🔐 Updating secret... (ID: df3f6eb1159a4f10ac5fe836e2b8169c)
+✅ Updated secret! (ID: 36dabbe4d01c49de82847b9a22673cbd)
+┌────────┬──────────────────────────────────┬──────────────────────────────────┬────────────────────────┬─────────┬─────────┬──────────────────────┬──────────────────────┐
+│ Name   │ ID                               │ StoreID                          │ Comment                │ Scopes  │ Status  │ Created              │ Modified             │
+├────────┼──────────────────────────────────┼──────────────────────────────────┼────────────────────────┼─────────┼─────────┼──────────────────────┼──────────────────────┤
+│ DB_KEY │ 36dabbe4d01c49de82847b9a22673cbd │ 850e0805c1084551bb46d150b5dfe414 │ wrangler secret update │ workers │ pending │ 3/5/2025, 9:56:40 PM │ 3/5/2025, 9:56:40 PM │
+└────────┴──────────────────────────────────┴──────────────────────────────────┴────────────────────────┴─────────┴─────────┴──────────────────────┴──────────────────────┘"`);
+		});
+
+		it("errors in updating a secret when no store-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret update --secret-id df3f6eb1159a4f10ac5fe836e2b8169c " +
+						"--name TEST_SECRET " +
+						"--value 'shhhhhhh!' " +
+						"--scopes 'workers' " +
+						"--comment 'wrangler secret' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Not enough non-option arguments: got 0, need at least 1"
+			`);
+		});
+
+		it("errors in updating a secret when no secret-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret update " +
+						"850e0805c1084551bb46d150b5dfe414 " +
+						"--value 'shhhhhhh!' " +
+						"--scopes 'workers' " +
+						"--comment 'wrangler secret' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Missing required argument: secret-id"
+			`);
+		});
+
+		it("errors in updating a secret when no params to update are passed", async () => {
+			mockConfirm({
+				text: "Do you want to update the secret value?",
+				result: true,
+			});
+
+			mockPrompt({
+				text: "Enter a secret value:",
+				options: { isSecret: true },
+				result: ``,
+			});
+
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret update " +
+						"850e0805c1084551bb46d150b5dfe414 " +
+						"--secret-id df3f6eb1159a4f10ac5fe836e2b8169c " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+
+			expect(err?.message).toMatchInlineSnapshot(
+				`"Need to pass in a new field using \`--value\`, \`--scopes\`, or \`--comment\` to update a secret."`
+			);
+		});
+	});
+
+	describe("secrets-store secret duplicate", () => {
+		it("duplicates a secret", async () => {
+			const reqProm = mockSecretDuplicate();
+			await runWrangler(
+				"secrets-store secret duplicate " +
+					"850e0805c1084551bb46d150b5dfe414 " +
+					"--secret-id df3f6eb1159a4f10ac5fe836e2b8169c " +
+					"--name DUPLICATE_KEY " +
+					"--scopes 'workers' " +
+					"--comment 'wrangler secret update' " +
+					"--remote"
+			);
+
+			await expect(reqProm).resolves.toMatchInlineSnapshot(`
+        Object {
+          "comment": "wrangler secret update",
+          "name": "DUPLICATE_KEY",
+          "scopes": Array [
+            "workers",
+          ],
+        }
+      `);
+
+			expect(std.out).toMatchInlineSnapshot(`
+        "🔐 Duplicating secret... (ID: df3f6eb1159a4f10ac5fe836e2b8169c)
+✅ Duplicated secret! (ID: 36dabbe4d01c49de82847b9a22673cbd)
+┌────────┬──────────────────────────────────┬──────────────────────────────────┬────────────────────────┬─────────┬─────────┬──────────────────────┬──────────────────────┐
+│ Name   │ ID                               │ StoreID                          │ Comment                │ Scopes  │ Status  │ Created              │ Modified             │
+├────────┼──────────────────────────────────┼──────────────────────────────────┼────────────────────────┼─────────┼─────────┼──────────────────────┼──────────────────────┤
+│ DB_KEY │ 36dabbe4d01c49de82847b9a22673cbd │ 850e0805c1084551bb46d150b5dfe414 │ wrangler secret update │ workers │ pending │ 3/5/2025, 9:56:40 PM │ 3/5/2025, 9:56:40 PM │
+└────────┴──────────────────────────────────┴──────────────────────────────────┴────────────────────────┴─────────┴─────────┴──────────────────────┴──────────────────────┘"
+      `);
+		});
+
+		it("errors in duplicating a secret when no store-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret duplicate " +
+						"--secret-id df3f6eb1159a4f10ac5fe836e2b8169c " +
+						"--name DUPLICATE_KEY " +
+						"--scopes 'workers' " +
+						"--comment 'wrangler secret update' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Not enough non-option arguments: got 0, need at least 1"
+			`);
+		});
+
+		it("errors in duplicating a secret when no secret-id passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret duplicate " +
+						"850e0805c1084551bb46d150b5dfe414 " +
+						"--name DUPLICATE_KEY " +
+						"--scopes 'workers' " +
+						"--comment 'wrangler secret update' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Missing required argument: secret-id"
+			`);
+		});
+
+		it("errors in duplicating a secret when no name passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret duplicate " +
+						"--secret-id df3f6eb1159a4f10ac5fe836e2b8169c " +
+						"850e0805c1084551bb46d150b5dfe414 " +
+						"--scopes 'workers' " +
+						"--comment 'wrangler secret update' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Missing required argument: name"
+			`);
+		});
+
+		it("errors in duplicating a secret when no scopes passed", async () => {
+			let err: undefined | Error;
+			try {
+				await runWrangler(
+					"secrets-store secret duplicate " +
+						"--secret-id df3f6eb1159a4f10ac5fe836e2b8169c " +
+						"850e0805c1084551bb46d150b5dfe414 " +
+						"--name DUPLICATE_KEY " +
+						"--comment 'wrangler secret update' " +
+						"--remote"
+				);
+			} catch (e) {
+				err = e as Error;
+			}
+			expect(err?.message).toMatchInlineSnapshot(`
+				"Missing required argument: scopes"
+			`);
+		});
+	});
+});
+
+/** Create a mock handler for Secrets Store API POST /stores */
+function mockStoreCreate(): Promise<CreateStore> {
+	return new Promise((resolve) => {
+		msw.use(
+			http.post(
+				"*/accounts/some-account-id/secrets_store/stores",
+				async ({ request }) => {
+					const reqBody = (await request.json()) as CreateStore;
+
+					resolve(reqBody);
+
+					return HttpResponse.json(
+						createFetchResult(
+							{
+								id: "8b9199cad1954bc39add51c948767679",
+								account_id: "1b3ea6aa53af9903d51524c75900323a",
+								name: reqBody.name,
+								created: Date.now().toString(),
+								modified: Date.now().toString(),
+							},
+							true
+						)
+					);
+				},
+				{ once: true }
+			)
+		);
+	});
+}
+
+/** Create a mock handler for Secrets Store API GET /stores */
+function mockStoreList() {
+	msw.use(
+		http.get(
+			"*/accounts/some-account-id/secrets_store/stores",
+			async () => {
+				return HttpResponse.json(
+					createFetchResult(
+						[
+							{
+								id: "8686c49f762447988c02fd472f1fa82c",
+								account_id: "1b3ea6aa53af9903d51524c75900323a",
+								name: "test-store",
+								created: "2025-03-04T20:10:35.179029Z",
+								modified: "2025-03-04T20:10:35.179029Z",
+							},
+							{
+								id: "8686c49f762447988c02fd472f1fa82d",
+								account_id: "1b3ea6aa53af9903d51524c75900323a",
+								name: "other-store",
+								created: "2025-03-04T20:10:35.179029Z",
+								modified: "2025-03-04T20:10:35.179029Z",
+							},
+						],
+						true
+					)
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+/** Create a mock handler for Secrets Store API GET /stores (response empty) */
+function mockStoreListEmpty() {
+	msw.use(
+		http.get(
+			"*/accounts/some-account-id/secrets_store/stores",
+			async () => {
+				return HttpResponse.json(createFetchResult([], true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+/** Create a mock handler for Secrets Store API POST /secrets */
+function mockSecretCreate(): Promise<CreateSecret[]> {
+	return new Promise((resolve) => {
+		msw.use(
+			http.post(
+				"*/accounts/some-account-id/secrets_store/stores/850e0805c1084551bb46d150b5dfe414/secrets",
+				async ({ request }) => {
+					const reqBody = (await request.json()) as CreateSecret[];
+					resolve(reqBody);
+
+					return HttpResponse.json(
+						createFetchResult(
+							[
+								{
+									id: "36dabbe4d01c49de82847b9a22673cbd",
+									store_id: "850e0805c1084551bb46d150b5dfe414",
+									name: reqBody[0].name,
+									comment: reqBody[0].comment,
+									scopes: reqBody[0].scopes,
+									created: "2025-03-05T21:56:40.768422Z",
+									modified: "2025-03-05T21:56:40.768422Z",
+									status: "pending",
+								},
+							],
+							true
+						)
+					);
+				},
+				{ once: true }
+			)
+		);
+	});
+}
+
+/** Create a mock handler for Secrets Store API GET /secrets */
+function mockSecretList() {
+	msw.use(
+		http.get(
+			"*/accounts/some-account-id/secrets_store/stores/850e0805c1084551bb46d150b5dfe414/secrets?per_page=10&page1",
+			async () => {
+				return HttpResponse.json(
+					createFetchResult(
+						[
+							{
+								id: "8b108ac1cf244f91a17964f585ffa707",
+								store_id: "850e0805c1084551bb46d150b5dfe414",
+								name: "SECRET_KEY",
+								comment: "Key for Algolia search indexing",
+								scopes: ["workers"],
+								created: "2025-02-28T09:43:43.965906Z",
+								modified: "2025-02-28T09:43:45.256719Z",
+								status: "active",
+							},
+							{
+								id: "2821af4e600a446f87af4e9944b693c3",
+								store_id: "850e0805c1084551bb46d150b5dfe414",
+								name: "API_KEY",
+								comment: "Key for DigitalOcean droplets",
+								scopes: ["workers"],
+								created: "2025-02-28T09:43:43.965906Z",
+								modified: "2025-02-28T09:43:44.807687Z",
+								status: "active",
+							},
+							{
+								id: "df3f6eb1159a4f10ac5fe836e2b8169c",
+								store_id: "850e0805c1084551bb46d150b5dfe414",
+								name: "DB_KEY",
+								comment: "Key for PostgreSQL database",
+								scopes: ["workers"],
+								created: "2025-02-28T09:43:43.965906Z",
+								modified: "2025-02-28T09:43:45.255575Z",
+								status: "active",
+							},
+						],
+						true
+					)
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+/** Create a mock handler for Secrets Store API GET /secrets (response is empty) */
+function mockSecretListEmpty() {
+	msw.use(
+		http.get(
+			"*/accounts/some-account-id/secrets_store/stores/850e0805c1084551bb46d150b5dfe414/secrets?per_page=10&page1",
+			async () => {
+				return HttpResponse.json(createFetchResult([], true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+/** Create a mock handler for Secrets Store API GET /secrets/:id */
+function mockSecretGet() {
+	msw.use(
+		http.get(
+			"*/accounts/some-account-id/secrets_store/stores/850e0805c1084551bb46d150b5dfe414/secrets/df3f6eb1159a4f10ac5fe836e2b8169c",
+			async () => {
+				return HttpResponse.json(
+					createFetchResult(
+						{
+							id: "df3f6eb1159a4f10ac5fe836e2b8169c",
+							store_id: "850e0805c1084551bb46d150b5dfe414",
+							name: "DB_KEY",
+							comment: "Key for PostgreSQL database",
+							scopes: ["workers"],
+							created: "2025-02-28T09:43:43.965906Z",
+							modified: "2025-02-28T09:43:45.255575Z",
+							status: "active",
+						},
+						true
+					)
+				);
+			},
+			{ once: true }
+		)
+	);
+}
+
+/** Create a mock handler for Secrets Store API DELETE /secrets/:id */
+function mockSecretDelete() {
+	msw.use(
+		http.delete(
+			"*/accounts/some-account-id/secrets_store/stores/850e0805c1084551bb46d150b5dfe414/secrets/df3f6eb1159a4f10ac5fe836e2b8169c",
+			async () => {
+				return HttpResponse.json(createFetchResult({}, true));
+			},
+			{ once: true }
+		)
+	);
+}
+
+/** Create a mock handler for Secrets Store API PATCH /secrets/:id */
+function mockSecretUpdate(): Promise<UpdateSecret> {
+	return new Promise((resolve) => {
+		msw.use(
+			http.patch(
+				"*/accounts/some-account-id/secrets_store/stores/850e0805c1084551bb46d150b5dfe414/secrets/df3f6eb1159a4f10ac5fe836e2b8169c",
+				async ({ request }) => {
+					const reqBody = (await request.json()) as UpdateSecret;
+					resolve(reqBody);
+
+					return HttpResponse.json(
+						createFetchResult(
+							{
+								id: "36dabbe4d01c49de82847b9a22673cbd",
+								store_id: "850e0805c1084551bb46d150b5dfe414",
+								name: "DB_KEY",
+								comment: reqBody.comment,
+								scopes: reqBody.scopes,
+								created: "2025-03-05T21:56:40.768422Z",
+								modified: "2025-03-05T21:56:40.768422Z",
+								status: "pending",
+							},
+							true
+						)
+					);
+				},
+				{ once: true }
+			)
+		);
+	});
+}
+
+/** Create a mock handler for Secrets Store API POST /secrets/:id/duplicate */
+function mockSecretDuplicate(): Promise<UpdateSecret> {
+	return new Promise((resolve) => {
+		msw.use(
+			http.post(
+				"*/accounts/some-account-id/secrets_store/stores/850e0805c1084551bb46d150b5dfe414/secrets/df3f6eb1159a4f10ac5fe836e2b8169c/duplicate",
+				async ({ request }) => {
+					const reqBody = (await request.json()) as UpdateSecret;
+					resolve(reqBody);
+
+					return HttpResponse.json(
+						createFetchResult(
+							{
+								id: "36dabbe4d01c49de82847b9a22673cbd",
+								store_id: "850e0805c1084551bb46d150b5dfe414",
+								name: "DB_KEY",
+								comment: reqBody.comment,
+								scopes: reqBody.scopes,
+								created: "2025-03-05T21:56:40.768422Z",
+								modified: "2025-03-05T21:56:40.768422Z",
+								status: "pending",
+							},
+							true
+						)
+					);
+				},
+				{ once: true }
+			)
+		);
+	});
+}

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -68,7 +68,7 @@ describe("User", () => {
 			expect(counter).toBe(1);
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
-				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in."
 			`);
 			expect(readAuthConfigFile()).toEqual<UserAuthConfig>({
@@ -107,7 +107,7 @@ describe("User", () => {
 			expect(counter).toBe(1);
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
-				Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=4b2ea6cc-9421-4761-874b-ce550e0e3def&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+				Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=4b2ea6cc-9421-4761-874b-ce550e0e3def&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in."
 			`);
 
@@ -210,7 +210,7 @@ describe("User", () => {
 		expect(counter).toBe(1);
 		expect(std.out).toMatchInlineSnapshot(`
 			"Attempting to login via OAuth...
-			Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+			Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 			Successfully logged in."
 		`);
 		expect(std.warn).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -141,6 +141,22 @@ import {
 	secretPutCommand,
 } from "./secret";
 import {
+	secretsStoreNamespace,
+	secretsStoreSecretNamespace,
+	secretsStoreStoreNamespace,
+} from "./secrets-store";
+import {
+	secretsStoreSecretCreateCommand,
+	secretsStoreSecretDeleteCommand,
+	secretsStoreSecretDuplicateCommand,
+	secretsStoreSecretGetCommand,
+	secretsStoreSecretListCommand,
+	secretsStoreSecretUpdateCommand,
+	secretsStoreStoreCreateCommand,
+	secretsStoreStoreDeleteCommand,
+	secretsStoreStoreListCommand,
+} from "./secrets-store/commands";
+import {
 	addBreadcrumb,
 	captureGlobalException,
 	closeSentry,
@@ -810,6 +826,56 @@ export function createCLIParser(argv: string[]) {
 	wrangler.command("ai", "🤖 Manage AI models", (aiYargs) => {
 		return ai(aiYargs.command(subHelp));
 	});
+
+	// secrets store
+	registry.define([
+		{ command: "wrangler secrets-store", definition: secretsStoreNamespace },
+		{
+			command: "wrangler secrets-store store",
+			definition: secretsStoreStoreNamespace,
+		},
+		{
+			command: "wrangler secrets-store store create",
+			definition: secretsStoreStoreCreateCommand,
+		},
+		{
+			command: "wrangler secrets-store store delete",
+			definition: secretsStoreStoreDeleteCommand,
+		},
+		{
+			command: "wrangler secrets-store store list",
+			definition: secretsStoreStoreListCommand,
+		},
+		{
+			command: "wrangler secrets-store secret",
+			definition: secretsStoreSecretNamespace,
+		},
+		{
+			command: "wrangler secrets-store secret create",
+			definition: secretsStoreSecretCreateCommand,
+		},
+		{
+			command: "wrangler secrets-store secret list",
+			definition: secretsStoreSecretListCommand,
+		},
+		{
+			command: "wrangler secrets-store secret get",
+			definition: secretsStoreSecretGetCommand,
+		},
+		{
+			command: "wrangler secrets-store secret update",
+			definition: secretsStoreSecretUpdateCommand,
+		},
+		{
+			command: "wrangler secrets-store secret delete",
+			definition: secretsStoreSecretDeleteCommand,
+		},
+		{
+			command: "wrangler secrets-store secret duplicate",
+			definition: secretsStoreSecretDuplicateCommand,
+		},
+	]);
+	registry.registerNamespace("cert");
 
 	// workflows
 	registry.define([

--- a/packages/wrangler/src/secrets-store/client.ts
+++ b/packages/wrangler/src/secrets-store/client.ts
@@ -1,0 +1,166 @@
+import { fetchResult } from "../cfetch";
+
+// Stores API
+
+export type Store = {
+	id: string;
+	account_id: string;
+	name: string;
+	created: string;
+	modified: string;
+};
+
+export type CreateStore = {
+	name: string;
+};
+
+export async function createStore(
+	accountId: string,
+	body: CreateStore
+): Promise<Store> {
+	return await fetchResult(`/accounts/${accountId}/secrets_store/stores`, {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+}
+
+export async function deleteStore(
+	accountId: string,
+	storeId: string
+): Promise<Store> {
+	return await fetchResult(
+		`/accounts/${accountId}/secrets_store/stores/${storeId}`,
+		{
+			method: "DELETE",
+		}
+	);
+}
+
+export async function listStores(
+	accountId: string,
+	urlParams: URLSearchParams
+): Promise<Store[]> {
+	return await fetchResult(
+		`/accounts/${accountId}/secrets_store/stores`,
+		{
+			method: "GET",
+		},
+		urlParams
+	);
+}
+
+// Secrets API
+
+export type Secret = {
+	id: string;
+	store_id: string;
+	name: string;
+	comment: string;
+	scopes: string[];
+	created: string;
+	modified: string;
+	status: string;
+};
+
+export async function listSecrets(
+	accountId: string,
+	storeId: string,
+	urlParams: URLSearchParams
+): Promise<Secret[]> {
+	return await fetchResult(
+		`/accounts/${accountId}/secrets_store/stores/${storeId}/secrets`,
+		{
+			method: "GET",
+		},
+		urlParams
+	);
+}
+
+export async function getSecret(
+	accountId: string,
+	storeId: string,
+	secretId: string
+): Promise<Secret> {
+	return await fetchResult(
+		`/accounts/${accountId}/secrets_store/stores/${storeId}/secrets/${secretId}`,
+		{
+			method: "GET",
+		}
+	);
+}
+
+export type CreateSecret = {
+	name: string;
+	value: string;
+	scopes: string[];
+	comment?: string;
+};
+
+export async function createSecret(
+	accountId: string,
+	storeId: string,
+	body: CreateSecret
+): Promise<Secret[]> {
+	return await fetchResult(
+		`/accounts/${accountId}/secrets_store/stores/${storeId}/secrets`,
+		{
+			method: "POST",
+			body: JSON.stringify([body]),
+		}
+	);
+}
+
+export type UpdateSecret = {
+	value?: string;
+	scopes?: string[];
+	comment?: string;
+};
+
+export async function updateSecret(
+	accountId: string,
+	storeId: string,
+	secretId: string,
+	body: UpdateSecret
+): Promise<Secret> {
+	return await fetchResult(
+		`/accounts/${accountId}/secrets_store/stores/${storeId}/secrets/${secretId}`,
+		{
+			method: "PATCH",
+			body: JSON.stringify(body),
+		}
+	);
+}
+
+export async function deleteSecret(
+	accountId: string,
+	storeId: string,
+	secretId: string
+): Promise<Secret> {
+	return await fetchResult(
+		`/accounts/${accountId}/secrets_store/stores/${storeId}/secrets/${secretId}`,
+		{
+			method: "DELETE",
+		}
+	);
+}
+
+export type DuplicateSecret = {
+	name: string;
+	scopes: string[];
+	comment: string;
+};
+
+export async function duplicateSecret(
+	accountId: string,
+	storeId: string,
+	secretId: string,
+	body: DuplicateSecret
+): Promise<Secret> {
+	return await fetchResult(
+		`/accounts/${accountId}/secrets_store/stores/${storeId}/secrets/${secretId}/duplicate`,
+		{
+			method: "POST",
+			body: JSON.stringify(body),
+		}
+	);
+}

--- a/packages/wrangler/src/secrets-store/commands.ts
+++ b/packages/wrangler/src/secrets-store/commands.ts
@@ -1,0 +1,608 @@
+import { createCommand } from "../core/create-command";
+import { confirm, prompt } from "../dialogs";
+import { FatalError, UserError } from "../errors";
+import { logger } from "../logger";
+import { getAccountId } from "../user";
+import { readFromStdin, trimTrailingWhitespace } from "../utils/std";
+import {
+	createSecret,
+	createStore,
+	deleteSecret,
+	deleteStore,
+	duplicateSecret,
+	getSecret,
+	listSecrets,
+	listStores,
+	updateSecret,
+} from "./client";
+import type { Secret, Store } from "./client";
+
+// Store Commands
+
+export const secretsStoreStoreCreateCommand = createCommand({
+	metadata: {
+		description: "Create a store within an account",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+	positionalArgs: ["name"],
+	args: {
+		name: {
+			type: "string",
+			description: "Name of the store",
+			demandOption: true,
+			requiresArg: true,
+		},
+		remote: {
+			type: "boolean",
+			description: "Execute command against remote Secrets Store",
+			default: false,
+		},
+	},
+	async handler(args, { config }) {
+		let store: Store;
+		logger.log(`🔐 Creating store... (Name: ${args.name})`);
+		if (args.remote) {
+			const accountId = config.account_id || (await getAccountId());
+			store = await createStore(accountId, { name: args.name });
+		} else {
+			logger.log(`Local mode enabled, this command is a no-op.`);
+			return;
+		}
+		logger.log(`✅ Created store! (Name: ${args.name}, ID: ${store.id})`);
+	},
+});
+
+export const secretsStoreStoreDeleteCommand = createCommand({
+	metadata: {
+		description: "Delete a store within an account",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+	positionalArgs: ["store-id"],
+	args: {
+		"store-id": {
+			type: "string",
+			description: "ID of the store",
+			demandOption: true,
+			requiresArg: true,
+		},
+		remote: {
+			type: "boolean",
+			description: "Execute command against remote Secrets Store",
+			default: false,
+		},
+	},
+	async handler(args, { config }) {
+		logger.log(`🔐 Deleting store... (Name: ${args.storeId})`);
+		if (args.remote) {
+			const accountId = config.account_id || (await getAccountId());
+			await deleteStore(accountId, args.storeId);
+		} else {
+			logger.log(`Local mode enabled, this command is a no-op.`);
+			return;
+		}
+		logger.log(`✅ Deleted store! (ID: ${args.storeId})`);
+	},
+});
+
+export const secretsStoreStoreListCommand = createCommand({
+	metadata: {
+		description: "List stores within an account",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+	args: {
+		page: {
+			describe:
+				'Page number of stores listing results, can configure page size using "per-page"',
+			type: "number",
+			default: 1,
+		},
+		"per-page": {
+			describe: "Number of stores to show per page",
+			type: "number",
+			default: 10,
+		},
+		remote: {
+			type: "boolean",
+			description: "Execute command against remote Secrets Store",
+			default: false,
+		},
+	},
+	async handler(args, { config }) {
+		const urlParams = new URLSearchParams();
+
+		urlParams.set("per_page", args.perPage.toString());
+		urlParams.set("page", args.page.toString());
+
+		logger.log(`🔐 Listing stores...`);
+
+		let stores: Store[];
+		if (args.remote) {
+			const accountId = config.account_id || (await getAccountId());
+			stores = await listStores(accountId, urlParams);
+		} else {
+			throw new UserError(
+				"No local dev version of this command available, need to include --remote in command",
+				{ telemetryMessage: true }
+			);
+		}
+
+		if (stores.length === 0) {
+			throw new UserError("List request returned no stores.", {
+				telemetryMessage: true,
+			});
+		} else {
+			const prettierStores = stores
+				.sort((a, b) => a.name.localeCompare(b.name))
+				.map((store) => ({
+					Name: store.name,
+					ID: store.id,
+					AccountID: store.account_id,
+					Created: new Date(store.created).toLocaleString(),
+					Modified: new Date(store.modified).toLocaleString(),
+				}));
+			logger.table(prettierStores);
+		}
+	},
+});
+
+// Secret Commands
+
+export const secretsStoreSecretListCommand = createCommand({
+	metadata: {
+		description: "List secrets within a store",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+	positionalArgs: ["store-id"],
+	args: {
+		"store-id": {
+			describe: "ID of the store in which to list secrets",
+			type: "string",
+			demandOption: true,
+			requiresArg: true,
+		},
+		page: {
+			describe:
+				'Page number of secrets listing results, can configure page size using "per-page"',
+			type: "number",
+			default: 1,
+		},
+		"per-page": {
+			describe: "Number of secrets to show per page",
+			type: "number",
+			default: 10,
+		},
+		remote: {
+			type: "boolean",
+			description: "Execute command against remote Secrets Store",
+			default: false,
+		},
+	},
+	async handler(args, { config }) {
+		const urlParams = new URLSearchParams();
+
+		urlParams.set("per_page", args.perPage.toString());
+		urlParams.set("page", args.page.toString());
+
+		logger.log(
+			`🔐 Listing secrets... (store-id: ${args.storeId}, page: ${args.page}, per-page: ${args.perPage})`
+		);
+
+		let secrets: Secret[];
+		if (args.remote) {
+			const accountId = config.account_id || (await getAccountId());
+			secrets = await listSecrets(accountId, args.storeId, urlParams);
+		} else {
+			throw new UserError(
+				"No local dev version of this command available, need to include --remote in command",
+				{ telemetryMessage: true }
+			);
+		}
+
+		if (secrets.length === 0) {
+			throw new FatalError("List request returned no secrets.", 1, {
+				telemetryMessage: true,
+			});
+		} else {
+			const prettierSecrets = secrets.map((secret) => ({
+				Name: secret.name,
+				ID: secret.id,
+				Comment: secret.comment,
+				Scopes: secret.scopes.join(", "),
+				Status: secret.status === "active" ? "active " : "pending",
+				Created: new Date(secret.created).toLocaleString(),
+				Modified: new Date(secret.modified).toLocaleString(),
+			}));
+			logger.table(prettierSecrets);
+		}
+	},
+});
+
+export const secretsStoreSecretGetCommand = createCommand({
+	metadata: {
+		description: "Get a secret within a store",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+	positionalArgs: ["store-id"],
+	args: {
+		"store-id": {
+			describe: "ID of the store in which the secret resides",
+			type: "string",
+			demandOption: true,
+			requiresArg: true,
+		},
+		"secret-id": {
+			describe: "ID of the secret to retrieve",
+			type: "string",
+			demandOption: true,
+			requiresArg: true,
+		},
+		remote: {
+			type: "boolean",
+			description: "Execute command against remote Secrets Store",
+			default: false,
+		},
+	},
+	async handler(args, { config }) {
+		logger.log(`🔐 Getting secret... (ID: ${args.secretId})`);
+
+		let secret: Secret;
+		if (args.remote) {
+			const accountId = config.account_id || (await getAccountId());
+			secret = await getSecret(accountId, args.storeId, args.secretId);
+		} else {
+			throw new UserError(
+				"No local dev version of this command available, need to include --remote in command",
+				{ telemetryMessage: true }
+			);
+		}
+
+		const prettierSecret = [
+			{
+				Name: secret.name,
+				ID: secret.id,
+				StoreID: secret.store_id,
+				Comment: secret.comment,
+				Scopes: secret.scopes.join(", "),
+				Status: secret.status === "active" ? "active " : "pending",
+				Created: new Date(secret.created).toLocaleString(),
+				Modified: new Date(secret.modified).toLocaleString(),
+			},
+		];
+		logger.table(prettierSecret);
+	},
+});
+
+export const secretsStoreSecretCreateCommand = createCommand({
+	metadata: {
+		description: "Create a secret within a store",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+	positionalArgs: ["store-id"],
+	args: {
+		"store-id": {
+			describe: "ID of the store in which the secret resides",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		name: {
+			describe: "Name of the secret",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		value: {
+			describe:
+				"Value of the secret (Note: Only for testing. Not secure as this will leave secret value in plain-text in terminal history, exclude this flag and use automatic prompt instead)",
+			type: "string",
+		},
+		scopes: {
+			describe:
+				'Scopes for the secret (comma-separated list of scopes eg:"workers")',
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		comment: {
+			describe: "Comment for the secret",
+			type: "string",
+		},
+		remote: {
+			type: "boolean",
+			description: "Execute command against remote Secrets Store",
+			default: false,
+		},
+	},
+	async handler(args, { config }) {
+		let secretValue = "";
+
+		if (!args.value) {
+			const isInteractive = process.stdin.isTTY;
+			secretValue = trimTrailingWhitespace(
+				isInteractive
+					? await prompt("Enter a secret value:", { isSecret: true })
+					: await readFromStdin()
+			);
+		} else {
+			secretValue = args.value;
+		}
+
+		if (!secretValue) {
+			throw new UserError("Need to pass in a value when creating a secret.");
+		}
+
+		logger.log(
+			`\n🔐 Creating secret... (Name: ${args.name}, Value: REDACTED, Scopes: ${args.scopes}, Comment: ${args.comment})`
+		);
+
+		let secrets: Secret[];
+		if (args.remote) {
+			const accountId = config.account_id || (await getAccountId());
+			secrets = await createSecret(accountId, args.storeId, {
+				name: args.name,
+				value: secretValue,
+				scopes: args.scopes.split(","),
+				comment: args.comment,
+			});
+		} else {
+			throw new UserError(
+				"No local dev version of this command available, need to include --remote in command",
+				{ telemetryMessage: true }
+			);
+		}
+
+		if (secrets.length === 0) {
+			throw new FatalError("Failed to create a secret.", 1, {
+				telemetryMessage: true,
+			});
+		}
+		const secret = secrets[0];
+		logger.log(`✅ Created secret! (ID: ${secret.id})`);
+
+		const prettierSecret = [
+			{
+				Name: secret.name,
+				ID: secret.id,
+				StoreID: secret.store_id,
+				Comment: secret.comment,
+				Scopes: secret.scopes.join(", "),
+				Status: secret.status,
+				Created: new Date(secret.created).toLocaleString(),
+				Modified: new Date(secret.modified).toLocaleString(),
+			},
+		];
+		logger.table(prettierSecret);
+	},
+});
+
+export const secretsStoreSecretUpdateCommand = createCommand({
+	metadata: {
+		description: "Update a secret within a store",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+	positionalArgs: ["store-id"],
+	args: {
+		"store-id": {
+			describe: "ID of the store in which the secret resides",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		"secret-id": {
+			describe: "ID of the secret to update",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		value: {
+			describe:
+				"Updated value of the secret (Note: Only for testing. Not secure as this will leave secret value in plain-text in terminal history, exclude this flag and use automatic prompt instead)",
+			type: "string",
+		},
+		scopes: {
+			describe:
+				'Updated scopes for the secret (comma-separated list of scopes eg:"workers")',
+			type: "string",
+		},
+		comment: {
+			describe: "Updated comment for the secret",
+			type: "string",
+		},
+		remote: {
+			type: "boolean",
+			description: "Execute command against remote Secrets Store",
+			default: false,
+		},
+	},
+	async handler(args, { config }) {
+		let secretValue = "";
+
+		if (!args.value) {
+			const confirmValueUpdate = await confirm(
+				"Do you want to update the secret value?",
+				{ defaultValue: false }
+			);
+
+			if (confirmValueUpdate) {
+				const isInteractive = process.stdin.isTTY;
+				secretValue = trimTrailingWhitespace(
+					isInteractive
+						? await prompt("Enter a secret value:", { isSecret: true })
+						: await readFromStdin()
+				);
+			}
+		} else {
+			secretValue = args.value;
+		}
+
+		if (!secretValue && !args.scopes && !args.comment) {
+			throw new UserError(
+				"Need to pass in a new field using `--value`, `--scopes`, or `--comment` to update a secret."
+			);
+		}
+
+		logger.log(`🔐 Updating secret... (ID: ${args.secretId})`);
+
+		let secret: Secret;
+		if (args.remote) {
+			const accountId = config.account_id || (await getAccountId());
+			secret = await updateSecret(accountId, args.storeId, args.secretId, {
+				...(secretValue && { value: secretValue }),
+				...(args.scopes && { scopes: args.scopes.split(",") }),
+				...(args.comment && { comment: args.comment }),
+			});
+		} else {
+			throw new UserError(
+				"No local dev version of this command available, need to include --remote in command",
+				{ telemetryMessage: true }
+			);
+		}
+
+		logger.log(`✅ Updated secret! (ID: ${secret.id})`);
+
+		const prettierSecret = [
+			{
+				Name: secret.name,
+				ID: secret.id,
+				StoreID: secret.store_id,
+				Comment: secret.comment,
+				Scopes: secret.scopes.join(", "),
+				Status: secret.status,
+				Created: new Date(secret.created).toLocaleString(),
+				Modified: new Date(secret.modified).toLocaleString(),
+			},
+		];
+		logger.table(prettierSecret);
+	},
+});
+
+export const secretsStoreSecretDeleteCommand = createCommand({
+	metadata: {
+		description: "Delete a secret within a store",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+	positionalArgs: ["store-id"],
+	args: {
+		"store-id": {
+			describe: "ID of the store in which the secret resides",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		"secret-id": {
+			describe: "ID of the secret to delete",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		remote: {
+			type: "boolean",
+			description: "Execute command against remote Secrets Store",
+			default: false,
+		},
+	},
+	async handler(args, { config }) {
+		logger.log(`🔐 Deleting secret... (ID: ${args.secretId})`);
+
+		if (args.remote) {
+			const accountId = config.account_id || (await getAccountId());
+			await deleteSecret(accountId, args.storeId, args.secretId);
+		} else {
+			throw new UserError(
+				"No local dev version of this command available, need to include --remote in command",
+				{ telemetryMessage: true }
+			);
+		}
+		logger.log(`✅ Deleted secret! (ID: ${args.secretId})`);
+	},
+});
+
+export const secretsStoreSecretDuplicateCommand = createCommand({
+	metadata: {
+		description: "Duplicate a secret within a store",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+	positionalArgs: ["store-id"],
+	args: {
+		"store-id": {
+			describe: "ID of the store in which the secret resides",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		"secret-id": {
+			describe: "ID of the secret to duplicate the secret value of",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		name: {
+			describe: "Name of the new secret",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		scopes: {
+			describe: "Scopes for the new secret",
+			type: "string",
+			requiresArg: true,
+			demandOption: true,
+		},
+		comment: {
+			describe: "Comment for the new secret",
+			type: "string",
+		},
+		remote: {
+			type: "boolean",
+			description: "Execute command against remote Secrets Store",
+			default: false,
+		},
+	},
+	async handler(args, { config }) {
+		logger.log(`🔐 Duplicating secret... (ID: ${args.secretId})`);
+
+		let duplicatedSecret: Secret;
+		if (args.remote) {
+			const accountId = config.account_id || (await getAccountId());
+			duplicatedSecret = await duplicateSecret(
+				accountId,
+				args.storeId,
+				args.secretId,
+				{
+					name: args.name,
+					scopes: args.scopes.split(","),
+					comment: args.comment || "",
+				}
+			);
+		} else {
+			throw new UserError(
+				"No local dev version of this command available, need to include --remote in command",
+				{ telemetryMessage: true }
+			);
+		}
+
+		logger.log(`✅ Duplicated secret! (ID: ${duplicatedSecret.id})`);
+		const prettierSecret = [
+			{
+				Name: duplicatedSecret.name,
+				ID: duplicatedSecret.id,
+				StoreID: duplicatedSecret.store_id,
+				Comment: duplicatedSecret.comment,
+				Scopes: duplicatedSecret.scopes.join(", "),
+				Status: duplicatedSecret.status,
+				Created: new Date(duplicatedSecret.created).toLocaleString(),
+				Modified: new Date(duplicatedSecret.modified).toLocaleString(),
+			},
+		];
+		logger.table(prettierSecret);
+	},
+});

--- a/packages/wrangler/src/secrets-store/index.ts
+++ b/packages/wrangler/src/secrets-store/index.ts
@@ -1,0 +1,25 @@
+import { createNamespace } from "../core/create-command";
+
+export const secretsStoreNamespace = createNamespace({
+	metadata: {
+		description: `🔐 Manage the Secrets Store`,
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+});
+
+export const secretsStoreStoreNamespace = createNamespace({
+	metadata: {
+		description: "🔐 Manage Stores within the Secrets Store",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+});
+
+export const secretsStoreSecretNamespace = createNamespace({
+	metadata: {
+		description: "🔐 Manage Secrets within the Secrets Store",
+		status: "alpha",
+		owner: "Product: SSL",
+	},
+});

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -354,6 +354,8 @@ const DefaultScopes = {
 	"queues:write": "See and change Cloudflare Queues settings and data",
 	"pipelines:write":
 		"See and change Cloudflare Pipelines configurations and data",
+	"secrets_store:write":
+		"See and change secrets + stores within the Secrets Store",
 } as const;
 
 const OptionalScopes = {


### PR DESCRIPTION
This PR introduces the Secrets Store API to the Wrangler CLI. It adds commands namespaces for `wrangler secrets-store` with sub-namespaces of `wrangler secrets-store store` and `wrangler secrets-store secret` for acting upon store and secret resources respectively. The intent here is to be able to fully manage the stores+secrets for an account's Secret Store, from wrangler. 

Changes:
- Added `wrangler secrets-store store list|create|delete` commands
- Added `wrangler secrets-store secret list|get|create|update|delete|duplicate` commands
- All commands default to local dev, need to pass `--remote` for acting on remote

Todo:
- Will implement local dev version of commands (specifically create/delete secret), in a subsequent change
- Fix e2e test runner, what do I need to do for API tokens to get the test runner to have the right permissions? Add new api token role to bach, and then update the api token in the github ci to include that role/permissions? 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Waiting on public documentation until the Secrets Store is released as a product. 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
