### PR TITLE
Log whether a command is operating on a local or remote resource

### DIFF
--- a/.changeset/better-laws-follow.md
+++ b/.changeset/better-laws-follow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Log whether a command is operating on a remote or local resource

--- a/packages/create-cloudflare/templates/astro/workers/templates/ts/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/astro/workers/templates/ts/wrangler.jsonc
@@ -11,5 +11,8 @@
   },
   "observability": {
     "enabled": true
-  }
+  },
+	"vars":{
+		"TBD": "<TBD>"
+	}
 }

--- a/packages/wrangler/e2e/r2.test.ts
+++ b/packages/wrangler/e2e/r2.test.ts
@@ -42,7 +42,8 @@ describe("r2", () => {
 			`wrangler r2 object put ${bucketName}/testr2 --file test-r2.txt --content-type text/html --remote`
 		);
 		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
-			"Creating object "testr2" in bucket "tmp-e2e-r2-00000000-0000-0000-0000-000000000000".
+			"Resource location: remote
+			Creating object "testr2" in bucket "tmp-e2e-r2-00000000-0000-0000-0000-000000000000".
 			Upload complete."
 		`);
 	});
@@ -52,7 +53,8 @@ describe("r2", () => {
 			`wrangler r2 object get ${bucketName}/testr2 --file test-r2o.txt --remote`
 		);
 		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
-			"Downloading "testr2" from "tmp-e2e-r2-00000000-0000-0000-0000-000000000000".
+			"Resource location: remote
+			Downloading "testr2" from "tmp-e2e-r2-00000000-0000-0000-0000-000000000000".
 			Download complete."
 		`);
 		const file = await readFile(
@@ -67,7 +69,8 @@ describe("r2", () => {
 			`wrangler r2 object delete ${bucketName}/testr2 --remote`
 		);
 		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
-			"Deleting object "testr2" from bucket "tmp-e2e-r2-00000000-0000-0000-0000-000000000000".
+			"Resource location: remote
+			Deleting object "testr2" from bucket "tmp-e2e-r2-00000000-0000-0000-0000-000000000000".
 			Delete complete."
 		`);
 	});

--- a/packages/wrangler/src/__tests__/__snapshots__/kv.test.ts.snap
+++ b/packages/wrangler/src/__tests__/__snapshots__/kv.test.ts.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace 1`] = `
-"🌀 Creating namespace with title \\"UnitTestNamespace\\"
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace\\"
 ✨ Success!
 Add the following to your configuration file in your kv_namespaces array:
 {
@@ -15,7 +16,8 @@ Add the following to your configuration file in your kv_namespaces array:
 `;
 
 exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace in an environment if configured to do so 1`] = `
-"🌀 Creating namespace with title \\"customEnv-UnitTestNamespace\\"
+"Resource location: remote
+🌀 Creating namespace with title \\"customEnv-UnitTestNamespace\\"
 ✨ Success!
 Add the following to your configuration file in your kv_namespaces array under [env.customEnv]:
 {
@@ -29,7 +31,8 @@ Add the following to your configuration file in your kv_namespaces array under [
 `;
 
 exports[`wrangler > kv namespace > create > wrangler.json > should create a namespace using configured worker name 1`] = `
-"🌀 Creating namespace with title \\"UnitTestNamespace\\"
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace\\"
 ✨ Success!
 Add the following to your configuration file in your kv_namespaces array:
 {
@@ -43,7 +46,8 @@ Add the following to your configuration file in your kv_namespaces array:
 `;
 
 exports[`wrangler > kv namespace > create > wrangler.json > should create a preview namespace if configured to do so 1`] = `
-"🌀 Creating namespace with title \\"UnitTestNamespace_preview\\"
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace_preview\\"
 ✨ Success!
 Add the following to your configuration file in your kv_namespaces array:
 {
@@ -57,7 +61,8 @@ Add the following to your configuration file in your kv_namespaces array:
 `;
 
 exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace 1`] = `
-"🌀 Creating namespace with title \\"UnitTestNamespace\\"
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace\\"
 ✨ Success!
 Add the following to your configuration file in your kv_namespaces array:
 [[kv_namespaces]]
@@ -67,7 +72,8 @@ id = \\"some-namespace-id\\"
 `;
 
 exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace in an environment if configured to do so 1`] = `
-"🌀 Creating namespace with title \\"customEnv-UnitTestNamespace\\"
+"Resource location: remote
+🌀 Creating namespace with title \\"customEnv-UnitTestNamespace\\"
 ✨ Success!
 Add the following to your configuration file in your kv_namespaces array under [env.customEnv]:
 [[kv_namespaces]]
@@ -77,7 +83,8 @@ id = \\"some-namespace-id\\"
 `;
 
 exports[`wrangler > kv namespace > create > wrangler.toml > should create a namespace using configured worker name 1`] = `
-"🌀 Creating namespace with title \\"UnitTestNamespace\\"
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace\\"
 ✨ Success!
 Add the following to your configuration file in your kv_namespaces array:
 [[kv_namespaces]]
@@ -87,7 +94,8 @@ id = \\"some-namespace-id\\"
 `;
 
 exports[`wrangler > kv namespace > create > wrangler.toml > should create a preview namespace if configured to do so 1`] = `
-"🌀 Creating namespace with title \\"UnitTestNamespace_preview\\"
+"Resource location: remote
+🌀 Creating namespace with title \\"UnitTestNamespace_preview\\"
 ✨ Success!
 Add the following to your configuration file in your kv_namespaces array:
 [[kv_namespaces]]

--- a/packages/wrangler/src/__tests__/kv.local.test.ts
+++ b/packages/wrangler/src/__tests__/kv.local.test.ts
@@ -21,18 +21,24 @@ describe("wrangler", () => {
 				`kv key put val value --namespace-id some-namespace-id `
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Value not found
-			Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id."
-		`);
+				"Value not found
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id."
+			`);
 
 			await runWrangler(
 				`kv key get val --namespace-id some-namespace-id --text`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Value not found
-			Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
-			value"
-		`);
+				"Value not found
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
+				value"
+			`);
 		});
 
 		it("should list local kv storage", async () => {
@@ -63,23 +69,26 @@ describe("wrangler", () => {
 
 			await runWrangler(`kv key list --namespace-id some-namespace-id`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"[]
-			Success!
-			[
-			  {
-			    \\"name\\": \\"a\\"
-			  },
-			  {
-			    \\"name\\": \\"a/b\\"
-			  },
-			  {
-			    \\"name\\": \\"a/c\\"
-			  },
-			  {
-			    \\"name\\": \\"b\\"
-			  }
-			]"
-		`);
+				"[]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[
+				  {
+				    \\"name\\": \\"a\\"
+				  },
+				  {
+				    \\"name\\": \\"a/b\\"
+				  },
+				  {
+				    \\"name\\": \\"a/c\\"
+				  },
+				  {
+				    \\"name\\": \\"b\\"
+				  }
+				]"
+			`);
 
 			await runWrangler(
 				`kv key list --namespace-id some-namespace-id --prefix a`
@@ -92,40 +101,43 @@ describe("wrangler", () => {
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
-			"[]
-			Success!
-			[
-			  {
-			    \\"name\\": \\"a\\"
-			  },
-			  {
-			    \\"name\\": \\"a/b\\"
-			  },
-			  {
-			    \\"name\\": \\"a/c\\"
-			  },
-			  {
-			    \\"name\\": \\"b\\"
-			  }
-			]
-			[
-			  {
-			    \\"name\\": \\"a\\"
-			  },
-			  {
-			    \\"name\\": \\"a/b\\"
-			  },
-			  {
-			    \\"name\\": \\"a/c\\"
-			  }
-			]
-			[
-			  {
-			    \\"name\\": \\"a/b\\"
-			  }
-			]
-			[]"
-		`);
+				"[]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[
+				  {
+				    \\"name\\": \\"a\\"
+				  },
+				  {
+				    \\"name\\": \\"a/b\\"
+				  },
+				  {
+				    \\"name\\": \\"a/c\\"
+				  },
+				  {
+				    \\"name\\": \\"b\\"
+				  }
+				]
+				[
+				  {
+				    \\"name\\": \\"a\\"
+				  },
+				  {
+				    \\"name\\": \\"a/b\\"
+				  },
+				  {
+				    \\"name\\": \\"a/c\\"
+				  }
+				]
+				[
+				  {
+				    \\"name\\": \\"a/b\\"
+				  }
+				]
+				[]"
+			`);
 		});
 
 		it("should delete local kv storage", async () => {
@@ -136,24 +148,39 @@ describe("wrangler", () => {
 				`kv key get val --namespace-id some-namespace-id --text`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
-			value"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
+				value"
+			`);
 			await runWrangler(`kv key delete val --namespace-id some-namespace-id`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
-			value
-			Deleting the key \\"val\\" on namespace some-namespace-id."
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
+				value
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Deleting the key \\"val\\" on namespace some-namespace-id."
+			`);
 
 			await runWrangler(
 				`kv key get val --namespace-id some-namespace-id --text`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
-			value
-			Deleting the key \\"val\\" on namespace some-namespace-id.
-			Value not found"
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
+				value
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Deleting the key \\"val\\" on namespace some-namespace-id.
+				Value not found"
 			`);
 		});
 
@@ -181,47 +208,59 @@ describe("wrangler", () => {
 				`kv bulk put keys.json --namespace-id bulk-namespace-id`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"[]
-			Success!"
-		`);
+				"[]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!"
+			`);
 
 			await runWrangler(
 				`kv key get test --namespace-id bulk-namespace-id --text`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"[]
-			Success!
-			value"
-		`);
+				"[]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				value"
+			`);
 
 			await runWrangler(
 				`kv key get encoded --namespace-id bulk-namespace-id --text`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"[]
-			Success!
-			value
-			some raw data"
-		`);
+				"[]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				value
+				some raw data"
+			`);
 
 			await runWrangler(`kv key list --namespace-id bulk-namespace-id`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"[]
-			Success!
-			value
-			some raw data
-			[
-			  {
-			    \\"name\\": \\"encoded\\"
-			  },
-			  {
-			    \\"name\\": \\"hello\\"
-			  },
-			  {
-			    \\"name\\": \\"test\\"
-			  }
-			]"
-		`);
+				"[]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				value
+				some raw data
+				[
+				  {
+				    \\"name\\": \\"encoded\\"
+				  },
+				  {
+				    \\"name\\": \\"hello\\"
+				  },
+				  {
+				    \\"name\\": \\"test\\"
+				  }
+				]"
+			`);
 		});
 
 		it("should delete local bulk kv storage", async () => {
@@ -241,48 +280,63 @@ describe("wrangler", () => {
 			);
 			await runWrangler(`kv key list --namespace-id bulk-namespace-id`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Success!
-			[
-			  {
-			    \\"name\\": \\"hello\\"
-			  },
-			  {
-			    \\"name\\": \\"test\\"
-			  }
-			]"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[
+				  {
+				    \\"name\\": \\"hello\\"
+				  },
+				  {
+				    \\"name\\": \\"test\\"
+				  }
+				]"
+			`);
 			const keys = ["hello", "test"];
 			writeFileSync("./keys.json", JSON.stringify(keys));
 			await runWrangler(
 				`kv bulk delete keys.json --namespace-id bulk-namespace-id --force`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Success!
-			[
-			  {
-			    \\"name\\": \\"hello\\"
-			  },
-			  {
-			    \\"name\\": \\"test\\"
-			  }
-			]
-			Success!"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[
+				  {
+				    \\"name\\": \\"hello\\"
+				  },
+				  {
+				    \\"name\\": \\"test\\"
+				  }
+				]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!"
+			`);
 
 			await runWrangler(`kv key list --namespace-id bulk-namespace-id`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Success!
-			[
-			  {
-			    \\"name\\": \\"hello\\"
-			  },
-			  {
-			    \\"name\\": \\"test\\"
-			  }
-			]
-			Success!
-			[]"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[
+				  {
+				    \\"name\\": \\"hello\\"
+				  },
+				  {
+				    \\"name\\": \\"test\\"
+				  }
+				]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[]"
+			`);
 		});
 
 		it("should delete local bulk kv storage ({ name })", async () => {
@@ -302,16 +356,19 @@ describe("wrangler", () => {
 			);
 			await runWrangler(`kv key list --namespace-id bulk-namespace-id`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Success!
-			[
-			  {
-			    \\"name\\": \\"hello\\"
-			  },
-			  {
-			    \\"name\\": \\"test\\"
-			  }
-			]"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[
+				  {
+				    \\"name\\": \\"hello\\"
+				  },
+				  {
+				    \\"name\\": \\"test\\"
+				  }
+				]"
+			`);
 			const keys = [
 				{
 					name: "hello",
@@ -325,32 +382,44 @@ describe("wrangler", () => {
 				`kv bulk delete keys.json --namespace-id bulk-namespace-id --force`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Success!
-			[
-			  {
-			    \\"name\\": \\"hello\\"
-			  },
-			  {
-			    \\"name\\": \\"test\\"
-			  }
-			]
-			Success!"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[
+				  {
+				    \\"name\\": \\"hello\\"
+				  },
+				  {
+				    \\"name\\": \\"test\\"
+				  }
+				]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!"
+			`);
 
 			await runWrangler(`kv key list --namespace-id bulk-namespace-id`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Success!
-			[
-			  {
-			    \\"name\\": \\"hello\\"
-			  },
-			  {
-			    \\"name\\": \\"test\\"
-			  }
-			]
-			Success!
-			[]"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[
+				  {
+				    \\"name\\": \\"hello\\"
+				  },
+				  {
+				    \\"name\\": \\"test\\"
+				  }
+				]
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[]"
+			`);
 		});
 
 		it("should get local bulk kv storage", async () => {
@@ -370,23 +439,29 @@ describe("wrangler", () => {
 			);
 			await runWrangler(`kv key list --namespace-id bulk-namespace-id`);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Success!
-			[
-			  {
-			    \\"name\\": \\"hello\\"
-			  },
-			  {
-			    \\"name\\": \\"test\\"
-			  }
-			]"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
+				[
+				  {
+				    \\"name\\": \\"hello\\"
+				  },
+				  {
+				    \\"name\\": \\"test\\"
+				  }
+				]"
+			`);
 			const keys = ["hello", "test"];
 			writeFileSync("./keys.json", JSON.stringify(keys));
 			await runWrangler(
 				`kv bulk get keys.json --namespace-id bulk-namespace-id`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-				"Success!
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Success!
 				[
 				  {
 				    \\"name\\": \\"hello\\"
@@ -417,28 +492,46 @@ describe("wrangler", () => {
 				`kv key put val persistValue --namespace-id some-namespace-id --persist-to ./persistdir`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
-			Writing the value \\"persistValue\\" to key \\"val\\" on namespace some-namespace-id."
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"persistValue\\" to key \\"val\\" on namespace some-namespace-id."
+			`);
 
 			await runWrangler(
 				`kv key get val --namespace-id some-namespace-id --text`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
-			Writing the value \\"persistValue\\" to key \\"val\\" on namespace some-namespace-id.
-			value"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"persistValue\\" to key \\"val\\" on namespace some-namespace-id.
+				value"
+			`);
 
 			await runWrangler(
 				`kv key get val --namespace-id some-namespace-id --text --persist-to ./persistdir`
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-			"Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
-			Writing the value \\"persistValue\\" to key \\"val\\" on namespace some-namespace-id.
-			value
-			persistValue"
-		`);
+				"Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"value\\" to key \\"val\\" on namespace some-namespace-id.
+				Resource location: local
+				Use --remote if you want to access the remote instance.
+
+				Writing the value \\"persistValue\\" to key \\"val\\" on namespace some-namespace-id.
+				value
+				persistValue"
+			`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/kv.test.ts
+++ b/packages/wrangler/src/__tests__/kv.test.ts
@@ -361,7 +361,8 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-					"Deleting KV namespace env-bound-id.
+					"Resource location: remote
+					Deleting KV namespace env-bound-id.
 					Deleted KV namespace env-bound-id."
 				`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -443,7 +444,10 @@ describe("wrangler", () => {
 
 				expect(requests.count).toEqual(1);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace some-namespace-id."`
+					`
+					"Resource location: remote
+					Writing the value \\"my-value\\" to key \\"my-key\\" on namespace some-namespace-id."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -460,7 +464,10 @@ describe("wrangler", () => {
 
 				expect(requests.count).toEqual(1);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"my-value\\" to key \\"/my-key\\" on namespace DS9."`
+					`
+					"Resource location: remote
+					Writing the value \\"my-value\\" to key \\"/my-key\\" on namespace DS9."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -476,7 +483,10 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace bound-id."`
+					`
+					"Resource location: remote
+					Writing the value \\"my-value\\" to key \\"my-key\\" on namespace bound-id."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -494,7 +504,10 @@ describe("wrangler", () => {
 				);
 
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace preview-bound-id."`
+					`
+					"Resource location: remote
+					Writing the value \\"my-value\\" to key \\"my-key\\" on namespace preview-bound-id."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -512,7 +525,10 @@ describe("wrangler", () => {
 				);
 				expect(requests.count).toEqual(1);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace some-namespace-id."`
+					`
+					"Resource location: remote
+					Writing the value \\"my-value\\" to key \\"my-key\\" on namespace some-namespace-id."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -527,7 +543,10 @@ describe("wrangler", () => {
 					"kv key put --remote my-key my-value --binding someBinding --env some-environment --preview false"
 				);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"my-value\\" to key \\"my-key\\" on namespace env-bound-id."`
+					`
+					"Resource location: remote
+					Writing the value \\"my-value\\" to key \\"my-key\\" on namespace env-bound-id."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -544,7 +563,10 @@ describe("wrangler", () => {
 					"kv key put --remote my-key --namespace-id some-namespace-id --path foo.txt"
 				);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the contents of foo.txt to the key \\"my-key\\" on namespace some-namespace-id."`
+					`
+					"Resource location: remote
+					Writing the contents of foo.txt to the key \\"my-key\\" on namespace some-namespace-id."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -564,7 +586,10 @@ describe("wrangler", () => {
 					"kv key put --remote my-key --namespace-id another-namespace-id --path test.png"
 				);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the contents of test.png to the key \\"my-key\\" on namespace another-namespace-id."`
+					`
+					"Resource location: remote
+					Writing the contents of test.png to the key \\"my-key\\" on namespace another-namespace-id."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -583,7 +608,10 @@ describe("wrangler", () => {
 				);
 				expect(requests.count).toEqual(1);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the value \\"dVal\\" to key \\"dKey\\" on namespace some-namespace-id with metadata \\"{\\"mKey\\":\\"mValue\\"}\\"."`
+					`
+					"Resource location: remote
+					Writing the value \\"dVal\\" to key \\"dKey\\" on namespace some-namespace-id with metadata \\"{\\"mKey\\":\\"mValue\\"}\\"."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -606,7 +634,10 @@ describe("wrangler", () => {
 				);
 				expect(requests.count).toEqual(1);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Writing the contents of test.png to the key \\"another-my-key\\" on namespace some-namespace-id with metadata \\"{\\"mKey\\":\\"mValue\\"}\\"."`
+					`
+					"Resource location: remote
+					Writing the contents of test.png to the key \\"another-my-key\\" on namespace some-namespace-id with metadata \\"{\\"mKey\\":\\"mValue\\"}\\"."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -881,7 +912,10 @@ describe("wrangler", () => {
 					`[Error: A namespace with binding name "otherBinding" was not found in the configured "kv_namespaces".]`
 				);
 
-				expect(std.out).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					"
+				`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA namespace with binding name \\"otherBinding\\" was not found in the configured \\"kv_namespaces\\".[0m
 
@@ -902,7 +936,10 @@ describe("wrangler", () => {
 				).rejects.toThrowErrorMatchingInlineSnapshot(
 					`[Error: someBinding has both a namespace ID and a preview ID. Specify "--preview" or "--preview false" to avoid writing data to the wrong namespace.]`
 				);
-				expect(std.out).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					"
+				`);
 				expect(std.err).toMatchInlineSnapshot(`
 			          "[31mX [41;31m[[41;97mERROR[41;31m][0m [1msomeBinding has both a namespace ID and a preview ID. Specify \\"--preview\\" or \\"--preview false\\" to avoid writing data to the wrong namespace.[0m
 
@@ -1469,7 +1506,10 @@ describe("wrangler", () => {
 
 				expect(requests.count).toEqual(1);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Deleting the key \\"/NCC-74656\\" on namespace voyager."`
+					`
+					"Resource location: remote
+					Deleting the key \\"/NCC-74656\\" on namespace voyager."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -1514,7 +1554,10 @@ describe("wrangler", () => {
 					`kv key delete --remote --binding someBinding --env some-environment --preview false someKey`
 				);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Deleting the key \\"someKey\\" on namespace env-bound-id."`
+					`
+					"Resource location: remote
+					Deleting the key \\"someKey\\" on namespace env-bound-id."
+				`
 				);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(requests.count).toEqual(1);
@@ -1573,7 +1616,10 @@ describe("wrangler", () => {
 					`kv bulk put --remote --namespace-id some-namespace-id keys.json`
 				);
 				expect(requests.count).toEqual(1);
-				expect(std.out).toMatchInlineSnapshot(`"Success!"`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					Success!"
+				`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -1590,7 +1636,8 @@ describe("wrangler", () => {
 				);
 				expect(requests.count).toEqual(12);
 				expect(std.out).toMatchInlineSnapshot(`
-					"Uploaded 0% (0 out of 12,000)
+					"Resource location: remote
+					Uploaded 0% (0 out of 12,000)
 					Uploaded 8% (1,000 out of 12,000)
 					Uploaded 16% (2,000 out of 12,000)
 					Uploaded 25% (3,000 out of 12,000)
@@ -1620,7 +1667,10 @@ describe("wrangler", () => {
 					[Error: Unexpected JSON input from "keys.json".
 					Expected an array of key-value objects but got type "object".]
 				`);
-				expect(std.out).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					"
+				`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
@@ -1681,7 +1731,10 @@ describe("wrangler", () => {
 					The item at index 12 is {"key":"someKey1","value":"someValue1","base64":"string"}]
 				`);
 
-				expect(std.out).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					"
+				`);
 				expect(std.warn).toMatchInlineSnapshot(`
 			          "[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mUnexpected key-value properties in \\"keys.json\\".[0m
 
@@ -1735,7 +1788,10 @@ describe("wrangler", () => {
 					`kv bulk delete --remote --namespace-id some-namespace-id keys.json`
 				);
 				expect(requests.count).toEqual(1);
-				expect(std.out).toMatchInlineSnapshot(`"Success!"`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					Success!"
+				`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -1755,7 +1811,10 @@ describe("wrangler", () => {
 					`kv bulk delete --remote --namespace-id some-namespace-id keys.json`
 				);
 				expect(requests.count).toEqual(1);
-				expect(std.out).toMatchInlineSnapshot(`"Success!"`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					Success!"
+				`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -1773,7 +1832,8 @@ describe("wrangler", () => {
 				);
 				expect(requests.count).toEqual(12);
 				expect(std.out).toMatchInlineSnapshot(`
-					"Deleted 0% (0 out of 12,000)
+					"Resource location: remote
+					Deleted 0% (0 out of 12,000)
 					Deleted 8% (1,000 out of 12,000)
 					Deleted 16% (2,000 out of 12,000)
 					Deleted 25% (3,000 out of 12,000)
@@ -1803,7 +1863,10 @@ describe("wrangler", () => {
 					`kv bulk delete --remote --namespace-id some-namespace-id keys.json`
 				);
 				expect(std.out).toMatchInlineSnapshot(
-					`"Not deleting keys read from \\"keys.json\\"."`
+					`
+					"Resource location: remote
+					Not deleting keys read from \\"keys.json\\"."
+				`
 				);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -1817,7 +1880,10 @@ describe("wrangler", () => {
 					`kv bulk delete --remote --namespace-id some-namespace-id keys.json --force`
 				);
 				expect(requests.count).toEqual(1);
-				expect(std.out).toMatchInlineSnapshot(`"Success!"`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					Success!"
+				`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -1830,7 +1896,10 @@ describe("wrangler", () => {
 					`kv bulk delete --remote --namespace-id some-namespace-id keys.json -f`
 				);
 				expect(requests.count).toEqual(1);
-				expect(std.out).toMatchInlineSnapshot(`"Success!"`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					Success!"
+				`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 			});
@@ -1851,7 +1920,10 @@ describe("wrangler", () => {
 					Expected an array of strings but got:
 					12354]
 				`);
-				expect(std.out).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					"
+				`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
@@ -1873,7 +1945,10 @@ describe("wrangler", () => {
 					The item at index 2 is type: "object" - {"key":"someKey"}
 					The item at index 3 is type: "object" - null]
 				`);
-				expect(std.out).toMatchInlineSnapshot(`""`);
+				expect(std.out).toMatchInlineSnapshot(`
+					"Resource location: remote
+					"
+				`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 		});

--- a/packages/wrangler/src/__tests__/r2.local.test.ts
+++ b/packages/wrangler/src/__tests__/r2.local.test.ts
@@ -23,34 +23,43 @@ describe("r2", () => {
 					`[Error: The specified key does not exist.]`
 				);
 
-				expect(std.warn).toMatchInlineSnapshot(`
-					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mBy default, \`wrangler r2\` commands access a local simulator of your R2 bucket, the same as that used by \`wrangler dev\`. To access your remote R2 bucket, re-run the command with the --remote flag[0m
-
-					"
-				`);
-
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				await runWrangler(
 					`r2 object put bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-			"Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					"Resource location: local
+					Use --remote if you want to access the remote instance.
 
-			Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
-			Upload complete."
-		`);
+					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+
+					Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Upload complete."
+				`);
 
 				await runWrangler(
 					`r2 object get bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-			"Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					"Resource location: local
+					Use --remote if you want to access the remote instance.
 
-			Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
-			Upload complete.
-			Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
-			Download complete."
-		`);
+					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+
+					Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Upload complete.
+					Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					Download complete."
+				`);
 			});
 
 			it("should delete R2 object from local bucket", async () => {
@@ -58,33 +67,44 @@ describe("r2", () => {
 				await runWrangler(
 					`r2 object put bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
 				);
-				expect(std.warn).toMatchInlineSnapshot(`
-					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mBy default, \`wrangler r2\` commands access a local simulator of your R2 bucket, the same as that used by \`wrangler dev\`. To access your remote R2 bucket, re-run the command with the --remote flag[0m
-
-					"
-				`);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
 
 				await runWrangler(
 					`r2 object get bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-			"Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
-			Upload complete.
-			Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
-			Download complete."
-		`);
+					"Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Upload complete.
+					Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					Download complete."
+				`);
 
 				await runWrangler(
 					`r2 object delete bucketName-object-test/wormhole-img.png `
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-			"Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
-			Upload complete.
-			Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
-			Download complete.
-			Deleting object \\"wormhole-img.png\\" from bucket \\"bucketName-object-test\\".
-			Delete complete."
-		`);
+					"Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Upload complete.
+					Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					Download complete.
+					Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Deleting object \\"wormhole-img.png\\" from bucket \\"bucketName-object-test\\".
+					Delete complete."
+				`);
 
 				await expect(() =>
 					runWrangler(
@@ -117,15 +137,27 @@ describe("r2", () => {
 					`r2 object get bucketName-object-test/file-two --file ./wormhole-img.png  --persist-to ./different-dir`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
-			"Creating object \\"file-one\\" in bucket \\"bucketName-object-test\\".
-			Upload complete.
-			Creating object \\"file-two\\" in bucket \\"bucketName-object-test\\".
-			Upload complete.
-			Downloading \\"file-one\\" from \\"bucketName-object-test\\".
+					"Resource location: local
+					Use --remote if you want to access the remote instance.
 
-			Downloading \\"file-two\\" from \\"bucketName-object-test\\".
-			Download complete."
-		`);
+					Creating object \\"file-one\\" in bucket \\"bucketName-object-test\\".
+					Upload complete.
+					Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Creating object \\"file-two\\" in bucket \\"bucketName-object-test\\".
+					Upload complete.
+					Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Downloading \\"file-one\\" from \\"bucketName-object-test\\".
+
+					Resource location: local
+					Use --remote if you want to access the remote instance.
+
+					Downloading \\"file-two\\" from \\"bucketName-object-test\\".
+					Download complete."
+				`);
 			});
 		});
 	});

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -3220,9 +3220,10 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-			"Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
-			Download complete."
-		`);
+					"Resource location: remote
+					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					Download complete."
+				`);
 			});
 
 			it("should download R2 object from bucket into directory", async () => {
@@ -3241,9 +3242,10 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-			"Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
-			Upload complete."
-		`);
+					"Resource location: remote
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Upload complete."
+				`);
 			});
 
 			it("should upload R2 object with storage class to bucket", async () => {
@@ -3253,9 +3255,10 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-			"Creating object \\"wormhole-img.png\\" with InfrequentAccess storage class in bucket \\"bucketName-object-test\\".
-			Upload complete."
-		`);
+					"Resource location: remote
+					Creating object \\"wormhole-img.png\\" with InfrequentAccess storage class in bucket \\"bucketName-object-test\\".
+					Upload complete."
+				`);
 			});
 
 			it("should fail to upload R2 object to bucket if too large", async () => {
@@ -3317,9 +3320,10 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-			"Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
-			Upload complete."
-		`);
+					"Resource location: remote
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Upload complete."
+				`);
 			});
 
 			it("should delete R2 object from bucket", async () => {
@@ -3328,9 +3332,10 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 				);
 
 				expect(std.out).toMatchInlineSnapshot(`
-			"Deleting object \\"wormhole-img.png\\" from bucket \\"bucketName-object-test\\".
-			Delete complete."
-		`);
+					"Resource location: remote
+					Deleting object \\"wormhole-img.png\\" from bucket \\"bucketName-object-test\\".
+					Delete complete."
+				`);
 			});
 
 			it("should not allow `--pipe` & `--file` to run together", async () => {

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import { fetchResult } from "../cfetch";
 import { readConfig } from "../config";
 import { defaultWranglerConfig } from "../config/config";

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -92,7 +92,11 @@ function createHandler(def: CommandDefinition) {
 
 			await def.validateArgs?.(args);
 
-			if (def.behaviour?.printResourceLocation) {
+			const shouldPrintResourceLocation =
+				typeof def.behaviour?.printResourceLocation === "function"
+					? def.behaviour?.printResourceLocation(args)
+					: def.behaviour?.printResourceLocation;
+			if (shouldPrintResourceLocation) {
 				// we don't have the type of args here :(
 				const remote =
 					"remote" in args && typeof args.remote === "boolean"

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -4,6 +4,7 @@ import { defaultWranglerConfig } from "../config/config";
 import { FatalError, UserError } from "../errors";
 import { run } from "../experimental-flags";
 import { logger } from "../logger";
+import { printResourceLocation } from "../utils/is-local";
 import { printWranglerBanner } from "../wrangler-banner";
 import { demandSingleValue } from "./helpers";
 import type { CommonYargsArgv, SubHelp } from "../yargs-types";
@@ -90,6 +91,23 @@ function createHandler(def: CommandDefinition) {
 			// TODO(telemetry): send command started event
 
 			await def.validateArgs?.(args);
+
+			if (def.behaviour?.printLocalResourceWarning) {
+				// if remote is undefined, it defaults to local
+				let remote = "remote" in args ? args.remote : undefined;
+				if ("local" in args && args.local === false) {
+					remote = false;
+				}
+				if (remote) {
+					printResourceLocation("remote");
+				} else {
+					printResourceLocation("local");
+					logger.log(
+						`Use --remote if you want to access the remote instance.\n`
+					);
+				}
+			}
+
 			const experimentalFlags = def.behaviour?.overrideExperimentalFlags
 				? def.behaviour?.overrideExperimentalFlags(args)
 				: {

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -123,6 +123,13 @@ export type CommandDefinition<
 		 * If true, then look for a redirect file at `.wrangler/deploy/config.json` and use that to find the Wrangler configuration file.
 		 */
 		useConfigRedirectIfAvailable?: boolean;
+
+		/**
+		 * If true, print a message about whether the command is operating on a local or remote resource
+		 */
+		printLocalResourceWarning?:
+			| ((args?: HandlerArgs<NamedArgDefs>) => boolean)
+			| boolean;
 	};
 
 	/**

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -127,7 +127,7 @@ export type CommandDefinition<
 		/**
 		 * If true, print a message about whether the command is operating on a local or remote resource
 		 */
-		printLocalResourceWarning?:
+		printResourceLocation?:
 			| ((args?: HandlerArgs<NamedArgDefs>) => boolean)
 			| boolean;
 	};

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -11,7 +11,7 @@ import * as metrics from "../metrics";
 import { parseJSON, readFileSync, readFileSyncToBuffer } from "../parse";
 import { requireAuth } from "../user";
 import { getValidBindingName } from "../utils/getValidBindingName";
-import { isLocal } from "../utils/is-local";
+import { isLocal, printResourceLocation } from "../utils/is-local";
 import {
 	createKVNamespace,
 	deleteKVBulkKeyValue,
@@ -90,9 +90,8 @@ export const kvNamespaceCreateCommand = createCommand({
 		const title = `${environment}${args.namespace}${preview}`;
 
 		const accountId = await requireAuth(config);
-
+		printResourceLocation("remote");
 		// TODO: generate a binding name stripping non alphanumeric chars
-
 		logger.log(`🌀 Creating namespace with title "${title}"`);
 		const namespaceId = await createKVNamespace(accountId, title);
 		metrics.sendMetricsEvent("create kv namespace", {
@@ -132,7 +131,7 @@ export const kvNamespaceListCommand = createCommand({
 
 	args: {},
 
-	behaviour: { printBanner: false },
+	behaviour: { printBanner: false, printLocalResourceWarning: false },
 	async handler(args) {
 		const config = readConfig(args);
 
@@ -153,7 +152,6 @@ export const kvNamespaceDeleteCommand = createCommand({
 		status: "stable",
 		owner: "Product: KV",
 	},
-
 	args: {
 		binding: {
 			type: "string",
@@ -177,7 +175,7 @@ export const kvNamespaceDeleteCommand = createCommand({
 
 	async handler(args) {
 		const config = readConfig(args);
-
+		printResourceLocation("remote");
 		let id;
 		try {
 			id = getKVNamespaceId(args, config);
@@ -222,7 +220,9 @@ export const kvKeyPutCommand = createCommand({
 		status: "stable",
 		owner: "Product: KV",
 	},
-
+	behaviour: {
+		printLocalResourceWarning: true,
+	},
 	positionalArgs: ["key", "value"],
 	args: {
 		key: {
@@ -354,6 +354,11 @@ export const kvKeyListCommand = createCommand({
 		status: "stable",
 		owner: "Product: KV",
 	},
+	behaviour: {
+		// implicitly expects to output JSON only
+		printLocalResourceWarning: false,
+		printBanner: false,
+	},
 
 	args: {
 		binding: {
@@ -395,7 +400,6 @@ export const kvKeyListCommand = createCommand({
 		demandOneOfOption("binding", "namespace-id")(args);
 	},
 
-	behaviour: { printBanner: false },
 	async handler({ prefix, ...args }) {
 		const localMode = isLocal(args);
 		// TODO: support for limit+cursor (pagination)
@@ -434,7 +438,10 @@ export const kvKeyGetCommand = createCommand({
 		status: "stable",
 		owner: "Product: KV",
 	},
-
+	behaviour: {
+		printBanner: false,
+		printLocalResourceWarning: false,
+	},
 	positionalArgs: ["key"],
 	args: {
 		key: {
@@ -480,8 +487,6 @@ export const kvKeyGetCommand = createCommand({
 	validateArgs(args) {
 		demandOneOfOption("binding", "namespace-id")(args);
 	},
-
-	behaviour: { printBanner: false },
 	async handler({ key, ...args }) {
 		const localMode = isLocal(args);
 		const config = readConfig(args);
@@ -535,7 +540,9 @@ export const kvKeyDeleteCommand = createCommand({
 		status: "stable",
 		owner: "Product: KV",
 	},
-
+	behaviour: {
+		printLocalResourceWarning: true,
+	},
 	positionalArgs: ["key"],
 	args: {
 		key: {
@@ -607,7 +614,10 @@ export const kvBulkGetCommand = createCommand({
 		status: "open-beta",
 		owner: "Product: KV",
 	},
-
+	behaviour: {
+		printBanner: false,
+		printLocalResourceWarning: false,
+	},
 	positionalArgs: ["filename"],
 	args: {
 		filename: {
@@ -726,7 +736,9 @@ export const kvBulkPutCommand = createCommand({
 		status: "stable",
 		owner: "Product: KV",
 	},
-
+	behaviour: {
+		printLocalResourceWarning: true,
+	},
 	positionalArgs: ["filename"],
 	args: {
 		filename: {
@@ -878,7 +890,9 @@ export const kvBulkDeleteCommand = createCommand({
 		status: "stable",
 		owner: "Product: KV",
 	},
-
+	behaviour: {
+		printLocalResourceWarning: true,
+	},
 	positionalArgs: ["filename"],
 	args: {
 		filename: {

--- a/packages/wrangler/src/kv/index.ts
+++ b/packages/wrangler/src/kv/index.ts
@@ -131,7 +131,7 @@ export const kvNamespaceListCommand = createCommand({
 
 	args: {},
 
-	behaviour: { printBanner: false, printLocalResourceWarning: false },
+	behaviour: { printBanner: false, printResourceLocation: false },
 	async handler(args) {
 		const config = readConfig(args);
 
@@ -221,7 +221,7 @@ export const kvKeyPutCommand = createCommand({
 		owner: "Product: KV",
 	},
 	behaviour: {
-		printLocalResourceWarning: true,
+		printResourceLocation: true,
 	},
 	positionalArgs: ["key", "value"],
 	args: {
@@ -356,7 +356,7 @@ export const kvKeyListCommand = createCommand({
 	},
 	behaviour: {
 		// implicitly expects to output JSON only
-		printLocalResourceWarning: false,
+		printResourceLocation: false,
 		printBanner: false,
 	},
 
@@ -440,7 +440,7 @@ export const kvKeyGetCommand = createCommand({
 	},
 	behaviour: {
 		printBanner: false,
-		printLocalResourceWarning: false,
+		printResourceLocation: false,
 	},
 	positionalArgs: ["key"],
 	args: {
@@ -541,7 +541,7 @@ export const kvKeyDeleteCommand = createCommand({
 		owner: "Product: KV",
 	},
 	behaviour: {
-		printLocalResourceWarning: true,
+		printResourceLocation: true,
 	},
 	positionalArgs: ["key"],
 	args: {
@@ -616,7 +616,7 @@ export const kvBulkGetCommand = createCommand({
 	},
 	behaviour: {
 		printBanner: false,
-		printLocalResourceWarning: false,
+		printResourceLocation: false,
 	},
 	positionalArgs: ["filename"],
 	args: {
@@ -737,7 +737,7 @@ export const kvBulkPutCommand = createCommand({
 		owner: "Product: KV",
 	},
 	behaviour: {
-		printLocalResourceWarning: true,
+		printResourceLocation: true,
 	},
 	positionalArgs: ["filename"],
 	args: {
@@ -891,7 +891,7 @@ export const kvBulkDeleteCommand = createCommand({
 		owner: "Product: KV",
 	},
 	behaviour: {
-		printLocalResourceWarning: true,
+		printResourceLocation: true,
 	},
 	positionalArgs: ["filename"],
 	args: {

--- a/packages/wrangler/src/r2/object.ts
+++ b/packages/wrangler/src/r2/object.ts
@@ -75,7 +75,7 @@ export const r2ObjectGetCommand = createCommand({
 		},
 	},
 	behaviour: {
-		printLocalResourceWarning(args) {
+		printResourceLocation(args) {
 			return !args?.pipe;
 		},
 	},
@@ -223,7 +223,7 @@ export const r2ObjectPutCommand = createCommand({
 		},
 	},
 	behaviour: {
-		printLocalResourceWarning(args) {
+		printResourceLocation(args) {
 			return !args?.pipe;
 		},
 	},
@@ -391,7 +391,7 @@ export const r2ObjectDeleteCommand = createCommand({
 		},
 	},
 	behaviour: {
-		printLocalResourceWarning: true,
+		printResourceLocation: true,
 	},
 	async handler(args) {
 		const localMode = isLocal(args);

--- a/packages/wrangler/src/utils/is-local.ts
+++ b/packages/wrangler/src/utils/is-local.ts
@@ -1,7 +1,10 @@
+import chalk from "chalk";
+import { logger } from "../logger";
+
 export function isLocal(
 	args: {
-		local: boolean | undefined;
-		remote: boolean | undefined;
+		local?: boolean;
+		remote?: boolean;
 	},
 	defaultValue = true
 ): boolean {
@@ -9,4 +12,8 @@ export function isLocal(
 		return defaultValue;
 	}
 	return args.local === true || args.remote === false;
+}
+
+export function printResourceLocation(location: "remote" | "local") {
+	logger.log(chalk.hex("#BD5B08").bold("Resource location:"), location);
 }


### PR DESCRIPTION
Added to KV and R2 for now.

skipping d1 since its commands haven't been refactored to use createCommand yet.

Not added to KV list or get commands, since they seem to implicitly expect the relevant values to be returned (e.g. printBanner = false)

replaces #8665 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: messaging update
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not relevant to v3 (local by default happened in v4)

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
