### PR TITLE
[miniflare] fix: make sure that `miniflare#setOptions` allows the update of inspector ports

### DIFF
--- a/.changeset/sweet-doors-notice.md
+++ b/.changeset/sweet-doors-notice.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: make sure that `miniflare#setOptions` allows the update of inspector ports

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1485,7 +1485,10 @@ export class Miniflare {
 		// all of `requiredSockets` as keys.
 		this.#socketPorts = maybeSocketPorts;
 
-		if (this.#maybeInspectorProxyController !== undefined) {
+		if (
+			this.#maybeInspectorProxyController !== undefined &&
+			this.#sharedOpts.core.inspectorPort !== undefined
+		) {
 			// Try to get inspector port for the workers
 			const maybePort = this.#socketPorts.get(kInspectorSocket);
 			if (maybePort === undefined) {
@@ -1494,7 +1497,10 @@ export class Miniflare {
 					"Unable to access the runtime inspector socket."
 				);
 			} else {
-				this.#maybeInspectorProxyController.updateConnection(maybePort);
+				this.#maybeInspectorProxyController.updateConnection(
+					this.#sharedOpts.core.inspectorPort,
+					maybePort
+				);
 			}
 		}
 

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1497,7 +1497,7 @@ export class Miniflare {
 					"Unable to access the runtime inspector socket."
 				);
 			} else {
-				this.#maybeInspectorProxyController.updateConnection(
+				await this.#maybeInspectorProxyController.updateConnection(
 					this.#sharedOpts.core.inspectorPort,
 					maybePort
 				);

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -60,7 +60,12 @@ export class InspectorProxyController {
 
 		this.#initializeWebSocketServer(server);
 
+		const listeningPromise = new Promise<void>((resolve) =>
+			server.once("listening", resolve)
+		);
 		server.listen(await this.#inspectorPort);
+
+		await listeningPromise;
 
 		return server;
 	}
@@ -70,7 +75,11 @@ export class InspectorProxyController {
 		await new Promise<void>((resolve, reject) => {
 			server.close((err) => (err ? reject(err) : resolve()));
 		});
+		const listeningPromise = new Promise<void>((resolve) =>
+			server.once("listening", resolve)
+		);
 		server.listen(await this.#inspectorPort);
+		await listeningPromise;
 	}
 
 	#initializeWebSocketServer(server: Server) {

--- a/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
+++ b/packages/miniflare/src/plugins/core/inspector-proxy/inspector-proxy-controller.ts
@@ -72,6 +72,7 @@ export class InspectorProxyController {
 
 	async #restartServer() {
 		const server = await this.#server;
+		server.closeAllConnections();
 		await new Promise<void>((resolve, reject) => {
 			server.close((err) => (err ? reject(err) : resolve()));
 		});

--- a/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/inspector-proxy/index.spec.ts
@@ -191,7 +191,7 @@ test("InspectorProxy: should allow inspector port updating via miniflare#setOpti
 	const mf = new Miniflare({ ...options, inspectorPort: initialInspectorPort });
 	t.teardown(() => mf.dispose());
 
-	t.is(await getInspectorPortReady(mf), `${initialInspectorPort}`);
+	t.is(await getInspectorPortReady(mf), initialInspectorPort);
 
 	let res = await fetch(
 		`http://localhost:${initialInspectorPort}/json/version`
@@ -203,7 +203,7 @@ test("InspectorProxy: should allow inspector port updating via miniflare#setOpti
 
 	t.not(initialInspectorPort, newInspectorPort);
 
-	t.is(await getInspectorPortReady(mf), `${newInspectorPort}`);
+	t.is(await getInspectorPortReady(mf), newInspectorPort);
 
 	res = await fetch(`http://localhost:${newInspectorPort}/json/version`);
 	t.is(res.status, 200);
@@ -249,10 +249,10 @@ test("InspectorProxy: should not keep the same inspector port on miniflare#setOp
 	const mf = new Miniflare(options);
 	t.teardown(() => mf.dispose());
 
-	t.is(await getInspectorPortReady(mf), `${initialInspectorPort}`);
+	t.is(await getInspectorPortReady(mf), initialInspectorPort);
 
 	await mf.setOptions({ ...options, inspectorPort: 0 });
-	const newInspectorPort = parseInt(await getInspectorPortReady(mf));
+	const newInspectorPort = await getInspectorPortReady(mf);
 
 	t.not(initialInspectorPort, newInspectorPort);
 
@@ -375,13 +375,13 @@ test("InspectorProxy: the devtools websocket communication should adapt to an in
 		ws.close();
 	};
 
-	const initialInspectorPort = parseInt(await getInspectorPortReady(mf));
+	const initialInspectorPort = await getInspectorPortReady(mf);
 
 	await testDebuggingWorkerOn(initialInspectorPort);
 
 	mf.setOptions({ ...options, inspectorPort: await getPort() });
 
-	const newInspectorPort = parseInt(await getInspectorPortReady(mf));
+	const newInspectorPort = await getInspectorPortReady(mf);
 
 	t.not(initialInspectorPort, newInspectorPort);
 
@@ -602,5 +602,5 @@ async function getInspectorPortReady(mf: Miniflare) {
 	await setTimeout(150);
 
 	const { port } = await mf.getInspectorURL();
-	return port;
+	return parseInt(port);
 }


### PR DESCRIPTION
Currently if I use an `inspectorPort` in a miniflare instance and then try to change such
port via `setOptions` such change is not actually applied, this PR fixes that

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix of an undocumented feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: this is a bugfix of a miniflare feature not used by wrangler v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
