### PR TITLE
fix: remove stray main field in Hono Pages template

### DIFF
--- a/.changeset/wide-ideas-work.md
+++ b/.changeset/wide-ideas-work.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: remove `main` field in wrangler.jsonc of Hono Pages template

--- a/packages/create-cloudflare/e2e-tests/frameworks/framework-test-config.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks/framework-test-config.ts
@@ -237,7 +237,6 @@ export default function getFrameworkTestConfig(pm: string) {
 			verifyPreview: {
 				route: "/",
 				expectedText: "Hello!",
-				previewArgs: ["--host=127.0.0.1"],
 			},
 			promptHandlers: [
 				{

--- a/packages/create-cloudflare/templates/hono/pages/c3.ts
+++ b/packages/create-cloudflare/templates/hono/pages/c3.ts
@@ -33,10 +33,11 @@ const config: TemplateConfig = {
 	transformPackageJson: async () => ({
 		scripts: {
 			"cf-typegen": "wrangler types --env-interface CloudflareBindings",
+			preview: "vite build && wrangler pages dev",
 		},
 	}),
 	devScript: "dev",
 	deployScript: "deploy",
-	previewScript: "dev",
+	previewScript: "preview",
 };
 export default config;

--- a/packages/create-cloudflare/templates/hono/pages/templates/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hono/pages/templates/wrangler.jsonc
@@ -1,6 +1,5 @@
 {
   "name": "<TBD>",
-  "main": "src/index.ts",
   "compatibility_date": "<TBD>",
 	"pages_build_output_dir": "./dist",
   "observability": {


### PR DESCRIPTION
This snuck through because the preview tests used hono's vite plugin which doesn't care what's in the wrangler config.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: c3 change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
