### PR TITLE
V3 Backport [#9118]:  fix: remove outdated js-doc comment for unstable_startDevWorker's entrypoint

### DIFF
--- a/.changeset/deep-symbols-fix.md
+++ b/.changeset/deep-symbols-fix.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: remove outdated js-doc comment for `unstable_startDevWorker`'s `entrypoint`

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -63,7 +63,6 @@ export interface StartDevWorkerInput {
 	/**
 	 * The javascript or typescript entry-point of the worker.
 	 * This is the `main` property of a Wrangler configuration file.
-	 * You can specify a file path or provide the contents directly.
 	 */
 	entrypoint?: string;
 	/** The configuration of the worker. */


### PR DESCRIPTION
v3 backport for https://github.com/cloudflare/workers-sdk/pull/9118