### PR TITLE
remove `Application Starter` option in C3 experimental menu

### DIFF
--- a/.changeset/metal-shoes-cut.md
+++ b/.changeset/metal-shoes-cut.md
@@ -1,0 +1,9 @@
+---
+"create-cloudflare": patch
+---
+
+Remove categories in C3 that have no templates
+
+The `Application Starter` category doesn't contain any entries in experimental mode so we shouldn't show it.
+
+This change updates C3 to automatically exclude categories that have no templates.

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -11,20 +11,20 @@ import {
 	runC3,
 	test,
 } from "./helpers";
-import type { Suite } from "vitest";
 
 const experimental = process.env.E2E_EXPERIMENTAL === "true";
 const frameworkToTest = getFrameworkToTest({ experimental: false });
 const { name: pm } = detectPackageManager();
+
+beforeAll((ctx) => {
+	recreateLogFolder({ experimental }, ctx);
+});
+
 // Note: skipIf(frameworkToTest) makes it so that all the basic C3 functionality
 //       tests are skipped in case we are testing a specific framework
 describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 	"E2E: Basic C3 functionality ",
 	() => {
-		beforeAll((ctx) => {
-			recreateLogFolder({ experimental }, ctx as Suite);
-		});
-
 		test({ experimental })("--version", async ({ logStream }) => {
 			const { output } = await runC3(["--version"], [], logStream);
 			expect(output).toEqual(version);
@@ -442,3 +442,178 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 		});
 	},
 );
