### PR TITLE
IGLOO-45 replace underscore with slashes in catalog URI

### DIFF
--- a/.changeset/fine-cameras-nail.md
+++ b/.changeset/fine-cameras-nail.md
@@ -1,0 +1,5 @@
+---
+"wrangler": major
+---
+
+minor: R2 data catalog URIs now separate account ID and warehouse name with a slash rather than an underscore

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -973,7 +973,7 @@ describe("r2", () => {
 									createFetchResult(
 										{
 											id: "test-warehouse-id",
-											name: "test-warehouse-name",
+											name: "test-account-id_test-warehouse-name",
 										},
 										true
 									)
@@ -986,8 +986,8 @@ describe("r2", () => {
 					expect(std.out).toMatchInlineSnapshot(
 						`"✨ Successfully enabled data catalog on bucket 'testBucket'.
 
-Catalog URI: 'https://catalog.cloudflarestorage.com/test-warehouse-name'
-Warehouse: 'test-warehouse-name'
+Catalog URI: 'https://catalog.cloudflarestorage.com/test-account-id/test-warehouse-name'
+Warehouse: 'test-account-id_test-warehouse-name'
 
 Use this Catalog URI with Iceberg-compatible query engines (Spark, PyIceberg etc.) to query data as tables.
 Note: You will need a Cloudflare API token with 'R2 Data Catalog' permission to authenticate your client with this catalog.
@@ -1157,7 +1157,7 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 									createFetchResult(
 										{
 											id: "test-id",
-											name: "test-name",
+											name: "test-account-id_test-name",
 											bucket: "test-bucket",
 											status: "active",
 										},
@@ -1172,8 +1172,8 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 					expect(std.out).toMatchInlineSnapshot(`
 					"Getting data catalog status for 'test-bucket'...
 
-					Catalog URI:  https://catalog.cloudflarestorage.com/test-name
-					Warehouse:    test-name
+					Catalog URI:  https://catalog.cloudflarestorage.com/test-account-id/test-name
+					Warehouse:    test-account-id_test-name
 					Status:       active"
 				`);
 				});

--- a/packages/wrangler/src/r2/catalog.ts
+++ b/packages/wrangler/src/r2/catalog.ts
@@ -37,10 +37,11 @@ export const r2BucketCatalogEnableCommand = createCommand({
 
 		let catalogHost: string;
 		const env = getCloudflareApiEnvironmentFromEnv();
+		const path = response.name.replace("_", "/");
 		if (env === "staging") {
-			catalogHost = `https://catalog-staging.cloudflarestorage.com/${response.name}`;
+			catalogHost = `https://catalog-staging.cloudflarestorage.com/${path}`;
 		} else {
-			catalogHost = `https://catalog.cloudflarestorage.com/${response.name}`;
+			catalogHost = `https://catalog.cloudflarestorage.com/${path}`;
 		}
 
 		logger.log(
@@ -125,10 +126,11 @@ export const r2BucketCatalogGetCommand = createCommand({
 
 			const env = getCloudflareApiEnvironmentFromEnv();
 			let catalogHost: string;
+			const path = catalog.name.replace("_", "/");
 			if (env === "staging") {
-				catalogHost = `https://catalog-staging.cloudflarestorage.com/${catalog.name}`;
+				catalogHost = `https://catalog-staging.cloudflarestorage.com/${path}`;
 			} else {
-				catalogHost = `https://catalog.cloudflarestorage.com/${catalog.name}`;
+				catalogHost = `https://catalog.cloudflarestorage.com/${path}`;
 			}
 
 			const output = {


### PR DESCRIPTION
We're updating the backend service to use slashes in the catalog URI instead of underscores to separate account id and bucket name. This PR updates the frontend to match that.

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: we don't run E2E tests for this beta service yet
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: documentation isn't out yet
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: we are not supporting V3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
