### PR TITLE
Ensure that Node.js polyfills are pre-optimized before the first request

### DIFF
--- a/.changeset/five-camels-cheer.md
+++ b/.changeset/five-camels-cheer.md
@@ -1,0 +1,14 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Ensure that Node.js polyfills are pre-optimized before the first request
+
+Previously, these polyfills were only optimized on demand when Vite became aware of them.
+This was either because Vite was able to find an import to a polyfill when statically analysing the import tree of the entry-point,
+or when a polyfilled module was dynamically imported as part of a executing code to handle a request.
+
+In the second case, the optimizing of the dynamically imported dependency causes a reload of the Vite server, which can break applications that are holding state in modules during the request.
+This is the case of most React type frameworks, in particular React Router.
+
+Now, we pre-optimize all the possible Node.js polyfills when the server starts before the first request is handled.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,11 +43,10 @@ jobs:
       - name: Run Vite E2E tests
         run: pnpm test:e2e -F @cloudflare/vite-plugin --log-order=stream
         env:
+          # The AI tests need to connect to Cloudflare
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           NODE_OPTIONS: "--max_old_space_size=8192"
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-debug-logs/
-          TEST_REPORT_PATH: ${{ runner.temp }}/test-report/index.html
           CI_OS: ${{ matrix.os }}
 
       - name: Run Wrangler E2E tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Run Vite E2E tests
         run: pnpm test:e2e -F @cloudflare/vite-plugin --log-order=stream
         env:
+          NODE_DEBUG: "vite-plugin:test"
           # The AI tests need to connect to Cloudflare
           CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/vite-plugin-cloudflare/e2e/README.md
+++ b/packages/vite-plugin-cloudflare/e2e/README.md
@@ -25,8 +25,7 @@ The simplest test looks like:
 
 ```ts
 test("can serve a Worker request", async ({ expect, seed, viteDev }) => {
-	const projectPath = await seed("basic");
-	runCommand(`pnpm install`, projectPath);
+	const projectPath = await seed("basic", "pnpm");
 
 	const proc = await viteDev(projectPath);
 	const url = await waitForReady(proc);
@@ -34,8 +33,20 @@ test("can serve a Worker request", async ({ expect, seed, viteDev }) => {
 });
 ```
 
-- The `seed()` helper makes a copy of the named fixture into a temporary directory. It returns the path to the directory containing the copy (`projectPath` above). This directory will be deleted at the end of the test.
-- The `runCommand()` helper simply executes a one-shot command and resolves when it has exited. You can use this to install the dependencies of the fixture from the mock npm registry, as in the example above.
+- The `seed()` helper does the following:
+  - makes a copy of the named fixture into a temporary directory,
+  - updates the vite-plugin dependency in the package.json to match the local version
+  - runs `npm install` (or equivalent package manager command) in the temporary project
+  - returns the path to the directory containing the copy (`projectPath` above)
+  - the temporary directory will be deleted at the end of the test.
+- The `runCommand()` helper simply executes a one-shot command and resolves when it has exited. You can use this to install the dependencies of the fixture from the mock npm registry.
 - The `viteDev()` helper boots up the `vite dev` command and returns an object that can be used to monitor its output. The process will be killed at the end of the test.
 - The `waitForReady()` helper will resolve when the `vite dev` process has output its ready message, from which it will parse the url that can be fetched in the test.
 - The `fetchJson()` helper makes an Undici fetch to the url parsing the response into JSON. It will retry every 250ms for up to 10 secs to minimize flakes.
+
+## Debugging the tests
+
+You can provide the following environment variables to get access to the logs and the actual files being tested:
+
+- `NODE_DEBUG=vite-plugin:test` - this will display debugging log messages as well as the streamed output from the commands being run.
+- `CLOUDFLARE_VITE_E2E_KEEP_TEMP_DIRS=1` - this will prevent the temporary directory containing the test project from being deleted, so that you can go and play with it manually.

--- a/packages/vite-plugin-cloudflare/e2e/basic.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/basic.test.ts
@@ -1,5 +1,5 @@
 import { describe } from "vitest";
