### PR TITLE
[R2 Data Catalog] Add wrangler commands for R2 Data Catalog

### DIFF
--- a/.changeset/tangy-camels-write.md
+++ b/.changeset/tangy-camels-write.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+feat: Add wrangler commands for R2 Data Catalog

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -157,7 +157,7 @@ describe("r2", () => {
 				  wrangler r2 bucket info <bucket>    Get information about an R2 bucket
 				  wrangler r2 bucket delete <bucket>  Delete an R2 bucket
 				  wrangler r2 bucket sippy            Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST inferface so engines can query R2 data as tables [open-beta]
+				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark, DuckDB, and Trino [open-beta]
 				  wrangler r2 bucket notification     Manage event notification rules for an R2 bucket
 				  wrangler r2 bucket domain           Manage custom domains for an R2 bucket
 				  wrangler r2 bucket dev-url          Manage public access via the r2.dev URL for an R2 bucket
@@ -198,7 +198,7 @@ describe("r2", () => {
 				  wrangler r2 bucket info <bucket>    Get information about an R2 bucket
 				  wrangler r2 bucket delete <bucket>  Delete an R2 bucket
 				  wrangler r2 bucket sippy            Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST inferface so engines can query R2 data as tables [open-beta]
+				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark, DuckDB, and Trino [open-beta]
 				  wrangler r2 bucket notification     Manage event notification rules for an R2 bucket
 				  wrangler r2 bucket domain           Manage custom domains for an R2 bucket
 				  wrangler r2 bucket dev-url          Manage public access via the r2.dev URL for an R2 bucket
@@ -947,7 +947,7 @@ describe("r2", () => {
 					"
 					wrangler r2 bucket catalog
 
-					Manage the data catalog for your R2 buckets - provides an Iceberg REST inferface so engines can query R2 data as tables [open-beta]
+					Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark, DuckDB, and Trino [open-beta]
 
 					COMMANDS
 					  wrangler r2 bucket catalog enable <bucket>   Enable the data catalog on an R2 bucket [open-beta]
@@ -988,7 +988,7 @@ describe("r2", () => {
 
 			Catalog URI: 'https://catalog.cloudflarestorage.com/test-warehouse-name'
 
-			Use the Catalog URI in Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to read or manage data as tables.
+			Use this Catalog URI with Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to query data as tables.
 			Note: You'll need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
 			For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"`
 					);

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -157,7 +157,7 @@ describe("r2", () => {
 				  wrangler r2 bucket info <bucket>    Get information about an R2 bucket
 				  wrangler r2 bucket delete <bucket>  Delete an R2 bucket
 				  wrangler r2 bucket sippy            Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket catalog          Manage R2 bucket warehouses using the R2 Data Catalog [open-beta]
+				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST inferface so engines can query R2 data as tables [open-beta]
 				  wrangler r2 bucket notification     Manage event notification rules for an R2 bucket
 				  wrangler r2 bucket domain           Manage custom domains for an R2 bucket
 				  wrangler r2 bucket dev-url          Manage public access via the r2.dev URL for an R2 bucket
@@ -198,7 +198,7 @@ describe("r2", () => {
 				  wrangler r2 bucket info <bucket>    Get information about an R2 bucket
 				  wrangler r2 bucket delete <bucket>  Delete an R2 bucket
 				  wrangler r2 bucket sippy            Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket catalog          Manage R2 bucket warehouses using the R2 Data Catalog [open-beta]
+				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST inferface so engines can query R2 data as tables [open-beta]
 				  wrangler r2 bucket notification     Manage event notification rules for an R2 bucket
 				  wrangler r2 bucket domain           Manage custom domains for an R2 bucket
 				  wrangler r2 bucket dev-url          Manage public access via the r2.dev URL for an R2 bucket
@@ -947,13 +947,12 @@ describe("r2", () => {
 					"
 					wrangler r2 bucket catalog
 
-					Manage R2 bucket warehouses using the R2 Data Catalog [open-beta]
+					Manage the data catalog for your R2 buckets - provides an Iceberg REST inferface so engines can query R2 data as tables [open-beta]
 
 					COMMANDS
-					  wrangler r2 bucket catalog enable <bucket>   Enable an R2 bucket as an Iceberg warehouse [open-beta]
-					  wrangler r2 bucket catalog disable <bucket>  Disable R2 bucket as an Iceberg warehouse [open-beta]
-					  wrangler r2 bucket catalog get <bucket>      Check the status of the Iceberg warehouse on an R2 bucket [open-beta]
-					  wrangler r2 bucket catalog list              List the R2 bucket warehouses for your account [open-beta]
+					  wrangler r2 bucket catalog enable <bucket>   Enable the data catalog on an R2 bucket [open-beta]
+					  wrangler r2 bucket catalog disable <bucket>  Disable the data catalog for an R2 bucket [open-beta]
+					  wrangler r2 bucket catalog get <bucket>      Get the status of the data catalog for an R2 bucket [open-beta]
 
 					GLOBAL FLAGS
 					  -c, --config   Path to Wrangler configuration file  [string]
@@ -985,12 +984,13 @@ describe("r2", () => {
 					);
 					await runWrangler("r2 bucket catalog enable testBucket");
 					expect(std.out).toMatchInlineSnapshot(
-						`"✨ Successfully enabled R2 bucket 'testBucket' as an Iceberg warehouse. Warehouse name: 'test-warehouse-name', id: 'test-warehouse-id'.
+						`"✨ Successfully enabled data catalog on bucket 'testBucket'.
 
-			To integrate with your Iceberg Client, please use the Catalog Uri: 'https://catalog.cloudflarestorage.com/test-warehouse-name'.
+			Catalog URI: 'https://catalog.cloudflarestorage.com/test-warehouse-name'
 
-			You will need a Cloudflare API token with 'R2 Data Catalog' permissions for your Iceberg Client to integrate with the Catalog.
-			Please refer to https://developers.cloudflare.com/r2/api/s3/tokens/ for more details."`
+			Use the Catalog URI in Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to read or manage data as tables.
+			Note: You'll need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
+			For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"`
 					);
 				});
 
@@ -1004,7 +1004,7 @@ describe("r2", () => {
 						"
 						wrangler r2 bucket catalog enable <bucket>
 
-						Enable an R2 bucket as an Iceberg warehouse [open-beta]
+						Enable the data catalog on an R2 bucket [open-beta]
 
 						POSITIONALS
 						  bucket  The name of the bucket to enable  [string] [required]
@@ -1036,10 +1036,10 @@ describe("r2", () => {
 						"
 						wrangler r2 bucket catalog disable <bucket>
 
-						Disable R2 bucket as an Iceberg warehouse [open-beta]
+						Disable the data catalog for an R2 bucket [open-beta]
 
 						POSITIONALS
-						  bucket  The name of the bucket to disable  [string] [required]
+						  bucket  The name of the bucket to disable the data catalog for  [string] [required]
 
 						GLOBAL FLAGS
 						  -c, --config   Path to Wrangler configuration file  [string]
@@ -1058,7 +1058,7 @@ describe("r2", () => {
 				it("should disable R2 catalog for the given bucket", async () => {
 					setIsTTY(true);
 					mockConfirm({
-						text: "Are you sure you want to disable the warehouse for bucket 'testBucket'? Please note that this action is irreversible, and you will not be able to re-enable the warehouse on the bucket.",
+						text: "Are you sure you want to disable the data catalog for bucket 'testBucket'? This action is irreversible, and you cannot re-enable it on this bucket.",
 						result: true,
 					});
 					msw.use(
@@ -1072,7 +1072,7 @@ describe("r2", () => {
 					);
 					await runWrangler("r2 bucket catalog disable testBucket");
 					expect(std.out).toMatchInlineSnapshot(
-						`"✨ Successfully disabled R2 bucket 'testBucket' as an Iceberg warehouse."`
+						`"Successfully disabled the data catalog on bucket 'testBucket'."`
 					);
 				});
 			});
@@ -1088,10 +1088,10 @@ describe("r2", () => {
 						"
 						wrangler r2 bucket catalog get <bucket>
 
-						Check the status of the Iceberg warehouse on an R2 bucket [open-beta]
+						Get the status of the data catalog for an R2 bucket [open-beta]
 
 						POSITIONALS
-						  bucket  The name of the bucket to check  [string] [required]
+						  bucket  The name of the R2 bucket whose data catalog status to retrieve  [string] [required]
 
 						GLOBAL FLAGS
 						  -c, --config   Path to Wrangler configuration file  [string]
@@ -1132,12 +1132,11 @@ describe("r2", () => {
 					);
 					await runWrangler("r2 bucket catalog get test-bucket");
 					expect(std.out).toMatchInlineSnapshot(`
-					"Fetching warehouse status ...
-					┌─────────┬───────────┬─────────────┬────────┐
-					│ id      │ name      │ bucket      │ status │
-					├─────────┼───────────┼─────────────┼────────┤
-					│ test-id │ test-name │ test-bucket │ active │
-					└─────────┴───────────┴─────────────┴────────┘"
+					"Getting data catalog status for 'test-bucket'...
+					id:      test-id
+					name:    test-name
+					bucket:  test-bucket
+					status:  active"
 				`);
 				});
 
@@ -1168,68 +1167,8 @@ describe("r2", () => {
 					);
 					await runWrangler("r2 bucket catalog get test-bucket");
 					expect(std.out).toMatchInlineSnapshot(`
-					"Fetching warehouse status ...
-					No Catalog configuration found for the 'test-bucket' bucket."
-				`);
-				});
-			});
-
-			describe("list", () => {
-				it("should warn if no warehouses are found", async () => {
-					msw.use(
-						http.get(
-							"*/accounts/:accountId/r2-catalog",
-							async ({ params }) => {
-								const { accountId } = params;
-								expect(accountId).toEqual("some-account-id");
-								return HttpResponse.json(createFetchResult([], true));
-							},
-							{ once: true }
-						)
-					);
-					await runWrangler("r2 bucket catalog list");
-
-					expect(std.info).toMatchInlineSnapshot(`
-						"
-		You haven't created any warehouses on this account.
-
-		Use 'wrangler r2 catalog enable <bucket>' to enable one on your bucket.
-				"
-					`);
-				});
-
-				it("should list the warehouses", async () => {
-					msw.use(
-						http.get(
-							"*/accounts/:accountId/r2-catalog",
-							async ({ params }) => {
-								const { accountId } = params;
-								expect(accountId).toEqual("some-account-id");
-								return HttpResponse.json(
-									createFetchResult(
-										[
-											{
-												id: "test-id",
-												name: "test-name",
-												bucket: "test-bucket",
-												status: "active",
-											},
-										],
-										true
-									)
-								);
-							},
-							{ once: true }
-						)
-					);
-					await runWrangler("r2 bucket catalog list");
-					expect(std.out).toMatchInlineSnapshot(`
-					"Fetching warehouses ...
-					┌─────────┬───────────┬─────────────┬────────┐
-					│ id      │ name      │ bucket      │ status │
-					├─────────┼───────────┼─────────────┼────────┤
-					│ test-id │ test-name │ test-bucket │ active │
-					└─────────┴───────────┴─────────────┴────────┘"
+					"Getting data catalog status for 'test-bucket'...
+					Data catalog isn't enabled for bucket 'test-bucket'."
 				`);
 				});
 			});

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -986,11 +986,11 @@ describe("r2", () => {
 					expect(std.out).toMatchInlineSnapshot(
 						`"✨ Successfully enabled data catalog on bucket 'testBucket'.
 
-			Catalog URI: 'https://catalog.cloudflarestorage.com/test-warehouse-name'
+Catalog URI: 'https://catalog.cloudflarestorage.com/test-warehouse-name'
 
-			Use this Catalog URI with Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to query data as tables.
-			Note: You'll need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
-			For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"`
+Use this Catalog URI with Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to query data as tables.
+Note: You'll need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
+For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"`
 					);
 				});
 
@@ -1133,10 +1133,9 @@ describe("r2", () => {
 					await runWrangler("r2 bucket catalog get test-bucket");
 					expect(std.out).toMatchInlineSnapshot(`
 					"Getting data catalog status for 'test-bucket'...
-					id:      test-id
-					name:    test-name
-					bucket:  test-bucket
-					status:  active"
+					Bucket:       test-bucket
+					Catalog URI:  https://catalog.cloudflarestorage.com/test-name
+					Status:       active"
 				`);
 				});
 

--- a/packages/wrangler/src/core/teams.d.ts
+++ b/packages/wrangler/src/core/teams.d.ts
@@ -9,6 +9,7 @@ export type Teams =
 	| "Workers: Workers Observability"
 	| "Product: KV"
 	| "Product: R2"
+	| "Product: R2 Data Catalog"
 	| "Product: D1"
 	| "Product: Queues"
 	| "Product: AI"

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -82,6 +82,13 @@ import {
 	r2BucketUpdateStorageClassCommand,
 } from "./r2/bucket";
 import {
+	r2BucketCatalogDisableCommand,
+	r2BucketCatalogEnableCommand,
+	r2BucketCatalogGetCommand,
+	r2BucketCatalogListCommand,
+	r2BucketCatalogNamespace,
+} from "./r2/catalog";
+import {
 	r2BucketCORSDeleteCommand,
 	r2BucketCORSListCommand,
 	r2BucketCORSNamespace,
@@ -619,6 +626,26 @@ export function createCLIParser(argv: string[]) {
 		{
 			command: "wrangler r2 bucket sippy get",
 			definition: r2BucketSippyGetCommand,
+		},
+		{
+			command: "wrangler r2 bucket catalog",
+			definition: r2BucketCatalogNamespace,
+		},
+		{
+			command: "wrangler r2 bucket catalog enable",
+			definition: r2BucketCatalogEnableCommand,
+		},
+		{
+			command: "wrangler r2 bucket catalog disable",
+			definition: r2BucketCatalogDisableCommand,
+		},
+		{
+			command: "wrangler r2 bucket catalog get",
+			definition: r2BucketCatalogGetCommand,
+		},
+		{
+			command: "wrangler r2 bucket catalog list",
+			definition: r2BucketCatalogListCommand,
 		},
 		{
 			command: "wrangler r2 bucket notification",

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -85,7 +85,6 @@ import {
 	r2BucketCatalogDisableCommand,
 	r2BucketCatalogEnableCommand,
 	r2BucketCatalogGetCommand,
-	r2BucketCatalogListCommand,
 	r2BucketCatalogNamespace,
 } from "./r2/catalog";
 import {
@@ -642,10 +641,6 @@ export function createCLIParser(argv: string[]) {
 		{
 			command: "wrangler r2 bucket catalog get",
 			definition: r2BucketCatalogGetCommand,
-		},
-		{
-			command: "wrangler r2 bucket catalog list",
-			definition: r2BucketCatalogListCommand,
 		},
 		{
 			command: "wrangler r2 bucket notification",

--- a/packages/wrangler/src/r2/catalog.ts
+++ b/packages/wrangler/src/r2/catalog.ts
@@ -46,11 +46,11 @@ export const r2BucketCatalogEnableCommand = createCommand({
 		logger.log(
 			`✨ Successfully enabled data catalog on bucket '${args.bucket}'.
 
-			Catalog URI: '${catalogHost}'
+Catalog URI: '${catalogHost}'
 
-			Use this Catalog URI with Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to query data as tables.
-			Note: You'll need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
-			For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/`
+Use this Catalog URI with Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to query data as tables.
+Note: You'll need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
+For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/`
 		);
 	},
 });
@@ -111,11 +111,18 @@ export const r2BucketCatalogGetCommand = createCommand({
 		try {
 			const catalog = await getR2Catalog(accountId, args.bucket);
 
+			const env = getCloudflareApiEnvironmentFromEnv();
+			let catalogHost: string;
+			if (env === "staging") {
+				catalogHost = `https://catalog-staging.cloudflarestorage.com/${catalog.name}`;
+			} else {
+				catalogHost = `https://catalog.cloudflarestorage.com/${catalog.name}`;
+			}
+
 			const output = {
-				id: catalog.id,
-				name: catalog.name,
-				bucket: catalog.bucket,
-				status: catalog.status,
+				Bucket: args.bucket,
+				"Catalog URI": catalogHost,
+				Status: catalog.status,
 			};
 
 			logger.log(formatLabelledValues(output));

--- a/packages/wrangler/src/r2/catalog.ts
+++ b/packages/wrangler/src/r2/catalog.ts
@@ -1,0 +1,166 @@
+import { createCommand, createNamespace } from "../core/create-command";
+import { confirm } from "../dialogs";
+import { getCloudflareApiEnvironmentFromEnv } from "../environment-variables/misc-variables";
+import { logger } from "../logger";
+import { APIError } from "../parse";
+import { requireAuth } from "../user";
+import {
+	disableR2Catalog,
+	enableR2Catalog,
+	getR2Catalog,
+	listR2Catalog,
+} from "./helpers";
+
+export const r2BucketCatalogNamespace = createNamespace({
+	metadata: {
+		description: "Manage R2 bucket warehouses using the R2 Data Catalog",
+		status: "open-beta",
+		owner: "Product: R2 Data Catalog",
+	},
+});
+
+export const r2BucketCatalogEnableCommand = createCommand({
+	metadata: {
+		description: "Enable an R2 bucket as an Iceberg warehouse",
+		status: "open-beta",
+		owner: "Product: R2 Data Catalog",
+	},
+	positionalArgs: ["bucket"],
+	args: {
+		bucket: {
+			describe: "The name of the bucket to enable",
+			type: "string",
+			demandOption: true,
+		},
+	},
+	async handler(args, { config }) {
+		const accountId = await requireAuth(config);
+
+		const response = await enableR2Catalog(accountId, args.bucket);
+
+		let catalog_host: string;
+		const env = getCloudflareApiEnvironmentFromEnv();
+		if (env === "staging") {
+			catalog_host = `https://catalog-staging.cloudflarestorage.com/${response.name}`;
+		} else {
+			catalog_host = `https://catalog.cloudflarestorage.com/${response.name}`;
+		}
+
+		logger.log(
+			`✨ Successfully enabled R2 bucket '${args.bucket}' as an Iceberg warehouse. Warehouse name: '${response.name}', id: '${response.id}'.
+
+			To integrate with your Iceberg Client, please use the Catalog Uri: '${catalog_host}'.
+
+			You will need a Cloudflare API token with 'R2 Data Catalog' permissions for your Iceberg Client to integrate with the Catalog.
+			Please refer to https://developers.cloudflare.com/r2/api/s3/tokens/ for more details.`
+		);
+	},
+});
+
+export const r2BucketCatalogDisableCommand = createCommand({
+	metadata: {
+		description: "Disable R2 bucket as an Iceberg warehouse",
+		status: "open-beta",
+		owner: "Product: R2 Data Catalog",
+	},
+	positionalArgs: ["bucket"],
+	args: {
+		bucket: {
+			describe: "The name of the bucket to disable",
+			type: "string",
+			demandOption: true,
+		},
+	},
+	async handler(args, { config }) {
+		const accountId = await requireAuth(config);
+
+		const confirmedDisable = await confirm(
+			`Are you sure you want to disable the warehouse for bucket '${args.bucket}'? Please note that this action is irreversible, and you will not be able to re-enable the warehouse on the bucket.`
+		);
+		if (!confirmedDisable) {
+			logger.log("Disable cancelled.");
+			return;
+		}
+
+		await disableR2Catalog(accountId, args.bucket);
+
+		logger.log(
+			`✨ Successfully disabled R2 bucket '${args.bucket}' as an Iceberg warehouse.`
+		);
+	},
+});
+
+export const r2BucketCatalogGetCommand = createCommand({
+	metadata: {
+		description: "Check the status of the Iceberg warehouse on an R2 bucket",
+		status: "open-beta",
+		owner: "Product: R2 Data Catalog",
+	},
+	positionalArgs: ["bucket"],
+	args: {
+		bucket: {
+			describe: "The name of the bucket to check",
+			type: "string",
+			demandOption: true,
+		},
+	},
+	async handler(args, { config }) {
+		const accountId = await requireAuth(config);
+
+		try {
+			logger.log(`Fetching warehouse status ...`);
+			const warehouse = await getR2Catalog(accountId, args.bucket);
+			logger.table([
+				{
+					id: warehouse.id,
+					name: warehouse.name,
+					bucket: warehouse.bucket,
+					status: warehouse.status,
+				},
+			]);
+		} catch (e) {
+			// R2 Data Catalog 40401 corresponds to a 404
+			if (e instanceof APIError && e.code == 40401) {
+				logger.log(
+					`No Catalog configuration found for the '${args.bucket}' bucket.`
+				);
+			} else {
+				throw e;
+			}
+		}
+	},
+});
+
+export const r2BucketCatalogListCommand = createCommand({
+	metadata: {
+		description: "List the R2 bucket warehouses for your account",
+		status: "open-beta",
+		owner: "Product: R2 Data Catalog",
+	},
+	positionalArgs: [],
+	args: {},
+	async handler(args, { config }) {
+		const accountId = await requireAuth(config);
+
+		logger.log(`Fetching warehouses ...`);
+		const warehouses = await listR2Catalog(accountId);
+
+		if (warehouses.length === 0) {
+			logger.info(`
+		You haven't created any warehouses on this account.
+
+		Use 'wrangler r2 catalog enable <bucket>' to enable one on your bucket.
+				`);
+			return;
+		}
+
+		logger.table(
+			warehouses.map((warehouse) => ({
+				id: warehouse.id,
+				name: warehouse.name,
+				bucket: warehouse.bucket,
+				status: warehouse.status,
+			}))
+		);
+	},
+});

--- a/packages/wrangler/src/r2/catalog.ts
+++ b/packages/wrangler/src/r2/catalog.ts
@@ -10,7 +10,7 @@ import { disableR2Catalog, enableR2Catalog, getR2Catalog } from "./helpers";
 export const r2BucketCatalogNamespace = createNamespace({
 	metadata: {
 		description:
-			"Manage the data catalog for your R2 buckets - provides an Iceberg REST inferface so engines can query R2 data as tables",
+			"Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark, DuckDB, and Trino",
 		status: "open-beta",
 		owner: "Product: R2 Data Catalog",
 	},
@@ -48,7 +48,7 @@ export const r2BucketCatalogEnableCommand = createCommand({
 
 			Catalog URI: '${catalogHost}'
 
-			Use the Catalog URI in Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to read or manage data as tables.
+			Use this Catalog URI with Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to query data as tables.
 			Note: You'll need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
 			For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/`
 		);

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -492,6 +492,63 @@ export async function putR2Sippy(
 	);
 }
 
+type R2Warehouse = {
+	id: string;
+	name: string;
+	bucket: string;
+	status: "active" | "inactive";
+};
+
+/**
+ * Retreive all the active warehouses for the account
+ */
+export async function listR2Catalog(accountId: string): Promise<R2Warehouse[]> {
+	return await fetchResult(`/accounts/${accountId}/r2-catalog`, {
+		method: "GET",
+	});
+}
+
+/**
+ * Retreive the warehouse for the bucket with the given name
+ */
+export async function getR2Catalog(
+	accountId: string,
+	bucketName: string
+): Promise<R2Warehouse> {
+	return await fetchResult(`/accounts/${accountId}/r2-catalog/${bucketName}`, {
+		method: "GET",
+	});
+}
+
+type R2WarehouseEnableResponse = {
+	id: string;
+	name: string;
+};
+
+/**
+ * Activate the R2 bucket as an Iceberg warehouse
+ */
+export async function enableR2Catalog(
+	accountId: string,
+	bucketName: string
+): Promise<R2WarehouseEnableResponse> {
+	return await fetchResult(`/accounts/${accountId}/r2-catalog/${bucketName}`, {
+		method: "POST",
+	});
+}
+
+/**
+ * Deactivate the R2 bucket as an Iceberg warehouse
+ */
+export async function disableR2Catalog(
+	accountId: string,
+	bucketName: string
+): Promise<R2WarehouseEnableResponse> {
+	return await fetchResult(`/accounts/${accountId}/r2-catalog/${bucketName}`, {
+		method: "DELETE",
+	});
+}
+
 const R2EventableOperations = [
 	"PutObject",
 	"DeleteObject",

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -500,15 +500,6 @@ type R2Warehouse = {
 };
 
 /**
- * Retreive all the active warehouses for the account
- */
-export async function listR2Catalog(accountId: string): Promise<R2Warehouse[]> {
-	return await fetchResult(`/accounts/${accountId}/r2-catalog`, {
-		method: "GET",
-	});
-}
-
-/**
  * Retreive the warehouse for the bucket with the given name
  */
 export async function getR2Catalog(


### PR DESCRIPTION
Fixes IGLOO-10.

This change adds the wrangler commands to manage R2 buckets as iceberg warehouses. The commands would enable users to enable/disable buckets as warehouses as well as fetch and list warehouses by calling the R2 data catalog.

CR-1140509

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/issues/21030 <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
