### PR TITLE
Fix v3 maintenance

### DIFF
--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -31,3 +31,18 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+      - name: "Comment on PR with error details"
+        if: failure()
+        uses: marocchino/sticky-pull-request-comment@daa4a82a0a3f6c162c02b83fa44b3ab83946f7cb
+        with:
+          message: |
+            Failed to automatically backport this PR's changes to Wrangler v3. Please manually create a PR targeting the `v3-maintenance` branch with your changes. Thank you for helping us keep Wrangler v3 supported!
+
+            Depending on your changes, running `git rebase --onto v3-maintenance main ${{ github.head_ref }}` might be a good starting point.
+
+      - name: "Comment on PR with error details"
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@daa4a82a0a3f6c162c02b83fa44b3ab83946f7cb
+        with:
+          message: |
+            These changes have been automatically backported to Wrangler v3 :tada: You can view the automatically updated PR at https://github.com/cloudflare/workers-sdk/compare/v3-maintenance...v3-maintenance-${{ github.event.number }}. Please check that PR for correctness, and make sure it's merged after this one. Thank you for helping us keep Wrangler v3 supported!

--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -17,7 +17,7 @@ if (require.main === module) {
 		try {
 			// Open PR
 			execSync(
-				`gh pr create --base v2-maintenance --head v3-maintenance-${process.env.PR_NUMBER} --label "skip-pr-description-validation" --label "skip-v3-pr" --title "Backport #${process.env.PR_NUMBER} to Wrangler v3" --body "This is an automatically opened PR to backport patch changes from #${process.env.PR_NUMBER} to Wrangler v3"`
+				`gh pr create --base v3-maintenance --head v3-maintenance-${process.env.PR_NUMBER} --label "skip-pr-description-validation" --label "skip-v3-pr" --title "Backport #${process.env.PR_NUMBER} to Wrangler v3" --body "This is an automatically opened PR to backport patch changes from #${process.env.PR_NUMBER} to Wrangler v3"`
 			);
 		} catch {
 			// Ignore "PR already created failures"

--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -12,6 +12,10 @@ if (require.main === module) {
 		// Create a new branch for the v3 maintenance PR
 		execSync(`git checkout -b v3-maintenance-${process.env.PR_NUMBER} -f`);
 
+		execSync(
+			`git rebase --onto v3-maintenance main v3-maintenance-${process.env.PR_NUMBER}`
+		);
+
 		execSync(`git push origin HEAD --force`);
 
 		try {


### PR DESCRIPTION
Improves v3 maintenance mechanic by:
- changing the base branch to `v3`, not `v2`
- Adding comments to help PR openers understand the process