### PR TITLE
Add X-Forwarded-Host header to requests

### DIFF
--- a/.changeset/common-baths-fold.md
+++ b/.changeset/common-baths-fold.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Set the `x-forwarded-host` header to the original host in requests. This fixes a bug where libraries such as Clerk would redirect to the workerd host rather than the Vite host.

--- a/packages/vite-plugin-cloudflare/playground/worker/__tests__/worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/__tests__/worker.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { getTextResponse, serverLogs } from "../../__test-utils__";
+import { getTextResponse, serverLogs, viteTestUrl } from "../../__test-utils__";
 
 test("basic hello-world functionality", async () => {
 	expect(await getTextResponse()).toEqual("Hello World!");
@@ -9,4 +9,10 @@ test("basic dev logging", async () => {
 	expect(serverLogs.info.join()).toContain("__console log__");
 	expect(serverLogs.errors.join()).toContain("__console error__");
 	expect(serverLogs.errors.join()).toContain("__console warn__");
+});
+
+test("receives the original host as the `X-Forwarded-Host` header", async () => {
+	const testUrl = new URL(viteTestUrl);
+	const response = await getTextResponse("/x-forwarded-host");
+	expect(response).toBe(testUrl.host);
 });

--- a/packages/vite-plugin-cloudflare/playground/worker/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/worker/src/index.ts
@@ -1,5 +1,11 @@
 export default {
-	async fetch() {
+	async fetch(request) {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/x-forwarded-host") {
+			return new Response(request.headers.get("X-Forwarded-Host"));
+		}
+
 		console.log("__console log__");
 		console.warn("__console warn__");
 		console.error("__console error__");

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -22,6 +22,11 @@ export function getRouterWorker(miniflare: Miniflare) {
 }
 
 export function toMiniflareRequest(request: Request): MiniflareRequest {
+	// We set the X-Forwarded-Host header to the original host as the `Host` header inside a Worker will contain the workerd host
+	const host = request.headers.get("Host");
+	if (host) {
+		request.headers.set("X-Forwarded-Host", host);
+	}
 	// Undici sets the `Sec-Fetch-Mode` header to `cors` so we capture it in a custom header to be converted back later.
 	const secFetchMode = request.headers.get("Sec-Fetch-Mode");
 	if (secFetchMode) {


### PR DESCRIPTION
Fixes #8684.

This sets the `x-forwarded-host` header to the original host in requests. It fixes a bug where libraries such as Clerk would redirect to the workerd host rather than the Vite host.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
