### PR TITLE
Add --template-mode to create-cloudflare

### DIFF
--- a/.changeset/solid-needles-deny.md
+++ b/.changeset/solid-needles-deny.md
@@ -1,0 +1,7 @@
+---
+"create-cloudflare": minor
+---
+
+Add --template-mode argument to create-cloudflare to support templating from private repositories
+
+create-cloudflare uses degit under the hood to clone template git repositories. degit will attempt to download a tar file of the HEAD of a repository if it is served up on one of several allow listed repository hosting services including GitHub. However, the tar support does not support templating from private repositories. To support that, we needed to create the ability to tell degit to use "git" mode to download the template using the user's git credentials.

--- a/packages/create-cloudflare/src/__tests__/templates.test.ts
+++ b/packages/create-cloudflare/src/__tests__/templates.test.ts
@@ -279,6 +279,32 @@ describe("downloadRemoteTemplate", () => {
 
 		expect(spinner).not.toBeCalled();
 	});
+
+	test("should call degit with a mode of undefined if not specified", async () => {
+		const mock = mockDegit();
+
+		await downloadRemoteTemplate("cloudflare/workers-sdk");
+
+		expect(mock).toBeCalledWith("cloudflare/workers-sdk", {
+			cache: false,
+			verbose: false,
+			force: true,
+			mode: undefined,
+		});
+	});
+
+	test("should call degit with a mode of 'git' if specified", async () => {
+		const mock = mockDegit();
+
+		await downloadRemoteTemplate("cloudflare/workers-sdk", "git");
+
+		expect(mock).toBeCalledWith("cloudflare/workers-sdk", {
+			cache: false,
+			verbose: false,
+			force: true,
+			mode: "git",
+		});
+	});
 });
 
 describe("deriveCorrelatedArgs", () => {

--- a/packages/create-cloudflare/src/helpers/__tests__/args.test.ts
+++ b/packages/create-cloudflare/src/helpers/__tests__/args.test.ts
@@ -125,5 +125,22 @@ describe("Cli", () => {
 				expect.stringContaining(`Not enough arguments following: ${arg}`),
 			);
 		});
+
+		test("parsing template-mode correctly", async () => {
+			const result = await parseArgs(["--template-mode", "git"]);
+
+			assert(result.type === "default");
+			assert(result.args.templateMode === "git");
+		});
+
+		test("template-mode correctly defaults to be undefined", async () => {
+			const result = await parseArgs([
+				"--template",
+				"git@github.com:user/repo",
+			]);
+
+			assert(result.type === "default");
+			expect(result.args.templateMode).toBeUndefined();
+		});
 	});
 });

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -237,6 +237,28 @@ export const cliDefinition: ArgumentsDefinition = {
         `,
 		},
 		{
+			name: "template-mode",
+			type: "string",
+			requiresArg: true,
+			description: `The mechanism to use when fetching the template.
+				
+        Can be either "git" or "tar". "tar" does not support fetching from private 
+				repositories. Defaults to "tar".
+        `,
+			values: [
+				{
+					name: "git",
+					description:
+						"Use git to fetch the template. Supports private repositories.",
+				},
+				{
+					name: "tar",
+					description:
+						"Use tar to fetch the template. Only supported on public repositories hosted on GitHub, BitBucket, GitLab, or git.sr.ht.",
+				},
+			],
+		},
+		{
 			name: "accept-defaults",
 			alias: "y",
 			type: "boolean",

--- a/packages/create-cloudflare/src/helpers/args.ts
+++ b/packages/create-cloudflare/src/helpers/args.ts
@@ -243,7 +243,8 @@ export const cliDefinition: ArgumentsDefinition = {
 			description: `The mechanism to use when fetching the template.
 				
         Can be either "git" or "tar". "tar" does not support fetching from private 
-				repositories. Defaults to "tar".
+				repositories. By default, degit will use "tar" if the template is hosted on GitHub, BitBucket, GitLab, or git.sr.ht. 
+				Otherwise, it will use "git".
         `,
 			values: [
 				{

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -643,7 +643,7 @@ export const processRemoteTemplate = async (args: Partial<C3Args>) => {
 			.replace("/tree/main/", "/");
 	}
 
-	const path = await downloadRemoteTemplate(src);
+	const path = await downloadRemoteTemplate(src, args.templateMode);
 	const config = inferTemplateConfig(path);
 
 	validateTemplate(path, config);
@@ -730,7 +730,10 @@ const inferCopyFilesDefinition = (path: string): CopyFiles => {
  *            For convenience, `owner/repo` is also accepted.
  * @returns A path to a temporary directory containing the downloaded template
  */
-export const downloadRemoteTemplate = async (src: string) => {
+export const downloadRemoteTemplate = async (
+	src: string,
+	mode?: "git" | "tar",
+) => {
 	// degit runs `git clone` internally which may prompt for credentials if required
 	// Avoid using a `spinner()` during this operation -- use updateStatus instead.
 
@@ -741,6 +744,7 @@ export const downloadRemoteTemplate = async (src: string) => {
 			cache: false,
 			verbose: false,
 			force: true,
+			mode,
 		});
 
 		const tmpDir = await mkdtemp(join(tmpdir(), "c3-template"));

--- a/packages/create-cloudflare/src/types.ts
+++ b/packages/create-cloudflare/src/types.ts
@@ -17,6 +17,7 @@ export type C3Args = {
 	lang?: string;
 	existingScript?: string;
 	template?: string;
+	templateMode?: "tar" | "git";
 	acceptDefaults?: boolean;
 	wranglerDefaults?: boolean;
 	additionalArgs?: string[];


### PR DESCRIPTION
Fixes #[insert GH or internal issue link(s)].

create-cloudflare uses degit under the hood to clone template git repositories. degit will attempt to download a tar file of the HEAD of a repository if it is served up on one of several allow listed repository hosting services including GitHub. However, the tar support does not support templating from private repositories. To support that, we needed to create the ability to tell degit to use "git" mode to download the template using the user's git credentials.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
