### PR TITLE
fix(wrangler): skip non-successful deployments when tailing Pages logs

### DIFF
--- a/.changeset/eleven-months-hide.md
+++ b/.changeset/eleven-months-hide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix(wrangler): skip non-successful deployments when tailing Pages logs

--- a/packages/wrangler/src/pages/deployment-tails.ts
+++ b/packages/wrangler/src/pages/deployment-tails.ts
@@ -212,10 +212,11 @@ export const pagesDeploymentTailCommand = createCommand({
 			}
 
 			const latestDeployment = envDeployments
+				.filter((d) => d.latest_stage.status === "success")
 				.map((d) => ({ id: d.id, created_on: new Date(d.created_on) }))
 				.sort((a, b) => +b.created_on - +a.created_on)[0];
 
-			deploymentId = latestDeployment.id;
+			deploymentId = latestDeployment?.id;
 		}
 
 		if (!deploymentId || !projectName) {


### PR DESCRIPTION
Tailing logs of Pages deployments currently fails when a deployment was skipped, e.g. due to build watch paths.

```
$ wrangler pages deployment tail --project-name myproject
No deployment specified. Using latest deployment for production environment.

✘ [ERROR] A request to the Cloudflare API (/accounts/xxx/pages/projects/myproject/deployments/9dc87402-90c7-4227-b7cf-aa47630e588a/tails) failed.

  The requested Worker version could not be found, please check the ID being passed and try again.
  [code: 8000068]
```

Such skipped deployments have this latest stage:

```
latest_stage: { name: 'queued', started_on: null, ended_on: null, status: 'idle' },
```

(In an ideal world, the status should be `skipped` and not `idle`, but that's a different issue.)

To fix this problem, I changed the logic that finds the last deployment to consider successful deployments only.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
