### PR TITLE
[vite-plugin] improve inspector port handling

### DIFF
--- a/.changeset/hip-parents-shave.md
+++ b/.changeset/hip-parents-shave.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+fix: make sure that users can specify inspector port `0` to use a random port

--- a/.changeset/warm-mammals-invent.md
+++ b/.changeset/warm-mammals-invent.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+fix: make sure that the plugin keeps looking for available inspector ports by default
+
+this change updates the plugin so that if an inspector port is not specified and the
+default inspector port (9229) is not available it keeps looking for other available
+port instead of crashing

--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -376,7 +376,7 @@ It accepts an optional `PluginConfig` parameter.
 
 - `inspectorPort?: number | false`
 
-  Optional inspector port to use for debugging your workers, for more details on debugging see the [devtools section](#devtools). Can be set to `false` to disable the debugging inspector altogether. By default the vite plugin will attempt to use the first available port it can find starting at `9229`.
+  Optional inspector port to use for debugging your workers, for more details on debugging see the [devtools section](#devtools). Can be set to `false` to disable the debugging inspector altogether. If the value is `0` a random inspector port is chosen. By default the vite plugin will attempt to use the first available port it can find starting at `9229`.
 
 > [!NOTE]
 > When running `wrangler deploy`, only your main (entry) Worker will be deployed.

--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -376,7 +376,7 @@ It accepts an optional `PluginConfig` parameter.
 
 - `inspectorPort?: number | false`
 
-  Optional inspector port to use for debugging your workers, for more details on debugging see the [devtools section](#devtools). Can be set to `false` to disable the debugging inspector altogether. If the value is `0` a random inspector port is chosen. By default the vite plugin will attempt to use the first available port it can find starting at `9229`.
+  Optional inspector port to use for debugging your workers, for more details on debugging see the [devtools section](#devtools). By default the vite plugin will attempt to use the first available port it can find starting at `9229`.
 
 > [!NOTE]
 > When running `wrangler deploy`, only your main (entry) Worker will be deployed.

--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -376,7 +376,7 @@ It accepts an optional `PluginConfig` parameter.
 
 - `inspectorPort?: number | false`
 
-  Optional inspector port to use for debugging your workers, for more details on debugging see the [devtools section](#devtools). Can be set to `false` to disable the debugging inspector altogether. Defaults to `9229`.
+  Optional inspector port to use for debugging your workers, for more details on debugging see the [devtools section](#devtools). Can be set to `false` to disable the debugging inspector altogether. By default the vite plugin will attempt to use the first available port it can find starting at `9229`.
 
 > [!NOTE]
 > When running `wrangler deploy`, only your main (entry) Worker will be deployed.

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -44,6 +44,7 @@
 	"dependencies": {
 		"@cloudflare/unenv-preset": "workspace:*",
 		"@hattip/adapter-node": "^0.0.49",
+		"get-port": "^7.1.0",
 		"miniflare": "workspace:*",
 		"picocolors": "^1.1.1",
 		"tinyglobby": "^0.2.12",

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -370,7 +370,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 			async configurePreviewServer(vitePreviewServer) {
 				const workerConfigs = getWorkerConfigs(vitePreviewServer.config.root);
 
-				vitePreviewServer.config.logger.warnOnce;
 				const inputInspectorPort = await getInputInspectorPortOption(
 					pluginConfig,
 					vitePreviewServer

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -61,9 +61,6 @@ let workersConfigsWarningShown = false;
 
 let miniflare: Miniflare | undefined;
 
-/** The resolved inspector port (or undefined if inspecting is disabled) */
-let resolvedInspectorPort: number | undefined;
-
 /**
  * Vite plugin that enables a full-featured integration between Vite and the Cloudflare Workers runtime.
  *
@@ -78,6 +75,9 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 	const additionalModulePaths = new Set<string>();
 
 	const nodeJsCompatWarningsMap = new Map<WorkerConfig, NodeJsCompatWarnings>();
+
+	/** The resolved inspector port (or undefined if inspecting is disabled) */
+	let resolvedInspectorPort: number | undefined;
 
 	// This is set when the client environment is built to determine if the entry Worker should include assets
 	let hasClientBuild = false;

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -61,8 +61,8 @@ let workersConfigsWarningShown = false;
 
 let miniflare: Miniflare | undefined;
 
-/** The inspector port (or false if inspecting is disabled) to use for the vite preview command */
-let previewInspectorPort: number | false | undefined;
+/** The resolved inspector port (or undefined if inspecting is disabled) */
+let resolvedInspectorPort: number | undefined;
 
 /**
  * Vite plugin that enables a full-featured integration between Vite and the Cloudflare Workers runtime.
@@ -329,6 +329,11 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					);
 				}
 
+				if (resolvedPluginConfig.inspectorPort !== false) {
+					const miniflareInspectorUrl = await miniflare.getInspectorURL();
+					resolvedInspectorPort = Number.parseInt(miniflareInspectorUrl.port);
+				}
+
 				await initRunners(resolvedPluginConfig, viteDevServer, miniflare);
 
 				const middleware = createMiddleware(
@@ -359,7 +364,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 			async configurePreviewServer(vitePreviewServer) {
 				const workerConfigs = getWorkerConfigs(vitePreviewServer.config.root);
 
-				previewInspectorPort =
+				const requestedInspectorPort =
 					pluginConfig.inspectorPort ??
 					(await getFirstAvailablePort(DEFAULT_INSPECTOR_PORT));
 
@@ -368,9 +373,14 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 						vitePreviewServer,
 						workerConfigs,
 						pluginConfig.persistState ?? true,
-						previewInspectorPort
+						requestedInspectorPort
 					)
 				);
+
+				if (requestedInspectorPort !== false) {
+					const miniflareInspectorUrl = await miniflare.getInspectorURL();
+					resolvedInspectorPort = Number.parseInt(miniflareInspectorUrl.port);
+				}
 
 				const middleware = createMiddleware(
 					({ request }) => {
@@ -633,14 +643,8 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 							);
 
 				viteDevServer.middlewares.use((req, res, next) => {
-					if (
-						req.url === debuggingPath &&
-						resolvedPluginConfig.inspectorPort !== false
-					) {
-						const html = getDebugPathHtml(
-							workerNames,
-							resolvedPluginConfig.inspectorPort
-						);
+					if (req.url === debuggingPath && resolvedInspectorPort) {
+						const html = getDebugPathHtml(workerNames, resolvedInspectorPort);
 						res.setHeader("Content-Type", "text/html");
 						return res.end(html);
 					}
@@ -660,12 +664,8 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				});
 
 				vitePreviewServer.middlewares.use((req, res, next) => {
-					if (
-						req.url === debuggingPath &&
-						previewInspectorPort !== undefined &&
-						previewInspectorPort !== false
-					) {
-						const html = getDebugPathHtml(workerNames, previewInspectorPort);
+					if (req.url === debuggingPath && resolvedInspectorPort) {
+						const html = getDebugPathHtml(workerNames, resolvedInspectorPort);
 						res.setHeader("Content-Type", "text/html");
 						return res.end(html);
 					}

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -85,7 +85,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 			name: "vite-plugin-cloudflare",
 			// This only applies to this plugin so is safe to use while other plugins migrate to the Environment API
 			sharedDuringBuild: true,
-			async config(userConfig, env) {
+			config(userConfig, env) {
 				if (env.isPreview) {
 					// Short-circuit the whole configuration if we are in preview mode
 					return { appType: "custom" };

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -76,9 +76,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 
 	const nodeJsCompatWarningsMap = new Map<WorkerConfig, NodeJsCompatWarnings>();
 
-	/** The resolved inspector port (or undefined if inspecting is disabled) */
-	let resolvedInspectorPort: number | undefined;
-
 	// This is set when the client environment is built to determine if the entry Worker should include assets
 	let hasClientBuild = false;
 
@@ -341,11 +338,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					);
 				}
 
-				if (inspectorPort !== false) {
-					const miniflareInspectorUrl = await miniflare.getInspectorURL();
-					resolvedInspectorPort = Number.parseInt(miniflareInspectorUrl.port);
-				}
-
 				await initRunners(resolvedPluginConfig, viteDevServer, miniflare);
 
 				const middleware = createMiddleware(
@@ -388,11 +380,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 						requestedInspectorPort
 					)
 				);
-
-				if (requestedInspectorPort !== false) {
-					const miniflareInspectorUrl = await miniflare.getInspectorURL();
-					resolvedInspectorPort = Number.parseInt(miniflareInspectorUrl.port);
-				}
 
 				const middleware = createMiddleware(
 					({ request }) => {
@@ -639,7 +626,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 			// Note: this plugin needs to run before the main vite-plugin-cloudflare so that
 			//       the preview middleware here can take precedence
 			enforce: "pre",
-			configureServer(viteDevServer) {
+			async configureServer(viteDevServer) {
 				if (
 					resolvedPluginConfig.type === "workers" &&
 					pluginConfig.inspectorPort !== false
@@ -654,6 +641,9 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 								(worker) => worker.name
 							);
 
+				const resolvedInspectorPort =
+					await getResolvedInspectorPort(pluginConfig);
+
 				viteDevServer.middlewares.use((req, res, next) => {
 					if (req.url === debuggingPath && resolvedInspectorPort) {
 						const html = getDebugPathHtml(workerNames, resolvedInspectorPort);
@@ -663,7 +653,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					next();
 				});
 			},
-			configurePreviewServer(vitePreviewServer) {
+			async configurePreviewServer(vitePreviewServer) {
 				const workerConfigs = getWorkerConfigs(vitePreviewServer.config.root);
 
 				if (workerConfigs.length >= 1 && pluginConfig.inspectorPort !== false) {
@@ -674,6 +664,9 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					assert(worker.name, "Expected the Worker to have a name");
 					return worker.name;
 				});
+
+				const resolvedInspectorPort =
+					await getResolvedInspectorPort(pluginConfig);
 
 				vitePreviewServer.middlewares.use((req, res, next) => {
 					if (req.url === debuggingPath && resolvedInspectorPort) {
@@ -767,6 +760,20 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 			? resolvedPluginConfig.workers[environmentName]
 			: undefined;
 	}
+}
+
+/**
+ * Gets the resolved port of the inspector provided by miniflare
+ *
+ * @param pluginConfig the user's plugin configuration
+ * @returns the resolved port of null if the user opted out of debugging
+ */
+async function getResolvedInspectorPort(pluginConfig: PluginConfig) {
+	if (miniflare && pluginConfig.inspectorPort !== false) {
+		const miniflareInspectorUrl = await miniflare.getInspectorURL();
+		return Number.parseInt(miniflareInspectorUrl.port);
+	}
+	return null;
 }
 
 /**

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -16,7 +16,6 @@ import { getAssetsConfig } from "./asset-config";
 import {
 	ASSET_WORKER_NAME,
 	ASSET_WORKERS_COMPATIBILITY_DATE,
-	DEFAULT_INSPECTOR_PORT,
 	ROUTER_WORKER_NAME,
 } from "./constants";
 import { additionalModuleRE } from "./shared";
@@ -530,7 +529,7 @@ export function getPreviewMiniflareOptions(
 	vitePreviewServer: vite.PreviewServer,
 	workerConfigs: Unstable_Config[],
 	persistState: PersistState,
-	inspectorPort: number | false = DEFAULT_INSPECTOR_PORT
+	inspectorPort: number | false
 ): MiniflareOptions {
 	const resolvedViteConfig = vitePreviewServer.config;
 	const workers: Array<WorkerOptions> = workerConfigs.flatMap((config) => {

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -369,7 +369,10 @@ export function getDevMiniflareOptions(
 
 	return {
 		log: logger,
-		inspectorPort: resolvedPluginConfig.inspectorPort || undefined,
+		inspectorPort:
+			resolvedPluginConfig.inspectorPort === false
+				? undefined
+				: resolvedPluginConfig.inspectorPort,
 		unsafeInspectorProxy: resolvedPluginConfig.inspectorPort !== false,
 		handleRuntimeStdio(stdout, stderr) {
 			const decoder = new TextDecoder();
@@ -557,7 +560,7 @@ export function getPreviewMiniflareOptions(
 
 	return {
 		log: logger,
-		inspectorPort: inspectorPort || undefined,
+		inspectorPort: inspectorPort === false ? undefined : inspectorPort,
 		unsafeInspectorProxy: inspectorPort !== false,
 		handleRuntimeStdio(stdout, stderr) {
 			const decoder = new TextDecoder();

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -191,7 +191,8 @@ function getEntryWorkerConfig(
 
 export function getDevMiniflareOptions(
 	resolvedPluginConfig: ResolvedPluginConfig,
-	viteDevServer: vite.ViteDevServer
+	viteDevServer: vite.ViteDevServer,
+	inspectorPort: number | false
 ): MiniflareOptions {
 	const resolvedViteConfig = viteDevServer.config;
 	const entryWorkerConfig = getEntryWorkerConfig(resolvedPluginConfig);
@@ -297,8 +298,7 @@ export function getDevMiniflareOptions(
 							worker: {
 								...workerOptions,
 								name: workerOptions.name ?? workerConfig.name,
-								unsafeInspectorProxy:
-									resolvedPluginConfig.inspectorPort !== false,
+								unsafeInspectorProxy: inspectorPort !== false,
 								modulesRoot: miniflareModulesRoot,
 								unsafeEvalBinding: "__VITE_UNSAFE_EVAL__",
 								serviceBindings: {
@@ -369,11 +369,8 @@ export function getDevMiniflareOptions(
 
 	return {
 		log: logger,
-		inspectorPort:
-			resolvedPluginConfig.inspectorPort === false
-				? undefined
-				: resolvedPluginConfig.inspectorPort,
-		unsafeInspectorProxy: resolvedPluginConfig.inspectorPort !== false,
+		inspectorPort: inspectorPort === false ? undefined : inspectorPort,
+		unsafeInspectorProxy: inspectorPort !== false,
 		handleRuntimeStdio(stdout, stderr) {
 			const decoder = new TextDecoder();
 			stdout.forEach((data) => logger.info(decoder.decode(data)));

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -1,8 +1,6 @@
 import assert from "node:assert";
 import * as path from "node:path";
 import * as vite from "vite";
-import { DEFAULT_INSPECTOR_PORT } from "./constants";
-import { getFirstAvailablePort } from "./utils";
 import {
 	getValidatedWranglerConfigPath,
 	getWorkerConfig,

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -54,7 +54,6 @@ interface BasePluginConfig {
 	configPaths: Set<string>;
 	persistState: PersistState;
 	cloudflareEnv: string | undefined;
-	inspectorPort: number | false;
 	experimental: {
 		/** Experimental support for handling the _headers and _redirects files during Vite dev mode. */
 		headersAndRedirectsDevModeSupport?: boolean;
@@ -86,16 +85,13 @@ function workerNameToEnvironmentName(workerName: string) {
 	return workerName.replaceAll("-", "_");
 }
 
-export async function resolvePluginConfig(
+export function resolvePluginConfig(
 	pluginConfig: PluginConfig,
 	userConfig: vite.UserConfig,
 	viteEnv: vite.ConfigEnv
-): Promise<ResolvedPluginConfig> {
+): ResolvedPluginConfig {
 	const configPaths = new Set<string>();
 	const persistState = pluginConfig.persistState ?? true;
-	const inspectorPort =
-		pluginConfig.inspectorPort ??
-		(await getFirstAvailablePort(DEFAULT_INSPECTOR_PORT));
 	const experimental = pluginConfig.experimental ?? {};
 	const root = userConfig.root ? path.resolve(userConfig.root) : process.cwd();
 	const { CLOUDFLARE_ENV: cloudflareEnv } = vite.loadEnv(
@@ -123,7 +119,6 @@ export async function resolvePluginConfig(
 			type: "assets-only",
 			config: entryWorkerResolvedConfig.config,
 			configPaths,
-			inspectorPort,
 			persistState,
 			rawConfigs: {
 				entryWorker: entryWorkerResolvedConfig,
@@ -185,7 +180,6 @@ export async function resolvePluginConfig(
 		type: "workers",
 		configPaths,
 		persistState,
-		inspectorPort,
 		workers,
 		entryWorkerEnvironmentName,
 		rawConfigs: {

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import * as path from "node:path";
 import * as vite from "vite";
 import { DEFAULT_INSPECTOR_PORT } from "./constants";
+import { getFirstAvailablePort } from "./utils";
 import {
 	getValidatedWranglerConfigPath,
 	getWorkerConfig,
@@ -85,14 +86,16 @@ function workerNameToEnvironmentName(workerName: string) {
 	return workerName.replaceAll("-", "_");
 }
 
-export function resolvePluginConfig(
+export async function resolvePluginConfig(
 	pluginConfig: PluginConfig,
 	userConfig: vite.UserConfig,
 	viteEnv: vite.ConfigEnv
-): ResolvedPluginConfig {
+): Promise<ResolvedPluginConfig> {
 	const configPaths = new Set<string>();
 	const persistState = pluginConfig.persistState ?? true;
-	const inspectorPort = pluginConfig.inspectorPort ?? DEFAULT_INSPECTOR_PORT;
+	const inspectorPort =
+		pluginConfig.inspectorPort ??
+		(await getFirstAvailablePort(DEFAULT_INSPECTOR_PORT));
 	const experimental = pluginConfig.experimental ?? {};
 	const root = userConfig.root ? path.resolve(userConfig.root) : process.cwd();
 	const { CLOUDFLARE_ENV: cloudflareEnv } = vite.loadEnv(

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import getPort, { portNumbers } from "get-port";
 import { Request as MiniflareRequest } from "miniflare";
 import * as vite from "vite";
 import { ROUTER_WORKER_NAME } from "./constants";
@@ -66,3 +67,7 @@ export function cleanUrl(url: string): string {
 export type Optional<T, K extends keyof T> = Omit<T, K> & Pick<Partial<T>, K>;
 
 export type MaybePromise<T> = Promise<T> | T;
+
+export function getFirstAvailablePort(start: number) {
+	return getPort({ port: portNumbers(start, 65535) });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1848,6 +1848,9 @@ importers:
       '@hattip/adapter-node':
         specifier: ^0.0.49
         version: 0.0.49
+      get-port:
+        specifier: ^7.1.0
+        version: 7.1.0
       miniflare:
         specifier: workspace:*
         version: link:../miniflare


### PR DESCRIPTION
Fixes #8670

this change updates the plugin so that if an inspector port is not specified and the
default inspector port (9229) is not available it keeps looking for other available
port instead of crashing

this also makes sure that users can specify `0` to use a random port

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: there is not clean/simple way to test this functionality
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not a Wrangler change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: readme updated
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
