### PR TITLE
Add 'using' test

### DIFF
--- a/fixtures/worker-app/src/explicit-resource-management.js
+++ b/fixtures/worker-app/src/explicit-resource-management.js
@@ -1,0 +1,24 @@
+/** @param {string[]} logs */
+function connect(logs) {
+	logs.push("Connected");
+	return {
+		send(message) {
+			logs.push(`Sent ${message}`);
+		},
+		[Symbol.dispose]() {
+			logs.push("Disconnected synchronously");
+		},
+		async [Symbol.asyncDispose]() {
+			logs.push("Disconnected asynchronously");
+		},
+	};
+}
+
+/** @param {string[]} logs */
+export async function testExplicitResourceManagement(logs) {
+	using syncConnect = connect(logs);
+	await using asyncConnect = connect(logs);
+
+	syncConnect.send("hello");
+	asyncConnect.send("goodbye");
+}

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -1,6 +1,7 @@
 import cookie from "cookie";
 import { randomBytes } from "isomorphic-random-example";
 import { now } from "./dep";
+import { testExplicitResourceManagement } from "./explicit-resource-management";
 import { logErrors } from "./log";
 
 console.log("startup log");
@@ -57,6 +58,12 @@ export default {
 			return new Response("x".repeat(100), {
 				headers: { "Content-Encoding": "gzip" },
 			});
+		}
+
+		if (pathname === "/explicit-resource-management") {
+			const logs = [];
+			await testExplicitResourceManagement(logs);
+			return Response.json(logs);
 		}
 
 		if (request.headers.get("X-Test-URL") !== null) {

--- a/fixtures/worker-app/tests/index.test.ts
+++ b/fixtures/worker-app/tests/index.test.ts
@@ -182,4 +182,20 @@ describe("'wrangler dev' correctly renders pages", () => {
 		});
 		expect(await response.text()).toEqual("x".repeat(100));
 	});
+
+	it("uses explicit resource management", async ({ expect }) => {
+		const response = await fetch(
+			`http://${ip}:${port}/explicit-resource-management`
+		);
+		expect(await response.json()).toMatchInlineSnapshot(`
+			[
+			  "Connected",
+			  "Connected",
+			  "Sent hello",
+			  "Sent goodbye",
+			  "Disconnected asynchronously",
+			  "Disconnected synchronously",
+			]
+		`);
+	});
 });


### PR DESCRIPTION
Fixes WC-000.

With the latest esbuild, we now have bundling support for `using` and native support has landed in v8 and in workerd — we can now get rid of #5501! This just ports over a test in the PR we had to assert `using` works correctly.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/20797
  - [ ] Documentation not necessary because:

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
