### PR TITLE
chore: re-run v3 backport on label changes

### DIFF
--- a/.changeset/silver-comics-add.md
+++ b/.changeset/silver-comics-add.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+test only. do not merge!

--- a/.changeset/silver-comics-add.md
+++ b/.changeset/silver-comics-add.md
@@ -1,5 +1,0 @@
----
-"wrangler": patch
----
-
-test only. do not merge!

--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -3,12 +3,13 @@ name: v3 Maintenance
 on:
   pull_request:
     branches: main
+    types: [synchronize, opened, reopened, labeled, unlabeled]
     paths:
       - ".changeset/**.md"
 
 jobs:
   open-pr:
-    if: ${{ github.repository_owner == 'cloudflare' }}
+    if: ${{ github.repository_owner == 'cloudflare' && !contains(github.event.pull_request.labels.*.name, 'skip-v3-pr') }}
     name: Open backport PR for patches
     runs-on: macos-latest
     concurrency:
@@ -35,7 +36,6 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
           PR_TITLE: ${{ toJson(github.event.pull_request.title) }}
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
       # - name: "Comment on PR with error details"
       #   if: failure()
       #   uses: marocchino/sticky-pull-request-comment@daa4a82a0a3f6c162c02b83fa44b3ab83946f7cb

--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -4,11 +4,7 @@ import parseChangeset from "@changesets/parse";
 
 /* eslint-disable turbo/no-undeclared-env-vars */
 if (require.main === module) {
-	const parsedLabels = JSON.parse(process.env.LABELS as string) as string[];
-	if (
-		isWranglerPatch(process.env.FILES as string) &&
-		!parsedLabels.includes("skip-v3-pr")
-	) {
+	if (isWranglerPatch(process.env.FILES as string)) {
 		// Create a new branch for the v3 maintenance PR
 		execSync(`git checkout -b v3-maintenance-${process.env.PR_NUMBER} -f`);
 


### PR DESCRIPTION
Fixes n/a.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ci change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: ci change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: ci change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
