### PR TITLE
Show latest instance by default

### DIFF
--- a/.changeset/stale-feet-kick.md
+++ b/.changeset/stale-feet-kick.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Shows latest instance by default if none is provided

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -142,7 +142,7 @@ describe("wrangler workflows", () => {
 
 				COMMANDS
 				  wrangler workflows instances list <name>            Instance related commands (list, describe, terminate, pause, resume)
-				  wrangler workflows instances describe <name> <id>   Describe a workflow instance - see its logs, retries and errors
+				  wrangler workflows instances describe <name> [id]   Describe a workflow instance - see its logs, retries and errors
 				  wrangler workflows instances terminate <name> <id>  Terminate a workflow instance
 				  wrangler workflows instances pause <name> <id>      Pause a workflow instance
 				  wrangler workflows instances resume <name> <id>     Resume a workflow instance
@@ -314,6 +314,18 @@ describe("wrangler workflows", () => {
 						});
 					},
 					{ once: true }
+				),
+				http.get(
+					`*/accounts/:accountId/workflows/some-workflow/instances`,
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: [mockResponse],
+						});
+					},
+					{ once: true }
 				)
 			);
 		};
@@ -323,6 +335,20 @@ describe("wrangler workflows", () => {
 			await mockDescribeInstances();
 
 			await runWrangler(`workflows instances describe some-workflow bar`);
+			expect(std.out).toMatchInlineSnapshot(`
+"┌───────────────────────┬───────────────────────┬───────────┬────────────┬────────────────┐
+│ Start                 │ End                   │ Duration  │ State      │ Error          │
+├───────────────────────┼───────────────────────┼───────────┼────────────┼────────────────┤
+│ 1/1/2021, 12:00:00 AM │ 1/1/2021, 12:00:00 AM │ 0 seconds │ ✅ Success │ string: string │
+└───────────────────────┴───────────────────────┴───────────┴────────────┴────────────────┘"
+			`);
+		});
+
+		it("should describe the latest instance if none is provided", async () => {
+			writeWranglerConfig();
+			await mockDescribeInstances();
+
+			await runWrangler(`workflows instances describe some-workflow`);
 			expect(std.out).toMatchInlineSnapshot(`
 "┌───────────────────────┬───────────────────────┬───────────┬────────────┬────────────────┐
 │ Start                 │ End                   │ Duration  │ State      │ Error          │

--- a/packages/wrangler/src/workflows/commands/instances/describe.ts
+++ b/packages/wrangler/src/workflows/commands/instances/describe.ts
@@ -43,7 +43,8 @@ export const workflowsInstancesDescribeCommand = createCommand({
 			describe:
 				"ID of the instance - instead of an UUID you can type 'latest' to get the latest instance and describe it",
 			type: "string",
-			demandOption: true,
+			demandOption: false,
+			default: "latest",
 		},
 		"step-output": {
 			describe:


### PR DESCRIPTION
Fixes WOR-290

For convenience reasons, we default to the latest instance on the `wrangler instances describe <INSTANCE_NAME>` command. The `id` field becomes optional.

---


- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This change is correctly reflected on the `wrangler help` command
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: new features don't need backports