### PR TITLE
chore: add v3 maintenance workflow

### DIFF
--- a/.github/workflows/check-v3-backport-status.yml
+++ b/.github/workflows/check-v3-backport-status.yml
@@ -1,4 +1,6 @@
 name: v3 Maintenance
+permissions:
+  pull-requests: read
 
 on:
   pull_request:

--- a/.github/workflows/check-v3-backport-status.yml
+++ b/.github/workflows/check-v3-backport-status.yml
@@ -1,0 +1,32 @@
+name: v3 Maintenance
+
+on:
+  pull_request:
+    branches: v3-maintenance
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+    paths:
+      - ".changeset/**.md"
+
+jobs:
+  check-status:
+    if: ${{ github.repository_owner == 'cloudflare' }}
+    name: Is original PR merged
+    runs-on: macos-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Check original PR status
+        run: node -r esbuild-register tools/deployments/check-v3-backport-status.ts
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          BRANCH_NAME: ${{ github.head_ref }}

--- a/tools/deployments/__tests__/check-v3-backport-status.test.ts
+++ b/tools/deployments/__tests__/check-v3-backport-status.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { validateBackportPR } from "../check-v3-backport-status";
+
+describe("validateBackportPR", () => {
+	it("should return false if the branch name does not match the pattern", () => {
+		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const result = validateBackportPR("example/v3-maintenance-demo", () => {
+			throw new Error("Unexpected");
+		});
+
+		expect(result).toBe(false);
+		expect(consoleLog).not.toBeCalled();
+		expect(consoleError).toBeCalledWith(
+			`❌ Branch name "example/v3-maintenance-demo" does not match the expected pattern "v3-maintenance-<PR_NUMBER>"`
+		);
+	});
+
+	it("should return false if the original PR is not merged", () => {
+		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const isMergedMock = vi.fn(() => false);
+		const result = validateBackportPR("v3-maintenance-13579", isMergedMock);
+
+		expect(result).toBe(false);
+		expect(isMergedMock).toBeCalledWith("13579");
+		expect(consoleLog).toBeCalledWith(`🔍 Checking if PR #13579 is merged...`);
+		expect(consoleError).toBeCalledWith(`❌ PR #13579 is not merged.`);
+	});
+
+	it("should return true if the original PR is merged", () => {
+		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+		const isMergedMock = vi.fn(() => true);
+		const result = validateBackportPR("v3-maintenance-2468", isMergedMock);
+
+		expect(result).toBe(true);
+		expect(isMergedMock).toBeCalledWith("2468");
+		expect(consoleLog).toBeCalledWith(`🔍 Checking if PR #2468 is merged...`);
+		expect(consoleLog).toBeCalledWith(`✅ PR #2468 is merged.`);
+	});
+});

--- a/tools/deployments/check-v3-backport-status.ts
+++ b/tools/deployments/check-v3-backport-status.ts
@@ -1,0 +1,62 @@
+import { execSync } from "node:child_process";
+
+/* eslint-disable turbo/no-undeclared-env-vars */
+if (require.main === module) {
+	const branchName = process.env.BRANCH_NAME;
+
+	if (!branchName) {
+		console.error("Missing BRANCH_NAME environment variables.");
+		process.exit(1);
+	}
+
+	if (!validateBackportPR(branchName, isPullRequestMerged)) {
+		process.exit(1);
+	}
+}
+
+export function validateBackportPR(
+	branchName: string,
+	isMerged: (prNumber: string) => boolean
+): boolean {
+	const prNumber = extractPullRequestNumber(branchName);
+
+	if (!prNumber) {
+		console.error(
+			`❌ Branch name "${branchName}" does not match the expected pattern "v3-maintenance-<PR_NUMBER>"`
+		);
+		return false;
+	}
+
+	console.log(`🔍 Checking if PR #${prNumber} is merged...`);
+
+	try {
+		if (isMerged(prNumber)) {
+			console.log(`✅ PR #${prNumber} is merged.`);
+			return true;
+		} else {
+			console.error(`❌ PR #${prNumber} is not merged.`);
+			return false;
+		}
+	} catch (exception) {
+		console.error(`❌ Failed to fetch PR #${prNumber}:`, exception);
+		return false;
+	}
+}
+
+export function extractPullRequestNumber(branchName: string): string | null {
+	const match = branchName.match(/^v3-maintenance-(\d+)$/);
+
+	if (match && match[1]) {
+		return match[1];
+	}
+
+	return null;
+}
+
+export function isPullRequestMerged(prNumber: string): boolean {
+	const result = execSync(`gh pr view ${prNumber} --json state --jq .state`)
+		.toString()
+		.trim();
+
+	return result === "MERGED";
+}


### PR DESCRIPTION
Fixes #8962

After #8962 is merged, I have created #9046 to test the new workflow and realize the new job wasn't triggered which is likely because GitHub will run the workflow on the "base branch" of your pull request instead of the main branch. 

This fixes it by backporting the workflow to the `v3-maintenace` branch. 😅 

Tests:

1. [PR is not merged](https://github.com/cloudflare/workers-sdk/actions/runs/14705662684/job/41265419906?pr=9079) in #9079
2. [PR is merged](https://github.com/cloudflare/workers-sdk/actions/runs/14705782134/job/41265816062?pr=9080#step:4:12) in #9080

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: workflow change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: workflow change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: workflow change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: This is a backport

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
