### PR TITLE
Add log message when 'sec-fetch-mode: navigate' is responsible for assets routing decision in 'wrangler dev'

### DIFF
--- a/.changeset/cute-carpets-sneeze.md
+++ b/.changeset/cute-carpets-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/workers-shared": minor
+"miniflare": minor
+---
+
+Add log message when `Sec-Fetch-Mode: navigate` is responsible for assets routing decision in `wrangler dev`

--- a/packages/miniflare/src/plugins/assets/index.ts
+++ b/packages/miniflare/src/plugins/assets/index.ts
@@ -141,6 +141,7 @@ export const ASSETS_PLUGIN: Plugin<typeof AssetsOptionsSchema> = {
 			...options.assets.assetConfig,
 			redirects: parsedRedirects,
 			headers: parsedHeaders,
+			debug: true,
 		};
 
 		const id = options.assets.workerName;

--- a/packages/workers-shared/asset-worker/src/configuration.ts
+++ b/packages/workers-shared/asset-worker/src/configuration.ts
@@ -22,5 +22,6 @@ export const normalizeConfiguration = (
 		},
 		account_id: configuration?.account_id ?? -1,
 		script_id: configuration?.script_id ?? -1,
+		debug: configuration?.debug ?? false,
 	};
 };

--- a/packages/workers-shared/router-worker/src/configuration.ts
+++ b/packages/workers-shared/router-worker/src/configuration.ts
@@ -9,5 +9,6 @@ export const applyConfigurationDefaults = (
 		has_user_worker: configuration?.has_user_worker ?? false,
 		account_id: configuration?.account_id ?? -1,
 		script_id: configuration?.script_id ?? -1,
+		debug: configuration?.debug ?? false,
 	};
 };

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 const InternalConfigSchema = z.object({
 	account_id: z.number().optional(),
 	script_id: z.number().optional(),
+	debug: z.boolean().optional(),
 });
 
 export const RouterConfigSchema = z.object({


### PR DESCRIPTION
Fixes WC-3442 and fixes #8798

Adds a log message when `Sec-Fetch-Mode: navigate`.

<img width="899" alt="image" src="https://github.com/user-attachments/assets/237ee9c6-b4d1-4ee1-8ad1-e3d39c4cdbab" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: small change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a patch, not strictly Wrangler 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
