### PR TITLE
Adds waiting status to workflow list

### DIFF
--- a/.changeset/stale-turkeys-bow.md
+++ b/.changeset/stale-turkeys-bow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add waiting status to instance list command

--- a/packages/wrangler/src/workflows/types.ts
+++ b/packages/wrangler/src/workflows/types.ts
@@ -21,6 +21,7 @@ export type InstanceStatus =
 	| "paused"
 	| "errored"
 	| "terminated"
+	| "waiting"
 	| "complete";
 
 export type InstanceWithoutDates = {

--- a/packages/wrangler/src/workflows/utils.ts
+++ b/packages/wrangler/src/workflows/utils.ts
@@ -17,6 +17,10 @@ export const emojifyInstanceStatus = (status: InstanceStatus) => {
 			return "▶ Running";
 		case "terminated":
 			return "🚫 Terminated";
+		case "waiting":
+			return "⏰ Waiting";
+		default:
+			return "❓ Unknown";
 	}
 };
 


### PR DESCRIPTION
Fixes WOR-627

This PR contains a small fix to the `wrangler workflows instances list` command: `waiting` instances are now being shown correctly.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: This fix merely adds a missing `case` clause to a method that is currently not covered.
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: This fix merely adds a missing `case` clause to a method that is currently not covered.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This is a bug fix for a command that currently has incorrect behavior.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

