### PR TITLE
Update the C3 Durable Objects example to use SQLite

### DIFF
--- a/.changeset/chilled-moons-enjoy.md
+++ b/.changeset/chilled-moons-enjoy.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": minor
+---
+
+Update the C3 Durable Objects example to use SQLite

--- a/packages/create-cloudflare/templates/hello-world-durable-object/js/src/index.js
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/js/src/index.js
@@ -52,17 +52,18 @@ export default {
 	 * @returns {Promise<Response>} The response to be sent back to the client
 	 */
 	async fetch(request, env, ctx) {
-		// We will create a `DurableObjectId` using the pathname from the Worker request
-		// This id refers to a unique instance of our 'MyDurableObject' class above
-		let id = env.MY_DURABLE_OBJECT.idFromName(new URL(request.url).pathname);
+		// Create a `DurableObjectId` for an instance of the `MyDurableObject`
+		// class named "foo". Requests from all Workers to the instance named
+		// "foo" will go to a single globally unique Durable Object instance.
+		const id = env.MY_DURABLE_OBJECT.idFromName("foo");
 
-		// This stub creates a communication channel with the Durable Object instance
-		// The Durable Object constructor will be invoked upon the first call for a given id
-		let stub = env.MY_DURABLE_OBJECT.get(id);
+		// Create a stub to open a communication channel with the Durable
+		// Object instance.
+		const stub = env.MY_DURABLE_OBJECT.get(id);
 
-		// We call the `sayHello()` RPC method on the stub to invoke the method on the remote
-		// Durable Object instance
-		let greeting = await stub.sayHello("world");
+		// Call the `sayHello()` RPC method on the stub to invoke the method on
+		// the remote Durable Object instance
+		const greeting = await stub.sayHello("world");
 
 		return new Response(greeting);
 	},

--- a/packages/create-cloudflare/templates/hello-world-durable-object/js/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/js/wrangler.jsonc
@@ -4,7 +4,7 @@
   "compatibility_date": "<TBD>",
   "migrations": [
     {
-      "new_classes": [
+      "new_sqlite_classes": [
         "MyDurableObject"
       ],
       "tag": "v1"

--- a/packages/create-cloudflare/templates/hello-world-durable-object/ts/src/index.ts
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/ts/src/index.ts
@@ -48,17 +48,18 @@ export default {
 	 * @returns The response to be sent back to the client
 	 */
 	async fetch(request, env, ctx): Promise<Response> {
-		// We will create a `DurableObjectId` using the pathname from the Worker request
-		// This id refers to a unique instance of our 'MyDurableObject' class above
-		let id: DurableObjectId = env.MY_DURABLE_OBJECT.idFromName(new URL(request.url).pathname);
+		// Create a `DurableObjectId` for an instance of the `MyDurableObject`
+		// class named "foo". Requests from all Workers to the instance named
+		// "foo" will go to a single globally unique Durable Object instance.
+		const id: DurableObjectId = env.MY_DURABLE_OBJECT.idFromName("foo");
 
-		// This stub creates a communication channel with the Durable Object instance
-		// The Durable Object constructor will be invoked upon the first call for a given id
-		let stub = env.MY_DURABLE_OBJECT.get(id);
+		// Create a stub to open a communication channel with the Durable
+		// Object instance.
+		const stub = env.MY_DURABLE_OBJECT.get(id);
 
-		// We call the `sayHello()` RPC method on the stub to invoke the method on the remote
-		// Durable Object instance
-		let greeting = await stub.sayHello("world");
+		// Call the `sayHello()` RPC method on the stub to invoke the method on
+		// the remote Durable Object instance
+		const greeting = await stub.sayHello("world");
 
 		return new Response(greeting);
 	},

--- a/packages/create-cloudflare/templates/hello-world-durable-object/ts/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hello-world-durable-object/ts/wrangler.jsonc
@@ -4,7 +4,7 @@
   "compatibility_date": "<TBD>",
   "migrations": [
     {
-      "new_classes": [
+      "new_sqlite_classes": [
         "MyDurableObject"
       ],
       "tag": "v1"


### PR DESCRIPTION
Fixes STOR-4114.

Update the C3 Durable Objects example to use SQLite.

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: Manually tested
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: doc already covers SQLite

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
