### PR TITLE
Support autogates via `MINIFLARE_WORKERD_AUTOGATES` env var

### DIFF
--- a/.changeset/sweet-fans-arrive.md
+++ b/.changeset/sweet-fans-arrive.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Support `workerd` autogates via the `MINIFLARE_WORKERD_AUTOGATES` environment variable.

--- a/.changeset/sweet-fans-arrive.md
+++ b/.changeset/sweet-fans-arrive.md
@@ -1,5 +1,5 @@
 ---
-"miniflare": patch
+"miniflare": minor
 ---
 
 Support `workerd` autogates via the `MINIFLARE_WORKERD_AUTOGATES` environment variable.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2333,6 +2333,9 @@ export class Miniflare {
 			sockets,
 			extensions,
 			structuredLogging: this.#structuredWorkerdLogs,
+			autogates: process.env.MINIFLARE_WORKERD_AUTOGATES
+				? process.env.MINIFLARE_WORKERD_AUTOGATES.split(" ")
+				: [],
 		};
 	}
 

--- a/packages/miniflare/types/env.d.ts
+++ b/packages/miniflare/types/env.d.ts
@@ -5,5 +5,6 @@ declare namespace NodeJS {
 		MINIFLARE_WORKERD_PATH?: string;
 		MINIFLARE_WORKERD_CONFIG_DEBUG?: string;
 		MINIFLARE_ASSERT_BODIES_CONSUMED?: "true";
+		MINIFLARE_WORKERD_AUTOGATES?: string;
 	}
 }


### PR DESCRIPTION
Allow for setting the `autogates` property of `workerd` config via an env var: `MINIFLARE_WORKERD_AUTOGATES`. This accepts a space separated list of strings that will be passed directly to `workerd`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this should be manually tested, to ensure it correctly enables autogates. cc @danlapid do you have any ideas for how this could be tested in an automated fashion?
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Miniflare-only change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
