### PR TITLE
Update flags for Pipelines create and update

### DIFF
--- a/.changeset/wet-memes-mix.md
+++ b/.changeset/wet-memes-mix.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+- Hide `--transform-worker` flag on `wrangler pipelines <create|update>` during private beta.
+- Add `--shard-count` option for `wrangler pipelines <create|update>` for more control over Pipeline throughput or file
+  size

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -296,17 +296,17 @@ describe("pipelines", () => {
 				      --batch-max-rows     Maximum number of rows per batch before flushing  [number]
 				      --batch-max-seconds  Maximum age of batch in seconds before flushing  [number]
 
-				Transformations
-				      --transform-worker  Pipeline transform Worker and entrypoint (<worker>.<entrypoint>)  [string]
-
 				Destination settings
 				      --r2-bucket             Destination R2 bucket name  [string] [required]
 				      --r2-access-key-id      R2 service Access Key ID for authentication. Leave empty for OAuth confirmation.  [string]
 				      --r2-secret-access-key  R2 service Secret Access Key for authentication. Leave empty for OAuth confirmation.  [string]
 				      --r2-prefix             Prefix for storing files in the destination bucket  [string] [default: \\"\\"]
 				      --compression           Compression format for output files  [string] [choices: \\"none\\", \\"gzip\\", \\"deflate\\"] [default: \\"gzip\\"]
-				      --file-template         Template for individual file names (must include \${slug})  [string]
+				      --file-template         Template for individual file names (must include \${slug}). For example: \\"\${slug}.log.gz\\"  [string]
 				      --partition-template    Path template for partitioned files in the bucket. If not specified, the default will be used  [string]
+
+				Pipeline settings
+				      --shard-count  Number of pipeline shards. More shards handle higher request volume; fewer shards produce larger output files  [number]
 
 				GLOBAL FLAGS
 				  -c, --config   Path to Wrangler configuration file  [string]

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -96,6 +96,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 				describe:
 					"Pipeline transform Worker and entrypoint (<worker>.<entrypoint>)",
 				demandOption: false,
+				hidden: true, // TODO: Remove once transformations launch
 			})
 
 			// Destination options
@@ -163,7 +164,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			})
 			.option("file-template", {
 				type: "string",
-				describe: "Template for individual file names (must include ${slug})",
+				describe: `Template for individual file names (must include $\{slug}). For example: "$\{slug}.log.gz"`,
 				demandOption: false,
 				coerce: (val) => {
 					if (!val.includes("${slug}")) {
@@ -171,6 +172,15 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 					}
 					return val;
 				},
+			})
+
+			// Pipeline settings
+			.group(["shard-count"], `${chalk.bold("Pipeline settings")}`)
+			.option("shard-count", {
+				type: "number",
+				describe:
+					"Number of pipeline shards. More shards handle higher request volume; fewer shards produce larger output files",
+				demandOption: false,
 			})
 	);
 }
@@ -279,6 +289,10 @@ export async function createPipelineHandler(
 	}
 	if (args.fileTemplate) {
 		pipelineConfig.destination.path.filename = args.fileTemplate;
+	}
+
+	if (args.shardCount) {
+		pipelineConfig.metadata.shards = args.shardCount;
 	}
 
 	logger.log(`🌀 Creating Pipeline named "${name}"`);

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -106,6 +106,7 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 				describe:
 					'Pipeline transform Worker and entrypoint, to transform ingested records. Specified as <worker-name>.<entrypoint>, or "none".',
 				demandOption: false,
+				hidden: true, // TODO: Remove once transformations launch
 			})
 
 			// Destination options
@@ -173,6 +174,15 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 					}
 					return val;
 				},
+			})
+
+			// Pipeline settings
+			.group(["shard-count"], `${chalk.bold("Pipeline settings")}`)
+			.option("shard-count", {
+				type: "number",
+				describe:
+					"Number of pipeline shards. More shards handle higher request volume; fewer shards produce larger output files",
+				demandOption: false,
 			})
 	);
 }
@@ -298,6 +308,10 @@ export async function updatePipelineHandler(
 	}
 	if (args.fileTemplate) {
 		pipelineConfig.destination.path.filename = args.fileTemplate;
+	}
+
+	if (args.shardCount) {
+		pipelineConfig.metadata.shards = args.shardCount;
 	}
 
 	logger.log(`🌀 Updating Pipeline "${name}"`);

--- a/packages/wrangler/src/pipelines/client.ts
+++ b/packages/wrangler/src/pipelines/client.ts
@@ -11,9 +11,12 @@ import type { R2BucketInfo } from "../r2/helpers";
 
 // ensure this is in sync with:
 //   https://bitbucket.cfdata.org/projects/PIPE/repos/superpipe/browse/src/coordinator/types.ts#6
-type RecursivePartial<T> = {
-	[P in keyof T]?: RecursivePartial<T[P]>;
-};
+type RecursivePartial<T> = T extends object
+	? {
+			[P in keyof T]?: RecursivePartial<T[P]>;
+		}
+	: T;
+
 export type PartialExcept<T, K extends keyof T> = RecursivePartial<T> &
 	Pick<T, K>;
 
@@ -21,6 +24,7 @@ export type TransformConfig = {
 	script: string;
 	entrypoint: string;
 };
+
 export type HttpSource = {
 	type: "http";
 	format: string;
@@ -30,15 +34,23 @@ export type HttpSource = {
 		origins: ["*"] | string[];
 	};
 };
+
 export type BindingSource = {
 	type: "binding";
 	format: string;
 	schema?: string;
 };
+
+export type Metadata = {
+	shards?: number;
+	[x: string]: unknown;
+};
+
 export type Source = HttpSource | BindingSource;
+
 export type PipelineUserConfig = {
 	name: string;
-	metadata: { [x: string]: string };
+	metadata: Metadata;
 	source: Source[];
 	transforms: TransformConfig[];
 	destination: {


### PR DESCRIPTION
Transforms are not publicly available yet so we are hiding this from the help output. Private beta users will still be able to provide this flag.

This commit also introduces a new flag `--shard-count` for power users to hand tune their pipeline.

Fixes https://jira.cfdata.org/browse/PIPE-241, https://jira.cfdata.org/browse/PIPE-242

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: not needed
- Public documentation
  - [ ] TODO (before merge)
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18595
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: Not public yet. 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
