### PR TITLE
bump create-next-app to 15.3.0 for the Workers template

### DIFF
--- a/.changeset/tough-friends-share.md
+++ b/.changeset/tough-friends-share.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+bump create-next-app to 15.3.0 for the Workers template

--- a/packages/create-cloudflare/templates/next/workers/c3.ts
+++ b/packages/create-cloudflare/templates/next/workers/c3.ts
@@ -51,7 +51,7 @@ export default {
 	configVersion: 1,
 	id: "next",
 	frameworkCli: "create-next-app",
-	frameworkCliPinnedVersion: "~15.2.4",
+	frameworkCliPinnedVersion: "~15.3.0",
 	platform: "workers",
 	displayName: "Next.js (using Node.js compat + Workers Assets)",
 	path: "templates/next/workers",


### PR DESCRIPTION
Need to be rebased on #8952 (which fixes the tests)

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: version bump
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: version bump
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: c3 template

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->