### PR TITLE
fix(miniflare): parse pem file with regex

### DIFF
--- a/.changeset/soft-wasps-beg.md
+++ b/.changeset/soft-wasps-beg.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: skip comment lines when parsing `NODE_EXTRA_CA_CERTS`

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -84,9 +84,12 @@ if (process.env.NODE_EXTRA_CA_CERTS !== undefined) {
 		const extra = readFileSync(process.env.NODE_EXTRA_CA_CERTS, "utf8");
 		// Split bundle into individual certificates and add each individually:
 		// https://github.com/cloudflare/miniflare/pull/587/files#r1271579671
-		const pemBegin = "-----BEGIN";
-		for (const cert of extra.split(pemBegin)) {
-			if (cert.trim() !== "") trustedCertificates.push(pemBegin + cert);
+		const certs = extra.match(
+			/-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g
+		);
+
+		if (certs !== null) {
+			trustedCertificates.push(...certs);
 		}
 	} catch {}
 }

--- a/packages/miniflare/test/plugins/core/index.spec.ts
+++ b/packages/miniflare/test/plugins/core/index.spec.ts
@@ -48,7 +48,12 @@ opensslTest("NODE_EXTRA_CA_CERTS: loads certificates", async (t) => {
 	// (see https://github.com/cloudflare/miniflare/pull/587/files#r1271579671)
 	const caCertsPath = path.join(tmp, "bundle.pem");
 	const caCerts = [...tls.rootCertificates, cert];
-	await fs.writeFile(caCertsPath, caCerts.join("\n"));
+	await fs.writeFile(
+		caCertsPath,
+		["## This is a comment which should be ignored\n"].concat(
+			caCerts.join("\n")
+		)
+	);
 
 	// Start Miniflare with NODE_EXTRA_CA_CERTS environment variable
 	// (cannot use sync process methods here as that would block HTTPS server)


### PR DESCRIPTION
Fixes #8415.

The current logic simply split the text content by `--BEGIN` which might end up with a comment block that hold no certs.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact to wrangler
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
