### PR TITLE
Support customizing metafile limits

### DIFF
--- a/.changeset/early-maps-make.md
+++ b/.changeset/early-maps-make.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Support customizing the metafile limits

--- a/packages/workers-shared/utils/configuration/parseHeaders.ts
+++ b/packages/workers-shared/utils/configuration/parseHeaders.ts
@@ -12,7 +12,13 @@ import type { HeadersRule, InvalidHeadersRule, ParsedHeaders } from "./types";
 // We do the proper validation in `validateUrl` anyway :)
 const LINE_IS_PROBABLY_A_PATH = new RegExp(/^([^\s]+:\/\/|^\/)/);
 
-export function parseHeaders(input: string): ParsedHeaders {
+export function parseHeaders(
+	input: string,
+	{
+		maxRules = MAX_HEADER_RULES,
+		maxLineLength = MAX_LINE_LENGTH,
+	}: { maxRules?: number; maxLineLength?: number } = {}
+): ParsedHeaders {
 	const lines = input.split("\n");
 	const rules: HeadersRule[] = [];
 	const invalid: InvalidHeadersRule[] = [];
@@ -25,19 +31,19 @@ export function parseHeaders(input: string): ParsedHeaders {
 			continue;
 		}
 
-		if (line.length > MAX_LINE_LENGTH) {
+		if (line.length > maxLineLength) {
 			invalid.push({
 				message: `Ignoring line ${
 					i + 1
-				} as it exceeds the maximum allowed length of ${MAX_LINE_LENGTH}.`,
+				} as it exceeds the maximum allowed length of ${maxLineLength}.`,
 			});
 			continue;
 		}
 
 		if (LINE_IS_PROBABLY_A_PATH.test(line)) {
-			if (rules.length >= MAX_HEADER_RULES) {
+			if (rules.length >= maxRules) {
 				invalid.push({
-					message: `Maximum number of rules supported is ${MAX_HEADER_RULES}. Skipping remaining ${
+					message: `Maximum number of rules supported is ${maxRules}. Skipping remaining ${
 						lines.length - i
 					} lines of file.`,
 				});

--- a/packages/workers-shared/utils/configuration/parseRedirects.ts
+++ b/packages/workers-shared/utils/configuration/parseRedirects.ts
@@ -14,7 +14,18 @@ import type {
 	RedirectRule,
 } from "./types";
 
-export function parseRedirects(input: string): ParsedRedirects {
+export function parseRedirects(
+	input: string,
+	{
+		maxStaticRules = MAX_STATIC_REDIRECT_RULES,
+		maxDynamicRules = MAX_DYNAMIC_REDIRECT_RULES,
+		maxLineLength = MAX_LINE_LENGTH,
+	}: {
+		maxStaticRules?: number;
+		maxDynamicRules?: number;
+		maxLineLength?: number;
+	} = {}
+): ParsedRedirects {
 	const lines = input.split("\n");
 	const rules: RedirectRule[] = [];
 	const seen_paths = new Set<string>();
@@ -30,11 +41,11 @@ export function parseRedirects(input: string): ParsedRedirects {
 			continue;
 		}
 
-		if (line.length > MAX_LINE_LENGTH) {
+		if (line.length > maxLineLength) {
 			invalid.push({
 				message: `Ignoring line ${
 					i + 1
-				} as it exceeds the maximum allowed length of ${MAX_LINE_LENGTH}.`,
+				} as it exceeds the maximum allowed length of ${maxLineLength}.`,
 			});
 			continue;
 		}
@@ -70,9 +81,9 @@ export function parseRedirects(input: string): ParsedRedirects {
 		) {
 			staticRules += 1;
 
-			if (staticRules > MAX_STATIC_REDIRECT_RULES) {
+			if (staticRules > maxStaticRules) {
 				invalid.push({
-					message: `Maximum number of static rules supported is ${MAX_STATIC_REDIRECT_RULES}. Skipping line.`,
+					message: `Maximum number of static rules supported is ${maxStaticRules}. Skipping line.`,
 				});
 				continue;
 			}
@@ -80,9 +91,9 @@ export function parseRedirects(input: string): ParsedRedirects {
 			dynamicRules += 1;
 			canCreateStaticRule = false;
 
-			if (dynamicRules > MAX_DYNAMIC_REDIRECT_RULES) {
+			if (dynamicRules > maxDynamicRules) {
 				invalid.push({
-					message: `Maximum number of dynamic rules supported is ${MAX_DYNAMIC_REDIRECT_RULES}. Skipping remaining ${
+					message: `Maximum number of dynamic rules supported is ${maxDynamicRules}. Skipping remaining ${
 						lines.length - i
 					} lines of file.`,
 				});


### PR DESCRIPTION
Fixes WC-3325.

Allows customizing the limits of Workers Assets metafiles.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not Wrangler

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
