### PR TITLE
test: increase the timeouts on the workers-with-assets-spa tests

### DIFF
--- a/fixtures/workers-with-assets-spa/vitest.config.mts
+++ b/fixtures/workers-with-assets-spa/vitest.config.mts
@@ -1,0 +1,14 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {
+			// The `runWranglerDev` helper will wait up to 50 secs for Wrangler to boot up
+			// The `chromium.launch` helper will wait up to 30 secs for the browser to boot up.
+			hookTimeout: 50_000,
+			testTimeout: 50_000,
+		},
+	})
+);


### PR DESCRIPTION
It might be that these tests flake a lot simply because the timeouts are quite short up to now.