### PR TITLE
refactor: pass the request through the asset-worker `exists` and `getByETag` functions

### DIFF
--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -111,7 +111,12 @@ const getResponseOrAssetIntent = async (
 
 	const decodedPathname = decodePath(pathname);
 
-	const intent = await getIntent(decodedPathname, configuration, exists);
+	const intent = await getIntent(
+		decodedPathname,
+		request,
+		configuration,
+		exists
+	);
 
 	if (!intent) {
 		const response = proxied ? new NotFoundResponse() : new NoIntentResponse();
@@ -194,7 +199,7 @@ const resolveAssetIntentToResponse = async (
 			status: assetIntent.status,
 		});
 
-		return await getByETag(assetIntent.eTag);
+		return await getByETag(assetIntent.eTag, request);
 	});
 
 	const headers = getAssetHeaders(
@@ -310,6 +315,7 @@ type Intent =
 // TODO: Trace this
 export const getIntent = async (
 	pathname: string,
+	request: Request,
 	configuration: Required<AssetConfig>,
 	exists: typeof EntrypointType.prototype.unstable_exists,
 	skipRedirects = false
@@ -318,6 +324,7 @@ export const getIntent = async (
 		case "auto-trailing-slash": {
 			return htmlHandlingAutoTrailingSlash(
 				pathname,
+				request,
 				configuration,
 				exists,
 				skipRedirects
@@ -326,6 +333,7 @@ export const getIntent = async (
 		case "force-trailing-slash": {
 			return htmlHandlingForceTrailingSlash(
 				pathname,
+				request,
 				configuration,
 				exists,
 				skipRedirects
@@ -334,26 +342,28 @@ export const getIntent = async (
 		case "drop-trailing-slash": {
 			return htmlHandlingDropTrailingSlash(
 				pathname,
+				request,
 				configuration,
 				exists,
 				skipRedirects
 			);
 		}
 		case "none": {
-			return htmlHandlingNone(pathname, configuration, exists);
+			return htmlHandlingNone(pathname, request, configuration, exists);
 		}
 	}
 };
 
 const htmlHandlingAutoTrailingSlash = async (
 	pathname: string,
+	request: Request,
 	configuration: Required<AssetConfig>,
 	exists: typeof EntrypointType.prototype.unstable_exists,
 	skipRedirects: boolean
 ): Promise<Intent> => {
 	let redirectResult: Intent = null;
 	let eTagResult: string | null = null;
-	const exactETag = await exists(pathname);
+	const exactETag = await exists(pathname, request);
 	if (pathname.endsWith("/index")) {
 		if (exactETag) {
 			// there's a binary /index file
@@ -365,6 +375,7 @@ const htmlHandlingAutoTrailingSlash = async (
 			if (
 				(redirectResult = await safeRedirect(
 					`${pathname}.html`,
+					request,
 					pathname.slice(0, -"index".length),
 					configuration,
 					exists,
@@ -376,6 +387,7 @@ const htmlHandlingAutoTrailingSlash = async (
 			} else if (
 				(redirectResult = await safeRedirect(
 					`${pathname.slice(0, -"/index".length)}.html`,
+					request,
 					pathname.slice(0, -"/index".length),
 					configuration,
 					exists,
@@ -390,6 +402,7 @@ const htmlHandlingAutoTrailingSlash = async (
 		if (
 			(redirectResult = await safeRedirect(
 				pathname,
+				request,
 				pathname.slice(0, -"index.html".length),
 				configuration,
 				exists,
@@ -401,6 +414,7 @@ const htmlHandlingAutoTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				`${pathname.slice(0, -"/index.html".length)}.html`,
+				request,
 				pathname.slice(0, -"/index.html".length),
 				configuration,
 				exists,
@@ -411,7 +425,7 @@ const htmlHandlingAutoTrailingSlash = async (
 			return redirectResult;
 		}
 	} else if (pathname.endsWith("/")) {
-		if ((eTagResult = await exists(`${pathname}index.html`))) {
+		if ((eTagResult = await exists(`${pathname}index.html`, request))) {
 			// /foo/index.html exists so serve at /foo/
 			return {
 				asset: { eTag: eTagResult, status: OkResponse.status },
@@ -420,6 +434,7 @@ const htmlHandlingAutoTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				`${pathname.slice(0, -"/".length)}.html`,
+				request,
 				pathname.slice(0, -"/".length),
 				configuration,
 				exists,
@@ -433,6 +448,7 @@ const htmlHandlingAutoTrailingSlash = async (
 		if (
 			(redirectResult = await safeRedirect(
 				pathname,
+				request,
 				pathname.slice(0, -".html".length),
 				configuration,
 				exists,
@@ -444,6 +460,7 @@ const htmlHandlingAutoTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				`${pathname.slice(0, -".html".length)}/index.html`,
+				request,
 				`${pathname.slice(0, -".html".length)}/`,
 				configuration,
 				exists,
@@ -461,7 +478,7 @@ const htmlHandlingAutoTrailingSlash = async (
 			asset: { eTag: exactETag, status: OkResponse.status },
 			redirect: null,
 		};
-	} else if ((eTagResult = await exists(`${pathname}.html`))) {
+	} else if ((eTagResult = await exists(`${pathname}.html`, request))) {
 		// foo.html exists so serve at /foo
 		return {
 			asset: { eTag: eTagResult, status: OkResponse.status },
@@ -470,6 +487,7 @@ const htmlHandlingAutoTrailingSlash = async (
 	} else if (
 		(redirectResult = await safeRedirect(
 			`${pathname}/index.html`,
+			request,
 			`${pathname}/`,
 			configuration,
 			exists,
@@ -480,18 +498,19 @@ const htmlHandlingAutoTrailingSlash = async (
 		return redirectResult;
 	}
 
-	return notFound(pathname, configuration, exists);
+	return notFound(pathname, request, configuration, exists);
 };
 
 const htmlHandlingForceTrailingSlash = async (
 	pathname: string,
+	request: Request,
 	configuration: Required<AssetConfig>,
 	exists: typeof EntrypointType.prototype.unstable_exists,
 	skipRedirects: boolean
 ): Promise<Intent> => {
 	let redirectResult: Intent = null;
 	let eTagResult: string | null = null;
-	const exactETag = await exists(pathname);
+	const exactETag = await exists(pathname, request);
 	if (pathname.endsWith("/index")) {
 		if (exactETag) {
 			// there's a binary /index file
@@ -503,6 +522,7 @@ const htmlHandlingForceTrailingSlash = async (
 			if (
 				(redirectResult = await safeRedirect(
 					`${pathname}.html`,
+					request,
 					pathname.slice(0, -"index".length),
 					configuration,
 					exists,
@@ -514,6 +534,7 @@ const htmlHandlingForceTrailingSlash = async (
 			} else if (
 				(redirectResult = await safeRedirect(
 					`${pathname.slice(0, -"/index".length)}.html`,
+					request,
 					pathname.slice(0, -"index".length),
 					configuration,
 					exists,
@@ -528,6 +549,7 @@ const htmlHandlingForceTrailingSlash = async (
 		if (
 			(redirectResult = await safeRedirect(
 				pathname,
+				request,
 				pathname.slice(0, -"index.html".length),
 				configuration,
 				exists,
@@ -539,6 +561,7 @@ const htmlHandlingForceTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				`${pathname.slice(0, -"/index.html".length)}.html`,
+				request,
 				pathname.slice(0, -"index.html".length),
 				configuration,
 				exists,
@@ -549,14 +572,17 @@ const htmlHandlingForceTrailingSlash = async (
 			return redirectResult;
 		}
 	} else if (pathname.endsWith("/")) {
-		if ((eTagResult = await exists(`${pathname}index.html`))) {
+		if ((eTagResult = await exists(`${pathname}index.html`, request))) {
 			// /foo/index.html exists so serve at /foo/
 			return {
 				asset: { eTag: eTagResult, status: OkResponse.status },
 				redirect: null,
 			};
 		} else if (
-			(eTagResult = await exists(`${pathname.slice(0, -"/".length)}.html`))
+			(eTagResult = await exists(
+				`${pathname.slice(0, -"/".length)}.html`,
+				request
+			))
 		) {
 			// /foo.html exists so serve at /foo/
 			return {
@@ -568,6 +594,7 @@ const htmlHandlingForceTrailingSlash = async (
 		if (
 			(redirectResult = await safeRedirect(
 				pathname,
+				request,
 				`${pathname.slice(0, -".html".length)}/`,
 				configuration,
 				exists,
@@ -585,6 +612,7 @@ const htmlHandlingForceTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				`${pathname.slice(0, -".html".length)}/index.html`,
+				request,
 				`${pathname.slice(0, -".html".length)}/`,
 				configuration,
 				exists,
@@ -605,6 +633,7 @@ const htmlHandlingForceTrailingSlash = async (
 	} else if (
 		(redirectResult = await safeRedirect(
 			`${pathname}.html`,
+			request,
 			`${pathname}/`,
 			configuration,
 			exists,
@@ -616,6 +645,7 @@ const htmlHandlingForceTrailingSlash = async (
 	} else if (
 		(redirectResult = await safeRedirect(
 			`${pathname}/index.html`,
+			request,
 			`${pathname}/`,
 			configuration,
 			exists,
@@ -626,18 +656,19 @@ const htmlHandlingForceTrailingSlash = async (
 		return redirectResult;
 	}
 
-	return notFound(pathname, configuration, exists);
+	return notFound(pathname, request, configuration, exists);
 };
 
 const htmlHandlingDropTrailingSlash = async (
 	pathname: string,
+	request: Request,
 	configuration: Required<AssetConfig>,
 	exists: typeof EntrypointType.prototype.unstable_exists,
 	skipRedirects: boolean
 ): Promise<Intent> => {
 	let redirectResult: Intent = null;
 	let eTagResult: string | null = null;
-	const exactETag = await exists(pathname);
+	const exactETag = await exists(pathname, request);
 	if (pathname.endsWith("/index")) {
 		if (exactETag) {
 			// there's a binary /index file
@@ -650,6 +681,7 @@ const htmlHandlingDropTrailingSlash = async (
 				if (
 					(redirectResult = await safeRedirect(
 						"/index.html",
+						request,
 						"/",
 						configuration,
 						exists,
@@ -661,6 +693,7 @@ const htmlHandlingDropTrailingSlash = async (
 			} else if (
 				(redirectResult = await safeRedirect(
 					`${pathname.slice(0, -"/index".length)}.html`,
+					request,
 					pathname.slice(0, -"/index".length),
 					configuration,
 					exists,
@@ -672,6 +705,7 @@ const htmlHandlingDropTrailingSlash = async (
 			} else if (
 				(redirectResult = await safeRedirect(
 					`${pathname}.html`,
+					request,
 					pathname.slice(0, -"/index".length),
 					configuration,
 					exists,
@@ -688,6 +722,7 @@ const htmlHandlingDropTrailingSlash = async (
 			if (
 				(redirectResult = await safeRedirect(
 					"/index.html",
+					request,
 					"/",
 					configuration,
 					exists,
@@ -699,6 +734,7 @@ const htmlHandlingDropTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				pathname,
+				request,
 				pathname.slice(0, -"/index.html".length),
 				configuration,
 				exists,
@@ -716,6 +752,7 @@ const htmlHandlingDropTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				`${pathname.slice(0, -"/index.html".length)}.html`,
+				request,
 				pathname.slice(0, -"/index.html".length),
 				configuration,
 				exists,
@@ -727,7 +764,7 @@ const htmlHandlingDropTrailingSlash = async (
 		}
 	} else if (pathname.endsWith("/")) {
 		if (pathname === "/") {
-			if ((eTagResult = await exists("/index.html"))) {
+			if ((eTagResult = await exists("/index.html", request))) {
 				// /index.html exists so serve at /
 				return {
 					asset: { eTag: eTagResult, status: OkResponse.status },
@@ -737,6 +774,7 @@ const htmlHandlingDropTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				`${pathname.slice(0, -"/".length)}.html`,
+				request,
 				pathname.slice(0, -"/".length),
 				configuration,
 				exists,
@@ -748,6 +786,7 @@ const htmlHandlingDropTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				`${pathname.slice(0, -"/".length)}/index.html`,
+				request,
 				pathname.slice(0, -"/".length),
 				configuration,
 				exists,
@@ -761,6 +800,7 @@ const htmlHandlingDropTrailingSlash = async (
 		if (
 			(redirectResult = await safeRedirect(
 				pathname,
+				request,
 				pathname.slice(0, -".html".length),
 				configuration,
 				exists,
@@ -772,6 +812,7 @@ const htmlHandlingDropTrailingSlash = async (
 		} else if (
 			(redirectResult = await safeRedirect(
 				`${pathname.slice(0, -".html".length)}/index.html`,
+				request,
 				pathname.slice(0, -".html".length),
 				configuration,
 				exists,
@@ -789,13 +830,13 @@ const htmlHandlingDropTrailingSlash = async (
 			asset: { eTag: exactETag, status: OkResponse.status },
 			redirect: null,
 		};
-	} else if ((eTagResult = await exists(`${pathname}.html`))) {
+	} else if ((eTagResult = await exists(`${pathname}.html`, request))) {
 		// /foo.html exists so serve at /foo
 		return {
 			asset: { eTag: eTagResult, status: OkResponse.status },
 			redirect: null,
 		};
-	} else if ((eTagResult = await exists(`${pathname}/index.html`))) {
+	} else if ((eTagResult = await exists(`${pathname}/index.html`, request))) {
 		// /foo/index.html exists so serve at /foo
 		return {
 			asset: { eTag: eTagResult, status: OkResponse.status },
@@ -803,33 +844,35 @@ const htmlHandlingDropTrailingSlash = async (
 		};
 	}
 
-	return notFound(pathname, configuration, exists);
+	return notFound(pathname, request, configuration, exists);
 };
 
 const htmlHandlingNone = async (
 	pathname: string,
+	request: Request,
 	configuration: Required<AssetConfig>,
 	exists: typeof EntrypointType.prototype.unstable_exists
 ): Promise<Intent> => {
-	const exactETag = await exists(pathname);
+	const exactETag = await exists(pathname, request);
 	if (exactETag) {
 		return {
 			asset: { eTag: exactETag, status: OkResponse.status },
 			redirect: null,
 		};
 	} else {
-		return notFound(pathname, configuration, exists);
+		return notFound(pathname, request, configuration, exists);
 	}
 };
 
 const notFound = async (
 	pathname: string,
+	request: Request,
 	configuration: Required<AssetConfig>,
 	exists: typeof EntrypointType.prototype.unstable_exists
 ): Promise<Intent> => {
 	switch (configuration.not_found_handling) {
 		case "single-page-application": {
-			const eTag = await exists("/index.html");
+			const eTag = await exists("/index.html", request);
 			if (eTag) {
 				return {
 					asset: { eTag, status: OkResponse.status },
@@ -842,7 +885,7 @@ const notFound = async (
 			let cwd = pathname;
 			while (cwd) {
 				cwd = cwd.slice(0, cwd.lastIndexOf("/"));
-				const eTag = await exists(`${cwd}/404.html`);
+				const eTag = await exists(`${cwd}/404.html`, request);
 				if (eTag) {
 					return {
 						asset: { eTag, status: NotFoundResponse.status },
@@ -861,6 +904,7 @@ const notFound = async (
 
 const safeRedirect = async (
 	file: string,
+	request: Request,
 	destination: string,
 	configuration: Required<AssetConfig>,
 	exists: typeof EntrypointType.prototype.unstable_exists,
@@ -870,10 +914,16 @@ const safeRedirect = async (
 		return null;
 	}
 
-	if (!(await exists(destination))) {
-		const intent = await getIntent(destination, configuration, exists, true);
+	if (!(await exists(destination, request))) {
+		const intent = await getIntent(
+			destination,
+			request,
+			configuration,
+			exists,
+			true
+		);
 		// return only if the eTag matches - i.e. not the 404 case
-		if (intent?.asset && intent.asset.eTag === (await exists(file))) {
+		if (intent?.asset && intent.asset.eTag === (await exists(file, request))) {
 			return {
 				asset: null,
 				redirect: destination,

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -155,7 +155,7 @@ export default class extends WorkerEntrypoint<Env> {
 
 	async unstable_getByETag(
 		eTag: string,
-		_request: Request
+		_request?: Request
 	): Promise<{
 		readableStream: ReadableStream;
 		contentType: string | undefined;
@@ -188,7 +188,7 @@ export default class extends WorkerEntrypoint<Env> {
 
 	async unstable_getByPathname(
 		pathname: string,
-		request: Request
+		request?: Request
 	): Promise<{
 		readableStream: ReadableStream;
 		contentType: string | undefined;
@@ -204,7 +204,7 @@ export default class extends WorkerEntrypoint<Env> {
 
 	async unstable_exists(
 		pathname: string,
-		_request: Request
+		_request?: Request
 	): Promise<string | null> {
 		const analytics = new ExperimentAnalytics(this.env.EXPERIMENT_ANALYTICS);
 		const performance = new PerformanceTimer(this.env.UNSAFE_PERFORMANCE);

--- a/packages/workers-shared/asset-worker/src/index.ts
+++ b/packages/workers-shared/asset-worker/src/index.ts
@@ -153,7 +153,10 @@ export default class extends WorkerEntrypoint<Env> {
 		);
 	}
 
-	async unstable_getByETag(eTag: string): Promise<{
+	async unstable_getByETag(
+		eTag: string,
+		_request: Request
+	): Promise<{
 		readableStream: ReadableStream;
 		contentType: string | undefined;
 		cacheStatus: "HIT" | "MISS";
@@ -183,20 +186,26 @@ export default class extends WorkerEntrypoint<Env> {
 		};
 	}
 
-	async unstable_getByPathname(pathname: string): Promise<{
+	async unstable_getByPathname(
+		pathname: string,
+		request: Request
+	): Promise<{
 		readableStream: ReadableStream;
 		contentType: string | undefined;
 		cacheStatus: "HIT" | "MISS";
 	} | null> {
-		const eTag = await this.unstable_exists(pathname);
+		const eTag = await this.unstable_exists(pathname, request);
 		if (!eTag) {
 			return null;
 		}
 
-		return this.unstable_getByETag(eTag);
+		return this.unstable_getByETag(eTag, request);
 	}
 
-	async unstable_exists(pathname: string): Promise<string | null> {
+	async unstable_exists(
+		pathname: string,
+		_request: Request
+	): Promise<string | null> {
 		const analytics = new ExperimentAnalytics(this.env.EXPERIMENT_ANALYTICS);
 		const performance = new PerformanceTimer(this.env.UNSAFE_PERFORMANCE);
 


### PR DESCRIPTION
This has no effect on the deployed Worker in production, but is useful in local development for ensuring that the full request is available when overriding the functions.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: refactor - covered by current tests
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: refactor
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor - no user facing change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: will not affect Wrangler

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
