### PR TITLE
Bump to Node.js 20

### DIFF
--- a/.changeset/young-trainers-do.md
+++ b/.changeset/young-trainers-do.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Warn if the Node.js version is below Node.js 20

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -3,7 +3,7 @@ description: "Install dependencies, fetching from cache when possible"
 inputs:
   node-version:
     description: the version of Node.js to install
-    default: 18.20.6
+    default: 20.19.1
   turbo-api:
     description: the api URL for connecting to the turbo remote cache
   turbo-team:

--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
-        with:
-          node-version: 18.18
 
       - name: Build tools and libraries
         run: pnpm run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2022, ubuntu-22.04]
-        node: ["18"]
+        node: ["20.19.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13]
-        node: ["18"]
+        node: ["20.19.1"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -113,16 +113,12 @@ jobs:
         include:
           - os: ubuntu-24.04-arm
             os_name: Linux
-            node_version: 18.20.6
+            node_version: 20.19.1
             filter: '--filter="./tools" --filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground"'
           - os: windows-latest
             os_name: Windows
-            node_version: 18.20.6
+            node_version: 20.19.1
             filter: '--filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground"'
-          - os: ubuntu-24.04-arm
-            os_name: v20, Linux
-            node_version: 20
-            filter: '--filter="./packages/*"'
           - os: ubuntu-24.04-arm
             os_name: v22, Linux
             node_version: 22
@@ -182,7 +178,7 @@ jobs:
         include:
           - os: macos-latest
             os_name: macOS
-            node_version: 18.20.6
+            node_version: 20.19.1
             filter: '--filter="./packages/*" --filter="./fixtures/*" --filter="./packages/vite-plugin-cloudflare/playground" --summarize'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-old-node-error.yml
+++ b/.github/workflows/test-old-node-error.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js v16
+      - name: Use Node.js v18
         uses: actions/setup-node@v4
         with:
-          node-version: 16.13.0
+          node-version: 18.20.6
 
       - name: Check for error message
         run: node packages/wrangler/src/__tests__/test-old-node-version.js

--- a/.github/workflows/test-old-node-error.yml
+++ b/.github/workflows/test-old-node-error.yml
@@ -19,10 +19,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Use Node.js v16
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+
+      - name: Check for error message
+        run: node packages/wrangler/src/__tests__/test-old-node-version.js error
+
       - name: Use Node.js v18
         uses: actions/setup-node@v4
         with:
-          node-version: 18.20.6
+          node-version: 18
 
-      - name: Check for error message
-        run: node packages/wrangler/src/__tests__/test-old-node-version.js
+      - name: Check for warning message
+        run: node packages/wrangler/src/__tests__/test-old-node-version.js warn

--- a/fixtures/import-npm/package.json
+++ b/fixtures/import-npm/package.json
@@ -7,7 +7,7 @@
 		"packages/*"
 	],
 	"scripts": {
-		"_clean_install": "rm -rf node_modules && npm install --no-package-lock --workspaces",
+		"_clean_install": "rm -rf node_modules && npm install --no-package-lock",
 		"check:type": "npm run check:type --workspaces",
 		"test:ci": "npm run test:ci --workspaces",
 		"test:watch": "npm run test:watch --workspaces",

--- a/packages/miniflare/src/plugins/core/errors/callsite.ts
+++ b/packages/miniflare/src/plugins/core/errors/callsite.ts
@@ -79,7 +79,7 @@ function parseCallSite(line: string): CallSite | undefined {
 		typeName,
 		functionName,
 		methodName,
-		fileName: lineMatch[2] || null,
+		fileName: lineMatch[2],
 		lineNumber: parseInt(lineMatch[3]) || null,
 		columnNumber: parseInt(lineMatch[4]) || null,
 		native: isNative,
@@ -90,7 +90,7 @@ export interface CallSiteOptions {
 	typeName: string | null;
 	functionName: string | null;
 	methodName: string | null;
-	fileName: string | null;
+	fileName: string;
 	lineNumber: number | null;
 	columnNumber: number | null;
 	native: boolean;
@@ -101,6 +101,21 @@ export interface CallSiteOptions {
 // https://github.com/felixge/node-stack-trace/blob/4c41a4526e74470179b3b6dd5d75191ca8c56c17/index.js
 export class CallSite implements NodeJS.CallSite {
 	constructor(private readonly opts: CallSiteOptions) {}
+	getScriptHash(): string {
+		throw new Error("Method not implemented.");
+	}
+	getEnclosingColumnNumber(): number {
+		throw new Error("Method not implemented.");
+	}
+	getEnclosingLineNumber(): number {
+		throw new Error("Method not implemented.");
+	}
+	getPosition(): number {
+		throw new Error("Method not implemented.");
+	}
+	toString(): string {
+		throw new Error("Method not implemented.");
+	}
 
 	getThis(): unknown {
 		return null;
@@ -121,7 +136,7 @@ export class CallSite implements NodeJS.CallSite {
 	getFileName(): string | undefined {
 		return this.opts.fileName ?? undefined;
 	}
-	getScriptNameOrSourceURL(): string | null {
+	getScriptNameOrSourceURL(): string {
 		return this.opts.fileName;
 	}
 	getLineNumber(): number | null {

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -2,15 +2,15 @@
 const { spawn } = require("child_process");
 const path = require("path");
 
+const ERR_NODE_VERSION = "18.0.0";
 const MIN_NODE_VERSION = "20.0.0";
-
 let wranglerProcess;
 
 /**
  * Executes ../wrangler-dist/cli.js
  */
 function runWrangler() {
-	if (semiver(process.versions.node, MIN_NODE_VERSION) < 0) {
+	if (semiver(process.versions.node, ERR_NODE_VERSION) < 0) {
 		// Note Volta and nvm are also recommended in the official docs:
 		// https://developers.cloudflare.com/workers/get-started/guide#2-install-the-workers-cli
 		console.error(

--- a/packages/wrangler/bin/wrangler.js
+++ b/packages/wrangler/bin/wrangler.js
@@ -2,7 +2,7 @@
 const { spawn } = require("child_process");
 const path = require("path");
 
-const MIN_NODE_VERSION = "18.0.0";
+const MIN_NODE_VERSION = "20.0.0";
 
 let wranglerProcess;
 

--- a/packages/wrangler/src/__tests__/ai.local.test.ts
+++ b/packages/wrangler/src/__tests__/ai.local.test.ts
@@ -1,5 +1,6 @@
 import { Request } from "miniflare";
 import { HttpResponse } from "msw";
+import { Headers } from "undici";
 import { AIFetcher } from "../ai/fetcher";
 import * as internal from "../cfetch/internal";
 import * as user from "../user";

--- a/packages/wrangler/src/__tests__/test-old-node-version.js
+++ b/packages/wrangler/src/__tests__/test-old-node-version.js
@@ -5,23 +5,40 @@ const path = require("path");
 
 const assert = require("assert");
 
+const mode = process.argv[2];
+
 const wranglerProcess = spawn(
 	"node",
-	[path.join(__dirname, "../../bin/wrangler.js")],
+	[path.join(__dirname, "../../bin/wrangler.js"), "help"],
 	{ stdio: "pipe" }
 );
 
-const messageToMatch = "Wrangler requires at least Node.js v20";
+const messageToMatch = "Wrangler requires at least Node.js v";
 
 wranglerProcess.once("exit", (code) => {
 	try {
-		const errorMessage = wranglerProcess.stderr.read().toString();
+		if (mode === "error") {
+			const errorMessage = wranglerProcess.stderr.read().toString();
 
-		assert(code === 1, "Expected exit code 1");
-		assert(
-			errorMessage.includes(messageToMatch),
-			`Expected error message to include "${messageToMatch}"`
-		);
+			assert(code === 1, "Expected exit code 1");
+			assert(
+				errorMessage.includes(messageToMatch),
+				`Expected error message to include "${messageToMatch}"`
+			);
+		} else {
+			const warningMessage = wranglerProcess.stderr.read().toString();
+
+			assert(code === 1, "Expected exit code 1");
+			assert(
+				warningMessage.includes(messageToMatch),
+				`Expected error message to include "${messageToMatch}"`
+			);
+			// Wrangler should only warn, and so validate that the help text was shown
+			assert(
+				warningMessage.includes("Show help"),
+				`Expected error message to include "Show help"`
+			);
+		}
 	} catch (err) {
 		console.error("Error:", err);
 		throw new Error(

--- a/packages/wrangler/src/__tests__/test-old-node-version.js
+++ b/packages/wrangler/src/__tests__/test-old-node-version.js
@@ -11,7 +11,7 @@ const wranglerProcess = spawn(
 	{ stdio: "pipe" }
 );
 
-const messageToMatch = "Wrangler requires at least Node.js v18";
+const messageToMatch = "Wrangler requires at least Node.js v20";
 
 wranglerProcess.once("exit", (code) => {
 	try {
@@ -25,7 +25,7 @@ wranglerProcess.once("exit", (code) => {
 	} catch (err) {
 		console.error("Error:", err);
 		throw new Error(
-			"This test has to be run with a version of Node.js under 18 to pass"
+			"This test has to be run with a version of Node.js under 20 to pass"
 		);
 	}
 });

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -231,7 +231,7 @@ function lineMatchToCallSite(lineMatch: RegExpMatchArray): CallSite {
 		typeName,
 		functionName,
 		methodName,
-		fileName: lineMatch[2] || null,
+		fileName: lineMatch[2],
 		lineNumber: parseInt(lineMatch[3]) || null,
 		columnNumber: parseInt(lineMatch[4]) || null,
 		native: isNative,
@@ -242,7 +242,7 @@ interface CallSiteOptions {
 	typeName: string | null;
 	functionName: string | null;
 	methodName: string | null;
-	fileName: string | null;
+	fileName: string;
 	lineNumber: number | null;
 	columnNumber: number | null;
 	native: boolean;
@@ -253,6 +253,21 @@ interface CallSiteOptions {
 // https://github.com/felixge/node-stack-trace/blob/4c41a4526e74470179b3b6dd5d75191ca8c56c17/index.js
 class CallSite implements NodeJS.CallSite {
 	constructor(private readonly opts: CallSiteOptions) {}
+	getScriptHash(): string {
+		throw new Error("Method not implemented.");
+	}
+	getEnclosingColumnNumber(): number {
+		throw new Error("Method not implemented.");
+	}
+	getEnclosingLineNumber(): number {
+		throw new Error("Method not implemented.");
+	}
+	getPosition(): number {
+		throw new Error("Method not implemented.");
+	}
+	toString(): string {
+		throw new Error("Method not implemented.");
+	}
 
 	getThis(): unknown {
 		return null;
@@ -273,7 +288,7 @@ class CallSite implements NodeJS.CallSite {
 	getFileName(): string | undefined {
 		return this.opts.fileName ?? undefined;
 	}
-	getScriptNameOrSourceURL(): string | null {
+	getScriptNameOrSourceURL(): string {
 		return this.opts.fileName;
 	}
 	getLineNumber(): number | null {

--- a/packages/wrangler/src/wrangler-banner.ts
+++ b/packages/wrangler/src/wrangler-banner.ts
@@ -1,8 +1,11 @@
 import chalk from "chalk";
+import semiver from "semiver";
 import supportsColor from "supports-color";
 import { version as wranglerVersion } from "../package.json";
 import { logger } from "./logger";
 import { updateCheck } from "./update-check";
+
+const MIN_NODE_VERSION = "20.0.0";
 
 export async function printWranglerBanner(performUpdateCheck = true) {
 	let text = ` ⛅️ wrangler ${wranglerVersion}`;
@@ -23,6 +26,12 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 				: "-".repeat(text.length)) +
 			"\n"
 	);
+
+	if (semiver(process.versions.node, MIN_NODE_VERSION) < 0) {
+		logger.warn(
+			`Wrangler requires at least Node.js v${MIN_NODE_VERSION}. You are using v${process.versions.node}. Please update your version of Node.js.`
+		);
+	}
 
 	// Log a slightly more noticeable message if this is a major bump
 	if (maybeNewVersion !== undefined) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2340,7 +2340,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -16065,13 +16065,13 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/command-exists@1.2.0': {}
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/cookie@0.6.0': {}
 
@@ -16103,7 +16103,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.0.6':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -16256,12 +16256,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       '@types/send': 0.17.4
 
   '@types/service-worker-mock@2.0.4': {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ overrides:
   '@types/react-transition-group>@types/react': ^18
   '@cloudflare/elements>@types/react': ^18
   capnpc-ts>typescript: 4.2.4
-  '@types/node': ^18.19.75
+  '@types/node': ^20.17.32
   vitest>vite: ^5.0.0
 
 patchedDependencies:
@@ -96,8 +96,8 @@ importers:
         specifier: ^0.23.0
         version: 0.23.0
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.3.4
@@ -133,10 +133,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+        version: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   fixtures/additional-modules:
     devDependencies:
@@ -154,7 +154,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -172,7 +172,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -199,7 +199,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -220,7 +220,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -241,7 +241,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -256,7 +256,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -289,7 +289,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -310,7 +310,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -334,7 +334,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -358,7 +358,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   fixtures/isomorphic-random-example: {}
 
@@ -373,8 +373,8 @@ importers:
         specifier: ^4.20250428.0
         version: 4.20250428.0
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -383,7 +383,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -416,7 +416,7 @@ importers:
         version: 7.0.0
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -441,7 +441,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -459,7 +459,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -486,7 +486,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -504,7 +504,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -525,7 +525,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -553,7 +553,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -571,7 +571,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -589,7 +589,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -607,7 +607,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -628,7 +628,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -646,7 +646,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -683,7 +683,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -704,7 +704,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -719,7 +719,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -740,7 +740,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -758,7 +758,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -776,7 +776,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -794,7 +794,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -812,7 +812,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -830,7 +830,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -848,7 +848,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -866,7 +866,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -887,7 +887,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -902,7 +902,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -917,7 +917,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -986,8 +986,8 @@ importers:
         specifier: 1.0.0-rc.45
         version: 1.0.0-rc.45(@opentelemetry/api@1.7.0)
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       discord-api-types:
         specifier: 0.37.98
         version: 0.37.98
@@ -1011,10 +1011,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+        version: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1056,7 +1056,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1086,7 +1086,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1107,7 +1107,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1128,7 +1128,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1149,7 +1149,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1166,8 +1166,8 @@ importers:
         specifier: ^6.4.0
         version: 6.4.0
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       jest-image-snapshot:
         specifier: ^6.4.0
         version: 6.4.0
@@ -1182,7 +1182,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1203,7 +1203,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1221,7 +1221,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -1274,8 +1274,8 @@ importers:
         specifier: ^10.0.7
         version: 10.0.10
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@types/vscode':
         specifier: ^1.92.0
         version: 1.95.0
@@ -1364,8 +1364,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@types/semver':
         specifier: ^7.5.1
         version: 7.5.1
@@ -1440,13 +1440,13 @@ importers:
         version: 5.28.5
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+        version: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
       vite-tsconfig-paths:
         specifier: ^4.0.8
-        version: 4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
+        version: 4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       which-pm-runs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1573,8 +1573,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@types/service-worker-mock':
         specifier: ^2.0.1
         version: 2.0.4
@@ -1638,7 +1638,7 @@ importers:
         version: link:../workflows-shared
       '@microsoft/api-extractor':
         specifier: 7.49.1
-        version: 7.49.1(@types/node@18.19.76)
+        version: 7.49.1(@types/node@20.17.32)
       '@types/debug':
         specifier: ^4.1.7
         version: 4.1.7
@@ -1655,8 +1655,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@types/stoppable':
         specifier: ^1.1.1
         version: 1.1.3
@@ -1745,8 +1745,8 @@ importers:
   packages/mock-npm-registry:
     devDependencies:
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@verdaccio/types':
         specifier: ^10.8.0
         version: 10.8.0
@@ -1792,7 +1792,7 @@ importers:
         version: 0.4.1
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   packages/playground-preview-worker:
     dependencies:
@@ -1928,7 +1928,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -1979,8 +1979,8 @@ importers:
         specifier: ^4.20250428.0
         version: 4.20250428.0
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@types/ws':
         specifier: ^8.5.13
         version: 8.5.13
@@ -1992,7 +1992,7 @@ importers:
         version: 1.7.4
       tsup:
         specifier: 8.3.0
-        version: 8.3.0(@microsoft/api-extractor@7.49.1(@types/node@18.19.76))(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)
+        version: 8.3.0(@microsoft/api-extractor@7.49.1(@types/node@20.17.32))(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)
       typescript:
         specifier: catalog:default
         version: 5.7.3
@@ -2001,10 +2001,10 @@ importers:
         version: 5.28.5
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   packages/vite-plugin-cloudflare/playground:
     devDependencies:
@@ -2040,7 +2040,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2061,7 +2061,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2082,7 +2082,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2103,7 +2103,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2124,7 +2124,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2145,7 +2145,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2166,7 +2166,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2187,7 +2187,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2208,7 +2208,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2229,7 +2229,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2250,7 +2250,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2271,7 +2271,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2292,7 +2292,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2313,7 +2313,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2382,7 +2382,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2403,7 +2403,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2420,8 +2420,8 @@ importers:
         specifier: ^4.20250428.0
         version: 4.20250428.0
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@types/pg':
         specifier: ^8.11.2
         version: 8.11.6
@@ -2439,7 +2439,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2470,7 +2470,7 @@ importers:
         version: 4.20250428.0
       '@tailwindcss/vite':
         specifier: ^4.0.15
-        version: 4.0.15(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))
+        version: 4.0.15(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))
       '@types/react':
         specifier: ^19.0.0
         version: 19.0.7
@@ -2479,7 +2479,7 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))
+        version: 4.3.4(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))
       tailwindcss:
         specifier: ^4.0.15
         version: 4.0.15
@@ -2488,7 +2488,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2518,7 +2518,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2552,7 +2552,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2583,13 +2583,13 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))
+        version: 4.3.4(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))
       typescript:
         specifier: catalog:default
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2620,13 +2620,13 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))
+        version: 4.3.4(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))
       typescript:
         specifier: catalog:default
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2647,7 +2647,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2678,13 +2678,13 @@ importers:
         version: 19.0.3(@types/react@19.0.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))
+        version: 4.3.4(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))
       typescript:
         specifier: catalog:default
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2705,7 +2705,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2726,7 +2726,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2747,7 +2747,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2768,7 +2768,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2789,7 +2789,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2810,7 +2810,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: catalog:vite-plugin
-        version: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../../wrangler
@@ -2852,8 +2852,8 @@ importers:
         specifier: ^4.20250428.0
         version: 4.20250428.0
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@types/semver':
         specifier: ^7.5.1
         version: 7.5.1
@@ -2877,7 +2877,7 @@ importers:
         version: 5.28.5
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   packages/workers-editor-shared:
     dependencies:
@@ -2908,7 +2908,7 @@ importers:
         version: 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
+        version: 4.3.3(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -2920,10 +2920,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+        version: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
       vite-plugin-dts:
         specifier: ^4.0.1
-        version: 4.0.1(@types/node@18.19.76)(rollup@4.30.1)(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
+        version: 4.0.1(@types/node@20.17.32)(rollup@4.30.1)(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))
 
   packages/workers-playground:
     dependencies:
@@ -3029,7 +3029,7 @@ importers:
         version: 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
+        version: 4.3.3(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -3041,7 +3041,7 @@ importers:
         version: 5.28.5
       vite:
         specifier: catalog:default
-        version: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+        version: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:^
         version: link:../wrangler
@@ -3093,7 +3093,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: ~2.1.0
-        version: 2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)(lightningcss@1.29.2)
+        version: 2.1.9(@types/node@20.17.32)(@vitest/ui@2.1.9)(lightningcss@1.29.2)
 
   packages/workers-tsconfig: {}
 
@@ -3106,8 +3106,8 @@ importers:
         specifier: ^4.20250428.0
         version: 4.20250428.0
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       miniflare:
         specifier: workspace:*
         version: link:../miniflare
@@ -3116,7 +3116,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler:
         specifier: workspace:*
         version: link:../wrangler
@@ -3162,7 +3162,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   packages/wrangler:
     dependencies:
@@ -3230,7 +3230,7 @@ importers:
         version: 3.0.0
       '@microsoft/api-extractor':
         specifier: ^7.47.0
-        version: 7.47.4(@types/node@18.19.76)
+        version: 7.47.4(@types/node@20.17.32)
       '@sentry/node':
         specifier: ^7.86.0
         version: 7.87.0(supports-color@9.2.2)
@@ -3259,8 +3259,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.2
       '@types/node':
-        specifier: ^18.19.75
-        version: 18.19.76
+        specifier: ^20.17.32
+        version: 20.17.32
       '@types/node-forge':
         specifier: ^1.3.11
         version: 1.3.11
@@ -3422,7 +3422,7 @@ importers:
         version: 1.5.4
       vitest:
         specifier: catalog:default
-        version: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+        version: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       vitest-websocket-mock:
         specifier: ^0.4.0
         version: 0.4.0(vitest@3.1.1)
@@ -5938,7 +5938,7 @@ packages:
   '@rushstack/node-core-library@5.10.2':
     resolution: {integrity: sha512-xOF/2gVJZTfjTxbo4BDj9RtQq/HFnrrKdtem4JkyRLnwsRz2UDTg8gA1/et10fBx5RxmZD9bYVGST69W8ME5OQ==}
     peerDependencies:
-      '@types/node': ^18.19.75
+      '@types/node': ^20.17.32
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -5946,7 +5946,7 @@ packages:
   '@rushstack/node-core-library@5.5.1':
     resolution: {integrity: sha512-ZutW56qIzH8xIOlfyaLQJFx+8IBqdbVCZdnj+XT1MorQ1JqqxHse8vbCpEM+2MjsrqcbxcgDIbfggB1ZSQ2A3g==}
     peerDependencies:
-      '@types/node': ^18.19.75
+      '@types/node': ^20.17.32
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -5957,7 +5957,7 @@ packages:
   '@rushstack/terminal@0.13.3':
     resolution: {integrity: sha512-fc3zjXOw8E0pXS5t9vTiIPx9gHA0fIdTXsu9mT4WbH+P3mYvnrX0iAQ5a6NvyK1+CqYWBTw/wVNx7SDJkI+WYQ==}
     peerDependencies:
-      '@types/node': ^18.19.75
+      '@types/node': ^20.17.32
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -5965,7 +5965,7 @@ packages:
   '@rushstack/terminal@0.14.5':
     resolution: {integrity: sha512-TEOpNwwmsZVrkp0omnuTUTGZRJKTr6n6m4OITiNjkqzLAkcazVpwR1SOtBg6uzpkIBLgrcNHETqI8rbw3uiUfw==}
     peerDependencies:
-      '@types/node': ^18.19.75
+      '@types/node': ^20.17.32
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -6550,8 +6550,8 @@ packages:
   '@types/node-polyglot@2.4.2':
     resolution: {integrity: sha512-Tfx3TU/PBK8vW/BG1TK793EHlVpGnoHUj+DGxOwNOYwZiueLeu7FgksvDdpEyFSw4+AKKiEuiMm8EGUHUR4o6g==}
 
-  '@types/node@18.19.76':
-    resolution: {integrity: sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==}
+  '@types/node@20.17.32':
+    resolution: {integrity: sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw==}
 
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
@@ -12136,8 +12136,8 @@ packages:
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
@@ -12302,7 +12302,7 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.19.75
+      '@types/node': ^20.17.32
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
@@ -12333,7 +12333,7 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.19.75
+      '@types/node': ^20.17.32
       jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
@@ -12379,7 +12379,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.19.75
+      '@types/node': ^20.17.32
       '@vitest/browser': 2.1.9
       '@vitest/ui': 2.1.9
       happy-dom: '*'
@@ -12405,7 +12405,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
-      '@types/node': ^18.19.75
+      '@types/node': ^20.17.32
       '@vitest/browser': 3.1.1
       '@vitest/ui': 3.1.1
       happy-dom: '*'
@@ -13910,7 +13910,7 @@ snapshots:
       esbuild: 0.17.19
       miniflare: 3.20250310.0
       semver: 7.7.1
-      vitest: 2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)(lightningcss@1.29.2)
+      vitest: 2.1.9(@types/node@20.17.32)(@vitest/ui@2.1.9)(lightningcss@1.29.2)
       wrangler: 3.114.1(@cloudflare/workers-types@4.20250428.0)
       zod: 3.22.3
     transitivePeerDependencies:
@@ -13927,7 +13927,7 @@ snapshots:
       devalue: 4.3.2
       miniflare: 4.20250417.0
       semver: 7.7.1
-      vitest: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+      vitest: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
       wrangler: 4.12.1(@cloudflare/workers-types@4.20250428.0)
       zod: 3.22.3
     transitivePeerDependencies:
@@ -14647,7 +14647,7 @@ snapshots:
       '@inquirer/figures': 1.0.7
       '@inquirer/type': 2.0.0
       '@types/mute-stream': 0.0.4
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
@@ -14689,7 +14689,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
@@ -14739,7 +14739,7 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.22.5
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       find-up: 4.1.0
       fs-extra: 8.1.0
 
@@ -14796,31 +14796,31 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.7.0)
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@microsoft/api-extractor-model@7.29.4(@types/node@18.19.76)':
+  '@microsoft/api-extractor-model@7.29.4(@types/node@20.17.32)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.5.1(@types/node@18.19.76)
+      '@rushstack/node-core-library': 5.5.1(@types/node@20.17.32)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.30.2(@types/node@18.19.76)':
+  '@microsoft/api-extractor-model@7.30.2(@types/node@20.17.32)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@18.19.76)
+      '@rushstack/node-core-library': 5.10.2(@types/node@20.17.32)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.47.4(@types/node@18.19.76)':
+  '@microsoft/api-extractor@7.47.4(@types/node@20.17.32)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.4(@types/node@18.19.76)
+      '@microsoft/api-extractor-model': 7.29.4(@types/node@20.17.32)
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.5.1(@types/node@18.19.76)
+      '@rushstack/node-core-library': 5.5.1(@types/node@20.17.32)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.13.3(@types/node@18.19.76)
-      '@rushstack/ts-command-line': 4.22.3(@types/node@18.19.76)
+      '@rushstack/terminal': 0.13.3(@types/node@20.17.32)
+      '@rushstack/ts-command-line': 4.22.3(@types/node@20.17.32)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -14830,15 +14830,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.49.1(@types/node@18.19.76)':
+  '@microsoft/api-extractor@7.49.1(@types/node@20.17.32)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.2(@types/node@18.19.76)
+      '@microsoft/api-extractor-model': 7.30.2(@types/node@20.17.32)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.10.2(@types/node@18.19.76)
+      '@rushstack/node-core-library': 5.10.2(@types/node@20.17.32)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.5(@types/node@18.19.76)
-      '@rushstack/ts-command-line': 4.23.3(@types/node@18.19.76)
+      '@rushstack/terminal': 0.14.5(@types/node@20.17.32)
+      '@rushstack/ts-command-line': 4.23.3(@types/node@20.17.32)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -15413,7 +15413,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.30.1':
     optional: true
 
-  '@rushstack/node-core-library@5.10.2(@types/node@18.19.76)':
+  '@rushstack/node-core-library@5.10.2(@types/node@20.17.32)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -15424,9 +15424,9 @@ snapshots:
       resolve: 1.22.8
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
-  '@rushstack/node-core-library@5.5.1(@types/node@18.19.76)':
+  '@rushstack/node-core-library@5.5.1(@types/node@20.17.32)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -15437,39 +15437,39 @@ snapshots:
       resolve: 1.22.8
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.13.3(@types/node@18.19.76)':
+  '@rushstack/terminal@0.13.3(@types/node@20.17.32)':
     dependencies:
-      '@rushstack/node-core-library': 5.5.1(@types/node@18.19.76)
+      '@rushstack/node-core-library': 5.5.1(@types/node@20.17.32)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
-  '@rushstack/terminal@0.14.5(@types/node@18.19.76)':
+  '@rushstack/terminal@0.14.5(@types/node@20.17.32)':
     dependencies:
-      '@rushstack/node-core-library': 5.10.2(@types/node@18.19.76)
+      '@rushstack/node-core-library': 5.10.2(@types/node@20.17.32)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
-  '@rushstack/ts-command-line@4.22.3(@types/node@18.19.76)':
+  '@rushstack/ts-command-line@4.22.3(@types/node@20.17.32)':
     dependencies:
-      '@rushstack/terminal': 0.13.3(@types/node@18.19.76)
+      '@rushstack/terminal': 0.13.3(@types/node@20.17.32)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.1
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/ts-command-line@4.23.3(@types/node@18.19.76)':
+  '@rushstack/ts-command-line@4.23.3(@types/node@20.17.32)':
     dependencies:
-      '@rushstack/terminal': 0.14.5(@types/node@18.19.76)
+      '@rushstack/terminal': 0.14.5(@types/node@20.17.32)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.1
@@ -16029,13 +16029,13 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.0.15
       '@tailwindcss/oxide-win32-x64-msvc': 4.0.15
 
-  '@tailwindcss/vite@4.0.15(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))':
+  '@tailwindcss/vite@4.0.15(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))':
     dependencies:
       '@tailwindcss/node': 4.0.15
       '@tailwindcss/oxide': 4.0.15
       lightningcss: 1.29.2
       tailwindcss: 4.0.15
-      vite: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+      vite: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
 
   '@trysound/sax@0.2.0': {}
 
@@ -16077,7 +16077,7 @@ snapshots:
 
   '@types/cross-spawn@6.0.2':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/debug@4.1.7':
     dependencies:
@@ -16091,7 +16091,7 @@ snapshots:
 
   '@types/dns2@2.0.3':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/esprima@4.0.3':
     dependencies:
@@ -16119,7 +16119,7 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -16174,22 +16174,22 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       form-data: 4.0.0
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/node-polyglot@2.4.2': {}
 
-  '@types/node@18.19.76':
+  '@types/node@20.17.32':
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 6.19.8
 
   '@types/node@22.13.10':
     dependencies:
@@ -16197,17 +16197,17 @@ snapshots:
 
   '@types/pg@8.11.6':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       pg-protocol: 1.6.1
       pg-types: 4.0.2
 
   '@types/pixelmatch@5.2.6':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/prompts@2.0.14':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/prop-types@15.7.4': {}
 
@@ -16276,7 +16276,7 @@ snapshots:
 
   '@types/stoppable@1.1.3':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/strip-bom@3.0.0': {}
 
@@ -16288,7 +16288,7 @@ snapshots:
 
   '@types/tunnel@0.0.3':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/uuid@9.0.4': {}
 
@@ -16302,11 +16302,11 @@ snapshots:
 
   '@types/ws@8.5.10':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/ws@8.5.13':
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
 
   '@types/yargs-parser@20.2.1': {}
 
@@ -16664,25 +16664,25 @@ snapshots:
       minimatch: 7.4.6
       semver: 7.6.3
 
-  '@vitejs/plugin-react@4.3.3(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))':
+  '@vitejs/plugin-react@4.3.3(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+      vite: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2))':
+  '@vitejs/plugin-react@4.3.4(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+      vite: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -16700,22 +16700,22 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))':
+  '@vitest/mocker@2.1.9(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+      vite: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
 
-  '@vitest/mocker@3.1.1(msw@2.4.3(typescript@5.7.3))(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))':
+  '@vitest/mocker@3.1.1(msw@2.4.3(typescript@5.7.3))(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.4.3(typescript@5.7.3)
-      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+      vite: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -16768,7 +16768,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.13
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)(lightningcss@1.29.2)
+      vitest: 2.1.9(@types/node@20.17.32)(@vitest/ui@2.1.9)(lightningcss@1.29.2)
     optional: true
 
   '@vitest/ui@3.1.1(vitest@3.1.1)':
@@ -16780,7 +16780,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.13
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+      vitest: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   '@vitest/utils@2.1.8':
     dependencies:
@@ -19670,7 +19670,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.10
@@ -21084,7 +21084,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       long: 5.2.4
 
   proxy-addr@2.0.7:
@@ -21948,7 +21948,7 @@ snapshots:
 
   stripe@9.16.0:
     dependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       qs: 6.10.3
 
   strnum@1.0.5: {}
@@ -22234,7 +22234,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.3.0(@microsoft/api-extractor@7.49.1(@types/node@18.19.76))(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3):
+  tsup@8.3.0(@microsoft/api-extractor@7.49.1(@types/node@20.17.32))(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -22253,7 +22253,7 @@ snapshots:
       tinyglobby: 0.2.12
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.49.1(@types/node@18.19.76)
+      '@microsoft/api-extractor': 7.49.1(@types/node@20.17.32)
       postcss: 8.5.1
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -22447,7 +22447,7 @@ snapshots:
 
   underscore@1.13.7: {}
 
-  undici-types@5.26.5: {}
+  undici-types@6.19.8: {}
 
   undici-types@6.20.0: {}
 
@@ -22633,13 +22633,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-node@2.1.9(@types/node@18.19.76)(lightningcss@1.29.2):
+  vite-node@2.1.9(@types/node@20.17.32)(lightningcss@1.29.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.2.2)
       es-module-lexer: 1.5.4
       pathe: 1.1.2
-      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+      vite: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -22651,13 +22651,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.1.1(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)(supports-color@9.2.2):
+  vite-node@3.1.1(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)(supports-color@9.2.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.2.2)
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)
+      vite: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -22672,9 +22672,9 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.0.1(@types/node@18.19.76)(rollup@4.30.1)(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)):
+  vite-plugin-dts@4.0.1(@types/node@20.17.32)(rollup@4.30.1)(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)):
     dependencies:
-      '@microsoft/api-extractor': 7.47.4(@types/node@18.19.76)
+      '@microsoft/api-extractor': 7.47.4(@types/node@20.17.32)
       '@rollup/pluginutils': 5.1.0(rollup@4.30.1)
       '@volar/typescript': 2.3.4
       '@vue/language-core': 2.0.29(typescript@5.7.3)
@@ -22686,40 +22686,40 @@ snapshots:
       typescript: 5.7.3
       vue-tsc: 2.0.29(typescript@5.7.3)
     optionalDependencies:
-      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+      vite: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-tsconfig-paths@4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)):
+  vite-tsconfig-paths@4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)):
     dependencies:
       debug: 4.3.7(supports-color@9.2.2)
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.7.3)
     optionalDependencies:
-      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
+      vite: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2):
+  vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.30.1
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       fsevents: 2.3.3
       lightningcss: 1.29.2
 
-  vite@6.1.0(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2):
+  vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
       rollup: 4.30.1
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.2
@@ -22728,12 +22728,12 @@ snapshots:
     dependencies:
       '@vitest/utils': 2.1.8
       mock-socket: 9.3.1
-      vitest: 3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+      vitest: 3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
-  vitest@2.1.9(@types/node@18.19.76)(@vitest/ui@2.1.9)(lightningcss@1.29.2):
+  vitest@2.1.9(@types/node@20.17.32)(@vitest/ui@2.1.9)(lightningcss@1.29.2):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
+      '@vitest/mocker': 2.1.9(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -22749,11 +22749,11 @@ snapshots:
       tinyexec: 0.3.1
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
-      vite-node: 2.1.9(@types/node@18.19.76)(lightningcss@1.29.2)
+      vite: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
+      vite-node: 2.1.9(@types/node@20.17.32)(lightningcss@1.29.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       '@vitest/ui': 2.1.9(vitest@2.1.9)
     transitivePeerDependencies:
       - less
@@ -22766,10 +22766,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.1.1(@types/node@18.19.76)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2):
+  vitest@3.1.1(@types/node@20.17.32)(@vitest/ui@3.1.1)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(msw@2.4.3(typescript@5.7.3))(vite@5.4.14(@types/node@18.19.76)(lightningcss@1.29.2))
+      '@vitest/mocker': 3.1.1(msw@2.4.3(typescript@5.7.3))(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -22785,11 +22785,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.14(@types/node@18.19.76)(lightningcss@1.29.2)
-      vite-node: 3.1.1(@types/node@18.19.76)(jiti@2.4.2)(lightningcss@1.29.2)(supports-color@9.2.2)
+      vite: 5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)
+      vite-node: 3.1.1(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)(supports-color@9.2.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 18.19.76
+      '@types/node': 20.17.32
       '@vitest/ui': 3.1.1(vitest@3.1.1)
     transitivePeerDependencies:
       - jiti

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ packages:
   - "tools"
 
 catalog:
-  "@types/node": "^18.19.75"
+  "@types/node": "^20.17.32"
   "@vitest/runner": ~3.1.1
   "@vitest/snapshot": ~3.1.1
   "@vitest/ui": ~3.1.1


### PR DESCRIPTION
Following our [Node.js version support policy](https://developers.cloudflare.com/workers/wrangler/install-and-update/), Wrangler no longer supports running with Node.js 18 now that it's EOL. This PR updates workers-sdk to use `@types/node@20`, run CI against Node 20, and updates Wrangler to fail if run with Node 18.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Existing tests should pass
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Already documented
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a backportable change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
