### PR TITLE
fix: Validate input file for Vectorize inserts

### DIFF
--- a/.changeset/stupid-paws-slide.md
+++ b/.changeset/stupid-paws-slide.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: Validate input file for Vectorize inserts

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.test.ts
@@ -300,13 +300,9 @@ describe("vectorize commands", () => {
 
 		await expect(
 			runWrangler("vectorize create test-index --dimensions=1536")
-		).resolves.toBeUndefined();
-
-		expect(std.err).toMatchInlineSnapshot(`
-				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mYou must provide both dimensions and a metric, or a known model preset when creating an index.[0m
-
-"
-			`);
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: 🚨 You must provide both dimensions and a metric, or a known model preset when creating an index.]`
+		);
 	});
 
 	it("should handle listing vectorize V1 indexes", async () => {
@@ -462,13 +458,12 @@ describe("vectorize commands", () => {
 
 	it("should log error when getByIds does not receive ids", async () => {
 		mockVectorizeV2Request();
-		await runWrangler("vectorize get-vectors test-index --ids");
 
-		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Please provide valid vector identifiers.[0m
-
-"
-		`);
+		await expect(
+			runWrangler("vectorize get-vectors test-index --ids")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: 🚨 Please provide valid vector identifiers.]`
+		);
 	});
 
 	it("should handle a deleteByIds on a vectorize index", async () => {
@@ -482,13 +477,12 @@ describe("vectorize commands", () => {
 
 	it("should log error when deleteByIds does not receive ids", async () => {
 		mockVectorizeV2Request();
-		await runWrangler("vectorize delete-vectors test-index --ids");
 
-		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Please provide valid vector identifiers for deletion.[0m
-
-"
-		`);
+		await expect(
+			runWrangler("vectorize delete-vectors test-index --ids")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: 🚨 Please provide valid vector identifiers for deletion.]`
+		);
 	});
 
 	it("should handle a query on a vectorize index", async () => {
@@ -551,30 +545,22 @@ describe("vectorize commands", () => {
 
 	it("should fail query when neither vector nor vector-id is provided", async () => {
 		mockVectorizeV2RequestError();
-		await runWrangler(
-			"vectorize query test-index --top-k=2 --return-values=true"
+		await expect(
+			runWrangler("vectorize query test-index --top-k=2 --return-values=true")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: 🚨 Either vector or vector-id parameter must be provided, but not both.]`
 		);
-		expect(std.out).toMatchInlineSnapshot(`""`);
-
-		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Either vector or vector-id parameter must be provided, but not both.[0m
-
-"
-		`);
 	});
 
 	it("should fail query when both vector and vector-id are provided", async () => {
 		mockVectorizeV2RequestError();
-		await runWrangler(
-			"vectorize query test-index --vector 1 2 3 '4' --vector-id some-vector-id"
+		await expect(
+			runWrangler(
+				"vectorize query test-index --vector 1 2 3 '4' --vector-id some-vector-id"
+			)
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: 🚨 Either vector or vector-id parameter must be provided, but not both.]`
 		);
-		expect(std.out).toMatchInlineSnapshot(`""`);
-
-		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Either vector or vector-id parameter must be provided, but not both.[0m
-
-"
-		`);
 	});
 
 	it("should fail query with invalid return-metadata flag", async () => {

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
@@ -224,26 +224,20 @@ describe("dataset upsert", () => {
 	});
 
 	it("should reject an invalid file param", async () => {
-		await runWrangler(
-			`vectorize upsert my-index --file invalid_vectors.ndjson`
+		await expect(
+			runWrangler("vectorize upsert my-index --file invalid_vectors.ndjson")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: 🚨 Cannot read invalid or empty file: invalid_vectors.ndjson.]`
 		);