+
+describe.skipIf(frameworkToTest || isQuarantineMode())("help text", () => {
+	test({ experimental })("--help", async ({ logStream }) => {
+		if (experimental) {
+			const { output } = await runC3(
+				["--help", "--experimental"],
+				[],
+				logStream,
+			);
+			expect(normalizeOutput(output)).toMatchInlineSnapshot(`
+				"create-cloudflare <version>
+				  The create-cloudflare cli (also known as C3) is a command-line tool designed to help you set up and deploy new applications to Cloudflare. In addition to speed, it leverages officially developed templates for Workers and framework-specific setup guides to ensure each new application that you set up follows Cloudflare and any third-party best practices for deployment on the Cloudflare network.
+				USAGE
+				  <USAGE>
+				OPTIONS
+				You have selected experimental mode - the options below are filtered to those that support experimental mode.
+				  directory
+				    The directory where the application should be created. Also used as the name of the application.
+				    If a path is provided that includes intermediary directories, only the base name will be used as the name of the application.
+				  --category=<value>
+				    Specifies the kind of templates that should be created
+				    Allowed Values:
+				      hello-world
+				        Hello World example
+				      web-framework
+				        Framework Starter
+				  --type=<value>, -t
+				    When using a built-in template, specifies the type of application that should be created.
+				    Note that "--category" and "--template" are mutually exclusive options. If both are provided, "--category" will be used.
+				    Allowed Values:
+				      hello-world-assets-only
+				        Get started with a basic Worker that only serves static assets
+				      hello-world-with-assets
+				        Get started with a basic Worker that also serves static assets, in the language of your choice
+				      hello-world-durable-object-with-assets
+				        Get started with a basic stateful app to build projects like real-time chats, collaborative apps, and multiplayer games, which hosts assets
+				  --framework=<value>, -f
+				    The type of framework to use to create a web application (when using this option "--category" is coerced to "web-framework")
+				    When using the --framework option, C3 will dispatch to the official creation tool used by the framework (ex. "create-remix" is used for Remix).
+				    You may specify additional arguments to be passed directly to these underlying tools by adding them after a "--" argument, like so:
+				    npm create cloudflare -- --framework next -- --ts
+				    pnpm create cloudflare --framework next -- --ts
+				    Allowed Values:
+				      astro, hono, next, qwik, remix, solid, svelte
+				  --platform=<value>
+				    Whether the application should be deployed to Pages or Workers. This is only applicable for Frameworks templates that support both Pages and Workers.
+				    Allowed Values:
+				      pages
+				        Create a web application that can be deployed to Pages.
+				      workers
+				        Create a web application that can be deployed to Workers (BETA).
+				  --lang=<value>
+				    The programming language of the template
+				    Allowed Values:
+				      ts, js, python
+				  --deploy, --no-deploy
+				    Deploy your application after it has been created
+				  --git, --no-git
+				    Initialize a local git repository for your application
+				  --open, --no-open
+				    Opens the deployed application in your browser (this option is ignored if the application is not deployed)
+				  --existing-script=<value>
+				    The name of an existing Cloudflare Workers script to clone locally (when using this option "--type" is coerced to "pre-existing").
+				    When "--existing-script" is specified, "deploy" will be ignored.
+				  --template=<value>
+				    An external template to be used when creating your project.
+				    Any "degit" compatible string may be specified. For example:
+				    npm create cloudflare my-project -- --template github:user/repo
+				    npm create cloudflare my-project -- --template git@github.com:user/repo
+				    npm create cloudflare my-project -- --template https://github.com/user/repo
+				    npm create cloudflare my-project -- --template git@github.com:user/repo#dev (branch)
+				    npm create cloudflare my-project -- --template git@github.com:user/repo#v1.2.3 (tag)
+				    npm create cloudflare my-project -- --template git@github.com:user/repo#1234abcd (commit)
+				    Note that subdirectories may also be used. For example:
+				    npm create cloudflare -- --template https://github.com/cloudflare/workers-sdk/templates/worker-r2
+				  --accept-defaults, --no-accept-defaults, -y
+				    Use all the default C3 options (each can also be overridden by specifying it)
+				  --auto-update, --no-auto-update
+				    Automatically uses the latest version of C3"
+			`);
+		} else {
+			const { output } = await runC3(["--help"], [], logStream);
+			expect(normalizeOutput(output)).toMatchInlineSnapshot(`
+				"create-cloudflare <version>
+				  The create-cloudflare cli (also known as C3) is a command-line tool designed to help you set up and deploy new applications to Cloudflare. In addition to speed, it leverages officially developed templates for Workers and framework-specific setup guides to ensure each new application that you set up follows Cloudflare and any third-party best practices for deployment on the Cloudflare network.
+				USAGE
+				  <USAGE>
+				OPTIONS
+				  directory
+				    The directory where the application should be created. Also used as the name of the application.
+				    If a path is provided that includes intermediary directories, only the base name will be used as the name of the application.
+				  --category=<value>
+				    Specifies the kind of templates that should be created
+				    Allowed Values:
+				      hello-world
+				        Hello World example
+				      web-framework
+				        Framework Starter
+				      demo
+				        Application Starter
+				      remote-template
+				        Template from a GitHub repo
+				  --type=<value>, -t
+				    When using a built-in template, specifies the type of application that should be created.
+				    Note that "--category" and "--template" are mutually exclusive options. If both are provided, "--category" will be used.
+				    Allowed Values:
+				      hello-world
+				        Get started with a basic Worker in the language of your choice
+				      hello-world-durable-object
+				        Get started with a basic stateful app to build projects like real-time chats, collaborative apps, and multiplayer games
+				      common
+				        Create a Worker to route and forward requests to other services
+				      scheduled
+				        Create a Worker to be executed on a schedule for periodic (cron) jobs
+				      queues
+				        Get started with a Worker that processes background tasks and message batches with Cloudflare Queues
+				      openapi
+				        Get started building a basic API on Workers
+				      pre-existing
+				        Fetch a Worker initialized from the Cloudflare dashboard.
+				  --framework=<value>, -f
+				    The type of framework to use to create a web application (when using this option "--category" is coerced to "web-framework")
+				    When using the --framework option, C3 will dispatch to the official creation tool used by the framework (ex. "create-remix" is used for Remix).
+				    You may specify additional arguments to be passed directly to these underlying tools by adding them after a "--" argument, like so:
+				    npm create cloudflare -- --framework next -- --ts
+				    pnpm create cloudflare --framework next -- --ts
+				    Allowed Values:
+				      analog, angular, astro, docusaurus, gatsby, hono, next, nuxt, qwik, react, remix, solid, svelte, vue
+				  --platform=<value>
+				    Whether the application should be deployed to Pages or Workers. This is only applicable for Frameworks templates that support both Pages and Workers.
+				    Allowed Values:
+				      pages
+				        Create a web application that can be deployed to Pages.
+				      workers
+				        Create a web application that can be deployed to Workers (BETA).
+				  --lang=<value>
+				    The programming language of the template
+				    Allowed Values:
+				      ts, js, python
+				  --deploy, --no-deploy
+				    Deploy your application after it has been created
+				  --git, --no-git
+				    Initialize a local git repository for your application
+				  --open, --no-open
+				    Opens the deployed application in your browser (this option is ignored if the application is not deployed)
+				  --existing-script=<value>
+				    The name of an existing Cloudflare Workers script to clone locally (when using this option "--type" is coerced to "pre-existing").
+				    When "--existing-script" is specified, "deploy" will be ignored.
+				  --template=<value>
+				    An external template to be used when creating your project.
+				    Any "degit" compatible string may be specified. For example:
+				    npm create cloudflare my-project -- --template github:user/repo
+				    npm create cloudflare my-project -- --template git@github.com:user/repo
+				    npm create cloudflare my-project -- --template https://github.com/user/repo
+				    npm create cloudflare my-project -- --template git@github.com:user/repo#dev (branch)
+				    npm create cloudflare my-project -- --template git@github.com:user/repo#v1.2.3 (tag)
+				    npm create cloudflare my-project -- --template git@github.com:user/repo#1234abcd (commit)
+				    Note that subdirectories may also be used. For example:
+				    npm create cloudflare -- --template https://github.com/cloudflare/workers-sdk/templates/worker-r2
+				  --accept-defaults, --no-accept-defaults, -y
+				    Use all the default C3 options (each can also be overridden by specifying it)
+				  --auto-update, --no-auto-update
+				    Automatically uses the latest version of C3"
+			`);
+		}
+	});
+});
+
+function normalizeOutput(output: string): string {
+	return output
+		.replaceAll("\r\n", "\n")
+		.replaceAll(/\n\n+/g, "\n")
+		.replace(/create-cloudflare v\d+\.\d+\.\d+/, "create-cloudflare <version>")
+		.replace(/USAGE\n[^\n]+/, `USAGE\n  <USAGE>`);
+}

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -51,7 +51,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 			expect(output).toEqual(version);
 		});
 
