### PR TITLE
test: add console log "grouping" to Wrangler e2e tests

### DIFF
--- a/tools/e2e/runIndividualE2EFiles.ts
+++ b/tools/e2e/runIndividualE2EFiles.ts
@@ -14,19 +14,22 @@ import { readdirSync } from "fs";
 // Get a list of e2e test files, each of which should have an associated script
 const e2eTests = readdirSync("packages/wrangler/e2e");
 
-const tasks = new Set<string>();
+const tasks = new Map<string, string>();
 
 for (const file of e2eTests) {
 	// Ignore other files in the e2e directory (the README, for instance)
 	if (file.endsWith(".test.ts")) {
-		tasks.add(
+		tasks.set(
+			file,
 			`pnpm test:e2e --log-order=stream --output-logs=new-only --summarize --filter wrangler --concurrency 1 -- run ./e2e/${file}`
 		);
 	}
 }
 
-for (const task of tasks.values()) {
+for (const [file, task] of tasks.entries()) {
+	console.log("::group::Testing: " + file);
 	execSync(task, {
 		stdio: "inherit",
 	});
+	console.log("::endgroup::");
 }


### PR DESCRIPTION
This should make it easier to see what is happening in CI.
