### PR TITLE
chore: comment on v3 backport status only if it has wrangler patch

### DIFF
--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -31,13 +31,15 @@ jobs:
           format: "json"
 
       - run: node -r esbuild-register tools/deployments/open-v3-pr.ts
+        id: open_pr
         env:
           FILES: ${{ steps.files.outputs.all }}
           PR_NUMBER: ${{ github.event.number }}
           PR_TITLE: ${{ toJson(github.event.pull_request.title) }}
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
       - name: "Comment on PR with error details"
-        if: failure()
+        if: steps.open_pr.outputs.has_wrangler_patch == 'true' && failure()
         uses: marocchino/sticky-pull-request-comment@daa4a82a0a3f6c162c02b83fa44b3ab83946f7cb
         with:
           header: v3-backport
@@ -47,7 +49,7 @@ jobs:
             Depending on your changes, running `git rebase --onto v3-maintenance main ${{ github.head_ref }}` might be a good starting point.
 
       - name: "Comment on PR with backport PR details"
-        if: success()
+        if: steps.open_pr.outputs.has_wrangler_patch == 'true' && success()
         uses: marocchino/sticky-pull-request-comment@daa4a82a0a3f6c162c02b83fa44b3ab83946f7cb
         with:
           header: v3-backport

--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import parseChangeset from "@changesets/parse";
 
 /* eslint-disable turbo/no-undeclared-env-vars */
@@ -50,5 +50,13 @@ export function isWranglerPatch(changedFilesJson: string) {
 			}
 		}
 	}
+
+	if (process.env.GITHUB_OUTPUT) {
+		appendFileSync(
+			process.env.GITHUB_OUTPUT,
+			`has_wrangler_patch=${hasWranglerPatch ? "true" : "false"}\n`
+		);
+	}
+
 	return hasWranglerPatch;
 }


### PR DESCRIPTION
Fixes n/a

This makes sure no comment on the v3 backport status is added if the changeset is not a wrangler patch. I have tested it with a non wrangler patch changeset in https://github.com/cloudflare/workers-sdk/pull/8930/commits/d3d8710a057e9a0204d927f056beb0e1cd93488e (See [CI Job](https://github.com/cloudflare/workers-sdk/actions/runs/14444128966/job/40500683309)).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ci update
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: ci update
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci update
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: ci update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
