### PR TITLE
feat[wrangler]: Add deployment id to `wrangler pages deployment list` output

### DIFF
--- a/.changeset/sweet-rocks-clean.md
+++ b/.changeset/sweet-rocks-clean.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add the Pages deployment id to the JSON output for `wrangler pages deployment list`

--- a/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
+++ b/packages/wrangler/src/__tests__/pages/deployment-list.test.ts
@@ -11,7 +11,7 @@ describe("pages deployment list", () => {
 	runInTempDir();
 	mockAccountId();
 	mockApiToken();
-	mockConsoleMethods();
+	const std = mockConsoleMethods();
 
 	afterEach(async () => {
 		// Force a tick to ensure that all promises resolve
@@ -46,6 +46,13 @@ describe("pages deployment list", () => {
 		await runWrangler("pages deployment list --project-name=images");
 
 		expect(requests.count).toBe(1);
+		expect(std.out).toMatchInlineSnapshot(`
+			"┌──────────────────────────────────────┬─────────────┬────────┬─────────┬───────────────────────────────────┬─────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────┐
+			│ Id                                   │ Environment │ Branch │ Source  │ Deployment                        │ Status      │ Build                                                                                              │
+			├──────────────────────────────────────┼─────────────┼────────┼─────────┼───────────────────────────────────┼─────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
+			│ 87bbc8fe-16be-45cd-81e0-63d722e82cdf │ Preview     │ main   │ c764936 │ https://87bbc8fe.images.pages.dev │ 3 years ago │ https://dash.cloudflare.com/some-account-id/pages/view/images/87bbc8fe-16be-45cd-81e0-63d722e82cdf │
+			└──────────────────────────────────────┴─────────────┴────────┴─────────┴───────────────────────────────────┴─────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────┘"
+		`);
 	});
 
 	it("should pass no environment", async () => {

--- a/packages/wrangler/src/pages/deployments.ts
+++ b/packages/wrangler/src/pages/deployments.ts
@@ -72,6 +72,7 @@ export async function ListHandler({ projectName, environment }: ListArgs) {
 
 	const data = deployments.map((deployment) => {
 		return {
+			Id: deployment.id,
 			Environment: titleCase(deployment.environment),
 			Branch: deployment.deployment_trigger.metadata.branch,
 			Source: shortSha(deployment.deployment_trigger.metadata.commit_hash),


### PR DESCRIPTION
Fixes n/a

Add Pages deployment id to `wrangler pages deployment list` output

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because: covered by unit test
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because: command output is not documented
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: minor change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
