### PR TITLE
Set `target` in `optimizeDeps.esbuildOptions`

### DIFF
--- a/.changeset/nasty-bars-sniff.md
+++ b/.changeset/nasty-bars-sniff.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Set `target` in `optimizeDeps.esbuildOptions` to `es2022`. This fixes a bug where the target for prebundled dependencies did not match the build target.

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -119,6 +119,7 @@ const cloudflareBuiltInModules = [
 ];
 
 const defaultConditions = ["workerd", "module", "browser"];
+const target = "es2022";
 
 export function createCloudflareEnvironmentOptions(
 	workerConfig: WorkerConfig,
@@ -144,7 +145,7 @@ export function createCloudflareEnvironmentOptions(
 			createEnvironment(name, config) {
 				return new vite.BuildEnvironment(name, config);
 			},
-			target: "es2022",
+			target,
 			// We need to enable `emitAssets` in order to support additional modules defined by `rules`
 			emitAssets: true,
 			outDir: getOutputDirectory(userConfig, environmentName),
@@ -165,6 +166,7 @@ export function createCloudflareEnvironmentOptions(
 			exclude: [...cloudflareBuiltInModules],
 			esbuildOptions: {
 				platform: "neutral",
+				target,
 				conditions: [...defaultConditions, "development"],
 				resolveExtensions: [
 					".mjs",


### PR DESCRIPTION
Fixes #8511.

Sets `target` in `optimizeDeps.esbuildOptions` to `es2022`. This fixes a bug where the target for prebundled dependencies did not match the build target. This resulted in top-level await not being permitted in dependencies.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: N/A
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
