### PR TITLE
chore: remove unused `~utils` alias in vite-plugin-cloudflare playground

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/vitest.config.e2e.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest.config.e2e.ts
@@ -1,12 +1,6 @@
-import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-	resolve: {
-		alias: {
-			"~utils": resolve(__dirname, "__test-utils__"),
-		},
-	},
 	test: {
 		// We run these tests in a single fork to avoid them running in parallel.
 		// Otherwise we occasionally get flakes where two tests are overwriting


### PR DESCRIPTION
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: very minor chore
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not a Wrangler change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: very minor chore
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
