### PR TITLE
Use `coupleWebSocket` function from Miniflare

### DIFF
--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -277,11 +277,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					{ alwaysCallNext: false }
 				);
 
-				handleWebSocket(
-					viteDevServer.httpServer,
-					entryWorker.fetch,
-					viteDevServer.config.logger
-				);
+				handleWebSocket(viteDevServer.httpServer, entryWorker.fetch);
 
 				return () => {
 					viteDevServer.middlewares.use((req, res, next) => {
@@ -306,11 +302,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					{ alwaysCallNext: false }
 				);
 
-				handleWebSocket(
-					vitePreviewServer.httpServer,
-					miniflare.dispatchFetch,
-					vitePreviewServer.config.logger
-				);
+				handleWebSocket(vitePreviewServer.httpServer, miniflare.dispatchFetch);
 
 				return () => {
 					vitePreviewServer.middlewares.use((req, res, next) => {


### PR DESCRIPTION
Fixes #000.

While investigating improving the WebSocket implementation, I discovered that Miniflare exports a `coupleWebSocket` function. This is similar to our existing implementation but covers some additional edge cases and improves the error handling.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
