### PR TITLE
Fix Workers KV ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,9 +22,11 @@
 /packages/create-cloudflare/ @cloudflare/c3 @cloudflare/wrangler
 
 # Workers KV ownership
-/packages/wrangler/src/kv @cloudflare/kv @cloudflare/wrangler
-/packages/wrangler/src/__tests__/kv.local.test.ts @cloudflare/kv @cloudflare/wrangler
-/packages/wrangler/src/__tests__/kv.test.ts @cloudflare/kv @cloudflare/wrangler
+/packages/wrangler/src/kv @cloudflare/workers-kv @cloudflare/wrangler
+/packages/wrangler/src/__tests__/kv.local.test.ts @cloudflare/workers-kv @cloudflare/wrangler
+/packages/wrangler/src/__tests__/kv.test.ts @cloudflare/workers-kv @cloudflare/wrangler
+/packages/miniflare/src/workers/kv @cloudflare/workers-kv @cloudflare/wrangler
+/packages/miniflare/test/plugins/kv @cloudflare/workers-kv @cloudflare/wrangler
 
 # kv-asset-handler ownership
 /packages/kv-asset-handler/ @cloudflare/wrangler


### PR DESCRIPTION
There are two KV groups and wrong team is the code owner, fixing it, then other group can be removed.

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: codeowners fix
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: codeowners fix
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: codeowners fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: codeowners fix

