### PR TITLE
Unhide 'wrangler pages functions build'

### DIFF
--- a/.changeset/tiny-ideas-nail.md
+++ b/.changeset/tiny-ideas-nail.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+feat: Unhide `wrangler pages functions build` command.
+
+This is already documented for Pages Plugins and by officially documenting it, we can ease the transition to Workers Assets for users of Pages Functions.

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -24,6 +24,7 @@ describe("pages", () => {
 
 			COMMANDS
 			  wrangler pages dev [directory] [-- command..]  Develop your full-stack Pages application locally
+			  wrangler pages functions                       Helpers related to Pages Functions
 			  wrangler pages project                         Interact with your Pages projects
 			  wrangler pages deployment                      Interact with the deployments of a project
 			  wrangler pages deploy [directory]              Deploy a directory of static assets as a Pages deployment  [aliases: publish]

--- a/packages/wrangler/src/pages/build.ts
+++ b/packages/wrangler/src/pages/build.ts
@@ -50,6 +50,7 @@ export function Options(yargs: CommonYargsArgv) {
 			outfile: {
 				type: "string",
 				description: "The location of the output Worker script",
+				deprecated: true,
 			},
 			outdir: {
 				type: "string",

--- a/packages/wrangler/src/pages/index.ts
+++ b/packages/wrangler/src/pages/index.ts
@@ -25,114 +25,108 @@ process.on("SIGTERM", () => {
 });
 
 export function pages(yargs: CommonYargsArgv, subHelp: SubHelp) {
-	return (
-		yargs
-			.command(subHelp)
-			.command(
-				"dev [directory] [-- command..]",
-				"Develop your full-stack Pages application locally",
-				Dev.Options,
-				Dev.Handler
-			)
-			/**
-			 * `wrangler pages functions` is meant for internal use only for now,
-			 * so let's hide this command from the help output
-			 */
-			.command("functions", false, (args) =>
-				args
-					.command(subHelp)
-					.command(
-						"build [directory]",
-						"Compile a folder of Cloudflare Pages Functions into a single Worker",
-						Build.Options,
-						Build.Handler
-					)
-					.command(
-						"build-env [projectDir]",
-						"Render a list of environment variables from the config file",
-						BuildEnv.Options,
-						BuildEnv.Handler
-					)
-					.command(
-						"optimize-routes [routesPath] [outputRoutesPath]",
-						"Consolidate and optimize the route paths declared in _routes.json",
-						Functions.OptimizeRoutesOptions,
-						Functions.OptimizeRoutesHandler
-					)
-			)
-			.command("project", "Interact with your Pages projects", (args) =>
+	return yargs
+		.command(subHelp)
+		.command(
+			"dev [directory] [-- command..]",
+			"Develop your full-stack Pages application locally",
+			Dev.Options,
+			Dev.Handler
+		)
+		.command("functions", "Helpers related to Pages Functions", (args) =>
+			args
+				.command(subHelp)
+				.command(
+					"build [directory]",
+					"Compile a folder of Pages Functions into a single Worker",
+					Build.Options,
+					Build.Handler
+				)
+				.command(
+					"build-env [projectDir]",
+					false, // Render a list of environment variables from the config file
+					BuildEnv.Options,
+					BuildEnv.Handler
+				)
+				.command(
+					"optimize-routes [routesPath] [outputRoutesPath]",
+					false, // Consolidate and optimize the route paths declared in _routes.json
+					Functions.OptimizeRoutesOptions,
+					Functions.OptimizeRoutesHandler
+				)
+		)
+		.command("project", "Interact with your Pages projects", (args) =>
+			args
+				.command(subHelp)
+				.command(
+					"list",
+					"List your Cloudflare Pages projects",
+					Projects.ListOptions,
+					Projects.ListHandler
+				)
+				.command(
+					"create [project-name]",
+					"Create a new Cloudflare Pages project",
+					Projects.CreateOptions,
+					Projects.CreateHandler
+				)
+				.command(
+					"delete [project-name]",
+					"Delete a Cloudflare Pages project",
+					Projects.DeleteOptions,
+					Projects.DeleteHandler
+				)
+				.command("upload [directory]", false, Upload.Options, Upload.Handler)
+				.command(
+					"validate [directory]",
+					false,
+					Validate.Options,
+					Validate.Handler
+				)
+		)
+		.command(
+			"deployment",
+			"Interact with the deployments of a project",
+			(args) =>
 				args
 					.command(subHelp)
 					.command(
 						"list",
-						"List your Cloudflare Pages projects",
-						Projects.ListOptions,
-						Projects.ListHandler
+						"List deployments in your Cloudflare Pages project",
+						Deployments.ListOptions,
+						Deployments.ListHandler
 					)
 					.command(
-						"create [project-name]",
-						"Create a new Cloudflare Pages project",
-						Projects.CreateOptions,
-						Projects.CreateHandler
+						"create [directory]",
+						"Publish a directory of static assets as a Pages deployment",
+						Deploy.Options,
+						Deploy.Handler
 					)
 					.command(
-						"delete [project-name]",
-						"Delete a Cloudflare Pages project",
-						Projects.DeleteOptions,
-						Projects.DeleteHandler
+						"tail [deployment]",
+						"Start a tailing session for a project's deployment and " +
+							"livestream logs from your Functions",
+						DeploymentTails.Options,
+						DeploymentTails.Handler
 					)
-					.command("upload [directory]", false, Upload.Options, Upload.Handler)
-					.command(
-						"validate [directory]",
-						false,
-						Validate.Options,
-						Validate.Handler
-					)
+		)
+		.command(
+			["deploy [directory]", "publish [directory]"],
+			"Deploy a directory of static assets as a Pages deployment",
+			Deploy.Options,
+			Deploy.Handler
+		)
+		.command(
+			"secret",
+			"Generate a secret that can be referenced in a Pages project",
+			(secretYargs) => secret(secretYargs, subHelp)
+		)
+		.command("download", "Download settings from your project", (args) =>
+			args.command(
+				"config [projectName]",
+				"Experimental: Download your Pages project config as a Wrangler configuration file",
+				DownloadConfig.Options,
+				DownloadConfig.Handler
 			)
-			.command(
-				"deployment",
-				"Interact with the deployments of a project",
-				(args) =>
-					args
-						.command(subHelp)
-						.command(
-							"list",
-							"List deployments in your Cloudflare Pages project",
-							Deployments.ListOptions,
-							Deployments.ListHandler
-						)
-						.command(
-							"create [directory]",
-							"Publish a directory of static assets as a Pages deployment",
-							Deploy.Options,
-							Deploy.Handler
-						)
-						.command(
-							"tail [deployment]",
-							"Start a tailing session for a project's deployment and " +
-								"livestream logs from your Functions",
-							DeploymentTails.Options,
-							DeploymentTails.Handler
-						)
-			)
-			.command(
-				["deploy [directory]", "publish [directory]"],
-				"Deploy a directory of static assets as a Pages deployment",
-				Deploy.Options,
-				Deploy.Handler
-			)
-			.command(
-				"secret",
-				"Generate a secret that can be referenced in a Pages project",
-				(secretYargs) => secret(secretYargs, subHelp)
-			)
-			.command("download", "Download settings from your project", (args) =>
-				args.command(
-					"config [projectName]",
-					"Experimental: Download your Pages project config as a Wrangler configuration file",
-					DownloadConfig.Options,
-					DownloadConfig.Handler
-				)
-			)
-	);
+		);
 }

--- a/tools/deployments/__tests__/validate-pr-description.test.ts
+++ b/tools/deployments/__tests__/validate-pr-description.test.ts
@@ -116,6 +116,39 @@ Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
 		).toHaveLength(0);
 	});
 
+	it("should accept a docs link", () => {
+		expect(
+			validateDescription(
+				"",
+				`## What this PR solves / how to test
+
+Fixes [AA-000](https://jira.cfdata.org/browse/AA-000).
+
+## Author has addressed the following
+
+- Tests
+  - [ ] TODO (before merge)
+  - [x] Tests included
+  - [ ] Tests not necessary because:
+- E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
+  - [ ] I don't know
+  - [ ] Required
+  - [x] Not required because: test
+- Public documentation
+  - [ ] TODO (before merge)
+  - [x] Cloudflare docs PR(s): https://developers.cloudflare.com/workers/something-here/
+  - [ ] Documentation not necessary because:
+- Wrangler V3 Backport
+  - [ ] TODO (before merge)
+  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/123
+  - [ ] Not necessary because:
+`,
+				"[]",
+				'[".changeset/hello-world.md"]'
+			)
+		).toHaveLength(0);
+	});
+
 	it("should not accept e2e unknown", () => {
 		expect(
 			validateDescription(

--- a/tools/deployments/validate-pr-description.ts
+++ b/tools/deployments/validate-pr-description.ts
@@ -94,7 +94,7 @@ export function validateDescription(
 
 	if (
 		!(
-			/- \[x\] Cloudflare docs PR\(s\): https:\/\/github\.com\/cloudflare\/cloudflare-docs\/(pull|issues)\/\d+/i.test(
+			/- \[x\] Cloudflare docs PR\(s\): https:\/\/(github\.com\/cloudflare\/cloudflare-docs\/(pull|issues)\/\d+|developers\.cloudflare\.com\/.*)/i.test(
 				body
 			) || /- \[x\] Documentation not necessary because: .+/i.test(body)
 		)


### PR DESCRIPTION
Fixes WC-000.

This command is already documented, so this just makes it show up for `wrangler pages --help`. It also deprecates the now long-since unused `--outfile` (in favor of `--outdir`, which can support unbundleable files such as Wasm).

The other (internal and undocumented) `wrangler pages functions ...` commands are hidden to prevent them from showing up for `wrangler pages functions --help`.

Edit: also accepts live docs URLs in the PR description.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://developers.cloudflare.com/pages/functions/plugins/#1-create-a-new-pages-plugin
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a patch

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
