### PR TITLE
Amend `pages dev` error message when an environment is requested

### DIFF
--- a/.changeset/legal-camels-dance.md
+++ b/.changeset/legal-camels-dance.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Amend `pages dev` error message when an environment is requested

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -37,8 +37,6 @@ describe("pages dev", () => {
 	it("should error if the [--env] command line arg was specified", async () => {
 		await expect(
 			runWrangler("pages dev public --env=production")
-		).rejects.toThrowErrorMatchingInlineSnapshot(
-			`[Error: Pages does not support targeting an environment with the --env flag. Use the --branch flag to target your production or preview branch]`
-		);
+		).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Pages does not support targeting an environment with the --env flag during local development.]`);
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/dev.test.ts
+++ b/packages/wrangler/src/__tests__/pages/dev.test.ts
@@ -37,6 +37,8 @@ describe("pages dev", () => {
 	it("should error if the [--env] command line arg was specified", async () => {
 		await expect(
 			runWrangler("pages dev public --env=production")
-		).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Pages does not support targeting an environment with the --env flag during local development.]`);
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: Pages does not support targeting an environment with the --env flag during local development.]`
+		);
 	});
 });

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -281,7 +281,7 @@ export const Handler = async (args: PagesDevArguments) => {
 
 	if (args.env) {
 		throw new FatalError(
-			"Pages does not support targeting an environment with the --env flag. Use the --branch flag to target your production or preview branch",
+			"Pages does not support targeting an environment with the --env flag during local development.",
 			1
 		);
 	}


### PR DESCRIPTION
if users run `wrangler pages dev --env=my-env` they currently get an error saying to use `--branch` instead, the `--branch` option however only applies to `wrangler pages deploy`, so this error message can easily confuse users, the changes here update the error message to simply state that `--env` is not available for local development

Just something very minor I noticed and though I could quickly address

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because: 
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just a dx change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/8605
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
