### PR TITLE
fix: include asset binding when printing binding summary

### DIFF
--- a/.changeset/chatty-rockets-call.md
+++ b/.changeset/chatty-rockets-call.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: include assets binding when printing summary of bindings

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -247,7 +247,7 @@ describe.each([
 		flags: "",
 		async beforeAll() {},
 		async afterAll() {},
-		expectInitialStdout: (output: string) => {
+		expectAssetsOnlyStdout: (output: string) => {
 			expect(output).toEqual(`🌀 Building list of assets...
 🌀 Starting asset upload...
 🌀 Found 3 new or modified static assets to upload. Proceeding with upload...
@@ -265,7 +265,7 @@ Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 triggers (TIMINGS)
   https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev
 Current Version ID: 00000000-0000-0000-0000-000000000000`);
 		},
-		expectSubsequentStdout: (output: string) => {
+		expectWithWorkerStdout: (output: string) => {
 			expect(output).toContain(`🌀 Building list of assets...
 🌀 Starting asset upload...`);
 			// Unfortunately the server-side deduping logic isn't always 100% accurate, and sometimes a file is re-uploaded
@@ -321,7 +321,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 				`wrangler dispatch-namespace delete ${dispatchNamespaceName}`
 			);
 		},
-		expectInitialStdout: (output: string) => {
+		expectAssetsOnlyStdout: (output: string) => {
 			expect(output).toEqual(`🌀 Building list of assets...
 🌀 Starting asset upload...
 🌀 Found 3 new or modified static assets to upload. Proceeding with upload...
@@ -338,7 +338,7 @@ Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
   Dispatch Namespace: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
 Current Version ID: 00000000-0000-0000-0000-000000000000`);
 		},
-		expectSubsequentStdout: (output: string) => {
+		expectWithWorkerStdout: (output: string) => {
 			expect(output).toContain(`🌀 Building list of assets...
 🌀 Starting asset upload...`);
 			// Unfortunately the server-side deduping logic isn't always 100% accurate, and sometimes a file is re-uploaded
@@ -350,6 +350,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 					"No files to upload.",
 				].some((s) => output.includes(s))
 			).toBeTruthy();
+			expect(output).toContain("- Binding: ASSETS");
 		},
 	},
 ])("Workers + Assets deployment: $name", { timeout: TIMEOUT }, (testcase) => {
@@ -373,7 +374,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 		});
 
 		const output = await helper.run(`wrangler deploy ${testcase.flags}`);
-		testcase.expectInitialStdout(normalize(output.stdout));
+		testcase.expectAssetsOnlyStdout(normalize(output.stdout));
 		if (testcase.url) {
 			deployedUrl = testcase.url;
 		} else {
@@ -444,7 +445,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 		});
 		const output = await helper.run(`wrangler deploy ${testcase.flags}`);
 		// expect only no asset files to be uploaded as no new asset files have been added
-		testcase.expectSubsequentStdout(normalize(output.stdout));
+		testcase.expectWithWorkerStdout(normalize(output.stdout));
 		if (!deployedUrl) {
 			const match = output.stdout.match(
 				/(?<url>https:\/\/tmp-e2e-.+?\..+?\.workers\.dev)/
@@ -510,7 +511,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 
 		const output = await helper.run(`wrangler deploy ${testcase.flags}`);
 		// expect only no asset files to be uploaded as no new asset files have been added
-		testcase.expectSubsequentStdout(normalize(output.stdout));
+		testcase.expectWithWorkerStdout(normalize(output.stdout));
 		if (!deployedUrl) {
 			const match = output.stdout.match(
 				/(?<url>https:\/\/tmp-e2e-.+?\..+?\.workers\.dev)/

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -93,6 +93,7 @@ export function printBindings(
 		dispatch_namespaces,
 		mtls_certificates,
 		pipelines,
+		assets,
 	} = bindings;
 
 	if (data_blobs !== undefined && Object.keys(data_blobs).length > 0) {
@@ -391,6 +392,13 @@ export function printBindings(
 				key: binding,
 				value: addSuffix(pipeline),
 			})),
+		});
+	}
+
+	if (assets !== undefined) {
+		output.push({
+			name: friendlyBindingNames.assets,
+			entries: [{ key: "Binding", value: assets.binding }],
 		});
 	}
 


### PR DESCRIPTION
Fixes #8313 
<img width="502" alt="Screenshot 2025-03-10 at 17 26 17" src="https://github.com/user-attachments/assets/08211215-eecd-44c6-a8f2-5c9750e2b070" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/8682
  - [x] Not necessary because: we are not backporting patches for beta features


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
