### PR TITLE
Support Tail Workers in local dev

### DIFF
--- a/.changeset/wild-boxes-invite.md
+++ b/.changeset/wild-boxes-invite.md
@@ -1,0 +1,6 @@
+---
+"miniflare": minor
+"wrangler": minor
+---
+
+Support Tail Workers in local dev

--- a/fixtures/worker-app/src/index.js
+++ b/fixtures/worker-app/src/index.js
@@ -101,4 +101,7 @@ export default {
 		ctx.waitUntil(Promise.resolve(event.scheduledTime));
 		ctx.waitUntil(Promise.resolve(event.cron));
 	},
+	tail(events) {
+		console.log("tails", { events });
+	},
 };

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -593,7 +593,6 @@ export const CORE_PLUGIN: Plugin<
 		const services: Service[] = [];
 		const extensions: Extension[] = [];
 
-		console.log(options.tails);
 		if (isWrappedBinding) {
 			const stringName = JSON.stringify(name);
 			function invalidWrapped(reason: string): never {

--- a/packages/miniflare/src/runtime/config/workerd.ts
+++ b/packages/miniflare/src/runtime/config/workerd.ts
@@ -63,6 +63,7 @@ export type Worker = (
 	durableObjectUniqueKeyModifier?: string;
 	durableObjectStorage?: Worker_DurableObjectStorage;
 	moduleFallback?: string;
+	tails?: ServiceDesignator[];
 };
 
 export type Worker_DurableObjectStorage =

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Pages 'wrangler pages dev' > should merge (with override) \`wrangler.toml\` configuration with configuration provided via the command line, with command line args taking precedence 1`] = `
 "✨ Compiled Worker successfully
 Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
-Your worker has access to the following bindings:
+Your Worker has access to the following bindings:
 - Durable Objects:
   - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 [not connected])
   - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML [not connected])

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -30,7 +30,7 @@ Your worker has access to the following bindings:
   - VAR1: "(hidden)"
   - VAR2: "VAR_2_TOML"
   - VAR3: "(hidden)"
-Service bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
+Service bindings, durable object bindings, and tail consumers connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
 ▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
 "
 `;

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -30,7 +30,7 @@ Your worker has access to the following bindings:
   - VAR1: "(hidden)"
   - VAR2: "VAR_2_TOML"
   - VAR3: "(hidden)"
-Service bindings, durable object bindings, and tail consumers connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
+Service bindings, Durable Object bindings, and Tail consumers connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
 ▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
 "
 `;

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -373,7 +373,7 @@ Uploaded 2 of 3 assets
 Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
-Your worker has access to the following bindings:
+Your Worker has access to the following bindings:
 - Assets:
   - Binding: ASSETS
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
@@ -540,7 +540,7 @@ Uploaded 2 of 3 assets
 Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
-Your worker has access to the following bindings:
+Your Worker has access to the following bindings:
 - Assets:
   - Binding: ASSETS
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
@@ -662,7 +662,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 			);
 			normalizedStdout = normalize(output.stdout);
 			expect(normalizedStdout).toEqual(`Total Upload: xx KiB / gzip: xx KiB
-Your worker has access to the following bindings:
+Your Worker has access to the following bindings:
 - Dispatch Namespaces:
   - DISPATCH: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
@@ -762,7 +762,7 @@ Uploaded 2 of 3 assets
 Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
-Your worker has access to the following bindings:
+Your Worker has access to the following bindings:
 - Assets:
   - Binding: ASSETS
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
@@ -775,7 +775,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 			);
 			normalizedStdout = normalize(output.stdout);
 			expect(normalizedStdout).toEqual(`Total Upload: xx KiB / gzip: xx KiB
-Your worker has access to the following bindings:
+Your Worker has access to the following bindings:
 - Dispatch Namespaces:
   - DISPATCH: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
@@ -873,7 +873,7 @@ Uploaded 2 of 3 assets
 Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
-Your worker has access to the following bindings:
+Your Worker has access to the following bindings:
 - Assets:
   - Binding: ASSETS
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
@@ -886,7 +886,7 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 			);
 			normalizedStdout = normalize(output.stdout);
 			expect(normalizedStdout).toEqual(`Total Upload: xx KiB / gzip: xx KiB
-Your worker has access to the following bindings:
+Your Worker has access to the following bindings:
 - Dispatch Namespaces:
   - DISPATCH: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)

--- a/packages/wrangler/e2e/dev-registry.test.ts
+++ b/packages/wrangler/e2e/dev-registry.test.ts
@@ -375,7 +375,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 		);
 	});
 
