### PR TITLE
fix(wrangler): Make kv bulk put --local respect base64:true

### DIFF
--- a/.changeset/chatty-glasses-drum.md
+++ b/.changeset/chatty-glasses-drum.md
@@ -1,0 +1,15 @@
+---
+"wrangler": patch
+---
+
+Make kv bulk put --local respect base64:true
+
+The bulk put api has an optional "base64" boolean property for each key.
+Before storing the key, the value should be decoded from base64.
+
+For real (remote) kv, this is handled by the rest api. For local kv, it
+seems the base64 field was ignored, meaning encoded base64 content was
+stored locally rather than the raw values.
+
+To fix, we need to decode each value before putting to the local
+miniflare namespace when base64 is true.

--- a/packages/wrangler/src/__tests__/kv.local.test.ts
+++ b/packages/wrangler/src/__tests__/kv.local.test.ts
@@ -172,6 +172,11 @@ describe("wrangler", () => {
 					key: "test",
 					value: "value",
 				},
+				{
+					key: "encoded",
+					value: Buffer.from("some raw data").toString("base64"),
+					base64: true,
+				},
 			];
 			writeFileSync("./keys.json", JSON.stringify(keyValues));
 			await runWrangler(
@@ -191,12 +196,26 @@ describe("wrangler", () => {
 			value"
 		`);
 
+			await runWrangler(
+				`kv:key get encoded --namespace-id bulk-namespace-id --local --text`
+			);
+			expect(std.out).toMatchInlineSnapshot(`
+			"[]
+			Success!
+			value
+			some raw data"
+		`);
+
 			await runWrangler(`kv:key list --namespace-id bulk-namespace-id --local`);
 			expect(std.out).toMatchInlineSnapshot(`
 			"[]
 			Success!
 			value
+			some raw data
 			[
+			  {
+			    \\"name\\": \\"encoded\\"
+			  },
 			  {
 			    \\"name\\": \\"hello\\"
 			  },

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -734,7 +734,11 @@ export const kvBulkPutCommand = createCommand({
 				namespaceId,
 				async (namespace) => {
 					for (const value of content) {
-						await namespace.put(value.key, value.value, {
+						let data = value.value;
+						if (value.base64) {
+							data = Buffer.from(data, "base64").toString();
+						}
+						await namespace.put(value.key, data, {
 							expiration: value.expiration,
 							expirationTtl: value.expiration_ttl,
 							metadata: value.metadata,


### PR DESCRIPTION
The bulk put api has an optional "base64" boolean property for each key. Before storing the key, the value should be decoded from base64.

For real (remote) kv, this is handled by the rest api. For local kv, it seems the base64 field was ignored, meaning encoded base64 content was stored locally rather than the raw values.

To fix, we need to decode each value before putting to the local miniflare namespace when base64 is true.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required (https://github.com/cloudflare/workers-sdk/pull/8400)
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because:  Fixes bug in behavior described in docs

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
