### PR TITLE
vite dev support for SPA mode

### DIFF
--- a/.changeset/eight-cars-fall.md
+++ b/.changeset/eight-cars-fall.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+"wrangler": minor
+"@cloudflare/vite-plugin": patch
+---
+
+Add support for `assets_navigation_prefer_asset_serving` in Vite (`dev` and `preview`)

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -95,6 +95,14 @@ function getUserRequest(
 	// https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#accept-encoding
 	request.headers.set("Accept-Encoding", "br, gzip");
 
+	// `miniflare.dispatchFetch(request)` strips any `sec-fetch-mode` header. This allows clients to
+	// send it over a `x-mf-sec-fetch-mode` header instead (currently required by `vite preview`)
+	const secFetchMode = request.headers.get("X-Mf-Sec-Fetch-Mode");
+	if (secFetchMode) {
+		request.headers.set("Sec-Fetch-Mode", secFetchMode);
+	}
+	request.headers.delete("X-Mf-Sec-Fetch-Mode");
+
 	if (rewriteHeadersFromOriginalUrl) {
 		request.headers.set("Host", url.host);
 	}

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/spa-with-api.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/spa-with-api.spec.ts
@@ -1,5 +1,7 @@
+import { createConnection } from "node:net";
 import { expect, test } from "vitest";
 import { page } from "../../__test-utils__";
+import { viteTestUrl } from "../../vitest-setup";
 
 test("returns the correct home page", async () => {
 	const content = await page.textContent("h1");
@@ -17,4 +19,43 @@ test("returns the response from the API", async () => {
 	await responsePromise;
 	const contentAfter = await button.innerText();
 	expect(contentAfter).toBe("Name from API is: Cloudflare");
+});
+
+test("returns the home page even for 404-y pages", async () => {
+	await page.goto(`${viteTestUrl}/foo`);
+	const content = await page.textContent("h1");
+	expect(content).toBe("Vite + React");
+});
+
+test("returns the home page even for API-y pages", async () => {
+	await page.goto(`${viteTestUrl}/api/`);
+	const content = await page.textContent("h1");
+	expect(content).toBe("Vite + React");
+});
+
+test("requests made with/without explicit 'sec-fetch-mode: navigate' header to delegate correctly", async () => {
+	const responseWithoutHeader = await fetch(`${viteTestUrl}/foo`);
+	expect(responseWithoutHeader.status).toBe(404);
+	expect(await responseWithoutHeader.text()).toEqual("nothing here");
+
+	// can't make `fetch`es with `sec-fetch-mode: navigate` header, so we're doing it raw
+	const { hostname, port } = new URL(viteTestUrl);
+	const socket = createConnection(parseInt(port), hostname, () => {
+		socket.write(
+			`GET /foo HTTP/1.1\r\nHost: ${hostname}\r\nSec-Fetch-Mode: navigate\r\n\r\n`
+		);
+	});
+
+	let responseWithoutHeaderContentBuffer = "";
+	socket.on("data", (data) => {
+		responseWithoutHeaderContentBuffer += data.toString();
+	});
+
+	const responseWithoutHeaderContent = await new Promise((resolve) =>
+		socket.on("close", () => {
+			resolve(responseWithoutHeaderContentBuffer);
+		})
+	);
+
+	expect(responseWithoutHeaderContent).toContain("Vite + React");
 });

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/api/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/api/index.ts
@@ -12,6 +12,6 @@ export default {
 			});
 		}
 
-		return env.ASSETS.fetch(request);
+		return new Response("nothing here", { status: 404 });
 	},
 } satisfies ExportedHandler<Env>;

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/wrangler.toml
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/wrangler.toml
@@ -1,4 +1,5 @@
 name = "api"
 main = "./api/index.ts"
 compatibility_date = "2024-12-30"
+compatibility_flags = ["assets_navigation_prefers_asset_serving"]
 assets = { not_found_handling = "single-page-application", binding = "ASSETS" }

--- a/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
+++ b/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
@@ -1,15 +1,14 @@
 // @ts-ignore
 import AssetWorker from "@cloudflare/workers-shared/dist/asset-worker.mjs";
 import { UNKNOWN_HOST } from "../shared";
-import type { WorkerEntrypoint } from "cloudflare:workers";
 
 interface Env {
 	__VITE_ASSET_EXISTS__: Fetcher;
 	__VITE_FETCH_ASSET__: Fetcher;
 }
 
