### PR TITLE
containers: allow users to specify the kind of container rollout they want

### DIFF
--- a/.changeset/grumpy-baboons-post.md
+++ b/.changeset/grumpy-baboons-post.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+wrangler containers can be configured with the kind of application rollout on `apply`

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -303,6 +303,88 @@ describe("cloudchamber apply", () => {
 		/* eslint-enable */
 	});
 
+	test("can skip a simple existing application and create other", async () => {
+		setIsTTY(false);
+		writeAppConfiguration(
+			{
+				name: "my-container-app",
+				instances: 4,
+				class_name: "DurableObjectClass",
+				configuration: {
+					image: "./Dockerfile",
+				},
+				rollout_kind: "none",
+			},
+			{
+				name: "my-container-app-2",
+				instances: 1,
+				class_name: "DurableObjectClass2",
+				configuration: {
+					image: "other-app/Dockerfile",
+				},
+			}
+		);
+		mockGetApplications([
+			{
+				id: "abc",
+				name: "my-container-app",
+				instances: 3,
+				created_at: new Date().toString(),
+				account_id: "1",
+				version: 1,
+				scheduling_policy: SchedulingPolicy.REGIONAL,
+				configuration: {
+					image: "./Dockerfile",
+				},
+				constraints: {
+					tier: 1,
+				},
+			},
+		]);
+		mockCreateApplication({ id: "abc" } as Application);
+		await runWrangler("cloudchamber apply --json");
+
+		/* eslint-disable */
+		expect(std.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ EDIT my-container-app
+			│
+			│   [[containers]]
+			│ - instances = 3
+			│ + instances = 4
+			│   name = \\"my-container-app\\"
+			│ Skipping application rollout
+			│
+			├ NEW my-container-app-2
+			│
+			│   [[containers]]
+			│   name = \\"my-container-app-2\\"
+			│   instances = 1
+			│   scheduling_policy = \\"regional\\"
+			│
+			│   [containers.configuration]
+			│   image = \\"other-app/Dockerfile\\"
+			│
+			│   [containers.constraints]
+			│   tier = 1
+			│
+			├ Do you want to apply these changes?
+			│ yes
+			│
+			│
+			│  SUCCESS  Created application my-container-app-2 (Application ID: abc)
+			│
+			╰ Applied changes
+
+			"
+		`);
+		expect(std.stderr).toMatchInlineSnapshot(`""`);
+		/* eslint-enable */
+	});
+
 	test("can apply a simple existing application and create other", async () => {
 		setIsTTY(false);
 		writeAppConfiguration(

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -139,6 +139,7 @@ function containerAppToCreateApplication(
 	delete (app as Record<string, unknown>)["image_build_context"];
 	delete (app as Record<string, unknown>)["image_vars"];
 	delete (app as Record<string, unknown>)["rollout_step_percentage"];
+	delete (app as Record<string, unknown>)["rollout_kind"];
 
 	return app;
 }
@@ -366,6 +367,7 @@ export async function apply(
 				id: ApplicationID;
 				name: ApplicationName;
 				rollout_step_percentage?: number;
+				rollout_kind: CreateApplicationRolloutRequest.kind;
 		  }
 	)[] = [];
 
@@ -499,19 +501,24 @@ export async function apply(
 				}
 			}
 
-			actions.push({
-				action: "modify",
-				application: createApplicationToModifyApplication(appConfig),
-				id: application.id,
-				name: application.name,
-				// The rollout logic is still pretty much attached
-				// to the fact of the container application using DOs.
-				// When we allow rollouts on non-DO, this should not be necessary.
-				rollout_step_percentage:
-					application.durable_objects !== undefined
-						? appConfigNoDefaults.rollout_step_percentage ?? 25
-						: undefined,
-			});
+			if (appConfigNoDefaults.rollout_kind !== "none") {
+				actions.push({
+					action: "modify",
+					application: createApplicationToModifyApplication(appConfig),
+					id: application.id,
+					name: application.name,
+					rollout_step_percentage:
+						application.durable_objects !== undefined
+							? appConfigNoDefaults.rollout_step_percentage ?? 25
+							: appConfigNoDefaults.rollout_step_percentage,
+					rollout_kind:
+						appConfigNoDefaults.rollout_kind == "full_manual"
+							? CreateApplicationRolloutRequest.kind.FULL_MANUAL
+							: CreateApplicationRolloutRequest.kind.FULL_AUTO,
+				});
+			} else {
+				log("Skipping application rollout");
+			}
 
 			printLine("");
 			continue;
@@ -675,6 +682,7 @@ export async function apply(
 								(action.application
 									.configuration as ModifyDeploymentV2RequestBody) ?? {},
 							step_percentage: action.rollout_step_percentage,
+							kind: action.rollout_kind,
 						}),
 						{
 							json: args.json,

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -95,6 +95,14 @@ export type ContainerApp = {
 
 	/** How a rollout should be done, defining the size of it */
 	rollout_step_percentage?: number;
+
+	/**
+	 * How a rollout should be created. It supports the following modes:
+	 *  - full_auto: The container application will be rolled out fully automatically.
+	 *  - none: The container application won't have a roll out or update.
+	 *  - manual: The container application will be rollout fully by manually actioning progress steps.
+	 */
+	rollout_kind?: "full_auto" | "none" | "full_manual";
 };
 
 /**

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2295,6 +2295,22 @@ const validateContainerAppConfig: ValidatorFn = (
 		}
 
 		if (
+			"rollout_kind" in containerAppOptional &&
+			containerAppOptional.rollout_kind !== undefined
+		) {
+			if (
+				typeof containerAppOptional.rollout_kind !== "string" ||
+				!["full_auto", "full_manual", "none"].includes(
+					containerAppOptional.rollout_kind
+				)
+			) {
+				diagnostics.errors.push(
+					`"containers.rollout_kind" should be either 'full_auto', 'full_manual' or 'none', but got ${containerAppOptional.rollout_kind}`
+				);
+			}
+		}
+
+		if (
 			"image" in containerAppOptional &&
 			containerAppOptional.image !== undefined
 		) {


### PR DESCRIPTION
Users want to specify automated or manual rollouts on their container applications.
 
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Not used in E2E.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Internal/private product.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: New feature.
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
