### PR TITLE
asset-worker support for SPA mode

### DIFF
--- a/.changeset/all-mugs-give.md
+++ b/.changeset/all-mugs-give.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Add support for `single_page_application` mode in asset-worker

--- a/.changeset/all-mugs-give.md
+++ b/.changeset/all-mugs-give.md
@@ -2,4 +2,6 @@
 "@cloudflare/workers-shared": minor
 ---
 
-Add support for `single_page_application` mode in asset-worker
+Requests with a `Sec-Fetch-Mode: navigate` header, made to a project with `sec_fetch_mode_navigate_header_prefers_asset_serving` compatibility flag, will be routed to the asset-worker rather than a user Worker when no exact asset match is found.
+
+Requests without that header will continue to be routed to the user Worker when no exact asset match is found.

--- a/fixtures/asset-config/html-handling.test.ts
+++ b/fixtures/asset-config/html-handling.test.ts
@@ -1,6 +1,6 @@
 import { SELF } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { applyConfigurationDefaults } from "../../packages/workers-shared/asset-worker/src/configuration";
+import { normalizeConfiguration } from "../../packages/workers-shared/asset-worker/src/configuration";
 import Worker from "../../packages/workers-shared/asset-worker/src/index";
 import { getAssetWithMetadataFromKV } from "../../packages/workers-shared/asset-worker/src/utils/kv";
 import { encodingTestCases } from "./test-cases/encoding-test-cases";
