### PR TITLE
chore: cleanup e2e test certs

### DIFF
--- a/packages/wrangler/e2e/cert.test.ts
+++ b/packages/wrangler/e2e/cert.test.ts
@@ -125,8 +125,8 @@ describe("cert", () => {
 	const { certificate: caCert } = generateRootCaCert();
 
 	// Generate filenames for concurrent e2e test environment
-	const mtlsCertName = `tmp-e2e-mtls_cert_${randomUUID()}`;
-	const caCertName = `tmp-e2e-ca_cert_${randomUUID()}`;
+	const mtlsCertName = `tmp-e2e-mtls-cert-${randomUUID()}`;
+	const caCertName = `tmp-e2e-ca-cert-${randomUUID()}`;
 
 	it("upload mtls-certificate", async () => {
 		// locally generated certs/key
@@ -137,8 +137,8 @@ describe("cert", () => {
 			`wrangler cert upload mtls-certificate --name ${mtlsCertName} --cert mtls_client_cert_file.pem --key mtls_client_private_key_file.pem`
 		);
 		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
-			"Uploading mTLS Certificate mtls_cert_00000000-0000-0000-0000-000000000000...
-			Success! Uploaded mTLS Certificate mtls_cert_00000000-0000-0000-0000-000000000000
+			"Uploading mTLS Certificate tmp-e2e-mtls-cert-00000000-0000-0000-0000-000000000000...
+			Success! Uploaded mTLS Certificate tmp-e2e-mtls-cert-00000000-0000-0000-0000-000000000000
 			ID: 00000000-0000-0000-0000-000000000000
 			Issuer: CN=Root CA,O=Localhost Root CA,ST=California,C=US
 			Expires on 11/18/2034"
@@ -152,8 +152,8 @@ describe("cert", () => {
 			`wrangler cert upload certificate-authority --name ${caCertName} --ca-cert ca_chain_cert.pem`
 		);
 		expect(normalize(output.stdout)).toMatchInlineSnapshot(`
-			"Uploading CA Certificate ca_cert_00000000-0000-0000-0000-000000000000...
-			Success! Uploaded CA Certificate ca_cert_00000000-0000-0000-0000-000000000000
+			"Uploading CA Certificate tmp-e2e-ca-cert-00000000-0000-0000-0000-000000000000...
+			Success! Uploaded CA Certificate tmp-e2e-ca-cert-00000000-0000-0000-0000-000000000000
 			ID: 00000000-0000-0000-0000-000000000000
 			Issuer: CN=Localhost CA,OU=SSL Department,O=Localhost,L=San Francisco,ST=California,C=US
 			Expires on 11/18/2034"
@@ -164,10 +164,10 @@ describe("cert", () => {
 		const output = await helper.run(`wrangler cert list`);
 		const result = normalize(output.stdout);
 		expect(result).toContain(
-			`Name: mtls_cert_00000000-0000-0000-0000-000000000000`
+			`Name: tmp-e2e-mtls-cert-00000000-0000-0000-0000-000000000000`
 		);
 		expect(result).toContain(
-			`Name: ca_cert_00000000-0000-0000-0000-000000000000`
+			`Name: tmp-e2e-ca-cert-00000000-0000-0000-0000-000000000000`
 		);
 	});
 
@@ -177,9 +177,9 @@ describe("cert", () => {
 		);
 		expect(normalize(delete_mtls_cert_output.stdout)).toMatchInlineSnapshot(
 			`
-			"? Are you sure you want to delete certificate 00000000-0000-0000-0000-000000000000 (mtls_cert_00000000-0000-0000-0000-000000000000)?
+			"? Are you sure you want to delete certificate 00000000-0000-0000-0000-000000000000 (tmp-e2e-mtls-cert-00000000-0000-0000-0000-000000000000)?
 			🤖 Using fallback value in non-interactive context: yes
-			Deleted certificate 00000000-0000-0000-0000-000000000000 (mtls_cert_00000000-0000-0000-0000-000000000000) successfully"
+			Deleted certificate 00000000-0000-0000-0000-000000000000 (tmp-e2e-mtls-cert-00000000-0000-0000-0000-000000000000) successfully"
 			`
 		);
 	});
@@ -190,9 +190,9 @@ describe("cert", () => {
 		);
 		expect(normalize(delete_ca_cert_output.stdout)).toMatchInlineSnapshot(
 			`
-			"? Are you sure you want to delete certificate 00000000-0000-0000-0000-000000000000 (ca_cert_00000000-0000-0000-0000-000000000000)?
+			"? Are you sure you want to delete certificate 00000000-0000-0000-0000-000000000000 (tmp-e2e-ca-cert-00000000-0000-0000-0000-000000000000)?
 			🤖 Using fallback value in non-interactive context: yes
-			Deleted certificate 00000000-0000-0000-0000-000000000000 (ca_cert_00000000-0000-0000-0000-000000000000) successfully"
+			Deleted certificate 00000000-0000-0000-0000-000000000000 (tmp-e2e-ca-cert-00000000-0000-0000-0000-000000000000) successfully"
 			`
 		);
 	});

--- a/packages/wrangler/e2e/cert.test.ts
+++ b/packages/wrangler/e2e/cert.test.ts
@@ -125,8 +125,8 @@ describe("cert", () => {
 	const { certificate: caCert } = generateRootCaCert();
 
 	// Generate filenames for concurrent e2e test environment
-	const mtlsCertName = `mtls_cert_${randomUUID()}`;
-	const caCertName = `ca_cert_${randomUUID()}`;
+	const mtlsCertName = `tmp-e2e-mtls_cert_${randomUUID()}`;
+	const caCertName = `tmp-e2e-ca_cert_${randomUUID()}`;
 
 	it("upload mtls-certificate", async () => {
 		// locally generated certs/key

--- a/tools/e2e/common.ts
+++ b/tools/e2e/common.ts
@@ -36,6 +36,18 @@ export type HyperdriveConfig = {
 	created_on: string;
 };
 
+export type MTlsCertificateResponse = {
+	id: string;
+	name?: string;
+	ca: boolean;
+	certificates: string;
+	expires_on: string;
+	issuer: string;
+	serial_number: string;
+	signature: string;
+	uploaded_on: string;
+};
+
 class ApiError extends Error {
 	constructor(
 		readonly url: string,
@@ -259,6 +271,28 @@ export const listHyperdriveConfigs = async () => {
 export const deleteHyperdriveConfig = async (id: string) => {
 	await apiFetch(
 		`/hyperdrive/configs/${id}`,
+		{
+			method: "DELETE",
+		},
+		true
+	);
+};
+
+export const listCertificates = async () => {
+	const results = (await apiFetch(`/mtls_certificates`, {
+		method: "GET",
+	})) as MTlsCertificateResponse[];
+
+	return results.filter(
+		(cert) =>
+			cert.name?.includes("tmp-e2e") && // Certs are more than an hour old
+			Date.now() - new Date(cert.uploaded_on).valueOf() > 1000 * 60 * 60
+	);
+};
+
+export const deleteCertificate = async (id: string) => {
+	await apiFetch(
+		`/mtls_certificates/${id}`,
 		{
 			method: "DELETE",
 		},

--- a/tools/e2e/e2eCleanup.ts
+++ b/tools/e2e/e2eCleanup.ts
@@ -1,8 +1,10 @@
 import {
+	deleteCertificate,
 	deleteDatabase,
 	deleteKVNamespace,
 	deleteProject,
 	deleteWorker,
+	listCertificates,
 	listHyperdriveConfigs,
 	listTmpDatabases,
 	listTmpE2EProjects,
@@ -92,6 +94,19 @@ async function run() {
 	} else {
 		console.log(
 			`Successfully deleted ${hyperdriveConfigsToDelete.length} hyperdrive configs`
+		);
+	}
+
+	const mtlsCertificates = await listCertificates();
+	for (const certificate of mtlsCertificates) {
+		console.log("Deleting mTLS certificate: " + certificate.id);
+		await deleteCertificate(certificate.id);
+	}
+	if (mtlsCertificates.length === 0) {
+		console.log(`No mTLS certificates to delete.`);
+	} else {
+		console.log(
+			`Successfully deleted ${mtlsCertificates.length} mTLS certificates`
 		);
 	}
 }


### PR DESCRIPTION
Fixes n/a.

This make sure no stale certificates are left after running the e2e tests.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
