### PR TITLE
fix(create-cloudflare): improve html semantics from c3 init

### DIFF
--- a/.changeset/fluffy-icons-pump.md
+++ b/.changeset/fluffy-icons-pump.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Improves minor HTML semantics of the default index.html included in various templates with Workers Assets

--- a/packages/create-cloudflare/templates/hello-world-with-assets/js/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/js/public/index.html
@@ -7,8 +7,8 @@
 	</head>
 	<body>
 		<h1 id="heading"></h1>
-		<button id="button">Fetch a random UUID</button>
-		<div id="random"></div>
+		<button id="button" type="button">Fetch a random UUID</button>
+		<output id="random" for="button"></output>
 		<script>
 			fetch('/message')
 				.then((resp) => resp.text())

--- a/packages/create-cloudflare/templates/hello-world-with-assets/py/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/py/public/index.html
@@ -7,8 +7,8 @@
 	</head>
 	<body>
 		<h1 id="heading"></h1>
-		<button id="button">Fetch a random UUID</button>
-		<div id="random"></div>
+		<button id="button" type="button">Fetch a random UUID</button>
+		<output id="random" for="button"></output>
 		<script>
 			fetch('/message')
 				.then((resp) => resp.text())

--- a/packages/create-cloudflare/templates/hello-world-with-assets/ts/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/ts/public/index.html
@@ -7,8 +7,8 @@
 	</head>
 	<body>
 		<h1 id="heading"></h1>
-		<button id="button">Fetch a random UUID</button>
-		<div id="random"></div>
+		<button id="button" type="button">Fetch a random UUID</button>
+		<output id="random" for="button"></output>
 		<script>
 			fetch('/message')
 				.then((resp) => resp.text())


### PR DESCRIPTION
Fixes N/A

This improves the default HTML shipped with C3 templates to:

- use `type=button` on the button since it's not a form submission and browsers default to `type=submit`
- use the [`output`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output) element which is arguably more semantically correct as a result of a user action than the `div`

---



- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no functional changes
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no functional changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functional changes
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not wrangler change

