### PR TITLE
Fix inspector port change being logged on server restarts

### DIFF
--- a/.changeset/plain-lies-retire.md
+++ b/.changeset/plain-lies-retire.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Fix inspector port change being logged on server restarts. An available inspector port is now found on the initial server start and reused across restarts.

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -328,13 +328,13 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					"Unexpected error: No Vite HTTP server"
 				);
 
-				const inputInspectorPort = await getInputInspectorPortOption(
-					pluginConfig,
-					viteDevServer
-				);
+				if (!miniflare) {
+					const inputInspectorPort = await getInputInspectorPortOption(
+						pluginConfig,
+						viteDevServer
+					);
 
-				if (miniflare) {
-					await miniflare.setOptions(
+					miniflare = new Miniflare(
 						getDevMiniflareOptions(
 							resolvedPluginConfig,
 							viteDevServer,
@@ -342,11 +342,14 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 						)
 					);
 				} else {
-					miniflare = new Miniflare(
+					const resolvedInspectorPort =
+						await getResolvedInspectorPort(pluginConfig);
+
+					await miniflare.setOptions(
 						getDevMiniflareOptions(
 							resolvedPluginConfig,
 							viteDevServer,
-							inputInspectorPort
+							resolvedInspectorPort ?? false
 						)
 					);
 				}


### PR DESCRIPTION
Fixes #000.

Fixes inspector port changes being logged on server restarts. An available inspector port is now found on the initial server start and reused across restarts.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: existing test coverage
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: N/A

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
