### PR TITLE
[do-not-merge] feat: add an `event-subscriptions` subcommand

### DIFF
--- a/.changeset/small-sites-rest.md
+++ b/.changeset/small-sites-rest.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Added an `event-subscriptions` subcommand

--- a/packages/wrangler/src/__tests__/event-subscriptions.test.ts
+++ b/packages/wrangler/src/__tests__/event-subscriptions.test.ts
@@ -1,0 +1,857 @@
+import assert from "node:assert";
+import { http, HttpResponse } from "msw";
+import * as products from "../event-subscriptions/products";
+import { mockAccountId, mockApiToken } from "./helpers/mock-account-id";
+import { mockConsoleMethods } from "./helpers/mock-console";
+import { clearDialogs } from "./helpers/mock-dialogs";
+import { useMockIsTTY } from "./helpers/mock-istty";
+import { msw } from "./helpers/msw";
+import { runInTempDir } from "./helpers/run-in-tmp";
+import { runWrangler } from "./helpers/run-wrangler";
+
+const testAccountId = "some-account-id";
+
+describe("wrangler event-subscriptions", () => {
+	mockAccountId({ accountId: testAccountId });
+	mockApiToken();
+	runInTempDir();
+
+	const std = mockConsoleMethods();
+
+	const { setIsTTY } = useMockIsTTY();
+	beforeEach(() => {
+		setIsTTY(true);
+	});
+
+	afterEach(() => {
+		msw.restoreHandlers();
+		vi.restoreAllMocks();
+		clearDialogs();
+	});
+
+	describe("event-subscription browse", async () => {
+		test("shows all defined product events", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/events",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: [
+								{
+									id: "slurper",
+									name: "Super Slurper",
+									events: [{ name: "e1" }, { name: "e2" }],
+								},
+								{
+									id: "workflows",
+									name: "Workflows",
+									events: [{ name: "e10" }, { name: "e20" }],
+								},
+							],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler("event-subscriptions browse");
+
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌───────────────┬──────────┐
+				│ service       │ events   │
+				├───────────────┼──────────┤
+				│ Super Slurper │ e1, e2   │
+				├───────────────┼──────────┤
+				│ Workflows     │ e10, e20 │
+				└───────────────┴──────────┘"
+			`);
+		});
+
+		test("ignores products that do not exist on both QBW and Wrangler", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/events",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: [
+								{
+									id: "workflows",
+									name: "Workflows",
+									events: [{ name: "e10" }, { name: "e20" }],
+								},
+							],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler("event-subscriptions browse");
+
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌───────────┬──────────┐
+				│ service   │ events   │
+				├───────────┼──────────┤
+				│ Workflows │ e10, e20 │
+				└───────────┴──────────┘"
+			`);
+		});
+
+		test("can filter product ids with --source", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/events",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: [
+								{ id: "slurper", name: "Super Slurper", events: [] },
+								{ id: "workflows", name: "Workflows", events: [] },
+							],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler("event-subscriptions browse --source=slurp");
+
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌───────────────┬────────┐
+				│ service       │ events │
+				├───────────────┼────────┤
+				│ Super Slurper │        │
+				└───────────────┴────────┘"
+			`);
+		});
+
+		test("can filter multiple product ids with --source", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/events",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: [
+								{ id: "slurper", name: "Super Slurper", events: [] },
+								{ id: "workflows", name: "Workflows", events: [] },
+								{ id: "workersAI", name: "Workers AI", events: [] },
+							],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions browse --source=slurp,workfl"
+			);
+
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌───────────────┬────────┐
+				│ service       │ events │
+				├───────────────┼────────┤
+				│ Super Slurper │        │
+				├───────────────┼────────┤
+				│ Workflows     │        │
+				└───────────────┴────────┘"
+			`);
+		});
+
+		test("can filter product names with --source", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/events",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: [
+								{ id: "slurper", name: "Super Slurper", events: [] },
+								{ id: "workflows", name: "Workflows", events: [] },
+							],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler("event-subscriptions browse --source=super");
+
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌───────────────┬────────┐
+				│ service       │ events │
+				├───────────────┼────────┤
+				│ Super Slurper │        │
+				└───────────────┴────────┘"
+			`);
+		});
+
+		test("can filter multiple product names with --source", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/events",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: [
+								{ id: "slurper", name: "Super Slurper", events: [] },
+								{ id: "workflows", name: "Workflows", events: [] },
+								{ id: "workersAI", name: "Workers AI", events: [] },
+							],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions browse --source=super,ai"
+			);
+
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌───────────────┬────────┐
+				│ service       │ events │
+				├───────────────┼────────┤
+				│ Super Slurper │        │
+				├───────────────┼────────┤
+				│ Workers AI    │        │
+				└───────────────┴────────┘"
+			`);
+		});
+	});
+
+	describe("event-subscriptions list", async () => {
+		test("lists no subscriptions", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/subscriptions",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: [],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler("event-subscriptions list");
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌────┬──────┬────────┬─────────────┬────────┐
+				│ id │ name │ source │ destination │ events │
+				├────┼──────┼────────┼─────────────┼────────┤
+				│    │      │        │             │        │
+				└────┴──────┴────────┴─────────────┴────────┘"
+			`);
+		});
+
+		test("lists all subscriptions", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/subscriptions",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: [
+								{
+									id: "test-subscription-id-1",
+									name: "test-subscription-1",
+									enabled: true,
+									source: { service: "slurper" },
+									destination: { service: "queues", queue_id: "test-queue-id" },
+									events: ["e1", "e2"],
+								},
+								{
+									id: "test-subscription-id-2",
+									name: "test-subscription-2",
+									enabled: true,
+									source: {
+										service: "workflows",
+										workflow_name: "test-workflow-name",
+									},
+									destination: { service: "queues", queue_id: "test-queue-id" },
+									events: ["e1", "e2"],
+								},
+							],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler("event-subscriptions list");
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌────────────────────────┬─────────────────────┬──────────────────────────────┬──────────────────────┬────────┐
+				│ id                     │ name                │ source                       │ destination          │ events │
+				├────────────────────────┼─────────────────────┼──────────────────────────────┼──────────────────────┼────────┤
+				│ test-subscription-id-1 │ test-subscription-1 │ slurper                      │ queues.test-queue-id │ e1, e2 │
+				├────────────────────────┼─────────────────────┼──────────────────────────────┼──────────────────────┼────────┤
+				│ test-subscription-id-2 │ test-subscription-2 │ workflows.test-workflow-name │ queues.test-queue-id │ e1, e2 │
+				└────────────────────────┴─────────────────────┴──────────────────────────────┴──────────────────────┴────────┘"
+			`);
+		});
+
+		test("can handle subscriptions for unknown products", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/subscriptions",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: [
+								{
+									id: "test-subscription-id",
+									name: "test-subscription",
+									enabled: true,
+									source: { service: "workersKV", namespace: "test-namespace" },
+									destination: { service: "queues", queue_id: "test-queue-id" },
+									events: ["e1", "e2"],
+								},
+							],
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler("event-subscriptions list");
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌──────────────────────┬───────────────────┬──────────────────────────────────────────────────────┬─────────────────────────────────────────────────┬────────┐
+				│ id                   │ name              │ source                                               │ destination                                     │ events │
+				├──────────────────────┼───────────────────┼──────────────────────────────────────────────────────┼─────────────────────────────────────────────────┼────────┤
+				│ test-subscription-id │ test-subscription │ {\\"service\\":\\"workersKV\\",\\"namespace\\":\\"test-namespace\\"} │ {\\"service\\":\\"queues\\",\\"queue_id\\":\\"test-queue-id\\"} │ e1, e2 │
+				└──────────────────────┴───────────────────┴──────────────────────────────────────────────────────┴─────────────────────────────────────────────────┴────────┘"
+			`);
+		});
+	});
+
+	describe("event-subscriptions get", async () => {
+		test("gets a single subscription", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/:subscriptionId",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						expect(params.subscriptionId).toEqual("test-subscription-id");
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: {
+								id: "test-subscription-id-1",
+								name: "test-subscription-1",
+								enabled: true,
+								source: { service: "slurper" },
+								destination: { service: "queues", queue_id: "test-queue-id" },
+								events: ["e1", "e2"],
+							},
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions get test-subscription-id"
+			);
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌────────────────────────┬─────────────────────┬─────────┬──────────────────────┬────────┐
+				│ id                     │ name                │ source  │ destination          │ events │
+				├────────────────────────┼─────────────────────┼─────────┼──────────────────────┼────────┤
+				│ test-subscription-id-1 │ test-subscription-1 │ slurper │ queues.test-queue-id │ e1, e2 │
+				└────────────────────────┴─────────────────────┴─────────┴──────────────────────┴────────┘"
+			`);
+		});
+
+		test("errors if the subscription with the given ID does not exist", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/:subscriptionId",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						expect(params.subscriptionId).toEqual("test-subscription-id");
+						return HttpResponse.json(
+							{
+								success: false,
+								errors: [{ message: "No subscription with this ID" }],
+								result: {},
+							},
+							{ status: 404 }
+						);
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions get test-subscription-id"
+			);
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/event_subscriptions/subscriptions/test-subscription-id) failed.]`
+			);
+			expect(std.out).toMatch(new RegExp(/No subscription with this ID/));
+		});
+
+		test("can handle subscriptions for unknown products", async () => {
+			msw.use(
+				http.get(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/:subscriptionId",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						expect(params.subscriptionId).toEqual("test-subscription-id");
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: {
+								id: "test-subscription-id",
+								name: "test-subscription",
+								enabled: true,
+								source: { service: "workersKV", namespace: "test-namespace" },
+								destination: { service: "queues", queue_id: "test-queue-id" },
+								events: ["e1", "e2"],
+							},
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions get test-subscription-id"
+			);
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌──────────────────────┬───────────────────┬──────────────────────────────────────────────────────┬──────────────────────┬────────┐
+				│ id                   │ name              │ source                                               │ destination          │ events │
+				├──────────────────────┼───────────────────┼──────────────────────────────────────────────────────┼──────────────────────┼────────┤
+				│ test-subscription-id │ test-subscription │ {\\"service\\":\\"workersKV\\",\\"namespace\\":\\"test-namespace\\"} │ queues.test-queue-id │ e1, e2 │
+				└──────────────────────┴───────────────────┴──────────────────────────────────────────────────────┴──────────────────────┴────────┘"
+			`);
+		});
+	});
+
+	describe("event-subscription create", async () => {
+		test("creates a new subscription", async () => {
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/event_subscriptions/subscriptions",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: {
+								id: "test-subscription-id-1",
+								name: "test-subscription-1",
+								enabled: true,
+								source: { service: "slurper" },
+								destination: { service: "queues", queue_id: "test-queue-id" },
+								events: ["e1", "e2"],
+							},
+						});
+					},
+					{ once: true }
+				)
+			);
+			const result = runWrangler(
+				"event-subscriptions create test-subscription --source=slurper --destination=queues.queueId --events=e1,e2"
+			);
+
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌────────────────────────┬─────────────────────┬─────────┬──────────────────────┬────────┐
+				│ id                     │ name                │ source  │ destination          │ events │
+				├────────────────────────┼─────────────────────┼─────────┼──────────────────────┼────────┤
+				│ test-subscription-id-1 │ test-subscription-1 │ slurper │ queues.test-queue-id │ e1,e2  │
+				└────────────────────────┴─────────────────────┴─────────┴──────────────────────┴────────┘"
+			`);
+		});
+
+		test("errors for unrecognized sources", async () => {
+			const result = runWrangler(
+				"event-subscriptions create test-subscription --source=unrecognized.resourceId --destination=queues.queueId --events=e1,e2"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: Unrecognized source service. Must be one of slurper, workersAI, workersBuilds, workflows]`
+			);
+		});
+
+		test("errors for malformed sources", async () => {
+			const result = runWrangler(
+				"event-subscriptions create test-subscription --source=workflows --destination=queues.queueId --events=e1,e2"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: Invalid source. Must be formatted as workflows.<workflow_id>]`
+			);
+		});
+
+		test("errors for unrecognized destinations", async () => {
+			const result = runWrangler(
+				"event-subscriptions create test-subscription --source=slurper --destination=unrecognized --events=e1,e2"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: Invalid destination. Must be formatted as queues.<queue_id>]`
+			);
+		});
+
+		test("errors for malformed destinations", async () => {
+			const result = runWrangler(
+				"event-subscriptions create test-subscription --source=slurper --destination=queues --events=e1,e2"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: Invalid destination. Must be formatted as queues.<queue_id>]`
+			);
+		});
+
+		test("errors for unrecognized events", async () => {
+			msw.use(
+				http.post(
+					"*/accounts/:accountId/event_subscriptions/subscriptions",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json(
+							{
+								success: false,
+								errors: [
+									{
+										message: "Invalid event name",
+									},
+								],
+							},
+							{ status: 400 }
+						);
+					},
+					{ once: true }
+				)
+			);
+			const result = runWrangler(
+				"event-subscriptions create test-subscription --source=slurper --destination=queues.queueID --events=e1,e2"
+			);
+
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/event_subscriptions/subscriptions) failed.]`
+			);
+			expect(std.out).toMatch(new RegExp(/Invalid event name/));
+		});
+	});
+
+	describe("event-subscriptions update", async () => {
+		test("can update a subscription's name", async () => {
+			msw.use(
+				http.patch(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/:subscriptionId",
+					async ({ params, request }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						expect(params.subscriptionId).toEqual("test-subscription-id");
+						expect(await request.json()).toEqual({ name: "updated" });
+
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: {
+								id: "test-subscription-id",
+								name: "updated",
+								enabled: true,
+								source: { service: "slurper" },
+								destination: { service: "queues", queue_id: "test-queue-id" },
+								events: ["e1", "e2"],
+							},
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions update test-subscription-id --name=updated"
+			);
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌──────────────────────┬─────────┬─────────┬──────────────────────┬────────┐
+				│ id                   │ name    │ source  │ destination          │ events │
+				├──────────────────────┼─────────┼─────────┼──────────────────────┼────────┤
+				│ test-subscription-id │ updated │ slurper │ queues.test-queue-id │ e1, e2 │
+				└──────────────────────┴─────────┴─────────┴──────────────────────┴────────┘"
+			`);
+		});
+
+		test("can update a subscription's destination", async () => {
+			msw.use(
+				http.patch(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/:subscriptionId",
+					async ({ params, request }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						expect(params.subscriptionId).toEqual("test-subscription-id");
+						expect(await request.json()).toEqual({
+							destination: { service: "queues", queue_id: "updated" },
+						});
+
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: {
+								id: "test-subscription-id",
+								name: "updated",
+								enabled: true,
+								source: { service: "slurper" },
+								destination: { service: "queues", queue_id: "updated" },
+								events: ["e1", "e2"],
+							},
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions update test-subscription-id --destination=queues.updated"
+			);
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌──────────────────────┬─────────┬─────────┬────────────────┬────────┐
+				│ id                   │ name    │ source  │ destination    │ events │
+				├──────────────────────┼─────────┼─────────┼────────────────┼────────┤
+				│ test-subscription-id │ updated │ slurper │ queues.updated │ e1, e2 │
+				└──────────────────────┴─────────┴─────────┴────────────────┴────────┘"
+			`);
+		});
+
+		test("can update a subscription's events", async () => {
+			msw.use(
+				http.patch(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/:subscriptionId",
+					async ({ params, request }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						expect(params.subscriptionId).toEqual("test-subscription-id");
+						expect(await request.json()).toEqual({
+							events: ["e2"],
+						});
+
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: {
+								id: "test-subscription-id",
+								name: "updated",
+								enabled: true,
+								source: { service: "slurper" },
+								destination: { service: "queues", queue_id: "updated" },
+								events: ["e2"],
+							},
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions update test-subscription-id --events=e2"
+			);
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`
+				"┌──────────────────────┬─────────┬─────────┬────────────────┬────────┐
+				│ id                   │ name    │ source  │ destination    │ events │
+				├──────────────────────┼─────────┼─────────┼────────────────┼────────┤
+				│ test-subscription-id │ updated │ slurper │ queues.updated │ e2     │
+				└──────────────────────┴─────────┴─────────┴────────────────┴────────┘"
+			`);
+		});
+
+		test("can handle unrecognized destinations", async () => {
+			const result = runWrangler(
+				"event-subscriptions update test-subscription-id --destination=unrecognized.updated"
+			);
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: Invalid destination. Must be formatted as queues.<queue_id>]`
+			);
+		});
+
+		test("can handle malformed destinations", async () => {
+			msw.use(
+				http.patch(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/:subscriptionId",
+					async ({ params, request }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						expect(params.subscriptionId).toEqual("test-subscription-id");
+						expect(await request.json()).toEqual({
+							destination: { service: "queues", queue_id: "updated" },
+						});
+
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: {
+								id: "test-subscription-id",
+								name: "updated",
+								enabled: true,
+								source: { service: "slurper" },
+								destination: { service: "queues", queue_id: "updated" },
+								events: ["e1", "e2"],
+							},
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions update test-subscription-id --destination=queues"
+			);
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[Error: Invalid destination. Must be formatted as queues.<queue_id>]`
+			);
+		});
+
+		test("can handle unrecognized events", async () => {
+			msw.use(
+				http.patch(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/:subscriptionId",
+					async ({ params, request }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						expect(params.subscriptionId).toEqual("test-subscription-id");
+						expect(await request.json()).toEqual({
+							destination: { service: "queues", queue_id: "updated" },
+						});
+
+						return HttpResponse.json(
+							{
+								success: false,
+								errors: [{ message: "Invalid event names" }],
+							},
+							{ status: 404 }
+						);
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions update test-subscription-id --destination=queues.updated"
+			);
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/event_subscriptions/subscriptions/test-subscription-id) failed.]`
+			);
+			expect(std.out).toMatch(new RegExp(/Invalid event names/));
+		});
+
+		test("errors if the subscription with the given ID does not exist", async () => {
+			msw.use(
+				http.patch(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/test-subscription-id",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json(
+							{
+								success: false,
+								errors: [{ message: "No subscription with this ID" }],
+								result: null,
+							},
+							{ status: 404 }
+						);
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions update test-subscription-id --name=updated"
+			);
+			await expect(result).rejects.toBeDefined();
+			expect(std.out).toMatch(new RegExp(/No subscription with this ID/));
+		});
+	});
+
+	describe("event-subscriptions delete", async () => {
+		test("deletes a single subscription", async () => {
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/:subscriptionId",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						expect(params.subscriptionId).toEqual("test-subscription-id");
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							result: {
+								id: "test-subscription-id",
+								name: "test-subscription",
+								enabled: true,
+								source: { service: "slurper" },
+								destination: { service: "queues", queue_id: "test-queue-id" },
+								events: ["e1", "e2"],
+							},
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions delete test-subscription-id"
+			);
+			await expect(result).resolves.toBeUndefined();
+			expect(std.out).toMatchInlineSnapshot(`"Event subscription deleted!"`);
+		});
+
+		test("errors if the subscription with the given ID does not exist", async () => {
+			msw.use(
+				http.delete(
+					"*/accounts/:accountId/event_subscriptions/subscriptions/test-subscription-id",
+					async ({ params }) => {
+						expect(params.accountId).toEqual(testAccountId);
+						return HttpResponse.json(
+							{
+								success: false,
+								errors: [{ message: "No subscription with this ID" }],
+								result: null,
+							},
+							{ status: 404 }
+						);
+					},
+					{ once: true }
+				)
+			);
+
+			const result = runWrangler(
+				"event-subscriptions delete test-subscription-id"
+			);
+			await expect(result).rejects.toMatchInlineSnapshot(
+				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/event_subscriptions/subscriptions/test-subscription-id) failed.]`
+			);
+			expect(std.out).toMatch(new RegExp(/No subscription with this ID/));
+		});
+	});
+});

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -52,6 +52,7 @@ describe("wrangler", () => {
 
 				  wrangler kv                     🗂️  Manage Workers KV Namespaces
 				  wrangler queues                 🇶  Manage Workers Queues
+				  wrangler event-subscriptions    🔔 Manage Event Subscriptions [open-beta]
 				  wrangler r2                     📦 Manage R2 buckets & objects
 				  wrangler d1                     🗄  Manage Workers D1 databases
 				  wrangler vectorize              🧮 Manage Vectorize indexes [open beta]
@@ -110,6 +111,7 @@ describe("wrangler", () => {
 
 				  wrangler kv                     🗂️  Manage Workers KV Namespaces
 				  wrangler queues                 🇶  Manage Workers Queues
+				  wrangler event-subscriptions    🔔 Manage Event Subscriptions [open-beta]
 				  wrangler r2                     📦 Manage R2 buckets & objects
 				  wrangler d1                     🗄  Manage Workers D1 databases
 				  wrangler vectorize              🧮 Manage Vectorize indexes [open beta]

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -51,7 +51,7 @@ describe("wrangler", () => {
 				  wrangler types [path]           📝 Generate types from your Worker configuration
 
 				  wrangler kv                     🗂️  Manage Workers KV Namespaces
-				  wrangler queues                 🇶  Manage Workers Queues
+				  wrangler queues                 📬 Manage Workers Queues
 				  wrangler event-subscriptions    🔔 Manage Event Subscriptions [open-beta]
 				  wrangler r2                     📦 Manage R2 buckets & objects
 				  wrangler d1                     🗄  Manage Workers D1 databases
@@ -110,7 +110,7 @@ describe("wrangler", () => {
 				  wrangler types [path]           📝 Generate types from your Worker configuration
 
 				  wrangler kv                     🗂️  Manage Workers KV Namespaces
-				  wrangler queues                 🇶  Manage Workers Queues
+				  wrangler queues                 📬 Manage Workers Queues
 				  wrangler event-subscriptions    🔔 Manage Event Subscriptions [open-beta]
 				  wrangler r2                     📦 Manage R2 buckets & objects
 				  wrangler d1                     🗄  Manage Workers D1 databases

--- a/packages/wrangler/src/event-subscriptions/index.ts
+++ b/packages/wrangler/src/event-subscriptions/index.ts
@@ -1,0 +1,376 @@
+import { readConfig } from "../config";
+import { createCommand, createNamespace } from "../core/create-command";
+import { CommandLineArgsError } from "../errors";
+import { logger } from "../logger";
+import { requireAuth } from "../user";
+import { products } from "./products";
+import type { EventHubProductId, EventSubscription } from "./products";
+
+type EventSubscriptionEventSpec = {
+	id: string;
+	name: string;
+	events: Array<{ name: string; description: string }>;
+};
+
+export const eventSubscriptionsNamespace = createNamespace({
+	metadata: {
+		hidden: true,
+		owner: "Product: Queues",
+		status: "stable",
+		description: "🔔 Manage Event Subscriptions",
+	},
+});
+
+export const eventSubscriptionsBrowseCommand = createCommand({
+	metadata: {
+		owner: "Product: Queues",
+		status: "stable",
+		description: "List available sources and events",
+	},
+
+	args: {
+		source: {
+			type: "string",
+			description: "A comma-separated list of source services to filter by",
+			demandOption: false,
+		},
+	},
+
+	async handler(args, ctx) {
+		const config = readConfig(args);
+		const accountId = await requireAuth(config);
+
+		let events = await ctx.fetchResult<EventSubscriptionEventSpec[]>(
+			`/accounts/${accountId}/event_subscriptions/events`
+		);
+
+		// Only include products that are also defined in the `products()` object.
+		// This lets us avoid exposing objects that are not fully onboarded yet and
+		// causing confusion for users.
+		events = events.filter((e) =>
+			Object.keys(products(accountId)).includes(e.id)
+		);
+
+		if (args.source) {
+			// Only include products that somewhat match the ones the user requested,
+			// if they did
+			const sources = args.source
+				.split(",")
+				.map((s) => s.toLocaleLowerCase().trim());
+			events = events.filter((p) => {
+				const id = p.id.toLocaleLowerCase().trim();
+				const name = p.name.toLocaleLowerCase().trim();
+				return sources.some((s) => id.includes(s) || name.includes(s));
+			});
+		}
+
+		if (events.length === 0) {
+			logger.warn("No sources matched your query");
+			return logger.table([{ service: "", events: "" }]);
+		}
+
+		logger.table(
+			events.map((p) => ({
+				service: p.name,
+				events: p.events.map((e) => e.name).join(", "),
+			}))
+		);
+	},
+});
+
+export const eventSubscriptionsListCommand = createCommand({
+	metadata: {
+		owner: "Product: Queues",
+		status: "stable",
+		description: "List configured Event Subscriptions",
+	},
+
+	async handler(args, ctx) {
+		const config = readConfig(args);
+		const accountId = await requireAuth(config);
+
+		const res = await ctx.fetchResult<EventSubscription[]>(
+			`/accounts/${accountId}/event_subscriptions/subscriptions?per_page=100`
+		);
+
+		if (res.length === 0) {
+			logger.warn("No event subscriptions exist");
+			return logger.table([
+				{ id: "", name: "", source: "", destination: "", events: "" },
+			]);
+		}
+
+		logger.table(
+			res.map((s) => {
+				const product = products(accountId)[s.source.service];
+				// If this subscription belongs to a product that is not defined in the
+				// `products()` object, that means we do not definitively know how to
+				// deal with it yet. This will happen when the user is using a Wrangler
+				// version that is older than the version where the product was first
+				// defined. Instead of crashing / ignoring such subscriptions, we'll
+				// try our best to be helpful.
+				const source = product
+					? product.format(s.source)
+					: JSON.stringify(s.source);
+				const destination = product
+					? `${s.destination.service}.${s.destination.queue_id}`
+					: JSON.stringify(s.destination);
+				return {
+					id: s.id,
+					name: s.name,
+					source,
+					destination,
+					events: s.events.join(", "),
+				};
+			})
+		);
+	},
+});
+
+export const eventSubscriptionsGetCommand = createCommand({
+	metadata: {
+		owner: "Product: Queues",
+		status: "stable",
+		description: "Fetch details about a single Event Subscription",
+	},
+
+	positionalArgs: ["id"],
+	args: {
+		id: {
+			type: "string",
+			description: "ID of the Event Subscription",
+			demandOption: true,
+		},
+	},
+
+	async handler(args, ctx) {
+		const config = readConfig(args);
+		const accountId = await requireAuth(config);
+		const { id } = args;
+
+		const subscription = await ctx.fetchResult<EventSubscription>(
+			`/accounts/${accountId}/event_subscriptions/subscriptions/${id}`
+		);
+
+		const destination = `${subscription.destination.service}.${subscription.destination.queue_id}`;
+
+		const product = products(accountId)[subscription.source.service];
+		// If this subscription belongs to a product that is not defined in the
+		// `products()` object, that means we do not definitively know how to
+		// deal with it yet. This will happen when the user is using a Wrangler
+		// version that is older than the version where the product was first
+		// defined. Instead of crashing / ignoring such subscriptions, we'll
+		// try our best to be helpful.
+		const source = product
+			? product.format(subscription.source)
+			: JSON.stringify(subscription.source);
+
+		logger.table([
+			{
+				id: subscription.id,
+				name: subscription.name,
+				source,
+				destination,
+				events: subscription.events.join(", "),
+			},
+		]);
+	},
+});
+
+export const eventSubscriptionsCreateCommand = createCommand({
+	metadata: {
+		owner: "Product: Queues",
+		status: "stable",
+		description: "Create a new Event Subscription",
+	},
+
+	positionalArgs: ["name"],
+	args: {
+		name: {
+			type: "string",
+			description: "Name of the subscription",
+			demandOption: true,
+		},
+		source: {
+			type: "string",
+			description:
+				"The service & resource to create the subscription on. Use `event-subscriptions browse` to see available sources and events.",
+			demandOption: true,
+		},
+		destination: {
+			type: "string",
+			description: "ID of the Queue to send events to",
+			demandOption: true,
+		},
+		events: {
+			type: "string",
+			description: "Names of events to subscribe to",
+			demandOption: true,
+		},
+	},
+	async handler(args, ctx) {
+		const config = readConfig(args);
+		const accountId = await requireAuth(config);
+
+		const [productId] = args.source.split(".");
+		const product = products(accountId)[productId as EventHubProductId];
+		if (!productId || !product) {
+			throw new CommandLineArgsError(
+				`Unrecognized source service. Must be one of ${Object.keys(products(accountId)).join(", ")}`
+			);
+		}
+
+		const source = product.validate(args.source);
+
+		const [destinationService, destinationQueueId] =
+			args.destination.split(".");
+		if (
+			!destinationService ||
+			!destinationQueueId ||
+			destinationService !== "queues"
+		) {
+			throw new CommandLineArgsError(
+				`Invalid destination. Must be formatted as queues.<queue_id>`
+			);
+		}
+		const destination = { service: "queues", queue_id: destinationQueueId };
+
+		const subscription = await ctx.fetchResult<EventSubscription>(
+			`/accounts/${accountId}/event_subscriptions/subscriptions`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					name: args.name,
+					source,
+					destination,
+					events: args.events.split(",").map((e) => e.trim()),
+				}),
+			}
+		);
+
+		logger.table([
+			{
+				id: subscription.id,
+				name: subscription.name,
+				source: product.format(subscription.source),
+				destination: `${subscription.destination.service}.${subscription.destination.queue_id}`,
+				events: args.events,
+			},
+		]);
+	},
+});
+
+export const eventSubscriptionsUpdateCommand = createCommand({
+	metadata: {
+		owner: "Product: Queues",
+		status: "stable",
+		description: "Update an event subscription",
+	},
+
+	positionalArgs: ["id"],
+	args: {
+		id: {
+			type: "string",
+			description: "ID of the event subscription",
+			demandOption: true,
+		},
+		name: {
+			type: "string",
+			description: "New name of the subscription",
+		},
+		destination: {
+			type: "string",
+			description: "ID of the Queue to send events to",
+		},
+		events: {
+			type: "string",
+			description: "Names of events to subscribe to",
+		},
+	},
+
+	async handler(args, ctx) {
+		const config = readConfig(args);
+		const accountId = await requireAuth(config);
+
+		const { id, name, events } = args;
+
+		let destination: EventSubscription["destination"] | undefined = undefined;
+		if (args.destination) {
+			const [destinationService, destinationQueueId] =
+				args.destination.split(".");
+			if (
+				!destinationService ||
+				!destinationQueueId ||
+				destinationService !== "queues"
+			) {
+				throw new CommandLineArgsError(
+					`Invalid destination. Must be formatted as queues.<queue_id>`
+				);
+			}
+			destination = { service: "queues", queue_id: destinationQueueId };
+		}
+
+		const subscription = await ctx.fetchResult<EventSubscription>(
+			`/accounts/${accountId}/event_subscriptions/subscriptions/${id}`,
+			{
+				method: "PATCH",
+				body: JSON.stringify({
+					name,
+					destination,
+					events: events?.split(",").map((e) => e.trim()),
+				}),
+			}
+		);
+
+		const product = products(accountId)[subscription.source.service];
+		// If this subscription belongs to a product that is not defined in the
+		// `products()` object, that means we do not definitively know how to
+		// deal with it yet. This will happen when the user is using a Wrangler
+		// version that is older than the version where the product was first
+		// defined. Instead of crashing / ignoring such subscriptions, we'll
+		// try our best to be helpful.
+		const source = product
+			? product.format(subscription.source)
+			: JSON.stringify(subscription.source);
+
+		logger.table([
+			{
+				id,
+				name: subscription.name,
+				source,
+				destination: `${subscription.destination.service}.${subscription.destination.queue_id}`,
+				events: subscription.events.join(", "),
+			},
+		]);
+	},
+});
+
+export const eventSubscriptionsDeleteCommand = createCommand({
+	metadata: {
+		owner: "Product: Queues",
+		status: "stable",
+		description: "<TBD>",
+	},
+
+	positionalArgs: ["id"],
+	args: {
+		id: {
+			type: "string",
+			description: "ID of the event subscription",
+			demandOption: true,
+		},
+	},
+
+	async handler(args, ctx) {
+		const config = readConfig(args);
+		const accountId = await requireAuth(config);
+
+		const { id } = args;
+		await ctx.fetchResult<EventSubscription>(
+			`/accounts/${accountId}/event_subscriptions/subscriptions/${id}`,
+			{ method: "DELETE" }
+		);
+
+		logger.log(`Event subscription deleted!`);
+	},
+});

--- a/packages/wrangler/src/event-subscriptions/products.ts
+++ b/packages/wrangler/src/event-subscriptions/products.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert";
+import { CommandLineArgsError } from "../errors";
+
+export type EventSubscription = {
+	id: string;
+	created_at: Date;
+	modified_at: Date;
+	name: string;
+	enabled: boolean;
+	source:
+		| { service: "slurper" }
+		| { service: "workflows"; workflow_name: string }
+		| { service: "workersAI"; model: string }
+		| { service: "workersBuilds"; script: string };
+	destination: { service: "queues"; queue_id: string };
+	events: string[];
+};
+
+export const products = (
+	_accountTag: string
+): Record<EventHubProductId, EventHubProductSpec<EventHubSource>> => ({
+	slurper: {
+		validate: (source) => {
+			assert(source === "slurper");
+			return { service: "slurper" };
+		},
+		format: ({ service }) => {
+			assert(service === "slurper");
+			return service;
+		},
+	},
+	workersAI: {
+		validate: (source) => {
+			const [service, model] = source.split(".");
+			assert(service === "workersAI");
+
+			if (!model) {
+				throw new CommandLineArgsError(
+					`Invalid source. Must be formatted as workersAI.<model>`
+				);
+			}
+
+			return { service, model };
+		},
+		format: (source) => {
+			assert(source.service === "workersAI");
+			return `workersAI.${source.model}`;
+		},
+	},
+	workersBuilds: {
+		validate: (source) => {
+			const [service, script] = source.split(".");
+			assert(service === "workersBuilds");
+
+			if (!script) {
+				throw new CommandLineArgsError(
+					`Invalid source. Must be formatted as workersBuilds.<script_name>`
+				);
+			}
+
+			return { service, script };
+		},
+		format: (source) => {
+			assert(source.service === "workersBuilds");
+			return `workersBuilds.${source.script}`;
+		},
+	},
+	workflows: {
+		validate: (source) => {
+			const [service, workflowName] = source.split(".");
+			assert(service === "workflows");
+
+			if (!workflowName) {
+				throw new CommandLineArgsError(
+					`Invalid source. Must be formatted as workflows.<workflow_id>`
+				);
+			}
+
+			return { service, workflow_name: workflowName };
+		},
+		format: (source) => {
+			assert(source.service === "workflows");
+			return `workflows.${source.workflow_name}`;
+		},
+	},
+});
+
+/////////////////////////////////////////
+// No modifications beyond this please //
+/////////////////////////////////////////
+
+export type EventHubSource = EventSubscription["source"];
+export type EventHubProductId = EventHubSource["service"];
+export type EventHubProductSpec<S = EventHubSource> = {
+	/**
+	 * @argument source: The --source argument input by the user
+	 *
+	 * @returns The `source` property to send in the "Create Event Subscription"
+	 * request. The expected shape is documented
+	 * This is the same shape as the `source` Zod discriminated union you appended
+	 * to when you onboarded your service schema in the Queues codebase.
+	 */
+	validate: (source: string) => S;
+	/**
+	 * @argument source: The `source` property from the Event Subscription
+	 * response
+	 *
+	 * @returns A string that can be displayed to the user when listing
+	 * subscriptions. This should generally be in the format <ProductID>.<ResourceID>
+	 */
+	format: (source: S) => string;
+};

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -36,6 +36,15 @@ import {
 	JsonFriendlyFatalError,
 	UserError,
 } from "./errors";
+import {
+	eventSubscriptionsBrowseCommand,
+	eventSubscriptionsCreateCommand,
+	eventSubscriptionsDeleteCommand,
+	eventSubscriptionsGetCommand,
+	eventSubscriptionsListCommand,
+	eventSubscriptionsNamespace,
+	eventSubscriptionsUpdateCommand,
+} from "./event-subscriptions";
 import { hyperdrive } from "./hyperdrive/index";
 import { initHandler, initOptions } from "./init";
 import {
@@ -536,6 +545,39 @@ export function createCLIParser(argv: string[]) {
 	wrangler.command("queues", "🇶  Manage Workers Queues", (queuesYargs) => {
 		return queues(queuesYargs.command(subHelp));
 	});
+
+	// event-subscriptions
+	registry.define([
+		{
+			command: "wrangler event-subscriptions",
+			definition: eventSubscriptionsNamespace,
+		},
+		{
+			command: "wrangler event-subscriptions browse",
+			definition: eventSubscriptionsBrowseCommand,
+		},
+		{
+			command: "wrangler event-subscriptions list",
+			definition: eventSubscriptionsListCommand,
+		},
+		{
+			command: "wrangler event-subscriptions create",
+			definition: eventSubscriptionsCreateCommand,
+		},
+		{
+			command: "wrangler event-subscriptions update",
+			definition: eventSubscriptionsUpdateCommand,
+		},
+		{
+			command: "wrangler event-subscriptions delete",
+			definition: eventSubscriptionsDeleteCommand,
+		},
+		{
+			command: "wrangler event-subscriptions get",
+			definition: eventSubscriptionsGetCommand,
+		},
+	]);
+	registry.registerNamespace("event-subscriptions");
 
 	// r2
 	registry.define([

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -542,7 +542,7 @@ export function createCLIParser(argv: string[]) {
 	registry.registerNamespace("kv");
 
 	// queues
-	wrangler.command("queues", "🇶  Manage Workers Queues", (queuesYargs) => {
+	wrangler.command("queues", "📬 Manage Workers Queues", (queuesYargs) => {
 		return queues(queuesYargs.command(subHelp));
 	});
 


### PR DESCRIPTION
Fixes #MQ-845

Adds an `event-subscriptions` subcommand that will be used to manage Event Subscriptions

CR-1140468

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: this is a new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
