### PR TITLE
[vite-plugin-cloudflare] fix: secrets store persist path

### DIFF
--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -62,7 +62,7 @@ function getPersistence(
 		kvPersist: path.join(persistPath, "kv"),
 		r2Persist: path.join(persistPath, "r2"),
 		workflowsPersist: path.join(persistPath, "workflows"),
-		secretsStorePersist: path.join(persistPath, "secrets-store"),
+		secretsStorePersist: path.join(persistPath, "kv"),
 	};
 }
 

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -37,6 +37,7 @@ type PersistOptions = Pick<
 	| "kvPersist"
 	| "r2Persist"
 	| "workflowsPersist"
+	| "secretsStorePersist"
 >;
 
 function getPersistence(
@@ -61,6 +62,7 @@ function getPersistence(
 		kvPersist: path.join(persistPath, "kv"),
 		r2Persist: path.join(persistPath, "r2"),
 		workflowsPersist: path.join(persistPath, "workflows"),
+		secretsStorePersist: path.join(persistPath, "secrets-store"),
 	};
 }
 

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -204,6 +204,7 @@ function getMiniflarePersistOptions(
 	persist: GetPlatformProxyOptions["persist"]
 ): Pick<
 	MiniflareOptions,
+	| "secretsStorePersist"
 	| "kvPersist"
 	| "durableObjectsPersist"
 	| "r2Persist"
@@ -218,6 +219,7 @@ function getMiniflarePersistOptions(
 			r2Persist: false,
 			d1Persist: false,
 			workflowsPersist: false,
+			secretsStorePersist: false,
 		};
 	}
 
@@ -232,6 +234,7 @@ function getMiniflarePersistOptions(
 		r2Persist: `${persistPath}/r2`,
 		d1Persist: `${persistPath}/d1`,
 		workflowsPersist: `${persistPath}/workflows`,
+		secretsStorePersist: `${persistPath}/kv`,
 	};
 }
 

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -788,7 +788,7 @@ export function buildPersistOptions(
 			r2Persist: path.join(v3Path, "r2"),
 			d1Persist: path.join(v3Path, "d1"),
 			workflowsPersist: path.join(v3Path, "workflows"),
-			secretsStorePersist: path.join(v3Path, "secrets-store"),
+			secretsStorePersist: path.join(v3Path, "kv"),
 		};
 	}
 }


### PR DESCRIPTION
Fixes [#9006](https://github.com/cloudflare/workers-sdk/issues/9006).

_add persist path for secrets store for vite-plugin_

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
