### PR TITLE
fix(miniflare): kv services name should be unique per persist path

### DIFF
--- a/.changeset/cool-socks-stay.md
+++ b/.changeset/cool-socks-stay.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: kv services name should be unique per persist path
+
+This fix ensures that the KV and Secret Store plugin will create a dedicated object and storage service when they have a different persist path.

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -51,7 +51,7 @@ function addPersistPathSuffix(
 	persistPath: Persistence
 ): string {
 	if (typeof persistPath === "string") {
-		return `${baseName}:${persistPath}`;
+		return `${baseName}:${encodeURIComponent(persistPath)}`;
 	}
 
 	return baseName;


### PR DESCRIPTION
Fixes n/a.

This PR improves the KV store service name so that it could have several storage and object service with a different persist key.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: v4 only feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
