### PR TITLE
fix: return actual error in wrangler secrets bulk

### DIFF
--- a/.changeset/easy-pens-lie.md
+++ b/.changeset/easy-pens-lie.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: return actual error on `wrangler secret bulk`

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -8,20 +8,11 @@ import { clearDialogs, mockConfirm, mockPrompt } from "../helpers/mock-dialogs";
 import { useMockIsTTY } from "../helpers/mock-istty";
 import { mockGetMembershipsFail } from "../helpers/mock-oauth-flow";
 import { useMockStdin } from "../helpers/mock-stdin";
-import { msw } from "../helpers/msw";
+import { createFetchResult, msw } from "../helpers/msw";
 import { runInTempDir } from "../helpers/run-in-tmp";
 import { runWrangler } from "../helpers/run-wrangler";
 import type { PagesProject } from "../../pages/download-config";
 import type { Interface } from "node:readline";
-
-function createFetchResult(result: unknown, success = true) {
-	return {
-		success,
-		errors: [],
-		messages: [],
-		result,
-	};
-}
 
 export function mockGetMemberships(
 	accounts: { id: string; account: { id: string; name: string } }[]
@@ -690,20 +681,76 @@ describe("wrangler pages secret", () => {
 					"pages secret bulk ./secret.json --project some-project-name"
 				)
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: 🚨 7 secrets failed to upload]`
+				`[TypeError: Cannot read properties of null (reading 'success')]`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"🌀 Creating the secrets for the Pages project \\"some-project-name\\" (production)
-				Finished processing secrets file:
-				✨ 0 secrets successfully uploaded
-				"
+				🚨 Secrets failed to upload
+
+				[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 7 secrets failed to upload[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot read properties of null (reading 'success')[0m
 
-			"
-		`);
+				"
+			`);
+		});
+
+		it("throws a meaningful error", async () => {
+			writeFileSync(
+				"secret.json",
+				JSON.stringify({
+					"secret-name-1": "secret_text",
+					"secret-name-2": "secret_text",
+				})
+			);
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/scripts/:scriptName/settings`,
+					({ params }) => {
+						expect(params.accountId).toEqual("some-account-id");
+
+						return HttpResponse.json(createFetchResult({ bindings: [] }));
+					}
+				),
+				http.patch(
+					`*/accounts/:accountId/workers/scripts/:scriptName/settings`,
+					({ params }) => {
+						expect(params.accountId).toEqual("some-account-id");
+						return HttpResponse.json(
+							createFetchResult(null, false, [
+								{
+									message: "This is a helpful error",
+									code: 1,
+								},
+							])
+						);
+					}
+				)
+			);
+
+			await expect(async () => {
+				await runWrangler("secret bulk ./secret.json --name script-name");
+			}).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.]`
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"🌀 Creating the secrets for the Worker \\"script-name\\"
+
+				🚨 Secrets failed to upload
+
+				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.[0m
+
+				  This is a helpful error [code: 1]
+
+				  If you think this is a bug, please open an issue at:
+				  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
+
+				"
+			`);
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/pages/secret.test.ts
+++ b/packages/wrangler/src/__tests__/pages/secret.test.ts
@@ -671,7 +671,7 @@ describe("wrangler pages secret", () => {
 				http.patch(
 					"*/accounts/:accountId/pages/projects/:project",
 					async () => {
-						return HttpResponse.json(null);
+						return HttpResponse.error();
 					}
 				)
 			);
@@ -681,7 +681,7 @@ describe("wrangler pages secret", () => {
 					"pages secret bulk ./secret.json --project some-project-name"
 				)
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[TypeError: Cannot read properties of null (reading 'success')]`
+				`[TypeError: Failed to fetch]`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
@@ -691,7 +691,7 @@ describe("wrangler pages secret", () => {
 				[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
-				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot read properties of null (reading 'success')[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mFailed to fetch[0m
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -1,7 +1,6 @@
 import * as fs from "node:fs";
 import { writeFileSync } from "node:fs";
 import readline from "node:readline";
-import { success } from "@cloudflare/cli";
 import * as TOML from "@iarna/toml";
 import { http, HttpResponse } from "msw";
 import { vi } from "vitest";
@@ -821,9 +820,10 @@ describe("wrangler secret", () => {
 					`*/accounts/:accountId/workers/scripts/:scriptName/settings`,
 					({ params }) => {
 						expect(params.accountId).toEqual("some-account-id");
-						return HttpResponse.json(
-							returnNetworkError ? null : createFetchResult(null)
-						);
+						if (returnNetworkError) {
+							return HttpResponse.error();
+						}
+						return HttpResponse.json(createFetchResult(null));
 					}
 				)
 			);
@@ -995,7 +995,7 @@ describe("wrangler secret", () => {
 			await expect(async () => {
 				await runWrangler("secret bulk ./secret.json --name script-name");
 			}).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[TypeError: Cannot read properties of null (reading 'success')]`
+				`[TypeError: Failed to fetch]`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
@@ -1010,7 +1010,7 @@ describe("wrangler secret", () => {
 				[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
-				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot read properties of null (reading 'success')[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mFailed to fetch[0m
 
 				"
 			`);
@@ -1030,7 +1030,7 @@ describe("wrangler secret", () => {
 			await expect(async () => {
 				await runWrangler("secret bulk ./secret.json --name script-name");
 			}).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[TypeError: Cannot read properties of null (reading 'success')]`
+				`[TypeError: Failed to fetch]`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
@@ -1045,7 +1045,7 @@ describe("wrangler secret", () => {
 				[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
-				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot read properties of null (reading 'success')[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mFailed to fetch[0m
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import { writeFileSync } from "node:fs";
 import readline from "node:readline";
+import { success } from "@cloudflare/cli";
 import * as TOML from "@iarna/toml";
 import { http, HttpResponse } from "msw";
 import { vi } from "vitest";
@@ -994,7 +995,7 @@ describe("wrangler secret", () => {
 			await expect(async () => {
 				await runWrangler("secret bulk ./secret.json --name script-name");
 			}).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: 🚨 7 secrets failed to upload]`
+				`[TypeError: Cannot read properties of null (reading 'success')]`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
@@ -1004,16 +1005,15 @@ describe("wrangler secret", () => {
 
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 
-				Finished processing secrets JSON file:
-				✨ 0 secrets successfully uploaded
+				🚨 Secrets failed to upload
 
 				[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 7 secrets failed to upload[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot read properties of null (reading 'success')[0m
 
-			"
-		`);
+				"
+			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
 		});
 
@@ -1030,7 +1030,7 @@ describe("wrangler secret", () => {
 			await expect(async () => {
 				await runWrangler("secret bulk ./secret.json --name script-name");
 			}).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: 🚨 2 secrets failed to upload]`
+				`[TypeError: Cannot read properties of null (reading 'success')]`
 			);
 
 			expect(std.out).toMatchInlineSnapshot(`
@@ -1040,17 +1040,76 @@ describe("wrangler secret", () => {
 
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 
-				Finished processing secrets JSON file:
-				✨ 0 secrets successfully uploaded
+				🚨 Secrets failed to upload
 
 				[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 2 secrets failed to upload[0m
+				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mCannot read properties of null (reading 'success')[0m
 
-			"
-		`);
+				"
+			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("throws a meaningful error", async () => {
+			writeFileSync(
+				"secret.json",
+				JSON.stringify({
+					"secret-name-1": "secret_text",
+					"secret-name-2": "secret_text",
+				})
+			);
+
+			msw.use(
+				http.get(
+					`*/accounts/:accountId/workers/scripts/:scriptName/settings`,
+					({ params }) => {
+						expect(params.accountId).toEqual("some-account-id");
+
+						return HttpResponse.json(createFetchResult({ bindings: [] }));
+					}
+				),
+				http.patch(
+					`*/accounts/:accountId/workers/scripts/:scriptName/settings`,
+					({ params }) => {
+						expect(params.accountId).toEqual("some-account-id");
+						return HttpResponse.json(
+							createFetchResult(null, false, [
+								{
+									message: "This is a helpful error",
+									code: 1,
+								},
+							])
+						);
+					}
+				)
+			);
+
+			await expect(async () => {
+				await runWrangler("secret bulk ./secret.json --name script-name");
+			}).rejects.toThrowErrorMatchingInlineSnapshot(
+				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.]`
+			);
+
+			expect(std.out).toMatchInlineSnapshot(`
+				"
+				 ⛅️ wrangler x.x.x
+				------------------
+
+				🌀 Creating the secrets for the Worker \\"script-name\\"
+
+				🚨 Secrets failed to upload
+
+				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/script-name/settings) failed.[0m
+
+				  This is a helpful error [code: 1]
+
+				  If you think this is a bug, please open an issue at:
+				  [4mhttps://github.com/cloudflare/workers-sdk/issues/new/choose[0m
+
+				"
+			`);
 		});
 
 		it("should merge existing bindings and secrets when patching", async () => {

--- a/packages/wrangler/src/pages/secret/index.ts
+++ b/packages/wrangler/src/pages/secret/index.ts
@@ -231,11 +231,8 @@ export const secret = (secretYargs: CommonYargsArgv, subHelp: SubHelp) => {
 						} secrets successfully uploaded`
 					);
 				} catch (err) {
-					logger.log("Finished processing secrets file:");
-					logger.log(`✨ 0 secrets successfully uploaded`);
-					throw new FatalError(
-						`🚨 ${Object.keys(upsertBindings).length} secrets failed to upload`
-					);
+					logger.log(`🚨 Secrets failed to upload`);
+					throw err;
 				}
 			}
 		)

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -515,9 +515,8 @@ export const secretBulkCommand = createCommand({
 			logger.log(`✨ ${upsertBindings.length} secrets successfully uploaded`);
 		} catch (err) {
 			logger.log("");
-			logger.log("Finished processing secrets JSON file:");
-			logger.log(`✨ 0 secrets successfully uploaded`);
-			throw new Error(`🚨 ${upsertBindings.length} secrets failed to upload`);
+			logger.log(`🚨 Secrets failed to upload`);
+			throw err;
 		}
 	},
 });


### PR DESCRIPTION
Fixes #7287 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/8758
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
