### PR TITLE
Removes open-beta disclaimer from workflows commands

### DIFF
--- a/.changeset/eighty-knives-reply.md
+++ b/.changeset/eighty-knives-reply.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Remove open-beta disclaimer from workflows commands

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -12350,7 +12350,7 @@ export default{
 			msw.use(handler);
 		}
 
-		it("should not log open-beta warning when deploying a workflow", async () => {
+		it("should deploy a workflow", async () => {
 			writeWranglerConfig({
 				main: "index.js",
 				workflows: [

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -12350,7 +12350,7 @@ export default{
 			msw.use(handler);
 		}
 
-		it("should log open-beta warning when deploying a workflow", async () => {
+		it("should not log open-beta warning when deploying a workflow", async () => {
 			writeWranglerConfig({
 				main: "index.js",
 				workflows: [
@@ -12385,11 +12385,7 @@ export default{
 
 			await runWrangler("deploy");
 
-			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWorkflows is currently in open beta.[0m
-
-				"
-			`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -235,10 +235,6 @@ export const deployCommand = createCommand({
 
 		const entry = await getEntry(args, config, "deploy");
 
-		if (config.workflows?.length) {
-			logger.once.warn("Workflows is currently in open beta.");
-		}
-
 		validateAssetsArgsAndConfig(args, config);
 
 		const assetsOptions = getAssetsOptions(args, config);

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -284,8 +284,6 @@ export default async function triggersDeploy(
 	}
 
 	if (config.workflows?.length) {
-		logger.once.warn("Workflows is currently in open beta.");
-
 		for (const workflow of config.workflows) {
 			// NOTE: if the user provides a script_name thats not this script (aka bounds to another worker)
 			// we don't want to send this worker's config.

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -11,7 +11,6 @@ import { fetchResult } from "../cfetch";
 import { createCommand } from "../core/create-command";
 import { UserError } from "../errors";
 import { isNonInteractiveOrCI } from "../is-interactive";
-import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { writeOutput } from "../output";
 import { APIError } from "../parse";
@@ -117,10 +116,6 @@ export const versionsDeployCommand = createCommand({
 				'You need to provide a name of your worker. Either pass it as a cli arg with `--name <name>` or in your config file as `name = "<name>"`',
 				{ telemetryMessage: true }
 			);
-		}
-
-		if (config.workflows?.length) {
-			logger.once.warn("Workflows is currently in open beta.");
 		}
 
 		const versionCache: VersionCache = new Map();

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -281,10 +281,6 @@ export const versionsUploadCommand = createCommand({
 			);
 		}
 
-		if (config.workflows?.length) {
-			logger.once.warn("Workflows is currently in open beta.");
-		}
-
 		validateAssetsArgsAndConfig(
 			{
 				site: undefined,


### PR DESCRIPTION
Fixes WOR-637

This PR removes the open-beta disclaimer that is now outdated since Workflows is GA.

---


- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No new feature was added. This merely removes an outdated disclaimer.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: 
  - [x] Not necessary because: workflows is open beta in v3
