### PR TITLE
Don't crash on non-existent tails in Vite

### DIFF
--- a/.changeset/red-planes-wash.md
+++ b/.changeset/red-planes-wash.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Don't crash on non-existent tail consumers when running `vite dev`

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/__tests__/multi-worker.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/__tests__/multi-worker.spec.ts
@@ -26,8 +26,12 @@ describe.runIf(isBuild)("output directories", () => {
 });
 
 describe("multi-worker basic functionality", async () => {
-	test("worker configs warnings are not present in the terminal", async () => {
-		expect(serverLogs.warns).toEqual([]);
+	test("warning about non-existent tail is printed", async () => {
+		expect(serverLogs.warns).toEqual([
+			expect.stringMatching(
+				/Make sure you add it if you'd like to simulate receiving tail events locally/
+			),
+		]);
 	});
 
 	test("entry worker returns a response", async () => {

--- a/packages/vite-plugin-cloudflare/playground/multi-worker/worker-a/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/playground/multi-worker/worker-a/wrangler.jsonc
@@ -13,4 +13,5 @@
 			"entrypoint": "NamedEntrypoint",
 		},
 	],
+	"tail_consumers": [{ "service": "tail-a" }],
 }

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -211,7 +211,7 @@ function filterTails(
 			// Don't interfere with network-based tail connections (e.g. via the dev registry), or kCurrentWorker
 			return true;
 		}
-		const found = !!userWorkers.find((w) => w.name === name);
+		const found = userWorkers.some(w => w.name === name);
 
 		if (!found) {
 			log(

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -211,7 +211,7 @@ function filterTails(
 			// Don't interfere with network-based tail connections (e.g. via the dev registry), or kCurrentWorker
 			return true;
 		}
-		const found = userWorkers.some(w => w.name === name);
+		const found = userWorkers.some((w) => w.name === name);
 
 		if (!found) {
 			log(


### PR DESCRIPTION
In Vite, only connect the tail consumers that represent Workers that are defined in the Vite config. Warn that a tail will be omitted otherwise. This _differs from service bindings_ because tail consumers are "optional" in a sense, and shouldn't affect the runtime behaviour of a Worker. 

Fixes issues like https://github.com/getsentry/sentry-mcp/pull/134#issuecomment-2842683985
	

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by playgrounds
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: fix to a feature introduced in v4
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
