### PR TITLE
fix(miniflare): Simplify `RpcProxyWorker` and add more fixture tests

### DIFF
--- a/.changeset/thick-bars-sing.md
+++ b/.changeset/thick-bars-sing.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: Add support for property accessors in local dev RPC for Workers with assets

--- a/fixtures/workers-with-assets-and-service-bindings/tests/index.test.ts
+++ b/fixtures/workers-with-assets-and-service-bindings/tests/index.test.ts
@@ -127,6 +127,31 @@ describe.each(devCmds)(
 						"Hello from worker-b scheduled()"
 					);
 				});
+
+				it("should support promise pipelining", async ({ expect }) => {
+					// fetch URL is irrelevant here. workerA will internally call
+					// the appropriate fns on the service binding instead
+					let response = await fetch(`http://${ipWorkerA}:${portWorkerA}`);
+					let text = await response.text();
+					expect(response.status).toBe(200);
+					expect(text).toContain(
+						`env.DEFAULT_EXPORT.foo("✨").bar.buzz() response: You made it! ✨`
+					);
+				});
+
+				it("should support property access", async ({ expect }) => {
+					// fetch URL is irrelevant here. workerA will internally call
+					// the appropriate fns on the service binding instead
+					let response = await fetch(`http://${ipWorkerA}:${portWorkerA}`);
+					let text = await response.text();
+					expect(response.status).toBe(200);
+					expect(text).toContain(
+						`env.DEFAULT_EXPORT.honey response: Bees make honey in worker-b`
+					);
+					expect(text).toContain(
+						`env.DEFAULT_EXPORT.honeyBee response: I am worker-b's honeyBee prop`
+					);
+				});
 			});
 
 			describe("Service binding to default entrypoint", () => {
@@ -199,6 +224,34 @@ describe.each(devCmds)(
 						"Hello from worker-c scheduled()"
 					);
 				});
+
+				it("should support promise pipelining", async ({ expect }) => {
+					// fetch URL is irrelevant here. workerA will internally call
+					// the appropriate fns on the service binding instead
+					let response = await fetch(`http://${ipWorkerA}:${portWorkerA}`);
+					let text = await response.text();
+					expect(response.status).toBe(200);
+					expect(text).toContain(
+						`env.DEFAULT_ENTRYPOINT.foo("🐜").bar.buzz() response: You made it! 🐜`
+					);
+					expect(text).toContain(
+						`env.DEFAULT_ENTRYPOINT.newBeeCounter().value response: 2`
+					);
+				});
+
+				it("should support property access", async ({ expect }) => {
+					// fetch URL is irrelevant here. workerA will internally call
+					// the appropriate fns on the service binding instead
+					let response = await fetch(`http://${ipWorkerA}:${portWorkerA}`);
+					let text = await response.text();
+					expect(response.status).toBe(200);
+					expect(text).toContain(
+						`env.DEFAULT_ENTRYPOINT.honey response: Bees make honey in worker-c`
+					);
+					expect(text).toContain(
+						`env.DEFAULT_ENTRYPOINT.honeyBee response: I am worker-c's honeyBee prop`
+					);
+				});
 			});
 
 			describe("Service binding to named entrypoint", () => {
@@ -259,6 +312,20 @@ describe.each(devCmds)(
 					);
 					expect(text).toContain(
 						`env.NAMED_ENTRYPOINT.newBeeCounter().value response: 2`
+					);
+				});
+
+				it("should support property access", async ({ expect }) => {
+					// fetch URL is irrelevant here. workerA will internally call
+					// the appropriate fns on the service binding instead
+					let response = await fetch(`http://${ipWorkerA}:${portWorkerA}`);
+					let text = await response.text();
+					expect(response.status).toBe(200);
+					expect(text).toContain(
+						`env.NAMED_ENTRYPOINT.honey response: Bees make honey in worker-d`
+					);
+					expect(text).toContain(
+						`env.NAMED_ENTRYPOINT.honeyBee response: I am worker-d's honeyBee prop`
 					);
 				});
 			});

