### PR TITLE
Add Wasm helper

### DIFF
--- a/.changeset/eighty-glasses-talk.md
+++ b/.changeset/eighty-glasses-talk.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Add support for `.wasm?init` extension to load WebAssembly as documented by Vite (https://vite.dev/guide/features.html#webassembly).

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/__tests__/additional-modules.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/__tests__/additional-modules.spec.ts
@@ -28,6 +28,11 @@ test("supports CompiledWasm modules with a '.wasm' extension", async () => {
 });
 
 test("supports CompiledWasm modules with a '.wasm?module' extension", async () => {
-	const result = await getJsonResponse("/wasm-with-param");
+	const result = await getJsonResponse("/wasm-with-module-param");
 	expect(result).toEqual({ result: 11 });
+});
+
+test("supports CompiledWasm modules with a '.wasm?init' extension", async () => {
+	const result = await getJsonResponse("/wasm-with-init-param");
+	expect(result).toEqual({ result: 15 });
 });

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/src/index.ts
@@ -2,7 +2,8 @@ import bin from "./modules/bin-example.bin";
 import html from "./modules/html-example.html";
 import text from "./modules/text-example.txt";
 import wasm from "./modules/wasm-example.wasm";
-import wasmWithParam from "./modules/wasm-example.wasm?module";
+import init from "./modules/wasm-example.wasm?init";
+import wasmWithModuleParam from "./modules/wasm-example.wasm?module";
 
 export default {
 	async fetch(request) {
@@ -26,9 +27,15 @@ export default {
 
 				return Response.json({ result });
 			}
-			case "/wasm-with-param": {
-				const instance = await WebAssembly.instantiate(wasmWithParam);
+			case "/wasm-with-module-param": {
+				const instance = await WebAssembly.instantiate(wasmWithModuleParam);
 				const result = instance.exports.add(5, 6);
+
+				return Response.json({ result });
+			}
+			case "/wasm-with-init-param": {
+				const instance = await init();
+				const result = instance.exports.add(7, 8);
 
 				return Response.json({ result });
 			}

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -341,6 +341,26 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				});
 			},
 		},
+		// Plugin to support `.wasm?init` extension
+		{
+			name: "vite-plugin:wasm-helper",
+			enforce: "pre",
+			applyToEnvironment(environment) {
+				return getWorkerConfig(environment.name) !== undefined;
+			},
+			load(id) {
+				if (!id.endsWith(".wasm?init")) {
+					return;
+				}
+
+				return `
+					import wasm from "${cleanUrl(id)}";
+					export default function(opts = {}) {
+						return WebAssembly.instantiate(wasm, opts);
+					}
+				`;
+			},
+		},
 		// Plugin to support additional modules
 		{
 			name: "vite-plugin-cloudflare:additional-modules",

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -343,7 +343,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 		},
 		// Plugin to support `.wasm?init` extension
 		{
-			name: "vite-plugin:wasm-helper",
+			name: "vite-plugin-cloudflare:wasm-helper",
 			enforce: "pre",
 			applyToEnvironment(environment) {
 				return getWorkerConfig(environment.name) !== undefined;


### PR DESCRIPTION
Fixes #000.

This was just a bit of fun while I was waiting for CI. It adds support for `.wasm?init` imports, as documented by Vite (https://vite.dev/guide/features.html#webassembly). Not sure if it's something we should actually include or not so happy to close if you feel it's unnecessary.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: coming soon
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
