### PR TITLE
fix missing Vite capitalization in vite-pluging e2e test

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/invalid-worker-env-configs.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/invalid-worker-env-configs.test.ts
@@ -12,7 +12,7 @@ describe("during development wrangler config files are validated", () => {
 
 		expect(await proc.exitCode).not.toBe(0);
 		expect(proc.stderr).toContain(
-			"The following environment configurations are incompatible with the Cloudflare vite plugin"
+			"The following environment configurations are incompatible with the Cloudflare Vite plugin"
 		);
 	});
 });


### PR DESCRIPTION
I've applied the following suggested change: https://github.com/cloudflare/workers-sdk/pull/8672#discussion_r2022420432 but forgot to update one instance in which this was being tested, for some reason it seems like we didn't catch that in https://github.com/cloudflare/workers-sdk/pull/8672 😓 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fixing a broken test
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: fixing a broken Vite e2e test

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
