### PR TITLE
chore: add `--force` and `--non-interactive` flags to yarn install command in the vite-plugin e2es

### DIFF
--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -16,7 +16,7 @@ export default defineConfig({
 
 ## Documentation
 
-Full documentation can be found [here](https://developers.cloudflare.com/workers/vite-plugin/).
+Full documentation can be found in the [docs](https://developers.cloudflare.com/workers/vite-plugin/).
 
 ## Features
 

--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -49,10 +49,7 @@ export const test = baseTest.extend<{
 			if (pm === "yarn") {
 				// Note: we use --force and --non-interactive because
 				//       otherwise yarn gets stuck during installation in CI
-				runCommand(
-					`${pm} install --verbose --force --non-interactive`,
-					projectPath
-				);
+				runCommand(`${pm} install --force --non-interactive`, projectPath);
 			} else {
 				runCommand(`${pm} install`, projectPath);
 			}

--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -49,7 +49,10 @@ export const test = baseTest.extend<{
 			if (pm === "yarn") {
 				// Note: we use --force and --non-interactive because
 				//       otherwise yarn gets stuck during installation in CI
-				runCommand(`${pm} install --force --non-interactive`, projectPath);
+				runCommand(
+					`${pm} install --verbose --force --non-interactive`,
+					projectPath
+				);
 			} else {
 				runCommand(`${pm} install`, projectPath);
 			}

--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -46,9 +46,13 @@ export const test = baseTest.extend<{
 			debuglog("Fixture copied to " + projectPath);
 			await updateVitePluginVersion(projectPath);
 			debuglog("Updated vite-plugin version in package.json");
-			// Note: we use --force because otherwise yarn
-			//       gets stuck during installation in CI
-			runCommand(`${pm} install --force`, projectPath);
+			if (pm === "yarn") {
+				// Note: we use --force and --non-interactive because
+				//       otherwise yarn gets stuck during installation in CI
+				runCommand(`${pm} install --force --non-interactive`, projectPath);
+			} else {
+				runCommand(`${pm} install`, projectPath);
+			}
 			debuglog("Installed node modules");
 			projectPaths.push(projectPath);
 			return projectPath;

--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -46,7 +46,9 @@ export const test = baseTest.extend<{
 			debuglog("Fixture copied to " + projectPath);
 			await updateVitePluginVersion(projectPath);
 			debuglog("Updated vite-plugin version in package.json");
-			runCommand(`${pm} install`, projectPath);
+			// Note: we use --force because otherwise yarn
+			//       gets stuck during installation in CI
+			runCommand(`${pm} install --force`, projectPath);
 			debuglog("Installed node modules");
 			projectPaths.push(projectPath);
 			return projectPath;

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -88,7 +88,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 		{
 			name: "vite-plugin-cloudflare",
 			// This only applies to this plugin so is safe to use while other plugins migrate to the Environment API
-			sharedDuringBuild: true,
+			sharedDuringBuild: !!true,
 			config(userConfig, env) {
 				if (env.isPreview) {
 					// Short-circuit the whole configuration if we are in preview mode


### PR DESCRIPTION
Any vite-plugin e2e run is causing the GitHub CI to get stuck (see https://github.com/cloudflare/workers-sdk/pull/8786, https://github.com/cloudflare/workers-sdk/pull/8895)

this happens when we run `yarn install` for setting up the e2e fixtures, by testing it I've seen that passing the
`--force`  and `--non-interactive` flags seems to fix the issue, so that's what I'm adding here

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: fixing problematic e2es
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
