### PR TITLE
Improve the error messaging when the user provides neither an entry point nor an asset directory

### DIFF
--- a/.changeset/rude-socks-glow.md
+++ b/.changeset/rude-socks-glow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+improve the error messaging when the user provides neither an entry point nor an asset directory

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -2548,7 +2548,7 @@ addEventListener('fetch', event => {});`
 				`
 				[Error: Missing entry-point to Worker script or to assets directory
 
-				If you want to deploy a Worker that includes code, you can either:
+				If there is code to deploy, you can either:
 				- Specify an entry-point to your Worker script via the command line (ex: \`npx wrangler deploy src/index.ts\`)
 				- Or add the following to your "wrangler.toml" file:
 
@@ -2558,7 +2558,7 @@ addEventListener('fetch', event => {});`
 				\`\`\`
 
 
-				If you want to deploy only a directory of assets (with no server-side code), you can either:
+				If are uploading a directory of assets, you can either:
 				- Specify the path to the directory of assets via the command line: (ex: \`npx wrangler deploy --assets=./dist\`)
 				- Or add the following to your "wrangler.toml" file:
 
@@ -2576,7 +2576,7 @@ addEventListener('fetch', event => {});`
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing entry-point to Worker script or to assets directory[0m
 
 
-				  If you want to deploy a Worker that includes code, you can either:
+				  If there is code to deploy, you can either:
 				  - Specify an entry-point to your Worker script via the command line (ex: \`npx wrangler deploy
 				  src/index.ts\`)
 				  - Or add the following to your \\"wrangler.toml\\" file:
@@ -2587,7 +2587,7 @@ addEventListener('fetch', event => {});`
 				  \`\`\`
 
 
-				  If you want to deploy only a directory of assets (with no server-side code), you can either:
+				  If are uploading a directory of assets, you can either:
 				  - Specify the path to the directory of assets via the command line: (ex: \`npx wrangler deploy
 				  --assets=./dist\`)
 				  - Or add the following to your \\"wrangler.toml\\" file:

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -15,6 +15,7 @@ import {
 	printOffendingDependencies,
 } from "../deployment-bundle/bundle-reporter";
 import { clearOutputFilePath } from "../output";
+import { sniffUserAgent } from "../package-manager";
 import { writeAuthConfigFile } from "../user";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockAuthDomain } from "./helpers/mock-auth-domain";
@@ -2536,6 +2537,7 @@ addEventListener('fetch', event => {});`
 		});
 
 		it("should error if there is no entry-point specified", async () => {
+			vi.mocked(sniffUserAgent).mockReturnValue("npm");
 			writeWranglerConfig();
 			writeWorkerSource();
 			mockUploadWorkerRequest();
@@ -2543,15 +2545,62 @@ addEventListener('fetch', event => {});`
 			await expect(
 				runWrangler("deploy")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler deploy path/to/script\`) or the \`main\` config field.]`
+				`
+				[Error: Missing entry-point to Worker script or to assets directory
+
+				If you want to deploy a Worker that includes code, you can either:
+				- Specify an entry-point to your Worker script via the command line (ex: \`npx wrangler deploy src/index.ts\`)
+				- Or add the following to your "wrangler.toml" file:
+
+				\`\`\`
+				main = "src/index.ts"
+
+				\`\`\`
+
+
+				If you want to deploy only a directory of assets (with no server-side code), you can either:
+				- Specify the path to the directory of assets via the command line: (ex: \`npx wrangler deploy --assets=./dist\`)
+				- Or add the following to your "wrangler.toml" file:
+
+				\`\`\`
+				[assets]
+				directory = "./dist"
+
+				\`\`\`
+				]
+			`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`
-			        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler deploy path/to/script\`) or the \`main\` config field.[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing entry-point to Worker script or to assets directory[0m
 
-			        "
-		      `);
+
+				  If you want to deploy a Worker that includes code, you can either:
+				  - Specify an entry-point to your Worker script via the command line (ex: \`npx wrangler deploy
+				  src/index.ts\`)
+				  - Or add the following to your \\"wrangler.toml\\" file:
+
+				  \`\`\`
+				  main = \\"src/index.ts\\"
+
+				  \`\`\`
+
+
+				  If you want to deploy only a directory of assets (with no server-side code), you can either:
+				  - Specify the path to the directory of assets via the command line: (ex: \`npx wrangler deploy
+				  --assets=./dist\`)
+				  - Or add the following to your \\"wrangler.toml\\" file:
+
+				  \`\`\`
+				  [assets]
+				  directory = \\"./dist\\"
+
+				  \`\`\`
+
+
+				"
+			`);
 		});
 
 		describe("should source map validation errors", () => {

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -12,6 +12,7 @@ import { getWorkerAccountAndContext } from "../dev/remote";
 import { FatalError } from "../errors";
 import { CI } from "../is-ci";
 import { logger } from "../logger";
+import { sniffUserAgent } from "../package-manager";
 import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
 import { mockConsoleMethods } from "./helpers/mock-console";
 import { useMockIsTTY } from "./helpers/mock-istty";
@@ -298,20 +299,68 @@ describe.sequential("wrangler dev", () => {
 
 	describe("entry-points", () => {
 		it("should error if there is no entry-point specified", async () => {
+			vi.mocked(sniffUserAgent).mockReturnValue("npm");
 			writeWranglerConfig();
 
 			await expect(
 				runWrangler("dev")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler dev path/to/script\`) or the \`main\` config field.]`
+				`
+				[Error: Missing entry-point to Worker script or to assets directory
+
+				If you want to deploy a Worker that includes code, you can either:
+				- Specify an entry-point to your Worker script via the command line (ex: \`npx wrangler dev src/index.ts\`)
+				- Or add the following to your "wrangler.toml" file:
+
+				\`\`\`
+				main = "src/index.ts"
+
+				\`\`\`
+
+
+				If you want to deploy only a directory of assets (with no server-side code), you can either:
+				- Specify the path to the directory of assets via the command line: (ex: \`npx wrangler dev --assets=./dist\`)
+				- Or add the following to your "wrangler.toml" file:
+
+				\`\`\`
+				[assets]
+				directory = "./dist"
+
+				\`\`\`
+				]
+			`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`""`);
 			expect(std.err).toMatchInlineSnapshot(`
-			        "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler dev path/to/script\`) or the \`main\` config field.[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing entry-point to Worker script or to assets directory[0m
 
-			        "
-		      `);
+
+				  If you want to deploy a Worker that includes code, you can either:
+				  - Specify an entry-point to your Worker script via the command line (ex: \`npx wrangler dev
+				  src/index.ts\`)
+				  - Or add the following to your \\"wrangler.toml\\" file:
+
+				  \`\`\`
+				  main = \\"src/index.ts\\"
+
+				  \`\`\`
+
+
+				  If you want to deploy only a directory of assets (with no server-side code), you can either:
+				  - Specify the path to the directory of assets via the command line: (ex: \`npx wrangler dev
+				  --assets=./dist\`)
+				  - Or add the following to your \\"wrangler.toml\\" file:
+
+				  \`\`\`
+				  [assets]
+				  directory = \\"./dist\\"
+
+				  \`\`\`
+
+
+				"
+			`);
 		});
 
 		it("should use `main` from the top-level environment", async () => {

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -308,7 +308,7 @@ describe.sequential("wrangler dev", () => {
 				`
 				[Error: Missing entry-point to Worker script or to assets directory
 
-				If you want to deploy a Worker that includes code, you can either:
+				If there is code to deploy, you can either:
 				- Specify an entry-point to your Worker script via the command line (ex: \`npx wrangler dev src/index.ts\`)
 				- Or add the following to your "wrangler.toml" file:
 
@@ -318,7 +318,7 @@ describe.sequential("wrangler dev", () => {
 				\`\`\`
 
 
-				If you want to deploy only a directory of assets (with no server-side code), you can either:
+				If are uploading a directory of assets, you can either:
 				- Specify the path to the directory of assets via the command line: (ex: \`npx wrangler dev --assets=./dist\`)
 				- Or add the following to your "wrangler.toml" file:
 
@@ -336,7 +336,7 @@ describe.sequential("wrangler dev", () => {
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mMissing entry-point to Worker script or to assets directory[0m
 
 
-				  If you want to deploy a Worker that includes code, you can either:
+				  If there is code to deploy, you can either:
 				  - Specify an entry-point to your Worker script via the command line (ex: \`npx wrangler dev
 				  src/index.ts\`)
 				  - Or add the following to your \\"wrangler.toml\\" file:
@@ -347,7 +347,7 @@ describe.sequential("wrangler dev", () => {
 				  \`\`\`
 
 
-				  If you want to deploy only a directory of assets (with no server-side code), you can either:
+				  If are uploading a directory of assets, you can either:
 				  - Specify the path to the directory of assets via the command line: (ex: \`npx wrangler dev
 				  --assets=./dist\`)
 				  - Or add the following to your \\"wrangler.toml\\" file:

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -1,7 +1,9 @@
 import path from "node:path";
-import { configFileName } from "../config";
+import dedent from "ts-dedent";
+import { configFileName, formatConfigSnippet } from "../config";
 import { UserError } from "../errors";
 import { logger } from "../logger";
+import { sniffUserAgent } from "../package-manager";
 import guessWorkerFormat from "./guess-worker-format";
 import {
 	resolveEntryWithAssets,
@@ -10,7 +12,7 @@ import {
 	resolveEntryWithScript,
 } from "./resolve-entry";
 import { runCustomBuild } from "./run-custom-build";
-import type { Config } from "../config";
+import type { Config, RawConfig } from "../config";
 import type { DurableObjectBindings } from "../config/environment";
 import type { CfScriptFormat } from "./worker";
 
@@ -70,8 +72,47 @@ export async function getEntry(
 					"For Pages, please run `wrangler pages dev` instead."
 			);
 		}
+
+		const compatibilityDateStr = [
+			new Date().getFullYear(),
+			(new Date().getMonth() + 1 + "").padStart(2, "0"),
+			(new Date().getDate() + "").padStart(2, "0"),
+		].join("-");
+
+		const updateConfigMessage = (snippet: RawConfig) => dedent`
+			${
+				config.configPath
+					? `add the following to your "${configFileName(config.configPath)}" file:`
+					: `create a "wrangler.jsonc" file containing:`
+			}
+
+			\`\`\`
+			${formatConfigSnippet(
+				{
+					...(config.name ? {} : { name: "worker-name" }),
+					...(config.compatibility_date
+						? {}
+						: { compatibility_date: compatibilityDateStr }),
+					...snippet,
+				},
+				config.configPath
+			)}
+			\`\`\`
+
+			`;
+
+		const fullCommand = `${getNpxEquivalent()} wrangler ${command}`;
 		throw new UserError(
-			`Missing entry-point: The entry-point should be specified via the command line (e.g. \`wrangler ${command} path/to/script\`) or the \`main\` config field.`
+			dedent`
+			Missing entry-point to Worker script or to assets directory
+
+			If you want to deploy a Worker that includes code, you can either:
+			- Specify an entry-point to your Worker script via the command line (ex: \`${fullCommand} src/index.ts\`)
+			- Or ${updateConfigMessage({ main: "src/index.ts" })}
+
+			If you want to deploy only a directory of assets (with no server-side code), you can either:
+			- Specify the path to the directory of assets via the command line: (ex: \`${fullCommand} --assets=./dist\`)
+			- Or ${updateConfigMessage({ assets: { directory: "./dist" } })}`
 		);
 	}
 	await runCustomBuild(
@@ -166,4 +207,16 @@ function generateAddScriptNameExamples(
 			return `${currentBinding} ==> ${fixedBinding}`;
 		})
 		.join("\n");
+}
+
+export function getNpxEquivalent() {
+	switch (sniffUserAgent()) {
+		case "pnpm":
+			return "pnpm";
+		case "yarn":
+			return "yarn";
+		case "npm":
+		default:
+			return "npx";
+	}
 }

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -106,13 +106,14 @@ export async function getEntry(
 			dedent`
 			Missing entry-point to Worker script or to assets directory
 
-			If you want to deploy a Worker that includes code, you can either:
+			If there is code to deploy, you can either:
 			- Specify an entry-point to your Worker script via the command line (ex: \`${fullCommand} src/index.ts\`)
 			- Or ${updateConfigMessage({ main: "src/index.ts" })}
 
-			If you want to deploy only a directory of assets (with no server-side code), you can either:
+			If are uploading a directory of assets, you can either:
 			- Specify the path to the directory of assets via the command line: (ex: \`${fullCommand} --assets=./dist\`)
-			- Or ${updateConfigMessage({ assets: { directory: "./dist" } })}`
+			- Or ${updateConfigMessage({ assets: { directory: "./dist" } })}`,
+			{ telemetryMessage: "missing worker entrypoint or assets directory" }
 		);
 	}
 	await runCustomBuild(


### PR DESCRIPTION
<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor message change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/8535
  - [ ] Not necessary because:
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
