### PR TITLE
Fix dev server crashing on config changes

### DIFF
--- a/.changeset/shy-singers-kiss.md
+++ b/.changeset/shy-singers-kiss.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Fix a bug where updating config files would crash the dev server. This occurred because the previous Miniflare instance was not disposed before creating a new one. This would lead to a port collision because of the `inspectorPort` introduced by the new debugging features.

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -41,44 +41,44 @@ test.runIf(!isBuild)(
 	}
 );
 
-test.runIf(!isBuild)(
-	"reports errors in updates to the Worker config",
-	async ({ onTestFinished }) => {
-		const workerConfigPath = path.join(__dirname, "../wrangler.json");
-		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
+// test.runIf(!isBuild)(
+// 	"reports errors in updates to the Worker config",
+// 	async ({ onTestFinished }) => {
+// 		const workerConfigPath = path.join(__dirname, "../wrangler.json");
+// 		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
 
-		onTestFinished(async () => {
-			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
-			// We need to ensure that the original config is restored before the next test runs
-			await vi.waitFor(
-				async () => {
-					const revertedResponse = await getTextResponse();
-					expect(revertedResponse).toBe('The value of MY_VAR is "one"');
-				},
-				{ timeout: 5000 }
-			);
-		});
+// 		onTestFinished(async () => {
+// 			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
+// 			// We need to ensure that the original config is restored before the next test runs
+// 			await vi.waitFor(
+// 				async () => {
+// 					const revertedResponse = await getTextResponse();
+// 					expect(revertedResponse).toBe('The value of MY_VAR is "one"');
+// 				},
+// 				{ timeout: 5000 }
+// 			);
+// 		});
 
-		const originalResponse = await getTextResponse();
-		expect(originalResponse).toBe('The value of MY_VAR is "one"');
+// 		const originalResponse = await getTextResponse();
+// 		expect(originalResponse).toBe('The value of MY_VAR is "one"');
 
-		const updatedWorkerConfig = JSON.stringify({
-			...JSON.parse(originalWorkerConfig),
-			main: "./src/non-existing-file.ts",
-			vars: {
-				MY_VAR: "two",
-			},
-		});
-		fs.writeFileSync(workerConfigPath, updatedWorkerConfig);
-		await vi.waitFor(
-			async () => {
-				const newResponse = await getTextResponse();
-				expect(serverLogs.errors.join()).toMatch(
-					/.*The provided Wrangler config main field .+? doesn't point to an existing file.*/
-				);
-				expect(newResponse).toBe('The value of MY_VAR is "one"');
-			},
-			{ timeout: 5000 }
-		);
-	}
-);
+// 		const updatedWorkerConfig = JSON.stringify({
+// 			...JSON.parse(originalWorkerConfig),
+// 			main: "./src/non-existing-file.ts",
+// 			vars: {
+// 				MY_VAR: "two",
+// 			},
+// 		});
+// 		fs.writeFileSync(workerConfigPath, updatedWorkerConfig);
+// 		await vi.waitFor(
+// 			async () => {
+// 				const newResponse = await getTextResponse();
+// 				expect(serverLogs.errors.join()).toMatch(
+// 					/.*The provided Wrangler config main field .+? doesn't point to an existing file.*/
+// 				);
+// 				expect(newResponse).toBe('The value of MY_VAR is "one"');
+// 			},
+// 			{ timeout: 5000 }
+// 		);
+// 	}
+// );

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -6,7 +6,7 @@ import { getTextResponse, isBuild, serverLogs } from "../../__test-utils__";
 test.runIf(!isBuild)(
 	"successfully updates when a var is updated in the Worker config",
 	async ({ onTestFinished }) => {
-		const workerConfigPath = path.join(__dirname, "../wrangler.json");
+		const workerConfigPath = path.resolve(__dirname, "../wrangler.json");
 		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
 
 		onTestFinished(async () => {

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -12,10 +12,13 @@ test.runIf(!isBuild)(
 		onTestFinished(async () => {
 			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
 			// We need to ensure that the original config is restored before the next test runs
-			await vi.waitFor(async () => {
-				const revertedResponse = await getTextResponse();
-				expect(revertedResponse).toBe('The value of MY_VAR is "one"');
-			});
+			await vi.waitFor(
+				async () => {
+					const revertedResponse = await getTextResponse();
+					expect(revertedResponse).toBe('The value of MY_VAR is "one"');
+				},
+				{ timeout: 5000 }
+			);
 		});
 
 		const originalResponse = await getTextResponse();
@@ -28,10 +31,13 @@ test.runIf(!isBuild)(
 			},
 		});
 		fs.writeFileSync(workerConfigPath, updatedWorkerConfig);
-		await vi.waitFor(async () => {
-			const updatedResponse = await getTextResponse();
-			expect(updatedResponse).toBe('The value of MY_VAR is "two"');
-		});
+		await vi.waitFor(
+			async () => {
+				const updatedResponse = await getTextResponse();
+				expect(updatedResponse).toBe('The value of MY_VAR is "two"');
+			},
+			{ timeout: 5000 }
+		);
 	}
 );
 
@@ -44,10 +50,13 @@ test.runIf(!isBuild)(
 		onTestFinished(async () => {
 			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
 			// We need to ensure that the original config is restored before the next test runs
-			await vi.waitFor(async () => {
-				const revertedResponse = await getTextResponse();
-				expect(revertedResponse).toBe('The value of MY_VAR is "one"');
-			});
+			await vi.waitFor(
+				async () => {
+					const revertedResponse = await getTextResponse();
+					expect(revertedResponse).toBe('The value of MY_VAR is "one"');
+				},
+				{ timeout: 5000 }
+			);
 		});
 
 		const originalResponse = await getTextResponse();
@@ -61,12 +70,15 @@ test.runIf(!isBuild)(
 			},
 		});
 		fs.writeFileSync(workerConfigPath, updatedWorkerConfig);
