### PR TITLE
Do not include .wrangler and Wrangler config files in additional modules

### DIFF
--- a/.changeset/eager-bobcats-agree.md
+++ b/.changeset/eager-bobcats-agree.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Do not include .wrangler and Wrangler config files in additional modules
+
+Previously, if you added modules rules such as `**/*.js` or `**/*.json`, specified `no_bundle: true`, and the entry-point to the Worker was in the project root directory, Wrangler could include files that were not intended, such as `.wrangler/tmp/xxx.js` or the Wrangler config file itself. Now these files are automatically skipped when trying to find additional modules by searching the file tree.

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/__tests__/multi-worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/__tests__/multi-worker.spec.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, test } from "vitest";
@@ -12,6 +13,15 @@ describe.runIf(isBuild)("output directories", () => {
 	test("creates the correct output directories", () => {
 		expect(fs.existsSync(path.join(rootDir, "dist", "worker_a"))).toBe(true);
 		expect(fs.existsSync(path.join(rootDir, "dist", "worker_b"))).toBe(true);
+	});
+
+	test("does include unwanted files in deployment bundle", async () => {
+		const output = execSync("pnpm deploy-a --dry-run", {
+			cwd: rootDir,
+			encoding: "utf8",
+		});
+		// There should be no additional modules, in particular ones in `.wrangler/tmp`.
+		expect(output).not.toContain("Attaching additional modules");
 	});
 });
 

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/package.json
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/package.json
@@ -7,6 +7,8 @@
 		"build:custom-output-directories": "vite build --app -c ./vite.config.custom-output-directories.ts",
 		"build:with-worker-configs-warning": "vite build --app -c vite.config.with-worker-configs-warning.ts",
 		"check:types": "tsc --build",
