### PR TITLE
chore: run dependabot updates outside of busy times

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     directory: "/packages/create-cloudflare/src/frameworks"
     schedule:
       interval: "weekly"
+      # Don't run these at midday on Mondays, when we are busy trying to land PRs
+      day: "sunday"
+      time: "06:00"
     versioning-strategy: increase
     # the following is used to add the [C3] prefix to the PR title,
     # we override the commit message but setting a prefix like this
@@ -33,6 +36,7 @@ updates:
           - "@cloudflare/workers-types"
     schedule:
       interval: "daily"
+      time: "06:00" # the workerd release starts at 00:30 UTC each day
     versioning-strategy: increase
     assignees:
       - "@cloudflare/wrangler"


### PR DESCRIPTION
This should make life a bit simpler on Mondays and also easier to land updates to workerd in a timely fashion