### PR TITLE
Install `@opennextjs/cloudflare` as regular dependency

### DIFF
--- a/.changeset/heavy-sides-shake.md
+++ b/.changeset/heavy-sides-shake.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Install `@opennextjs/cloudflare` as regular dependency

--- a/packages/create-cloudflare/templates/next/workers/c3.ts
+++ b/packages/create-cloudflare/templates/next/workers/c3.ts
@@ -11,14 +11,9 @@ const generate = async (ctx: C3Context) => {
 };
 
 const configure = async (ctx: C3Context) => {
-	const packages = [
-		"@opennextjs/cloudflare@~1.0.0-beta.0 || ^1.0.0",
-		"@cloudflare/workers-types",
-	];
-	await installPackages(packages, {
-		dev: true,
+	await installPackages(["@opennextjs/cloudflare@~1.0.0-beta.0 || ^1.0.0"], {
 		startText: "Adding the Cloudflare adapter",
-		doneText: `${brandColor(`installed`)} ${dim(packages.join(", "))}`,
+		doneText: `${brandColor(`installed`)} @opennextjs/cloudflare)}`,
 	});
 
 	const usesTs = usesTypescript(ctx);


### PR DESCRIPTION
Changes in this PR:

- `@opennextjs/cloudflare` should be installed as a regular dep
- `@cloudflare/workers-types` is already installed and does not need to be explicitly installed (types should be generated soon).

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: already tested
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: template update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->