-		await vi.waitFor(async () => {
-			const newResponse = await getTextResponse();
-			expect(serverLogs.errors.join()).toMatch(
-				/.*The provided Wrangler config main field .+? doesn't point to an existing file.*/
-			);
-			expect(newResponse).toBe('The value of MY_VAR is "one"');
-		});
+		await vi.waitFor(
+			async () => {
+				const newResponse = await getTextResponse();
+				expect(serverLogs.errors.join()).toMatch(
+					/.*The provided Wrangler config main field .+? doesn't point to an existing file.*/
+				);
+				expect(newResponse).toBe('The value of MY_VAR is "one"');
+			},
+			{ timeout: 5000 }
+		);
 	}
 );

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -41,44 +41,44 @@ test.runIf(!isBuild)(
 	}
 );
 
-// test.runIf(!isBuild)(
-// 	"reports errors in updates to the Worker config",
-// 	async ({ onTestFinished }) => {
-// 		const workerConfigPath = path.join(__dirname, "../wrangler.json");
-// 		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
+test.runIf(!isBuild)(
+	"reports errors in updates to the Worker config",
+	async ({ onTestFinished }) => {
+		const workerConfigPath = path.join(__dirname, "../wrangler.json");
+		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
 
-// 		onTestFinished(async () => {
-// 			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
-// 			// We need to ensure that the original config is restored before the next test runs
-// 			await vi.waitFor(
-// 				async () => {
-// 					const revertedResponse = await getTextResponse();
-// 					expect(revertedResponse).toBe('The value of MY_VAR is "one"');
-// 				},
-// 				{ timeout: 5000 }
-// 			);
-// 		});
+		onTestFinished(async () => {
+			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
+			// We need to ensure that the original config is restored before the next test runs
+			await vi.waitFor(
+				async () => {
+					const revertedResponse = await getTextResponse();
+					expect(revertedResponse).toBe('The value of MY_VAR is "one"');
+				},
+				{ timeout: 5000 }
+			);
+		});
 
-// 		const originalResponse = await getTextResponse();
-// 		expect(originalResponse).toBe('The value of MY_VAR is "one"');
+		const originalResponse = await getTextResponse();
+		expect(originalResponse).toBe('The value of MY_VAR is "one"');
 
-// 		const updatedWorkerConfig = JSON.stringify({
-// 			...JSON.parse(originalWorkerConfig),
-// 			main: "./src/non-existing-file.ts",
-// 			vars: {
-// 				MY_VAR: "two",
-// 			},
-// 		});
-// 		fs.writeFileSync(workerConfigPath, updatedWorkerConfig);
-// 		await vi.waitFor(
-// 			async () => {
-// 				const newResponse = await getTextResponse();
-// 				expect(serverLogs.errors.join()).toMatch(
-// 					/.*The provided Wrangler config main field .+? doesn't point to an existing file.*/
-// 				);
-// 				expect(newResponse).toBe('The value of MY_VAR is "one"');
-// 			},
-// 			{ timeout: 5000 }
-// 		);
-// 	}
-// );
+		const updatedWorkerConfig = JSON.stringify({
+			...JSON.parse(originalWorkerConfig),
+			main: "./src/non-existing-file.ts",
+			vars: {
+				MY_VAR: "two",
+			},
+		});
+		fs.writeFileSync(workerConfigPath, updatedWorkerConfig);
+		await vi.waitFor(
+			async () => {
+				const newResponse = await getTextResponse();
+				expect(serverLogs.errors.join()).toMatch(
+					/.*The provided Wrangler config main field .+? doesn't point to an existing file.*/
+				);
+				expect(newResponse).toBe('The value of MY_VAR is "one"');
+			},
+			{ timeout: 5000 }
+		);
+	}
+);

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -1,27 +1,86 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { expect, test, vi } from "vitest";
-import { getTextResponse } from "../../__test-utils__";
+import { getTextResponse, isBuild, serverLogs } from "../../__test-utils__";
 
