### PR TITLE
chore: fix vite-plugin e2es using non existent `viteCommand` function

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/wrangler-configs-validation.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/wrangler-configs-validation.test.ts
@@ -5,11 +5,11 @@ import { runCommand, test } from "./helpers.js";
 //       testing regarding the validation there are unit tests in src/__tests__/get-validated-wrangler-config-path.spec.ts
 
 describe("during development wrangler config files are validated", () => {
-	test("for the entry worker", async ({ expect, seed, viteCommand }) => {
+	test("for the entry worker", async ({ expect, seed, viteDev }) => {
 		const projectPath = await seed("no-wrangler-config");
 		runCommand(`pnpm install`, projectPath);
 
-		const proc = await viteCommand("pnpm", "dev", projectPath);
+		const proc = viteDev(projectPath);
 
 		expect(await proc.exitCode).not.toBe(0);
 		expect(proc.stderr).toMatch(
@@ -17,11 +17,11 @@ describe("during development wrangler config files are validated", () => {
 		);
 	});
 
-	test("for auxiliary workers", async ({ expect, seed, viteCommand }) => {
+	test("for auxiliary workers", async ({ expect, seed, viteDev }) => {
 		const projectPath = await seed("no-wrangler-config-for-auxiliary-worker");
 		runCommand(`pnpm install`, projectPath);
 
-		const proc = await viteCommand("pnpm", "dev", projectPath);
+		const proc = viteDev(projectPath);
 
 		expect(await proc.exitCode).not.toBe(0);
 		expect(proc.stderr).toMatch(


### PR DESCRIPTION
<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: chore fixing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: chore fixing tests
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
