### PR TITLE
fix: General improvements for the R2 catalog commands

### DIFF
--- a/.changeset/tangy-badgers-grow.md
+++ b/.changeset/tangy-badgers-grow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: General improvements for the R2 catalog commands

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -523,9 +523,12 @@ export async function enableR2Catalog(
 	accountId: string,
 	bucketName: string
 ): Promise<R2WarehouseEnableResponse> {
-	return await fetchResult(`/accounts/${accountId}/r2-catalog/${bucketName}`, {
-		method: "POST",
-	});
+	return await fetchResult(
+		`/accounts/${accountId}/r2-catalog/${bucketName}/enable`,
+		{
+			method: "POST",
+		}
+	);
 }
 
 /**
@@ -535,9 +538,12 @@ export async function disableR2Catalog(
 	accountId: string,
 	bucketName: string
 ): Promise<R2WarehouseEnableResponse> {
-	return await fetchResult(`/accounts/${accountId}/r2-catalog/${bucketName}`, {
-		method: "DELETE",
-	});
+	return await fetchResult(
+		`/accounts/${accountId}/r2-catalog/${bucketName}/disable`,
+		{
+			method: "POST",
+		}
+	);
 }
 
 const R2EventableOperations = [


### PR DESCRIPTION
Fixes IGLOO-40.

Summary of changes: 
1. Update the routes for the r2 catalog enable and disable commands
2. Include the warehouse name in the enable and get command responses
3. Handle the "catalog never enabled" case for the disable command
4. Remove the irreversible action message from the disable command
5. Handling of the "catalog never enabled" case suggests the use of the enable command
6. Minor formatting changes.

[CR-1142756](https://jira.cfdata.org/browse/CR-1142756)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/issues/21030
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