-
-		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Cannot read invalid or empty file: invalid_vectors.ndjson.[0m
-
-"
-		`);
 	});
 
 	it("should reject an empty file param", async () => {
 		writeFileSync("empty_vectors.ndjson", "");
 
-		await runWrangler(`vectorize upsert my-index --file empty_vectors.ndjson`);
-
-		expect(std.err).toMatchInlineSnapshot(`
-			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Cannot read invalid or empty file: empty_vectors.ndjson.[0m
-
-"
-		`);
+		await expect(
+			runWrangler("vectorize upsert my-index --file empty_vectors.ndjson")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: 🚨 Cannot read invalid or empty file: empty_vectors.ndjson.]`
+		);
 	});
 });

--- a/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
+++ b/packages/wrangler/src/__tests__/vectorize/vectorize.upsert.test.ts
@@ -222,4 +222,28 @@ describe("dataset upsert", () => {
 		✅ Successfully enqueued 5 vectors into index 'my-index' for upsertion."
 	`);
 	});
+
+	it("should reject an invalid file param", async () => {
+		await runWrangler(
+			`vectorize upsert my-index --file invalid_vectors.ndjson`
+		);
+
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Cannot read invalid or empty file: invalid_vectors.ndjson.[0m
+
+"
+		`);
+	});
+
+	it("should reject an empty file param", async () => {
+		writeFileSync("empty_vectors.ndjson", "");
+
+		await runWrangler(`vectorize upsert my-index --file empty_vectors.ndjson`);
+
+		expect(std.err).toMatchInlineSnapshot(`
+			"[31mX [41;31m[[41;97mERROR[41;31m][0m [1m🚨 Cannot read invalid or empty file: empty_vectors.ndjson.[0m
+
+"
+		`);
+	});
 });

--- a/packages/wrangler/src/vectorize/common.ts
+++ b/packages/wrangler/src/vectorize/common.ts
@@ -1,3 +1,4 @@
+import { access, constants, stat } from "node:fs/promises";
 import { logger } from "../logger";
 import type { Interface as RLInterface } from "node:readline";
 
@@ -7,6 +8,20 @@ export const VECTORIZE_V1_MAX_BATCH_SIZE = 1_000;
 export const VECTORIZE_MAX_BATCH_SIZE = 5_000;
 export const VECTORIZE_UPSERT_BATCH_SIZE = VECTORIZE_V1_MAX_BATCH_SIZE;
 export const VECTORIZE_MAX_UPSERT_VECTOR_RECORDS = 100_000;
+
+// Helper function to carry out initial validations to a file supplied for
+// Vectorize upserts/inserts. This function returns true only if the file exists,
+// can be read, and is non-empty.
+export async function isValidFile(path: string): Promise<boolean> {
+	try {
+		await access(path, constants.R_OK);
+
+		const fileStat = await stat(path);
+		return fileStat.isFile() && fileStat.size > 0;
+	} catch (err) {
+		return false;
+	}
+}
 
 // helper method that reads an ndjson file line by line in batches. not this doesn't
 // actually do any parsing - that will be handled on the backend

--- a/packages/wrangler/src/vectorize/create.ts
+++ b/packages/wrangler/src/vectorize/create.ts
@@ -1,5 +1,6 @@
 import { configFileName, formatConfigSnippet } from "../config";
 import { createCommand } from "../core/create-command";
+import { UserError } from "../errors";
 import { logger } from "../logger";
 import { createIndex } from "./client";
 import { deprecatedV1DefaultFlag } from "./common";
