### PR TITLE
fix: replace `process.env.NODE_ENV` for nodejs_compat builds

### DIFF
--- a/.changeset/little-cities-yell.md
+++ b/.changeset/little-cities-yell.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+fix: replace `process.env.NODE_ENV` for nodejs_compat builds
+
+make sure that occurrences of `process.env.NODE_ENV` are replaced with the
+current `process.env.NODE_ENV` value or `"production"` on builds that include
+the `nodejs_compat` flag, this enables libraries checking such value
+(e.g. `react-dom`) to be properly treeshaken

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -44,6 +44,7 @@
 	"dependencies": {
 		"@cloudflare/unenv-preset": "workspace:*",
 		"@hattip/adapter-node": "^0.0.49",
+		"@rollup/plugin-replace": "^6.0.1",
 		"get-port": "^7.1.0",
 		"miniflare": "workspace:*",
 		"picocolors": "^1.1.1",

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/__tests__/base-tests.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/__tests__/base-tests.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "vitest";
+import { isBuild, page } from "../../__test-utils__";
+
+export function testPageContent() {
+	test("the page content has been server side rendered by react", async () => {
+		const h1Content = await page.textContent("h1");
+		expect(h1Content).toEqual("Server Side React");
+		const pContent = await page.textContent("p");
+		expect(pContent).toEqual(
+			"This page was server side rendered by using directly 'renderToString' from 'react-dom/server'"
+		);
+	});
+}
+
+test.skipIf(!isBuild)(
+	"the build output does not include react development code (such is tree-shaken away)",
+	async () => {
+		const outputJs = readFileSync("./dist/worker/index.js", "utf8");
+		expect(outputJs).not.toContain("react-dom.development.js");
+		// the react development code links to the facebook/react repo in a few places
+		expect(outputJs).not.toContain("https://github.com/facebook/react");
+	}
+);

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/__tests__/react-dom-server.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/__tests__/react-dom-server.spec.ts
@@ -1,0 +1,1 @@
+import "./base-tests";

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/__tests__/with-nodejs-compat/react-dom-server.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/__tests__/with-nodejs-compat/react-dom-server.spec.ts
@@ -1,0 +1,1 @@
+import "../base-tests";

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/package.json
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@playground/react-dom-server",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build --app",
+		"check:types": "tsc --build",
+		"dev": "vite dev",
+		"preview": "vite preview"
+	},
+	"dependencies": {
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "workspace:*",
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "^4.20250405.0",
+		"@types/react": "^19.1.0",
+		"@types/react-dom": "^19.1.1",
+		"typescript": "catalog:default",
+		"vite": "catalog:vite-plugin",
+		"wrangler": "workspace:*"
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/src/index.ts
@@ -1,0 +1,32 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+
+export default {
+	async fetch() {
+		const txt = renderToString(
+			React.createElement("div", null, [
+				React.createElement("h1", null, `Server Side React`),
+				React.createElement(
+					"p",
+					null,
+					"This page was server side rendered by using directly 'renderToString' from 'react-dom/server'"
+				),
+			])
+		);
+
+		return new Response(
+			`<!DOCTYPE html>
+			<html>
+				<head>
+					<title>React Server Render</title>
+				</head>
+				<body>
+					<div id="app">${txt}</div>
+				</body>
+			</html>`,
+			{
+				headers: { "Content-Type": "text/html" },
+			}
+		);
+	},
+};

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/tsconfig.json
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/tsconfig.node.json
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/tsconfig.node.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/base.json"],
+	"include": ["vite.config.ts", "__tests__"]
+}

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/tsconfig.worker.json
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/tsconfig.worker.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/worker.json"],
+	"include": ["src"]
+}

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/turbo.json
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://turbo.build/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["dist/**"]
+		}
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/vite.config.ts
@@ -1,0 +1,6 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
+});

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/vite.config.with-nodejs-compat.ts
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/vite.config.with-nodejs-compat.ts
@@ -1,0 +1,12 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [
+		cloudflare({
+			inspectorPort: false,
+			persistState: false,
+			configPath: "wrangler.with-nodejs-compat.jsonc",
+		}),
+	],
+});

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+	"name": "worker",
+	"main": "./src/index.ts",
+	"compatibility_date": "2024-12-30",
+}

--- a/packages/vite-plugin-cloudflare/playground/react-dom-server/wrangler.with-nodejs-compat.jsonc
+++ b/packages/vite-plugin-cloudflare/playground/react-dom-server/wrangler.with-nodejs-compat.jsonc
@@ -1,0 +1,6 @@
+{
+	"name": "worker",
+	"main": "./src/index.ts",
+	"compatibility_date": "2024-12-30",
+	"compatibility_flags": ["nodejs_compat"],
+}

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { createMiddleware } from "@hattip/adapter-node";
+import replace from "@rollup/plugin-replace";
 import MagicString from "magic-string";
 import { Miniflare } from "miniflare";
 import colors from "picocolors";
