### PR TITLE
fix: remove outdated js-doc comment for `unstable_startDevWorker`'s `entrypoint`

### DIFF
--- a/.changeset/deep-symbols-fix.md
+++ b/.changeset/deep-symbols-fix.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: remove outdated js-doc comment for `unstable_startDevWorker`'s `entrypoint`

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -65,7 +65,6 @@ export interface StartDevWorkerInput {
 	/**
 	 * The javascript or typescript entry-point of the worker.
 	 * This is the `main` property of a Wrangler configuration file.
-	 * You can specify a file path or provide the contents directly.
 	 */
 	entrypoint?: string;
 	/** The configuration of the worker. */


### PR DESCRIPTION
Remove the outdated/inaccurate js-doc comment informing consumers of `unstable_startWorker` that the `entrypoint` value can contain the worker's contents directly:

![Screenshot 2025-05-01 at 17 24 49](https://github.com/user-attachments/assets/8b9c837a-629c-42d8-8e66-0e92f96e9c97)


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this is a simple js-doc comment fix
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: this is a simple js-doc comment fix
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: this incorrect information is not present in [the `unstable_startWorker` docs ](https://developers.cloudflare.com/workers/wrangler/api/#unstable_startworker)
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/9128
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
