### PR TITLE
chore: define wrapper for cloudflare vite-plugin for the playground apps

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/__test-utils__/plugin.ts
+++ b/packages/vite-plugin-cloudflare/playground/__test-utils__/plugin.ts
@@ -1,0 +1,23 @@
+import { cloudflare as originalCloudflarePlugin } from "@cloudflare/vite-plugin";
+import type { PluginConfig } from "@cloudflare/vite-plugin";
+
+/**
+ * Wrapper of the cloudflare vite-plugin that sets some (overridable) default behavior
+ * that generally makes sense for all playground applications
+ */
+export function cloudflare(config?: PluginConfig) {
+	return originalCloudflarePlugin({
+		/**
+		 * since playground apps are used for testing and in CI inspectors are not tested
+		 * and potentially problematic (e.g. the right port needs to be available etc...)
+		 * let's disable inspectors
+		 */
+		inspectorPort: false,
+		/**
+		 * we don't generally care about persisting state for the playground apps (this is
+		 * a feature more geared to proper long-lived applications)
+		 */
+		persistState: false,
+		...config,
+	});
+}

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/cloudflare-env/vite.config.custom-mode.ts
+++ b/packages/vite-plugin-cloudflare/playground/cloudflare-env/vite.config.custom-mode.ts
@@ -1,7 +1,7 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	mode: "custom-mode",
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/cloudflare-env/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/cloudflare-env/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/custom-build-app/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/custom-build-app/vite.config.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	builder: {
@@ -13,5 +13,5 @@ export default defineConfig({
 			}
 		},
 	},
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/dev-vars/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/dev-vars/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/dev-vars/vite.config.with-specified-env.ts
+++ b/packages/vite-plugin-cloudflare/playground/dev-vars/vite.config.with-specified-env.ts
@@ -1,7 +1,7 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	mode: "with-specified-env",
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/durable-objects/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/durable-objects/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/dynamic-import-paths/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/dynamic-import-paths/vite.config.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	environments: {
@@ -13,5 +13,5 @@ export default defineConfig({
 			},
 		},
 	},
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/external-durable-objects/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-durable-objects/vite.config.ts
@@ -1,13 +1,11 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-a/wrangler.toml",
 			auxiliaryWorkers: [{ configPath: "./worker-b/wrangler.toml" }],
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/external-workers/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workers/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/external-workflows/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/vite.config.ts
@@ -1,13 +1,11 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-a/wrangler.toml",
 			auxiliaryWorkers: [{ configPath: "./worker-b/wrangler.toml" }],
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/hot-channel/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/hot-channel/vite.config.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	plugins: [
@@ -21,6 +21,6 @@ export default defineConfig({
 				};
 			},
 		},
-		cloudflare({ inspectorPort: false, persistState: false }),
+		cloudflare(),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.no-prebundling.ts
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.no-prebundling.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	resolve: {
@@ -23,8 +23,6 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			viteEnvironment: { name: "worker" },
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.nodejs-compat.ts
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.nodejs-compat.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	resolve: {
@@ -8,5 +8,5 @@ export default defineConfig({
 			"@alias/test": resolve(__dirname, "./src/aliasing.ts"),
 		},
 	},
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/module-resolution/vite.config.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	resolve: {
@@ -8,5 +8,5 @@ export default defineConfig({
 			"@alias/test": resolve(__dirname, "./src/aliasing.ts"),
 		},
 	},
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/vite.config.custom-output-directories.ts
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/vite.config.custom-output-directories.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	build: {
@@ -16,8 +16,6 @@ export default defineConfig({
 		cloudflare({
 			configPath: "./worker-a/wrangler.toml",
 			auxiliaryWorkers: [{ configPath: "./worker-b/wrangler.toml" }],
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/vite.config.ts
@@ -1,13 +1,11 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-a/wrangler.toml",
 			auxiliaryWorkers: [{ configPath: "./worker-b/wrangler.toml" }],
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/vite.config.with-worker-configs-warning.ts
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/vite.config.with-worker-configs-warning.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	plugins: [
@@ -8,8 +8,6 @@ export default defineConfig({
 			auxiliaryWorkers: [
 				{ configPath: "./worker-b/wrangler.with-warning.toml" },
 			],
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-basic.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-basic.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	build: {
@@ -8,8 +8,6 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-basic/wrangler.toml",
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-cross-env.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-cross-env.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	build: {
@@ -8,8 +8,6 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-cross-env/wrangler.toml",
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-crypto.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-crypto.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	build: {
@@ -8,8 +8,6 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-crypto/wrangler.toml",
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-postgres.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-postgres.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	build: {
@@ -8,8 +8,6 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-postgres/wrangler.toml",
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-process-populated-env.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-process-populated-env.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	build: {
@@ -8,8 +8,6 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-process-populated-env/wrangler.toml",
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-process.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-process.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	build: {
@@ -8,8 +8,6 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-process/wrangler.toml",
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-random.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/vite.config.worker-random.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	build: {
@@ -8,8 +8,6 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./worker-random/wrangler.toml",
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/partyserver/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/partyserver/vite.config.ts
@@ -1,7 +1,7 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [react(), cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [react(), cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/prisma/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/prisma/vite.config.ts
@@ -1,6 +1,11 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false })],
+	plugins: [
+		cloudflare({
+			// the app relies on local state for its D1 data
+			persistState: true,
+		}),
+	],
 });

--- a/packages/vite-plugin-cloudflare/playground/react-spa/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-spa/vite.config.ts
@@ -1,7 +1,7 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [react(), cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [react(), cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/same-worker-service-bindings/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/vite.config.custom-output-directories.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/vite.config.custom-output-directories.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	build: {
@@ -13,5 +13,5 @@ export default defineConfig({
 			},
 		},
 	},
-	plugins: [react(), cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [react(), cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/vite.config.ts
@@ -1,7 +1,7 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [react(), cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [react(), cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/static-mpa/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/static-mpa/vite.config.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	environments: {
@@ -18,5 +18,5 @@ export default defineConfig({
 			},
 		},
 	},
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/static-mpa/vite.config.with-worker-configs-warning.ts
+++ b/packages/vite-plugin-cloudflare/playground/static-mpa/vite.config.with-worker-configs-warning.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	environments: {
@@ -21,8 +21,6 @@ export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./wrangler.with-warning.toml",
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/static/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/static/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/static/vite.config.with-api.ts
+++ b/packages/vite-plugin-cloudflare/playground/static/vite.config.with-api.ts
@@ -1,12 +1,10 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	plugins: [
 		cloudflare({
 			configPath: "./wrangler.with-api.toml",
-			inspectorPort: false,
-			persistState: false,
 		}),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/virtual-modules/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/virtual-modules/vite.config.ts
@@ -1,5 +1,5 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
 	plugins: [
@@ -16,6 +16,6 @@ export default defineConfig({
 				}
 			},
 		},
-		cloudflare({ inspectorPort: false, persistState: false }),
+		cloudflare(),
 	],
 });

--- a/packages/vite-plugin-cloudflare/playground/websockets/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/websockets/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/worker/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });

--- a/packages/vite-plugin-cloudflare/playground/workflows/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/workflows/vite.config.ts
@@ -1,6 +1,6 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
+import { cloudflare } from "../__test-utils__/plugin";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare()],
 });


### PR DESCRIPTION
Quick idea I had so that we don't have to remember to always set `inspectorPort` and `persistState` to `false` when configuring a playground app

This could also be nice for future proofing, in care we introduce other properties that should be defaulted to something in all playground apps

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: is a testing utility change
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not a Wrangler change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
