### PR TITLE
[wrangler] Wrangler pages deployments list - added ID to output

### DIFF
--- a/.changeset/lemon-dragons-glow.md
+++ b/.changeset/lemon-dragons-glow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Wrangler pages deployments list - added ID to output

--- a/.changeset/lemon-dragons-glow.md
+++ b/.changeset/lemon-dragons-glow.md
@@ -2,4 +2,4 @@
 "wrangler": minor
 ---
 
-Wrangler pages deployments list - added ID to output
+Added the Pages deployment id to the JSON output for `wrangler pages deployment list`

--- a/packages/wrangler/src/pages/deployments.ts
+++ b/packages/wrangler/src/pages/deployments.ts
@@ -72,6 +72,7 @@ export async function ListHandler({ projectName, environment }: ListArgs) {
 
 	const data = deployments.map((deployment) => {
 		return {
+			Id: deployment.id,
 			Environment: titleCase(deployment.environment),
 			Branch: deployment.deployment_trigger.metadata.branch,
 			Source: shortSha(deployment.deployment_trigger.metadata.commit_hash),


### PR DESCRIPTION
Fixes N/A

Long time ago I raised [this issue](https://community.cloudflare.com/t/wrangler-delete-deployment/610630) on the forum, but it didn't really get any attention, so I decided to do it myself :smile: 
Basically, with this change here I could at least have a reliable API call chained after `pages deployments list` command. In the current implementation of it I'd need to rely on the `Build` URL but it is neither reliable (there is a TODO to use a url shortener) nor easy to use

I do intend to implement `pages deployments delete <deployment-id>` later, if you agree to have it

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no tests that check for the output fields
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: nothing in the docs specifies the output format
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a bugfix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
