### PR TITLE
Bump `youch` to 3.3.4

### DIFF
--- a/.changeset/bumpy-owls-fry.md
+++ b/.changeset/bumpy-owls-fry.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+update youch dependency to avoid vulnerable version of cookie

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -51,7 +51,7 @@
 		"undici": "catalog:default",
 		"workerd": "1.20250321.0",
 		"ws": "catalog:default",
-		"youch": "3.2.3",
+		"youch": "3.3.4",
 		"zod": "3.22.3"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1528,8 +1528,8 @@ importers:
         specifier: catalog:default
         version: 8.18.0
       youch:
-        specifier: 3.2.3
-        version: 3.2.3
+        specifier: 3.3.4
+        version: 3.3.4
       zod:
         specifier: 3.22.3
         version: 3.22.3
@@ -12150,6 +12150,9 @@ packages:
   youch@3.2.3:
     resolution: {integrity: sha512-ZBcWz/uzZaQVdCvfV4uk616Bbpf2ee+F/AvuKDR5EwX/Y4v06xWdtMluqTD7+KlZdM93lLm9gMZYo0sKBS0pgw==}
 
+  youch@3.3.4:
+    resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
+
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
@@ -19328,7 +19331,7 @@ snapshots:
       undici: 5.28.5
       workerd: 1.20241230.0
       ws: 8.18.0
-      youch: 3.2.3
+      youch: 3.3.4
       zod: 3.22.3
     transitivePeerDependencies:
       - bufferutil
@@ -22291,6 +22294,12 @@ snapshots:
   youch@3.2.3:
     dependencies:
       cookie: 0.5.0
+      mustache: 4.2.0
+      stacktracey: 2.1.8
+
+  youch@3.3.4:
+    dependencies:
+      cookie: 0.7.2
       mustache: 4.2.0
       stacktracey: 2.1.8
 


### PR DESCRIPTION
Upgrade `youch` to 3.3.4.
Currently Dependabot is alerting a vulnerable version of `cookie` `0.5.0`, which is required by `youch`. Bumping `youch` solves that.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no functional changes
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functional changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
