### PR TITLE
chore: remove dependabot PR assignees as team is not supported

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
     # makes it so that also the PR title gets such prefix
     commit-message:
       prefix: "[C3] "
-    assignees:
-      - "@cloudflare/c3"
     reviewers:
       - "@cloudflare/c3"
     labels:
@@ -38,8 +36,6 @@ updates:
       interval: "daily"
       time: "06:00" # the workerd release starts at 00:30 UTC each day
     versioning-strategy: increase
-    assignees:
-      - "@cloudflare/wrangler"
     reviewers:
       - "@cloudflare/wrangler"
     labels:


### PR DESCRIPTION
Fixes n/a.

This fixes the [warning message](https://github.com/cloudflare/workers-sdk/pull/8516#issuecomment-2729037403) in the dependabot PR about invalid assignee ( `@cloudflare/wrangler`). As it never works (e.g. https://github.com/cloudflare/workers-sdk/pull/7464) and https://github.com/dear-github/dear-github/issues/170 suggests this is not supported at all, this simply removes it from the dependabot config.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: dependabot change only
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: dependabot change only
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: dependabot change only
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: dependabot change only

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
