### PR TITLE
chore: make sure certs uploaded in the tests are deleted

### DIFF
--- a/packages/wrangler/e2e/cert.test.ts
+++ b/packages/wrangler/e2e/cert.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import * as forge from "node-forge";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { normalizeOutput } from "./helpers/normalize";
 
@@ -127,6 +127,13 @@ describe("cert", () => {
 	// Generate filenames for concurrent e2e test environment
 	const mtlsCertName = `mtls_cert_${randomUUID()}`;
 	const caCertName = `ca_cert_${randomUUID()}`;
+
+	afterAll(async () => {
+		// Make sure we clean up the certificates after the tests
+		// These certs are supposed to be deleted in the test, but in case of failure, we want to make sure they are deleted
+		await helper.run(`wrangler cert delete --name ${mtlsCertName}`);
+		await helper.run(`wrangler cert delete --name ${caCertName}`);
+	});
 
 	it("upload mtls-certificate", async () => {
 		// locally generated certs/key


### PR DESCRIPTION
Fixes n/a.

Ref: https://github.com/cloudflare/workers-sdk/actions/runs/14442592902/job/40503451734?pr=8924#step:5:160

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no new feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: no patch

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
