### PR TITLE
chore: app option to run the vite-plugin playground serve tests in parallel

### DIFF
--- a/packages/vite-plugin-cloudflare/playground/package.json
+++ b/packages/vite-plugin-cloudflare/playground/package.json
@@ -5,10 +5,13 @@
 	"type": "module",
 	"scripts": {
 		"check:types": "tsc --build",
-		"test:build": "cross-env VITE_TEST_BUILD=1 vitest run -c vitest.config.e2e.ts",
-		"pretest:ci": "pnpm playwright install chromium",
-		"test:ci": "pnpm test:serve && pnpm test:build",
-		"test:serve": "vitest run -c vitest.config.e2e.ts"
+		"playwright:install": "pnpm playwright install chromium",
+		"pretest:ci": "pnpm playwright:install",
+		"test:ci": "pnpm test:ci:serve && pnpm test:ci:build",
+		"test:ci:build": "cross-env VITE_TEST_BUILD=1 vitest run -c vitest.config.e2e.ts",
+		"test:ci:serve": "vitest run -c vitest.config.e2e.ts",
+		"pretest:serve": "pnpm playwright:install",
+		"test:serve": "pnpm test:ci:serve --poolOptions.forks.singleFork=false"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",


### PR DESCRIPTION
I think that the only vite-plugin playground tests needing to run sequentially are the build
ones (because of `.wrangler/deploy/config.json`) so I think we can just as well run the dev ones in parallel
to save time
(PS: my only small concern is prebundling since the `node_modules/.vite` directory is still shared across different
variants, but I don't think we ever encountered any issue with that)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: minor chore change
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not wrangler related
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: minor chore change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
