### PR TITLE
No longer warn if the user sets `upload_source_maps` in the Worker config.

### DIFF
--- a/.changeset/old-guests-smile.md
+++ b/.changeset/old-guests-smile.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+No longer warn if the user sets `upload_source_maps` in the Worker config.

--- a/packages/vite-plugin-cloudflare/src/__tests__/fixtures/wrangler-with-fields-to-ignore.toml
+++ b/packages/vite-plugin-cloudflare/src/__tests__/fixtures/wrangler-with-fields-to-ignore.toml
@@ -18,8 +18,6 @@ rules = [{ type = "Text", globs = ["**/*.md"], fallthrough = true }]
 
 tsconfig = "./tsconfig.custom.json"
 
-upload_source_maps = false
-
 [alias]
 "my-test" = "./my-test.ts"
 "my-test-a" = "./my-test-a.ts"

--- a/packages/vite-plugin-cloudflare/src/__tests__/get-worker-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/get-worker-config.spec.ts
@@ -29,7 +29,6 @@ describe("getWorkerConfig", () => {
 		expect(raw.rules).toEqual([]);
 		expect(raw.site).toBeUndefined();
 		expect(raw.tsconfig).toBeUndefined();
-		expect(raw.upload_source_maps).toBeUndefined();
 	});
 
 	test("should return a simple config without non-applicable fields", () => {
@@ -75,7 +74,6 @@ describe("getWorkerConfig", () => {
 		expect(config.rules).toEqual([]);
 		expect(config.site).toBeUndefined();
 		expect(config.tsconfig).toBeUndefined();
-		expect(config.upload_source_maps).toBeUndefined();
 
 		expect(nonApplicable).toEqual({
 			replacedByVite: new Set(),
@@ -135,8 +133,6 @@ describe("getWorkerConfig", () => {
 		});
 		expect("tsconfig" in config).toBeFalsy();
 		expect(raw.tsconfig).toMatch(/tsconfig\.custom\.json$/);
-		expect("upload_source_maps" in config).toBeFalsy();
-		expect(raw.upload_source_maps).toBe(false);
 
 		expect(nonApplicable.replacedByVite).toEqual(
 			new Set(["define", "alias", "minify"])
@@ -151,7 +147,6 @@ describe("getWorkerConfig", () => {
 				"rules",
 				"site",
 				"tsconfig",
-				"upload_source_maps",
 			])
 		);
 	});

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -5,6 +5,7 @@ import {
 	getValidatedWranglerConfigPath,
 	getWorkerConfig,
 } from "./workers-configs";
+import type { Defined } from "./utils";
 import type {
 	AssetsOnlyWorkerResolvedConfig,
 	SanitizedWorkerConfig,
@@ -35,8 +36,6 @@ export interface PluginConfig extends EntryWorkerConfig {
 		headersAndRedirectsDevModeSupport?: boolean;
 	};
 }
-
-type Defined<T> = Exclude<T, undefined>;
 
 export interface AssetsOnlyConfig extends SanitizedWorkerConfig {
 	topLevelName: Defined<SanitizedWorkerConfig["topLevelName"]>;

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -68,6 +68,8 @@ export type Optional<T, K extends keyof T> = Omit<T, K> & Pick<Partial<T>, K>;
 
 export type MaybePromise<T> = Promise<T> | T;
 
+export type Defined<T> = Exclude<T, undefined>;
+
 export function getFirstAvailablePort(start: number) {
 	return getPort({ port: portNumbers(start, 65535) });
 }

--- a/packages/vite-plugin-cloudflare/src/workers-configs.ts
+++ b/packages/vite-plugin-cloudflare/src/workers-configs.ts
@@ -93,7 +93,6 @@ export const nonApplicableWorkerConfigs = {
 		"rules",
 		"site",
 		"tsconfig",
-		"upload_source_maps",
 	],
 } as const;
 
@@ -109,7 +108,6 @@ const nullableNonApplicable = [
 	"preserve_file_names",
 	"site",
 	"tsconfig",
-	"upload_source_maps",
 ] as const;
 
 function readWorkerConfig(


### PR DESCRIPTION
Fixes #000.

No longer warn if the user sets `upload_source_maps` in the Worker config.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: N/A

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
