### PR TITLE
Revert "[wrangler] Wrangler pages deployments list - added ID to output"

### DIFF
--- a/.changeset/lemon-dragons-glow.md
+++ b/.changeset/lemon-dragons-glow.md
@@ -1,5 +1,0 @@
----
-"wrangler": minor
----
-
-Added the Pages deployment id to the JSON output for `wrangler pages deployment list`

--- a/packages/wrangler/src/pages/deployments.ts
+++ b/packages/wrangler/src/pages/deployments.ts
@@ -72,7 +72,6 @@ export async function ListHandler({ projectName, environment }: ListArgs) {
 
 	const data = deployments.map((deployment) => {
 		return {
-			Id: deployment.id,
 			Environment: titleCase(deployment.environment),
 			Branch: deployment.deployment_trigger.metadata.branch,
 			Source: shortSha(deployment.deployment_trigger.metadata.commit_hash),


### PR DESCRIPTION
Reverts cloudflare/workers-sdk#8641. Accidentally merged minor changes, when only patches are allowed