### PR TITLE
fix(create-cloudflare): keep the default _headers and _redirects files in the qwik workers template

### DIFF
--- a/.changeset/fancy-cobras-rhyme.md
+++ b/.changeset/fancy-cobras-rhyme.md
@@ -1,5 +1,5 @@
 ---
-"create-cloudflare": patch
+"create-cloudflare": minor
 ---
 
 updated the qwik cloudflare workers template to keep the default \_headers and \_redirects files

--- a/.changeset/fancy-cobras-rhyme.md
+++ b/.changeset/fancy-cobras-rhyme.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+updated the qwik cloudflare workers template to keep the default \_headers and \_redirects files

--- a/packages/create-cloudflare/templates/qwik/workers/c3.ts
+++ b/packages/create-cloudflare/templates/qwik/workers/c3.ts
@@ -1,4 +1,4 @@
-import { crash, endSection } from "@cloudflare/cli";
+import { endSection } from "@cloudflare/cli";
 import { brandColor } from "@cloudflare/cli/colors";
 import { spinner } from "@cloudflare/cli/interactive";
 import { runFrameworkGenerator } from "frameworks/index";
@@ -24,8 +24,6 @@ const configure = async (ctx: C3Context) => {
 	await runCommand(cmd);
 
 	// Remove the extraneous Pages files
-	removeFile("./public/_headers");
-	removeFile("./public/_redirects");
 	removeFile("./public/_routes.json");
 
 	addBindingsProxy(ctx);
@@ -81,7 +79,7 @@ const addBindingsProxy = (ctx: C3Context) => {
 			}
 
 			if (configArgument.type !== "ObjectExpression") {
-				crash("Failed to update `vite.config.ts`");
+				throw new Error("Failed to update `vite.config.ts`");
 			}
 
 			// Add the `platform` object to the object


### PR DESCRIPTION
Fixes [DEVX-1692](https://jira.cfdata.org/browse/DEVX-1692)

_headers and _redirects are now supported with Static Assets

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact to wrangler or vite
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature change. just an optimization.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: no impact to wrangler or vite

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
