### PR TITLE
Add `x-mixed-mode` flag

### DIFF
--- a/.changeset/violet-planets-march.md
+++ b/.changeset/violet-planets-march.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Add `x-mixed-mode` flag
+
+This experimental flag currently has no effect. More details will be shared as we roll out its functionality.

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -2401,6 +2401,7 @@ describe("normalizeAndValidateConfig()", () => {
 					{
 						RESOURCES_PROVISION: true,
 						MULTIWORKER: false,
+						MIXED_MODE: false,
 					},
 					() =>
 						normalizeAndValidateConfig(
@@ -2556,6 +2557,7 @@ describe("normalizeAndValidateConfig()", () => {
 					{
 						RESOURCES_PROVISION: true,
 						MULTIWORKER: false,
+						MIXED_MODE: false,
 					},
 					() =>
 						normalizeAndValidateConfig(
@@ -2885,6 +2887,7 @@ describe("normalizeAndValidateConfig()", () => {
 					{
 						RESOURCES_PROVISION: true,
 						MULTIWORKER: false,
+						MIXED_MODE: false,
 					},
 					() =>
 						normalizeAndValidateConfig(

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -211,6 +211,7 @@ export async function unstable_dev(
 		logLevel: options?.logLevel ?? defaultLogLevel,
 		port: options?.port ?? 0,
 		experimentalProvision: undefined,
+		experimentalMixedMode: false,
 		experimentalVectorizeBindToProd: vectorizeBindToProd ?? false,
 		experimentalImagesLocalMode: imagesLocalMode ?? false,
 		enableIpc: options?.experimental?.enableIpc,

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -224,6 +224,7 @@ export async function unstable_dev(
 			// TODO: can we make this work?
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: false,
+			MIXED_MODE: false,
 		},
 		() => startDev(devOptions)
 	);

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -108,6 +108,8 @@ export async function getPlatformProxy<
 		{
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: false,
+			// TODO: when possible mixed mode should be made available for getPlatformProxy
+			MIXED_MODE: false,
 		},
 		() => getMiniflareOptionsFromConfig(rawConfig, env, options)
 	);

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -154,6 +154,7 @@ function createHandler(def: CommandDefinition) {
 				: {
 						MULTIWORKER: false,
 						RESOURCES_PROVISION: args.experimentalProvision ?? false,
+						MIXED_MODE: args.experimentalMixedMode ?? false,
 					};
 
 			await run(experimentalFlags, () =>

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -211,6 +211,7 @@ export const deployCommand = createCommand({
 		overrideExperimentalFlags: (args) => ({
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
+			MIXED_MODE: false,
 		}),
 	},
 	validateArgs(args) {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -60,6 +60,7 @@ export const dev = createCommand({
 		overrideExperimentalFlags: (args) => ({
 			MULTIWORKER: Array.isArray(args.config),
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
+			MIXED_MODE: args.experimentalMixedMode ?? false,
 		}),
 	},
 	metadata: {

--- a/packages/wrangler/src/experimental-flags.ts
+++ b/packages/wrangler/src/experimental-flags.ts
@@ -4,6 +4,7 @@ import { logger } from "./logger";
 export type ExperimentalFlags = {
 	MULTIWORKER: boolean;
 	RESOURCES_PROVISION: boolean;
+	MIXED_MODE: boolean;
 };
 
 const flags = new AsyncLocalStorage<ExperimentalFlags>();

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -425,6 +425,12 @@ export function createCLIParser(argv: string[]) {
 			hidden: true,
 			alias: ["x-provision"],
 		})
+		.option("experimental-mixed-mode", {
+			describe: `Experimental: Enable Mixed Mode`,
+			type: "boolean",
+			hidden: true,
+			alias: ["x-mixed-mode"],
+		})
 		.epilogue(
 			`Please report any issues to ${chalk.hex("#3B818D")(
 				"https://github.com/cloudflare/workers-sdk/issues/new/choose"

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -947,6 +947,7 @@ export const pagesDevCommand = createCommand({
 					persistTo: args.persistTo,
 					logLevel: args.logLevel ?? "log",
 					experimentalProvision: undefined,
+					experimentalMixedMode: false,
 					experimentalVectorizeBindToProd: false,
 					experimentalImagesLocalMode: false,
 					enableIpc: true,

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -882,6 +882,7 @@ export const pagesDevCommand = createCommand({
 			{
 				MULTIWORKER: Array.isArray(args.config),
 				RESOURCES_PROVISION: false,
+				MIXED_MODE: false,
 			},
 			() =>
 				startDev({

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -254,6 +254,7 @@ export const versionsUploadCommand = createCommand({
 		overrideExperimentalFlags: (args) => ({
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
+			MIXED_MODE: false,
 		}),
 	},
 	handler: async function versionsUploadHandler(args, { config }) {

--- a/packages/wrangler/src/yargs-types.ts
+++ b/packages/wrangler/src/yargs-types.ts
@@ -10,6 +10,7 @@ export interface CommonYargsOptions {
 	config: string | undefined;
 	env: string | undefined;
 	"experimental-provision": boolean | undefined;
+	"experimental-mixed-mode": boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
Fixes [DEVX-1833](https://jira.cfdata.org/browse/DEVX-1833)

Introduction of the `--x-mixed-mode` experimental flag (currently no-op)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no feature implemented on the experimental flag yet
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no impact to existing features
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unreleased experimental feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: experimental flag for a new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
