### PR TITLE
fix(miniflare): decouple KV plugin from Secrets Store plugin to avoid service name conflicts

### DIFF
--- a/.changeset/silver-bats-brush.md
+++ b/.changeset/silver-bats-brush.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+---
+
+fix: decouple KV plugin from secrets store plugin
+
+The KV plugin previously configured both KV namespace and secrets store bindings with the same service name but different persistence paths, causing conflicts when both were defined. This change copies the KV binding implementation into the secrets store plugin and customizes its service name to prevent collisions.

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -56,7 +56,7 @@ export const KVSharedOptionsSchema = z.object({
 
 const SERVICE_NAMESPACE_PREFIX = `${KV_PLUGIN_NAME}:ns`;
 const KV_STORAGE_SERVICE_NAME = `${KV_PLUGIN_NAME}:storage`;
-const KV_NAMESPACE_OBJECT_CLASS_NAME = "KVNamespaceObject";
+export const KV_NAMESPACE_OBJECT_CLASS_NAME = "KVNamespaceObject";
 const KV_NAMESPACE_OBJECT: Worker_Binding_DurableObjectNamespaceDesignator = {
 	serviceName: SERVICE_NAMESPACE_PREFIX,
 	className: KV_NAMESPACE_OBJECT_CLASS_NAME,

--- a/packages/miniflare/src/plugins/secret-store/index.ts
+++ b/packages/miniflare/src/plugins/secret-store/index.ts
@@ -4,6 +4,7 @@ import SCRIPT_SECRETS_STORE_SECRET from "worker:secrets-store/secret";
 import { z } from "zod";
 import { Service, Worker_Binding } from "../../runtime";
 import { SharedBindings } from "../../workers";
+import { KV_NAMESPACE_OBJECT_CLASS_NAME } from "../kv";
 import {
 	getMiniflareObjectBindings,
 	getPersistPath,
@@ -83,7 +84,6 @@ export const SECRET_STORE_PLUGIN: Plugin<
 
 		await fs.mkdir(persistPath, { recursive: true });
 
-		const KV_NAMESPACE_OBJECT_CLASS_NAME = "KVNamespaceObject";
 		const storageService = {
 			name: `${SECRET_STORE_PLUGIN_NAME}:storage`,
 			disk: { path: persistPath, writable: true },

--- a/packages/miniflare/src/plugins/secret-store/index.ts
+++ b/packages/miniflare/src/plugins/secret-store/index.ts
@@ -1,8 +1,18 @@
+import fs from "fs/promises";
+import SCRIPT_KV_NAMESPACE_OBJECT from "worker:kv/namespace";
 import SCRIPT_SECRETS_STORE_SECRET from "worker:secrets-store/secret";
 import { z } from "zod";
-import { ServiceDesignator, Worker_Binding } from "../../runtime";
-import { KV_PLUGIN, KVOptionsSchema } from "../kv";
-import { PersistenceSchema, Plugin, ProxyNodeBinding } from "../shared";
+import { Service, Worker_Binding } from "../../runtime";
+import { SharedBindings } from "../../workers";
+import {
+	getMiniflareObjectBindings,
+	getPersistPath,
+	objectEntryWorker,
+	PersistenceSchema,
+	Plugin,
+	ProxyNodeBinding,
+	SERVICE_LOOPBACK,
+} from "../shared";
 
 const SecretsStoreSecretsSchema = z.record(
 	z.object({
@@ -20,30 +30,6 @@ export const SecretsStoreSecretsSharedOptionsSchema = z.object({
 });
 
 export const SECRET_STORE_PLUGIN_NAME = "secrets-store";
-
-function getkvNamespacesOptions(
-	secretsStoreSecrets: z.input<typeof SecretsStoreSecretsSchema>
-): z.input<typeof KVOptionsSchema> {
-	// Get unique store ids
-	const storeIds = new Set(
-		Object.values(secretsStoreSecrets).map((store) => store.store_id)
-	);
-	// Setup a KV Namespace per store id with store id as the binding name
-	const storeIdKvNamespaceEntries = Array.from(storeIds).map((storeId) => [
-		storeId,
-		`${SECRET_STORE_PLUGIN_NAME}:${storeId}`,
-	]);
-
-	return {
-		kvNamespaces: Object.fromEntries(storeIdKvNamespaceEntries),
-	};
-}
-
-function isKvBinding(
-	binding: Worker_Binding
-): binding is Worker_Binding & { kvNamespace: ServiceDesignator } {
-	return "kvNamespace" in binding;
-}
 
 export const SECRET_STORE_PLUGIN: Plugin<
 	typeof SecretsStoreSecretsOptionsSchema,
@@ -80,65 +66,100 @@ export const SECRET_STORE_PLUGIN: Plugin<
 			])
 		);
 	},
-	async getServices({ options, sharedOptions, ...restOptions }) {
-		if (!options.secretsStoreSecrets) {
+	async getServices({ options, sharedOptions, tmpPath, unsafeStickyBlobs }) {
+		const configs = options.secretsStoreSecrets
+			? Object.values(options.secretsStoreSecrets)
+			: [];
+
+		if (configs.length === 0) {
 			return [];
 		}
 
-		const kvServices = await KV_PLUGIN.getServices({
-			options: getkvNamespacesOptions(options.secretsStoreSecrets),
-			sharedOptions: {
-				kvPersist: sharedOptions.secretsStorePersist,
-			},
-			...restOptions,
-		});
-
-		const kvBindings = await KV_PLUGIN.getBindings(
-			getkvNamespacesOptions(options.secretsStoreSecrets),
-			restOptions.workerIndex
+		const persistPath = getPersistPath(
+			SECRET_STORE_PLUGIN_NAME,
+			tmpPath,
+			sharedOptions.secretsStorePersist
 		);
 
-		if (!kvBindings || !kvBindings.every(isKvBinding)) {
-			throw new Error(
-				"Expected KV plugin to return bindings with kvNamespace defined"
-			);
-		}
+		await fs.mkdir(persistPath, { recursive: true });
 
-		if (!Array.isArray(kvServices)) {
-			throw new Error("Expected KV plugin to return an array of services");
-		}
-
-		return [
-			...kvServices,
-			...Object.entries(options.secretsStoreSecrets).map<Worker_Binding>(
-				([_, config]) => {
-					return {
-						name: `${SECRET_STORE_PLUGIN_NAME}:${config.store_id}:${config.secret_name}`,
-						worker: {
-							compatibilityDate: "2025-01-01",
-							modules: [
-								{
-									name: "secret.worker.js",
-									esModule: SCRIPT_SECRETS_STORE_SECRET(),
-								},
-							],
-							bindings: [
-								{
-									name: "store",
-									kvNamespace: kvBindings.find(
-										// Look up the corresponding KV namespace for the store id
-										(binding) => binding.name === config.store_id
-									)?.kvNamespace,
-								},
-								{
-									name: "secret_name",
-									json: JSON.stringify(config.secret_name),
-								},
-							],
+		const KV_NAMESPACE_OBJECT_CLASS_NAME = "KVNamespaceObject";
+		const storageService = {
+			name: `${SECRET_STORE_PLUGIN_NAME}:storage`,
+			disk: { path: persistPath, writable: true },
+		} satisfies Service;
+		const objectService = {
+			name: `${SECRET_STORE_PLUGIN_NAME}:ns`,
+			worker: {
+				compatibilityDate: "2023-07-24",
+				compatibilityFlags: ["nodejs_compat", "experimental"],
+				modules: [
+					{
+						name: "namespace.worker.js",
+						esModule: SCRIPT_KV_NAMESPACE_OBJECT(),
+					},
+				],
+				durableObjectNamespaces: [
+					{
+						className: KV_NAMESPACE_OBJECT_CLASS_NAME,
+						uniqueKey: `miniflare-secrets-store-${KV_NAMESPACE_OBJECT_CLASS_NAME}`,
+					},
+				],
+				// Store Durable Object SQL databases in persist path
+				durableObjectStorage: { localDisk: storageService.name },
+				// Bind blob disk directory service to object
+				bindings: [
+					{
+						name: SharedBindings.MAYBE_SERVICE_BLOBS,
+						service: { name: storageService.name },
+					},
+					{
+						name: SharedBindings.MAYBE_SERVICE_LOOPBACK,
+						service: { name: SERVICE_LOOPBACK },
+					},
+					...getMiniflareObjectBindings(unsafeStickyBlobs),
+				],
+			},
+		} satisfies Service;
+		const services = configs.flatMap<Service>((config) => {
+			const kvNamespaceService = {
+				name: `${SECRET_STORE_PLUGIN_NAME}:ns:${config.store_id}`,
+				worker: objectEntryWorker(
+					{
+						serviceName: objectService.name,
+						className: KV_NAMESPACE_OBJECT_CLASS_NAME,
+					},
+					config.store_id
+				),
+			} satisfies Service;
+			const secretStoreSecretService = {
+				name: `${SECRET_STORE_PLUGIN_NAME}:${config.store_id}:${config.secret_name}`,
+				worker: {
+					compatibilityDate: "2025-01-01",
+					modules: [
+						{
+							name: "secret.worker.js",
+							esModule: SCRIPT_SECRETS_STORE_SECRET(),
 						},
-					};
-				}
-			),
-		];
+					],
+					bindings: [
+						{
+							name: "store",
+							kvNamespace: {
+								name: kvNamespaceService.name,
+							},
+						},
+						{
+							name: "secret_name",
+							json: JSON.stringify(config.secret_name),
+						},
+					],
+				},
+			} satisfies Service;
+
+			return [kvNamespaceService, secretStoreSecretService];
+		});
+
+		return [...services, storageService, objectService];
 	},
 };

--- a/packages/wrangler/e2e/dev-with-resources.test.ts
+++ b/packages/wrangler/e2e/dev-with-resources.test.ts
@@ -370,6 +370,10 @@ describe.sequential.each(RUNTIMES)("Bindings: $flags", ({ runtime, flags }) => {
 				name = "${workerName}"
 				main = "src/index.ts"
 				compatibility_date = "2025-01-01"
+				# Regression test for https://github.com/cloudflare/workers-sdk/issues/9006
+				kv_namespaces = [
+					${isLocal ? `{ binding = "KV", id = "LOCAL_ONLY" }` : ""}
+				]
 				secrets_store_secrets = [
 					{ binding = "SECRET", store_id = "${storeId}", secret_name = "${secret_name}" }
 				]


### PR DESCRIPTION
Fixes #9006.

We were relying on the KV plugin to setup the object and storage service for the internal KV namespaced used by the local sercets store binding. However, this creates an issue when the users have both a KV namespace and secret binding defined with each creating a storage service sharing the same name while having a different persist path.

This decouples kv plugin from the sercets store plugin by copying the implementation in the kv bindings with the service named customzied for the secret store plugin.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: v4 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