-test("restart", async ({ onTestFinished }) => {
-	const workerConfigPath = path.join(__dirname, "../wrangler.json");
-	const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
-	onTestFinished(() => {
+test.runIf(!isBuild)(
+	"successfully updates when a var is updated in the Worker config",
+	async ({ onTestFailed }) => {
+		const workerConfigPath = path.join(__dirname, "../wrangler.json");
+		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
+
+		onTestFailed(async () => {
+			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
+
+			await vi.waitFor(async () => {
+				const revertedResponse = await getTextResponse();
+				expect(revertedResponse).toBe('The value of MY_VAR is "one"');
+			});
+		});
+
+		const originalResponse = await getTextResponse();
+		expect(originalResponse).toBe('The value of MY_VAR is "one"');
+
+		const updatedWorkerConfig = JSON.stringify({
+			...JSON.parse(originalWorkerConfig),
+			vars: {
+				MY_VAR: "two",
+			},
+		});
+		fs.writeFileSync(workerConfigPath, updatedWorkerConfig);
+		await vi.waitFor(async () => {
+			const updatedResponse = await getTextResponse();
+			expect(updatedResponse).toBe('The value of MY_VAR is "two"');
+		});
+
 		fs.writeFileSync(workerConfigPath, originalWorkerConfig);
-	});
-	const originalResponse = await getTextResponse();
-	expect(originalResponse).toBe('The value of MY_VAR is "one"');
+		// We need to ensure that the original config is restored before the next test runs
+		await vi.waitFor(async () => {
+			const revertedResponse = await getTextResponse();
+			expect(revertedResponse).toBe('The value of MY_VAR is "one"');
+		});
+	}
+);
 
-	const newWorkerConfig = JSON.stringify({
-		...JSON.parse(originalWorkerConfig),
-		vars: {
-			MY_VAR: "two",
-		},
-	});
-	fs.writeFileSync(workerConfigPath, newWorkerConfig);
+test.runIf(!isBuild)(
+	"reports errors in updates to the Worker config",
+	async ({ onTestFailed }) => {
+		const workerConfigPath = path.join(__dirname, "../wrangler.json");
+		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
 
-	await vi.waitFor(async () => {
-		const newResponse = await getTextResponse();
-		expect(newResponse).toBe('The value of MY_VAR is "two"');
-	});
-});
+		onTestFailed(async () => {
+			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
+
+			await vi.waitFor(async () => {
+				const revertedResponse = await getTextResponse();
+				expect(revertedResponse).toBe('The value of MY_VAR is "one"');
+			});
+		});
+
+		const originalResponse = await getTextResponse();
+		expect(originalResponse).toBe('The value of MY_VAR is "one"');
+
+		const updatedWorkerConfig = JSON.stringify({
+			...JSON.parse(originalWorkerConfig),
+			main: "./src/non-existing-file.ts",
+			vars: {
+				MY_VAR: "two",
+			},
+		});
+		fs.writeFileSync(workerConfigPath, updatedWorkerConfig);
+		await vi.waitFor(async () => {
+			const newResponse = await getTextResponse();
+			expect(serverLogs.errors.join()).toMatch(
+				/.*The provided Wrangler config main field .+? doesn't point to an existing file.*/
+			);
+			expect(newResponse).toBe('The value of MY_VAR is "one"');
+		});
+
+		fs.writeFileSync(workerConfigPath, originalWorkerConfig);
+		// We need to ensure that the original config is restored before the next test runs
+		await vi.waitFor(async () => {
+			const revertedResponse = await getTextResponse();
+			expect(revertedResponse).toBe('The value of MY_VAR is "one"');
+		});
+	}
+);

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -1,0 +1,27 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { expect, test, vi } from "vitest";
+import { getTextResponse } from "../../__test-utils__";
+
+test("restart", async ({ onTestFinished }) => {
+	const workerConfigPath = path.join(__dirname, "../wrangler.json");
+	const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
+	onTestFinished(() => {
+		fs.writeFileSync(workerConfigPath, originalWorkerConfig);
+	});
+	const originalResponse = await getTextResponse();
+	expect(originalResponse).toBe('The value of MY_VAR is "one"');
+
+	const newWorkerConfig = JSON.stringify({
+		...JSON.parse(originalWorkerConfig),
+		vars: {
+			MY_VAR: "two",
+		},
+	});
+	fs.writeFileSync(workerConfigPath, newWorkerConfig);
+
+	await vi.waitFor(async () => {
+		const newResponse = await getTextResponse();
+		expect(newResponse).toBe('The value of MY_VAR is "two"');
+	});
+});

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -5,13 +5,13 @@ import { getTextResponse, isBuild, serverLogs } from "../../__test-utils__";
 
 test.runIf(!isBuild)(
 	"successfully updates when a var is updated in the Worker config",
-	async ({ onTestFailed }) => {
+	async ({ onTestFinished }) => {
 		const workerConfigPath = path.join(__dirname, "../wrangler.json");
 		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
 
-		onTestFailed(async () => {
+		onTestFinished(async () => {
 			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
-
+			// We need to ensure that the original config is restored before the next test runs
 			await vi.waitFor(async () => {
 				const revertedResponse = await getTextResponse();
 				expect(revertedResponse).toBe('The value of MY_VAR is "one"');
@@ -32,25 +32,18 @@ test.runIf(!isBuild)(
 			const updatedResponse = await getTextResponse();
 			expect(updatedResponse).toBe('The value of MY_VAR is "two"');
 		});
-
-		fs.writeFileSync(workerConfigPath, originalWorkerConfig);
-		// We need to ensure that the original config is restored before the next test runs
-		await vi.waitFor(async () => {
-			const revertedResponse = await getTextResponse();
-			expect(revertedResponse).toBe('The value of MY_VAR is "one"');
-		});
 	}
 );
 
 test.runIf(!isBuild)(
 	"reports errors in updates to the Worker config",
-	async ({ onTestFailed }) => {
+	async ({ onTestFinished }) => {
 		const workerConfigPath = path.join(__dirname, "../wrangler.json");
 		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
 
-		onTestFailed(async () => {
+		onTestFinished(async () => {
 			fs.writeFileSync(workerConfigPath, originalWorkerConfig);
-
+			// We need to ensure that the original config is restored before the next test runs
 			await vi.waitFor(async () => {
 				const revertedResponse = await getTextResponse();
 				expect(revertedResponse).toBe('The value of MY_VAR is "one"');
@@ -74,13 +67,6 @@ test.runIf(!isBuild)(
 				/.*The provided Wrangler config main field .+? doesn't point to an existing file.*/
 			);
 			expect(newResponse).toBe('The value of MY_VAR is "one"');
-		});
-
-		fs.writeFileSync(workerConfigPath, originalWorkerConfig);
-		// We need to ensure that the original config is restored before the next test runs
-		await vi.waitFor(async () => {
-			const revertedResponse = await getTextResponse();
-			expect(revertedResponse).toBe('The value of MY_VAR is "one"');
 		});
 	}
 );

--- a/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/__tests__/config-changes.spec.ts
@@ -6,7 +6,7 @@ import { getTextResponse, isBuild, serverLogs } from "../../__test-utils__";
 test.runIf(!isBuild)(
 	"successfully updates when a var is updated in the Worker config",
 	async ({ onTestFinished }) => {
-		const workerConfigPath = path.resolve(__dirname, "../wrangler.json");
+		const workerConfigPath = path.join(__dirname, "../wrangler.json");
 		const originalWorkerConfig = fs.readFileSync(workerConfigPath, "utf-8");
 
 		onTestFinished(async () => {

--- a/packages/vite-plugin-cloudflare/playground/config-changes/package.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@playground/config-changes",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build --app",
+		"check:types": "tsc --build",
+		"dev": "vite dev",
+		"preview": "vite preview"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "workspace:*",
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "^4.20250320.0",
+		"typescript": "catalog:default",
+		"vite": "catalog:vite-plugin",
+		"wrangler": "workspace:*"
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/config-changes/package.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250320.0",
+		"@cloudflare/workers-types": "^4.20250321.0",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/config-changes/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/src/index.ts
@@ -1,0 +1,9 @@
+interface Env {
+	MY_VAR: string;
+}
+
+export default {
+	async fetch(_, env) {
+		return new Response(`The value of MY_VAR is "${env.MY_VAR}"`);
+	},
+} satisfies ExportedHandler<Env>;

--- a/packages/vite-plugin-cloudflare/playground/config-changes/tsconfig.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/packages/vite-plugin-cloudflare/playground/config-changes/tsconfig.node.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/tsconfig.node.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/base.json"],
+	"include": ["vite.config.ts", "__tests__"]
+}

--- a/packages/vite-plugin-cloudflare/playground/config-changes/tsconfig.worker.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/tsconfig.worker.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/worker.json"],
+	"include": ["src"]
+}

--- a/packages/vite-plugin-cloudflare/playground/config-changes/turbo.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://turbo.build/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["dist/**"]
+		}
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/config-changes/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/vite.config.ts
@@ -1,0 +1,6 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+});

--- a/packages/vite-plugin-cloudflare/playground/config-changes/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/vite.config.ts
@@ -2,6 +2,6 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	// We leave the `inspectorPort` enabled in this playground to verify that there are no port collisions on server restarts
-	plugins: [cloudflare({ persistState: false })],
+	// We should enable `inspectorPort` in this playground when it's possible to do so to verify that there are no port collisions on server restarts
+	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
 });

--- a/packages/vite-plugin-cloudflare/playground/config-changes/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/vite.config.ts
@@ -2,5 +2,6 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+	// We leave the `inspectorPort` enabled in this playground to verify that there are no port collisions on server restarts
+	plugins: [cloudflare({ persistState: false })],
 });

--- a/packages/vite-plugin-cloudflare/playground/config-changes/wrangler.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/wrangler.json
@@ -3,7 +3,5 @@
 	"name": "worker",
 	"compatibility_date": "2024-12-30",
 	"main": "./src/index.ts",
-	"vars": {
-		"MY_VAR": "one"
-	}
+	"vars": { "MY_VAR": "one" }
 }

--- a/packages/vite-plugin-cloudflare/playground/config-changes/wrangler.json
+++ b/packages/vite-plugin-cloudflare/playground/config-changes/wrangler.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "worker",
+	"compatibility_date": "2024-12-30",
+	"main": "./src/index.ts",
+	"vars": {
+		"MY_VAR": "one"
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/external-workflows/__tests__/workflows.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, vi } from "vitest";
 import { getJsonResponse } from "../../__test-utils__";
 
 test("creates a Workflow with an ID", async () => {
-	const instanceId = "test-id";
+	const instanceId = "external-workflows-test-id";
 
 	expect(await getJsonResponse(`/create?id=${instanceId}`)).toEqual({
 		id: instanceId,

--- a/packages/vite-plugin-cloudflare/playground/partyserver/package.json
+++ b/packages/vite-plugin-cloudflare/playground/partyserver/package.json
@@ -18,9 +18,11 @@
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20250321.0",
+		"@tailwindcss/vite": "^4.0.15",
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
 		"@vitejs/plugin-react": "^4.3.4",
+		"tailwindcss": "^4.0.15",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",
 		"wrangler": "workspace:*"

--- a/packages/vite-plugin-cloudflare/playground/partyserver/src/App.tsx
+++ b/packages/vite-plugin-cloudflare/playground/partyserver/src/App.tsx
@@ -1,5 +1,6 @@
 import { usePartySocket } from "partysocket/react";
 import { useState } from "react";
+import "./tailwind.css";
 
 function App() {
 	const [message, setMessage] = useState();

--- a/packages/vite-plugin-cloudflare/playground/partyserver/src/tailwind.css
+++ b/packages/vite-plugin-cloudflare/playground/partyserver/src/tailwind.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/packages/vite-plugin-cloudflare/playground/partyserver/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/partyserver/vite.config.ts
@@ -1,7 +1,12 @@
 import { cloudflare } from "@cloudflare/vite-plugin";
+import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [react(), cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [
+		react(),
+		cloudflare({ inspectorPort: false, persistState: false }),
+		tailwindcss(),
+	],
 });

--- a/packages/vite-plugin-cloudflare/playground/vitest.config.e2e.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest.config.e2e.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 		setupFiles: ["./vitest-setup.ts"],
 		globalSetup: ["./vitest-global-setup.ts"],
 		reporters: "dot",
-		// onConsoleLog: () => false,
+		onConsoleLog: () => false,
 		testTimeout: 10000,
 	},
 	publicDir: false,

--- a/packages/vite-plugin-cloudflare/playground/vitest.config.e2e.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest.config.e2e.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 		setupFiles: ["./vitest-setup.ts"],
 		globalSetup: ["./vitest-global-setup.ts"],
 		reporters: "dot",
-		onConsoleLog: () => false,
+		// onConsoleLog: () => false,
 		testTimeout: 10000,
 	},
 	publicDir: false,

--- a/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/workflows/__tests__/workflows.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, vi } from "vitest";
 import { getJsonResponse } from "../../__test-utils__";
 
 test("creates a Workflow with an ID", async () => {
-	const instanceId = "test-id";
+	const instanceId = "workflows-test-id";
 
 	expect(await getJsonResponse(`/create?id=${instanceId}`)).toEqual({
 		id: instanceId,

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -317,7 +317,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				}
 
 				await initRunners(resolvedPluginConfig, viteDevServer, miniflare);
-				const routerWorker = await getRouterWorker(miniflare);
 
 				const middleware = createMiddleware(
 					async ({ request }) => {

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -339,7 +339,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				});
 
 				return () => {
-					viteDevServer.middlewares.use(async (req, res, next) => {
+					viteDevServer.middlewares.use((req, res, next) => {
 						middleware(req, res, next);
 					});
 				};

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -287,7 +287,8 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 			},
 			handleHotUpdate(options) {
 				if (
-					resolvedPluginConfig.configPaths.has(options.file) ||
+					// Vite normalizes `options.file` so we use `path.resolve` for Windows compatibility
+					resolvedPluginConfig.configPaths.has(path.resolve(options.file)) ||
 					hasAssetsConfigChanged(
 						resolvedPluginConfig,
 						resolvedViteConfig,

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -320,22 +320,21 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 
 				const middleware = createMiddleware(
 					async ({ request }) => {
-						if (miniflare) {
-							const routerWorker = await getRouterWorker(miniflare);
+						assert(miniflare, `Miniflare not defined`);
+						const routerWorker = await getRouterWorker(miniflare);
 
-							return routerWorker.fetch(toMiniflareRequest(request), {
-								redirect: "manual",
-							}) as any;
-						}
+						return routerWorker.fetch(toMiniflareRequest(request), {
+							redirect: "manual",
+						}) as any;
 					},
 					{ alwaysCallNext: false }
 				);
 
 				handleWebSocket(viteDevServer.httpServer, async () => {
-					if (miniflare) {
-						const routerWorker = await getRouterWorker(miniflare);
-						return routerWorker.fetch;
-					}
+					assert(miniflare, `Miniflare not defined`);
+					const routerWorker = await getRouterWorker(miniflare);
+
+					return routerWorker.fetch;
 				});
 
 				return () => {

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -572,6 +572,8 @@ export function getPreviewMiniflareOptions(
 	};
 }
 
+const removedMessages = [/^Ready on http/, /^Updated and ready on http/];
+
 /**
  * A Miniflare logger that forwards messages onto a Vite logger.
  */
@@ -583,9 +585,12 @@ class ViteMiniflareLogger extends Log {
 	}
 
 	override logWithLevel(level: LogLevel, message: string) {
-		if (/^Ready on http/.test(message)) {
-			level = LogLevel.DEBUG;
+		for (const removedMessage of removedMessages) {
+			if (removedMessage.test(message)) {
+				return;
+			}
 		}
+
 		switch (level) {
 			case LogLevel.ERROR:
 				return this.logger.error(message);

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -59,3 +59,5 @@ export function cleanUrl(url: string): string {
 }
 
 export type Optional<T, K extends keyof T> = Omit<T, K> & Pick<Partial<T>, K>;
+
+export type MaybePromise<T> = Promise<T> | T;

--- a/packages/vite-plugin-cloudflare/src/websockets.ts
+++ b/packages/vite-plugin-cloudflare/src/websockets.ts
@@ -14,9 +14,7 @@ import type * as vite from "vite";
  */
 export function handleWebSocket(
 	httpServer: vite.HttpServer,
-	getFetcher: () => MaybePromise<
-		ReplaceWorkersTypes<Fetcher>["fetch"] | undefined
-	>
+	getFetcher: () => MaybePromise<ReplaceWorkersTypes<Fetcher>["fetch"]>
 ) {
 	const nodeWebSocket = new WebSocketServer({ noServer: true });
 
@@ -32,11 +30,11 @@ export function handleWebSocket(
 
 			const headers = nodeHeadersToWebHeaders(request.headers);
 			const fetcher = await getFetcher();
-			const response = await fetcher?.(url, {
+			const response = await fetcher(url, {
 				headers,
 				method: request.method,
 			});
-			const workerWebSocket = response?.webSocket;
+			const workerWebSocket = response.webSocket;
 
 			if (!workerWebSocket) {
 				socket.destroy();

--- a/packages/vite-plugin-cloudflare/src/workers-configs.ts
+++ b/packages/vite-plugin-cloudflare/src/workers-configs.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as vite from "vite";
 import { unstable_readConfig } from "wrangler";
 import type { AssetsOnlyConfig, WorkerConfig } from "./plugin-config";
 import type { Optional } from "./utils";
@@ -287,7 +288,7 @@ export function getWorkerConfig(
 
 	const { raw, config, nonApplicable } = readWorkerConfig(configPath, env);
 
-	opts?.visitedConfigPaths?.add(configPath);
+	opts?.visitedConfigPaths?.add(vite.normalizePath(configPath));
 
 	if (!config.name) {
 		throw new Error(missingFieldErrorMessage(`'name'`, configPath, env));

--- a/packages/vite-plugin-cloudflare/src/workers-configs.ts
+++ b/packages/vite-plugin-cloudflare/src/workers-configs.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as vite from "vite";
 import { unstable_readConfig } from "wrangler";
 import type { AssetsOnlyConfig, WorkerConfig } from "./plugin-config";
 import type { Optional } from "./utils";
@@ -288,7 +287,7 @@ export function getWorkerConfig(
 
 	const { raw, config, nonApplicable } = readWorkerConfig(configPath, env);
 
-	opts?.visitedConfigPaths?.add(vite.normalizePath(configPath));
+	opts?.visitedConfigPaths?.add(configPath);
 
 	if (!config.name) {
 		throw new Error(missingFieldErrorMessage(`'name'`, configPath, env));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,10 +130,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)
+        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   fixtures/additional-modules:
     devDependencies:
@@ -151,7 +151,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -169,7 +169,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -196,7 +196,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -217,7 +217,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -238,7 +238,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -253,7 +253,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -271,7 +271,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -292,7 +292,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -316,7 +316,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -340,7 +340,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   fixtures/isomorphic-random-example: {}
 
@@ -365,7 +365,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -377,7 +377,7 @@ importers:
         version: 7.0.0
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -402,7 +402,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -420,7 +420,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -447,7 +447,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -465,7 +465,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -486,7 +486,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -514,7 +514,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -532,7 +532,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -550,7 +550,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -568,7 +568,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -589,7 +589,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -607,7 +607,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -644,7 +644,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -665,7 +665,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -680,7 +680,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -701,7 +701,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -719,7 +719,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -737,7 +737,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -755,7 +755,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -773,7 +773,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -791,7 +791,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -809,7 +809,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -827,7 +827,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -848,7 +848,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -863,7 +863,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -927,10 +927,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)
+        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -972,7 +972,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1002,7 +1002,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1023,7 +1023,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1044,7 +1044,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1065,7 +1065,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1098,7 +1098,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1116,7 +1116,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1134,7 +1134,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1353,13 +1353,13 @@ importers:
         version: 5.28.5
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)
+        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
       vite-tsconfig-paths:
         specifier: ^4.0.8
-        version: 4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76))
+        version: 4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1699,7 +1699,7 @@ importers:
         version: 0.4.1
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   packages/playground-preview-worker:
     dependencies:
@@ -1835,7 +1835,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -1902,10 +1902,10 @@ importers:
         version: 5.28.5
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   packages/vite-plugin-cloudflare/playground:
     devDependencies:
@@ -1938,7 +1938,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -1959,7 +1959,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -1980,7 +1980,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2001,7 +2001,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2022,7 +2022,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2043,7 +2043,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2064,7 +2064,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2085,7 +2085,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2106,7 +2106,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2127,7 +2127,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2148,7 +2148,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2169,7 +2169,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2211,7 +2211,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2232,7 +2232,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2268,7 +2268,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2297,6 +2297,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20250321.0
         version: 4.20250321.0
+      '@tailwindcss/vite':
+        specifier: ^4.0.15
+        version: 4.0.15(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))
       '@types/react':
         specifier: ^19.0.0
         version: 19.0.7
@@ -2305,13 +2308,16 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2))
+        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))
+      tailwindcss:
+        specifier: ^4.0.15
+        version: 4.0.15
       typescript:
         specifier: catalog:default
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2341,7 +2347,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2372,13 +2378,13 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2))
+        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))
       typescript:
         specifier: catalog:default
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2399,7 +2405,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2430,13 +2436,13 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2))
+        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))
       typescript:
         specifier: catalog:default
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2457,7 +2463,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2478,7 +2484,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2499,7 +2505,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2520,7 +2526,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2541,7 +2547,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2562,7 +2568,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2632,7 +2638,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   packages/workers-editor-shared:
     dependencies:
@@ -2663,7 +2669,7 @@ importers:
         version: 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.14(@types/node@18.19.76))
+        version: 4.3.3(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -2675,10 +2681,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)
+        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
       vite-plugin-dts:
         specifier: ^4.0.1
-        version: 4.0.1(@types/node@18.19.76)(rollup@4.30.1)(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76))
+        version: 4.0.1(@types/node@18.19.76)(rollup@4.30.1)(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
 
   packages/workers-playground:
     dependencies:
@@ -2784,7 +2790,7 @@ importers:
         version: 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.14(@types/node@18.19.76))
+        version: 4.3.3(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -2796,7 +2802,7 @@ importers:
         version: 5.28.5
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)
+        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:^
         version: link:../wrangler
@@ -2848,7 +2854,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: ~2.1.0
-        version: 2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)
+        version: 2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)(lightningcss@1.29.2)
 
   packages/workers-tsconfig: {}
 
@@ -2871,7 +2877,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -2917,7 +2923,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   packages/wrangler:
     dependencies:
@@ -3177,7 +3183,7 @@ importers:
         version: 1.5.4
       vitest:
         specifier: catalog:default
-        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       vitest-websocket-mock:
         specifier: ^0.4.0
         version: 0.4.0(vitest@3.0.8)
@@ -5926,6 +5932,84 @@ packages:
   '@styled-system/variant@5.1.5':
     resolution: {integrity: sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==}
 
+  '@tailwindcss/node@4.0.15':
+    resolution: {integrity: sha512-IODaJjNmiasfZX3IoS+4Em3iu0fD2HS0/tgrnkYfW4hyUor01Smnr5eY3jc4rRgaTDrJlDmBTHbFO0ETTDaxWA==}
+
+  '@tailwindcss/oxide-android-arm64@4.0.15':
+    resolution: {integrity: sha512-EBuyfSKkom7N+CB3A+7c0m4+qzKuiN0WCvzPvj5ZoRu4NlQadg/mthc1tl5k9b5ffRGsbDvP4k21azU4VwVk3Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.0.15':
+    resolution: {integrity: sha512-ObVAnEpLepMhV9VoO0JSit66jiN5C4YCqW3TflsE9boo2Z7FIjV80RFbgeL2opBhtxbaNEDa6D0/hq/EP03kgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.0.15':
+    resolution: {integrity: sha512-IElwoFhUinOr9MyKmGTPNi1Rwdh68JReFgYWibPWTGuevkHkLWKEflZc2jtI5lWZ5U9JjUnUfnY43I4fEXrc4g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.0.15':
+    resolution: {integrity: sha512-6BLLqyx7SIYRBOnTZ8wgfXANLJV5TQd3PevRJZp0vn42eO58A2LykRKdvL1qyPfdpmEVtF+uVOEZ4QTMqDRAWA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.0.15':
+    resolution: {integrity: sha512-Zy63EVqO9241Pfg6G0IlRIWyY5vNcWrL5dd2WAKVJZRQVeolXEf1KfjkyeAAlErDj72cnyXObEZjMoPEKHpdNw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.0.15':
+    resolution: {integrity: sha512-2NemGQeaTbtIp1Z2wyerbVEJZTkAWhMDOhhR5z/zJ75yMNf8yLnE+sAlyf6yGDNr+1RqvWrRhhCFt7i0CIxe4Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.0.15':
+    resolution: {integrity: sha512-342GVnhH/6PkVgKtEzvNVuQ4D+Q7B7qplvuH20Cfz9qEtydG6IQczTZ5IT4JPlh931MG1NUCVxg+CIorr1WJyw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.0.15':
+    resolution: {integrity: sha512-g76GxlKH124RuGqacCEFc2nbzRl7bBrlC8qDQMiUABkiifDRHOIUjgKbLNG4RuR9hQAD/MKsqZ7A8L08zsoBrw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.0.15':
+    resolution: {integrity: sha512-Gg/Y1XrKEvKpq6WeNt2h8rMIKOBj/W3mNa5NMvkQgMC7iO0+UNLrYmt6zgZufht66HozNpn+tJMbbkZ5a3LczA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.0.15':
+    resolution: {integrity: sha512-7QtSSJwYZ7ZK1phVgcNZpuf7c7gaCj8Wb0xjliligT5qCGCp79OV2n3SJummVZdw4fbTNKUOYMO7m1GinppZyA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.0.15':
+    resolution: {integrity: sha512-JQ5H+5MLhOjpgNp6KomouE0ZuKmk3hO5h7/ClMNAQ8gZI2zkli3IH8ZqLbd2DVfXDbdxN2xvooIEeIlkIoSCqw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.0.15':
+    resolution: {integrity: sha512-e0uHrKfPu7JJGMfjwVNyt5M0u+OP8kUmhACwIRlM+JNBuReDVQ63yAD1NWe5DwJtdaHjugNBil76j+ks3zlk6g==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/vite@4.0.15':
+    resolution: {integrity: sha512-JRexava80NijI8cTcLXNM3nQL5A0ptTHI8oJLLe8z1MpNB6p5J4WCdJJP8RoyHu8/eB1JzEdbpH86eGfbuaezQ==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6
+
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -7652,6 +7736,10 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
+  enhanced-resolve@5.18.1:
+    resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
+    engines: {node: '>=10.13.0'}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
@@ -8969,6 +9057,70 @@ packages:
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  lightningcss-darwin-arm64@1.29.2:
+    resolution: {integrity: sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.29.2:
+    resolution: {integrity: sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.29.2:
+    resolution: {integrity: sha512-wDk7M2tM78Ii8ek9YjnY8MjV5f5JN2qNVO+/0BAGZRvXKtQrBC4/cn4ssQIpKIPP44YXw6gFdpUF+Ps+RGsCwg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.29.2:
+    resolution: {integrity: sha512-IRUrOrAF2Z+KExdExe3Rz7NSTuuJ2HvCGlMKoquK5pjvo2JY4Rybr+NrKnq0U0hZnx5AnGsuFHjGnNT14w26sg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.29.2:
+    resolution: {integrity: sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.29.2:
+    resolution: {integrity: sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.29.2:
+    resolution: {integrity: sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.29.2:
+    resolution: {integrity: sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.29.2:
+    resolution: {integrity: sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.29.2:
+    resolution: {integrity: sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.29.2:
+    resolution: {integrity: sha512-6b6gd/RUXKaw5keVdSEtqFVdzWnU5jMxTUjA2bVcMNPLwSQ08Sv/UodBVtETLCn7k4S1Ibxwh7k68IwLZPgKaA==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -11018,6 +11170,13 @@ packages:
   synckit@0.8.5:
     resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwindcss@4.0.15:
+    resolution: {integrity: sha512-6ZMg+hHdMJpjpeCCFasX7K+U615U9D+7k5/cDK/iRwl6GptF24+I/AbKgOnXhVKePzrEyIXutLv36n4cRsq3Sg==}
+
+  tapable@2.2.1:
+    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
+    engines: {node: '>=6'}
 
   tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
@@ -13148,7 +13307,7 @@ snapshots:
       esbuild: 0.17.19
       miniflare: 3.20241230.0
       semver: 7.7.1
-      vitest: 2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)
+      vitest: 2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)(lightningcss@1.29.2)
       wrangler: 3.100.0(@cloudflare/workers-types@4.20250321.0)
       zod: 3.22.3
     transitivePeerDependencies:
@@ -13167,7 +13326,7 @@ snapshots:
       esbuild: 0.17.19
       miniflare: 3.20250214.0
       semver: 7.7.1
-      vitest: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+      vitest: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler: 3.109.2(@cloudflare/workers-types@4.20250321.0)
       zod: 3.22.3
     transitivePeerDependencies:
@@ -13185,7 +13344,7 @@ snapshots:
       esbuild: 0.17.19
       miniflare: 3.20250214.0
       semver: 7.7.1
-      vitest: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+      vitest: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler: 3.109.2(@cloudflare/workers-types@4.20250321.0)
       zod: 3.22.3
     transitivePeerDependencies:
@@ -15159,6 +15318,67 @@ snapshots:
       '@styled-system/core': 5.1.2
       '@styled-system/css': 5.1.5
 
+  '@tailwindcss/node@4.0.15':
+    dependencies:
+      enhanced-resolve: 5.18.1
+      jiti: 2.4.2
+      tailwindcss: 4.0.15
+
+  '@tailwindcss/oxide-android-arm64@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.0.15':
+    optional: true
+
+  '@tailwindcss/oxide@4.0.15':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.0.15
+      '@tailwindcss/oxide-darwin-arm64': 4.0.15
+      '@tailwindcss/oxide-darwin-x64': 4.0.15
+      '@tailwindcss/oxide-freebsd-x64': 4.0.15
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.0.15
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.0.15
+      '@tailwindcss/oxide-linux-arm64-musl': 4.0.15
+      '@tailwindcss/oxide-linux-x64-gnu': 4.0.15
+      '@tailwindcss/oxide-linux-x64-musl': 4.0.15
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.0.15
+      '@tailwindcss/oxide-win32-x64-msvc': 4.0.15
+
+  '@tailwindcss/vite@4.0.15(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))':
+    dependencies:
+      '@tailwindcss/node': 4.0.15
+      '@tailwindcss/oxide': 4.0.15
+      lightningcss: 1.29.2
+      tailwindcss: 4.0.15
+      vite: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+
   '@trysound/sax@0.2.0': {}
 
   '@types/argparse@1.0.38': {}
@@ -15733,25 +15953,25 @@ snapshots:
       minimatch: 7.4.6
       semver: 7.6.3
 
-  '@vitejs/plugin-react@4.3.3(vite@5.4.14(@types/node@18.19.76))':
+  '@vitejs/plugin-react@4.3.3(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.14(@types/node@18.19.76)
+      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2))':
+  '@vitejs/plugin-react@4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+      vite: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -15769,22 +15989,22 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.14(@types/node@18.19.76))':
+  '@vitest/mocker@2.1.9(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.14(@types/node@18.19.76)
+      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
 
-  '@vitest/mocker@3.0.8(msw@2.4.3(typescript@5.7.3))(vite@5.4.14(@types/node@18.19.76))':
+  '@vitest/mocker@3.0.8(msw@2.4.3(typescript@5.7.3))(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))':
     dependencies:
       '@vitest/spy': 3.0.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.4.3(typescript@5.7.3)
-      vite: 5.4.14(@types/node@18.19.76)
+      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -15837,7 +16057,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)
+      vitest: 2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)(lightningcss@1.29.2)
     optional: true
 
   '@vitest/ui@3.0.8(vitest@3.0.8)':
@@ -15849,7 +16069,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.12
       tinyrainbow: 2.0.0
-      vitest: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+      vitest: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   '@vitest/utils@2.1.8':
     dependencies:
@@ -17056,8 +17276,7 @@ snapshots:
 
   detect-libc@2.0.2: {}
 
-  detect-libc@2.0.3:
-    optional: true
+  detect-libc@2.0.3: {}
 
   detect-newline@3.1.0: {}
 
@@ -17197,6 +17416,11 @@ snapshots:
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
+
+  enhanced-resolve@5.18.1:
+    dependencies:
+      graceful-fs: 4.2.10
+      tapable: 2.2.1
 
   enquirer@2.4.1:
     dependencies:
@@ -18752,6 +18976,51 @@ snapshots:
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
+
+  lightningcss-darwin-arm64@1.29.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.29.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.29.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.29.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.29.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.29.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.29.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.29.2:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.29.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.29.2:
+    optional: true
+
+  lightningcss@1.29.2:
+    dependencies:
+      detect-libc: 2.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.29.2
+      lightningcss-darwin-x64: 1.29.2
+      lightningcss-freebsd-x64: 1.29.2
+      lightningcss-linux-arm-gnueabihf: 1.29.2
+      lightningcss-linux-arm64-gnu: 1.29.2
+      lightningcss-linux-arm64-musl: 1.29.2
+      lightningcss-linux-x64-gnu: 1.29.2
+      lightningcss-linux-x64-musl: 1.29.2
+      lightningcss-win32-arm64-msvc: 1.29.2
+      lightningcss-win32-x64-msvc: 1.29.2
 
   lilconfig@3.1.3: {}
 
@@ -20854,6 +21123,10 @@ snapshots:
       '@pkgr/utils': 2.4.1
       tslib: 2.8.1
 
+  tailwindcss@4.0.15: {}
+
+  tapable@2.2.1: {}
+
   tar-fs@2.1.1:
     dependencies:
       chownr: 1.1.4
@@ -21449,13 +21722,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-node@2.1.9(@types/node@18.19.76):
+  vite-node@2.1.9(@types/node@18.19.76)(lightningcss@1.29.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.2.2)
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.14(@types/node@18.19.76)
+      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -21467,13 +21740,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.0.8(@types/node@18.19.76)(jiti@2.4.2)(supports-color@9.2.2):
+  vite-node@3.0.8(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)(supports-color@9.2.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.2.2)
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+      vite: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -21488,7 +21761,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.0.1(@types/node@18.19.76)(rollup@4.30.1)(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)):
+  vite-plugin-dts@4.0.1(@types/node@18.19.76)(rollup@4.30.1)(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)):
     dependencies:
       '@microsoft/api-extractor': 7.47.4(@types/node@18.19.76)
       '@rollup/pluginutils': 5.1.0(rollup@4.30.1)
@@ -21502,24 +21775,24 @@ snapshots:
       typescript: 5.7.3
       vue-tsc: 2.0.29(typescript@5.7.3)
     optionalDependencies:
-      vite: 5.4.14(@types/node@18.19.76)
+      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-tsconfig-paths@4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)):
+  vite-tsconfig-paths@4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)):
     dependencies:
       debug: 4.3.7(supports-color@9.2.2)
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.7.3)
     optionalDependencies:
-      vite: 5.4.14(@types/node@18.19.76)
+      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.14(@types/node@18.19.76):
+  vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
@@ -21527,8 +21800,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.76
       fsevents: 2.3.3
+      lightningcss: 1.29.2
 
-  vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2):
+  vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
@@ -21537,17 +21811,18 @@ snapshots:
       '@types/node': 18.19.76
       fsevents: 2.3.3
       jiti: 2.4.2
+      lightningcss: 1.29.2
 
   vitest-websocket-mock@0.4.0(vitest@3.0.8):
     dependencies:
       '@vitest/utils': 2.1.8
       mock-socket: 9.3.1
-      vitest: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+      vitest: 3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
-  vitest@2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9):
+  vitest@2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)(lightningcss@1.29.2):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.14(@types/node@18.19.76))
+      '@vitest/mocker': 2.1.9(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -21563,8 +21838,8 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.14(@types/node@18.19.76)
-      vite-node: 2.1.9(@types/node@18.19.76)
+      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+      vite-node: 2.1.9(@types/node@18.19.76)(lightningcss@1.29.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.19.76
@@ -21580,10 +21855,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2):
+  vitest@3.0.8(@types/node@18.19.76)(@vitest/ui@3.0.8)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2):
     dependencies:
       '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(msw@2.4.3(typescript@5.7.3))(vite@5.4.14(@types/node@18.19.76))
+      '@vitest/mocker': 3.0.8(msw@2.4.3(typescript@5.7.3))(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
       '@vitest/pretty-format': 3.0.8
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8
@@ -21599,8 +21874,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.14(@types/node@18.19.76)
-      vite-node: 3.0.8(@types/node@18.19.76)(jiti@2.4.2)(supports-color@9.2.2)
+      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+      vite-node: 3.0.8(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)(supports-color@9.2.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.19.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1964,6 +1964,27 @@ importers:
         specifier: workspace:*
         version: link:../../../wrangler
 
+  packages/vite-plugin-cloudflare/playground/config-changes:
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: workspace:*
+        version: link:../..
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../../workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20250320.0
+        version: 4.20250320.0
+      typescript:
+        specifier: catalog:default
+        version: 5.7.3
+      vite:
+        specifier: catalog:vite-plugin
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)
+      wrangler:
+        specifier: workspace:*
+        version: link:../../../wrangler
+
   packages/vite-plugin-cloudflare/playground/custom-build-app:
     devDependencies:
       '@cloudflare/vite-plugin':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1973,8 +1973,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250320.0
-        version: 4.20250320.0
+        specifier: ^4.20250321.0
+        version: 4.20250321.0
       typescript:
         specifier: catalog:default
         version: 5.7.3


### PR DESCRIPTION
Fixes #8646.

This fixes a bug where updating config files would crash the dev server. This occurred because the previous Miniflare instance was not disposed before creating a new one. This would lead to a port collision because of the `inspectorPort` introduced by the new debugging features.

The relevant Vite code, showing that the new server is created before closing the old one is here - https://github.com/vitejs/vite/blob/262b5ec7ae4981208339b7b87fefbd3dd8465851/packages/vite/src/node/server/index.ts#L1187-L1206

I've also added a test for reporting config errors on Worker config changes

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
