### PR TITLE
Provide more informative error messages for Workers CI tag validation

### DIFF
--- a/packages/wrangler/src/environment-variables/misc-variables.ts
+++ b/packages/wrangler/src/environment-variables/misc-variables.ts
@@ -93,18 +93,18 @@ export const getOutputFilePathFromEnv = getEnvironmentVariableFactory({
 });
 
 /**
- * `WRANGLER_CI_MATCH_TAG` specifies a worker tag
+ * `WRANGLER_CI_MATCH_TAG` specifies a Worker tag
  *
- * If this is set, Wrangler will ensure the worker being targeted has this tag
+ * If this is set, Wrangler will ensure the Worker being targeted has this tag
  */
 export const getCIMatchTag = getEnvironmentVariableFactory({
 	variableName: "WRANGLER_CI_MATCH_TAG",
 });
 
 /**
- * `WRANGLER_CI_OVERRIDE_TAG` specifies a worker tag
+ * `WRANGLER_CI_OVERRIDE_NAME` specifies a Worker name
  *
- * If this is set, Wrangler will override the worker name with this tag
+ * If this is set, Wrangler will override the Worker name with this one
  */
 export const getCIOverrideName = getEnvironmentVariableFactory({
 	variableName: "WRANGLER_CI_OVERRIDE_NAME",

--- a/packages/wrangler/src/match-tag.ts
+++ b/packages/wrangler/src/match-tag.ts
@@ -3,6 +3,7 @@ import { configFileName, formatConfigSnippet } from "./config";
 import { getCIMatchTag } from "./environment-variables/misc-variables";
 import { FatalError } from "./errors";
 import { logger } from "./logger";
+import { APIError } from "./parse";
 import { getCloudflareAccountIdFromEnv } from "./user/auth-variables";
 import type { ServiceMetadataRes } from "./init";
 
@@ -48,9 +49,17 @@ export async function verifyWorkerMatchesCITag(
 			throw new FatalError(
 				`The name in your ${configFileName(configPath)} file (${workerName}) must match the name of your Worker. Please update the name field in your ${configFileName(configPath)} file.`
 			);
+		} else if (e instanceof APIError) {
+			throw new FatalError(
+				"An error occurred while trying to validate that the Worker name matches what is expected by the build system.\n" +
+					e.message +
+					"\n" +
+					e.notes.map((note) => note.text).join("\n")
+			);
 		} else {
 			throw new FatalError(
-				"Wrangler cannot validate that your Worker name matches what is expected by the build system. Please retry the build."
+				"Wrangler cannot validate that your Worker name matches what is expected by the build system. Please retry the build. " +
+					"If the problem persists, please contact support."
 			);
 		}
 	}


### PR DESCRIPTION
Fixes CUSTESC-49792

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not covered
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Workers CI internal usage change
