### PR TITLE
wrangler deploy: Add containers configuration to PUT script

### DIFF
--- a/.changeset/common-paws-invite.md
+++ b/.changeset/common-paws-invite.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+wrangler deploy includes container configuration when uploading the script

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -22,7 +22,7 @@ function writeAppConfiguration(...app: ContainerApp[]) {
 		"./wrangler.toml",
 		TOML.stringify({
 			name: "my-container",
-			containers: { app },
+			containers: app,
 		}),
 
 		"utf-8"
@@ -103,6 +103,7 @@ describe("cloudchamber apply", () => {
 		writeAppConfiguration({
 			name: "my-container-app",
 			instances: 3,
+			class_name: "DurableObjectClass",
 			configuration: {
 				image: "./Dockerfile",
 			},
@@ -122,15 +123,15 @@ describe("cloudchamber apply", () => {
 			│
 			├ NEW my-container-app
 			│
-			│   [[containers.app]]
+			│   [[containers]]
 			│   name = \\"my-container-app\\"
 			│   instances = 3
 			│   scheduling_policy = \\"regional\\"
 			│
-			│   [containers.app.configuration]
+			│   [containers.configuration]
 			│   image = \\"./Dockerfile\\"
 			│
-			│   [containers.app.constraints]
+			│   [containers.constraints]
 			│   tier = 2
 			│
 			├ Do you want to apply these changes?
@@ -150,6 +151,7 @@ describe("cloudchamber apply", () => {
 		setIsTTY(false);
 		writeAppConfiguration({
 			name: "my-container-app",
+			class_name: "DurableObjectClass",
 			instances: 4,
 			configuration: {
 				image: "./Dockerfile",
@@ -184,12 +186,12 @@ describe("cloudchamber apply", () => {
 			│
 			├ EDIT my-container-app
 			│
-			│   [[containers.app]]
+			│   [[containers]]
 			│ - instances = 3
 			│ + instances = 4
 			│   name = \\"my-container-app\\"
 			│
-			│   [containers.app.constraints]
+			│   [containers.constraints]
 			│ - tier = 3
 			│ + tier = 2
 			│
@@ -216,6 +218,7 @@ describe("cloudchamber apply", () => {
 			{
 				name: "my-container-app",
 				instances: 4,
+				class_name: "DurableObjectClass",
 				configuration: {
 					image: "./Dockerfile",
 				},
@@ -223,6 +226,7 @@ describe("cloudchamber apply", () => {
 			{
 				name: "my-container-app-2",
 				instances: 1,
+				class_name: "DurableObjectClass2",
 				configuration: {
 					image: "other-app/Dockerfile",
 				},
@@ -256,22 +260,22 @@ describe("cloudchamber apply", () => {
 			│
 			├ EDIT my-container-app
 			│
-			│   [[containers.app]]
+			│   [[containers]]
 			│ - instances = 3
 			│ + instances = 4
 			│   name = \\"my-container-app\\"
 			│
 			├ NEW my-container-app-2
 			│
-			│   [[containers.app]]
+			│   [[containers]]
 			│   name = \\"my-container-app-2\\"
 			│   instances = 1
 			│   scheduling_policy = \\"regional\\"
 			│
-			│   [containers.app.configuration]
+			│   [containers.configuration]
 			│   image = \\"other-app/Dockerfile\\"
 			│
-			│   [containers.app.constraints]
+			│   [containers.constraints]
 			│   tier = 1
 			│
 			├ Do you want to apply these changes?
@@ -296,6 +300,7 @@ describe("cloudchamber apply", () => {
 		writeAppConfiguration({
 			name: "my-container-app",
 			instances: 4,
+			class_name: "DurableObjectClass",
 			configuration: {
 				image: "./Dockerfile",
 				labels: [
@@ -380,24 +385,24 @@ describe("cloudchamber apply", () => {
 			│
 			├ EDIT my-container-app
 			│
-			│   [[containers.app]]
+			│   [[containers]]
 			│ - instances = 3
 			│ + instances = 4
 			│   name = \\"my-container-app\\"
 			│
-			│   [[containers.app.configuration.labels]]
+			│   [[containers.configuration.labels]]
 			│ + name = \\"name-1\\"
 			│ + value = \\"value-1\\"
 			│
-			│ + [[containers.app.configuration.labels]]
+			│ + [[containers.configuration.labels]]
 			│   name = \\"name-2\\"
 			│
-			│   [[containers.app.configuration.secrets]]
+			│   [[containers.configuration.secrets]]
 			│ - name = \\"MY_SECRET_1\\"
 			│ - secret = \\"SECRET_NAME_1\\"
 			│ - type = \\"env\\"
 			│
-			│ - [[containers.app.configuration.secrets]]
+			│ - [[containers.configuration.secrets]]
 			│   name = \\"MY_SECRET_2\\"
 			│
 			├ Do you want to apply these changes?
@@ -417,6 +422,7 @@ describe("cloudchamber apply", () => {
 	test("can apply an application, and there is no changes", async () => {
 		setIsTTY(false);
 		writeAppConfiguration({
+			class_name: "DurableObjectClass",
 			name: "my-container-app",
 			instances: 3,
 			configuration: {
@@ -516,6 +522,7 @@ describe("cloudchamber apply", () => {
 		const app = {
 			name: "my-container-app",
 			instances: 3,
+			class_name: "DurableObjectClass",
 			configuration: {
 				image: "./Dockerfile",
 				labels: [
@@ -554,6 +561,7 @@ describe("cloudchamber apply", () => {
 			name: "my-container-app",
 			instances: 3,
 			created_at: new Date().toString(),
+			class_name: "DurableObjectClass",
 			account_id: "1",
 			scheduling_policy: SchedulingPolicy.REGIONAL,
 			configuration: {

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -78,7 +78,7 @@ describe("normalizeAndValidateConfig()", () => {
 				upstream_protocol: "http",
 				host: undefined,
 			},
-			containers: { app: [] },
+			containers: undefined,
 			cloudchamber: {},
 			durable_objects: {
 				bindings: [],

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8547,6 +8547,66 @@ addEventListener('fetch', event => {});`
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
+			it("should support durable object bindings to SQLite classes with containers", async () => {
+				writeWranglerConfig({
+					durable_objects: {
+						bindings: [
+							{
+								name: "EXAMPLE_DO_BINDING",
+								class_name: "ExampleDurableObject",
+							},
+						],
+					},
+					containers: [
+						{
+							name: "my-container",
+							instances: 10,
+							class_name: "ExampleDurableObject",
+							configuration: {
+								image: "docker.io/hello:world",
+							},
+						},
+					],
+					migrations: [
+						{ tag: "v1", new_sqlite_classes: ["ExampleDurableObject"] },
+					],
+				});
+				fs.writeFileSync(
+					"index.js",
+					`export class ExampleDurableObject {}; export default{};`
+				);
+				mockSubDomainRequest();
+				mockLegacyScriptData({
+					scripts: [{ id: "test-name", migration_tag: "v1" }],
+				});
+				mockUploadWorkerRequest({
+					expectedBindings: [
+						{
+							class_name: "ExampleDurableObject",
+							name: "EXAMPLE_DO_BINDING",
+							type: "durable_object_namespace",
+						},
+					],
+					useOldUploadApi: true,
+					expectedContainers: [{ class_name: "ExampleDurableObject" }],
+				});
+
+				await runWrangler("deploy index.js");
+				expect(std.out).toMatchInlineSnapshot(`
+			"Total Upload: xx KiB / gzip: xx KiB
+			Worker Startup Time: 100 ms
+			Your worker has access to the following bindings:
+			- Durable Objects:
+			  - EXAMPLE_DO_BINDING: ExampleDurableObject
+			Uploaded test-name (TIMINGS)
+			Deployed test-name triggers (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Version ID: Galaxy-Class"
+		`);
+				expect(std.err).toMatchInlineSnapshot(`""`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
+
 			it("should support durable objects and D1", async () => {
 				writeWranglerConfig({
 					main: "index.js",

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -39,6 +39,7 @@ export function mockUploadWorkerRequest(
 		useOldUploadApi?: boolean;
 		expectedObservability?: CfWorkerInit["observability"];
 		expectedSettingsPatch?: Partial<NonVersionedScriptSettings>;
+		expectedContainers?: { class_name: string }[];
 	} = {}
 ) {
 	const expectedScriptName = (options.expectedScriptName ??= "test-name");
@@ -117,6 +118,10 @@ export function mockUploadWorkerRequest(
 		if ("expectedObservability" in options) {
 			expect(metadata.observability).toEqual(expectedObservability);
 		}
+		if ("expectedContainers" in options) {
+			expect(metadata.containers).toEqual(expectedContainers);
+		}
+
 		if (expectedUnsafeMetaData !== undefined) {
 			Object.keys(expectedUnsafeMetaData).forEach((key) => {
 				expect(metadata[key]).toEqual(expectedUnsafeMetaData[key]);
@@ -172,6 +177,7 @@ export function mockUploadWorkerRequest(
 		expectedUnsafeMetaData,
 		expectedCapnpSchema,
 		expectedLimits,
+		expectedContainers,
 		keepVars,
 		keepSecrets,
 		expectedDispatchNamespace,

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -129,7 +129,7 @@ const bindingsConfigMock: Omit<
 		],
 	},
 	workflows: [],
-	containers: { app: [] },
+	containers: undefined,
 	r2_buckets: [
 		{
 			binding: "R2_BUCKET_BINDING",

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -342,7 +342,7 @@ export const defaultWranglerConfig: Config = {
 	/** NON-INHERITABLE ENVIRONMENT FIELDS **/
 	define: {},
 	cloudchamber: {},
-	containers: { app: [] },
+	containers: undefined,
 	send_email: [],
 	browser: undefined,
 	unsafe: {},

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -49,6 +49,12 @@ export type ContainerApp = {
 	name: string;
 	/* Number of application instances */
 	instances: number;
+
+	/* The user can set both image in here or under configuration */
+	image?: string;
+
+	class_name: string;
+
 	/* The scheduling policy of the application, default is regional */
 	scheduling_policy?: "regional" | "moon";
 	/* Configuration of the container */
@@ -457,19 +463,11 @@ export interface EnvironmentNonInheritable {
 
 	/**
 	 * Container related configuration
+	 *
+	 * @default []
+	 * @nonInheritable
 	 */
-	containers: {
-		/**
-		 * Container app configuration
-		 *
-		 * NOTE: This field is not automatically inherited from the top level environment,
-		 * and so must be specified in every named environment.
-		 *
-		 * @default {}
-		 * @nonInheritable
-		 */
-		app: ContainerApp[];
-	};
+	containers?: ContainerApp[];
 
 	/**
 	 * These specify any Workers KV Namespaces you want to

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -685,6 +685,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			bindings,
 			migrations,
 			modules,
+			containers: config.containers ?? undefined,
 			sourceMaps: uploadSourceMaps
 				? loadSourceMaps(main, modules, bundle)
 				: undefined,
@@ -743,13 +744,15 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		// * aren't a service Worker
 		// * we don't have DO migrations
 		// * we aren't an fpw
+		// * not a container worker
 		const canUseNewVersionsDeploymentsApi =
 			workerExists &&
 			props.dispatchNamespace === undefined &&
 			prod &&
 			format === "modules" &&
 			migrations === undefined &&
-			!config.first_party_worker;
+			!config.first_party_worker &&
+			config.containers === undefined;
 
 		let workerBundle: FormData;
 

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -650,6 +650,11 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 			? { main_module: main.name }
 			: { body_part: main.name }),
 		bindings: metadataBindings,
+		containers:
+			worker.containers === undefined
+				? undefined
+				: worker.containers.map((c) => ({ class_name: c.class_name })),
+
 		...(compatibility_date && { compatibility_date }),
 		...(compatibility_flags && {
 			compatibility_flags,

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -349,6 +349,9 @@ export interface CfWorkerInit {
 		unsafe: CfUnsafe | undefined;
 		assets: CfAssetsBinding | undefined;
 	};
+
+	containers?: { class_name: string }[];
+
 	/**
 	 * The raw bindings - this is basically never provided and it'll be the bindings above
 	 * but if we're just taking from the api and re-putting then this is how we can do that


### PR DESCRIPTION
Right now, container configuration only works on the PUT script path, but this will be fixed in further API changes.

This change makes sure that when container configurations are included in wrangler, it will include the `containers` configuration in wrangler deploy. These changes break `wrangler cloudchamber apply` users, but as the product is in early-stages and private only for now, we consider these breaking changes worth doing. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No e2e tests for containers yet.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal features

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
