### PR TITLE
Bump `@cloudflare/unenv-preset` to 2.3.1

### DIFF
--- a/.changeset/green-donuts-run.md
+++ b/.changeset/green-donuts-run.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Bump `@cloudflare/unenv-preset` to 2.3.1
+
+Use the workerd native implementation of `createSecureContext` and `checkServerIdentity` from `node:tls`. The functions have been implemented in `cloudflare/workerd#3754`.

--- a/fixtures/nodejs-hybrid-app/src/index.ts
+++ b/fixtures/nodejs-hybrid-app/src/index.ts
@@ -208,8 +208,16 @@ async function testTls() {
 	assert.strictEqual(typeof tls.connect, "function");
 	assert.strictEqual(typeof tls.TLSSocket, "function");
 	assert.strictEqual(typeof tls.checkServerIdentity, "function");
-	assert.strictEqual(typeof tls.createSecureContext, "function");
+	assert.strictEqual(
+		tls.checkServerIdentity("a.com", { subject: { CN: "a.com" } }),
+		undefined
+	);
 	assert.strictEqual(typeof tls.SecureContext, "function");
+	assert.strictEqual(typeof tls.createSecureContext, "function");
+	assert.strictEqual(
+		tls.createSecureContext({}) instanceof tls.SecureContext,
+		true
+	);
 
 	return new Response("OK");
 }

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -70,7 +70,7 @@
 	},
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "workspace:*",
-		"@cloudflare/unenv-preset": "2.3.0",
+		"@cloudflare/unenv-preset": "2.3.1",
 		"blake3-wasm": "2.1.5",
 		"esbuild": "catalog:default",
 		"miniflare": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2904,8 +2904,8 @@ importers:
         specifier: workspace:*
         version: link:../kv-asset-handler
       '@cloudflare/unenv-preset':
-        specifier: 2.3.0
-        version: 2.3.0(unenv@2.0.0-rc.15)(workerd@1.20250321.0)
+        specifier: 2.3.1
+        version: 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250321.0)
       blake3-wasm:
         specifier: 2.1.5
         version: 2.1.5
@@ -3748,11 +3748,11 @@ packages:
     peerDependencies:
       react: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
 
-  '@cloudflare/unenv-preset@2.3.0':
-    resolution: {integrity: sha512-AaKYnbFpHaVDZGh3Hjy3oLYd12+LZw9aupAOudYJ+tjekahxcIqlSAr0zK9kPOdtgn10tzaqH7QJFUWcLE+k7g==}
+  '@cloudflare/unenv-preset@2.3.1':
+    resolution: {integrity: sha512-Xq57Qd+ADpt6hibcVBO0uLG9zzRgyRhfCUgBT9s+g3+3Ivg5zDyVgLFy40ES1VdNcu8rPNSivm9A+kGP5IVaPg==}
     peerDependencies:
       unenv: 2.0.0-rc.15
-      workerd: ^1.20250311.0
+      workerd: ^1.20250320.0
     peerDependenciesMeta:
       workerd:
         optional: true
@@ -13096,7 +13096,7 @@ snapshots:
       '@cloudflare/util-en-garde': 8.0.10
       react: 18.3.1
 
-  '@cloudflare/unenv-preset@2.3.0(unenv@2.0.0-rc.15)(workerd@1.20250321.0)':
+  '@cloudflare/unenv-preset@2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250321.0)':
     dependencies:
       unenv: 2.0.0-rc.15
     optionalDependencies:


### PR DESCRIPTION
Use the workerd native implementation of `createSecureContext` and `checkServerIdentity` from `node:tls`. The functions have been implemented in `cloudflare/workerd#3754`.

/cc @anonrig @thomasgauvin 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: requires workerd >= v1.20250320.0

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
