### PR TITLE
feat(create-cloudflare): update react template to fix type errors

### DIFF
--- a/.changeset/fluffy-mice-attack.md
+++ b/.changeset/fluffy-mice-attack.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+update react template to fix type errors

--- a/packages/create-cloudflare/templates/react/workers/c3.ts
+++ b/packages/create-cloudflare/templates/react/workers/c3.ts
@@ -36,7 +36,7 @@ const configure = async (ctx: C3Context) => {
 		doneText: `${brandColor(`installed`)} ${dim("@cloudflare/vite-plugin")}`,
 	});
 
-	await transformViteConfig(ctx);
+	transformViteConfig(ctx);
 
 	if (usesTypescript(ctx)) {
 		updateTsconfigJson();

--- a/packages/create-cloudflare/templates/react/workers/ts/tsconfig.worker.json
+++ b/packages/create-cloudflare/templates/react/workers/ts/tsconfig.worker.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.node.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
-    "types": ["@cloudflare/workers-types/2023-07-01", "./worker-configuration.d.ts", "vite/client"],
+    "types": ["@cloudflare/workers-types/2023-07-01", "vite/client"]
   },
-  "include": ["worker"],
+  "include": ["./worker-configuration.d.ts", "./worker"]
 }


### PR DESCRIPTION
- remove the `await` keyword used when calling non-async function.
- update React workers template to fix type errors

#### before
<img width="472" alt="스크린샷 2025-04-23 오후 1 30 00" src="https://github.com/user-attachments/assets/2d5f2099-6fba-4094-8c2e-6893c2bc8d11" />

#### after
<img width="853" alt="스크린샷 2025-04-23 오후 1 30 30" src="https://github.com/user-attachments/assets/3d0eda70-7d2a-450c-884a-2acad5183d29" />

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tsconfig change + remove unnecessary `await`
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: tsconfig change + remove unnecessary `await`
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tsconfig change + remove unnecessary `await`
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
