### PR TITLE
feat(wrangler): Error if worker-level fields are configured in a static-site only Worker

### DIFF
--- a/.changeset/tiny-hands-refuse.md
+++ b/.changeset/tiny-hands-refuse.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Error if worker-level fields are configured in a static-site only Worker

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4442,7 +4442,6 @@ addEventListener('fetch', event => {});`
 				.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Assets-only Workers do not support the following configuration keys:
 
-				⋅ "send_metrics"
 				⋅ "vars"
 				⋅ "kv_namespaces"
 				⋅ "services"
@@ -4474,7 +4473,6 @@ addEventListener('fetch', event => {});`
 				.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Assets-only Workers do not support the following configuration keys:
 
-				⋅ "send_metrics"
 				⋅ "vars"
 				⋅ "kv_namespaces"
 				⋅ "services"
@@ -4508,7 +4506,6 @@ addEventListener('fetch', event => {});`
 					.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Assets-only Workers do not support the following configuration keys:
 
-				⋅ "send_metrics"
 				⋅ "vars"
 				⋅ "kv_namespaces"
 				⋅ "services"

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4416,6 +4416,108 @@ addEventListener('fetch', event => {});`
 			`);
 		});
 
+		it("should error when deploying an assets-only Worker with unsupported configuration for assets-only", async () => {
+			writeWranglerConfig({
+				assets: {
+					directory: "assets",
+				},
+				send_metrics: true,
+				vars: {
+					MY_VAR: "my var",
+				},
+				services: [
+					{
+						binding: "BINDING_NAME",
+						service: "WORKER_NAME",
+					},
+				],
+				kv_namespaces: [
+					{
+						id: "123",
+						binding: "KV_BINDING_NAME",
+					},
+				],
+			});
+			await expect(runWrangler("deploy")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Assets-only Workers do not support the following configuration keys:
+
+				⋅ "send_metrics"
+				⋅ "vars"
+				⋅ "kv_namespaces"
+				⋅ "services"
+
+				Please remove these fields from your configuration file, or configure the "main" field if you are trying to deploy a Worker with assets.]
+			`);
+		});
+
+		it("should error when deploying an assets-only Worker via the --assets flag, with unsupported configuration for assets-only", async () => {
+			writeWranglerConfig({
+				send_metrics: true,
+				vars: {
+					MY_VAR: "my var",
+				},
+				services: [
+					{
+						binding: "BINDING_NAME",
+						service: "WORKER_NAME",
+					},
+				],
+				kv_namespaces: [
+					{
+						id: "123",
+						binding: "KV_BINDING_NAME",
+					},
+				],
+			});
+			await expect(runWrangler("deploy --assets assets")).rejects
+				.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Assets-only Workers do not support the following configuration keys:
+
+				⋅ "send_metrics"
+				⋅ "vars"
+				⋅ "kv_namespaces"
+				⋅ "services"
+
+				Please remove these fields from your configuration file, or configure the "main" field if you are trying to deploy a Worker with assets.]
+			`);
+		});
+
+		it.fails(
+			"should error when deploying an assets-only Worker with unsupported flags for assets-only set",
+			async () => {
+				writeWranglerConfig({
+					assets: {
+						directory: "xyz",
+					},
+					send_metrics: true,
+					services: [
+						{
+							binding: "BINDING_NAME",
+							service: "WORKER_NAME",
+						},
+					],
+					kv_namespaces: [
+						{
+							id: "123",
+							binding: "KV_BINDING_NAME",
+						},
+					],
+				});
+				await expect(runWrangler("deploy --var MY_VAR:13")).rejects
+					.toThrowErrorMatchingInlineSnapshot(`
+				[Error: Assets-only Workers do not support the following configuration keys:
+
+				⋅ "send_metrics"
+				⋅ "vars"
+				⋅ "kv_namespaces"
+				⋅ "services"
+
+				Please remove these fields from your configuration file, or configure the "main" field if you are trying to deploy a Worker with assets.]
+			`);
+			}
+		);
+
 		it("should warn when using smart placement with Worker first", async () => {
 			const assets = [
 				{ filePath: ".assetsignore", content: "*.bak\nsub-dir" },

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1537,7 +1537,6 @@ describe.sequential("wrangler dev", () => {
 				.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Assets-only Workers do not support the following configuration keys:
 
-				⋅ "send_metrics"
 				⋅ "vars"
 				⋅ "kv_namespaces"
 				⋅ "services"
@@ -1570,7 +1569,6 @@ describe.sequential("wrangler dev", () => {
 				.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Assets-only Workers do not support the following configuration keys:
 
-				⋅ "send_metrics"
 				⋅ "vars"
 				⋅ "kv_namespaces"
 				⋅ "services"
@@ -1605,7 +1603,6 @@ describe.sequential("wrangler dev", () => {
 					.toThrowErrorMatchingInlineSnapshot(`
 				[Error: Assets-only Workers do not support the following configuration keys:
 
-				⋅ "send_metrics"
 				⋅ "vars"
 				⋅ "kv_namespaces"
 				⋅ "services"

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -199,7 +199,6 @@ describe("versions upload", () => {
 			.toThrowErrorMatchingInlineSnapshot(`
 			[Error: Assets-only Workers do not support the following configuration keys:
 
-			⋅ "send_metrics"
 			⋅ "vars"
 			⋅ "kv_namespaces"
 			⋅ "services"
@@ -231,7 +230,6 @@ describe("versions upload", () => {
 			.toThrowErrorMatchingInlineSnapshot(`
 			[Error: Assets-only Workers do not support the following configuration keys:
 
-			⋅ "send_metrics"
 			⋅ "vars"
 			⋅ "kv_namespaces"
 			⋅ "services"

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -172,4 +172,71 @@ describe("versions upload", () => {
 
 		expect(std.info).toContain("Retrying API call after error...");
 	});
+
+	it("should error when uploading an assets-only Worker with unsupported configuration for assets-only", async () => {
+		writeWranglerConfig({
+			assets: {
+				directory: "xyz",
+			},
+			send_metrics: true,
+			vars: {
+				MY_VAR: "my var",
+			},
+			services: [
+				{
+					binding: "BINDING_NAME",
+					service: "WORKER_NAME",
+				},
+			],
+			kv_namespaces: [
+				{
+					id: "123",
+					binding: "KV_BINDING_NAME",
+				},
+			],
+		});
+		await expect(runWrangler("versions upload")).rejects
+			.toThrowErrorMatchingInlineSnapshot(`
+			[Error: Assets-only Workers do not support the following configuration keys:
+
+			⋅ "send_metrics"
+			⋅ "vars"
+			⋅ "kv_namespaces"
+			⋅ "services"
+
+			Please remove these fields from your configuration file, or configure the "main" field if you are trying to deploy a Worker with assets.]
+		`);
+	});
+
+	it("should error when uploading an assets-only Worker via the --assets flag, with unsupported configuration for assets-only", async () => {
+		writeWranglerConfig({
+			send_metrics: true,
+			vars: {
+				MY_VAR: "my var",
+			},
+			services: [
+				{
+					binding: "BINDING_NAME",
+					service: "WORKER_NAME",
+				},
+			],
+			kv_namespaces: [
+				{
+					id: "123",
+					binding: "KV_BINDING_NAME",
+				},
+			],
+		});
+		await expect(runWrangler("versions upload --assets assets")).rejects
+			.toThrowErrorMatchingInlineSnapshot(`
+			[Error: Assets-only Workers do not support the following configuration keys:
+
+			⋅ "send_metrics"
+			⋅ "vars"
+			⋅ "kv_namespaces"
+			⋅ "services"
+
+			Please remove these fields from your configuration file, or configure the "main" field if you are trying to deploy a Worker with assets.]
+		`);
+	});
 });

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -328,7 +328,14 @@ async function resolveConfig(
 		);
 	}
 
-	validateAssetsArgsAndConfig(resolved);
+	validateAssetsArgsAndConfig(
+		{
+			site: resolved.legacy.site?.bucket,
+			assets: input.assets,
+			script: input.entrypoint,
+		},
+		config
+	);
 
 	const services = extractBindingsOfType("service", resolved.bindings);
 	if (services && services.length > 0 && resolved.dev?.remote) {

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -556,6 +556,7 @@ function getConfigKeysUnsupportedByAssetsOnly(config: Config): Array<string> {
 		"build",
 		"dev",
 		"routes",
+		"send_metrics",
 		// computed fields (see normalizeAndValidateConfig())
 		"configPath",
 		"userConfigPath",

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -235,7 +235,14 @@ export const deployCommand = createCommand({
 
 		const entry = await getEntry(args, config, "deploy");
 
-		validateAssetsArgsAndConfig(args, config);
+		validateAssetsArgsAndConfig(
+			{
+				site: args.site,
+				assets: args.assets,
+				script: args.script,
+			},
+			config
+		);
 
 		const assetsOptions = getAssetsOptions(args, config);
 


### PR DESCRIPTION
Fixes DEVX-1560.

Some configuration fields don't make sense for assets-only Workers, and are silently dropped on deploy. This PR throws an error if such fields are found in the `wrangler.toml` file.

<img width="1294" alt="Screenshot 2025-04-17 at 13 34 13" src="https://github.com/user-attachments/assets/09aae038-68e7-4d6c-a489-d5196ebe4c0c" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not docummented
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: minor change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
