### PR TITLE
Support wrangler types for Pipelines

### DIFF
--- a/.changeset/swift-beers-battle.md
+++ b/.changeset/swift-beers-battle.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Support wrangler types for Pipelines

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -203,7 +203,7 @@ const bindingsConfigMock: Omit<
 		},
 		{ type: "CompiledWasm", globs: ["**/*.wasm"], fallthrough: true },
 	],
-	pipelines: [],
+	pipelines: [{ binding: "PIPELINE", pipeline: "my-pipeline" }],
 	assets: {
 		binding: "ASSETS_BINDING",
 		directory: "/assets",
@@ -437,6 +437,7 @@ describe("generate types", () => {
 					IMAGES_BINDING: ImagesBinding;
 					VERSION_METADATA_BINDING: { id: string; tag: string };
 					ASSETS_BINDING: Fetcher;
+					PIPELINE: import(\\"cloudflare:pipelines\\").Pipeline;
 				}
 			}
 			interface Env extends Cloudflare.Env {}
@@ -525,6 +526,7 @@ describe("generate types", () => {
 					IMAGES_BINDING: ImagesBinding;
 					VERSION_METADATA_BINDING: { id: string; tag: string };
 					ASSETS_BINDING: Fetcher;
+					PIPELINE: import(\\"cloudflare:pipelines\\").Pipeline;
 				}
 			}
 			interface Env extends Cloudflare.Env {}

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -437,7 +437,7 @@ describe("generate types", () => {
 					IMAGES_BINDING: ImagesBinding;
 					VERSION_METADATA_BINDING: { id: string; tag: string };
 					ASSETS_BINDING: Fetcher;
-					PIPELINE: import(\\"cloudflare:pipelines\\").Pipeline;
+					PIPELINE: import(\\"cloudflare:pipelines\\").Pipeline<import(\\"cloudflare:pipelines\\").PipelineRecord>;
 				}
 			}
 			interface Env extends Cloudflare.Env {}
@@ -526,7 +526,7 @@ describe("generate types", () => {
 					IMAGES_BINDING: ImagesBinding;
 					VERSION_METADATA_BINDING: { id: string; tag: string };
 					ASSETS_BINDING: Fetcher;
-					PIPELINE: import(\\"cloudflare:pipelines\\").Pipeline;
+					PIPELINE: import(\\"cloudflare:pipelines\\").Pipeline<import(\\"cloudflare:pipelines\\").PipelineRecord>;
 				}
 			}
 			interface Env extends Cloudflare.Env {}

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -516,7 +516,7 @@ export async function generateEnvTypes(
 		for (const pipeline of configToDTS.pipelines) {
 			envTypeStructure.push([
 				constructTypeKey(pipeline.binding),
-				`import("cloudflare:pipelines").Pipeline`,
+				`import("cloudflare:pipelines").Pipeline<import("cloudflare:pipelines").PipelineRecord>`,
 			]);
 		}
 	}

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -294,6 +294,7 @@ export async function generateEnvTypes(
 		secrets,
 		assets: config.assets,
 		workflows: config.workflows,
+		pipelines: config.pipelines,
 	};
 
 	const entrypointFormat = entrypoint?.format ?? "modules";
@@ -508,6 +509,15 @@ export async function generateEnvTypes(
 	if (configToDTS.workflows) {
 		for (const workflow of configToDTS.workflows) {
 			envTypeStructure.push([constructTypeKey(workflow.binding), "Workflow"]);
+		}
+	}
+
+	if (configToDTS.pipelines) {
+		for (const pipeline of configToDTS.pipelines) {
+			envTypeStructure.push([
+				constructTypeKey(pipeline.binding),
+				`import("cloudflare:pipelines").Pipeline`,
+			]);
 		}
 	}
 


### PR DESCRIPTION
Adds support for `wrangler types` command to generate the necessary types for Workers Pipelines.

Fixes https://jira.cfdata.org/browse/PIPE-181

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: type generation tests cover this
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: covered by existing docs `wrangler types -h`
