### PR TITLE
feat(wrangler): Require user confirmation before running remote dev with assets

### DIFF
--- a/.changeset/cold-pans-crash.md
+++ b/.changeset/cold-pans-crash.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Require user confirmation before running a remote development session with Workers + assets


### PR DESCRIPTION
Fixes DEVX-1562

This PR adds a prompt when running `wrangler dev --remote` with assets, informing users of possible consequences, and requiring user confirmation to proceed 

<img width="1032" alt="Screenshot 2025-04-17 at 14 37 21" src="https://github.com/user-attachments/assets/7c2037c6-ea22-434f-ad14-aac0b2f2fafc" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not documented
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: minor change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
