### PR TITLE
Update types of changes in contrib guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -420,9 +420,9 @@ We should be consistent with the word that describes how we get a worker to the 
 
 We use the following guidelines to determine the kind of change for a PR:
 
-- Bugfixes and experimental features are considered to be 'patch' changes. Be sure to log warnings when experimental features are used.
+- Bugfixes and experimental, beta, and pre-1.0-package features are considered to be 'patch' changes. Be sure to log warnings when experimental features are used.
 - New stable features and new deprecation warnings for future breaking changes are considered 'minor' changes. These changes shouldn't break existing code, but the deprecation warnings should suggest alternate solutions to not trigger the warning.
-- Breaking changes are considered to be 'major' changes. These are usually when deprecations take effect, or functional breaking behaviour is added with relevant logs (either as errors or warnings.)
+- Breaking changes are considered to be 'major' changes. These are usually when deprecations take effect, or functional breaking behaviour is added with relevant logs (either as errors or warnings). Note: breaking changes for experimental, beta, or pre-1.0-package features are considered to be 'minor' changes.
 
 ### Styleguide
 


### PR DESCRIPTION
Fixes N/A.

Update contributing guide with more detail about types of changes.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: just updating contrib guide
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: just updating contrib guide
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: just updating contrib guide
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: just updating contrib guide

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
