### PR TITLE
chore: update changeset

### DIFF
--- a/.changeset/nine-weeks-hug.md
+++ b/.changeset/nine-weeks-hug.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
 Promote workflows commands to stable


### PR DESCRIPTION
Updated changeset as stated in the contributing guide:

> New stable features and new deprecation warnings for future breaking changes are considered 'minor' changes. These changes shouldn't break existing code, but the deprecation warnings should suggest alternate solutions to not trigger the warning.