### PR TITLE
fix: Fix error in `open-v3-pr` script

### DIFF
--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -13,7 +13,7 @@ if (require.main === module) {
 		execSync(`git checkout -b v3-maintenance-${process.env.PR_NUMBER} -f`);
 
 		execSync(
-			`git rebase --onto v3-maintenance origin/main v3-maintenance-${process.env.PR_NUMBER}`
+			`git rebase --onto origin/v3-maintenance origin/main v3-maintenance-${process.env.PR_NUMBER}`
 		);
 
 		execSync(`git push origin HEAD --force`);


### PR DESCRIPTION
Fixes n/a

Fix `fatal: Does not point to a valid commit 'v3-maintenance'` error in `open-v3-pr` script (see https://github.com/cloudflare/workers-sdk/actions/runs/13857544424/job/38777668482?pr=8401 for failure)


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: gh action change
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: gh action change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because: gh action change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
