### PR TITLE
Allow users to specify `none` to remove transformation

### DIFF
--- a/.changeset/warm-forks-visit.md
+++ b/.changeset/warm-forks-visit.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Allow `wrangler pipelines update <pipelineName> --transform-worker none` to remove transformations from a Pipeline.

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -601,6 +601,25 @@ describe("pipelines", () => {
 			`);
 			expect(requests.count).toEqual(1);
 		});
+
+		it("should remove transformations", async () => {
+			const pipeline: Pipeline = samplePipeline;
+			mockShowRequest(pipeline.name, pipeline);
+
+			const update = JSON.parse(JSON.stringify(pipeline));
+			update.transforms = [
+				{
+					script: "hello",
+					entrypoint: "MyTransform",
+				},
+			];
+			const updateReq = mockUpdateRequest(update.name, update);
+
+			await runWrangler("pipelines update my-pipeline --transform-worker none");
+
+			expect(updateReq.count).toEqual(1);
+			expect(updateReq.body?.transforms.length).toEqual(0);
+		});
 	});
 
 	describe("delete", () => {

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -104,7 +104,7 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 			.option("transform-worker", {
 				type: "string",
 				describe:
-					"Pipeline transform Worker and entrypoint (<worker>.<entrypoint>)",
+					'Pipeline transform Worker and entrypoint, to transform ingested records. Specified as <worker-name>.<entrypoint>, or "none".',
 				demandOption: false,
 			})
 
@@ -282,7 +282,12 @@ export async function updatePipelineHandler(
 	}
 
 	if (args.transformWorker) {
-		pipelineConfig.transforms.push(parseTransform(args.transformWorker));
+		if (args.transformWorker === "none") {
+			// Unset transformations
+			pipelineConfig.transforms = [];
+		} else {
+			pipelineConfig.transforms.push(parseTransform(args.transformWorker));
+		}
 	}
 
 	if (args.r2Prefix) {


### PR DESCRIPTION
Allow `wrangler pipelines update <pipelineName> --transform-worker none` to remove transformations from a Pipeline.

Fixes https://jira.cfdata.org/browse/PIPE-232

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: there are no e2e tests for this API
- Public documentation
  - [ ] TODO (before merge)
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18595
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: pipelines is still experimental

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
