### PR TITLE
wrangler types - Import correct types for bound services

### DIFF
--- a/.changeset/khaki-plums-clap.md
+++ b/.changeset/khaki-plums-clap.md
@@ -1,0 +1,19 @@
+---
+"wrangler": minor
+---
+
+This adds support for more accurate types for service bindings when running `wrangler types`. Previously, running `wrangler types` with a config including a service binding would generate an `Env` type like this:
+
+```ts
+interface Env {
+  SERVICE_BINDING: Fetcher
+}
+```
+
+This type was "correct", but didn't capture the possibility of using JSRPC to communicate with the service binding. Now, running `wrangler types -c wrangler.json -c ../service/wrangler.json` (the first config representing the current Worker, and any additional configs representing service bound Workers) will generate an `Env` type like this:
+
+```ts
+interface Env {
+  SERVICE_BINDING: Service<import("../service/src/index").Entrypoint>;
+}
+```

--- a/.changeset/khaki-plums-clap.md
+++ b/.changeset/khaki-plums-clap.md
@@ -6,7 +6,7 @@ This adds support for more accurate types for service bindings when running `wra
 
 ```ts
 interface Env {
-  SERVICE_BINDING: Fetcher
+	SERVICE_BINDING: Fetcher;
 }
 ```
 
@@ -14,6 +14,6 @@ This type was "correct", but didn't capture the possibility of using JSRPC to co
 
 ```ts
 interface Env {
-  SERVICE_BINDING: Service<import("../service/src/index").Entrypoint>;
+	SERVICE_BINDING: Service<import("../service/src/index").Entrypoint>;
 }
 ```

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -122,12 +122,12 @@ const bindingsConfigMock: Omit<
 			{ name: "DURABLE_RE_EXPORT", class_name: "DurableReexport" },
 			{ name: "DURABLE_NO_EXPORT", class_name: "DurableNoexport" },
 			{
-				name: "DURABLE_EXTERNAL",
+				name: "DURABLE_EXTERNAL_UNKNOWN_ENTRY",
 				class_name: "DurableExternal",
 				script_name: "external-worker",
 			},
 			{
-				name: "REAL_DURABLE_EXTERNAL",
+				name: "DURABLE_EXTERNAL_PROVIDED_ENTRY",
 				class_name: "RealDurableExternal",
 				script_name: "service_name_2",
 			},
@@ -438,8 +438,8 @@ describe("generate types", () => {
 					DURABLE_DIRECT_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableDirect>;
 					DURABLE_RE_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableReexport>;
 					DURABLE_NO_EXPORT: DurableObjectNamespace /* DurableNoexport */;
-					DURABLE_EXTERNAL: DurableObjectNamespace /* DurableExternal from external-worker */;
-					REAL_DURABLE_EXTERNAL: DurableObjectNamespace /* RealDurableExternal from service_name_2 */;
+					DURABLE_EXTERNAL_UNKNOWN_ENTRY: DurableObjectNamespace /* DurableExternal from external-worker */;
+					DURABLE_EXTERNAL_PROVIDED_ENTRY: DurableObjectNamespace /* RealDurableExternal from service_name_2 */;
 					R2_BUCKET_BINDING: R2Bucket;
 					D1_TESTING_SOMETHING: D1Database;
 					SECRET: SecretsStoreSecret;
@@ -531,8 +531,8 @@ describe("generate types", () => {
 					DURABLE_DIRECT_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableDirect>;
 					DURABLE_RE_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableReexport>;
 					DURABLE_NO_EXPORT: DurableObjectNamespace /* DurableNoexport */;
-					DURABLE_EXTERNAL: DurableObjectNamespace /* DurableExternal from external-worker */;
-					REAL_DURABLE_EXTERNAL: DurableObjectNamespace /* RealDurableExternal from service_name_2 */;
+					DURABLE_EXTERNAL_UNKNOWN_ENTRY: DurableObjectNamespace /* DurableExternal from external-worker */;
+					DURABLE_EXTERNAL_PROVIDED_ENTRY: DurableObjectNamespace /* RealDurableExternal from service_name_2 */;
 					R2_BUCKET_BINDING: R2Bucket;
 					D1_TESTING_SOMETHING: D1Database;
 					SECRET: SecretsStoreSecret;
@@ -688,8 +688,8 @@ describe("generate types", () => {
 					DURABLE_DIRECT_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableDirect>;
 					DURABLE_RE_EXPORT: DurableObjectNamespace /* DurableReexport */;
 					DURABLE_NO_EXPORT: DurableObjectNamespace /* DurableNoexport */;
-					DURABLE_EXTERNAL: DurableObjectNamespace /* DurableExternal from external-worker */;
-					REAL_DURABLE_EXTERNAL: DurableObjectNamespace<import(\\"../c/index\\").RealDurableExternal>;
+					DURABLE_EXTERNAL_UNKNOWN_ENTRY: DurableObjectNamespace /* DurableExternal from external-worker */;
+					DURABLE_EXTERNAL_PROVIDED_ENTRY: DurableObjectNamespace<import(\\"../c/index\\").RealDurableExternal>;
 					R2_BUCKET_BINDING: R2Bucket;
 					D1_TESTING_SOMETHING: D1Database;
 					SECRET: SecretsStoreSecret;

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs";
-import * as TOML from "@iarna/toml";
 import {
 	constructTSModuleGlob,
 	constructTypeKey,

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -277,38 +277,38 @@ describe("generate types", () => {
 
 	it("should respect the top level -c|--config flag", async () => {
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				compatibility_flags: ["fake-compat-1"],
 				vars: {
 					var: "from wrangler toml",
 				},
-			} as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
 		fs.writeFileSync(
-			"./my-wrangler-config-a.toml",
-			TOML.stringify({
+			"./my-wrangler-config-a.jsonc",
+			JSON.stringify({
 				compatibility_date: "2023-01-12",
 				compatibility_flags: ["fake-compat-2"],
 				vars: {
 					var: "from my-wrangler-config-a",
 				},
-			} as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
 		fs.writeFileSync(
-			"./my-wrangler-config-b.toml",
-			TOML.stringify({
+			"./my-wrangler-config-b.jsonc",
+			JSON.stringify({
 				compatibility_date: "2024-01-12",
 				compatibility_flags: ["fake-compat-3"],
 				vars: {
 					var: "from my-wrangler-config-b",
 				},
-			} as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
@@ -321,7 +321,7 @@ describe("generate types", () => {
 			outFile: "worker-configuration.d.ts",
 		});
 
-		await runWrangler("types --config ./my-wrangler-config-a.toml");
+		await runWrangler("types --config ./my-wrangler-config-a.jsonc");
 		expect(spy).toHaveBeenNthCalledWith(2, {
 			config: expect.objectContaining({
 				compatibility_date: "2023-01-12",
@@ -330,7 +330,7 @@ describe("generate types", () => {
 			outFile: "worker-configuration.d.ts",
 		});
 
-		await runWrangler("types -c my-wrangler-config-b.toml");
+		await runWrangler("types -c my-wrangler-config-b.jsonc");
 		expect(spy).toHaveBeenNthCalledWith(3, {
 			config: expect.objectContaining({
 				compatibility_date: "2024-01-12",
@@ -357,7 +357,7 @@ describe("generate types", () => {
 
 			📖 Read about runtime types
 			https://developers.cloudflare.com/workers/languages/typescript/#generate-types
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 
 			Generating project types...
 
@@ -377,7 +377,7 @@ describe("generate types", () => {
 
 			📖 Read about runtime types
 			https://developers.cloudflare.com/workers/languages/typescript/#generate-types
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 
 			Generating project types...
 
@@ -397,7 +397,7 @@ describe("generate types", () => {
 
 			📖 Read about runtime types
 			https://developers.cloudflare.com/workers/languages/typescript/#generate-types
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
@@ -413,14 +413,14 @@ describe("generate types", () => {
 				export class DurableExternal extends DurableObject {}`
 		);
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				name: "test-name",
 				main: "./index.ts",
 				...bindingsConfigMock,
 				unsafe: bindingsConfigMock.unsafe,
