### PR TITLE
Update Next.js version in the experimental template

### DIFF
--- a/.changeset/real-clocks-ask.md
+++ b/.changeset/real-clocks-ask.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Update the Next experimental template to use version ~15.2.2

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -49,10 +49,8 @@ export default {
 	configVersion: 1,
 	id: "next",
 	frameworkCli: "create-next-app",
-	// TODO: here we need to specify a version of create-next-app which is different from the
-	//       standard one used in the stable Next.js template, that's because our open-next adapter
-	//       is not yet fully ready for Next.js 15, once it is we should remove the following
-	frameworkCliPinnedVersion: "^14.2.23",
+	// TODO: Stop using a pinned version when the template graduates.
+	frameworkCliPinnedVersion: "~15.2.2",
 	platform: "workers",
 	displayName: "Next.js (using Node.js compat + Workers Assets)",
 	path: "templates-experimental/next",

--- a/packages/create-cloudflare/templates-experimental/next/c3.ts
+++ b/packages/create-cloudflare/templates-experimental/next/c3.ts
@@ -1,7 +1,7 @@
 import { brandColor, dim } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
-import { readFile, writeFile } from "helpers/files";
+import { readFile, usesTypescript, writeFile } from "helpers/files";
 import { installPackages } from "helpers/packages";
 import type { TemplateConfig } from "../../src/templates";
 import type { C3Context } from "types";
@@ -10,7 +10,7 @@ const generate = async (ctx: C3Context) => {
 	await runFrameworkGenerator(ctx, [ctx.project.name]);
 };
 
-const configure = async () => {
+const configure = async (ctx: C3Context) => {
 	const packages = [
 		"@opennextjs/cloudflare@0.5.x",
 		"@cloudflare/workers-types",
@@ -21,13 +21,15 @@ const configure = async () => {
 		doneText: `${brandColor(`installed`)} ${dim(packages.join(", "))}`,
 	});
 
-	updateNextConfig();
+	const usesTs = usesTypescript(ctx);
+
+	updateNextConfig(usesTs);
 };
 
-const updateNextConfig = () => {
+const updateNextConfig = (usesTs: boolean) => {
 	const s = spinner();
 
-	const configFile = "next.config.mjs";
+	const configFile = `next.config.${usesTs ? "ts" : "mjs"}`;
 	s.start(`Updating \`${configFile}\``);
 
 	const configContent = readFile(configFile);

--- a/packages/create-cloudflare/templates-experimental/next/templates/open-next.config.ts
+++ b/packages/create-cloudflare/templates-experimental/next/templates/open-next.config.ts
@@ -1,28 +1,6 @@
-import cache from "@opennextjs/cloudflare/kvCache";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import kvIncrementalCache from "@opennextjs/cloudflare/kv-cache";
 
-const config = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      incrementalCache: async () => cache,
-      tagCache: "dummy",
-      queue: "dummy",
-    },
-  },
-
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-    },
-  },
-
-  dangerous: {
-    enableCacheInterception: false,
-  },
-};
-
-export default config;
+export default defineCloudflareConfig({
+  incrementalCache: kvIncrementalCache,
+});

--- a/packages/create-cloudflare/templates-experimental/next/templates/wrangler.jsonc
+++ b/packages/create-cloudflare/templates-experimental/next/templates/wrangler.jsonc
@@ -5,7 +5,6 @@
   "compatibility_flags": [
     "nodejs_compat"
   ],
-  "minify": true,
   "assets": {
     "binding": "ASSETS",
     "directory": ".open-next/assets"


### PR DESCRIPTION
Update Next.js to ~15.2.2

Also:
- drop minify (for consistency with other templates + code already minified by OpenNext)
- simplify the config
- handle `next.config.ts` which is now generated by the Next CLI in TS mode (similar to what is done for Next on Pages)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: already tested
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: already updated

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