-	describe("tails", () => {
+	describe("Tail consumers", () => {
 		beforeEach(async () => {
 			await baseSeed(a, {
 				"wrangler.toml": dedent`

--- a/packages/wrangler/e2e/dev-registry.test.ts
+++ b/packages/wrangler/e2e/dev-registry.test.ts
@@ -375,6 +375,69 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 		);
 	});
 
+	describe("tails", () => {
+		beforeEach(async () => {
+			await baseSeed(a, {
+				"wrangler.toml": dedent`
+							name = "${workerName}"
+							main = "src/index.ts"
+							compatibility_date = "2025-04-28"
+
+							[[tail_consumers]]
+							service = "${workerName2}"
+					`,
+				"src/index.ts": dedent/* javascript */ `
+						export default {
+							async fetch(req, env) {
+								console.log("log something")
+								return new Response("hello from a")
+							},
+						};
+						`,
+			});
+
+			b = await makeRoot();
+			await baseSeed(b, {
+				"wrangler.toml": dedent`
+							name = "${workerName2}"
+							main = "src/index.ts"
+							compatibility_date = "2025-04-28"
+					`,
+				"src/index.ts": dedent/* javascript */ `
+						export default {
+							async tail(event) {
+								console.log("received tail event", event)
+							},
+						};
+					`,
+			});
+		});
+
+		it("can fetch a without b running", async () => {
+			const workerA = helper.runLongLived(cmd, { cwd: a });
+			const { url } = await workerA.waitForReady(5_000);
+
+			await expect(fetchText(`${url}`)).resolves.toBe("hello from a");
+		});
+
+		it("tail event sent to b", async () => {
+			const workerA = helper.runLongLived(cmd, { cwd: a });
+			const { url } = await workerA.waitForReady(5_000);
+
+			const workerB = helper.runLongLived(cmd, { cwd: b });
+
+			await workerA.readUntil(/connected/);
+
+			await expect(fetchText(`${url}`)).resolves.toBe("hello from a");
+
+			await vi.waitFor(
+				async () =>
+					expect(workerB.currentOutput).includes("received tail event"),
+				{ interval: 1000, timeout: 10_000 }
+			);
+		});
+	});
+
 	describe("durable objects", () => {
 		beforeEach(async () => {
 			await baseSeed(a, {

--- a/packages/wrangler/e2e/dev-registry.test.ts
+++ b/packages/wrangler/e2e/dev-registry.test.ts
@@ -302,7 +302,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 			);
 
 			expect(normalizeOutput(workerA.currentOutput)).toContain(
-				"bindings connect to other `wrangler dev` processes running locally"
+				"connect to other `wrangler dev` processes running locally"
 			);
 		});
 
@@ -589,7 +589,7 @@ describe.each([{ cmd: "wrangler dev" }])("dev registry $cmd", ({ cmd }) => {
 			);
 
 			expect(normalizeOutput(workerA.currentOutput)).toContain(
-				"bindings connect to other `wrangler dev` processes running locally"
+				"connect to other `wrangler dev` processes running locally"
 			);
 		});
 

--- a/packages/wrangler/e2e/multiworker-dev.test.ts
+++ b/packages/wrangler/e2e/multiworker-dev.test.ts
@@ -389,7 +389,7 @@ describe("multiworker", () => {
 		});
 	});
 
-	describe("tails", () => {
+	describe("Tail consumers", () => {
 		beforeEach(async () => {
 			await baseSeed(a, {
 				"wrangler.toml": dedent`

--- a/packages/wrangler/e2e/multiworker-dev.test.ts
+++ b/packages/wrangler/e2e/multiworker-dev.test.ts
@@ -389,6 +389,69 @@ describe("multiworker", () => {
 		});
 	});
 
+	describe("tails", () => {
+		beforeEach(async () => {
+			await baseSeed(a, {
+				"wrangler.toml": dedent`
+						name = "${workerName}"
+						main = "src/index.ts"
+						compatibility_date = "2025-04-28"
+
+						[[tail_consumers]]
+						service = "${workerName2}"
+				`,
+				"src/index.ts": dedent/* javascript */ `
+					export default {
+						async fetch(req, env) {
+							console.log("log something")
+							return new Response("hello from a")
+						},
+					};
+					`,
+			});
+
+			b = await makeRoot();
+			await baseSeed(b, {
+				"wrangler.toml": dedent`
+						name = "${workerName2}"
+						main = "src/index.ts"
+						compatibility_date = "2025-04-28"
+				`,
+				"src/index.ts": dedent/* javascript */ `
+					export default {
+						async tail(event) {
+							console.log("received tail event", event)
+						},
+					};
+				`,
+			});
+		});
+
+		it("can fetch a without b running", async () => {
+			const worker = helper.runLongLived(`wrangler dev`, { cwd: a });
+
+			const { url } = await worker.waitForReady(5_000);
+
+			await expect(fetchText(`${url}`)).resolves.toBe("hello from a");
+		});
+
+		it("tail event sent to b", async () => {
+			const worker = helper.runLongLived(
+				`wrangler dev -c wrangler.toml -c ${b}/wrangler.toml`,
+				{ cwd: a }
+			);
+			const { url } = await worker.waitForReady(5_000);
+
+			await expect(fetchText(`${url}`)).resolves.toBe("hello from a");
+
+			await vi.waitFor(
+				async () =>
+					expect(worker.currentOutput).includes("received tail event"),
+				{ interval: 1000, timeout: 10_000 }
+			);
+		});
+	});
+
 	describe("pages", () => {
 		beforeEach(async () => {
 			await baseSeed(a, {

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -119,7 +119,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 			);
 			await worker.waitForReady();
 			expect(normalizeOutput(worker.currentOutput)).toContain(
-				dedent`Your worker has access to the following bindings:
+				dedent`Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - TEST_DO: TestDurableObject (defined in a [not connected])
 					- KV Namespaces:
@@ -325,7 +325,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 
 			expect(text).toBe("⚡️ Pages ⚡️ supports wrangler.toml");
 			expect(normalizeOutput(worker.currentOutput)).toContain(
-				dedent`Your worker has access to the following bindings:
+				dedent`Your Worker has access to the following bindings:
 					- KV Namespaces:
 					  - KV_BINDING_TOML: KV_ID_TOML [simulated locally]
 					- Vars:

--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -90,7 +90,7 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 			🌀 Creating new R2 Bucket "tmp-e2e-worker-00000000-0000-0000-0000-000000000000-r2"...
 			✨ R2 provisioned 🎉
 			🎉 All resources provisioned, continuing with deployment...
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- KV Namespaces:
 			  - KV: 00000000000000000000000000000000
 			- D1 Databases:
@@ -132,7 +132,7 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 		const output = await worker.output;
 		expect(normalize(output)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- KV Namespaces:
 			  - KV
 			- D1 Databases:
@@ -184,7 +184,7 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 			✨ KV2 provisioned 🎉
 			🎉 All resources provisioned, continuing with deployment...
 			Worker Startup Time: (TIMINGS)
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- KV Namespaces:
 			  - KV2: 00000000000000000000000000000000
 			- R2 Buckets:

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -7267,6 +7267,9 @@ addEventListener('fetch', event => {});`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				No bindings found.
+				Your worker is sending Tail events to the following workers:
+				- listener
+				- test-listener
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -296,7 +296,7 @@ describe("deploy", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- Vars:
 			  - xyz: 123
 			Uploaded test-name (TIMINGS)
@@ -336,7 +336,7 @@ describe("deploy", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- Vars:
 			  - xyz: 123
 			Uploaded test-worker (TIMINGS)
@@ -410,7 +410,7 @@ describe("deploy", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- Vars:
 			  - xyz: 123
 			Uploaded test-worker-jsonc (TIMINGS)
@@ -1091,7 +1091,7 @@ describe("deploy", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- Vars:
 			  - xyz: 123
 			Uploaded test-name (TIMINGS)
@@ -6668,7 +6668,7 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Durable Objects:
 				  - SOMENAME: SomeClass
 				Uploaded test-name (TIMINGS)
@@ -6721,7 +6721,7 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Durable Objects:
 				  - SOMENAME: SomeClass (defined in some-script)
 				Uploaded test-name (TIMINGS)
@@ -6767,7 +6767,7 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Durable Objects:
 				  - SOMENAME: SomeClass
 				  - SOMEOTHERNAME: SomeOtherClass
@@ -6822,7 +6822,7 @@ addEventListener('fetch', event => {});`
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Durable Objects:
 				  - SOMENAME: SomeClass
 				  - SOMEOTHERNAME: SomeOtherClass
@@ -6869,7 +6869,7 @@ addEventListener('fetch', event => {});`
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Durable Objects:
 				  - SOMENAME: SomeClass
 				  - SOMEOTHERNAME: SomeOtherClass
@@ -6918,7 +6918,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - SOMENAME: SomeClass
 					  - SOMEOTHERNAME: SomeOtherClass
@@ -6984,7 +6984,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - SOMENAME: SomeClass
 					  - SOMEOTHERNAME: SomeOtherClass
@@ -7049,7 +7049,7 @@ addEventListener('fetch', event => {});`
 					  "info": "",
 					  "out": "Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - SOMENAME: SomeClass
 					  - SOMEOTHERNAME: SomeOtherClass
@@ -7122,7 +7122,7 @@ addEventListener('fetch', event => {});`
 					  "info": "",
 					  "out": "Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - SOMENAME: SomeClass
 					  - SOMEOTHERNAME: SomeOtherClass
@@ -7181,7 +7181,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - SOMENAME: SomeClass
 					  - SOMEOTHERNAME: SomeOtherClass
@@ -7233,7 +7233,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - SOMENAME: SomeClass
 					  - SOMEOTHERNAME: SomeOtherClass
@@ -7267,7 +7267,7 @@ addEventListener('fetch', event => {});`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				No bindings found.
-				Your worker is sending Tail events to the following workers:
+				Your Worker is sending Tail events to the following Workers:
 				- listener
 				- test-listener
 				Uploaded test-name (TIMINGS)
@@ -7521,7 +7521,7 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Data Blobs:
 				  - DATA_BLOB_ONE: some-data-blob.bin
 				  - DATA_BLOB_TWO: more-data-blob.bin
@@ -7972,7 +7972,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Wasm Modules:
 					  - TESTWASMNAME: path/to/test.wasm
 					Uploaded test-name (TIMINGS)
@@ -8042,7 +8042,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Wasm Modules:
 					  - TESTWASMNAME: path/to/and/the/path/to/test.wasm
 					Uploaded test-name (TIMINGS)
@@ -8119,7 +8119,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Text Blobs:
 					  - TESTTEXTBLOBNAME: path/to/text.file
 					Uploaded test-name (TIMINGS)
@@ -8193,7 +8193,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Text Blobs:
 					  - TESTTEXTBLOBNAME: path/to/and/the/path/to/text.file
 					Uploaded test-name (TIMINGS)
@@ -8233,7 +8233,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Data Blobs:
 					  - TESTDATABLOBNAME: path/to/data.bin
 					Uploaded test-name (TIMINGS)
@@ -8307,7 +8307,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Data Blobs:
 					  - TESTDATABLOBNAME: path/to/and/the/path/to/data.bin
 					Uploaded test-name (TIMINGS)
@@ -8347,7 +8347,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Vars:
 					  - text: \\"plain ol' string\\"
 					  - count: 1
@@ -8377,7 +8377,7 @@ addEventListener('fetch', event => {});`
 					  "info": "",
 					  "out": "Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Vars:
 					  - TEXT: \\"(hidden)\\"
 					  - COUNT: \\"(hidden)\\"
@@ -8408,7 +8408,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- R2 Buckets:
 					  - FOO: foo-bucket
 					Uploaded test-name (TIMINGS)
@@ -8458,7 +8458,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- logfwdr:
 					  - httplogs: httplogs
 					  - trace: trace
@@ -8532,7 +8532,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - EXAMPLE_DO_BINDING: ExampleDurableObject
 					Uploaded test-name (TIMINGS)
@@ -8578,16 +8578,16 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("deploy index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			"Total Upload: xx KiB / gzip: xx KiB
-			Worker Startup Time: 100 ms
-			Your worker has access to the following bindings:
-			- Durable Objects:
-			  - EXAMPLE_DO_BINDING: ExampleDurableObject
-			Uploaded test-name (TIMINGS)
-			Deployed test-name triggers (TIMINGS)
-			  https://test-name.test-sub-domain.workers.dev
-			Current Version ID: Galaxy-Class"
-		`);
+					"Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Your Worker has access to the following bindings:
+					- Durable Objects:
+					  - EXAMPLE_DO_BINDING: ExampleDurableObject
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
+				`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -8623,7 +8623,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - EXAMPLE_DO_BINDING: ExampleDurableObject (defined in example-do-binding-worker)
 					Uploaded test-name (TIMINGS)
@@ -8670,7 +8670,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Durable Objects:
 					  - EXAMPLE_DO_BINDING: ExampleDurableObject
 					Uploaded test-name (TIMINGS)
@@ -8728,16 +8728,16 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("deploy index.js");
 				expect(std.out).toMatchInlineSnapshot(`
-			"Total Upload: xx KiB / gzip: xx KiB
-			Worker Startup Time: 100 ms
-			Your worker has access to the following bindings:
-			- Durable Objects:
-			  - EXAMPLE_DO_BINDING: ExampleDurableObject
-			Uploaded test-name (TIMINGS)
-			Deployed test-name triggers (TIMINGS)
-			  https://test-name.test-sub-domain.workers.dev
-			Current Version ID: Galaxy-Class"
-		`);
+					"Total Upload: xx KiB / gzip: xx KiB
+					Worker Startup Time: 100 ms
+					Your Worker has access to the following bindings:
+					- Durable Objects:
+					  - EXAMPLE_DO_BINDING: ExampleDurableObject
+					Uploaded test-name (TIMINGS)
+					Deployed test-name triggers (TIMINGS)
+					  https://test-name.test-sub-domain.workers.dev
+					Current Version ID: Galaxy-Class"
+				`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
@@ -8783,14 +8783,14 @@ addEventListener('fetch', event => {});`
 
 				await runWrangler("deploy index.js --outdir tmp --dry-run");
 				expect(std.out).toMatchInlineSnapshot(`
-			"Total Upload: xx KiB / gzip: xx KiB
-			Your worker has access to the following bindings:
-			- Durable Objects:
-			  - EXAMPLE_DO_BINDING: ExampleDurableObject
-			- D1 Databases:
-			  - DB: test-d1-db (UUID-1-2-3-4), Preview: (UUID-1-2-3-4)
-			--dry-run: exiting now."
-		`);
+					"Total Upload: xx KiB / gzip: xx KiB
+					Your Worker has access to the following bindings:
+					- Durable Objects:
+					  - EXAMPLE_DO_BINDING: ExampleDurableObject
+					- D1 Databases:
+					  - DB: test-d1-db (UUID-1-2-3-4), Preview: (UUID-1-2-3-4)
+					--dry-run: exiting now."
+				`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 				const output = fs.readFileSync("tmp/index.js", "utf-8");
@@ -8853,7 +8853,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Services:
 					  - FOO: foo-service
 					Uploaded test-name (TIMINGS)
@@ -8894,7 +8894,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Services:
 					  - FOO: foo-service#MyHandler
 					Uploaded test-name (TIMINGS)
@@ -8933,7 +8933,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Services:
 					  - FOO: foo-service
 					Uploaded test-name (TIMINGS)
@@ -8965,7 +8965,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Analytics Engine Datasets:
 					  - FOO: foo-dataset
 					Uploaded test-name (TIMINGS)
@@ -9003,7 +9003,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Dispatch Namespaces:
 					  - foo: Foo
 					Uploaded test-name (TIMINGS)
@@ -9061,7 +9061,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Dispatch Namespaces:
 					  - foo: Foo (outbound -> foo_outbound)
 					  - bar: Bar (outbound -> bar_outbound)
@@ -9112,7 +9112,7 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					Your worker has access to the following bindings:
+					Your Worker has access to the following bindings:
 					- Dispatch Namespaces:
 					  - foo: Foo (outbound -> foo_outbound)
 					Uploaded test-name (TIMINGS)
@@ -9156,7 +9156,7 @@ addEventListener('fetch', event => {});`
 					expect(std.out).toMatchInlineSnapshot(`
 						"Total Upload: xx KiB / gzip: xx KiB
 						Worker Startup Time: 100 ms
-						Your worker has access to the following bindings:
+						Your Worker has access to the following bindings:
 						- Unsafe Metadata:
 						  - stringify: true
 						  - something: \\"else\\"
@@ -9197,7 +9197,7 @@ addEventListener('fetch', event => {});`
 					expect(std.out).toMatchInlineSnapshot(`
 						"Total Upload: xx KiB / gzip: xx KiB
 						Worker Startup Time: 100 ms
-						Your worker has access to the following bindings:
+						Your Worker has access to the following bindings:
 						- Unsafe Metadata:
 						  - binding-type: my-binding
 						Uploaded test-name (TIMINGS)
@@ -9244,7 +9244,7 @@ addEventListener('fetch', event => {});`
 					expect(std.out).toMatchInlineSnapshot(`
 						"Total Upload: xx KiB / gzip: xx KiB
 						Worker Startup Time: 100 ms
-						Your worker has access to the following bindings:
+						Your Worker has access to the following bindings:
 						- Unsafe Metadata:
 						  - plain_text: my-binding
 						Uploaded test-name (TIMINGS)
@@ -10308,7 +10308,7 @@ export default{
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- KV Namespaces:
 				  - KV: kv-namespace-id
 				Uploaded test-name (TIMINGS)
@@ -10518,7 +10518,7 @@ export default{
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- KV Namespaces:
 				  - KV: kv-namespace-id
 				Uploaded test-name (TIMINGS)
@@ -10553,18 +10553,18 @@ export default{
 			vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "");
 			await runWrangler("deploy index.js --dry-run");
 			expect(std).toMatchInlineSnapshot(`
-			Object {
-			  "debug": "",
-			  "err": "",
-			  "info": "",
-			  "out": "Total Upload: xx KiB / gzip: xx KiB
-			Your worker has access to the following bindings:
-			- Durable Objects:
-			  - NAME: SomeClass
-			--dry-run: exiting now.",
-			  "warn": "",
-			}
-		`);
+				Object {
+				  "debug": "",
+				  "err": "",
+				  "info": "",
+				  "out": "Total Upload: xx KiB / gzip: xx KiB
+				Your Worker has access to the following bindings:
+				- Durable Objects:
+				  - NAME: SomeClass
+				--dry-run: exiting now.",
+				  "warn": "",
+				}
+			`);
 		});
 	});
 
@@ -11190,7 +11190,7 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Queues:
 				  - QUEUE_ONE: queue1
 				Uploaded test-name (TIMINGS)
@@ -11237,7 +11237,7 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Queues:
 				  - MY_QUEUE: queue1
 				Uploaded test-name (TIMINGS)
@@ -11987,7 +11987,7 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Browser:
 				  - Name: MYBROWSER
 				- AI:
@@ -12020,7 +12020,7 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Images:
 				  - Name: IMAGES_BIND
 				Uploaded test-name (TIMINGS)
@@ -12134,7 +12134,7 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Hyperdrive Configs:
 				  - HYPERDRIVE: 343cd4f1d58c42fbb5bd082592fd7143
 				Uploaded test-name (TIMINGS)
@@ -12166,7 +12166,7 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- mTLS Certificates:
 				  - CERT_ONE: 1234
 				Uploaded test-name (TIMINGS)
@@ -12201,16 +12201,16 @@ export default{
 
 			await runWrangler("deploy index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			"Total Upload: xx KiB / gzip: xx KiB
-			Worker Startup Time: 100 ms
-			Your worker has access to the following bindings:
-			- Pipelines:
-			  - MY_PIPELINE: my-pipeline
-			Uploaded test-name (TIMINGS)
-			Deployed test-name triggers (TIMINGS)
-			  https://test-name.test-sub-domain.workers.dev
-			Current Version ID: Galaxy-Class"
-		`);
+				"Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Your Worker has access to the following bindings:
+				- Pipelines:
+				  - MY_PIPELINE: my-pipeline
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
 		});
 	});
 
@@ -12240,16 +12240,16 @@ export default{
 
 			await runWrangler("deploy index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-			"Total Upload: xx KiB / gzip: xx KiB
-			Worker Startup Time: 100 ms
-			Your worker has access to the following bindings:
-			- Secrets Store Secrets:
-			  - SECRET: store_id/secret_name
-			Uploaded test-name (TIMINGS)
-			Deployed test-name triggers (TIMINGS)
-			  https://test-name.test-sub-domain.workers.dev
-			Current Version ID: Galaxy-Class"
-		`);
+				"Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				Your Worker has access to the following bindings:
+				- Secrets Store Secrets:
+				  - SECRET: store_id/secret_name
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
 		});
 	});
 
@@ -12509,7 +12509,7 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Workflows:
 				  - WORKFLOW: MyWorkflow
 				Uploaded test-name (TIMINGS)
@@ -12570,7 +12570,7 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Workflows:
 				  - WORKFLOW: MyWorkflow (defined in another-script)
 				Uploaded this-script (TIMINGS)

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1262,7 +1262,7 @@ describe.sequential("wrangler dev", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
 
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Durable Objects:
 				  - NAME_1: CLASS_1
 				  - NAME_2: CLASS_2 (defined in SCRIPT_A [not connected])
@@ -1346,7 +1346,7 @@ describe.sequential("wrangler dev", () => {
 				"Using vars defined in .dev.vars
 				Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
 
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Vars:
 				  - VAR_1: \\"(hidden)\\"
 				  - VAR_2: \\"original value 2\\"
@@ -1382,7 +1382,7 @@ describe.sequential("wrangler dev", () => {
 				"Using vars defined in .dev.vars.custom
 				Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
 
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Vars:
 				  - CUSTOM_VAR: \\"(hidden)\\"
 				"
@@ -1588,7 +1588,7 @@ describe.sequential("wrangler dev", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
 
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Services:
 				  - WorkerA: A [not connected]
 				  - WorkerB: B [not connected]
@@ -1611,7 +1611,7 @@ describe.sequential("wrangler dev", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
 
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Services:
 				  - WorkerA: A [not connected]
 				  - WorkerB: B [not connected]
@@ -1640,7 +1640,7 @@ describe.sequential("wrangler dev", () => {
 				"Using vars defined in .dev.vars
 				Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
 
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- Vars:
 				  - variable: 123
 				  - overriden: \\"(hidden)\\"

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -89,20 +89,20 @@ describe("--x-provision", () => {
 
 		await runWrangler("deploy --x-provision --x-auto-create=false");
 		expect(std.out).toMatchInlineSnapshot(`
-				"Total Upload: xx KiB / gzip: xx KiB
-				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
-				- KV Namespaces:
-				  - KV
-				- D1 Databases:
-				  - D1
-				- R2 Buckets:
-				  - R2
-				Uploaded test-name (TIMINGS)
-				Deployed test-name triggers (TIMINGS)
-				  https://test-name.test-sub-domain.workers.dev
-				Current Version ID: Galaxy-Class"
-			`);
+			"Total Upload: xx KiB / gzip: xx KiB
+			Worker Startup Time: 100 ms
+			Your Worker has access to the following bindings:
+			- KV Namespaces:
+			  - KV
+			- D1 Databases:
+			  - D1
+			- R2 Buckets:
+			  - R2
+			Uploaded test-name (TIMINGS)
+			Deployed test-name triggers (TIMINGS)
+			  https://test-name.test-sub-domain.workers.dev
+			Current Version ID: Galaxy-Class"
+		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 	});
@@ -196,7 +196,7 @@ describe("--x-provision", () => {
 				🎉 All resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- KV Namespaces:
 				  - KV: existing-kv-id
 				- D1 Databases:
@@ -315,7 +315,7 @@ describe("--x-provision", () => {
 				🎉 All resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- KV Namespaces:
 				  - KV: existing-kv-id-1
 				- D1 Databases:
@@ -447,7 +447,7 @@ describe("--x-provision", () => {
 				🎉 All resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- KV Namespaces:
 				  - KV: new-kv-id
 				- D1 Databases:
@@ -516,7 +516,7 @@ describe("--x-provision", () => {
 				🎉 All resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- D1 Databases:
 				  - D1: prefilled-d1-name (new-d1-id)
 				Uploaded test-name (TIMINGS)
@@ -558,7 +558,7 @@ describe("--x-provision", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- D1 Databases:
 				  - D1: prefilled-d1-name
 				Uploaded test-name (TIMINGS)
@@ -635,7 +635,7 @@ describe("--x-provision", () => {
 				🎉 All resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- D1 Databases:
 				  - D1: new-d1-name (new-d1-id)
 				Uploaded test-name (TIMINGS)
@@ -708,7 +708,7 @@ describe("--x-provision", () => {
 				🎉 All resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- R2 Buckets:
 				  - BUCKET: prefilled-r2-name (eu)
 				Uploaded test-name (TIMINGS)
@@ -762,7 +762,7 @@ describe("--x-provision", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- R2 Buckets:
 				  - BUCKET: existing-bucket-name (eu)
 				Uploaded test-name (TIMINGS)
@@ -806,7 +806,7 @@ describe("--x-provision", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- D1 Databases:
 				  - DB_NAME: existing-db-name (existing-d1-id)
 				Uploaded test-name (TIMINGS)
@@ -890,7 +890,7 @@ describe("--x-provision", () => {
 				🎉 All resources provisioned, continuing with deployment...
 
 				Worker Startup Time: 100 ms
-				Your worker has access to the following bindings:
+				Your Worker has access to the following bindings:
 				- R2 Buckets:
 				  - BUCKET: existing-bucket-name (eu)
 				Uploaded test-name (TIMINGS)

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -93,7 +93,7 @@ describe("versions upload", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 500 ms
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- KV Namespaces:
 			  - KV: xxxx-xxxx-xxxx-xxxx
 			- Vars:
@@ -131,7 +131,7 @@ describe("versions upload", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 500 ms
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- Vars:
 			  - TEST: \\"test-string\\"
 			Uploaded test-name (TIMINGS)
@@ -163,7 +163,7 @@ describe("versions upload", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 500 ms
-			Your worker has access to the following bindings:
+			Your Worker has access to the following bindings:
 			- Vars:
 			  - TEST: \\"test-string\\"
 			Uploaded test-name (TIMINGS)

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -157,7 +157,7 @@ async function getMiniflareOptionsFromConfig(
 		name: rawConfig.name,
 		services: bindings.services,
 		durableObjects: rawConfig["durable_objects"],
-		tails: [],
+		tailConsumers: [],
 	});
 
 	const { bindingOptions, externalWorkers } = buildMiniflareBindingOptions({

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -157,6 +157,7 @@ async function getMiniflareOptionsFromConfig(
 		name: rawConfig.name,
 		services: bindings.services,
 		durableObjects: rawConfig["durable_objects"],
+		tails: [],
 	});
 
 	const { bindingOptions, externalWorkers } = buildMiniflareBindingOptions({
@@ -168,6 +169,7 @@ async function getMiniflareOptionsFromConfig(
 		serviceBindings: {},
 		migrations: rawConfig.migrations,
 		imagesLocalMode: false,
+		tails: [],
 	});
 
 	const persistOptions = getMiniflarePersistOptions(options.persist);
@@ -296,6 +298,7 @@ export function unstable_getMiniflareWorkerOptions(
 		serviceBindings: {},
 		migrations: config.migrations,
 		imagesLocalMode: !!options?.imagesLocalMode,
+		tails: config.tail_consumers,
 	});
 
 	// This function is currently only exported for the Workers Vitest pool.

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -168,7 +168,7 @@ async function resolveBindings(
 			...bindings,
 			vars: maskedVars,
 		},
-		input.tails ?? config.tail_consumers,
+		input.tailConsumers ?? config.tail_consumers,
 		{
 			registry: input.dev?.registry,
 			local: !input.dev?.remote,
@@ -316,7 +316,7 @@ async function resolveConfig(
 			metadata: input.unsafe?.metadata ?? unsafe?.metadata,
 		},
 		assets: assetsOptions,
-		tails: config.tail_consumers ?? [],
+		tailConsumers: config.tail_consumers ?? [],
 	} satisfies StartDevWorkerOptions;
 
 	if (

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -168,6 +168,7 @@ async function resolveBindings(
 			...bindings,
 			vars: maskedVars,
 		},
+		input.tails ?? config.tail_consumers,
 		{
 			registry: input.dev?.registry,
 			local: !input.dev?.remote,
@@ -315,6 +316,7 @@ async function resolveConfig(
 			metadata: input.unsafe?.metadata ?? unsafe?.metadata,
 		},
 		assets: assetsOptions,
+		tails: config.tail_consumers ?? [],
 	} satisfies StartDevWorkerOptions;
 
 	if (

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -120,7 +120,7 @@ export async function convertToConfigBundle(
 		bindVectorizeToProd: event.config.dev?.bindVectorizeToProd ?? false,
 		imagesLocalMode: event.config.dev?.imagesLocalMode ?? false,
 		testScheduled: !!event.config.dev.testScheduled,
-		tails: event.config.tails,
+		tails: event.config.tailConsumers,
 	};
 }
 

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -120,6 +120,7 @@ export async function convertToConfigBundle(
 		bindVectorizeToProd: event.config.dev?.bindVectorizeToProd ?? false,
 		imagesLocalMode: event.config.dev?.imagesLocalMode ?? false,
 		testScheduled: !!event.config.dev.testScheduled,
+		tails: event.config.tails,
 	};
 }
 

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -84,7 +84,7 @@ export interface StartDevWorkerInput {
 	/** The triggers which will cause the worker's exported default handlers to be called. */
 	triggers?: Trigger[];
 
-	tails?: CfTailConsumer[];
+	tailConsumers?: CfTailConsumer[];
 
 	/**
 	 * Whether Wrangler should send usage metrics to Cloudflare for this project.

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -24,6 +24,7 @@ import type {
 	CfSecretsStoreSecrets,
 	CfSendEmailBindings,
 	CfService,
+	CfTailConsumer,
 	CfUnsafe,
 	CfVectorize,
 	CfWorkflow,
@@ -82,6 +83,8 @@ export interface StartDevWorkerInput {
 	migrations?: DurableObjectMigration[];
 	/** The triggers which will cause the worker's exported default handlers to be called. */
 	triggers?: Trigger[];
+
+	tails?: CfTailConsumer[];
 
 	/**
 	 * Whether Wrangler should send usage metrics to Cloudflare for this project.

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -757,7 +757,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 		if (props.dryRun) {
 			workerBundle = createWorkerUploadForm(worker);
-			printBindings({ ...withoutStaticAssets, vars: maskedVars });
+			printBindings(
+				{ ...withoutStaticAssets, vars: maskedVars },
+				config.tail_consumers
+			);
 		} else {
 			assert(accountId, "Missing accountId");
 
@@ -853,7 +856,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				}
 				bindingsPrinted = true;
 
-				printBindings({ ...withoutStaticAssets, vars: maskedVars });
+				printBindings(
+					{ ...withoutStaticAssets, vars: maskedVars },
+					config.tail_consumers
+				);
 
 				versionId = parseNonHyphenedUuid(result.deployment_id);
 
@@ -879,7 +885,10 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 				}
 			} catch (err) {
 				if (!bindingsPrinted) {
-					printBindings({ ...withoutStaticAssets, vars: maskedVars });
+					printBindings(
+						{ ...withoutStaticAssets, vars: maskedVars },
+						config.tail_consumers
+					);
 				}
 				await helpIfErrorIsSizeOrScriptStartup(
 					err,

--- a/packages/wrangler/src/deployment-bundle/bindings.ts
+++ b/packages/wrangler/src/deployment-bundle/bindings.ts
@@ -405,7 +405,7 @@ export async function provisionBindings(
 			printable[resource.resourceType] ??= [];
 			printable[resource.resourceType].push({ binding: resource.binding });
 		}
-		printBindings(printable, { provisioning: true });
+		printBindings(printable, config.tail_consumers, { provisioning: true });
 		logger.log();
 
 		const existingResources: Record<string, NormalisedResourceInfo[]> = {};

--- a/packages/wrangler/src/dev-registry/index.ts
+++ b/packages/wrangler/src/dev-registry/index.ts
@@ -55,6 +55,7 @@ export async function getBoundRegisteredWorkers(
 		name,
 		services,
 		durableObjects,
+		tails,
 	}: {
 		name: string | undefined;
 		services:
@@ -65,10 +66,11 @@ export async function getBoundRegisteredWorkers(
 			| Config["durable_objects"]
 			| { bindings: Extract<Binding, { type: "durable_object_namespace" }>[] }
 			| undefined;
+		tails: Config["tail_consumers"] | undefined;
 	},
 	existingWorkerDefinitions?: WorkerRegistry | undefined
 ): Promise<WorkerRegistry | undefined> {
-	const serviceNames = (services || []).map(
+	const serviceNames = [...(services || []), ...(tails ?? [])].map(
 		(serviceBinding) => serviceBinding.service
 	);
 	const durableObjectServices = (

--- a/packages/wrangler/src/dev-registry/index.ts
+++ b/packages/wrangler/src/dev-registry/index.ts
@@ -55,7 +55,7 @@ export async function getBoundRegisteredWorkers(
 		name,
 		services,
 		durableObjects,
-		tails,
+		tailConsumers,
 	}: {
 		name: string | undefined;
 		services:
@@ -66,11 +66,11 @@ export async function getBoundRegisteredWorkers(
 			| Config["durable_objects"]
 			| { bindings: Extract<Binding, { type: "durable_object_namespace" }>[] }
 			| undefined;
-		tails: Config["tail_consumers"] | undefined;
+		tailConsumers: Config["tail_consumers"] | undefined;
 	},
 	existingWorkerDefinitions?: WorkerRegistry | undefined
 ): Promise<WorkerRegistry | undefined> {
-	const serviceNames = [...(services || []), ...(tails ?? [])].map(
+	const serviceNames = [...(services || []), ...(tailConsumers ?? [])].map(
 		(serviceBinding) => serviceBinding.service
 	);
 	const durableObjectServices = (

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -407,7 +407,7 @@ async function updateDevEnvRegistry(
 					devEnv.config.latestConfig?.bindings
 				),
 			},
-			tails: devEnv.config.latestConfig?.tails,
+			tailConsumers: devEnv.config.latestConfig?.tailConsumers,
 		},
 		registry
 	);

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -407,6 +407,7 @@ async function updateDevEnvRegistry(
 					devEnv.config.latestConfig?.bindings
 				),
 			},
+			tails: devEnv.config.latestConfig?.tails,
 		},
 		registry
 	);

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -192,6 +192,7 @@ export interface ConfigBundle {
 	upstreamProtocol: "http" | "https";
 	inspect: boolean;
 	services: Config["services"] | undefined;
+	tails: Config["tail_consumers"] | undefined;
 	serviceBindings: Record<string, ServiceFetch>;
 	bindVectorizeToProd: boolean;
 	imagesLocalMode: boolean;
@@ -387,6 +388,7 @@ type WorkerOptionsBindings = Pick<
 	| "secretsStoreSecrets"
 	| "email"
 	| "analyticsEngineDatasets"
+	| "tails"
 >;
 
 type MiniflareBindingsConfig = Pick<
@@ -399,6 +401,7 @@ type MiniflareBindingsConfig = Pick<
 	| "services"
 	| "serviceBindings"
 	| "imagesLocalMode"
+	| "tails"
 > &
 	Partial<Pick<ConfigBundle, "format" | "bundle" | "assets">>;
 
@@ -521,6 +524,50 @@ export function buildMiniflareBindingOptions(config: MiniflareBindingsConfig): {
 				},
 			};
 		}
+	}
+
+	const tails: NonNullable<WorkerOptions["tails"]> = [];
+	const notFoundTails = new Set<string>();
+	for (const tail of config.tails ?? []) {
+		if (tail.service === config.name || config.workerDefinitions === null) {
+			// If this is a tail binding to the current worker or the registry is disabled,
+			// don't bother using the dev registry to look up the address, just bind to it directly.
+			tails.push({ name: tail.service });
+
+			continue;
+		}
+
+		const target = config.workerDefinitions?.[tail.service];
+
+		// Tail consumers are always on the default entrypoint
+		const defaultEntrypoint = target?.entrypointAddresses?.["default"];
+		if (
+			target?.host === undefined ||
+			target.port === undefined ||
+			defaultEntrypoint === undefined
+		) {
+			notFoundTails.add(tail.service);
+		} else {
+			const style = HttpOptions_Style.PROXY;
+			const address = `${defaultEntrypoint.host}:${defaultEntrypoint.port}`;
+
+			tails.push({
+				external: {
+					address,
+					http: {
+						style,
+						cfBlobHeader: CoreHeaders.CF_BLOB,
+					},
+				},
+			});
+		}
+	}
+
+	if (notFoundTails.size > 0) {
+		logger.debug(
+			"Couldn't connect to the following configured `tail_consumers`: ",
+			[...notFoundTails.values()].join(", ")
+		);
 	}
 
 	const classNameToUseSQLite = getClassNamesWhichUseSQLite(config.migrations);
@@ -774,6 +821,7 @@ export function buildMiniflareBindingOptions(config: MiniflareBindingsConfig): {
 
 		serviceBindings,
 		wrappedBindings: wrappedBindings,
+		tails,
 	};
 
 	return {
@@ -982,8 +1030,8 @@ export async function buildMiniflareOptions(
 	if (config.crons.length > 0 && !config.testScheduled) {
 		if (!didWarnMiniflareCronSupport) {
 			didWarnMiniflareCronSupport = true;
-			log.warn(
-				"Miniflare 3 does not currently trigger scheduled Workers automatically.\nUse `--test-scheduled` to forward fetch triggers."
+			logger.warn(
+				"Miniflare does not currently trigger scheduled Workers automatically.\nRefer to https://developers.cloudflare.com/workers/configuration/cron-triggers/#test-cron-triggers for more details "
 			);
 		}
 	}

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -530,7 +530,7 @@ export function buildMiniflareBindingOptions(config: MiniflareBindingsConfig): {
 	const notFoundTails = new Set<string>();
 	for (const tail of config.tails ?? []) {
 		if (tail.service === config.name || config.workerDefinitions === null) {
-			// If this is a tail binding to the current worker or the registry is disabled,
+			// If this is a tail binding to the current Worker or the registry is disabled,
 			// don't bother using the dev registry to look up the address, just bind to it directly.
 			tails.push({ name: tail.service });
 

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { getFlag } from "../experimental-flags";
 import { logger } from "../logger";
-import type { CfWorkerInit } from "../deployment-bundle/worker";
+import type { CfTailConsumer, CfWorkerInit } from "../deployment-bundle/worker";
 import type { WorkerRegistry } from "../dev-registry";
 
 export const friendlyBindingNames: Record<
@@ -41,6 +41,7 @@ export const friendlyBindingNames: Record<
  */
 export function printBindings(
 	bindings: Partial<CfWorkerInit["bindings"]>,
+	tails: CfTailConsumer[] = [],
 	context: {
 		registry?: WorkerRegistry | null;
 		local?: boolean;
@@ -68,6 +69,8 @@ export function printBindings(
 		name: string;
 		entries: { key: string; value: string | boolean }[];
 	}[] = [];
+
+	let tailConsumers: string[] = [];
 
 	const {
 		data_blobs,
@@ -345,6 +348,24 @@ export function printBindings(
 		});
 	}
 
+	if (tails !== undefined && tails.length > 0) {
+		tailConsumers = tails.map(({ service }) => {
+			let value = service;
+
+			if (context.local && context.registry !== null) {
+				const registryDefinition = context.registry?.[service];
+				hasConnectionStatus = true;
+
+				if (registryDefinition) {
+					value = value + " " + chalk.green("[connected]");
+				} else {
+					value = value + " " + chalk.red("[not connected]");
+				}
+			}
+			return value;
+		});
+	}
+
 	if (
 		analytics_engine_datasets !== undefined &&
 		analytics_engine_datasets.length > 0
@@ -515,44 +536,58 @@ export function printBindings(
 	}
 
 	if (output.length === 0) {
-		logger.log("No bindings found.");
-		return;
-	}
+		if (context.name && getFlag("MULTIWORKER")) {
+			logger.log(`No bindings found for ${chalk.blue(context.name)}`);
+		} else {
+			logger.log("No bindings found.");
+		}
+	} else {
+		if (context.local) {
+			logger.once.log(
+				`Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.\n`
+			);
+		}
 
-	if (context.local) {
-		logger.once.log(
-			`Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.\n`
+		let title: string;
+		if (context.provisioning) {
+			title = "The following bindings need to be provisioned:";
+		} else if (context.name && getFlag("MULTIWORKER")) {
+			title = `${chalk.blue(context.name)} has access to the following bindings:`;
+		} else {
+			title = "Your worker has access to the following bindings:";
+		}
+
+		const message = [
+			title,
+			...output
+				.map((bindingGroup) => {
+					return [
+						`- ${bindingGroup.name}:`,
+						bindingGroup.entries.map(
+							({ key, value }) => `  - ${key}${value ? ":" : ""} ${value}`
+						),
+					];
+				})
+				.flat(2),
+		].join("\n");
+
+		logger.log(message);
+	}
+	let title: string;
+	if (context.name && getFlag("MULTIWORKER")) {
+		title = `${chalk.blue(context.name)} is sending Tail events to the following workers:`;
+	} else {
+		title = "Your worker is sending Tail events to the following workers:";
+	}
+	if (tailConsumers.length > 0) {
+		logger.log(
+			`${title}\n${tailConsumers.map((worker) => `- ${worker}`).join("\n")}`
 		);
 	}
 
-	let title: string;
-	if (context.provisioning) {
-		title = "The following bindings need to be provisioned:";
-	} else if (context.name && getFlag("MULTIWORKER")) {
-		title = `${chalk.blue(context.name)} has access to the following bindings:`;
-	} else {
-		title = "Your worker has access to the following bindings:";
-	}
-
-	const message = [
-		title,
-		...output
-			.map((bindingGroup) => {
-				return [
-					`- ${bindingGroup.name}:`,
-					bindingGroup.entries.map(
-						({ key, value }) => `  - ${key}${value ? ":" : ""} ${value}`
-					),
-				];
-			})
-			.flat(2),
-	].join("\n");
-
-	logger.log(message);
-
 	if (hasConnectionStatus) {
 		logger.once.info(
-			`\nService bindings & durable object bindings connect to other \`wrangler dev\` processes running locally, with their connection status indicated by ${chalk.green("[connected]")} or ${chalk.red("[not connected]")}. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development\n`
+			`\nService bindings, durable object bindings, and tail consumers connect to other \`wrangler dev\` processes running locally, with their connection status indicated by ${chalk.green("[connected]")} or ${chalk.red("[not connected]")}. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development\n`
 		);
 	}
 }

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -554,7 +554,7 @@ export function printBindings(
 		} else if (context.name && getFlag("MULTIWORKER")) {
 			title = `${chalk.blue(context.name)} has access to the following bindings:`;
 		} else {
-			title = "Your worker has access to the following bindings:";
+			title = "Your Worker has access to the following bindings:";
 		}
 
 		const message = [
@@ -575,9 +575,9 @@ export function printBindings(
 	}
 	let title: string;
 	if (context.name && getFlag("MULTIWORKER")) {
-		title = `${chalk.blue(context.name)} is sending Tail events to the following workers:`;
+		title = `${chalk.blue(context.name)} is sending Tail events to the following Workers:`;
 	} else {
-		title = "Your worker is sending Tail events to the following workers:";
+		title = "Your Worker is sending Tail events to the following Workers:";
 	}
 	if (tailConsumers.length > 0) {
 		logger.log(
@@ -587,7 +587,7 @@ export function printBindings(
 
 	if (hasConnectionStatus) {
 		logger.once.info(
-			`\nService bindings, durable object bindings, and tail consumers connect to other \`wrangler dev\` processes running locally, with their connection status indicated by ${chalk.green("[connected]")} or ${chalk.red("[not connected]")}. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development\n`
+			`\nService bindings, Durable Object bindings, and Tail consumers connect to other \`wrangler dev\` processes running locally, with their connection status indicated by ${chalk.green("[connected]")} or ${chalk.red("[not connected]")}. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development\n`
 		);
 	}
 }

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -563,19 +563,18 @@ export function printBindings(
 		logger.log(
 			`${title}\n${tailConsumers
 				.map(({ service }) => {
-					let value = service;
-
 					if (context.local && context.registry !== null) {
 						const registryDefinition = context.registry?.[service];
 						hasConnectionStatus = true;
 
 						if (registryDefinition) {
-							value = `- ${value} ${chalk.green("[connected]")}`;
+							return `- ${service} ${chalk.green("[connected]")}`;
 						} else {
-							value = `- ${value} ${chalk.red("[not connected]")}`;
+							return `- ${service} ${chalk.red("[not connected]")}`;
 						}
+					} else {
+						return `- ${service}`;
 					}
-					return value;
 				})
 				.join("\n")}`
 		);

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -700,7 +700,7 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 		if (props.dryRun) {
 			workerBundle = createWorkerUploadForm(worker);
-			printBindings({ ...bindings, vars: maskedVars });
+			printBindings({ ...bindings, vars: maskedVars }, config.tail_consumers);
 		} else {
 			assert(accountId, "Missing accountId");
 			if (getFlag("RESOURCES_PROVISION")) {
@@ -735,12 +735,15 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 
 				logger.log("Worker Startup Time:", result.startup_time_ms, "ms");
 				bindingsPrinted = true;
-				printBindings({ ...bindings, vars: maskedVars });
+				printBindings({ ...bindings, vars: maskedVars }, config.tail_consumers);
 				versionId = result.id;
 				hasPreview = result.metadata.has_preview;
 			} catch (err) {
 				if (!bindingsPrinted) {
-					printBindings({ ...bindings, vars: maskedVars });
+					printBindings(
+						{ ...bindings, vars: maskedVars },
+						config.tail_consumers
+					);
 				}
 
 				await helpIfErrorIsSizeOrScriptStartup(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,15 +1061,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
-  fixtures/worker-tail:
-    devDependencies:
-      '@cloudflare/workers-types':
-        specifier: ^4.20250121.0
-        version: 4.20250422.0
-      wrangler:
-        specifier: workspace:*
-        version: link:../../packages/wrangler
-
   fixtures/worker-ts:
     devDependencies:
       '@cloudflare/workers-types':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,6 +1061,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/worker-tail:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250121.0
+        version: 4.20250422.0
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/worker-ts:
     devDependencies:
       '@cloudflare/workers-types':


### PR DESCRIPTION
This is a follow up to the work in `workerd` to support Tail Workers locally, and ensures that Tail Workers are supported in Miniflare. Additionally, they're supported in both `wrangler dev` modes (dev registry & single process).

This can be testing be adding a `[[tail_consumer]]` section to a worker's `wrangler.toml` file, and then adding a `tail()` handler to a second worker, and running them both locally.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: local dev support for an existing feature. we didn't previoulsy call out the lack of local dev support
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