@@ -547,6 +548,17 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				// Only configure this environment if it is a Worker using Node.js compatibility.
 				if (isNodeCompat(getWorkerConfig(name))) {
 					return {
+						build: {
+							rollupOptions: {
+								plugins: [
+									replace({
+										"process.env.NODE_ENV": JSON.stringify(
+											process.env.NODE_ENV ?? "production"
+										),
+									}),
+								],
+							},
+						},
 						resolve: {
 							builtins: [...nodeCompatExternals],
 						},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -891,7 +891,7 @@ importers:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250224.0
-        version: 4.20250404.0
+        version: 4.20250405.0
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1875,6 +1875,9 @@ importers:
       '@hattip/adapter-node':
         specifier: ^0.0.49
         version: 0.0.49
+      '@rollup/plugin-replace':
+        specifier: ^6.0.1
+        version: 6.0.2(rollup@4.30.1)
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
@@ -2396,6 +2399,40 @@ importers:
       prisma:
         specifier: ^6.3.0
         version: 6.3.1(typescript@5.7.3)
+      typescript:
+        specifier: catalog:default
+        version: 5.7.3
+      vite:
+        specifier: catalog:vite-plugin
+        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+      wrangler:
+        specifier: workspace:*
+        version: link:../../../wrangler
+
+  packages/vite-plugin-cloudflare/playground/react-dom-server:
+    dependencies:
+      react:
+        specifier: ^19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: workspace:*
+        version: link:../..
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../../workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20250405.0
+        version: 4.20250405.0
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.1.0
+      '@types/react-dom':
+        specifier: ^19.1.1
+        version: 19.1.1(@types/react@19.1.0)
       typescript:
         specifier: catalog:default
         version: 5.7.3
@@ -3027,7 +3064,7 @@ importers:
         version: link:../pages-shared
       '@cloudflare/types':
         specifier: 6.18.4
-        version: 6.18.4(react@19.0.0)
+        version: 6.18.4(react@19.1.0)
       '@cloudflare/workers-shared':
         specifier: workspace:*
         version: link:../workers-shared
@@ -6206,6 +6243,11 @@ packages:
     peerDependencies:
       '@types/react': ^19.0.0
 
+  '@types/react-dom@19.1.1':
+    resolution: {integrity: sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w==}
+    peerDependencies:
+      '@types/react': ^19.0.0
+
   '@types/react@18.3.18':
     resolution: {integrity: sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==}
 
@@ -6214,6 +6256,9 @@ packages:
 
   '@types/react@19.0.7':
     resolution: {integrity: sha512-MoFsEJKkAtZCrC1r6CM8U22GzhG7u2Wir8ons/aCKH6MBdD1ibV24zOSSkdZVUKqN5i396zG5VKLYZ3yaUZdLA==}
+
+  '@types/react@19.1.0':
+    resolution: {integrity: sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -10558,6 +10603,11 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
+  react-dom@19.1.0:
+    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
+    peerDependencies:
+      react: ^19.1.0
+
   react-fela@11.7.0:
     resolution: {integrity: sha512-c6sTQ2AFX8WT8Epd6icTxulC6Z/pzqIlEiywTvy5e5VJw8uKxJLs997I3v71nJ9XXs4B5HPxWayflhycaCJiaQ==}
     peerDependencies:
@@ -10620,6 +10670,10 @@ packages:
 
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.1.0:
+    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -10840,6 +10894,9 @@ packages:
 
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
+
+  scheduler@0.26.0:
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -13294,9 +13351,9 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@cloudflare/intl-types@1.5.1(react@19.0.0)':
+  '@cloudflare/intl-types@1.5.1(react@19.1.0)':
     dependencies:
-      react: 19.0.0
+      react: 19.1.0
 
   '@cloudflare/kv-asset-handler@0.1.3':
     dependencies:
@@ -13343,11 +13400,11 @@ snapshots:
       react-fela: 11.7.0(fela@11.7.0)(react@18.3.1)
       react-test-renderer: 17.0.2(react@18.3.1)
 
-  '@cloudflare/types@6.18.4(react@19.0.0)':
+  '@cloudflare/types@6.18.4(react@19.1.0)':
     dependencies:
-      '@cloudflare/intl-types': 1.5.1(react@19.0.0)
+      '@cloudflare/intl-types': 1.5.1(react@19.1.0)
       '@cloudflare/util-en-garde': 8.0.10
-      react: 19.0.0
+      react: 19.1.0
 
   '@cloudflare/types@6.23.6(react@18.3.1)':
     dependencies:
@@ -15612,6 +15669,10 @@ snapshots:
     dependencies:
       '@types/react': 19.0.7
 
+  '@types/react-dom@19.1.1(@types/react@19.1.0)':
+    dependencies:
+      '@types/react': 19.1.0
+
   '@types/react@18.3.18':
     dependencies:
       '@types/prop-types': 15.7.4
@@ -15623,6 +15684,10 @@ snapshots:
       csstype: 3.1.2
 
   '@types/react@19.0.7':
+    dependencies:
+      csstype: 3.1.2
+
+  '@types/react@19.1.0':
     dependencies:
       csstype: 3.1.2
 
@@ -20419,6 +20484,11 @@ snapshots:
       react: 19.0.0
       scheduler: 0.25.0
 
+  react-dom@19.1.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.26.0
+
   react-fela@11.7.0(fela@11.7.0)(react@18.3.1):
     dependencies:
       fela: 11.7.0
@@ -20482,6 +20552,8 @@ snapshots:
       loose-envify: 1.4.0
 
   react@19.0.0: {}
+
+  react@19.1.0: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -20739,6 +20811,8 @@ snapshots:
       loose-envify: 1.4.0
 
   scheduler@0.25.0: {}
+
+  scheduler@0.26.0: {}
 
   scule@1.3.0: {}
 


### PR DESCRIPTION
This PR makes sure that occurrences of `process.env.NODE_ENV` are replaced with the
current `process.env.NODE_ENV` value or `"production"` on builds that include
the `nodejs_compat` flag, this enables libraries checking such value
(e.g. `react-dom`) to be properly treeshaken

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
