### PR TITLE
Pipelines CLI Improvements

### DIFF
--- a/.changeset/busy-chairs-happen.md
+++ b/.changeset/busy-chairs-happen.md
@@ -3,6 +3,8 @@
 ---
 
 - Rename `wrangler pipelines show` to `wrangler pipelines get`
-- Replace `--enable-worker-binding` and `--enable-http` with `--source worker` and `--source http` (or `--source http worker` for both)
+- Replace `--enable-worker-binding` and `--enable-http` with `--source worker` and `--source http` (or
+  `--source http worker` for both)
 - Remove `--file-template` and `--partition-template` flags from `wrangler pipelines create|update`
 - Add pretty output for `wrangler pipelines get <pipeline>`. Existing output is available using `--format=json`.
+- Clarify the minimums, maximums, and defaults (if unset) for `wrangler pipelines create` commands.

--- a/.changeset/busy-chairs-happen.md
+++ b/.changeset/busy-chairs-happen.md
@@ -4,3 +4,4 @@
 
 - Rename `wrangler pipelines show` to `wrangler pipelines get`
 - Replace `--enable-worker-binding` and `--enable-http` with `--source worker` and `--source http` (or `--source http worker` for both)
+- Remove `--file-template` and `--partition-template` flags from `wrangler pipelines create|update`

--- a/.changeset/busy-chairs-happen.md
+++ b/.changeset/busy-chairs-happen.md
@@ -2,4 +2,5 @@
 "wrangler": patch
 ---
 
-Rename `wrangler pipelines show` to `wrangler pipelines get`
+- Rename `wrangler pipelines show` to `wrangler pipelines get`
+- Replace `--enable-worker-binding` and `--enable-http` with `--source worker` and `--source http` (or `--source http worker` for both)

--- a/.changeset/busy-chairs-happen.md
+++ b/.changeset/busy-chairs-happen.md
@@ -5,3 +5,4 @@
 - Rename `wrangler pipelines show` to `wrangler pipelines get`
 - Replace `--enable-worker-binding` and `--enable-http` with `--source worker` and `--source http` (or `--source http worker` for both)
 - Remove `--file-template` and `--partition-template` flags from `wrangler pipelines create|update`
+- Add pretty output for `wrangler pipelines get <pipeline>`. Existing output is available using `--format=json`.

--- a/.changeset/busy-chairs-happen.md
+++ b/.changeset/busy-chairs-happen.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Rename `wrangler pipelines show` to `wrangler pipelines get`