-		test({ experimental }).skipIf(process.platform === "win32")(
+		test({ experimental }).skipIf(process.platform === "win32" || experimental)(
 			"Using arrow keys + enter",
 			async ({ logStream, project }) => {
 				const { output } = await runC3(

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -82,7 +82,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 				);
 
 				expect(project.path).toExist();
-				expect(output).toContain(`category Hello World Starter`);
+				expect(output).toContain(`category Hello World example`);
 				expect(output).toContain(`type Worker + Assets`);
 				expect(output).toContain(`lang TypeScript`);
 				expect(output).toContain(`no deploy`);

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -528,7 +528,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())("help text", () => {
 				    Specifies the kind of templates that should be created
 				    Allowed Values:
 				      hello-world
-				        Hello World example
+				        Hello World Starter
 				      web-framework
 				        Framework Starter
 				      demo
@@ -540,9 +540,15 @@ describe.skipIf(frameworkToTest || isQuarantineMode())("help text", () => {
 				    Note that "--category" and "--template" are mutually exclusive options. If both are provided, "--category" will be used.
 				    Allowed Values:
 				      hello-world
-				        Get started with a basic Worker in the language of your choice
+				        For processing requests, transforming responses, or API endpoints
+				      hello-world-assets-only
+				        For static sites (including SPAs) or when using your own backend
+				      hello-world-with-assets
+				        For static sites with an API or server-side rendering (SSR)
 				      hello-world-durable-object
-				        Get started with a basic stateful app to build projects like real-time chats, collaborative apps, and multiplayer games
+				        For multiplayer apps using WebSockets, or when you need synchronization
+				      hello-world-durable-object-with-assets
+				        For full-stack applications requiring static assets, an API, and real-time coordination
 				      common
 				        Create a Worker to route and forward requests to other services
 				      scheduled

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -476,7 +476,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())("help text", () => {
 				    npm create cloudflare -- --framework next -- --ts
 				    pnpm create cloudflare --framework next -- --ts
 				    Allowed Values:
-				      next, qwik, solid
+				      next, solid
 				  --platform=<value>
 				    Whether the application should be deployed to Pages or Workers. This is only applicable for Frameworks templates that support both Pages and Workers.
 				    Allowed Values:

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -464,20 +464,11 @@ describe.skipIf(frameworkToTest || isQuarantineMode())("help text", () => {
 				  --category=<value>
 				    Specifies the kind of templates that should be created
 				    Allowed Values:
-				      hello-world
-				        Hello World example
 				      web-framework
 				        Framework Starter
 				  --type=<value>, -t
 				    When using a built-in template, specifies the type of application that should be created.
 				    Note that "--category" and "--template" are mutually exclusive options. If both are provided, "--category" will be used.
-				    Allowed Values:
-				      hello-world-assets-only
-				        Get started with a basic Worker that only serves static assets
-				      hello-world-with-assets
-				        Get started with a basic Worker that also serves static assets, in the language of your choice
-				      hello-world-durable-object-with-assets
-				        Get started with a basic stateful app to build projects like real-time chats, collaborative apps, and multiplayer games, which hosts assets
 				  --framework=<value>, -f
 				    The type of framework to use to create a web application (when using this option "--category" is coerced to "web-framework")
 				    When using the --framework option, C3 will dispatch to the official creation tool used by the framework (ex. "create-remix" is used for Remix).
@@ -485,7 +476,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())("help text", () => {
 				    npm create cloudflare -- --framework next -- --ts
 				    pnpm create cloudflare --framework next -- --ts
 				    Allowed Values:
-				      astro, hono, next, qwik, remix, solid, svelte
+				      next, qwik, solid
 				  --platform=<value>
 				    Whether the application should be deployed to Pages or Workers. This is only applicable for Frameworks templates that support both Pages and Workers.
 				    Allowed Values:

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -376,7 +376,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 							matcher: /What would you like to start with\?/,
 							input: {
 								type: "select",
-								target: "Hello World Starter",
+								target: "Hello World example",
 								assertDefaultSelection: "Framework Starter",
 							},
 						},

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -269,7 +269,7 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 				);
 
 				expect(project.path).toExist();
-				expect(output).toContain(`category Hello World Starter`);
+				expect(output).toContain(`category Hello World example`);
 				expect(output).toContain(`type Worker only`);
 				expect(output).toContain(`lang Python`);
 			},

--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -566,7 +566,7 @@ describe.skipIf(frameworkToTest || isQuarantineMode())("help text", () => {
 				    npm create cloudflare -- --framework next -- --ts
 				    pnpm create cloudflare --framework next -- --ts
 				    Allowed Values:
-				      analog, angular, astro, docusaurus, gatsby, hono, next, nuxt, qwik, react, remix, solid, svelte, vue
+				      analog, angular, astro, docusaurus, gatsby, hono, next, nuxt, qwik, react, react-router, remix, solid, svelte, vue
 				  --platform=<value>
 				    Whether the application should be deployed to Pages or Workers. This is only applicable for Frameworks templates that support both Pages and Workers.
 				    Allowed Values:

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -5,8 +5,9 @@ import { version } from "../../package.json";
 import { reporter } from "../metrics";
 import {
 	getFrameworkMap,
+	getHelloWorldTemplateMap,
 	getNamesAndDescriptions,
-	getTemplateMap,
+	getOtherTemplateMap,
 } from "../templates";
 import { C3_DEFAULTS, WRANGLER_DEFAULTS } from "./cli";
 import type { PromptConfig } from "@cloudflare/cli/interactive";
@@ -98,45 +99,10 @@ export const cliDefinition: ArgumentsDefinition = {
         `,
 			values(args) {
 				const experimental = Boolean(args?.["experimental"]);
-				if (experimental) {
-					return getNamesAndDescriptions(getTemplateMap({ experimental }));
-				} else {
-					return [
-						{
-							name: "hello-world",
-							description: "A basic “Hello World” Cloudflare Worker.",
-						},
-						{
-							name: "hello-world-durable-object",
-							description:
-								"A basic “Hello World” Cloudflare Worker with a Durable Worker.",
-						},
-						{
-							name: "common",
-							description:
-								"A Cloudflare Worker which implements a common example of routing/proxying functionalities.",
-						},
-						{
-							name: "scheduled",
-							description:
-								"A scheduled Cloudflare Worker (triggered via Cron Triggers).",
-						},
-						{
-							name: "queues",
-							description:
-								"A Cloudflare Worker which is both a consumer and produced of Queues.",
-						},
-						{
-							name: "openapi",
-							description: "A Worker implementing an OpenAPI REST endpoint.",
-						},
-						{
-							name: "pre-existing",
-							description:
-								"Fetch a Worker initialized from the Cloudflare dashboard.",
-						},
-					];
-				}
+				return getNamesAndDescriptions({
+					...getHelloWorldTemplateMap({ experimental }),
+					...getOtherTemplateMap({ experimental }),
+				});
 			},
 		},
 		{
@@ -151,7 +117,7 @@ export const cliDefinition: ArgumentsDefinition = {
       You may specify additional arguments to be passed directly to these underlying tools by adding them after a "--" argument, like so:
 
       npm create cloudflare -- --framework next -- --ts
-      pnpm create clouldfare --framework next -- --ts
+      pnpm create cloudflare --framework next -- --ts
       `,
 			values: (args) =>
 				getNamesAndDescriptions(

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -70,10 +70,7 @@ export const cliDefinition: ArgumentsDefinition = {
 			values(args) {
 				const experimental = Boolean(args?.["experimental"]);
 				if (experimental) {
-					return [
-						{ name: "hello-world", description: "Hello World Starter" },
-						{ name: "web-framework", description: "Framework Starter" },
-					];
+					return [{ name: "web-framework", description: "Framework Starter" }];
 				} else {
 					return [
 						{ name: "hello-world", description: "Hello World Starter" },

--- a/packages/create-cloudflare/templates/common/c3.ts
+++ b/packages/create-cloudflare/templates/common/c3.ts
@@ -1,4 +1,6 @@
-export default {
+import type { TemplateConfig } from "../../src/templates";
+
+const config: TemplateConfig = {
 	configVersion: 1,
 	id: "common",
 	displayName: "Example router & proxy Worker",
@@ -17,3 +19,5 @@ export default {
 		},
 	},
 };
+
+export default config;

--- a/packages/create-cloudflare/templates/hello-world-durable-object/c3.ts
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/c3.ts
@@ -1,4 +1,6 @@
-export default {
+import type { TemplateConfig } from "../../src/templates";
+
+const config: TemplateConfig = {
 	configVersion: 1,
 	id: "hello-world-durable-object",
 	displayName: "Worker + Durable Objects",
@@ -16,3 +18,4 @@ export default {
 		},
 	},
 };
+export default config;

--- a/packages/create-cloudflare/templates/hello-world-with-assets/c3.ts
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/c3.ts
@@ -1,4 +1,6 @@
-export default {
+import type { TemplateConfig } from "../../src/templates";
+
+const config: TemplateConfig = {
 	configVersion: 1,
 	id: "hello-world-with-assets",
 	path: "templates/hello-world-with-assets",
@@ -19,3 +21,4 @@ export default {
 		},
 	},
 };
+export default config;

--- a/packages/create-cloudflare/templates/openapi/c3.ts
+++ b/packages/create-cloudflare/templates/openapi/c3.ts
@@ -1,4 +1,6 @@
-export default {
+import type { TemplateConfig } from "../../src/templates";
+
+const config: TemplateConfig = {
 	configVersion: 1,
 	id: "openapi",
 	displayName: "API starter (OpenAPI compliant)",
@@ -8,3 +10,5 @@ export default {
 		path: "./ts",
 	},
 };
+
+export default config;

--- a/packages/create-cloudflare/templates/pre-existing/c3.ts
+++ b/packages/create-cloudflare/templates/pre-existing/c3.ts
@@ -6,6 +6,7 @@ import { processArgument } from "helpers/args";
 import { runCommand } from "helpers/command";
 import { detectPackageManager } from "helpers/packageManagers";
 import { chooseAccount, wranglerLogin } from "../../src/wrangler/accounts";
+import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
 
 export async function copyExistingWorkerFiles(ctx: C3Context) {
@@ -63,10 +64,11 @@ export async function copyExistingWorkerFiles(ctx: C3Context) {
 	);
 }
 
-export default {
+const config: TemplateConfig = {
 	configVersion: 1,
 	id: "pre-existing",
 	displayName: "Pre-existing Worker (from Dashboard)",
+	description: "Fetch a Worker initialized from the Cloudflare dashboard.",
 	platform: "workers",
 	hidden: true,
 	copyFiles: {
@@ -78,6 +80,8 @@ export default {
 		copyFiles: copyExistingWorkerFiles,
 	}),
 };
+
+export default config;
 
 export interface ConfigureParams {
 	login: (ctx: C3Context) => Promise<boolean>;

--- a/packages/create-cloudflare/templates/queues/c3.ts
+++ b/packages/create-cloudflare/templates/queues/c3.ts
@@ -1,4 +1,6 @@
-export default {
+import type { TemplateConfig } from "../../src/templates";
+
+const config: TemplateConfig = {
 	configVersion: 1,
 	id: "queues",
 	displayName: "Queue consumer & producer Worker",
@@ -26,3 +28,5 @@ export default {
 		],
 	},
 };
+
+export default config;

--- a/packages/create-cloudflare/templates/scheduled/c3.ts
+++ b/packages/create-cloudflare/templates/scheduled/c3.ts
@@ -1,4 +1,6 @@
-export default {
+import type { TemplateConfig } from "../../src/templates";
+
+const config: TemplateConfig = {
 	configVersion: 1,
 	id: "scheduled",
 	displayName: "Scheduled Worker (Cron Trigger)",
@@ -16,3 +18,5 @@ export default {
 		},
 	},
 };
+
+export default config;


### PR DESCRIPTION
Pretty minor, this simply removes this unneeded category with no entries in C3's experimental mode:
![Kapture 2025-03-07 at 15 01 54](https://github.com/user-attachments/assets/82375f1e-01f9-4540-86c5-41001d1d101e)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this workflow is generally already tested
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not related to wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not something needing documentation
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
