### PR TITLE
fix: make console.logs not hang vitest-pool-workers when using workflows

### DIFF
--- a/.changeset/eleven-papayas-take.md
+++ b/.changeset/eleven-papayas-take.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Make vitest-pool-workers not hang when console.\* is used in a Workflow

--- a/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
+++ b/fixtures/vitest-pool-workers-examples/workflows/src/index.ts
@@ -7,6 +7,7 @@ import {
 
 export class TestWorkflow extends WorkflowEntrypoint<Env> {
 	async run(_event: Readonly<WorkflowEvent<unknown>>, step: WorkflowStep) {
+		console.log("ola");
 		return "test-workflow";
 	}
 }

--- a/packages/vitest-pool-workers/src/worker/entrypoints.ts
+++ b/packages/vitest-pool-workers/src/worker/entrypoints.ts
@@ -543,7 +543,9 @@ export function createWorkflowEntrypointWrapper(entrypoint: string) {
 			}
 			const maybeFn = instance["run"];
 			if (typeof maybeFn === "function") {
-				return maybeFn.call(instance, ...args);
+				return patchAndRunWithHandlerContext(this.ctx, () =>
+					maybeFn.call(instance, ...args)
+				);
 			} else {
 				const message = `Expected ${entrypoint} export of ${mainPath} to define a \`run()\` method, but got ${typeof maybeFn}`;
 				throw new TypeError(message);


### PR DESCRIPTION
This goes way beyond me, but I noticed that I didn't use `patchAndRunWithHandlerContext` in `createWorkflowEntrypointWrapper` but other entrypoints did it - that seems to fix it.

However, I'm not really sure how does `ExecutionContext` relate to our custom `Console` mock. Probably the test runner (which is a worker AFAICT) uses `waitUntil` to write into vitest's stdout?

Fixes #8791 and WOR-605

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not vite and not wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it's a patch change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: vitest-pool-workers-change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
