### PR TITLE
Add Jaeger tracing to unstable asset-worker methods

### DIFF
--- a/.changeset/blue-suns-battle.md
+++ b/.changeset/blue-suns-battle.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Adds tracing into asset-worker unstable methods so we can better measure/debug these.

--- a/packages/workers-shared/asset-worker/wrangler.toml
+++ b/packages/workers-shared/asset-worker/wrangler.toml
@@ -73,5 +73,5 @@ name = "ASSETS_KV_NAMESPACE"
 type = "internal_assets"
 
 [[env.staging.unsafe.bindings]]
-name = "workers-asset-worker"
+name = "workers-asset-worker-staging"
 type = "internal_capability_grants"

--- a/packages/workers-shared/router-worker/wrangler.toml
+++ b/packages/workers-shared/router-worker/wrangler.toml
@@ -65,5 +65,5 @@ stable_id = "cloudflare/cf_router_worker"
 networks = ["cf","jdc"]
 
 [[env.staging.unsafe.bindings]]
-name = "workers-router-worker"
+name = "workers-router-worker-staging"
 type = "internal_capability_grants"


### PR DESCRIPTION
Fixes n/a.

Adds tracing into asset-worker unstable methods so we can better measure/debug these.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: internal tracing
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal only
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