@@ -76,10 +77,9 @@ export const vectorizeCreateCommand = createCommand({
 				dimensions: args.dimensions,
 			};
 		} else {
-			logger.error(
-				"You must provide both dimensions and a metric, or a known model preset when creating an index."
+			throw new UserError(
+				"🚨 You must provide both dimensions and a metric, or a known model preset when creating an index."
 			);
-			return;
 		}
 
 		if (args.deprecatedV1) {

--- a/packages/wrangler/src/vectorize/deleteByIds.ts
+++ b/packages/wrangler/src/vectorize/deleteByIds.ts
@@ -1,4 +1,5 @@
 import { createCommand } from "../core/create-command";
+import { UserError } from "../errors";
 import { logger } from "../logger";
 import { deleteByIds } from "./client";
 import type { VectorizeVectorIds } from "./types";
@@ -26,8 +27,9 @@ export const vectorizeDeleteVectorsCommand = createCommand({
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
 		if (args.ids.length === 0) {
-			logger.error("🚨 Please provide valid vector identifiers for deletion.");
-			return;
+			throw new UserError(
+				"🚨 Please provide valid vector identifiers for deletion."
+			);
 		}
 
 		logger.log(`📋 Deleting vectors...`);

--- a/packages/wrangler/src/vectorize/getByIds.ts
+++ b/packages/wrangler/src/vectorize/getByIds.ts
@@ -1,4 +1,5 @@
 import { createCommand } from "../core/create-command";
+import { UserError } from "../errors";
 import { logger } from "../logger";
 import { getByIds } from "./client";
 import type { VectorizeVectorIds } from "./types";
@@ -26,8 +27,7 @@ export const vectorizeGetVectorsCommand = createCommand({
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
 		if (args.ids.length === 0) {
-			logger.error("🚨 Please provide valid vector identifiers.");
-			return;
+			throw new UserError("🚨 Please provide valid vector identifiers.");
 		}
 
 		logger.log(`📋 Fetching vectors...`);

--- a/packages/wrangler/src/vectorize/insert.ts
+++ b/packages/wrangler/src/vectorize/insert.ts
@@ -7,6 +7,7 @@ import { insertIntoIndex, insertIntoIndexV1 } from "./client";
 import {
 	deprecatedV1DefaultFlag,
 	getBatchFromFile,
+	isValidFile,
 	VECTORIZE_MAX_BATCH_SIZE,
 	VECTORIZE_MAX_UPSERT_VECTOR_RECORDS,
 	VECTORIZE_UPSERT_BATCH_SIZE,
@@ -54,6 +55,11 @@ export const vectorizeInsertCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
+		if (!(await isValidFile(args.file))) {
+			logger.error(`🚨 Cannot read invalid or empty file: ${args.file}.`);
+			return;
+		}
+
 		const rl = createInterface({ input: createReadStream(args.file) });
 
 		if (

--- a/packages/wrangler/src/vectorize/insert.ts
+++ b/packages/wrangler/src/vectorize/insert.ts
@@ -2,6 +2,7 @@ import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 import { File, FormData } from "undici";
 import { createCommand } from "../core/create-command";
+import { UserError } from "../errors";
 import { logger } from "../logger";
 import { insertIntoIndex, insertIntoIndexV1 } from "./client";
 import {
@@ -56,8 +57,9 @@ export const vectorizeInsertCommand = createCommand({
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
 		if (!(await isValidFile(args.file))) {
-			logger.error(`🚨 Cannot read invalid or empty file: ${args.file}.`);
-			return;
+			throw new UserError(
+				`🚨 Cannot read invalid or empty file: ${args.file}.`
+			);
 		}
 
 		const rl = createInterface({ input: createReadStream(args.file) });
@@ -66,18 +68,16 @@ export const vectorizeInsertCommand = createCommand({
 			args.deprecatedV1 &&
 			Number(args.batchSize) > VECTORIZE_V1_MAX_BATCH_SIZE
 		) {
-			logger.error(
+			throw new UserError(
 				`🚨 Vectorize currently limits upload batches to ${VECTORIZE_V1_MAX_BATCH_SIZE} records at a time.`
 			);
-			return;
 		} else if (
 			!args.deprecatedV1 &&
 			Number(args.batchSize) > VECTORIZE_MAX_BATCH_SIZE
 		) {
-			logger.error(
-				`🚨 The global rate limit for the Cloudflare API is 1200 requests per five minutes. Vectorize V2 indexes currently limit upload batches to ${VECTORIZE_MAX_BATCH_SIZE} records at a time to stay within the service limits`
+			throw new UserError(
+				`🚨 The global rate limit for the Cloudflare API is 1200 requests per five minutes. Vectorize V2 indexes currently limit upload batches to ${VECTORIZE_MAX_BATCH_SIZE} records at a time to stay within the service limits.`
 			);
-			return;
 		}
 
 		let vectorInsertCount = 0;

--- a/packages/wrangler/src/vectorize/query.ts
+++ b/packages/wrangler/src/vectorize/query.ts
@@ -1,4 +1,5 @@
 import { createCommand } from "../core/create-command";
+import { UserError } from "../errors";
 import { logger } from "../logger";
 import { queryIndexByVector, queryIndexByVectorId } from "./client";
 import type {
@@ -115,10 +116,9 @@ export const vectorizeQueryCommand = createCommand({
 			(args.vector === undefined && args.vectorId === undefined) ||
 			(args.vector !== undefined && args.vectorId !== undefined)
 		) {
-			logger.error(
+			throw new UserError(
 				"🚨 Either vector or vector-id parameter must be provided, but not both."
 			);
-			return;
 		}
 
 		logger.log(`📋 Searching for relevant vectors...`);

--- a/packages/wrangler/src/vectorize/upsert.ts
+++ b/packages/wrangler/src/vectorize/upsert.ts
@@ -6,6 +6,7 @@ import { logger } from "../logger";
 import { upsertIntoIndex } from "./client";
 import {
 	getBatchFromFile,
+	isValidFile,
 	VECTORIZE_MAX_BATCH_SIZE,
 	VECTORIZE_MAX_UPSERT_VECTOR_RECORDS,
 } from "./common";
@@ -45,6 +46,11 @@ export const vectorizeUpsertCommand = createCommand({
 	},
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
+		if (!(await isValidFile(args.file))) {
+			logger.error(`🚨 Cannot read invalid or empty file: ${args.file}.`);
+			return;
+		}
+
 		const rl = createInterface({ input: createReadStream(args.file) });
 
 		if (Number(args.batchSize) > VECTORIZE_MAX_BATCH_SIZE) {

--- a/packages/wrangler/src/vectorize/upsert.ts
+++ b/packages/wrangler/src/vectorize/upsert.ts
@@ -2,6 +2,7 @@ import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 import { File, FormData } from "undici";
 import { createCommand } from "../core/create-command";
+import { UserError } from "../errors";
 import { logger } from "../logger";
 import { upsertIntoIndex } from "./client";
 import {
@@ -47,17 +48,17 @@ export const vectorizeUpsertCommand = createCommand({
 	positionalArgs: ["name"],
 	async handler(args, { config }) {
 		if (!(await isValidFile(args.file))) {
-			logger.error(`🚨 Cannot read invalid or empty file: ${args.file}.`);
-			return;
+			throw new UserError(
+				`🚨 Cannot read invalid or empty file: ${args.file}.`
+			);
 		}
 
 		const rl = createInterface({ input: createReadStream(args.file) });
 
 		if (Number(args.batchSize) > VECTORIZE_MAX_BATCH_SIZE) {
-			logger.error(
-				`🚨 The global rate limit for the Cloudflare API is 1200 requests per five minutes. Vectorize indexes currently limit upload batches to ${VECTORIZE_MAX_BATCH_SIZE} records at a time to stay within the service limits`
+			throw new UserError(
+				`🚨 The global rate limit for the Cloudflare API is 1200 requests per five minutes. Vectorize indexes currently limit upload batches to ${VECTORIZE_MAX_BATCH_SIZE} records at a time to stay within the service limits.`
 			);
-			return;
 		}
 
 		let vectorUpsertCount = 0;


### PR DESCRIPTION
This PR adds logic to validate input files for Vectorize inserts/upserts. Only valid file paths, with non-empty files would be accepted with this change. Since the validation check only checks the file metadata, and does not read/parse the file, it should have no impact on command performance/resource consumption.

Context: As of now, customers can supply invalid/empty files as part of the Vectorize insert/upsert commands in Wrangler. The Vectorize commands display an error while parsing the file, but then proceed with processing an invalid input file (the command then behaves like a no-op). This PR improves user experience by carrying out a validation check before parsing the file, returns an error message on finding an invalid file, and also returns early. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: This PR just adds a validation check to existing commands.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/9093
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
