### PR TITLE
[wrangler] Added pages deployment delete command

### DIFF
--- a/.changeset/dry-spies-lay.md
+++ b/.changeset/dry-spies-lay.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Added `pages deployment delete <deployment>` command

--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ tools/deployment-status.json
 
 # IntelliJ
 .idea/
+*.iml
 
 # VSCode Theme
 *.vsix

--- a/packages/wrangler/src/__tests__/pages/pages-deployement-delete.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployement-delete.test.ts
@@ -1,0 +1,80 @@
+import { http, HttpResponse } from "msw";
+import { endEventLoop } from "../helpers/end-event-loop";
+import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { msw } from "../helpers/msw";
+import { runInTempDir } from "../helpers/run-in-tmp";
+import { runWrangler } from "../helpers/run-wrangler";
+
+const PROJECT_NAME = "images";
+const DEPLOYMENT = "deployment";
+
+describe("pages deployment delete", () => {
+	runInTempDir();
+	mockAccountId();
+	mockApiToken();
+	mockConsoleMethods();
+
+	afterEach(async () => {
+		await endEventLoop();
+		msw.resetHandlers();
+		msw.restoreHandlers();
+	});
+
+	it("should make request to delete deployment", async () => {
+		const requests = mockDeploymentDeleteRequest(DEPLOYMENT);
+		await runWrangler(
+			`pages deployment delete ${DEPLOYMENT} --project-name=${PROJECT_NAME}`
+		);
+		expect(requests.count).toBe(1);
+	});
+
+	it("should throw an error if deployment ID is missing", async () => {
+		await expect(
+			runWrangler(`pages deployment delete --project-name=${PROJECT_NAME}`)
+		).rejects.toThrow("Must specify a project name and deployment.");
+	});
+
+	it("should throw an error if project name is missing in non-interactive mode", async () => {
+		await expect(
+			runWrangler(`pages deployment delete ${DEPLOYMENT}`)
+		).rejects.toThrow("Must specify a project name in non-interactive mode.");
+	});
+});
+
+/* -------------------------------------------------- */
+/*                    Helper Functions                */
+/* -------------------------------------------------- */
+
+type RequestLogger = {
+	count: number;
+	queryParams: [string, string][][];
+};
+
+function mockDeploymentDeleteRequest(deployment: string): RequestLogger {
+	const requests: RequestLogger = { count: 0, queryParams: [] };
+	msw.use(
+		http.delete(
+			"*/accounts/:accountId/pages/projects/:project/deployments/:deployment",
+			({ request, params }) => {
+				requests.count++;
+				const url = new URL(request.url);
+				requests.queryParams.push(Array.from(url.searchParams.entries()));
+				expect(params.project).toEqual(PROJECT_NAME);
+				expect(params.accountId).toEqual("some-account-id");
+
+				return HttpResponse.json(
+					{
+						success: true,
+						errors: [],
+						messages: [],
+						result: deployment,
+					},
+					{ status: 200 }
+				);
+			},
+			{ once: true }
+		)
+	);
+	return requests;
+}

--- a/packages/wrangler/src/pages/delete.ts
+++ b/packages/wrangler/src/pages/delete.ts
@@ -1,0 +1,60 @@
+import { fetchResult } from "../cfetch";
+import { getConfigCache } from "../config-cache";
+import { FatalError } from "../errors";
+import isInteractive from "../is-interactive";
+import { logger } from "../logger";
+import { requireAuth } from "../user";
+import { PAGES_CONFIG_CACHE_FILENAME } from "./constants";
+import { promptSelectProject } from "./prompt-select-project";
+import type {
+	CommonYargsArgv,
+	StrictYargsOptionsToInterface,
+} from "../yargs-types";
+import type { PagesConfigCache } from "./types";
+
+export function Options(yargs: CommonYargsArgv) {
+	return yargs
+		.positional("deployment", {
+			type: "string",
+			description: "The ID of the deployment you wish to delete",
+		})
+		.options({
+			"project-name": {
+				type: "string",
+				description:
+					"The name of the project you would like to delete the deployment from",
+			},
+		});
+}
+
+export async function Handler({
+	deployment,
+	projectName,
+}: StrictYargsOptionsToInterface<typeof Options>) {
+	const config = getConfigCache<PagesConfigCache>(PAGES_CONFIG_CACHE_FILENAME);
+	const accountId = await requireAuth(config);
+
+	projectName ??= config.project_name;
+
+	if (!projectName) {
+		if (isInteractive()) {
+			projectName = await promptSelectProject({ accountId });
+		} else {
+			throw new FatalError(
+				"Must specify a project name in non-interactive mode.",
+				1
+			);
+		}
+	}
+
+	if (!deployment || !projectName) {
+		throw new FatalError("Must specify a project name and deployment.", 1);
+	}
+
+	await fetchResult(
+		`/accounts/${accountId}/pages/projects/${projectName}/deployments/${deployment}`,
+		{ method: "DELETE" }
+	);
+
+	logger.log(`Deployment ${deployment} was successfully deleted.`);
+}

--- a/packages/wrangler/src/pages/index.ts
+++ b/packages/wrangler/src/pages/index.ts
@@ -2,6 +2,7 @@
 
 import * as Build from "./build";
 import * as BuildEnv from "./build-env";
+import * as Delete from "./delete";
 import * as Deploy from "./deploy";
 import * as DeploymentTails from "./deployment-tails";
 import * as Deployments from "./deployments";
@@ -108,6 +109,12 @@ export function pages(yargs: CommonYargsArgv, subHelp: SubHelp) {
 							"livestream logs from your Functions",
 						DeploymentTails.Options,
 						DeploymentTails.Handler
+					)
+					.command(
+						"delete [deployment]",
+						"Delete a deployment",
+						Delete.Options,
+						Delete.Handler
 					)
 		)
 		.command(


### PR DESCRIPTION
Fixes https://community.cloudflare.com/t/wrangler-delete-deployment/610630

Following up on my post on the forum I added `pages deployment delete <deployment>` command

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: E2E test for the all `pages deployment` functionality should be added probably
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/21654
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Nice-to-have feature, no need to backport

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
