### PR TITLE
fix: Minor refactor for the R2 catalog commands

### DIFF
--- a/.changeset/tricky-eagles-peel.md
+++ b/.changeset/tricky-eagles-peel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Minor refactor for the r2 data catalog commands

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -157,7 +157,7 @@ describe("r2", () => {
 				  wrangler r2 bucket info <bucket>    Get information about an R2 bucket
 				  wrangler r2 bucket delete <bucket>  Delete an R2 bucket
 				  wrangler r2 bucket sippy            Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark, DuckDB, and Trino [open-beta]
+				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark and PyIceberg [open-beta]
 				  wrangler r2 bucket notification     Manage event notification rules for an R2 bucket
 				  wrangler r2 bucket domain           Manage custom domains for an R2 bucket
 				  wrangler r2 bucket dev-url          Manage public access via the r2.dev URL for an R2 bucket
@@ -198,7 +198,7 @@ describe("r2", () => {
 				  wrangler r2 bucket info <bucket>    Get information about an R2 bucket
 				  wrangler r2 bucket delete <bucket>  Delete an R2 bucket
 				  wrangler r2 bucket sippy            Manage Sippy incremental migration on an R2 bucket
-				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark, DuckDB, and Trino [open-beta]
+				  wrangler r2 bucket catalog          Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark and PyIceberg [open-beta]
 				  wrangler r2 bucket notification     Manage event notification rules for an R2 bucket
 				  wrangler r2 bucket domain           Manage custom domains for an R2 bucket
 				  wrangler r2 bucket dev-url          Manage public access via the r2.dev URL for an R2 bucket
@@ -947,7 +947,7 @@ describe("r2", () => {
 					"
 					wrangler r2 bucket catalog
 
-					Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark, DuckDB, and Trino [open-beta]
+					Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark and PyIceberg [open-beta]
 
 					COMMANDS
 					  wrangler r2 bucket catalog enable <bucket>   Enable the data catalog on an R2 bucket [open-beta]
@@ -989,7 +989,7 @@ describe("r2", () => {
 Catalog URI: 'https://catalog.cloudflarestorage.com/test-warehouse-name'
 Warehouse: 'test-warehouse-name'
 
-Use this Catalog URI with Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to query data as tables.
+Use this Catalog URI with Iceberg-compatible query engines (Spark, PyIceberg etc.) to query data as tables.
 Note: You will need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
 For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"`
 					);
@@ -1172,7 +1172,6 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 					expect(std.out).toMatchInlineSnapshot(`
 					"Getting data catalog status for 'test-bucket'...
 
-					Bucket:       test-bucket
 					Catalog URI:  https://catalog.cloudflarestorage.com/test-name
 					Warehouse:    test-name
 					Status:       active"

--- a/packages/wrangler/src/r2/catalog.ts
+++ b/packages/wrangler/src/r2/catalog.ts
@@ -10,7 +10,7 @@ import { disableR2Catalog, enableR2Catalog, getR2Catalog } from "./helpers";
 export const r2BucketCatalogNamespace = createNamespace({
 	metadata: {
 		description:
-			"Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark, DuckDB, and Trino",
+			"Manage the data catalog for your R2 buckets - provides an Iceberg REST interface for query engines like Spark and PyIceberg",
 		status: "open-beta",
 		owner: "Product: R2 Data Catalog",
 	},
@@ -49,7 +49,7 @@ export const r2BucketCatalogEnableCommand = createCommand({
 Catalog URI: '${catalogHost}'
 Warehouse: '${response.name}'
 
-Use this Catalog URI with Iceberg-compatible query engines (Spark, DuckDB, Trino, etc.) to query data as tables.
+Use this Catalog URI with Iceberg-compatible query engines (Spark, PyIceberg etc.) to query data as tables.
 Note: You will need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
 For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/`
 		);
@@ -132,7 +132,6 @@ export const r2BucketCatalogGetCommand = createCommand({
 			}
 
 			const output = {
-				Bucket: args.bucket,
 				"Catalog URI": catalogHost,
 				Warehouse: catalog.name,
 				Status: catalog.status,


### PR DESCRIPTION
fix: Minor refactor in the R2 data catalog wrangler commands

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required (https://github.com/cloudflare/workers-sdk/pull/8761)
  - [ ] Not required because:
- Public documentation
  - [] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/issues/21030
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: patching commands for a new product that was only added to wrangler v4

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