--- a/fixtures/workers-with-assets-and-service-bindings/workerA/src/index.ts
+++ b/fixtures/workers-with-assets-and-service-bindings/workerA/src/index.ts
@@ -14,16 +14,26 @@ export default {
 				`env.DEFAULT_EXPORT.fetch() response: ${workerBResponses.fetchResponse}\n` +
 				`env.DEFAULT_EXPORT.bee() response: ${workerBResponses.beeResult}\n` +
 				`env.DEFAULT_EXPORT.busyBee("🐝") response: ${workerBResponses.busyBeeResult}\n` +
+				`env.DEFAULT_EXPORT.honey response: ${workerBResponses.honeyResponse}\n` +
+				`env.DEFAULT_EXPORT.honeyBee response: ${workerBResponses.honeyBeeResponse}\n` +
+				`env.DEFAULT_EXPORT.foo("✨").bar.buzz() response: ${workerBResponses.buzzResult}\n` +
+				`env.DEFAULT_EXPORT.newBeeCounter().value response: ${workerBResponses.beeCountResult}\n` +
 				`env.DEFAULT_EXPORT.scheduled() response: ${workerBResponses.scheduledResponse}\n\n` +
 				`"worker-c" Responses\n` +
 				`env.DEFAULT_ENTRYPOINT.fetch() response: ${workerCResponses.fetchResponse}\n` +
 				`env.DEFAULT_ENTRYPOINT.bee() response: ${workerCResponses.beeResult}\n` +
 				`env.DEFAULT_ENTRYPOINT.busyBee("🐝") response: ${workerCResponses.busyBeeResult}\n` +
+				`env.DEFAULT_ENTRYPOINT.honey response: ${workerCResponses.honeyResponse}\n` +
+				`env.DEFAULT_ENTRYPOINT.honeyBee response: ${workerCResponses.honeyBeeResponse}\n` +
+				`env.DEFAULT_ENTRYPOINT.foo("🐜").bar.buzz() response: ${workerCResponses.buzzResult}\n` +
+				`env.DEFAULT_ENTRYPOINT.newBeeCounter().value response: ${workerCResponses.beeCountResult}\n` +
 				`env.DEFAULT_ENTRYPOINT.scheduled() response: ${workerCResponses.scheduledResponse}\n\n` +
 				`"worker-d" Responses\n` +
 				`env.NAMED_ENTRYPOINT.fetch() response: ${workerDResponses.fetchResponse}\n` +
 				`env.NAMED_ENTRYPOINT.bee() response: ${workerDResponses.beeResult}\n` +
 				`env.NAMED_ENTRYPOINT.busyBee("🐝") response: ${workerDResponses.busyBeeResult}\n` +
+				`env.NAMED_ENTRYPOINT.honey response: ${workerDResponses.honeyResponse}\n` +
+				`env.NAMED_ENTRYPOINT.honeyBee response: ${workerDResponses.honeyBeeResponse}\n` +
 				`env.NAMED_ENTRYPOINT.foo("🐙").bar.buzz() response: ${workerDResponses.buzzResult}\n` +
 				`env.NAMED_ENTRYPOINT.newBeeCounter().value response: ${workerDResponses.beeCountResult}\n` +
 				`env.NAMED_ENTRYPOINT.scheduled() response: ${workerDResponses.scheduledResponse}\n\n`

--- a/fixtures/workers-with-assets-and-service-bindings/workerA/src/workerB.util.ts
+++ b/fixtures/workers-with-assets-and-service-bindings/workerA/src/workerB.util.ts
@@ -13,6 +13,19 @@ export async function getWorkerBResponses(request: Request, env) {
 	// test named functions with strictly one parameter
 	const busyBeeResult = await env.DEFAULT_EXPORT.busyBee("🐝");
 
+	// test properties
+	const honeyResponse = await env.DEFAULT_EXPORT.honey;
+	const honeyBeeResponse = await env.DEFAULT_EXPORT.honeyBee;
+
+	// test nested functions + promise pipelining
+	using foo = env.DEFAULT_EXPORT.foo("✨");
+	const buzzResult = await foo.bar.buzz();
+
+	// test RPCTarget + promise pipelining
+	// this is not supported in non-class based syntax
+	const beeCountResult =
+		"RpcTarget is not supported in non-class based syntax Workers.";
+
 	// tests Cron Triggers
 	const scheduledResponse = await env.DEFAULT_EXPORT.scheduled({
 		cron: "* * * * *",
@@ -22,6 +35,10 @@ export async function getWorkerBResponses(request: Request, env) {
 		fetchResponse,
 		beeResult,
 		busyBeeResult,
+		honeyResponse,
+		honeyBeeResponse,
+		buzzResult,
+		beeCountResult,
 		scheduledResponse,
 	};
 }

--- a/fixtures/workers-with-assets-and-service-bindings/workerA/src/workerC.util.ts
+++ b/fixtures/workers-with-assets-and-service-bindings/workerA/src/workerC.util.ts
@@ -9,6 +9,21 @@ export async function getWorkerCResponses(request: Request, env) {
 	// test named functions with parameters
 	const busyBeeResult = await env.DEFAULT_ENTRYPOINT.busyBee("🐝");
 
+	// test properties
+	const honeyResponse = await env.DEFAULT_ENTRYPOINT.honey;
+	const honeyBeeResponse = await env.DEFAULT_ENTRYPOINT.honeyBee;
+
+	// test nested functions + promise pipelining
+	const foo = env.DEFAULT_ENTRYPOINT.foo("🐜");
+	const buzzResult = await foo.bar.buzz();
+
+	// test RpcTarget + promise pipelining
+	using beeCounter = env.DEFAULT_ENTRYPOINT.newBeeCounter();
+	beeCounter.increment(1); // returns 1
+	beeCounter.increment(2); // returns 3
+	beeCounter.increment(-1); // returns 2
+	const beeCountResult = await beeCounter.value; // returns 2
+
 	// tests Cron Triggers
 	const scheduledResponse = await env.DEFAULT_ENTRYPOINT.scheduled({
 		cron: "* * * * *",
@@ -18,6 +33,10 @@ export async function getWorkerCResponses(request: Request, env) {
 		fetchResponse,
 		beeResult,
 		busyBeeResult,
+		honeyResponse,
+		honeyBeeResponse,
+		buzzResult,
+		beeCountResult,
 		scheduledResponse,
 	};
 }

--- a/fixtures/workers-with-assets-and-service-bindings/workerA/src/workerD.util.ts
+++ b/fixtures/workers-with-assets-and-service-bindings/workerA/src/workerD.util.ts
@@ -9,6 +9,10 @@ export async function getWorkerDResponses(request: Request, env) {
 	// test named functions with parameters
 	const busyBeeResult = await env.NAMED_ENTRYPOINT.busyBee("🐝");
 
+	// test properties
+	const honeyResponse = await env.NAMED_ENTRYPOINT.honey;
+	const honeyBeeResponse = await env.NAMED_ENTRYPOINT.honeyBee;
+
 	// test nested functions + promise pipelining
 	const foo = env.NAMED_ENTRYPOINT.foo("🐙");
 	const buzzResult = await foo.bar.buzz();
@@ -27,6 +31,8 @@ export async function getWorkerDResponses(request: Request, env) {
 		fetchResponse,
 		beeResult,
 		busyBeeResult,
+		honeyResponse,
+		honeyBeeResponse,
 		buzzResult,
 		beeCountResult,
 		scheduledResponse:

--- a/fixtures/workers-with-assets-and-service-bindings/workerB-with-default-export/src/index.ts
+++ b/fixtures/workers-with-assets-and-service-bindings/workerB-with-default-export/src/index.ts
@@ -1,4 +1,12 @@
+const honeyBee = "I am worker-b's honeyBee prop";
+
 export default {
+	honeyBee,
+
+	get honey() {
+		return "Bees make honey in worker-b";
+	},
+
 	/*
 	 * HTTP fetch
 	 *

--- a/fixtures/workers-with-assets-and-service-bindings/workerC-with-default-entrypoint/src/index.ts
+++ b/fixtures/workers-with-assets-and-service-bindings/workerC-with-default-entrypoint/src/index.ts
@@ -1,6 +1,17 @@
 import { RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
 
 export default class extends WorkerEntrypoint {
+	#honey = "Bees make honey in worker-c";
+	#honeyBee = "I am worker-c's honeyBee prop";
+
+	get honey() {
+		return this.#honey;
+	}
+
+	get honeyBee() {
+		return this.#honeyBee;
+	}
+
 	/*
 	 * HTTP fetch
 	 *

--- a/fixtures/workers-with-assets-and-service-bindings/workerD-with-named-entrypoint/src/index.ts
+++ b/fixtures/workers-with-assets-and-service-bindings/workerD-with-named-entrypoint/src/index.ts
@@ -1,6 +1,17 @@
 import { RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
 
 export class EntrypointD extends WorkerEntrypoint {
+	#honey = "Bees make honey in worker-d";
+	#honeyBee = "I am worker-d's honeyBee prop";
+
+	get honey() {
+		return this.#honey;
+	}
+
+	get honeyBee() {
+		return this.#honeyBee;
+	}
+
 	/*
 	 * `fetch` method
 	 */

--- a/packages/miniflare/src/workers/assets/rpc-proxy.worker.ts
+++ b/packages/miniflare/src/workers/assets/rpc-proxy.worker.ts
@@ -45,10 +45,7 @@ export default class RPCProxyWorker extends WorkerEntrypoint<Env> {
 				/*
 				 * Otherwise, forward to the USER_WORKER and return its response
 				 */
-				return function (...args: Array<unknown>) {
-					// @ts-expect-error
-					return Reflect.apply(target.env.USER_WORKER[prop], target, args);
-				};
+				return Reflect.get(target.env.USER_WORKER, prop);
 			},
 		});
 	}


### PR DESCRIPTION
This PR simplifies the `RpcProxyWorker` even further, and adds further fixture tests that confirm that promise pipelining, nested functions, and property accessors work as expected. Yay!!

Fixes DEVX-1643

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: experimental feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
