### PR TITLE
chore: add missing `inspectorPort: false` in vite-plugin playground app

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-process-populated-env.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-process-populated-env.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-process-populated-env/wrangler.toml",
+			inspectorPort: false,
 			persistState: false,
 		}),
 	],


### PR DESCRIPTION
In all the vite-plugin playground apps we need to set the `inspectorPort` option to `false` otherwise the CI doesn't seem to properly cope, one (from https://github.com/cloudflare/workers-sdk/pull/8489) is missing (simply because https://github.com/cloudflare/workers-sdk/pull/8441 got merged when out of date with `main`) causing the following issue:
https://github.com/cloudflare/workers-sdk/actions/runs/13974580123/job/39124949648?pr=8596

This PR addresses that

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ci chore
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not wrangler related
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci chore
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
