### PR TITLE
docs: fix worker compat URL in docstring

### DIFF
--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -117,7 +117,7 @@ interface EnvironmentInheritable {
 	 * A date in the form yyyy-mm-dd, which will be used to determine
 	 * which version of the Workers runtime is used.
 	 *
-	 * More details at https://developers.cloudflare.com/workers/platform/compatibility-dates
+	 * More details at https://developers.cloudflare.com/workers/configuration/compatibility-dates
 	 *
 	 * @inheritable
 	 */

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -127,7 +127,7 @@ interface EnvironmentInheritable {
 	 * A list of flags that enable features from upcoming features of
 	 * the Workers runtime, usually used together with compatibility_date.
 	 *
-	 * More details at https://developers.cloudflare.com/workers/platform/compatibility-flags
+	 * More details at https://developers.cloudflare.com/workers/configuration/compatibility-flags/
 	 *
 	 * @default []
 	 * @inheritable


### PR DESCRIPTION
This PR fixes a small docs typo that I noticed while working with the Drizzle ORM's setup guide that points to the wrong URL for compatibility in the docstring

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