--- a/packages/wrangler/src/__tests__/index.test.ts
+++ b/packages/wrangler/src/__tests__/index.test.ts
@@ -63,6 +63,7 @@ describe("wrangler", () => {
 				  wrangler dispatch-namespace     🏗️  Manage dispatch namespaces
 				  wrangler ai                     🤖 Manage AI models
 				  wrangler workflows              🔁 Manage Workflows [open-beta]
+				  wrangler pipelines              🚰 Manage Worker Pipelines [open beta]
 				  wrangler login                  🔓 Login to Cloudflare
 				  wrangler logout                 🚪 Logout from Cloudflare
 				  wrangler whoami                 🕵️  Retrieve your user information
@@ -122,6 +123,7 @@ describe("wrangler", () => {
 				  wrangler dispatch-namespace     🏗️  Manage dispatch namespaces
 				  wrangler ai                     🤖 Manage AI models
 				  wrangler workflows              🔁 Manage Workflows [open-beta]
+				  wrangler pipelines              🚰 Manage Worker Pipelines [open beta]
 				  wrangler login                  🔓 Login to Cloudflare
 				  wrangler logout                 🚪 Logout from Cloudflare
 				  wrangler whoami                 🕵️  Retrieve your user information

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -274,6 +274,8 @@ describe("pipelines", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"wrangler pipelines
 
+			🚰 Manage Worker Pipelines [open beta]
+
 			COMMANDS
 			  wrangler pipelines create <pipeline>  Create a new Pipeline
 			  wrangler pipelines list               List current Pipelines

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -301,8 +301,6 @@ describe("pipelines", () => {
 				      --r2-secret-access-key  R2 service Secret Access Key for authentication. Leave empty for OAuth confirmation.  [string]
 				      --r2-prefix             Prefix for storing files in the destination bucket  [string] [default: \\"\\"]
 				      --compression           Compression format for output files  [string] [choices: \\"none\\", \\"gzip\\", \\"deflate\\"] [default: \\"gzip\\"]
-				      --file-template         Template for individual file names (must include \${slug}). For example: \\"\${slug}.log.gz\\"  [string]
-				      --partition-template    Path template for partitioned files in the bucket. If not specified, the default will be used  [string]
 
 				Pipeline settings
 				      --shard-count  Number of pipeline shards. More shards handle higher request volume; fewer shards produce larger output files  [number]

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -307,22 +307,22 @@ describe("pipelines", () => {
 				Source settings
 				      --source             Space separated list of allowed sources. Options are 'http' or 'worker'  [array] [default: [\\"http\\",\\"worker\\"]]
 				      --require-http-auth  Require Cloudflare API Token for HTTPS endpoint authentication  [boolean] [default: false]
-				      --cors-origins       CORS origin allowlist for HTTP endpoint (use * for any origin)  [array]
+				      --cors-origins       CORS origin allowlist for HTTP endpoint (use * for any origin). Defaults to an empty array  [array]
 
 				Batch hints
-				      --batch-max-mb       Maximum batch size in megabytes before flushing  [number]
-				      --batch-max-rows     Maximum number of rows per batch before flushing  [number]
-				      --batch-max-seconds  Maximum age of batch in seconds before flushing  [number]
+				      --batch-max-mb       Maximum batch size in megabytes before flushing. Defaults to 100 MB if unset. Minimum: 1, Maximum: 100  [number]
+				      --batch-max-rows     Maximum number of rows per batch before flushing. Defaults to 10,000,000 if unset. Minimum: 100, Maximum: 10,000,000  [number]
+				      --batch-max-seconds  Maximum age of batch in seconds before flushing. Defaults to 300 if unset. Minimum: 1, Maximum: 300  [number]
 
 				Destination settings
 				      --r2-bucket             Destination R2 bucket name  [string] [required]
 				      --r2-access-key-id      R2 service Access Key ID for authentication. Leave empty for OAuth confirmation.  [string]
 				      --r2-secret-access-key  R2 service Secret Access Key for authentication. Leave empty for OAuth confirmation.  [string]
-				      --r2-prefix             Prefix for storing files in the destination bucket  [string] [default: \\"\\"]
+				      --r2-prefix             Prefix for storing files in the destination bucket. Default is no prefix  [string] [default: \\"\\"]
 				      --compression           Compression format for output files  [string] [choices: \\"none\\", \\"gzip\\", \\"deflate\\"] [default: \\"gzip\\"]
 
 				Pipeline settings
-				      --shard-count  Number of pipeline shards. More shards handle higher request volume; fewer shards produce larger output files  [number]
+				      --shard-count  Number of pipeline shards. More shards handle higher request volume; fewer shards produce larger output files. Defaults to 2 if unset. Minimum: 1, Maximum: 15  [number]
 
 				GLOBAL FLAGS
 				  -c, --config   Path to Wrangler configuration file  [string]
@@ -364,7 +364,7 @@ describe("pipelines", () => {
 
 				🎉 You can now send data to your Pipeline!
 
-				To start interacting with this Pipeline from a Worker, open your Worker’s config file and add the following binding configuration:
+				To send data to your pipeline from a Worker, add the following to your wrangler config file:
 
 				{
 				  \\"pipelines\\": [

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -142,7 +142,7 @@ describe("pipelines", () => {
 		return requests;
 	}
 
-	function mockShowRequest(
+	function mockGetRequest(
 		name: string,
 		pipeline: Pipeline | null,
 		status: number = 200,
@@ -258,7 +258,7 @@ describe("pipelines", () => {
 			COMMANDS
 			  wrangler pipelines create <pipeline>  Create a new Pipeline
 			  wrangler pipelines list               List current Pipelines
-			  wrangler pipelines show <pipeline>    Show a Pipeline configuration
+			  wrangler pipelines get <pipeline>     Get a Pipeline configuration
 			  wrangler pipelines update <pipeline>  Update a Pipeline
 			  wrangler pipelines delete <pipeline>  Delete a Pipeline
 
@@ -409,10 +409,10 @@ describe("pipelines", () => {
 		expect(requests.count).toEqual(1);
 	});
 
-	describe("show", () => {
-		it("should show pipeline", async () => {
-			const requests = mockShowRequest("foo", samplePipeline);
-			await runWrangler("pipelines show foo");
+	describe("get", () => {
+		it("should get pipeline", async () => {
+			const requests = mockGetRequest("foo", samplePipeline);
+			await runWrangler("pipelines get foo");
 
 			expect(std.err).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
@@ -452,12 +452,12 @@ describe("pipelines", () => {
 		});
 
 		it("should fail on missing pipeline", async () => {
-			const requests = mockShowRequest("bad-pipeline", null, 404, {
+			const requests = mockGetRequest("bad-pipeline", null, 404, {
 				code: 1000,
 				message: "Pipeline does not exist",
 			});
 			await expect(
-				runWrangler("pipelines show bad-pipeline")
+				runWrangler("pipelines get bad-pipeline")
 			).rejects.toThrowError();
 
 			await endEventLoop();
@@ -477,7 +477,7 @@ describe("pipelines", () => {
 	describe("update", () => {
 		it("should update a pipeline", async () => {
 			const pipeline: Pipeline = samplePipeline;
-			mockShowRequest(pipeline.name, pipeline);
+			mockGetRequest(pipeline.name, pipeline);
 
 			const update = JSON.parse(JSON.stringify(pipeline));
 			update.destination.compression.type = "gzip";
@@ -489,7 +489,7 @@ describe("pipelines", () => {
 
 		it("should update a pipeline with new bucket", async () => {
 			const pipeline: Pipeline = samplePipeline;
-			mockShowRequest(pipeline.name, pipeline);
+			mockGetRequest(pipeline.name, pipeline);
 
 			const update = JSON.parse(JSON.stringify(pipeline));
 			update.destination.path.bucket = "new_bucket";
@@ -509,7 +509,7 @@ describe("pipelines", () => {
 
 		it("should update a pipeline with new credential", async () => {
 			const pipeline: Pipeline = samplePipeline;
-			mockShowRequest(pipeline.name, pipeline);
+			mockGetRequest(pipeline.name, pipeline);
 
 			const update = JSON.parse(JSON.stringify(pipeline));
 			update.destination.path.bucket = "new-bucket";
@@ -529,7 +529,7 @@ describe("pipelines", () => {
 
 		it("should update a pipeline with source changes http auth", async () => {
 			const pipeline: Pipeline = samplePipeline;
-			mockShowRequest(pipeline.name, pipeline);
+			mockGetRequest(pipeline.name, pipeline);
 
 			const update = JSON.parse(JSON.stringify(pipeline));
 			update.source = [
@@ -555,7 +555,7 @@ describe("pipelines", () => {
 
 		it("should update a pipeline cors headers", async () => {
 			const pipeline: Pipeline = samplePipeline;
-			mockShowRequest(pipeline.name, pipeline);
+			mockGetRequest(pipeline.name, pipeline);
 
 			const update = JSON.parse(JSON.stringify(pipeline));
 			update.source = [
@@ -580,7 +580,7 @@ describe("pipelines", () => {
 		});
 
 		it("should fail a missing pipeline", async () => {
-			const requests = mockShowRequest("bad-pipeline", null, 404, {
+			const requests = mockGetRequest("bad-pipeline", null, 404, {
 				code: 1000,
 				message: "Pipeline does not exist",
 			});
@@ -604,7 +604,7 @@ describe("pipelines", () => {
 
 		it("should remove transformations", async () => {
 			const pipeline: Pipeline = samplePipeline;
-			mockShowRequest(pipeline.name, pipeline);
+			mockGetRequest(pipeline.name, pipeline);
 
 			const update = JSON.parse(JSON.stringify(pipeline));
 			update.transforms = [

--- a/packages/wrangler/src/__tests__/pipelines.test.ts
+++ b/packages/wrangler/src/__tests__/pipelines.test.ts
@@ -643,13 +643,13 @@ describe("pipelines", () => {
 			const updateReq = mockUpdateRequest(update.name, update);
 
 			await runWrangler(
-				"pipelines update my-pipeline --source http --cors-origins http://localhost:8787"
+				"pipelines update my-pipeline --cors-origins http://localhost:8787"
 			);
 
 			expect(updateReq.count).toEqual(1);
-			expect(updateReq.body?.source.length).toEqual(1);
-			expect(updateReq.body?.source[0].type).toEqual("http");
-			expect((updateReq.body?.source[0] as HttpSource).cors?.origins).toEqual([
+			expect(updateReq.body?.source.length).toEqual(2);
+			expect(updateReq.body?.source[1].type).toEqual("http");
+			expect((updateReq.body?.source[1] as HttpSource).cors?.origins).toEqual([
 				"http://localhost:8787",
 			]);
 		});

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -955,10 +955,14 @@ export function createCLIParser(argv: string[]) {
 	]);
 	registry.registerNamespace("workflows");
 
-	// pipelines
-	wrangler.command("pipelines", false, (pipelinesYargs) => {
-		return pipelines(pipelinesYargs.command(subHelp));
-	});
+	// [OPEN BETA] pipelines
+	wrangler.command(
+		"pipelines",
+		`🚰 Manage Worker Pipelines ${chalk.hex(betaCmdColor)("[open beta]")}`,
+		(pipelinesYargs) => {
+			return pipelines(pipelinesYargs.command(subHelp));
+		}
+	);
 
 	/******************** CMD GROUP ***********************/
 

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -102,8 +102,6 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 					"r2-secret-access-key",
 					"r2-prefix",
 					"compression",
-					"file-template",
-					"partition-template",
 				],
 				`${chalk.bold("Destination settings")}`
 			)
@@ -150,23 +148,6 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 				choices: ["none", "gzip", "deflate"],
 				default: "gzip",
 				demandOption: false,
-			})
-			.option("partition-template", {
-				type: "string",
-				describe:
-					"Path template for partitioned files in the bucket. If not specified, the default will be used",
-				demandOption: false,
-			})
-			.option("file-template", {
-				type: "string",
-				describe: `Template for individual file names (must include $\{slug}). For example: "$\{slug}.log.gz"`,
-				demandOption: false,
-				coerce: (val) => {
-					if (!val.includes("${slug}")) {
-						throw new UserError("filename must contain ${slug}");
-					}
-					return val;
-				},
 			})
 
 			// Pipeline settings
@@ -286,13 +267,6 @@ export async function createPipelineHandler(
 	if (args.r2Prefix) {
 		pipelineConfig.destination.path.prefix = args.r2Prefix;
 	}
-	if (args.partitionTemplate) {
-		pipelineConfig.destination.path.filepath = args.partitionTemplate;
-	}
-	if (args.fileTemplate) {
-		pipelineConfig.destination.path.filename = args.fileTemplate;
-	}
-
 	if (args.shardCount) {
 		pipelineConfig.metadata.shards = args.shardCount;
 	}

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -78,7 +78,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 				describe:
 					"Maximum number of rows per batch before flushing. Defaults to 10,000,000 if unset. Minimum: 100, Maximum: 10,000,000",
 				demandOption: false,
-				coerce: validateInRange("batch-max-rows", 100, 10_00_000),
+				coerce: validateInRange("batch-max-rows", 100, 10_000_000),
 			})
 			.option("batch-max-seconds", {
 				type: "number",

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -9,6 +9,7 @@ import { createPipeline } from "../client";
 import {
 	authorizeR2Bucket,
 	BYTES_PER_MB,
+	formatPipelinePretty,
 	getAccountR2Endpoint,
 	parseTransform,
 } from "../index";
@@ -274,17 +275,10 @@ export async function createPipelineHandler(
 	logger.log(`🌀 Creating Pipeline named "${name}"`);
 	const pipeline = await createPipeline(accountId, pipelineConfig);
 
-	// Produces a summary of what was created and instructions for how to begin using Pipelines
 	logger.log(
-		`✅ Successfully created Pipeline "${pipeline.name}" with ID ${pipeline.id}
-- Source(s): ${pipeline.source.map((s) => (s.type === "http" ? "HTTP" : "Worker")).join(", ")}
-- Destination: ${pipeline.destination.type.toUpperCase()} ${pipeline.destination.path.bucket}
-- Output: new-line delimited JSON files
-
-To see the full pipeline configuration, run \`wrangler pipelines get ${pipeline.name}\`
-`
+		`✅ Successfully created Pipeline "${pipeline.name}" with ID ${pipeline.id}\n`
 	);
-
+	logger.log(formatPipelinePretty(pipeline));
 	logger.log("🎉 You can now send data to your Pipeline!");
 
 	if (args.source.includes("worker")) {

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -56,7 +56,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			.option("cors-origins", {
 				type: "array",
 				describe:
-					"CORS origin allowlist for HTTP endpoint (use * for any origin)",
+					"CORS origin allowlist for HTTP endpoint (use * for any origin). Defaults to an empty array",
 				demandOption: false,
 				coerce: validateCorsOrigins,
 			})
@@ -68,19 +68,23 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			)
 			.option("batch-max-mb", {
 				type: "number",
-				describe: "Maximum batch size in megabytes before flushing",
+				describe:
+					"Maximum batch size in megabytes before flushing. Defaults to 100 MB if unset. Minimum: 1, Maximum: 100",
 				demandOption: false,
 				coerce: validateInRange("batch-max-mb", 1, 100),
 			})
 			.option("batch-max-rows", {
 				type: "number",
-				describe: "Maximum number of rows per batch before flushing",
+				describe:
+					"Maximum number of rows per batch before flushing. Defaults to 10,000,000 if unset. Minimum: 100, Maximum: 10,000,000",
 				demandOption: false,
-				coerce: validateInRange("batch-max-rows", 100, 1000000),
+				coerce: validateInRange("batch-max-rows", 100, 10_00_000),
 			})
 			.option("batch-max-seconds", {
 				type: "number",
-				describe: "Maximum age of batch in seconds before flushing",
+				describe:
+					"Maximum age of batch in seconds before flushing. Defaults to 300 if unset. Minimum: 1, Maximum: 300",
+
 				demandOption: false,
 				coerce: validateInRange("batch-max-seconds", 1, 300),
 			})
@@ -139,7 +143,8 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			})
 			.option("r2-prefix", {
 				type: "string",
-				describe: "Prefix for storing files in the destination bucket",
+				describe:
+					"Prefix for storing files in the destination bucket. Default is no prefix",
 				default: "",
 				demandOption: false,
 			})
@@ -156,7 +161,7 @@ export function addCreateOptions(yargs: Argv<CommonYargsOptions>) {
 			.option("shard-count", {
 				type: "number",
 				describe:
-					"Number of pipeline shards. More shards handle higher request volume; fewer shards produce larger output files",
+					"Number of pipeline shards. More shards handle higher request volume; fewer shards produce larger output files. Defaults to 2 if unset. Minimum: 1, Maximum: 15",
 				demandOption: false,
 			})
 	);
@@ -283,7 +288,7 @@ export async function createPipelineHandler(
 
 	if (args.source.includes("worker")) {
 		logger.log(
-			`\nTo start interacting with this Pipeline from a Worker, open your Worker’s config file and add the following binding configuration:\n`
+			`\nTo send data to your pipeline from a Worker, add the following to your wrangler config file:\n`
 		);
 		logger.log(
 			formatConfigSnippet(

--- a/packages/wrangler/src/pipelines/cli/get.ts
+++ b/packages/wrangler/src/pipelines/cli/get.ts
@@ -10,7 +10,7 @@ import type {
 } from "../../yargs-types";
 import type { Argv } from "yargs";
 
-export function addShowOptions(yargs: Argv<CommonYargsOptions>) {
+export function addGetOptions(yargs: Argv<CommonYargsOptions>) {
 	return yargs.positional("pipeline", {
 		type: "string",
 		describe: "The name of the Pipeline to show",
@@ -18,8 +18,8 @@ export function addShowOptions(yargs: Argv<CommonYargsOptions>) {
 	});
 }
 
-export async function showPipelineHandler(
-	args: StrictYargsOptionsToInterface<typeof addShowOptions>
+export async function getPipelineHandler(
+	args: StrictYargsOptionsToInterface<typeof addGetOptions>
 ) {
 	await printWranglerBanner();
 	const config = readConfig(args);

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -108,8 +108,6 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 					"r2-secret-access-key",
 					"r2-prefix",
 					"compression",
-					"file-template",
-					"partition-template",
 				],
 				`${chalk.bold("Destination settings")}`
 			)
@@ -149,22 +147,6 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 				describe: "Compression format for output files",
 				choices: ["none", "gzip", "deflate"],
 				demandOption: false,
-			})
-			.option("partition-template", {
-				type: "string",
-				describe: "Path template for partitioned files in the bucket",
-				demandOption: false,
-			})
-			.option("file-template", {
-				type: "string",
-				describe: "Template for individual file names (must include ${slug})",
-				demandOption: false,
-				coerce: (val: string) => {
-					if (!val.includes("${slug}")) {
-						throw new Error("filename must contain ${slug}");
-					}
-					return val;
-				},
 			})
 
 			// Pipeline settings
@@ -293,12 +275,6 @@ export async function updatePipelineHandler(
 
 	if (args.r2Prefix) {
 		pipelineConfig.destination.path.prefix = args.r2Prefix;
-	}
-	if (args.partitionTemplate) {
-		pipelineConfig.destination.path.filepath = args.partitionTemplate;
-	}
-	if (args.fileTemplate) {
-		pipelineConfig.destination.path.filename = args.fileTemplate;
 	}
 
 	if (args.shardCount) {

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -49,7 +49,7 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 			.option("source", {
 				type: "array",
 				describe:
-					"Space separated list of allowed sources. Options are 'http' or 'worker'",
+					"Space separated list of allowed sources. Options are 'http' or 'worker'. Setting this will remove all other existing sources.",
 				demandOption: false,
 			})
 			.option("require-http-auth", {
@@ -73,19 +73,22 @@ export function addUpdateOptions(yargs: Argv<CommonYargsOptions>) {
 			)
 			.option("batch-max-mb", {
 				type: "number",
-				describe: "Maximum batch size in megabytes before flushing",
+				describe:
+					"Maximum batch size in megabytes before flushing. Minimum: 1, Maximum: 100",
 				demandOption: false,
 				coerce: validateInRange("batch-max-mb", 1, 100),
 			})
 			.option("batch-max-rows", {
 				type: "number",
-				describe: "Maximum number of rows per batch before flushing",
+				describe:
+					"Maximum number of rows per batch before flushing. Minimum: 100, Maximum: 10,000,000",
 				demandOption: false,
-				coerce: validateInRange("batch-max-rows", 100, 1000000),
+				coerce: validateInRange("batch-max-rows", 100, 10_000_000),
 			})
 			.option("batch-max-seconds", {
 				type: "number",
-				describe: "Maximum age of batch in seconds before flushing",
+				describe:
+					"Maximum age of batch in seconds before flushing. Minimum: 1, Maximum: 300",
 				demandOption: false,
 				coerce: validateInRange("batch-max-seconds", 1, 300),
 			})

--- a/packages/wrangler/src/pipelines/cli/update.ts
+++ b/packages/wrangler/src/pipelines/cli/update.ts
@@ -284,6 +284,20 @@ export async function updatePipelineHandler(
 		pipelineConfig.metadata.shards = args.shardCount;
 	}
 
+	// This covers the case where `--source` wasn't passed but `--cors-origins` or
+	// `--require-http-auth` was.
+	const httpSource = pipelineConfig.source.find(
+		(s: Source) => s.type === "http"
+	);
+	if (httpSource) {
+		if (args.requireHttpAuth) {
+			httpSource.authentication = args.requireHttpAuth;
+		}
+		if (args.corsOrigins && args.corsOrigins.length > 0) {
+			httpSource.cors = { origins: args.corsOrigins };
+		}
+	}
+
 	logger.log(`🌀 Updating Pipeline "${name}"`);
 	const pipeline = await updatePipeline(accountId, name, pipelineConfig);
 

--- a/packages/wrangler/src/pipelines/index.ts
+++ b/packages/wrangler/src/pipelines/index.ts
@@ -6,8 +6,8 @@ import { logger } from "../logger";
 import { APIError } from "../parse";
 import { addCreateOptions, createPipelineHandler } from "./cli/create";
 import { addDeleteOptions, deletePipelineHandler } from "./cli/delete";
+import { addGetOptions, getPipelineHandler } from "./cli/get";
 import { listPipelinesHandler } from "./cli/list";
-import { addShowOptions, showPipelineHandler } from "./cli/show";
 import { addUpdateOptions, updatePipelineHandler } from "./cli/update";
 import { generateR2ServiceToken, getR2Bucket } from "./client";
 import type { CommonYargsArgv } from "../yargs-types";
@@ -133,10 +133,10 @@ export function pipelines(pipelineYargs: CommonYargsArgv) {
 			listPipelinesHandler
 		)
 		.command(
-			"show <pipeline>",
-			"Show a Pipeline configuration",
-			addShowOptions,
-			showPipelineHandler
+			"get <pipeline>",
+			"Get a Pipeline configuration",
+			addGetOptions,
+			getPipelineHandler
 		)
 		.command(
 			"update <pipeline>",

--- a/packages/wrangler/src/pipelines/index.ts
+++ b/packages/wrangler/src/pipelines/index.ts
@@ -1,9 +1,11 @@
 import { setTimeout } from "node:timers/promises";
 import { HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import prettyBytes from "pretty-bytes";
 import { getCloudflareApiEnvironmentFromEnv } from "../environment-variables/misc-variables";
 import { FatalError } from "../errors";
 import { logger } from "../logger";
 import { APIError } from "../parse";
+import formatLabelledValues from "../utils/render-labelled-values";
 import { addCreateOptions, createPipelineHandler } from "./cli/create";
 import { addDeleteOptions, deletePipelineHandler } from "./cli/delete";
 import { addGetOptions, getPipelineHandler } from "./cli/get";
@@ -11,6 +13,7 @@ import { listPipelinesHandler } from "./cli/list";
 import { addUpdateOptions, updatePipelineHandler } from "./cli/update";
 import { generateR2ServiceToken, getR2Bucket } from "./client";
 import type { CommonYargsArgv } from "../yargs-types";
+import type { Pipeline } from "./client";
 
 export const BYTES_PER_MB = 1000 * 1000;
 
@@ -155,4 +158,77 @@ export function pipelines(pipelineYargs: CommonYargsArgv) {
 // Test exception to remove delays
 export function __testSkipDelays() {
 	__testSkipDelaysFlag = true;
+}
+
+/*
+
+ */
+export function formatPipelinePretty(pipeline: Pipeline) {
+	let buffer = "";
+
+	const formatTypeLabels: Record<string, string> = {
+		json: "JSON",
+	};
+
+	buffer += `${formatLabelledValues({
+		Id: pipeline.id,
+		Name: pipeline.name,
+	})}\n`;
+
+	buffer += "Sources:\n";
+	const httpSource = pipeline.source.find((s) => s.type === "http");
+	if (httpSource) {
+		const httpInfo = {
+			Endpoint: pipeline.endpoint,
+			Authentication: httpSource.authentication === true ? "on" : "off",
+			...(httpSource?.cors?.origins && {
+				"CORS Origins": httpSource.cors.origins.join(", "),
+			}),
+			Format: formatTypeLabels[httpSource.format],
+		};
+		buffer += "  HTTP:\n";
+		buffer += `${formatLabelledValues(httpInfo, { indentationCount: 4 })}\n`;
+	}
+
+	const bindingSource = pipeline.source.find((s) => s.type === "binding");
+	if (bindingSource) {
+		const bindingInfo = {
+			Format: formatTypeLabels[bindingSource.format],
+		};
+		buffer += "  Worker:\n";
+		buffer += `${formatLabelledValues(bindingInfo, { indentationCount: 4 })}\n`;
+	}
+
+	const destinationInfo = {
+		Type: pipeline.destination.type.toUpperCase(),
+		Bucket: pipeline.destination.path.bucket,
+		Format: "newline-delimited JSON", // TODO: Make dynamic once we support more output formats
+		...(pipeline.destination.path.prefix && {
+			Prefix: pipeline.destination.path.prefix,
+		}),
+		...(pipeline.destination.compression.type && {
+			Compression: pipeline.destination.compression.type.toUpperCase(),
+		}),
+	};
+	buffer += "Destination:\n";
+	buffer += `${formatLabelledValues(destinationInfo, { indentationCount: 2 })}\n`;
+
+	const batchHints = {
+		...(pipeline.destination.batch.max_bytes && {
+			"Max bytes": prettyBytes(pipeline.destination.batch.max_bytes),
+		}),
+		...(pipeline.destination.batch.max_duration_s && {
+			"Max duration": `${pipeline.destination.batch.max_duration_s?.toLocaleString()} seconds`,
+		}),
+		...(pipeline.destination.batch.max_rows && {
+			"Max records": pipeline.destination.batch.max_rows?.toLocaleString(),
+		}),
+	};
+
+	if (Object.keys(batchHints).length > 0) {
+		buffer += "  Batch hints:\n";
+		buffer += `${formatLabelledValues(batchHints, { indentationCount: 4 })}\n`;
+	}
+
+	return buffer;
 }


### PR DESCRIPTION
We are preparing for an open beta and cleaning some things up and improving the output of some of the commands. In short:

- Rename `wrangler pipelines show` to `wrangler pipelines get`
- Replace `--enable-worker-binding` and `--enable-http` with `--source worker` and `--source http` (or `--source http worker` for both)
- Remove `--file-template` and `--partition-template` flags from `wrangler pipelines create|update`
- Add pretty output for `wrangler pipelines get <pipeline>`. Existing output is available using `--format=json`.

Fixes https://jira.cfdata.org/browse/PIPE-248

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [X] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [X] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/18595
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: Not GA

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
