### PR TITLE
Add `experimental_startMixedModeSession` no-op utility

### DIFF
--- a/.changeset/spicy-crews-give.md
+++ b/.changeset/spicy-crews-give.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Add `experimental_startMixedModeSession` no-op utility
+
+This experimental utility has no effect. More details will be shared as we roll out its functionality.

--- a/fixtures/mixed-mode-node-test/package.json
+++ b/fixtures/mixed-mode-node-test/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "mixed-mode-node-test",
+	"private": true,
+	"description": "",
+	"license": "ISC",
+	"author": "",
+	"type": "module",
+	"scripts": {
+		"test:ci": "node --test"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"wrangler": "workspace:*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/fixtures/mixed-mode-node-test/tests/startMixedModeSession.test.js
+++ b/fixtures/mixed-mode-node-test/tests/startMixedModeSession.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert";
+import test, { describe } from "node:test";
+import { experimental_startMixedModeSession } from "wrangler";
+
+describe("startMixedModeSession", () => {
+	test("no-op mixed-mode proxyServerWorker", async (t) => {
+		if (
+			!process.env.CLOUDFLARE_ACCOUNT_ID ||
+			!process.env.CLOUDFLARE_API_TOKEN
+		) {
+			return t.skip();
+		}
+
+		const mixedModeSession = await experimental_startMixedModeSession({});
+		const proxyServerUrl =
+			mixedModeSession.mixedModeConnectionString.toString();
+		assert.match(proxyServerUrl, /http:\/\/localhost:\d{4,5}\//);
+		assert.strictEqual(
+			await (await fetch(proxyServerUrl)).text(),
+			"no-op mixed-mode proxyServerWorker"
+		);
+		await mixedModeSession.ready;
+		await mixedModeSession.dispose();
+	});
+});

--- a/fixtures/mixed-mode-node-test/tsconfig.json
+++ b/fixtures/mixed-mode-node-test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"types": ["node"]
+	},
+	"include": ["**/*.ts"]
+}

--- a/packages/wrangler/src/api/index.ts
+++ b/packages/wrangler/src/api/index.ts
@@ -12,3 +12,4 @@ export {
 } from "./mtls-certificate";
 export * from "./startDevWorker";
 export * from "./integrations";
+export * from "./mixedMode";

--- a/packages/wrangler/src/api/mixedMode/index.ts
+++ b/packages/wrangler/src/api/mixedMode/index.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+import { getBasePath } from "../../paths";
+import { startWorker } from "../startDevWorker";
+import type { StartDevWorkerInput, Worker } from "../startDevWorker/types";
+
+type MixedModeSession = Pick<Worker, "ready" | "setConfig"> & {
+	["mixedModeConnectionString"]: MixedModeConnectionString;
+};
+
+declare const __brand: unique symbol;
+export type MixedModeConnectionString = Awaited<Worker["url"]> & {
+	[__brand]: "MixedModeConnectionString";
+};
+
+export async function experimental_startMixedModeSession(
+	bindings: StartDevWorkerInput["bindings"]
+): Promise<MixedModeSession> {
+	const proxyServerWorkerEntrypoint = path.resolve(
+		getBasePath(),
+		"templates/mixedMode/proxyServerWorker.ts"
+	);
+	const { ready, setConfig, url } = await startWorker({
+		entrypoint: proxyServerWorkerEntrypoint,
+		dev: {
+			remote: true,
+		},
+		bindings,
+	});
+
+	return {
+		ready,
+		setConfig,
+		mixedModeConnectionString: (await url) as MixedModeConnectionString,
+	};
+}

--- a/packages/wrangler/src/api/mixedMode/index.ts
+++ b/packages/wrangler/src/api/mixedMode/index.ts
@@ -12,7 +12,7 @@ export type MixedModeConnectionString = Awaited<Worker["url"]> & {
 	[__brand]: "MixedModeConnectionString";
 };
 
-export async function experimental_startMixedModeSession(
+export async function startMixedModeSession(
 	bindings: StartDevWorkerInput["bindings"]
 ): Promise<MixedModeSession> {
 	const proxyServerWorkerEntrypoint = path.resolve(

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -61,4 +61,4 @@ export { generateASSETSBinding as unstable_generateASSETSBinding };
 export { experimental_readRawConfig } from "./config";
 export { experimental_patchConfig } from "./config/patch-config";
 
-export { experimental_startMixedModeSession } from "./api";
+export { startMixedModeSession as experimental_startMixedModeSession } from "./api";

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -60,3 +60,5 @@ export { generateASSETSBinding as unstable_generateASSETSBinding };
 
 export { experimental_readRawConfig } from "./config";
 export { experimental_patchConfig } from "./config/patch-config";
+
+export { experimental_startMixedModeSession } from "./api";

--- a/packages/wrangler/templates/mixedMode/proxyServerWorker.ts
+++ b/packages/wrangler/templates/mixedMode/proxyServerWorker.ts
@@ -1,0 +1,5 @@
+export default {
+	fetch() {
+		return new Response("");
+	},
+};

--- a/packages/wrangler/templates/mixedMode/proxyServerWorker.ts
+++ b/packages/wrangler/templates/mixedMode/proxyServerWorker.ts
@@ -1,5 +1,0 @@
-export default {
-	fetch() {
-		return new Response("");
-	},
-};

--- a/packages/wrangler/templates/mixedMode/proxyServerWorker/index.ts
+++ b/packages/wrangler/templates/mixedMode/proxyServerWorker/index.ts
@@ -1,0 +1,5 @@
+export default {
+	fetch() {
+		return new Response("no-op mixed-mode proxyServerWorker");
+	},
+};

--- a/packages/wrangler/templates/mixedMode/proxyServerWorker/wrangler.jsonc
+++ b/packages/wrangler/templates/mixedMode/proxyServerWorker/wrangler.jsonc
@@ -1,0 +1,4 @@
+{
+	"main": "./index.ts",
+	"compatibility_date": "2025-04-28",
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/mixed-mode-node-test:
+    devDependencies:
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/workers-tsconfig
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/no-bundle-import:
     devDependencies:
       get-port:


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1836

Add `experimental_startMixedModeSession` no-op utility

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no-op implementation for the experimental utility[^1]
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no-op implementation for the experimental utility
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unreleased experimental feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: experimental new feature

[^1]: I considered adding some tests to make sure that the values returned by the utility are those that we expect, but I figured that the correctness of the returned value is already guaranteed by the utility's types so I didn't think that adding tests for the utility at this stage would really add any value here

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
