### PR TITLE
c3: pin C3 e2e tests to use the local version of create-cloudflare rather than latest

### DIFF
--- a/packages/create-cloudflare/e2e-tests/helpers.ts
+++ b/packages/create-cloudflare/e2e-tests/helpers.ts
@@ -109,7 +109,7 @@ export const runC3 = async (
 	// We don't use the "test" package manager here (i.e. TEST_PM and TEST_PM_VERSION) because yarn 1.x doesn't actually provide a `dlx` version.
 	// And in any case, this first step just installs a temp copy of create-cloudflare and executes it.
 	// The point of `detectPackageManager()` is for delegating to framework tooling when generating a project correctly.
-	const cmd = ["pnpx", "create-cloudflare", ...argv];
+	const cmd = ["pnpx", `create-cloudflare@${version}`, ...argv];
 	const proc = spawnWithLogging(
 		cmd,
 		{ env: testEnv, cwd: tmpdir() },


### PR DESCRIPTION

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: C3
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
