### PR TITLE
Fix multiple request logging

### DIFF
--- a/.changeset/sour-islands-watch.md
+++ b/.changeset/sour-islands-watch.md
@@ -1,0 +1,6 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+fix: Only log requests to the Wrangler dev server once

--- a/packages/miniflare/src/workers/core/entry.worker.ts
+++ b/packages/miniflare/src/workers/core/entry.worker.ts
@@ -28,6 +28,7 @@ type Env = {
 	[CoreBindings.DURABLE_OBJECT_NAMESPACE_PROXY]: DurableObjectNamespace;
 	[CoreBindings.DATA_PROXY_SHARED_SECRET]?: ArrayBuffer;
 	[CoreBindings.TRIGGER_HANDLERS]: boolean;
+	[CoreBindings.LOG_REQUESTS]: boolean;
 } & {
 	[K in `${typeof CoreBindings.SERVICE_USER_ROUTE_PREFIX}${string}`]:
 		| Fetcher
@@ -421,7 +422,9 @@ export default <ExportedHandler<Env>>{
 			}
 			response = maybeInjectLiveReload(response, env, ctx);
 			response = ensureAcceptableEncoding(clientAcceptEncoding, response);
-			maybeLogRequest(request, response, env, ctx, startTime);
+			if (env[CoreBindings.LOG_REQUESTS]) {
+				maybeLogRequest(request, response, env, ctx, startTime);
+			}
 			return response;
 		} catch (e: any) {
 			return new Response(e?.stack ?? String(e), { status: 500 });

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -69,6 +69,9 @@ describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --remote" }])(
 
 			await worker.waitForReload();
 
+			// Regression test for issue where multiple request logs were being logged per request
+			expect([...worker.currentOutput.matchAll(/GET /g)].length).toBe(1);
+
 			await expect(fetchText(url)).resolves.toMatchSnapshot();
 		});
 


### PR DESCRIPTION
Only log requests once (fixes regression in 4.9 where we started logging requests to the Wrangler dev server twice)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: bug introduced in 4.9

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