-export default class CustomAssetWorker extends (AssetWorker as typeof WorkerEntrypoint<Env>) {
-	override async fetch(request: Request): Promise<Response> {
+export default class CustomAssetWorker extends AssetWorker {
+	async fetch(request: Request): Promise<Response> {
 		const response = await super.fetch!(request);
 		const modifiedResponse = new Response(response.body, response);
 		modifiedResponse.headers.delete("ETag");
@@ -21,7 +20,9 @@ export default class CustomAssetWorker extends (AssetWorker as typeof WorkerEntr
 		eTag: string
 	): Promise<{ readableStream: ReadableStream; contentType: string }> {
 		const url = new URL(eTag, UNKNOWN_HOST);
-		const response = await this.env.__VITE_FETCH_ASSET__.fetch(url);
+		const response = await (
+			this as typeof AssetWorker as { env: Env }
+		).env.__VITE_FETCH_ASSET__.fetch(url);
 
 		if (!response.body) {
 			throw new Error(`Unexpected error. No HTML found for ${eTag}.`);
@@ -32,9 +33,20 @@ export default class CustomAssetWorker extends (AssetWorker as typeof WorkerEntr
 	async unstable_exists(pathname: string): Promise<string | null> {
 		// We need this regex to avoid getting `//` as a pathname, which results in an invalid URL. Should this be fixed upstream?
 		const url = new URL(pathname.replace(/^\/{2,}/, "/"), UNKNOWN_HOST);
-		const response = await this.env.__VITE_ASSET_EXISTS__.fetch(url);
+		const response = await (
+			this as typeof AssetWorker as { env: Env }
+		).env.__VITE_ASSET_EXISTS__.fetch(url);
 		const exists = await response.json();
 
 		return exists ? pathname : null;
+	}
+	async unstable_canFetch(request: Request) {
+		// the 'sec-fetch-mode: navigate' header is stripped by something on its way into this worker
+		// so we restore it from 'x-mf-sec-fetch-mode'
+		const secFetchMode = request.headers.get("X-Mf-Sec-Fetch-Mode");
+		if (secFetchMode) {
+			request.headers.set("Sec-Fetch-Mode", secFetchMode);
+		}
+		return await super.unstable_canFetch(request);
 	}
 }

--- a/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
+++ b/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
@@ -16,9 +16,10 @@ export default class CustomAssetWorker extends AssetWorker {
 
 		return modifiedResponse;
 	}
-	async unstable_getByETag(
-		eTag: string
-	): Promise<{ readableStream: ReadableStream; contentType: string }> {
+	async unstable_getByETag(eTag: string): Promise<{
+		readableStream: ReadableStream;
+		contentType: string | undefined;
+	}> {
 		const url = new URL(eTag, UNKNOWN_HOST);
 		const response = await (
 			this as typeof AssetWorker as { env: Env }
@@ -28,7 +29,10 @@ export default class CustomAssetWorker extends AssetWorker {
 			throw new Error(`Unexpected error. No HTML found for ${eTag}.`);
 		}
 
-		return { readableStream: response.body, contentType: "text/html" };
+		return {
+			readableStream: response.body,
+			contentType: response.headers.get("Content-Type") ?? undefined,
+		};
 	}
 	async unstable_exists(pathname: string): Promise<string | null> {
 		// We need this regex to avoid getting `//` as a pathname, which results in an invalid URL. Should this be fixed upstream?

--- a/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
+++ b/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
@@ -16,10 +16,9 @@ export default class CustomAssetWorker extends AssetWorker {
 
 		return modifiedResponse;
 	}
-	async unstable_getByETag(eTag: string): Promise<{
-		readableStream: ReadableStream;
-		contentType: string | undefined;
-	}> {
+	async unstable_getByETag(
+		eTag: string
+	): Promise<{ readableStream: ReadableStream; contentType: string }> {
 		const url = new URL(eTag, UNKNOWN_HOST);
 		const response = await (
 			this as typeof AssetWorker as { env: Env }
@@ -29,10 +28,7 @@ export default class CustomAssetWorker extends AssetWorker {
 			throw new Error(`Unexpected error. No HTML found for ${eTag}.`);
 		}
 
-		return {
-			readableStream: response.body,
-			contentType: response.headers.get("Content-Type") ?? undefined,
-		};
+		return { readableStream: response.body, contentType: "text/html" };
 	}
 	async unstable_exists(pathname: string): Promise<string | null> {
 		// We need this regex to avoid getting `//` as a pathname, which results in an invalid URL. Should this be fixed upstream?

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -242,6 +242,12 @@ export function getDevMiniflareOptions(
 			],
 			bindings: {
 				CONFIG: {
+					...(entryWorkerConfig?.compatibility_date
+						? { compatibility_date: entryWorkerConfig?.compatibility_date }
+						: {}),
+					...(entryWorkerConfig?.compatibility_flags
+						? { compatibility_flags: entryWorkerConfig.compatibility_flags }
+						: {}),
 					...(assetsConfig?.html_handling
 						? { html_handling: assetsConfig.html_handling }
 						: {}),

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -203,6 +203,21 @@ export function getDevMiniflareOptions(
 			? resolvedPluginConfig.config.assets
 			: entryWorkerConfig?.assets;
 
+	const compatibilityOptions =
+		resolvedPluginConfig.type === "assets-only"
+			? {
+					compatibility_date: resolvedPluginConfig.config.compatibility_date,
+					compatibility_flags: resolvedPluginConfig.config.compatibility_flags,
+				}
+			: {
+					...(entryWorkerConfig?.compatibility_date
+						? { compatibility_date: entryWorkerConfig?.compatibility_date }
+						: {}),
+					...(entryWorkerConfig?.compatibility_flags
+						? { compatibility_flags: entryWorkerConfig?.compatibility_flags }
+						: {}),
+				};
+
 	const assetWorkers: Array<WorkerOptions> = [
 		{
 			name: ROUTER_WORKER_NAME,
@@ -242,12 +257,7 @@ export function getDevMiniflareOptions(
 			],
 			bindings: {
 				CONFIG: {
-					...(entryWorkerConfig?.compatibility_date
-						? { compatibility_date: entryWorkerConfig?.compatibility_date }
-						: {}),
-					...(entryWorkerConfig?.compatibility_flags
-						? { compatibility_flags: entryWorkerConfig.compatibility_flags }
-						: {}),
+					...compatibilityOptions,
 					...(assetsConfig?.html_handling
 						? { html_handling: assetsConfig.html_handling }
 						: {}),

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -36,6 +36,7 @@ export interface AssetsOnlyConfig extends SanitizedWorkerConfig {
 	topLevelName: Defined<SanitizedWorkerConfig["topLevelName"]>;
 	name: Defined<SanitizedWorkerConfig["name"]>;
 	compatibility_date: Defined<SanitizedWorkerConfig["compatibility_date"]>;
+	compatibility_flags: Defined<SanitizedWorkerConfig["compatibility_flags"]>;
 }
 
 export interface WorkerConfig extends AssetsOnlyConfig {

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -36,7 +36,6 @@ export interface AssetsOnlyConfig extends SanitizedWorkerConfig {
 	topLevelName: Defined<SanitizedWorkerConfig["topLevelName"]>;
 	name: Defined<SanitizedWorkerConfig["name"]>;
 	compatibility_date: Defined<SanitizedWorkerConfig["compatibility_date"]>;
-	compatibility_flags: Defined<SanitizedWorkerConfig["compatibility_flags"]>;
 }
 
 export interface WorkerConfig extends AssetsOnlyConfig {

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -22,6 +22,14 @@ export function getRouterWorker(miniflare: Miniflare) {
 }
 
 export function toMiniflareRequest(request: Request): MiniflareRequest {
+	// something about how we dispatch this request strips the 'sec-fetch-mode: navigate' and replaces it with 'sec-fetch-mode: cors'
+	// current theory is that it is hattip or undici as it converts it for transport
+	// so, because this isn't a real security use-case,
+	// we can just set some arbitrary other header and convert that back into 'sec-fetch-mode: navigate' in our worker
+	const secFetchMode = request.headers.get("Sec-Fetch-Mode");
+	if (secFetchMode) {
+		request.headers.set("X-Mf-Sec-Fetch-Mode", secFetchMode);
+	}
 	return new MiniflareRequest(request.url, {
 		method: request.method,
 		headers: [["accept-encoding", "identity"], ...request.headers],

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -22,10 +22,7 @@ export function getRouterWorker(miniflare: Miniflare) {
 }
 
 export function toMiniflareRequest(request: Request): MiniflareRequest {
-	// something about how we dispatch this request strips the 'sec-fetch-mode: navigate' and replaces it with 'sec-fetch-mode: cors'
-	// current theory is that it is hattip or undici as it converts it for transport
-	// so, because this isn't a real security use-case,
-	// we can just set some arbitrary other header and convert that back into 'sec-fetch-mode: navigate' in our worker
+	// Undici sets the `Sec-Fetch-Mode` header to `cors` so we capture it in a custom header to be converted back later.
 	const secFetchMode = request.headers.get("Sec-Fetch-Mode");
 	if (secFetchMode) {
 		request.headers.set("X-Mf-Sec-Fetch-Mode", secFetchMode);

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -436,7 +436,8 @@ export function getAssetsOptions(
 		html_handling: config.assets?.html_handling,
 		not_found_handling: config.assets?.not_found_handling,
 		// The _redirects and _headers files are parsed in Miniflare in dev and parsing is not required for deploy
-		// Similarly, `compatibility_date` and `compatibility_flags` are populated by Miniflare from the Worker definition and also are not required for deploy
+		compatibility_date: config.compatibility_date,
+		compatibility_flags: config.compatibility_flags,
 	};
 
 	return {


### PR DESCRIPTION
Fixes WC-3319.

Implements `vite dev` support for Workers Assets' new SPA mode.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: will follow up once everything lands
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
