### PR TITLE
Add `global_fetch_strictly_public` to the Next template for workers

### DIFF
--- a/.changeset/kind-dolls-swim.md
+++ b/.changeset/kind-dolls-swim.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Add the `global_fetch_strictly_public` flag to the Next template for workers

--- a/packages/create-cloudflare/templates/next/workers/templates/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/next/workers/templates/wrangler.jsonc
@@ -3,7 +3,8 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2025-03-01",
   "compatibility_flags": [
-    "nodejs_compat"
+    "nodejs_compat",
+    "global_fetch_strictly_public"
   ],
   "assets": {
     "binding": "ASSETS",


### PR DESCRIPTION
Fetching from the same worker (more generally a worker in the same zone) fails for deployed workers without this flag. Adding this flag makes sense when there is no origin server - probably we should consider adding it for all frameworks?

(note that same worker fetch works with wrangler dev)

Our current workaround is to create a service binding in [wrangler.jsonc](https://opennext.js.org/cloudflare/caching#:~:text=NEXT_TAG_CACHE_D1.%20The-,WORKER_SELF_REFERENCE,-service%20binding%20should) - this PR will allow to simplify the config.

Ref:

- https://github.com/cloudflare/workerd/blob/b85dbe26804b6a534e21c1d2df1cf3775645c0f2/src/workerd/io/compatibility-date.capnp#L476-L510
- https://github.com/cloudflare/cloudflare-docs/pull/22017
- https://github.com/opennextjs/opennextjs-cloudflare/issues/602

/cc @conico974 @james-elicx 

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: I'll updatre the OpenNext docs later
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: does not apply there

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