-			} as unknown as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
@@ -433,8 +433,8 @@ describe("generate types", () => {
 					TEST_KV_NAMESPACE: KVNamespace;
 					SOMETHING: \\"asdasdfasdf\\";
 					ANOTHER: \\"thing\\";
-					\\"some-other-var\\": \\"some-other-value\\";
 					OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+					\\"some-other-var\\": \\"some-other-value\\";
 					DURABLE_DIRECT_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableDirect>;
 					DURABLE_RE_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableReexport>;
 					DURABLE_NO_EXPORT: DurableObjectNamespace /* DurableNoexport */;
@@ -484,7 +484,7 @@ describe("generate types", () => {
 			────────────────────────────────────────────────────────────
 			✨ Types written to worker-configuration.d.ts
 
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
@@ -500,8 +500,8 @@ describe("generate types", () => {
 				export class DurableExternal extends DurableObject {}`
 		);
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				compatibility_flags: [
 					"nodejs_compat",
@@ -511,7 +511,7 @@ describe("generate types", () => {
 				main: "./index.ts",
 				...bindingsConfigMock,
 				unsafe: bindingsConfigMock.unsafe,
-			} as unknown as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 		fs.writeFileSync("./.dev.vars", "SECRET=test", "utf-8");
@@ -525,8 +525,8 @@ describe("generate types", () => {
 					TEST_KV_NAMESPACE: KVNamespace;
 					SOMETHING: \\"asdasdfasdf\\";
 					ANOTHER: \\"thing\\";
-					\\"some-other-var\\": \\"some-other-value\\";
 					OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+					\\"some-other-var\\": \\"some-other-value\\";
 					SECRET: string;
 					DURABLE_DIRECT_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableDirect>;
 					DURABLE_RE_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableReexport>;
@@ -566,7 +566,7 @@ describe("generate types", () => {
 				[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 			};
 			declare namespace NodeJS {
-				interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, \\"SOMETHING\\" | \\"ANOTHER\\" | \\"some-other-var\\" | \\"OBJECT_VAR\\" | \\"SECRET\\">> {}
+				interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, \\"SOMETHING\\" | \\"ANOTHER\\" | \\"OBJECT_VAR\\" | \\"some-other-var\\" | \\"SECRET\\">> {}
 			}
 			declare module \\"*.txt\\" {
 				const value: string;
@@ -583,7 +583,7 @@ describe("generate types", () => {
 			────────────────────────────────────────────────────────────
 			✨ Types written to worker-configuration.d.ts
 
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
@@ -598,8 +598,8 @@ describe("generate types", () => {
 				export class DurableDirect extends DurableObject {}`
 		);
 		fs.writeFileSync(
-			"./a/wrangler.toml",
-			TOML.stringify({
+			"./a/wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				compatibility_flags: [
 					"nodejs_compat",
@@ -609,7 +609,7 @@ describe("generate types", () => {
 				main: "./index.ts",
 				...bindingsConfigMock,
 				unsafe: bindingsConfigMock.unsafe,
-			} as unknown as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 		fs.writeFileSync("./a/.dev.vars", "SECRET=test", "utf-8");
@@ -618,8 +618,8 @@ describe("generate types", () => {
 
 		fs.writeFileSync("./b/index.ts", `export default { async fetch () {} };`);
 		fs.writeFileSync(
-			"./b/wrangler.toml",
-			TOML.stringify({
+			"./b/wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				compatibility_flags: [
 					"nodejs_compat",
@@ -631,7 +631,7 @@ describe("generate types", () => {
 					// This should not be included in the generated types
 					WORKER_B_VAR: "worker b var",
 				},
-			} as unknown as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 		// This should not be included in the generated types
@@ -650,8 +650,8 @@ describe("generate types", () => {
 				`
 		);
 		fs.writeFileSync(
-			"./c/wrangler.toml",
-			TOML.stringify({
+			"./c/wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				compatibility_flags: [
 					"nodejs_compat",
@@ -663,18 +663,18 @@ describe("generate types", () => {
 					// This should not be included in the generated types
 					WORKER_C_VAR: "worker c var",
 				},
-			} as unknown as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 		// This should not be included in the generated types
 		fs.writeFileSync("./c/.dev.vars", "SECRET_C=hidden", "utf-8");
 
 		await runWrangler(
-			"types --include-runtime=false -c a/wrangler.toml -c b/wrangler.toml -c c/wrangler.toml --path a/worker-configuration.d.ts"
+			"types --include-runtime=false -c a/wrangler.jsonc -c b/wrangler.jsonc -c c/wrangler.jsonc --path a/worker-configuration.d.ts"
 		);
 		expect(std.out).toMatchInlineSnapshot(`
-			"- Found Worker 'service_name' at 'b/index.ts' (b/wrangler.toml)
-			- Found Worker 'service_name_2' at 'c/index.ts' (c/wrangler.toml)
+			"- Found Worker 'service_name' at 'b/index.ts' (b/wrangler.jsonc)
+			- Found Worker 'service_name_2' at 'c/index.ts' (c/wrangler.jsonc)
 			Generating project types...
 
 			declare namespace Cloudflare {
@@ -682,8 +682,8 @@ describe("generate types", () => {
 					TEST_KV_NAMESPACE: KVNamespace;
 					SOMETHING: \\"asdasdfasdf\\";
 					ANOTHER: \\"thing\\";
-					\\"some-other-var\\": \\"some-other-value\\";
 					OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+					\\"some-other-var\\": \\"some-other-value\\";
 					SECRET: string;
 					DURABLE_DIRECT_EXPORT: DurableObjectNamespace<import(\\"./index\\").DurableDirect>;
 					DURABLE_RE_EXPORT: DurableObjectNamespace /* DurableReexport */;
@@ -723,7 +723,7 @@ describe("generate types", () => {
 				[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 			};
 			declare namespace NodeJS {
-				interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, \\"SOMETHING\\" | \\"ANOTHER\\" | \\"some-other-var\\" | \\"OBJECT_VAR\\" | \\"SECRET\\">> {}
+				interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, \\"SOMETHING\\" | \\"ANOTHER\\" | \\"OBJECT_VAR\\" | \\"some-other-var\\" | \\"SECRET\\">> {}
 			}
 			declare module \\"*.txt\\" {
 				const value: string;
@@ -740,7 +740,7 @@ describe("generate types", () => {
 			────────────────────────────────────────────────────────────
 			✨ Types written to a/worker-configuration.d.ts
 
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
@@ -748,8 +748,8 @@ describe("generate types", () => {
 	it("should create a DTS file at the location that the command is executed from", async () => {
 		fs.writeFileSync("./index.ts", "export default { async fetch () {} };");
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				name: "test-name",
 				main: "./index.ts",
@@ -763,14 +763,14 @@ describe("generate types", () => {
 		expect(fs.readFileSync("./worker-configuration.d.ts", "utf-8"))
 			.toMatchInlineSnapshot(`
 				"/* eslint-disable */
-				// Generated by Wrangler by running \`wrangler\` (hash: a123396658ac84465faf6f0f82c0337b)
+				// Generated by Wrangler by running \`wrangler\` (hash: fc5d598f2fb05668416eab9ae2c2898d)
 				// Runtime types generated with workerd@
 				declare namespace Cloudflare {
 					interface Env {
 						SOMETHING: \\"asdasdfasdf\\";
 						ANOTHER: \\"thing\\";
-						\\"some-other-var\\": \\"some-other-value\\";
 						OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+						\\"some-other-var\\": \\"some-other-value\\";
 					}
 				}
 				interface Env extends Cloudflare.Env {}
@@ -787,8 +787,8 @@ describe("generate types", () => {
 				'addEventListener("fetch", event => { event.respondWith(() => new Response("")); })'
 			);
 			fs.writeFileSync(
-				"./wrangler.toml",
-				TOML.stringify({
+				"./wrangler.jsonc",
+				JSON.stringify({
 					compatibility_date: "2022-01-12",
 					name: "test-name",
 					main: "./index.ts",
@@ -804,7 +804,7 @@ describe("generate types", () => {
 				No project types to add.
 
 				────────────────────────────────────────────────────────────
-				📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+				📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 				"
 			`);
 		});
@@ -815,8 +815,8 @@ describe("generate types", () => {
 				'addEventListener("fetch", event => { event.respondWith(() => new Response("")); })'
 			);
 			fs.writeFileSync(
-				"./wrangler.toml",
-				TOML.stringify({
+				"./wrangler.jsonc",
+				JSON.stringify({
 					compatibility_date: "2022-01-12",
 					name: "test-name",
 					main: "./index.ts",
@@ -846,7 +846,7 @@ describe("generate types", () => {
 
 				📖 Read about runtime types
 				https://developers.cloudflare.com/workers/languages/typescript/#generate-types
-				📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+				📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 				"
 			`);
 		});
@@ -854,8 +854,8 @@ describe("generate types", () => {
 		it("should create a DTS file with an empty env interface for module syntax workers", async () => {
 			fs.writeFileSync("./index.ts", "export default { async fetch () {} };");
 			fs.writeFileSync(
-				"./wrangler.toml",
-				TOML.stringify({
+				"./wrangler.jsonc",
+				JSON.stringify({
 					compatibility_date: "2022-01-12",
 					name: "test-name",
 					main: "./index.ts",
@@ -877,7 +877,7 @@ describe("generate types", () => {
 				────────────────────────────────────────────────────────────
 				✨ Types written to worker-configuration.d.ts
 
-				📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+				📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 				"
 			`);
 		});
@@ -890,13 +890,13 @@ describe("generate types", () => {
 		);
 		fs.writeFileSync("./index.ts", "export default { async fetch () {} };");
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				name: "test-name",
 				main: "./index.ts",
 				vars: bindingsConfigMock.vars,
-			} as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
@@ -913,8 +913,8 @@ describe("generate types", () => {
 		}); async function handleRequest(request) {  return new Response('Hello worker!', {headers: { 'content-type': 'text/plain' },});}`
 		);
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				name: "test-name",
 				main: "./index.ts",
@@ -924,7 +924,7 @@ describe("generate types", () => {
 							metadata: bindingsConfigMock.unsafe.metadata,
 						}
 					: undefined,
-			} as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
@@ -941,18 +941,18 @@ describe("generate types", () => {
 			────────────────────────────────────────────────────────────
 			✨ Types written to worker-configuration.d.ts
 
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
 
 	it("should accept a toml file without an entrypoint and fallback to the standard modules declarations", async () => {
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				compatibility_date: "2022-01-12",
 				vars: bindingsConfigMock.vars,
-			} as unknown as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
@@ -964,8 +964,8 @@ describe("generate types", () => {
 				interface Env {
 					SOMETHING: \\"asdasdfasdf\\";
 					ANOTHER: \\"thing\\";
-					\\"some-other-var\\": \\"some-other-value\\";
 					OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+					\\"some-other-var\\": \\"some-other-value\\";
 				}
 			}
 			interface Env extends Cloudflare.Env {}
@@ -979,18 +979,18 @@ describe("generate types", () => {
 
 			📖 Read about runtime types
 			https://developers.cloudflare.com/workers/languages/typescript/#generate-types
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
 
 	it("should not error if expected entrypoint is not found and assume module worker", async () => {
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				main: "index.ts",
 				vars: bindingsConfigMock.vars,
-			} as unknown as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 		expect(fs.existsSync("index.ts")).toEqual(false);
@@ -1003,8 +1003,8 @@ describe("generate types", () => {
 				interface Env {
 					SOMETHING: \\"asdasdfasdf\\";
 					ANOTHER: \\"thing\\";
-					\\"some-other-var\\": \\"some-other-value\\";
 					OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+					\\"some-other-var\\": \\"some-other-value\\";
 				}
 			}
 			interface Env extends Cloudflare.Env {}
@@ -1012,20 +1012,20 @@ describe("generate types", () => {
 			────────────────────────────────────────────────────────────
 			✨ Types written to worker-configuration.d.ts
 
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
 
 	it("should include secret keys from .dev.vars", async () => {
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				vars: {
 					myTomlVarA: "A from wrangler toml",
 					myTomlVarB: "B from wrangler toml",
 				},
-			} as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
@@ -1057,22 +1057,22 @@ describe("generate types", () => {
 			────────────────────────────────────────────────────────────
 			✨ Types written to worker-configuration.d.ts
 
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
 
 	it("should allow opting out of strict-vars", async () => {
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				vars: {
 					varStr: "A from wrangler toml",
 					varArrNum: [1, 2, 3],
 					varArrMix: [1, "two", 3, true],
 					varObj: { test: true },
 				},
-			} as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
@@ -1094,20 +1094,20 @@ describe("generate types", () => {
 			────────────────────────────────────────────────────────────
 			✨ Types written to worker-configuration.d.ts
 
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
 
 	it("should override vars with secrets", async () => {
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				vars: {
 					MY_VARIABLE_A: "my variable",
 					MY_VARIABLE_B: { variable: true },
 				},
-			} as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 
@@ -1134,15 +1134,15 @@ describe("generate types", () => {
 			────────────────────────────────────────────────────────────
 			✨ Types written to worker-configuration.d.ts
 
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
 
 	it("various different types of vars", async () => {
 		fs.writeFileSync(
-			"./wrangler.toml",
-			TOML.stringify({
+			"./wrangler.jsonc",
+			JSON.stringify({
 				vars: {
 					"var-a": '"a\\""',
 					"var-a-1": '"a\\\\"',
@@ -1154,7 +1154,7 @@ describe("generate types", () => {
 					false: false,
 					"multi\nline\nvar": "this\nis\na\nmulti\nline\nvariable!",
 				},
-			} as TOML.JsonMap),
+			}),
 			"utf-8"
 		);
 		await runWrangler("types --include-runtime=false");
@@ -1182,7 +1182,7 @@ describe("generate types", () => {
 			────────────────────────────────────────────────────────────
 			✨ Types written to worker-configuration.d.ts
 
-			📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+			📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 			"
 		`);
 	});
@@ -1190,8 +1190,8 @@ describe("generate types", () => {
 	describe("vars present in multiple environments", () => {
 		beforeEach(() => {
 			fs.writeFileSync(
-				"./wrangler.toml",
-				TOML.stringify({
+				"./wrangler.jsonc",
+				JSON.stringify({
 					vars: {
 						MY_VAR: "a var",
 						MY_VAR_A: "A (dev)",
@@ -1213,7 +1213,7 @@ describe("generate types", () => {
 							},
 						},
 					},
-				} as TOML.JsonMap),
+				}),
 				"utf-8"
 			);
 		});
@@ -1228,8 +1228,8 @@ describe("generate types", () => {
 					interface Env {
 						MY_VAR: \\"a var\\";
 						MY_VAR_A: \\"A (dev)\\" | \\"A (prod)\\" | \\"A (stag)\\";
-						MY_VAR_C: [\\"a\\",\\"b\\",\\"c\\"] | [1,2,3];
 						MY_VAR_B: {\\"value\\":\\"B (dev)\\"} | {\\"value\\":\\"B (prod)\\"};
+						MY_VAR_C: [\\"a\\",\\"b\\",\\"c\\"] | [1,2,3];
 					}
 				}
 				interface Env extends Cloudflare.Env {}
@@ -1237,7 +1237,7 @@ describe("generate types", () => {
 				────────────────────────────────────────────────────────────
 				✨ Types written to worker-configuration.d.ts
 
-				📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+				📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 				"
 			`);
 		});
@@ -1252,8 +1252,8 @@ describe("generate types", () => {
 					interface Env {
 						MY_VAR: string;
 						MY_VAR_A: string;
-						MY_VAR_C: string[] | number[];
 						MY_VAR_B: object;
+						MY_VAR_C: string[] | number[];
 					}
 				}
 				interface Env extends Cloudflare.Env {}
@@ -1261,7 +1261,7 @@ describe("generate types", () => {
 				────────────────────────────────────────────────────────────
 				✨ Types written to worker-configuration.d.ts
 
-				📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+				📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 				"
 			`);
 		});
@@ -1271,10 +1271,10 @@ describe("generate types", () => {
 		describe("env", () => {
 			it("should allow the user to customize the interface name", async () => {
 				fs.writeFileSync(
-					"./wrangler.toml",
-					TOML.stringify({
+					"./wrangler.jsonc",
+					JSON.stringify({
 						vars: bindingsConfigMock.vars,
-					} as TOML.JsonMap),
+					}),
 					"utf-8"
 				);
 
@@ -1288,8 +1288,8 @@ describe("generate types", () => {
 						interface Env {
 							SOMETHING: \\"asdasdfasdf\\";
 							ANOTHER: \\"thing\\";
-							\\"some-other-var\\": \\"some-other-value\\";
 							OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+							\\"some-other-var\\": \\"some-other-value\\";
 						}
 					}
 					interface CloudflareEnv extends Cloudflare.Env {}
@@ -1297,17 +1297,17 @@ describe("generate types", () => {
 					────────────────────────────────────────────────────────────
 					✨ Types written to worker-configuration.d.ts
 
-					📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+					📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 					"
 				`);
 			});
 
 			it("should error if --env-interface is specified with no argument", async () => {
 				fs.writeFileSync(
-					"./wrangler.toml",
-					TOML.stringify({
+					"./wrangler.jsonc",
+					JSON.stringify({
 						vars: bindingsConfigMock.vars,
-					} as TOML.JsonMap),
+					}),
 					"utf-8"
 				);
 
@@ -1318,10 +1318,10 @@ describe("generate types", () => {
 
 			it("should error if an invalid interface identifier is provided to --env-interface", async () => {
 				fs.writeFileSync(
-					"./wrangler.toml",
-					TOML.stringify({
+					"./wrangler.jsonc",
+					JSON.stringify({
 						vars: bindingsConfigMock.vars,
-					} as TOML.JsonMap),
+					}),
 					"utf-8"
 				);
 
@@ -1350,12 +1350,12 @@ describe("generate types", () => {
 				}); async function handleRequest(request) {  return new Response('Hello worker!', {headers: { 'content-type': 'text/plain' },});}`
 				);
 				fs.writeFileSync(
-					"./wrangler.toml",
-					TOML.stringify({
+					"./wrangler.jsonc",
+					JSON.stringify({
 						name: "test-name",
 						main: "./index.ts",
 						vars: bindingsConfigMock.vars,
-					} as TOML.JsonMap),
+					}),
 					"utf-8"
 				);
 
@@ -1370,11 +1370,11 @@ describe("generate types", () => {
 		describe("output file", () => {
 			it("should allow the user to specify where to write the result", async () => {
 				fs.writeFileSync(
-					"./wrangler.toml",
-					TOML.stringify({
+					"./wrangler.jsonc",
+					JSON.stringify({
 						compatibility_date: "2022-01-12",
 						vars: bindingsConfigMock.vars,
-					} as TOML.JsonMap),
+					}),
 					"utf-8"
 				);
 
@@ -1385,14 +1385,14 @@ describe("generate types", () => {
 				expect(fs.readFileSync("./cloudflare-env.d.ts", "utf-8"))
 					.toMatchInlineSnapshot(`
 						"/* eslint-disable */
-						// Generated by Wrangler by running \`wrangler\` (hash: a123396658ac84465faf6f0f82c0337b)
+						// Generated by Wrangler by running \`wrangler\` (hash: fc5d598f2fb05668416eab9ae2c2898d)
 						// Runtime types generated with workerd@
 						declare namespace Cloudflare {
 							interface Env {
 								SOMETHING: \\"asdasdfasdf\\";
 								ANOTHER: \\"thing\\";
-								\\"some-other-var\\": \\"some-other-value\\";
 								OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+								\\"some-other-var\\": \\"some-other-value\\";
 							}
 						}
 						interface Env extends Cloudflare.Env {}
@@ -1404,10 +1404,10 @@ describe("generate types", () => {
 
 			it("should error if the user points to a non-d.ts file", async () => {
 				fs.writeFileSync(
-					"./wrangler.toml",
-					TOML.stringify({
+					"./wrangler.jsonc",
+					JSON.stringify({
 						vars: bindingsConfigMock.vars,
-					} as TOML.JsonMap),
+					}),
 					"utf-8"
 				);
 
@@ -1429,10 +1429,10 @@ describe("generate types", () => {
 
 		it("should allow multiple customizations to be applied together", async () => {
 			fs.writeFileSync(
-				"./wrangler.toml",
-				TOML.stringify({
+				"./wrangler.jsonc",
+				JSON.stringify({
 					vars: bindingsConfigMock.vars,
-				} as TOML.JsonMap),
+				}),
 				"utf-8"
 			);
 
@@ -1443,14 +1443,14 @@ describe("generate types", () => {
 			expect(fs.readFileSync("./my-cloudflare-env-interface.d.ts", "utf-8"))
 				.toMatchInlineSnapshot(`
 					"/* eslint-disable */
-					// Generated by Wrangler by running \`wrangler\` (hash: 7e48a0a15b531f54ca31c564fe6cb101)
+					// Generated by Wrangler by running \`wrangler\` (hash: 60930eb00599b0244bd44c7fd113844b)
 					// Runtime types generated with workerd@
 					declare namespace Cloudflare {
 						interface Env {
 							SOMETHING: \\"asdasdfasdf\\";
 							ANOTHER: \\"thing\\";
-							\\"some-other-var\\": \\"some-other-value\\";
 							OBJECT_VAR: {\\"enterprise\\":\\"1701-D\\",\\"activeDuty\\":true,\\"captian\\":\\"Picard\\"};
+							\\"some-other-var\\": \\"some-other-value\\";
 						}
 					}
 					interface MyCloudflareEnvInterface extends Cloudflare.Env {}
@@ -1464,13 +1464,13 @@ describe("generate types", () => {
 	describe("runtime types output", () => {
 		beforeEach(() => {
 			fs.writeFileSync(
-				"./wrangler.toml",
-				TOML.stringify({
+				"./wrangler.jsonc",
+				JSON.stringify({
 					compatibility_date: "2022-12-12",
 					vars: {
 						"var-a": "a",
 					},
-				} as TOML.JsonMap),
+				}),
 				"utf-8"
 			);
 		});
@@ -1505,7 +1505,7 @@ describe("generate types", () => {
 
 				📖 Read about runtime types
 				https://developers.cloudflare.com/workers/languages/typescript/#generate-types
-				📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+				📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 				"
 			`);
 		});
@@ -1538,7 +1538,7 @@ describe("generate types", () => {
 
 				📖 Read about runtime types
 				https://developers.cloudflare.com/workers/languages/typescript/#generate-types
-				📣 Remember to rerun 'wrangler types' after you change your wrangler.toml file.
+				📣 Remember to rerun 'wrangler types' after you change your wrangler.json file.
 				"
 			`);
 		});

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -371,6 +371,7 @@ export function createCLIParser(argv: string[]) {
 				"config",
 				(configArgv) =>
 					configArgv["_"][0] === "dev" ||
+					configArgv["_"][0] === "types" ||
 					(configArgv["_"][0] === "pages" && configArgv["_"][1] === "dev")
 			)
 		)

--- a/packages/wrangler/src/type-generation/helpers.ts
+++ b/packages/wrangler/src/type-generation/helpers.ts
@@ -43,6 +43,7 @@ export const checkTypesDiff = async (config: Config, entry: Entry) => {
 			previousEnvInterface ?? "Env",
 			"worker-configuration.d.ts",
 			entry,
+			new Map(),
 			// don't log anything
 			false
 		);

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -146,7 +146,7 @@ export const typesCommand = createCommand({
 			for (const secondaryConfig of secondaryConfigs) {
 				const serviceEntry = await getEntry({}, secondaryConfig, "types");
 
-				if (serviceEntry?.name) {
+				if (serviceEntry.name) {
 					const key = serviceEntry.name;
 					if (serviceEntries.has(key)) {
 						logger.warn(
@@ -395,19 +395,17 @@ export async function generateEnvTypes(
 
 	if (configToDTS.durable_objects?.bindings) {
 		for (const durableObject of configToDTS.durable_objects.bindings) {
-			const entrypointFile = durableObject.script_name
-				? serviceEntries?.get(durableObject.script_name)?.file
-				: entrypoint?.file;
+			const doEntrypoint = durableObject.script_name
+				? serviceEntries?.get(durableObject.script_name)
+				: entrypoint;
 
-			const importPath = entrypointFile
-				? generateImportSpecifier(fullOutputPath, entrypointFile)
+			const importPath = doEntrypoint
+				? generateImportSpecifier(fullOutputPath, doEntrypoint.file)
 				: undefined;
 
-			const exportExists = (
-				durableObject.script_name
-					? serviceEntries?.get(durableObject.script_name)
-					: entrypoint
-			)?.exports?.some((e) => e === durableObject.class_name);
+			const exportExists = doEntrypoint?.exports?.some(
+				(e) => e === durableObject.class_name
+			);
 
 			let typeName: string;
 
@@ -446,20 +444,18 @@ export async function generateEnvTypes(
 
 	if (configToDTS.services) {
 		for (const service of configToDTS.services) {
-			const entrypointFile =
-				service.service !== entrypoint?.name
-					? serviceEntries?.get(service.service)?.file
-					: entrypoint?.file;
-
-			const importPath = entrypointFile
-				? generateImportSpecifier(fullOutputPath, entrypointFile)
-				: undefined;
-
-			const exportExists = (
+			const serviceEntry =
 				service.service !== entrypoint?.name
 					? serviceEntries?.get(service.service)
-					: entrypoint
-			)?.exports?.some((e) => e === service.entrypoint);
+					: entrypoint;
+
+			const importPath = serviceEntry
+				? generateImportSpecifier(fullOutputPath, serviceEntry.file)
+				: undefined;
+
+			const exportExists = serviceEntry?.exports?.some(
+				(e) => e === service.entrypoint
+			);
 
 			let typeName: string;
 

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -140,7 +140,7 @@ export const typesCommand = createCommand({
 			);
 		}
 
-		const serviceEntries: Map<string, Entry> = new Map();
+		const secondaryEntries: Map<string, Entry> = new Map();
 
 		if (secondaryConfigs.length > 0) {
 			for (const secondaryConfig of secondaryConfigs) {
@@ -148,20 +148,20 @@ export const typesCommand = createCommand({
 
 				if (serviceEntry.name) {
 					const key = serviceEntry.name;
-					if (serviceEntries.has(key)) {
+					if (secondaryEntries.has(key)) {
 						logger.warn(
 							`Configuration file for Worker '${key}' has been passed in more than once using \`--config\`. To remove this warning, only pass each unique Worker config file once.`
 						);
 					}
-					serviceEntries.set(key, serviceEntry);
+					secondaryEntries.set(key, serviceEntry);
 					logger.log(
 						chalk.dim(
 							`- Found Worker '${key}' at '${relative(process.cwd(), serviceEntry.file)}' (${secondaryConfig.configPath})`
 						)
 					);
 				} else {
-					logger.warn(
-						`Could not resolve entry point for service config '${secondaryConfig}'. Types may be incomplete.`
+					throw new UserError(
+						`Could not resolve entry point for service config '${secondaryConfig}'.`
 					);
 				}
 			}
@@ -194,7 +194,7 @@ export const typesCommand = createCommand({
 				envInterface,
 				outputPath,
 				entrypoint,
-				serviceEntries
+				secondaryEntries
 			);
 			if (envHeader && envTypes) {
 				header.push(envHeader);


### PR DESCRIPTION
I created this based on some DMs with Cloudflare Team members. Apologies for not creating an issue or discussion.


### what this does

If extra wrangler configs are provided to `wrangler types` as:

```
wrangler types --service-config path/to/worker-a/wrangler.toml --service-config path/to/worker-b/wrangler.toml
```

This will use those to find the type definitions for the bound service, matching on the service name where it exists.

I took inspiration from the wrangler dev command which already allows passing in multiple wrangler files to then determine the locations of the implementations of each of the bound services on Env.

and I took inspiration from the DurableObject binding code already in the type generation


![image](https://github.com/user-attachments/assets/01f0de8e-d684-420b-bc46-71e2c4f5c979)

Now my generated types have all the correct methods attached.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/22290
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a patch change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
