### PR TITLE
Show latest instance by default

### DIFF
--- a/.changeset/yummy-dolls-rescue.md
+++ b/.changeset/yummy-dolls-rescue.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Show latest instance by dafault on `workflows instances describe` command

--- a/.changeset/yummy-dolls-rescue.md
+++ b/.changeset/yummy-dolls-rescue.md
@@ -2,4 +2,4 @@
 "wrangler": minor
 ---
 
-Show latest instance by dafault on `workflows instances describe` command
+Show latest instance by default on `workflows instances describe` command

--- a/packages/wrangler/src/__tests__/workflows.test.ts
+++ b/packages/wrangler/src/__tests__/workflows.test.ts
@@ -150,7 +150,7 @@ describe("wrangler workflows", () => {
 
 				COMMANDS
 				  wrangler workflows instances list <name>            Instance related commands (list, describe, terminate, pause, resume)
-				  wrangler workflows instances describe <name> <id>   Describe a workflow instance - see its logs, retries and errors
+				  wrangler workflows instances describe <name> [id]   Describe a workflow instance - see its logs, retries and errors
 				  wrangler workflows instances terminate <name> <id>  Terminate a workflow instance
 				  wrangler workflows instances pause <name> <id>      Pause a workflow instance
 				  wrangler workflows instances resume <name> <id>     Resume a workflow instance
@@ -380,6 +380,18 @@ describe("wrangler workflows", () => {
 						});
 					},
 					{ once: true }
+				),
+				http.get(
+					`*/accounts/:accountId/workflows/some-workflow/instances`,
+					async () => {
+						return HttpResponse.json({
+							success: true,
+							errors: [],
+							messages: [],
+							result: [mockResponse],
+						});
+					},
+					{ once: true }
 				)
 			);
 		};
@@ -389,6 +401,33 @@ describe("wrangler workflows", () => {
 			await mockDescribeInstances();
 
 			await runWrangler(`workflows instances describe some-workflow bar`);
+			expect(std.out).toMatchInlineSnapshot(`
+				"  Name:      event
+				  Type:      👀 Waiting for event
+				  Start:     [mock-start-date]
+				  End:       [mock-end-date]
+				  Duration:  4 years
+				  Output:    {}
+				  Name:      string
+				  Type:      🎯 Step
+				  Start:     [mock-start-date]
+				  End:       [mock-end-date]
+				  Duration:  4 years
+				  Success:   ✅ Yes
+				  Output:    {}
+				┌─┬─┬─┬─┬─┐
+				│ Start │ End │ Duration │ State │ Error │
+				├─┼─┼─┼─┼─┤
+				│ [mock-start-date] │ [mock-end-date] │ 4 years │ ✅ Success │ string: string │
+				└─┴─┴─┴─┴─┘"
+			`);
+		});
+
+		it("should describe the latest instance if none is given", async () => {
+			writeWranglerConfig();
+			await mockDescribeInstances();
+
+			await runWrangler(`workflows instances describe some-workflow`);
 			expect(std.out).toMatchInlineSnapshot(`
 				"  Name:      event
 				  Type:      👀 Waiting for event

--- a/packages/wrangler/src/workflows/commands/instances/describe.ts
+++ b/packages/wrangler/src/workflows/commands/instances/describe.ts
@@ -44,7 +44,8 @@ export const workflowsInstancesDescribeCommand = createCommand({
 			describe:
 				"ID of the instance - instead of an UUID you can type 'latest' to get the latest instance and describe it",
 			type: "string",
-			demandOption: true,
+			demandOption: false,
+			default: "latest",
 		},
 		"step-output": {
 			describe:
@@ -78,6 +79,7 @@ export const workflowsInstancesDescribeCommand = createCommand({
 				return;
 			}
 
+			logRaw("Describing latest instance:");
 			id = instances[0].id;
 		}
 


### PR DESCRIPTION
Fixes WOR-290

For convenience reasons, we default to the latest instance on the `wrangler instances describe <WORKFLOW_NAME>` command. The `id` field becomes optional.


- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/21784
  - [ ] Documentation not necessary because: This change is correctly reflected on the `wrangler help` command.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR:
  - [x] Not necessary because: not a patch change
