### PR TITLE
chore: add v3 backport to PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,10 @@ The following selections do not need to be completed if this PR only contains ch
   - [ ] TODO (before merge)
   - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
   - [ ] Documentation not necessary because:
+- Wrangler V3 Backport
+  - [ ] TODO (before merge)
+  - [ ] PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
+  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->
 
 <!--
 Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?

--- a/tools/deployments/__tests__/validate-pr-description.test.ts
+++ b/tools/deployments/__tests__/validate-pr-description.test.ts
@@ -30,6 +30,10 @@ Fixes #[insert GH or internal issue number(s)].
   - [x] TODO (before merge)
   - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
   - [ ] Documentation not necessary because:
+- Wrangler V3 Backport
+  - [x] TODO (before merge)
+  - [ ] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/123
+  - [ ] Not necessary because:
 `,
 				"[]",
 				"[]"
@@ -41,6 +45,7 @@ Fixes #[insert GH or internal issue number(s)].
 			  "Your PR must run E2E tests, or provide justification for why running them is not required",
 			  "Your PR doesn't include a changeset. Either include one (following the instructions in CONTRIBUTING.md) or add the 'no-changeset-required' label to bypass this check. Most PRs should have a changeset, so only bypass this check if you're sure that your change doesn't need one: see https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets for more details.",
 			  "Your PR must include documentation (in the form of a link to a Cloudflare Docs issue or PR), or provide justification for why no documentation is required",
+			  "Your PR must include a v3 back-port (in the form of a link to a workers-sdk PR), or provide justification for why this is not required. A PR should automatically be opened up for you if this is required - this is only needed for patch changes to Wrangler (excluding experimental features labelled as \`patch\`).",
 			]
 		`);
 	});
@@ -67,6 +72,10 @@ Fixes #[insert GH or internal issue number(s)].
   - [ ] TODO (before merge)
   - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
   - [x] Documentation not necessary because: test
+- Wrangler V3 Backport
+  - [ ] TODO (before merge)
+  - [ ] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/123
+  - [x] Not necessary because: test
 `,
 				'["no-changeset-required"]',
 				"[]"
@@ -92,14 +101,14 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
   - [ ] I don't know
   - [ ] Required
   - [x] Not required because: test
-- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
-  - [ ] TODO (before merge)
-  - [x] Changeset included
-  - [ ] Changeset not necessary because:
 - Public documentation
   - [ ] TODO (before merge)
   - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/123
   - [ ] Documentation not necessary because:
+- Wrangler V3 Backport
+  - [ ] TODO (before merge)
+  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/123
+  - [ ] Not necessary because:
 `,
 				"[]",
 				'[".changeset/hello-world.md"]'
@@ -125,14 +134,14 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
   - [x] I don't know
   - [ ] Required
   - [ ] Not required because: test
-- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
-  - [ ] TODO (before merge)
-  - [x] Changeset included
-  - [ ] Changeset not necessary because:
 - Public documentation
   - [ ] TODO (before merge)
   - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/123
   - [ ] Documentation not necessary because:
+- Wrangler V3 Backport
+  - [ ] TODO (before merge)
+  - [ ] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/123
+  - [x] Not necessary because: test
 `,
 				"[]",
 				'[".changeset/hello-world.md"]'
@@ -163,14 +172,14 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
   - [ ] I don't know
   - [x] Required
   - [ ] Not required because: test
-- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
-  - [ ] TODO (before merge)
-  - [x] Changeset included
-  - [ ] Changeset not necessary because:
 - Public documentation
   - [ ] TODO (before merge)
   - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/123
   - [ ] Documentation not necessary because:
+- Wrangler V3 Backport
+  - [ ] TODO (before merge)
+  - [ ] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/123
+  - [x] Not necessary because: test
 `,
 				"[]",
 				'[".changeset/hello-world.md"]'
@@ -200,14 +209,14 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
   - [ ] I don't know
   - [x] Required
   - [ ] Not required because: test
-- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
-  - [ ] TODO (before merge)
-  - [x] Changeset included
-  - [ ] Changeset not necessary because:
 - Public documentation
   - [ ] TODO (before merge)
   - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/123
   - [ ] Documentation not necessary because:
+- Wrangler V3 Backport
+  - [ ] TODO (before merge)
+  - [ ] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/123
+  - [x] Not necessary because: test
 `,
 				'["e2e"]',
 				'[".changeset/hello-world.md"]'
@@ -233,18 +242,55 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
   - [ ] I don't know
   - [X] Required
   - [ ] Not required because: test
-- Changeset ([Changeset guidelines](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md#changesets))
-  - [ ] TODO (before merge)
-  - [X] Changeset included
-  - [ ] Changeset not necessary because:
 - Public documentation
   - [ ] TODO (before merge)
   - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/123
   - [ ] Documentation not necessary because:
+- Wrangler V3 Backport
+  - [ ] TODO (before merge)
+  - [ ] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/123
+  - [x] Not necessary because: test
 `,
 				'["e2e"]',
 				'[".changeset/hello-world.md"]'
 			)
 		).toHaveLength(0);
+	});
+
+	it("should not accept v3 back port none", () => {
+		expect(
+			validateDescription(
+				"",
+				`## What this PR solves / how to test
+
+Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
+
+## Author has addressed the following
+
+- Tests
+  - [ ] TODO (before merge)
+  - [x] Tests included
+  - [ ] Tests not necessary because:
+- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
+  - [ ] I don't know
+  - [ ] Required
+  - [x] Not required because: test
+- Public documentation
+  - [ ] TODO (before merge)
+  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/123
+  - [ ] Documentation not necessary because:
+- Wrangler V3 Backport
+  - [ ] TODO (before merge)
+  - [ ] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/123
+  - [ ] Not necessary because: test
+`,
+				"[]",
+				'[".changeset/hello-world.md"]'
+			)
+		).toMatchInlineSnapshot(`
+			[
+			  "Your PR must include a v3 back-port (in the form of a link to a workers-sdk PR), or provide justification for why this is not required. A PR should automatically be opened up for you if this is required - this is only needed for patch changes to Wrangler (excluding experimental features labelled as \`patch\`).",
+			]
+		`);
 	});
 });

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -104,5 +104,17 @@ export function validateDescription(
 		);
 	}
 
+	if (
+		!(
+			/- \[x\] Wrangler PR: https:\/\/github\.com\/cloudflare\/workers-sdk\/(pull)\/\d+/i.test(
+				body
+			) || /- \[x\] Not necessary because: .+/i.test(body)
+		)
+	) {
+		errors.push(
+			"Your PR must include a v3 back-port (in the form of a link to a workers-sdk PR), or provide justification for why this is not required. A PR should automatically be opened up for you if this is required - this is only needed for patch changes to Wrangler (excluding experimental features labelled as `patch`)."
+		);
+	}
+
 	return errors;
 }


### PR DESCRIPTION
Adds v3 back port to our pr checklist

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: is documentation
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