-import { fetchJson, runCommand, test, waitForReady } from "./helpers.js";
+import { fetchJson, test, waitForReady } from "./helpers.js";
 
 describe("node compatibility", () => {
 	describe.each(["pnpm", "npm", "yarn"])("using %s", (pm) => {

--- a/packages/vite-plugin-cloudflare/e2e/basic.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/basic.test.ts
@@ -2,10 +2,9 @@ import { describe } from "vitest";
 import { fetchJson, runCommand, test, waitForReady } from "./helpers.js";
 
 describe("node compatibility", () => {
-	describe.each(["pnpm --no-store", "npm", "yarn"])("using %s", (pm) => {
+	describe.each(["pnpm", "npm", "yarn"])("using %s", (pm) => {
 		test("can serve a Worker request", async ({ expect, seed, viteDev }) => {
-			const projectPath = await seed("basic");
-			runCommand(`${pm} install`, projectPath);
+			const projectPath = await seed("basic", pm);
 
 			const proc = await viteDev(projectPath);
 			const url = await waitForReady(proc);
@@ -17,8 +16,7 @@ describe("node compatibility", () => {
 // This test checks that wrapped bindings which rely on additional workers with an authed connection to the CF API work
 describe("Workers AI", () => {
 	test("can serve a Worker request", async ({ expect, seed, viteDev }) => {
-		const projectPath = await seed("basic");
-		runCommand(`npm install`, projectPath);
+		const projectPath = await seed("basic", "npm");
 
 		const proc = await viteDev(projectPath);
 		const url = await waitForReady(proc);

--- a/packages/vite-plugin-cloudflare/e2e/dynamic.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/dynamic.test.ts
@@ -1,0 +1,22 @@
+import { describe } from "vitest";
+import { fetchJson, test, waitForReady } from "./helpers.js";
+
+describe("prebundling Node.js compatibility", () => {
+	describe.each(["pnpm", "npm", "yarn"])("using %s", (pm) => {
+		test("will not cause a reload on a dynamic import of a Node.js module", async ({
+			expect,
+			seed,
+			viteDev,
+		}) => {
+			const projectPath = await seed("dynamic", pm);
+
+			const proc = await viteDev(projectPath);
+			const url = await waitForReady(proc);
+			expect(await fetchJson(url)).toEqual("OK!");
+			expect(proc.stdout).not.toContain(
+				"optimized dependencies changed. reloading"
+			);
+			expect(proc.stdout).not.toContain("[vite] program reload");
+		});
+	});
+});

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/basic/wrangler.toml
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/basic/wrangler.toml
@@ -1,4 +1,4 @@
-name = "cloudflare-vite-tutorial"
+name = "cloudflare-vite-e2e-basic"
 compatibility_date = "2024-12-30"
 compatibility_flags = [ "nodejs_compat" ]
 assets = { not_found_handling = "single-page-application", binding = "ASSETS" }

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/package.json
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/package.json
@@ -1,25 +1,18 @@
 {
-	"name": "cloudflare-vite-e2e-basic",
+	"name": "cloudflare-vite-e2e-dynamic",
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"build": "tsc -b && vite build",
+		"build": "vite build",
 		"dev": "vite",
 		"lint": "eslint .",
 		"preview": "vite preview"
-	},
-	"dependencies": {
-		"react": "^19.0.0",
-		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "*",
 		"@cloudflare/workers-types": "^4.20250204.0",
 		"@eslint/js": "^9.19.0",
-		"@types/react": "^19.0.8",
-		"@types/react-dom": "^19.0.3",
-		"@vitejs/plugin-react": "^4.3.4",
 		"eslint": "^9.19.0",
 		"eslint-plugin-react-hooks": "^5.0.0",
 		"eslint-plugin-react-refresh": "^0.4.18",

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/src/dynamic.ts
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/src/dynamic.ts
@@ -1,0 +1,8 @@
+// This dynamically imported module relies upon Node.js
+// When Vite becomes aware of this file it will need to optimize the `node:asset` library
+// if it hasn't already.
+
+import assert from "node:assert/strict";
+
+assert(true, "the world is broken!");
+export const x = '"OK!"';

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/src/index.ts
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/src/index.ts
@@ -1,0 +1,8 @@
+export default {
+	async fetch() {
+		// By dynamically importing the `./dynamic` module we prevent Vite from being able to statically
+		// analyze the imports and pre-optimize the Node.js import that is within it.
+		const { x } = await import("./dynamic");
+		return new Response(x);
+	},
+} satisfies ExportedHandler;

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/tsconfig.json
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/tsconfig.node.json
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+		"target": "ES2022",
+		"lib": ["ES2023"],
+		"module": "ESNext",
+		"skipLibCheck": true,
+
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"isolatedModules": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+
+		/* Linting */
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true
+	},
+	"include": ["vite.config.ts"]
+}

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/tsconfig.worker.json
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/tsconfig.worker.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.node.json",
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
+		"types": ["@cloudflare/workers-types/2023-07-01", "vite/client"]
+	},
+	"include": ["src"]
+}

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/vite.config.ts
@@ -1,7 +1,6 @@
 import { cloudflare } from "@cloudflare/vite-plugin";
-import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [react(), cloudflare({ inspectorPort: false, persistState: false })],
+	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
 });

--- a/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/wrangler.toml
+++ b/packages/vite-plugin-cloudflare/e2e/fixtures/dynamic/wrangler.toml
@@ -1,0 +1,4 @@
+name = "cloudflare-vite-e2e-dynamic"
+main = "./src/index.ts"
+compatibility_date = "2024-12-30"
+compatibility_flags = ["nodejs_compat"]

--- a/packages/vite-plugin-cloudflare/e2e/tsconfig.json
+++ b/packages/vite-plugin-cloudflare/e2e/tsconfig.json
@@ -5,7 +5,9 @@
 		"skipLibCheck": true,
 		"types": ["node", "vitest"],
 		"target": "ESNext",
-		"moduleResolution": "NodeNext",
-		"module": "NodeNext"
+		"moduleResolution": "Node",
+		"module": "ESNext",
+		"esModuleInterop": true,
+		"resolveJsonModule": true
 	}
 }

--- a/packages/vite-plugin-cloudflare/e2e/wrangler-configs-validation.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/wrangler-configs-validation.test.ts
@@ -1,13 +1,12 @@
 import { describe } from "vitest";
-import { runCommand, test } from "./helpers.js";
+import { test } from "./helpers.js";
 
 // Note: the tests here just make sure that the validation does take place, for more fine grained
 //       testing regarding the validation there are unit tests in src/__tests__/get-validated-wrangler-config-path.spec.ts
 
 describe("during development wrangler config files are validated", () => {
 	test("for the entry worker", async ({ expect, seed, viteDev }) => {
-		const projectPath = await seed("no-wrangler-config");
-		runCommand(`pnpm install`, projectPath);
+		const projectPath = await seed("no-wrangler-config", "pnpm");
 
 		const proc = viteDev(projectPath);
 
@@ -18,8 +17,10 @@ describe("during development wrangler config files are validated", () => {
 	});
 
 	test("for auxiliary workers", async ({ expect, seed, viteDev }) => {
-		const projectPath = await seed("no-wrangler-config-for-auxiliary-worker");
-		runCommand(`pnpm install`, projectPath);
+		const projectPath = await seed(
+			"no-wrangler-config-for-auxiliary-worker",
+			"pnpm"
+		);
 
 		const proc = viteDev(projectPath);
 

--- a/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-warnings/warnings.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/node-compat/__tests__/worker-warnings/warnings.spec.ts
@@ -8,8 +8,7 @@ test("should display warnings if nodejs_compat is missing", async () => {
 	await vi.waitFor(async () => {
 		expect(serverLogs.warns[0]?.replaceAll("\\", "/")).toContain(
 			dedent`
-				Unexpected Node.js imports for environment "worker". Do you need to enable the "nodejs_compat" compatibility flag?
-				Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.
+				Unexpected Node.js imports for environment "worker". Do you need to enable the "nodejs_compat" compatibility flag? Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.
 				 - "node:assert/strict" imported from "worker-warnings/index.ts"
 				 - "perf_hooks" imported from "worker-warnings/index.ts"
 				`

--- a/packages/vite-plugin-cloudflare/playground/prisma/__tests__/prisma.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/prisma/__tests__/prisma.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { getJsonResponse } from "../../__test-utils__";
+import { getJsonResponse, serverLogs } from "../../__test-utils__";
 
 // Need to remove the `.wrangler` directory and run the following commands before the tests:
 //
@@ -14,4 +14,8 @@ test("runs D1 query using Prisma", async () => {
 	expect(result).toEqual([
 		{ id: 1, email: "jane@prisma.io", name: "Jane Doe (Local)" },
 	]);
+
+	const info = serverLogs.info.join("\n");
+	expect(info).not.toContain("optimized dependencies changed. reloading");
+	expect(info).not.toContain("[vite] program reload");
 });

--- a/packages/vite-plugin-cloudflare/playground/prisma/__tests__/serve.ts
+++ b/packages/vite-plugin-cloudflare/playground/prisma/__tests__/serve.ts
@@ -1,9 +1,9 @@
 import { execSync } from "node:child_process";
 import { rmSync } from "node:fs";
 import { resolve } from "node:path";
-import { startDefaultServe } from "../../vitest-setup";
+import { loadConfig, startDefaultServe } from "../../vitest-setup";
 
-export function preServe() {
+export async function preServe() {
 	const cwd = process.cwd();
 	try {
 		process.chdir(resolve(__dirname, ".."));
@@ -16,6 +16,13 @@ export function preServe() {
 	} finally {
 		process.chdir(cwd);
 	}
+
+	// Remove the cache directory that stores the pre-bundled optimized dependencies.
+	const config = await loadConfig({ command: "serve", mode: "development" });
+	rmSync(resolve(config.root, config.cacheDir), {
+		force: true,
+		recursive: true,
+	});
 }
 
 export async function serve() {

--- a/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
@@ -184,7 +184,7 @@ beforeEach(async () => {
 	await page.goto(viteTestUrl);
 });
 
-async function loadConfig(configEnv: ConfigEnv) {
+export async function loadConfig(configEnv: ConfigEnv) {
 	let config: UserConfig | null = null;
 	let cacheDir = "node_modules/.vite";
 

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -688,7 +688,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 												{ filter: NODEJS_MODULES_RE },
 												({ path, importer }) => {
 													// We have to delay getting this `nodeJsCompatWarnings` from the `nodeJsCompatWarningsMap` until we are in this function.
-													// It has not been added to the map until the `configureServer()` hook is called, which is after the `configEnvironment()` hook.
+													// It has not been added to the map until the `resolveId()` hook is called, which is after the `configEnvironment()` hook.
 													const nodeJsCompatWarnings =
 														nodeJsCompatWarningsMap.get(workerConfig);
 													assert(
@@ -701,13 +701,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 													return { path, external: true };
 												}
 											);
-											build.onEnd(() => {
-												const nodeJsCompatWarnings =
-													nodeJsCompatWarningsMap.get(workerConfig);
-												if (nodeJsCompatWarnings) {
-													nodeJsCompatWarnings.renderWarnings();
-												}
-											});
 										},
 									},
 								],
@@ -728,9 +721,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					nodeJsCompatWarningsMap.set(workerConfig, nodeJsCompatWarnings);
 					if (nodejsBuiltins.has(source)) {
 						nodeJsCompatWarnings?.registerImport(source, importer);
-						// We don't have a natural place to trigger the rendering of the warnings
-						// So we trigger a rendering to happen soon after this round of processing.
-						nodeJsCompatWarnings?.renderWarningsOnIdle();
 						// Mark this path as external to avoid messy unwanted resolve errors.
 						// It will fail at runtime but we will log warnings to the user.
 						return {

--- a/packages/vite-plugin-cloudflare/src/node-js-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/node-js-compat.ts
@@ -153,9 +153,10 @@ export class NodeJsCompatWarnings {
 		const importers = this.sources.get(source) ?? new Set();
 		this.sources.set(source, importers);
 		importers.add(importer);
+		this.renderWarningsOnIdle();
 	}
 
-	renderWarningsOnIdle() {
+	private renderWarningsOnIdle() {
 		if (this.timer) {
 			clearTimeout(this.timer);
 		}
@@ -165,10 +166,11 @@ export class NodeJsCompatWarnings {
 		}, 500);
 	}
 
-	renderWarnings() {
+	private renderWarnings() {
 		if (this.sources.size > 0) {
 			let message =
-				`\n\nUnexpected Node.js imports for environment "${this.environment.name}". Do you need to enable the "nodejs_compat" compatibility flag?\n` +
+				`Unexpected Node.js imports for environment "${this.environment.name}". ` +
+				`Do you need to enable the "nodejs_compat" compatibility flag? ` +
 				"Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.\n";
 			this.sources.forEach((importers, source) => {
 				importers.forEach((importer) => {
@@ -177,6 +179,7 @@ export class NodeJsCompatWarnings {
 			});
 			this.environment.logger.warn(message, {
 				environment: this.environment.name,
+				timestamp: true,
 			});
 			this.sources.clear();
 		}

--- a/packages/vite-plugin-cloudflare/src/node-js-compat.ts
+++ b/packages/vite-plugin-cloudflare/src/node-js-compat.ts
@@ -147,7 +147,10 @@ export class NodeJsCompatWarnings {
 	private sources = new Map<string, Set<string>>();
 	private timer: NodeJS.Timeout | undefined;
 
-	constructor(private readonly environment: vite.Environment) {}
+	constructor(
+		private readonly environmentName: string,
+		private readonly resolvedViteConfig: vite.ResolvedConfig
+	) {}
 
 	registerImport(source: string, importer = "<unknown>") {
 		const importers = this.sources.get(source) ?? new Set();
@@ -169,16 +172,15 @@ export class NodeJsCompatWarnings {
 	private renderWarnings() {
 		if (this.sources.size > 0) {
 			let message =
-				`Unexpected Node.js imports for environment "${this.environment.name}". ` +
+				`Unexpected Node.js imports for environment "${this.environmentName}". ` +
 				`Do you need to enable the "nodejs_compat" compatibility flag? ` +
 				"Refer to https://developers.cloudflare.com/workers/runtime-apis/nodejs/ for more details.\n";
 			this.sources.forEach((importers, source) => {
 				importers.forEach((importer) => {
-					message += ` - "${source}" imported from "${path.relative(this.environment.config.root, importer)}"\n`;
+					message += ` - "${source}" imported from "${path.relative(this.resolvedViteConfig.root, importer)}"\n`;
 				});
 			});
-			this.environment.logger.warn(message, {
-				environment: this.environment.name,
+			this.resolvedViteConfig.logger.warn(message, {
 				timestamp: true,
 			});
 			this.sources.clear();

--- a/packages/vite-plugin-cloudflare/turbo.json
+++ b/packages/vite-plugin-cloudflare/turbo.json
@@ -7,7 +7,12 @@
 			"outputs": ["dist/**"]
 		},
 		"test:e2e": {
-			"env": ["CLOUDFLARE_VITE_E2E_KEEP_TEMP_DIRS", "NODE_DEBUG"],
+			"env": [
+				"CLOUDFLARE_VITE_E2E_KEEP_TEMP_DIRS",
+				"NODE_DEBUG",
+				"CLOUDFLARE_ACCOUNT_ID",
+				"CLOUDFLARE_API_TOKEN"
+			],
 			"inputs": ["e2e/**"]
 		}
 	}

--- a/packages/vite-plugin-cloudflare/turbo.json
+++ b/packages/vite-plugin-cloudflare/turbo.json
@@ -7,6 +7,7 @@
 			"outputs": ["dist/**"]
 		},
 		"test:e2e": {
+			"env": ["CLOUDFLARE_VITE_E2E_KEEP_TEMP_DIRS", "NODE_DEBUG"],
 			"inputs": ["e2e/**"]
 		}
 	}


### PR DESCRIPTION
Fixes [DEVX-1769](https://jira.cfdata.org/browse/DEVX-1769)

Previously, these polyfills were only optimized on demand when Vite became aware of them.
This was either because Vite was able to find an import to a polyfill when statically analysing the import tree of the entry-point,
or when a polyfilled module was dynamically imported as part of a executing code to handle a request.

In the second case, the optimizing of the dynamically imported dependency causes a reload of the Vite server, which can break applications that are holding state in modules during the request.
This is the case of most React type frameworks, in particular React Router.

Now, we pre-optimize all the possible Node.js polyfills when the server starts before the first request is handled.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix / refactor
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: vite plugin is not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
