### PR TITLE
Add support for `waitForEvent` step type

### DIFF
--- a/packages/wrangler/src/workflows/types.ts
+++ b/packages/wrangler/src/workflows/types.ts
@@ -90,6 +90,16 @@ export type InstanceTerminateLog = {
 	};
 };
 
+export type InstanceWaitForEventLog = {
+	name: string;
+	start: string;
+	end: string;
+	finished: boolean;
+	error: { name: string; message: string } | null;
+	output: unknown;
+	type: "waitForEvent";
+};
+
 export type InstanceStatusAndLogs = {
 	status: InstanceStatus;
 	params: Record<string, unknown>;
@@ -100,7 +110,12 @@ export type InstanceStatusAndLogs = {
 	queued: string;
 	start: string | null;
 	end: string | null;
-	steps: (InstanceStepLog | InstanceSleepLog | InstanceTerminateLog)[];
+	steps: (
+		| InstanceStepLog
+		| InstanceSleepLog
+		| InstanceTerminateLog
+		| InstanceWaitForEventLog
+	)[];
 	success: boolean | null;
 	error: { name: string; message: string } | null;
 };

--- a/packages/wrangler/src/workflows/utils.ts
+++ b/packages/wrangler/src/workflows/utils.ts
@@ -41,6 +41,8 @@ export const emojifyStepType = (type: string) => {
 			return "🎯 Step";
 		case "sleep":
 			return "💤 Sleeping";
+		case "waitForEvent":
+			return "👀 Waiting for event";
 		case "termination":
 			return "🚫 Termination";
 		default:


### PR DESCRIPTION
Fixes WOR-628
This PR adds support for `waitForEvent` step type. It also shows the event's formatted output.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
