### PR TITLE
[wrangler] Add containers subcommand

### DIFF
--- a/.changeset/orange-gifts-cover.md
+++ b/.changeset/orange-gifts-cover.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add initial containers subcommand to wrangler.

--- a/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/images.test.ts
@@ -181,7 +181,7 @@ describe("cloudchamber image list", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler cloudchamber images list
 
-			perform operations on images in your cloudchamber registry
+			perform operations on images in your Cloudflare managed registry
 
 			GLOBAL FLAGS
 			  -c, --config   Path to Wrangler configuration file  [string]

--- a/packages/wrangler/src/cloudchamber/images/list.ts
+++ b/packages/wrangler/src/cloudchamber/images/list.ts
@@ -25,7 +25,7 @@ export const imagesCommand = (yargs: CommonYargsArgvJSON) => {
 	return yargs
 		.command(
 			"list",
-			"perform operations on images in your cloudchamber registry",
+			"perform operations on images in your Cloudflare managed registry",
 			(args) => listImagesYargs(args),
 			(args) =>
 				handleFailure(async (_args: CommonYargsArgvSanitizedJSON, config) => {
@@ -34,7 +34,7 @@ export const imagesCommand = (yargs: CommonYargsArgvJSON) => {
 		)
 		.command(
 			"delete [image]",
-			"remove an image from your cloudchamber registry",
+			"remove an image from your Cloudflare managed registry",
 			(args) => deleteImageYargs(args),
 			(args) =>
 				handleFailure(async (_args: CommonYargsArgvSanitizedJSON, config) => {

--- a/packages/wrangler/src/containers/index.ts
+++ b/packages/wrangler/src/containers/index.ts
@@ -1,0 +1,34 @@
+import {
+	buildCommand,
+	buildYargs,
+	pushCommand,
+	pushYargs,
+} from "../cloudchamber/build";
+import { handleFailure } from "../cloudchamber/common";
+import { imagesCommand } from "../cloudchamber/images/list";
+import type { CommonYargsArgvJSON, CommonYargsOptions } from "../yargs-types";
+import type { CommandModule } from "yargs";
+
+export const containers = (
+	yargs: CommonYargsArgvJSON,
+	subHelp: CommandModule<CommonYargsOptions, CommonYargsOptions>
+) => {
+	return yargs
+		.command(
+			"build [PATH]",
+			"build a dockerfile",
+			(args) => buildYargs(args),
+			(args) => handleFailure(buildCommand)(args)
+		)
+		.command(
+			"push [TAG]",
+			"push a tagged image to a Cloudflare managed registry, which is automatically integrated with your account",
+			(args) => pushYargs(args),
+			(args) => handleFailure(pushCommand)(args)
+		)
+		.command(
+			"images",
+			"perform operations on images in your Cloudflare managed registry",
+			(args) => imagesCommand(args).command(subHelp)
+		);
+};

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -16,6 +16,7 @@ import {
 import { checkNamespace, checkStartupCommand } from "./check/commands";
 import { cloudchamber } from "./cloudchamber";
 import { experimental_readRawConfig, loadDotEnv } from "./config";
+import { containers } from "./containers";
 import { demandSingleValue } from "./core";
 import { CommandRegistry } from "./core/CommandRegistry";
 import { createRegisterYargsCommand } from "./core/register-yargs-command";
@@ -780,6 +781,11 @@ export function createCLIParser(argv: string[]) {
 	// cloudchamber
 	wrangler.command("cloudchamber", false, (cloudchamberArgs) => {
 		return cloudchamber(asJson(cloudchamberArgs.command(subHelp)), subHelp);
+	});
+
+	// containers
+	wrangler.command("containers", false, (containersArgs) => {
+		return containers(asJson(containersArgs.command(subHelp)), subHelp);
 	});
 
 	// [PRIVATE BETA] pubsub


### PR DESCRIPTION
Adding an initial containers subcommand. This re-uses a subset of the cloudchamber commands that are relevant to both.

More unique containers commands will be added in future PRs.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: This is re-using commands from cloudchamber which have tests
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No e2e tests exists for cloudchamber/containers
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: These commands are not documented in that repo.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not needed for new features

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