@@ -65,8 +65,8 @@ describe.each(testSuites)("$title", ({ title, suite }) => {
 				await vi.importActual<
 					typeof import("../../packages/workers-shared/asset-worker/src/configuration")
 				>("../../packages/workers-shared/asset-worker/src/configuration")
-			).applyConfigurationDefaults;
-			vi.mocked(applyConfigurationDefaults).mockImplementation(() => ({
+			).normalizeConfiguration;
+			vi.mocked(normalizeConfiguration).mockImplementation(() => ({
 				...originalApplyConfigurationDefaults({}),
 				html_handling,
 				not_found_handling: "none",

--- a/fixtures/asset-config/redirects.test.ts
+++ b/fixtures/asset-config/redirects.test.ts
@@ -1,6 +1,6 @@
 import { SELF } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { applyConfigurationDefaults } from "../../packages/workers-shared/asset-worker/src/configuration";
+import { normalizeConfiguration } from "../../packages/workers-shared/asset-worker/src/configuration";
 import Worker from "../../packages/workers-shared/asset-worker/src/index";
 import { getAssetWithMetadataFromKV } from "../../packages/workers-shared/asset-worker/src/utils/kv";
 import type { AssetMetadata } from "../../packages/workers-shared/asset-worker/src/utils/kv";
@@ -42,8 +42,8 @@ describe("[Asset Worker] `test location rewrite`", () => {
 			await vi.importActual<
 				typeof import("../../packages/workers-shared/asset-worker/src/configuration")
 			>("../../packages/workers-shared/asset-worker/src/configuration")
-		).applyConfigurationDefaults;
-		vi.mocked(applyConfigurationDefaults).mockImplementation(() => ({
+		).normalizeConfiguration;
+		vi.mocked(normalizeConfiguration).mockImplementation(() => ({
 			...originalApplyConfigurationDefaults({}),
 			html_handling: "none",
 			not_found_handling: "none",

--- a/fixtures/asset-config/url-normalization.test.ts
+++ b/fixtures/asset-config/url-normalization.test.ts
@@ -1,6 +1,6 @@
 import { SELF } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
-import { applyConfigurationDefaults } from "../../packages/workers-shared/asset-worker/src/configuration";
+import { normalizeConfiguration } from "../../packages/workers-shared/asset-worker/src/configuration";
 import Worker from "../../packages/workers-shared/asset-worker/src/index";
 import { getAssetWithMetadataFromKV } from "../../packages/workers-shared/asset-worker/src/utils/kv";
 import type { AssetMetadata } from "../../packages/workers-shared/asset-worker/src/utils/kv";
@@ -42,8 +42,8 @@ describe("[Asset Worker] `test slash normalization`", () => {
 			await vi.importActual<
 				typeof import("../../packages/workers-shared/asset-worker/src/configuration")
 			>("../../packages/workers-shared/asset-worker/src/configuration")
-		).applyConfigurationDefaults;
-		vi.mocked(applyConfigurationDefaults).mockImplementation(() => ({
+		).normalizeConfiguration;
+		vi.mocked(normalizeConfiguration).mockImplementation(() => ({
 			...originalApplyConfigurationDefaults({}),
 			html_handling: "none",
 			not_found_handling: "none",

--- a/packages/workers-shared/asset-worker/src/analytics.ts
+++ b/packages/workers-shared/asset-worker/src/analytics.ts
@@ -20,6 +20,8 @@ type Data = {
 	coloTier?: number;
 	// double5 - Response status code
 	status?: number;
+	// double6 - Single page application option
+	singlePageApplication?: boolean;
 
 	// -- Blobs --
 	// blob1 - Hostname of the request
@@ -71,6 +73,11 @@ export class Analytics {
 				this.data.metalId ?? -1, // double3
 				this.data.coloTier ?? -1, // double4
 				this.data.status ?? -1, // double5
+				this.data.singlePageApplication === true // double6
+					? 1
+					: this.data.singlePageApplication === false
+						? 0
+						: -1,
 			],
 			blobs: [
 				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes

--- a/packages/workers-shared/asset-worker/src/analytics.ts
+++ b/packages/workers-shared/asset-worker/src/analytics.ts
@@ -1,3 +1,4 @@
+import type { ENABLEMENT_COMPATIBILITY_FLAGS } from "./compatibility-flags";
 import type { ReadyAnalytics } from "./types";
 
 // This will allow us to make breaking changes to the analytic schema
@@ -20,8 +21,8 @@ type Data = {
 	coloTier?: number;
 	// double5 - Response status code
 	status?: number;
-	// double6 - Single page application option
-	singlePageApplication?: boolean;
+	// double6 - Compatibility flags
+	compatibilityFlags?: string[]; // converted into a bitmask
 
 	// -- Blobs --
 	// blob1 - Hostname of the request
@@ -41,6 +42,14 @@ type Data = {
 	// blob8 - The cache status of the request
 	cacheStatus?: string;
 };
+
+const COMPATIBILITY_FLAG_MASKS: Record<ENABLEMENT_COMPATIBILITY_FLAGS, number> =
+	{
+		assets_navigation_prefers_asset_serving: 1 << 0,
+		// next_one: 1 << 1
+		// one_after_that: 1 << 2
+		// etc: 1 << 3
+	};
 
 export class Analytics {
 	private data: Data = {};
@@ -63,6 +72,17 @@ export class Analytics {
 			return;
 		}
 
+		let compatibilityFlagsBitmask = 0;
+		for (const compatibilityFlag of this.data.compatibilityFlags || []) {
+			const mask =
+				COMPATIBILITY_FLAG_MASKS[
+					compatibilityFlag as ENABLEMENT_COMPATIBILITY_FLAGS
+				];
+			if (mask) {
+				compatibilityFlagsBitmask += mask;
+			}
+		}
+
 		this.readyAnalytics.logEvent({
 			version: VERSION,
 			accountId: this.data.accountId,
@@ -73,11 +93,7 @@ export class Analytics {
 				this.data.metalId ?? -1, // double3
 				this.data.coloTier ?? -1, // double4
 				this.data.status ?? -1, // double5
-				this.data.singlePageApplication === true // double6
-					? 1
-					: this.data.singlePageApplication === false
-						? 0
-						: -1,
+				compatibilityFlagsBitmask, // double6
 			],
 			blobs: [
 				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes

--- a/packages/workers-shared/asset-worker/src/compatibility-flags.ts
+++ b/packages/workers-shared/asset-worker/src/compatibility-flags.ts
@@ -1,0 +1,55 @@
+import type { AssetConfig } from "../../utils/types";
+
+interface CompatibilityFlag {
+	enable: `assets_${string}`;
+	disable: `assets_${string}`;
+	onByDefaultAfter?: string;
+}
+
+export const SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING = {
+	enable: "assets_navigation_prefers_asset_serving",
+	disable: "assets_navigation_has_no_effect",
+	onByDefaultAfter: "2025-04-01",
+} satisfies CompatibilityFlag;
+
+const COMPATIBILITY_FLAGS = [
+	SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING,
+] as const;
+
+export type ENABLEMENT_COMPATIBILITY_FLAGS =
+	(typeof COMPATIBILITY_FLAGS)[number]["enable"];
+
+export const resolveCompatibilityOptions = (configuration?: AssetConfig) => {
+	const compatibilityDate = configuration?.compatibility_date ?? "2021-11-02";
+	const compatibilityFlags = configuration?.compatibility_flags ?? [];
+
+	const resolvedCompatibilityFlags = compatibilityFlags;
+	for (const compatibilityFlag of COMPATIBILITY_FLAGS) {
+		if (
+			compatibilityFlag.onByDefaultAfter &&
+			compatibilityDate >= compatibilityFlag.onByDefaultAfter &&
+			!resolvedCompatibilityFlags.find(
+				(flag) => flag === compatibilityFlag.disable
+			) &&
+			!resolvedCompatibilityFlags.find(
+				(flag) => flag === compatibilityFlag.enable
+			)
+		) {
+			resolvedCompatibilityFlags.push(compatibilityFlag.enable);
+		}
+	}
+
+	return {
+		compatibilityDate,
+		compatibilityFlags: resolvedCompatibilityFlags,
+	};
+};
+
+export const flagIsEnabled = (
+	configuration: Required<AssetConfig>,
+	compatibilityFlag: (typeof COMPATIBILITY_FLAGS)[number]
+) => {
+	return !!configuration.compatibility_flags.find(
+		(flag) => flag === compatibilityFlag.enable
+	);
+};

--- a/packages/workers-shared/asset-worker/src/configuration.ts
+++ b/packages/workers-shared/asset-worker/src/configuration.ts
@@ -1,13 +1,16 @@
 import type { AssetConfig } from "../../utils/types";
 
-export const applyConfigurationDefaults = (
+export const normalizeConfiguration = (
 	configuration?: AssetConfig
 ): Required<AssetConfig> => {
 	return {
 		compatibility_date: configuration?.compatibility_date ?? "2021-11-02",
 		compatibility_flags: configuration?.compatibility_flags ?? [],
 		html_handling: configuration?.html_handling ?? "auto-trailing-slash",
-		not_found_handling: configuration?.not_found_handling ?? "none",
+		not_found_handling: configuration?.single_page_application
+			? "single-page-application"
+			: configuration?.not_found_handling ?? "none",
+		single_page_application: configuration?.single_page_application ?? false,
 		redirects: configuration?.redirects ?? {
 			version: 1,
 			staticRules: {},

--- a/packages/workers-shared/asset-worker/src/configuration.ts
+++ b/packages/workers-shared/asset-worker/src/configuration.ts
@@ -1,16 +1,16 @@
+import { resolveCompatibilityOptions } from "./compatibility-flags";
 import type { AssetConfig } from "../../utils/types";
 
 export const normalizeConfiguration = (
 	configuration?: AssetConfig
 ): Required<AssetConfig> => {
+	const compatibilityOptions = resolveCompatibilityOptions(configuration);
+
 	return {
-		compatibility_date: configuration?.compatibility_date ?? "2021-11-02",
-		compatibility_flags: configuration?.compatibility_flags ?? [],
+		compatibility_date: compatibilityOptions.compatibilityDate,
+		compatibility_flags: compatibilityOptions.compatibilityFlags,
 		html_handling: configuration?.html_handling ?? "auto-trailing-slash",
-		not_found_handling: configuration?.single_page_application
-			? "single-page-application"
-			: configuration?.not_found_handling ?? "none",
-		single_page_application: configuration?.single_page_application ?? false,
+		not_found_handling: configuration?.not_found_handling ?? "none",
 		redirects: configuration?.redirects ?? {
 			version: 1,
 			staticRules: {},

--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -238,13 +238,25 @@ export const canFetch = async (
 	configuration: Required<AssetConfig>,
 	exists: typeof EntrypointType.prototype.unstable_exists
 ): Promise<boolean> => {
+	if (
+		configuration.single_page_application &&
+		request.headers.get("Sec-Fetch-Mode") === "navigate"
+	) {
+		configuration = {
+			...configuration,
+			not_found_handling: "single-page-application",
+		};
+	} else {
+		configuration = {
+			...configuration,
+			not_found_handling: "none",
+		};
+	}
+
 	const responseOrAssetIntent = await getResponseOrAssetIntent(
 		request,
 		env,
-		{
-			...configuration,
-			not_found_handling: "none",
-		},
+		configuration,
 		exists
 	);
 

--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -11,6 +11,10 @@ import {
 	SeeOtherResponse,
 	TemporaryRedirectResponse,
 } from "../../utils/responses";
+import {
+	flagIsEnabled,
+	SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING,
+} from "./compatibility-flags";
 import { attachCustomHeaders, getAssetHeaders } from "./utils/headers";
 import { generateRulesMatcher, replacer } from "./utils/rules-engine";
 import type { AssetConfig } from "../../utils/types";
@@ -239,14 +243,13 @@ export const canFetch = async (
 	exists: typeof EntrypointType.prototype.unstable_exists
 ): Promise<boolean> => {
 	if (
-		configuration.single_page_application &&
-		request.headers.get("Sec-Fetch-Mode") === "navigate"
+		!(
+			flagIsEnabled(
+				configuration,
+				SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING
+			) && request.headers.get("Sec-Fetch-Mode") === "navigate"
+		)
 	) {
-		configuration = {
-			...configuration,
-			not_found_handling: "single-page-application",
-		};
-	} else {
 		configuration = {
 			...configuration,
 			not_found_handling: "none",

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -4,7 +4,7 @@ import { setupSentry } from "../../utils/sentry";
 import { mockJaegerBinding } from "../../utils/tracing";
 import { Analytics } from "./analytics";
 import { AssetsManifest } from "./assets-manifest";
-import { applyConfigurationDefaults } from "./configuration";
+import { normalizeConfiguration } from "./configuration";
 import { ExperimentAnalytics } from "./experiment-analytics";
 import { canFetch, handleRequest } from "./handler";
 import { handleError, submitMetrics } from "./utils/final-operations";
@@ -80,7 +80,7 @@ export default class extends WorkerEntrypoint<Env> {
 				this.env.CONFIG?.script_id
 			);
 
-			const config = applyConfigurationDefaults(this.env.CONFIG);
+			const config = normalizeConfiguration(this.env.CONFIG);
 			const userAgent = request.headers.get("user-agent") ?? "UA UNKNOWN";
 
 			const url = new URL(request.url);
@@ -102,6 +102,7 @@ export default class extends WorkerEntrypoint<Env> {
 					hostname: url.hostname,
 					htmlHandling: config.html_handling,
 					notFoundHandling: config.not_found_handling,
+					singlePageApplication: config.single_page_application,
 					userAgent: userAgent,
 				});
 			}
@@ -142,7 +143,7 @@ export default class extends WorkerEntrypoint<Env> {
 		return canFetch(
 			request,
 			this.env,
-			applyConfigurationDefaults(this.env.CONFIG),
+			normalizeConfiguration(this.env.CONFIG),
 			this.unstable_exists.bind(this)
 		);
 	}

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -81,6 +81,11 @@ export default class extends WorkerEntrypoint<Env> {
 			);
 
 			const config = normalizeConfiguration(this.env.CONFIG);
+			sentry?.setContext("compatibilityOptions", {
+				compatibilityDate: config.compatibility_date,
+				compatibilityFlags: config.compatibility_flags,
+				originalCompatibilityFlags: this.env.CONFIG.compatibility_flags,
+			});
 			const userAgent = request.headers.get("user-agent") ?? "UA UNKNOWN";
 
 			const url = new URL(request.url);
@@ -102,7 +107,7 @@ export default class extends WorkerEntrypoint<Env> {
 					hostname: url.hostname,
 					htmlHandling: config.html_handling,
 					notFoundHandling: config.not_found_handling,
-					singlePageApplication: config.single_page_application,
+					compatibilityFlags: config.compatibility_flags,
 					userAgent: userAgent,
 				});
 			}

--- a/packages/workers-shared/asset-worker/tests/compatibility-flags.test.ts
+++ b/packages/workers-shared/asset-worker/tests/compatibility-flags.test.ts
@@ -1,0 +1,67 @@
+import { resolveCompatibilityOptions } from "../src/compatibility-flags";
+
+describe("resolveCompatibilityOptions", () => {
+	test("it does not interfere with existing flags", () => {
+		expect(resolveCompatibilityOptions({ compatibility_flags: ["foo", "bar"] }))
+			.toMatchInlineSnapshot(`
+			{
+			  "compatibilityDate": "2021-11-02",
+			  "compatibilityFlags": [
+			    "foo",
+			    "bar",
+			  ],
+			}
+		`);
+	});
+
+	test("it opts you into new flags if you have a future date", () => {
+		const { compatibilityDate, compatibilityFlags } =
+			resolveCompatibilityOptions({
+				compatibility_flags: ["foo", "bar"],
+				compatibility_date: "2099-12-12",
+			});
+
+		expect(compatibilityDate).toEqual("2099-12-12");
+		expect(compatibilityFlags).toContain("foo");
+		expect(compatibilityFlags).toContain("bar");
+		expect(compatibilityFlags).toContain(
+			"assets_navigation_prefers_asset_serving"
+		);
+	});
+
+	test("it doesn't double you up if you've already opted into new flags and have a future date", () => {
+		const { compatibilityDate, compatibilityFlags } =
+			resolveCompatibilityOptions({
+				compatibility_flags: [
+					"foo",
+					"bar",
+					"assets_navigation_prefers_asset_serving",
+				],
+				compatibility_date: "2099-12-12",
+			});
+
+		expect(compatibilityDate).toEqual("2099-12-12");
+		expect(compatibilityFlags).toContain("foo");
+		expect(compatibilityFlags).toContain("bar");
+		expect(
+			compatibilityFlags.filter(
+				(flag) => flag === "assets_navigation_prefers_asset_serving"
+			).length
+		).toBe(1);
+	});
+
+	test("it doesn't opt you into new flags if you have a future date and have disabled it", () => {
+		const { compatibilityDate, compatibilityFlags } =
+			resolveCompatibilityOptions({
+				compatibility_flags: ["foo", "bar", "assets_navigation_has_no_effect"],
+				compatibility_date: "2099-12-12",
+			});
+
+		expect(compatibilityDate).toEqual("2099-12-12");
+		expect(compatibilityFlags).toContain("foo");
+		expect(compatibilityFlags).toContain("bar");
+		expect(compatibilityFlags).not.toContain(
+			"assets_navigation_prefers_asset_serving"
+		);
+	});
+});

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -64,6 +64,7 @@ export const AssetConfigSchema = z.object({
 	not_found_handling: z
 		.enum(["single-page-application", "404-page", "none"])
 		.optional(),
+	single_page_application: z.boolean().optional(),
 	redirects: RedirectsSchema,
 	headers: HeadersSchema,
 	...InternalConfigSchema.shape,

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -64,7 +64,6 @@ export const AssetConfigSchema = z.object({
 	not_found_handling: z
 		.enum(["single-page-application", "404-page", "none"])
 		.optional(),
-	single_page_application: z.boolean().optional(),
 	redirects: RedirectsSchema,
 	headers: HeadersSchema,
 	...InternalConfigSchema.shape,


### PR DESCRIPTION
Fixes WC-3321.

Implements SPA mode in asset-worker

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage (yet)
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: will follow up once everything has landed

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
