### PR TITLE
Add undefined/null checks to containers list

### DIFF
--- a/.changeset/cold-aliens-learn.md
+++ b/.changeset/cold-aliens-learn.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Correctly handle 0 length responses to wrangler containers list.

--- a/packages/wrangler/src/containers/containers.ts
+++ b/packages/wrangler/src/containers/containers.ts
@@ -175,6 +175,18 @@ async function listCommandHandle(
 			return;
 		}
 
+		// If we don't get multiple applications for any reason exit
+		if (
+			applications === undefined ||
+			applications === null ||
+			applications.length === 0
+		) {
+			logRaw(
+				"No containers found. See https://dash.cloudflare.com/?to=/:account/workers/containers to learn more."
+			);
+			return;
+		}
+
 		const applicationDetails = (a: Application) => {
 			const details = flatDetails(a);
 			return {


### PR DESCRIPTION
Provide helpful error message when user lists containers but has none to list instead of an obscure error.

_Describe your change..._
Fixes an error where a user doing:
`wrangler containers list` but had no containers would get an error message like:

"Cannot read properties of undefined..." 
Because the returned applications list was empty.

This adds checks for undefined/null/length 0 and provides a reasonable error message with a link to the containers dash which has pointers to 
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: This is a change to an interactive command which does not have tests yet.
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No e2e exists for containers/cloudchamber.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No behavior change.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: The containers subcommand is only present in v4.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
