### PR TITLE
Disable C3 Bun tests

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -38,7 +38,6 @@ jobs:
           [
             { name: npm, version: "0.0.0" },
             { name: pnpm, version: "9.12.0" },
-            { name: bun, version: "1.0.3" },
             { name: yarn, version: "1.0.0" },
           ]
         # include a single windows test with pnpm


### PR DESCRIPTION
This disables C3 E2E tests for bun. Unfortunately, these have proved to be fairly flaky, and in particular have recently started throwing transient errors related to package installation e.g. https://github.com/cloudflare/workers-sdk/actions/runs/13999803837/job/39203491072?pr=8613:

```
 Resolving dependencies
  error: ConnectionRefused downloading tarball tar@6.2.1
  error: ConnectionRefused downloading tarball chownr@2.0.0
  error: ConnectionRefused downloading tarball mkdirp@1.0.4
  error: ConnectionRefused downloading tarball yallist@4.0.0
  error: ConnectionRefused downloading tarball minipass@5.0.0
  error: ConnectionRefused downloading tarball minizlib@2.1.2
  error: ConnectionRefused downloading tarball minipass@3.3.6
  error: ConnectionRefused downloading tarball is-fullwidth-code-point@4.0.0
  error: ConnectionRefused downloading tarball type-fest@1.4.0
  error: ConnectionRefused downloading tarball onetime@5.1.2
  error: ConnectionRefused downloading tarball signal-exit@3.0.7
  error: ConnectionRefused downloading tarball mimic-fn@2.1.0
```

There are several bun issues that seem related: https://github.com/oven-sh/bun/issues/4988, https://github.com/oven-sh/bun/issues/12737