### PR TITLE
fix(wrangler): Disambiguate the "No files to upload. Proceeding with deployment..." message

### DIFF
--- a/.changeset/mean-badgers-battle.md
+++ b/.changeset/mean-badgers-battle.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Disambiguate the "No files to upload. Proceeding with deployment..." message

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -274,7 +274,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 				[
 					"Uploaded 1 of 1 assets",
 					"Uploaded 1 of 2 assets",
-					"No files to upload.",
+					"No updated asset files to upload.",
 				].some((s) => output.includes(s))
 			).toBeTruthy();
 		},
@@ -347,7 +347,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 				[
 					"Uploaded 1 of 1 assets",
 					"Uploaded 1 of 2 assets",
-					"No files to upload.",
+					"No updated asset files to upload.",
 				].some((s) => output.includes(s))
 			).toBeTruthy();
 			expect(output).toContain("- Binding: ASSETS");

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -89,7 +89,9 @@ export const syncAssets = async (
 				{ telemetryMessage: true }
 			);
 		}
-		logger.info(`No files to upload. Proceeding with deployment...`);
+		logger.info(
+			`No updated asset files to upload. Proceeding with deployment...`
+		);
 		return initializeAssetsResponse.jwt;
 	}
 


### PR DESCRIPTION
Some folks are confused about the "No files to upload. Proceeding with deployment..." message when deploying Workers with Assets, especially when lacking the context that wrangler is diffing the local files with the asset manifest and only uploading the changes. This PR disambiguates this messages to something hopefully more meaningful

Fixes DEVX-1572

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: copy change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: copy change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: assets is a beta feature in wrangler v3. we don't backport patches to beta features

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
