### PR TITLE
Fix metafiles in child directory

### DIFF
--- a/.changeset/mighty-lies-see.md
+++ b/.changeset/mighty-lies-see.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix Workers Assets metafiles (`_headers` and `_redirects`) resolution when running Wrangler from a different directory

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4668,10 +4668,12 @@ addEventListener('fetch', event => {});`
 		});
 
 		it("should ignore assets that match patterns in an .assetsignore file in the root of the assets directory", async () => {
+			const redirectsContent = "/foo /bar";
+			const headersContent = "/some-path\nX-Header: Custom-Value";
 			const assets = [
 				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },
-				{ filePath: "_redirects", content: "/foo /bar" },
-				{ filePath: "_headers", content: "/some-path\nX-Header: Custom-Value" },
+				{ filePath: "_redirects", content: redirectsContent },
+				{ filePath: "_headers", content: headersContent },
 				{ filePath: "file-1.txt", content: "Content of file-1" },
 				{ filePath: "file-2.bak", content: "Content of file-2" },
 				{ filePath: "file-3.txt", content: "Content of file-3" },
@@ -4691,7 +4693,10 @@ addEventListener('fetch', event => {});`
 			mockUploadWorkerRequest({
 				expectedAssets: {
 					jwt: "<<aus-completion-token>>",
-					config: {},
+					config: {
+						_headers: headersContent,
+						_redirects: redirectsContent,
+					},
 				},
 				expectedType: "none",
 			});

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -426,8 +426,10 @@ export function getAssetsOptions(
 		);
 	}
 
-	const redirects = maybeGetFile(path.join(directory, REDIRECTS_FILENAME));
-	const headers = maybeGetFile(path.join(directory, HEADERS_FILENAME));
+	const redirects = maybeGetFile(
+		path.join(resolvedAssetsPath, REDIRECTS_FILENAME)
+	);
+	const headers = maybeGetFile(path.join(resolvedAssetsPath, HEADERS_FILENAME));
 
 	// defaults are set in asset worker
 	const assetConfig: AssetConfig = {


### PR DESCRIPTION
Fixes WC-3357.

Metafiles weren't being picked up when Wrangler was running in a different directory. This fixes that. Thanks for catching that, @petebacondarwin !

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
