### PR TITLE
V3 backport[#8990]: Fix version metadata binding type in when generating env type

### DIFF
--- a/.changeset/plenty-beans-enjoy.md
+++ b/.changeset/plenty-beans-enjoy.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: When generating Env types, set type of version metadata binding to `WorkerVersionMetadata`. This means it now correctly includes the `timestamp` field.

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -342,7 +342,7 @@ describe("generateTypes()", () => {
 			BROWSER_BINDING: Fetcher;
 			AI_BINDING: Ai;
 			IMAGES_BINDING: ImagesBinding;
-			VERSION_METADATA_BINDING: { id: string; tag: string };
+			VERSION_METADATA_BINDING: WorkerVersionMetadata;
 			ASSETS_BINDING: Fetcher;
 		}
 		declare module \\"*.txt\\" {

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -428,7 +428,7 @@ async function generateTypes(
 	if (configToDTS.version_metadata) {
 		envTypeStructure.push([
 			configToDTS.version_metadata.binding,
-			"{ id: string; tag: string }",
+			"WorkerVersionMetadata",
 		]);
 	}
 


### PR DESCRIPTION
Manual backport PR of https://github.com/cloudflare/workers-sdk/pull/8990

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
