### PR TITLE
fix types Wrangler e2e test

### DIFF
--- a/packages/wrangler/e2e/types.test.ts
+++ b/packages/wrangler/e2e/types.test.ts
@@ -59,7 +59,7 @@ describe("types", () => {
 			path.join(helper.tmpPath, "./worker-configuration.d.ts"),
 			"utf8"
 		);
-		expect(file).contains('declare module "cloudflare:workers"');
+		expect(file).matches(/declare module ['"]cloudflare:workers["']/);
 		expect(file).contains("interface Env");
 	});
 


### PR DESCRIPTION
The type generation changed from using double quotes to single quotes.