+		"deploy-a": "wrangler deploy -c ./dist/worker_a/wrangler.json",
+		"deploy-b": "wrangler deploy -c ./dist/worker_b/wrangler.json",
 		"dev": "vite dev",
 		"dev:with-worker-configs-warning": "vite dev -c vite.config.with-worker-configs-warning.ts",
 		"preview": "vite preview",

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -89,6 +89,7 @@ function makeEsbuildBundle(testBundle: TestBundle): Bundle {
 		entry: {
 			file: "index.mjs",
 			projectRoot: "/virtual/",
+			configPath: undefined,
 			format: "modules",
 			moduleRoot: "/virtual",
 			name: undefined,
@@ -234,6 +235,7 @@ describe("LocalRuntimeController", () => {
 				entry: {
 					file: "esm/index.mjs",
 					projectRoot: "/virtual/",
+					configPath: undefined,
 					format: "modules",
 					moduleRoot: "/virtual",
 					name: undefined,
@@ -348,6 +350,7 @@ describe("LocalRuntimeController", () => {
 				entry: {
 					file: "index.js",
 					projectRoot: "/virtual/",
+					configPath: undefined,
 					format: "service-worker",
 					moduleRoot: "/virtual",
 					name: undefined,

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -12037,30 +12037,20 @@ export default{
 				main: "index.py",
 				compatibility_flags: ["python_workers"],
 			});
-			await fs.promises.writeFile(
-				"index.py",
-				"from js import Response;\ndef fetch(request):\n return Response.new('hello')"
-			);
+			const expectedModules = {
+				"index.py":
+					"from js import Response;\ndef fetch(request):\n return Response.new('hello')",
+			};
+			await fs.promises.writeFile("index.py", expectedModules["index.py"]);
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({
 				expectedMainModule: "index.py",
+				expectedModules,
 			});
 
 			await runWrangler("deploy");
-			expect(
-				std.out.replace(
-					/.wrangler\/tmp\/deploy-(.+)\/index.py/,
-					".wrangler/tmp/deploy/index.py"
-				)
-			).toMatchInlineSnapshot(`
-				"┌──────────────────────────────────────┬────────┬──────────┐
-				│ Name                                 │ Type   │ Size     │
-				├──────────────────────────────────────┼────────┼──────────┤
-				│ .wrangler/tmp/deploy/index.py │ python │ xx KiB │
-				├──────────────────────────────────────┼────────┼──────────┤
-				│ Total (1 module)                     │        │ xx KiB │
-				└──────────────────────────────────────┴────────┴──────────┘
-				Total Upload: xx KiB / gzip: xx KiB
+			expect(std.out).toMatchInlineSnapshot(`
+				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				No bindings found.
 				Uploaded test-name (TIMINGS)
@@ -12074,30 +12064,20 @@ export default{
 			writeWranglerConfig({
 				compatibility_flags: ["python_workers"],
 			});
-			await fs.promises.writeFile(
-				"index.py",
-				"from js import Response;\ndef fetch(request):\n return Response.new('hello')"
-			);
+			const expectedModules = {
+				"index.py":
+					"from js import Response;\ndef fetch(request):\n return Response.new('hello')",
+			};
+			await fs.promises.writeFile("index.py", expectedModules["index.py"]);
 			mockSubDomainRequest();
 			mockUploadWorkerRequest({
 				expectedMainModule: "index.py",
+				expectedModules,
 			});
 
 			await runWrangler("deploy index.py");
-			expect(
-				std.out.replace(
-					/.wrangler\/tmp\/deploy-(.+)\/index.py/,
-					".wrangler/tmp/deploy/index.py"
-				)
-			).toMatchInlineSnapshot(`
-				"┌──────────────────────────────────────┬────────┬──────────┐
-				│ Name                                 │ Type   │ Size     │
-				├──────────────────────────────────────┼────────┼──────────┤
-				│ .wrangler/tmp/deploy/index.py │ python │ xx KiB │
-				├──────────────────────────────────────┼────────┼──────────┤
-				│ Total (1 module)                     │        │ xx KiB │
-				└──────────────────────────────────────┴────────┴──────────┘
-				Total Upload: xx KiB / gzip: xx KiB
+			expect(std.out).toMatchInlineSnapshot(`
+				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				No bindings found.
 				Uploaded test-name (TIMINGS)

--- a/packages/wrangler/src/__tests__/find-additional-modules.test.ts
+++ b/packages/wrangler/src/__tests__/find-additional-modules.test.ts
@@ -242,11 +242,7 @@ describe("traverse module graph", () => {
 			]
 		);
 
-		expect(modules.map((m) => m.name)).toMatchInlineSnapshot(`
-			Array [
-			  "wrangler.jsonc",
-			]
-		`);
+		expect(modules.map((m) => m.name)).toMatchInlineSnapshot(`Array []`);
 	});
 
 	it("should resolve files that match the default rules", async () => {

--- a/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
+++ b/packages/wrangler/src/__tests__/navigator-user-agent.test.ts
@@ -105,6 +105,7 @@ describe("defineNavigatorUserAgent is respected", () => {
 			{
 				file: path.resolve("src/index.js"),
 				projectRoot: process.cwd(),
+				configPath: undefined,
 				format: "modules",
 				moduleRoot: path.dirname(path.resolve("src/index.js")),
 				exports: [],
@@ -166,6 +167,7 @@ describe("defineNavigatorUserAgent is respected", () => {
 			{
 				file: path.resolve("src/index.js"),
 				projectRoot: process.cwd(),
+				configPath: undefined,
 				format: "modules",
 				moduleRoot: path.dirname(path.resolve("src/index.js")),
 				exports: [],

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -80,6 +80,7 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 			const entry: Entry = {
 				file: config.entrypoint,
 				projectRoot: config.projectRoot,
+				configPath: config.config,
 				format: config.build.format,
 				moduleRoot: config.build.moduleRoot,
 				exports: config.build.exports,
@@ -228,6 +229,7 @@ export class BundlerController extends Controller<BundlerControllerEventMap> {
 		const entry: Entry = {
 			file: config.entrypoint,
 			projectRoot: config.projectRoot,
+			configPath: config.config,
 			format: config.build.format,
 			moduleRoot: config.build.moduleRoot,
 			exports: config.build.exports,

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -25,6 +25,8 @@ export type Entry = {
 	file: string;
 	/** A worker's directory. Usually where the Wrangler configuration file is located */
 	projectRoot: string;
+	/** The path to the config file, if it exists. */
+	configPath: string | undefined;
 	/** Is this a module worker or a service worker? */
 	format: CfScriptFormat;
 	/** The directory that contains all of a `--no-bundle` worker's modules. Usually `${directory}/src`. Defaults to path.dirname(file) */
@@ -148,6 +150,7 @@ export async function getEntry(
 	return {
 		file: paths.absolutePath,
 		projectRoot,
+		configPath: config.configPath,
 		format,
 		moduleRoot:
 			args.moduleRoot ?? config.base_dir ?? path.dirname(paths.absolutePath),

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -24,14 +24,17 @@ async function* getFiles(
 	for (const file of await readdir(moduleRoot, { withFileTypes: true })) {
 		const absPath = path.join(moduleRoot, file.name);
 		if (file.isDirectory()) {
-			// Skip the hidden Wrangler directory and Wrangler config path, so we don't accidentally bundle non-user files.
-			if (absPath !== wranglerHiddenDirPath && absPath !== configPath) {
-				yield* getFiles(configPath, absPath, relativeTo, wranglerHiddenDirPath);
+			// Skip the hidden Wrangler directory so we don't accidentally bundle non-user files.
+			if (absPath !== wranglerHiddenDirPath) {
+				yield* getFiles(configPath, absPath, relativeTo, projectRoot);
 			}
 		} else {
-			// Module names should always use `/`. This is also required to match globs correctly on Windows. Later code will
-			// `path.resolve()` with these names to read contents which will perform appropriate normalisation.
-			yield path.relative(relativeTo, absPath).replaceAll("\\", "/");
+			// don't bundle the wrangler config file
+			if (absPath !== configPath) {
+				// Module names should always use `/`. This is also required to match globs correctly on Windows. Later code will
+				// `path.resolve()` with these names to read contents which will perform appropriate normalisation.
+				yield path.relative(relativeTo, absPath).replaceAll("\\", "/");
+			}
 		}
 	}
 }

--- a/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
+++ b/packages/wrangler/src/deployment-bundle/find-additional-modules.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import globToRegExp from "glob-to-regexp";
 import { UserError } from "../errors";
 import { logger } from "../logger";
+import { getWranglerHiddenDirPath } from "../paths";
 import { getBundleType } from "./bundle-type";
 import { RuleTypeToModuleType } from "./module-collection";
 import { parseRules } from "./rules";
@@ -14,18 +15,23 @@ import type { ParsedRules } from "./rules";
 import type { CfModule } from "./worker";
 
 async function* getFiles(
-	root: string,
-	relativeTo: string
+	configPath: string | undefined,
+	moduleRoot: string,
+	relativeTo: string,
+	projectRoot: string
 ): AsyncGenerator<string> {
-	for (const file of await readdir(root, { withFileTypes: true })) {
+	const wranglerHiddenDirPath = getWranglerHiddenDirPath(projectRoot);
+	for (const file of await readdir(moduleRoot, { withFileTypes: true })) {
+		const absPath = path.join(moduleRoot, file.name);
 		if (file.isDirectory()) {
-			yield* getFiles(path.join(root, file.name), relativeTo);
+			// Skip the hidden Wrangler directory and Wrangler config path, so we don't accidentally bundle non-user files.
+			if (absPath !== wranglerHiddenDirPath && absPath !== configPath) {
+				yield* getFiles(configPath, absPath, relativeTo, wranglerHiddenDirPath);
+			}
 		} else {
 			// Module names should always use `/`. This is also required to match globs correctly on Windows. Later code will
 			// `path.resolve()` with these names to read contents which will perform appropriate normalisation.
-			yield path
-				.relative(relativeTo, path.join(root, file.name))
-				.replaceAll("\\", "/");
+			yield path.relative(relativeTo, absPath).replaceAll("\\", "/");
 		}
 	}
 }
@@ -49,7 +55,12 @@ export async function findAdditionalModules(
 	rules: Rule[] | ParsedRules,
 	attachSourcemaps = false
 ): Promise<CfModule[]> {
-	const files = getFiles(entry.moduleRoot, entry.moduleRoot);
+	const files = getFiles(
+		entry.configPath,
+		entry.moduleRoot,
+		entry.moduleRoot,
+		entry.projectRoot
+	);
 	const relativeEntryPoint = path
 		.relative(entry.moduleRoot, entry.file)
 		.replaceAll("\\", "/");

--- a/packages/wrangler/src/pages/functions/buildPlugin.ts
+++ b/packages/wrangler/src/pages/functions/buildPlugin.ts
@@ -31,6 +31,7 @@ export function buildPluginFromFunctions({
 	const entry: Entry = {
 		file: resolve(getBasePath(), "templates/pages-template-plugin.ts"),
 		projectRoot: functionsDirectory,
+		configPath: undefined,
 		format: "modules",
 		moduleRoot: functionsDirectory,
 		exports: [],

--- a/packages/wrangler/src/pages/functions/buildWorker.ts
+++ b/packages/wrangler/src/pages/functions/buildWorker.ts
@@ -58,6 +58,7 @@ export function buildWorkerFromFunctions({
 	const entry: Entry = {
 		file: resolve(getBasePath(), "templates/pages-template-worker.ts"),
 		projectRoot: functionsDirectory,
+		configPath: undefined,
 		format: "modules",
 		moduleRoot: functionsDirectory,
 		exports: [],
@@ -152,6 +153,7 @@ export function buildRawWorker({
 	const entry: Entry = {
 		file: workerScriptPath,
 		projectRoot: resolve(directory),
+		configPath: undefined,
 		format: "modules",
 		moduleRoot: resolve(directory),
 		exports: [],
@@ -237,6 +239,7 @@ export async function produceWorkerBundleForWorkerJSDirectory({
 		{
 			file: entrypoint,
 			projectRoot: resolve(workerJSDirectory),
+			configPath: undefined,
 			format: "modules",
 			moduleRoot: resolve(workerJSDirectory),
 			exports: [],

--- a/packages/wrangler/src/paths.ts
+++ b/packages/wrangler/src/paths.ts
@@ -82,6 +82,16 @@ export interface EphemeralDirectory {
 }
 
 /**
+ * Gets the path to the project's `.wrangler` folder.
+ */
+export function getWranglerHiddenDirPath(
+	projectRoot: string | undefined
+): string {
+	projectRoot ??= process.cwd();
+	return path.join(projectRoot, ".wrangler");
+}
+
+/**
  * Gets a temporary directory in the project's `.wrangler` folder with the
  * specified prefix. We create temporary directories in `.wrangler` as opposed
  * to the OS's temporary directory to avoid issues with different drive letters
@@ -93,8 +103,7 @@ export function getWranglerTmpDir(
 	prefix: string,
 	cleanup = true
 ): EphemeralDirectory {
-	projectRoot ??= process.cwd();
-	const tmpRoot = path.join(projectRoot, ".wrangler", "tmp");
+	const tmpRoot = path.join(getWranglerHiddenDirPath(projectRoot), "tmp");
 	fs.mkdirSync(tmpRoot, { recursive: true });
 
 	const tmpPrefix = path.join(tmpRoot, `${prefix}-`);


### PR DESCRIPTION
Previously, if you added modules rules such as `**/*.js` or `**/*.json`, specified `no_bundle: true`, and the entry-point to the Worker was in the project root directory, Wrangler could include files that were not intended, such as `.wrangler/tmp/xxx.js` or the Wrangler config file itself. Now these files are automatically skipped when trying to find additional modules by searching the file tree.

Fixes #8940
Fixes https://github.com/cloudflare/workers-sdk/issues/8911

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/9086
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

