### PR TITLE
Add 'allowTrailingCommas' configuration to config-schema.json

### DIFF
--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -58,7 +58,7 @@
 		"clean": "rimraf wrangler-dist miniflare-dist emitted-types",
 		"dev": "pnpm run clean && concurrently -c black,blue --kill-others-on-fail false \"pnpm run bundle --watch\" \"pnpm run check:type --watch --preserveWatchOutput\"",
 		"emit-types": "tsc -p tsconfig.emit.json && node -r esbuild-register scripts/emit-types.ts",
-		"generate-json-schema": "pnpm exec ts-json-schema-generator --no-type-check --path src/config/config.ts --type RawConfig --out config-schema.json",
+		"generate-json-schema": "node -r esbuild-register scripts/generate-json-schema.ts",
 		"prepublishOnly": "cross-env SOURCEMAPS=false pnpm exec turbo build -F wrangler",
 		"start": "pnpm run bundle && cross-env NODE_OPTIONS=--enable-source-maps ./bin/wrangler.js",
 		"test": "dotenv -- pnpm run assert-git-version && dotenv -- vitest",

--- a/packages/wrangler/scripts/generate-json-schema.ts
+++ b/packages/wrangler/scripts/generate-json-schema.ts
@@ -1,0 +1,24 @@
+import { writeFileSync } from "fs";
+import { join } from "path";
+import { createGenerator } from "ts-json-schema-generator";
+import type { Config, Schema } from "ts-json-schema-generator";
+
+const config: Config = {
+	path: join(__dirname, "../src/config/config.ts"),
+	tsconfig: join(__dirname, "../tsconfig.json"),
+	type: "RawConfig",
+	skipTypeCheck: true,
+};
+
+const applyFormattingRules = (schema: Schema) => {
+	return { ...schema, allowTrailingCommas: true };
+};
+
+const schema = applyFormattingRules(
+	createGenerator(config).createSchema(config.type)
+);
+
+writeFileSync(
+	join(__dirname, "../config-schema.json"),
+	JSON.stringify(schema, null, 2)
+);


### PR DESCRIPTION
Fixes WC-000.

VSCode and other editors pick up the `allowTrailingCommas` property here. This allows for a nicer JSONC experience.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no coverage
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tiny change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
