### PR TITLE
V3 Backport [#9124]: make that `unstable_startWorker` can correctly throw configuration errors

### DIFF
--- a/.changeset/metal-clubs-vanish.md
+++ b/.changeset/metal-clubs-vanish.md
@@ -1,0 +1,14 @@
+---
+"wrangler": patch
+---
+
+make that `unstable_startWorker` can correctly throw configuration errors
+
+make sure that `unstable_startWorker` can throw configuration related errors when:
+
+- the utility is called
+- the worker's `setConfig` is called with the `throwErrors` argument set to `true`
+
+additionally when an error is thrown when `unstable_startWorker` is called make sure
+that the worker is properly disposed (since, given the fact that it is not returned
+by the utility the utility's caller wouldn't have any way to dispose it themselves)

--- a/fixtures/start-worker-node-test/src/config-errors.test.js
+++ b/fixtures/start-worker-node-test/src/config-errors.test.js
@@ -1,0 +1,93 @@
+import assert from "node:assert";
+import test, { describe } from "node:test";
+import { setTimeout } from "node:timers/promises";
+import getPort from "get-port";
+import { unstable_startWorker } from "wrangler";
+
+describe("startWorker - configuration errors", () => {
+	test("providing an incorrect entrypoint to startWorker", async () => {
+		await assert.rejects(
+			unstable_startWorker({
+				entrypoint: "not a real entrypoint",
+			}),
+			(err) => {
+				assert(err instanceof Error);
+				assert.match(
+					err.message,
+					/he entry-point file at "not a real entrypoint" was not found./
+				);
+				return true;
+			}
+		);
+	});
+
+	test("providing a non existing config file to startWorker", async () => {
+		await assert.rejects(
+			unstable_startWorker({ config: "non-existing-config" }),
+			(err) => {
+				assert(err instanceof Error);
+				assert.match(
+					err.message,
+					/Missing entry-point to Worker script or to assets directory/
+				);
+				return true;
+			}
+		);
+	});
+
+	test("providing an incorrect config to setConfig", async () => {
+		const worker = await unstable_startWorker({
+			config: "wrangler.json",
+			dev: {
+				server: {
+					port: await getPort(),
+				},
+				inspector: { port: await getPort() },
+			},
+		});
+
+		await assert.rejects(
+			worker.setConfig({ config: "non-existing-config" }, true),
+			(err) => {
+				assert(err instanceof Error);
+				assert.match(
+					err.message,
+					/Missing entry-point to Worker script or to assets directory/
+				);
+				return true;
+			}
+		);
+
+		// TODO: worker.dispose() should itself await worker.ready
+		await worker.ready;
+		await worker.dispose();
+	});
+
+	test("providing an incorrect entrypoint to setConfig", async () => {
+		const worker = await unstable_startWorker({
+			config: "wrangler.json",
+			dev: {
+				server: {
+					port: await getPort(),
+				},
+				inspector: { port: await getPort() },
+			},
+		});
+
+		await assert.rejects(
+			worker.setConfig({ entrypoint: "not a real entrypoint" }, true),
+			(err) => {
+				assert(err instanceof Error);
+				assert.strictEqual(
+					err.message,
+					'The entry-point file at "not a real entrypoint" was not found.'
+				);
+				return true;
+			}
+		);
+
+		// TODO: worker.dispose() should itself await worker.ready
+		await worker.ready;
+		await worker.dispose();
+	});
+});

--- a/packages/wrangler/src/api/startDevWorker/DevEnv.ts
+++ b/packages/wrangler/src/api/startDevWorker/DevEnv.ts
@@ -20,7 +20,12 @@ export class DevEnv extends EventEmitter {
 	async startWorker(options: StartDevWorkerInput): Promise<Worker> {
 		const worker = createWorkerObject(this);
 
-		await this.config.set(options);
+		try {
+			await this.config.set(options, true);
+		} catch (e) {
+			await worker.dispose();
+			throw e;
+		}
 
 		return worker;
 	}
@@ -148,8 +153,8 @@ function createWorkerObject(devEnv: DevEnv): Worker {
 			assert(devEnv.config.latestConfig);
 			return devEnv.config.latestConfig;
 		},
-		setConfig(config) {
-			return devEnv.config.set(config);
+		async setConfig(config, throwErrors) {
+			return devEnv.config.set(config, throwErrors);
 		},
 		patchConfig(config) {
 			return devEnv.config.patch(config);


### PR DESCRIPTION
v3 backport for https://github.com/cloudflare/workers-sdk/pull/9124
