### PR TITLE
fix(wrangler): throw if fail to determine the module type

### DIFF
--- a/packages/wrangler/src/check/commands.ts
+++ b/packages/wrangler/src/check/commands.ts
@@ -148,7 +148,15 @@ async function getEntryValue(
 
 function getModuleType(entry: FormDataEntryValue) {
 	if (entry instanceof Blob) {
-		return ModuleTypeToRuleType[mimeTypeModuleType[entry.type]];
+		const type = ModuleTypeToRuleType[mimeTypeModuleType[entry.type]];
+
+		if (!type) {
+			throw new Error(
+				`Unable to determine module type for ${entry.type} mime type`
+			);
+		}
+
+		return type;
 	} else {
 		return "Text";
 	}


### PR DESCRIPTION
Fixes n/a.

We have received some Sentry reports of users seeing Zod validation errors from miniflare when checking the startup time, which we believe to be caused by an unknown mimetype. This update ensures that we explicitly throw an error when this occurs so we can follow up with a proper fix.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: We will add some tests when we identify the root clause.
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
