### PR TITLE
Support HTTPS and HTTP/2

### DIFF
--- a/.changeset/cold-emus-jog.md
+++ b/.changeset/cold-emus-jog.md
@@ -2,4 +2,4 @@
 "@cloudflare/vite-plugin": minor
 ---
 
-Support HTTPS and HTTP/2. Configuring `server.https` in your Vite config (https://vite.dev/config/server-options.html#server-https) now works as expected. This was previously broken because Undici would add a `transfer-encoding` header for streamed responses. We now remove this header if the request uses HTTP/2.
+Support HTTPS and HTTP/2. Configuring [`server.https`](https://vite.dev/config/server-options#server-https) and/or [`preview.https`](https://vite.dev/config/preview-options#preview-https) in your Vite config now works as expected. This was previously broken because Undici would add a `transfer-encoding` header for streamed responses. We now remove this header if the request uses HTTP/2.

--- a/.changeset/cold-emus-jog.md
+++ b/.changeset/cold-emus-jog.md
@@ -2,4 +2,4 @@
 "@cloudflare/vite-plugin": minor
 ---
 
-Support HTTPS and HTTP/2. Configuring `server.https` in your Vite config (https://vite.dev/config/server-options.html#server-https) now works as expected.
+Support HTTPS and HTTP/2. Configuring `server.https` in your Vite config (https://vite.dev/config/server-options.html#server-https) now works as expected. This was previously broken because Undici would add a `transfer-encoding` header for streamed responses. We now remove this header if the request uses HTTP/2.

--- a/.changeset/cold-emus-jog.md
+++ b/.changeset/cold-emus-jog.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Support HTTPS and HTTP/2. Configuring `server.https` in your Vite config (https://vite.dev/config/server-options.html#server-https) now works as expected.

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -43,7 +43,7 @@
 	},
 	"dependencies": {
 		"@cloudflare/unenv-preset": "workspace:*",
-		"@hattip/adapter-node": "^0.0.49",
+		"@mjackson/node-fetch-server": "^0.6.1",
 		"@rollup/plugin-replace": "^6.0.1",
 		"get-port": "^7.1.0",
 		"miniflare": "workspace:*",

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/https/spa-with-api.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/__tests__/https/spa-with-api.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "vitest";
+import { page } from "../../../__test-utils__";
+
+test("returns the correct home page", async () => {
+	const content = await page.textContent("h1");
+	expect(content).toBe("Vite + React");
+});

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
@@ -5,11 +5,13 @@
 	"scripts": {
 		"build": "vite build --app",
 		"build:custom-output-directories": "vite build --app -c ./vite.config.custom-output-directories.ts",
+		"build:https": "vite build --app -c ./vite.config.https.ts",
 		"check:types": "tsc --build",
 		"dev": "vite dev",
 		"dev:https": "vite dev -c ./vite.config.https.ts",
 		"preview": "vite preview",
-		"preview:custom-output-directories": "vite preview -c ./vite.config.custom-output-directories.ts"
+		"preview:custom-output-directories": "vite preview -c ./vite.config.custom-output-directories.ts",
+		"preview:https": "vite preview -c ./vite.config.https.ts"
 	},
 	"dependencies": {
 		"react": "^19.0.0",

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/package.json
@@ -7,6 +7,7 @@
 		"build:custom-output-directories": "vite build --app -c ./vite.config.custom-output-directories.ts",
 		"check:types": "tsc --build",
 		"dev": "vite dev",
+		"dev:https": "vite dev -c ./vite.config.https.ts",
 		"preview": "vite preview",
 		"preview:custom-output-directories": "vite preview -c ./vite.config.custom-output-directories.ts"
 	},
@@ -20,6 +21,7 @@
 		"@cloudflare/workers-types": "^4.20250507.0",
 		"@types/react": "^19.0.0",
 		"@types/react-dom": "^19.0.0",
+		"@vitejs/plugin-basic-ssl": "^2.0.0",
 		"@vitejs/plugin-react": "^4.3.4",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/tsconfig.node.json
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/tsconfig.node.json
@@ -1,4 +1,9 @@
 {
 	"extends": ["@cloudflare/workers-tsconfig/base.json"],
-	"include": ["vite.config.ts", "__tests__"]
+	"include": [
+		"vite.config.ts",
+		"vite.config.custom-output-directories.ts",
+		"vite.config.https.ts",
+		"__tests__"
+	]
 }

--- a/packages/vite-plugin-cloudflare/playground/spa-with-api/vite.config.https.ts
+++ b/packages/vite-plugin-cloudflare/playground/spa-with-api/vite.config.https.ts
@@ -1,0 +1,12 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import basicSsl from "@vitejs/plugin-basic-ssl";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [
+		react(),
+		cloudflare({ inspectorPort: false, persistState: false }),
+		basicSsl(),
+	],
+});

--- a/packages/vite-plugin-cloudflare/playground/streaming/__tests__/base-tests.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/__tests__/base-tests.ts
@@ -1,0 +1,12 @@
+import { expect, test, vi } from "vitest";
+import { page } from "../../__test-utils__";
+
+test("renders HTML stream", async () => {
+	const heading = await page.textContent("h1");
+	expect(heading).toBe("Streaming example");
+	const finalChunk = await vi.waitUntil(() => page.textContent("#two"), {
+		timeout: 5000,
+		interval: 500,
+	});
+	expect(finalChunk).toBe("Chunk after 2 seconds");
+});

--- a/packages/vite-plugin-cloudflare/playground/streaming/__tests__/https/streaming.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/__tests__/https/streaming.spec.ts
@@ -1,0 +1,1 @@
+import "../base-tests";

--- a/packages/vite-plugin-cloudflare/playground/streaming/__tests__/streaming.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/__tests__/streaming.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test, vi } from "vitest";
+import { page } from "../../__test-utils__";
+
+test("renders HTML stream", async () => {
+	const heading = await page.textContent("h1");
+	expect(heading).toBe("Streaming example");
+	const finalChunk = await vi.waitUntil(() => page.textContent("#three"), {
+		timeout: 5000,
+		interval: 1000,
+	});
+	expect(finalChunk).toBe("Chunk after 3 seconds");
+});

--- a/packages/vite-plugin-cloudflare/playground/streaming/__tests__/streaming.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/__tests__/streaming.spec.ts
@@ -1,12 +1,1 @@
-import { expect, test, vi } from "vitest";
-import { page } from "../../__test-utils__";
-
-test("renders HTML stream", async () => {
-	const heading = await page.textContent("h1");
-	expect(heading).toBe("Streaming example");
-	const finalChunk = await vi.waitUntil(() => page.textContent("#three"), {
-		timeout: 5000,
-		interval: 1000,
-	});
-	expect(finalChunk).toBe("Chunk after 3 seconds");
-});
+import "./base-tests";

--- a/packages/vite-plugin-cloudflare/playground/streaming/package.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
-		"@cloudflare/workers-types": "^4.20250506.0",
+		"@cloudflare/workers-types": "^4.20250507.0",
 		"@vitejs/plugin-basic-ssl": "^2.0.0",
 		"typescript": "catalog:default",
 		"vite": "catalog:vite-plugin",

--- a/packages/vite-plugin-cloudflare/playground/streaming/package.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "@playground/streaming",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build --app",
+		"check:types": "tsc --build",
+		"dev": "vite dev",
+		"preview": "vite preview"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "workspace:*",
+		"@cloudflare/workers-tsconfig": "workspace:*",
+		"@cloudflare/workers-types": "^4.20250506.0",
+		"@vitejs/plugin-basic-ssl": "^2.0.0",
+		"typescript": "catalog:default",
+		"vite": "catalog:vite-plugin",
+		"wrangler": "workspace:*"
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/streaming/package.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/package.json
@@ -3,10 +3,13 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"build": "vite build --app",
+		"build": "vite build",
+		"build:https": "vite build -c ./vite.config.https.ts",
 		"check:types": "tsc --build",
 		"dev": "vite dev",
-		"preview": "vite preview"
+		"dev:https": "vite dev -c ./vite.config.https.ts",
+		"preview": "vite preview",
+		"preview:https": "vite preview -c ./vite.config.https.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "workspace:*",

--- a/packages/vite-plugin-cloudflare/playground/streaming/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/src/index.ts
@@ -1,0 +1,49 @@
+function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function streamResponse(writable: WritableStream) {
+	const writer = writable.getWriter();
+	const encoder = new TextEncoder();
+
+	await writer.write(
+		encoder.encode(`
+	<!DOCTYPE html>
+	<html>
+	<head>
+		<title>Streaming example</title>
+	</head>
+	<body>
+		<h1>Streaming example</h1>
+		<p>Loading content...</p>
+	`)
+	);
+
+	await sleep(1000);
+	await writer.write(encoder.encode(`<p id="one">Chunk after 1 second`));
+	await sleep(1000);
+	await writer.write(encoder.encode(`<p id="two">Chunk after 2 seconds`));
+	await sleep(1000);
+	await writer.write(
+		encoder.encode(`<p id="three">Chunk after 3 seconds</p></body></html>`)
+	);
+	await writer.close();
+}
+
+export default {
+	async fetch(request, env) {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/") {
+			const { readable, writable } = new TransformStream();
+
+			streamResponse(writable);
+
+			return new Response(readable, {
+				headers: { "Content-Type": "text/html; charset=UTF-8" },
+			});
+		} else {
+			return new Response(null, { status: 404 });
+		}
+	},
+} satisfies ExportedHandler;

--- a/packages/vite-plugin-cloudflare/playground/streaming/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/src/index.ts
@@ -8,24 +8,25 @@ async function streamResponse(writable: WritableStream) {
 
 	await writer.write(
 		encoder.encode(`
-	<!DOCTYPE html>
-	<html>
-	<head>
-		<title>Streaming example</title>
-	</head>
-	<body>
-		<h1>Streaming example</h1>
-		<p>Loading content...</p>
-	`)
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Streaming example</title>
+</head>
+<body>
+	<h1>Streaming example</h1>
+	<p>Loading content...</p>
+		`)
 	);
 
 	await sleep(1000);
 	await writer.write(encoder.encode(`<p id="one">Chunk after 1 second`));
 	await sleep(1000);
-	await writer.write(encoder.encode(`<p id="two">Chunk after 2 seconds`));
-	await sleep(1000);
 	await writer.write(
-		encoder.encode(`<p id="three">Chunk after 3 seconds</p></body></html>`)
+		encoder.encode(`
+	<p id="two">Chunk after 2 seconds</p>
+</body></html>
+		`)
 	);
 	await writer.close();
 }

--- a/packages/vite-plugin-cloudflare/playground/streaming/tsconfig.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/packages/vite-plugin-cloudflare/playground/streaming/tsconfig.node.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/tsconfig.node.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/base.json"],
+	"include": ["vite.config.ts", "__tests__"]
+}

--- a/packages/vite-plugin-cloudflare/playground/streaming/tsconfig.node.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/tsconfig.node.json
@@ -1,4 +1,4 @@
 {
 	"extends": ["@cloudflare/workers-tsconfig/base.json"],
-	"include": ["vite.config.ts", "__tests__"]
+	"include": ["vite.config.ts", "vite.config.https.ts", "__tests__"]
 }

--- a/packages/vite-plugin-cloudflare/playground/streaming/tsconfig.worker.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/tsconfig.worker.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@cloudflare/workers-tsconfig/worker.json"],
+	"include": ["src"]
+}

--- a/packages/vite-plugin-cloudflare/playground/streaming/turbo.json
+++ b/packages/vite-plugin-cloudflare/playground/streaming/turbo.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "http://turbo.build/schema.json",
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"outputs": ["dist/**"]
+		}
+	}
+}

--- a/packages/vite-plugin-cloudflare/playground/streaming/vite.config.https.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/vite.config.https.ts
@@ -1,0 +1,10 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import basicSsl from "@vitejs/plugin-basic-ssl";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [
+		cloudflare({ inspectorPort: false, persistState: false }),
+		basicSsl(),
+	],
+});

--- a/packages/vite-plugin-cloudflare/playground/streaming/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/vite.config.ts
@@ -1,0 +1,10 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import basicSsl from "@vitejs/plugin-basic-ssl";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [
+		cloudflare({ inspectorPort: false, persistState: false }),
+		basicSsl(),
+	],
+});

--- a/packages/vite-plugin-cloudflare/playground/streaming/vite.config.ts
+++ b/packages/vite-plugin-cloudflare/playground/streaming/vite.config.ts
@@ -1,10 +1,6 @@
 import { cloudflare } from "@cloudflare/vite-plugin";
-import basicSsl from "@vitejs/plugin-basic-ssl";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [
-		cloudflare({ inspectorPort: false, persistState: false }),
-		basicSsl(),
-	],
+	plugins: [cloudflare({ inspectorPort: false, persistState: false })],
 });

--- a/packages/vite-plugin-cloudflare/playground/streaming/wrangler.jsonc
+++ b/packages/vite-plugin-cloudflare/playground/streaming/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+	"name": "worker",
+	"main": "./src/index.ts",
+	"compatibility_date": "2024-09-09",
+}

--- a/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
@@ -96,7 +96,7 @@ beforeAll(async (s) => {
 	}
 
 	browser = await chromium.connect(wsEndpoint);
-	page = await browser.newPage();
+	page = await browser.newPage({ ignoreHTTPSErrors: true });
 
 	const globalConsole = console;
 	const warn = globalConsole.warn;

--- a/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
+++ b/packages/vite-plugin-cloudflare/playground/vitest-setup.ts
@@ -96,6 +96,7 @@ beforeAll(async (s) => {
 	}
 
 	browser = await chromium.connect(wsEndpoint);
+	// `@vitejs/plugin-basic-ssl` requires a manual confirmation step in the browser so we enable `ignoreHTTPSErrors` to bypass this
 	page = await browser.newPage({ ignoreHTTPSErrors: true });
 
 	const globalConsole = console;

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -378,7 +378,9 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 								}
 							);
 
+							// Vite uses HTTP/2 when `server.https` is enabled
 							if (req.httpVersionMajor === 2) {
+								// HTTP/2 disallows use of the `transfer-encoding` header
 								response.headers.delete("transfer-encoding");
 							}
 
@@ -420,7 +422,9 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 							{ redirect: "manual" }
 						);
 
+						// Vite uses HTTP/2 when `preview.https` is enabled
 						if (req.httpVersionMajor === 2) {
+							// HTTP/2 disallows use of the `transfer-encoding` header
 							response.headers.delete("transfer-encoding");
 						}
 

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -370,10 +370,10 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 
 				return () => {
 					viteDevServer.middlewares.use(async (req, res, next) => {
-						assert(miniflare, `Miniflare not defined`);
-						const routerWorker = await getRouterWorker(miniflare);
-
 						try {
+							assert(miniflare, `Miniflare not defined`);
+							const routerWorker = await getRouterWorker(miniflare);
+
 							const request = createRequest(req, res);
 							const response = await routerWorker.fetch(
 								toMiniflareRequest(request),

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -415,10 +415,17 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					() => miniflare.dispatchFetch
 				);
 
-				const requestListener = createRequestListener((request) => {
-					return miniflare.dispatchFetch(toMiniflareRequest(request), {
-						redirect: "manual",
-					}) as any;
+				const requestListener = createRequestListener(async (request) => {
+					const response = (await miniflare.dispatchFetch(
+						toMiniflareRequest(request),
+						{
+							redirect: "manual",
+						}
+					)) as any;
+
+					console.log(response.headers);
+
+					return response;
 				});
 
 				// In preview mode we put our middleware at the front of the chain so that all assets are handled in Miniflare

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -2,7 +2,11 @@ import assert from "node:assert";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
-import { createMiddleware } from "@hattip/adapter-node";
+import {
+	createRequest,
+	createRequestListener,
+	sendResponse,
+} from "@mjackson/node-fetch-server";
 import replace from "@rollup/plugin-replace";
 import MagicString from "magic-string";
 import { Miniflare } from "miniflare";
@@ -354,18 +358,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 
 				await initRunners(resolvedPluginConfig, viteDevServer, miniflare);
 
-				const middleware = createMiddleware(
-					async ({ request }) => {
-						assert(miniflare, `Miniflare not defined`);
-						const routerWorker = await getRouterWorker(miniflare);
-
-						return routerWorker.fetch(toMiniflareRequest(request), {
-							redirect: "manual",
-						}) as any;
-					},
-					{ alwaysCallNext: false }
-				);
-
 				// The HTTP server is not available in middleware mode
 				if (viteDevServer.httpServer) {
 					handleWebSocket(viteDevServer.httpServer, async () => {
@@ -377,8 +369,23 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				}
 
 				return () => {
-					viteDevServer.middlewares.use((req, res, next) => {
-						middleware(req, res, next);
+					viteDevServer.middlewares.use(async (req, res) => {
+						assert(miniflare, `Miniflare not defined`);
+						const routerWorker = await getRouterWorker(miniflare);
+
+						const request = createRequest(req, res);
+						const response = await routerWorker.fetch(
+							toMiniflareRequest(request),
+							{
+								redirect: "manual",
+							}
+						);
+
+						if (req.httpVersionMajor === 2) {
+							response.headers.delete("transfer-encoding");
+						}
+
+						await sendResponse(res, response as any);
 					});
 				};
 			},
@@ -399,23 +406,20 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 					)
 				);
 
-				const middleware = createMiddleware(
-					({ request }) => {
-						return miniflare.dispatchFetch(toMiniflareRequest(request), {
-							redirect: "manual",
-						}) as any;
-					},
-					{ alwaysCallNext: false }
-				);
-
 				handleWebSocket(
 					vitePreviewServer.httpServer,
 					() => miniflare.dispatchFetch
 				);
 
+				const requestListener = createRequestListener((request) => {
+					return miniflare.dispatchFetch(toMiniflareRequest(request), {
+						redirect: "manual",
+					}) as any;
+				});
+
 				// In preview mode we put our middleware at the front of the chain so that all assets are handled in Miniflare
-				vitePreviewServer.middlewares.use((req, res, next) => {
-					middleware(req, res, next);
+				vitePreviewServer.middlewares.use((req, res) => {
+					requestListener(req, res);
 				});
 			},
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2754,8 +2754,8 @@ importers:
         specifier: workspace:*
         version: link:../../../workers-tsconfig
       '@cloudflare/workers-types':
-        specifier: ^4.20250506.0
-        version: 4.20250506.0
+        specifier: ^4.20250507.0
+        version: 4.20250507.0
       '@vitejs/plugin-basic-ssl':
         specifier: ^2.0.0
         version: 2.0.0(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))
@@ -16528,7 +16528,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -16564,7 +16564,7 @@ snapshots:
       '@typescript-eslint/types': 6.10.0
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.7.3
@@ -16577,7 +16577,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.3
@@ -16763,7 +16763,7 @@ snapshots:
 
   '@verdaccio/loaders@8.0.0-next-8.4':
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -16824,7 +16824,7 @@ snapshots:
 
   '@verdaccio/signature@8.0.0-next-8.1':
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       jsonwebtoken: 9.0.2
     transitivePeerDependencies:
       - supports-color
@@ -17399,7 +17399,7 @@ snapshots:
       common-path-prefix: 3.0.0
       concordance: 5.0.4
       currently-unhandled: 0.4.1
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       emittery: 1.0.1
       figures: 6.0.1
       globby: 14.0.1
@@ -18460,8 +18460,8 @@ snapshots:
 
   esbuild-register@3.5.0(esbuild@0.25.4):
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
-      esbuild: 0.25.2
+      debug: 4.3.7(supports-color@9.2.2)
+      esbuild: 0.25.4
     transitivePeerDependencies:
       - supports-color
 
@@ -18797,7 +18797,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -22452,7 +22452,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 3.6.0
       consola: 3.3.3
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       esbuild: 0.23.1
       execa: 5.1.1
       joycon: 3.1.1
@@ -22889,7 +22889,7 @@ snapshots:
       '@volar/typescript': 2.3.4
       '@vue/language-core': 2.0.29(typescript@5.7.3)
       compare-versions: 6.1.1
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       kolorist: 1.8.0
       local-pkg: 0.5.0
       magic-string: 0.30.17
@@ -22904,7 +22904,7 @@ snapshots:
 
   vite-tsconfig-paths@4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)):
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.7.3)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1949,9 +1949,9 @@ importers:
       '@cloudflare/unenv-preset':
         specifier: workspace:*
         version: link:../unenv-preset
-      '@hattip/adapter-node':
-        specifier: ^0.0.49
-        version: 0.0.49
+      '@mjackson/node-fetch-server':
+        specifier: ^0.6.1
+        version: 0.6.1
       '@rollup/plugin-replace':
         specifier: ^6.0.1
         version: 6.0.2(rollup@4.30.1)
@@ -5264,22 +5264,6 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@hattip/adapter-node@0.0.49':
-    resolution: {integrity: sha512-BE+Y8Q4U0YcH34FZUYU4DssGKOaZLbNL0zK57Z41UZp0m9kS79ZIolBmjjpPhTVpIlRY3Rs+uhXbVXKk7mUcJA==}
-
-  '@hattip/core@0.0.49':
-    resolution: {integrity: sha512-3/ZJtC17cv8m6Sph8+nw4exUp9yhEf2Shi7HK6AHSUSBtaaQXZ9rJBVxTfZj3PGNOR/P49UBXOym/52WYKFTJQ==}
-
-  '@hattip/headers@0.0.49':
-    resolution: {integrity: sha512-rrB2lEhTf0+MNVt5WdW184Ky706F1Ze9Aazn/R8c+/FMUYF9yjem2CgXp49csPt3dALsecrnAUOHFiV0LrrHXA==}
-
-  '@hattip/polyfills@0.0.49':
-    resolution: {integrity: sha512-5g7W5s6Gq+HDxwULGFQ861yAnEx3yd9V8GDwS96HBZ1nM1u93vN+KTuwXvNsV7Z3FJmCrD/pgU8WakvchclYuA==}
-
-  '@hattip/walk@0.0.49':
-    resolution: {integrity: sha512-AgJgKLooZyQnzMfoFg5Mo/aHM+HGBC9ExpXIjNqGimYTRgNbL/K7X5EM1kR2JY90BNKk9lo6Usq1T/nWFdT7TQ==}
-    hasBin: true
-
   '@hono/zod-validator@0.4.2':
     resolution: {integrity: sha512-1rrlBg+EpDPhzOV4hT9pxr5+xDVmKuz6YJl+la7VCwK6ass5ldyKm5fD+umJdV2zhHD6jROoCCv8NbTwyfhT0g==}
     peerDependencies:
@@ -5477,9 +5461,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@kamilkisiela/fast-url-parser@1.1.4':
-    resolution: {integrity: sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==}
-
   '@manypkg/cli@0.23.0':
     resolution: {integrity: sha512-9N0GuhUZhrDbOS2rer1/ZWaO8RvPOUI+kKTwlq74iQXomL+725E9Vfvl9U64FYwnLkQCxCmPZ9nBs/u8JwFnSw==}
     engines: {node: '>=18.0.0'}
@@ -5537,6 +5518,9 @@ packages:
 
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
+  '@mjackson/node-fetch-server@0.6.1':
+    resolution: {integrity: sha512-9ZJnk/DJjt805uv5PPv11haJIW+HHf3YEEyVXv+8iLQxLD/iXA68FH220XoiTPBC4gCg5q+IMadDw8qPqlA5wg==}
 
   '@mswjs/interceptors@0.29.1':
     resolution: {integrity: sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==}
@@ -7209,14 +7193,6 @@ packages:
   '@webcontainer/env@1.1.0':
     resolution: {integrity: sha512-DreJFHUui8vq1N3nQGU3HwK5UI4hVNW7VQfhAOmeQbBVnpKtGhoNobjDNF8LzlN7ssmFI9Uhkc9Au4mtKvPK6Q==}
 
-  '@whatwg-node/fetch@0.9.23':
-    resolution: {integrity: sha512-7xlqWel9JsmxahJnYVUj/LLxWcnA93DR4c9xlw3U814jWTiYalryiH1qToik1hOxweKKRLi4haXHM5ycRksPBA==}
-    engines: {node: '>=18.0.0'}
-
-  '@whatwg-node/node-fetch@0.6.0':
-    resolution: {integrity: sha512-tcZAhrpx6oVlkEsRngeTEEE7I5/QdLjeEz4IlekabGaESP7+Dkm/6a9KcF1KdCBB7mO9PXtBkwCuTCt8+UPg8Q==}
-    engines: {node: '>=18.0.0'}
-
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
@@ -7614,10 +7590,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
-
-  busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -8744,9 +8716,6 @@ packages:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
 
-  fast-decode-uri-component@1.0.1:
-    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -8768,9 +8737,6 @@ packages:
 
   fast-loops@1.1.4:
     resolution: {integrity: sha512-8dbd3XWoKCTms18ize6JmQF1SFnnfj5s0B7rRry22EofgMu7B6LKHVh+XfFqFGsqnbH54xgeO83PzpKI+ODhlg==}
-
-  fast-querystring@1.1.2:
-    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
@@ -10293,9 +10259,6 @@ packages:
   node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
 
-  node-fetch-native@1.6.4:
-    resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
-
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -11780,10 +11743,6 @@ packages:
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
-  streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
-
   streamx@2.21.1:
     resolution: {integrity: sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==}
 
@@ -12388,9 +12347,6 @@ packages:
   url-search-params@0.10.2:
     resolution: {integrity: sha512-d6GYsr992Bo9rzTZFc9BUw3UFAAg3prE9JGVBgW2TLTbI3rSvg4VDa0BFXHMzKkWbAuhrmaFWpucpRJl+3W7Jg==}
     deprecated: now available as @ungap/url-search-params
-
-  urlpattern-polyfill@10.0.0:
-    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
 
   use-sync-external-store@1.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
@@ -14755,30 +14711,6 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@hattip/adapter-node@0.0.49':
-    dependencies:
-      '@hattip/core': 0.0.49
-      '@hattip/polyfills': 0.0.49
-      '@hattip/walk': 0.0.49
-
-  '@hattip/core@0.0.49': {}
-
-  '@hattip/headers@0.0.49':
-    dependencies:
-      '@hattip/core': 0.0.49
-
-  '@hattip/polyfills@0.0.49':
-    dependencies:
-      '@hattip/core': 0.0.49
-      '@whatwg-node/fetch': 0.9.23
-      node-fetch-native: 1.6.4
-
-  '@hattip/walk@0.0.49':
-    dependencies:
-      '@hattip/headers': 0.0.49
-      cac: 6.7.14
-      mime-types: 2.1.35
-
   '@hono/zod-validator@0.4.2(hono@4.7.1)(zod@3.22.3)':
     dependencies:
       hono: 4.7.1
@@ -14970,8 +14902,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@kamilkisiela/fast-url-parser@1.1.4': {}
-
   '@manypkg/cli@0.23.0':
     dependencies:
       '@manypkg/get-packages': 2.2.1
@@ -15115,6 +15045,8 @@ snapshots:
   '@microsoft/tsdoc@0.15.0': {}
 
   '@microsoft/tsdoc@0.15.1': {}
+
+  '@mjackson/node-fetch-server@0.6.1': {}
 
   '@mswjs/interceptors@0.29.1':
     dependencies:
@@ -16572,7 +16504,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -16608,7 +16540,7 @@ snapshots:
       '@typescript-eslint/types': 6.10.0
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.7.3
@@ -16621,7 +16553,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.3
@@ -16807,7 +16739,7 @@ snapshots:
 
   '@verdaccio/loaders@8.0.0-next-8.4':
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -16868,7 +16800,7 @@ snapshots:
 
   '@verdaccio/signature@8.0.0-next-8.1':
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       jsonwebtoken: 9.0.2
     transitivePeerDependencies:
       - supports-color
@@ -17165,18 +17097,6 @@ snapshots:
 
   '@webcontainer/env@1.1.0': {}
 
-  '@whatwg-node/fetch@0.9.23':
-    dependencies:
-      '@whatwg-node/node-fetch': 0.6.0
-      urlpattern-polyfill: 10.0.0
-
-  '@whatwg-node/node-fetch@0.6.0':
-    dependencies:
-      '@kamilkisiela/fast-url-parser': 1.1.4
-      busboy: 1.6.0
-      fast-querystring: 1.1.2
-      tslib: 2.8.1
-
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -17455,7 +17375,7 @@ snapshots:
       common-path-prefix: 3.0.0
       concordance: 5.0.4
       currently-unhandled: 0.4.1
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       emittery: 1.0.1
       figures: 6.0.1
       globby: 14.0.1
@@ -17648,10 +17568,6 @@ snapshots:
     dependencies:
       esbuild: 0.23.1
       load-tsconfig: 0.2.5
-
-  busboy@1.6.0:
-    dependencies:
-      streamsearch: 1.1.0
 
   bytes@3.1.2: {}
 
@@ -18521,8 +18437,6 @@ snapshots:
   esbuild-register@3.5.0(esbuild@0.25.4):
     dependencies:
       debug: 4.3.7(supports-color@9.2.2)
-      esbuild: 0.25.4
-      debug: 4.3.7(supports-color@8.1.1)
       esbuild: 0.25.2
     transitivePeerDependencies:
       - supports-color
@@ -18859,7 +18773,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -19069,8 +18983,6 @@ snapshots:
 
   extsprintf@1.3.0: {}
 
-  fast-decode-uri-component@1.0.1: {}
-
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.2.0: {}
@@ -19090,10 +19002,6 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-loops@1.1.4: {}
-
-  fast-querystring@1.1.2:
-    dependencies:
-      fast-decode-uri-component: 1.0.1
 
   fast-redact@3.5.0: {}
 
@@ -20603,8 +20511,6 @@ snapshots:
       semver: 7.7.1
 
   node-addon-api@4.3.0: {}
-
-  node-fetch-native@1.6.4: {}
 
   node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
@@ -22136,8 +22042,6 @@ snapshots:
 
   stream-shift@1.0.3: {}
 
-  streamsearch@1.1.0: {}
-
   streamx@2.21.1:
     dependencies:
       fast-fifo: 1.3.2
@@ -22524,7 +22428,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 3.6.0
       consola: 3.3.3
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       esbuild: 0.23.1
       execa: 5.1.1
       joycon: 3.1.1
@@ -22815,8 +22719,6 @@ snapshots:
 
   url-search-params@0.10.2: {}
 
-  urlpattern-polyfill@10.0.0: {}
-
   use-sync-external-store@1.2.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -22963,7 +22865,7 @@ snapshots:
       '@volar/typescript': 2.3.4
       '@vue/language-core': 2.0.29(typescript@5.7.3)
       compare-versions: 6.1.1
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       kolorist: 1.8.0
       local-pkg: 0.5.0
       magic-string: 0.30.17
@@ -22978,7 +22880,7 @@ snapshots:
 
   vite-tsconfig-paths@4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)):
     dependencies:
-      debug: 4.3.7(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@9.2.2)
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.7.3)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2687,6 +2687,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.0.3(@types/react@19.0.7)
+      '@vitejs/plugin-basic-ssl':
+        specifier: ^2.0.0
+        version: 2.0.0(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))
@@ -7047,6 +7050,12 @@ packages:
   '@verdaccio/utils@8.1.0-next-8.7':
     resolution: {integrity: sha512-4eqPCnPAJsL6gdVs0/oqZNgs2PnQW3HHBMgBHyEbb5A/ESI10TvRp+B7MRl9glUmy/aR5B6YSI68rgXvAFjdxA==}
     engines: {node: '>=12'}
+
+  '@vitejs/plugin-basic-ssl@2.0.0':
+    resolution: {integrity: sha512-gc9Tjg8bUxBVSTzeWT3Njc0Cl3PakHFKdNfABnZWiUgbxqmHDEn7uECv3fHVylxoYgNzAcmU7ZrILz+BwSo3sA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    peerDependencies:
+      vite: ^6.0.0
 
   '@vitejs/plugin-react@4.3.3':
     resolution: {integrity: sha512-NooDe9GpHGqNns1i8XDERg0Vsg5SSYRhRxxyTGogUdkdNt47jal+fbuYi+Yfq6pzRCKXyoPcWisfxE6RIM3GKA==}
@@ -16563,7 +16572,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -16599,7 +16608,7 @@ snapshots:
       '@typescript-eslint/types': 6.10.0
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.7.3
@@ -16612,7 +16621,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.3
@@ -16798,7 +16807,7 @@ snapshots:
 
   '@verdaccio/loaders@8.0.0-next-8.4':
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -16859,7 +16868,7 @@ snapshots:
 
   '@verdaccio/signature@8.0.0-next-8.1':
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       jsonwebtoken: 9.0.2
     transitivePeerDependencies:
       - supports-color
@@ -16904,6 +16913,10 @@ snapshots:
       lodash: 4.17.21
       minimatch: 7.4.6
       semver: 7.6.3
+
+  '@vitejs/plugin-basic-ssl@2.0.0(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))':
+    dependencies:
+      vite: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
 
   '@vitejs/plugin-react@4.3.3(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))':
     dependencies:
@@ -17442,7 +17455,7 @@ snapshots:
       common-path-prefix: 3.0.0
       concordance: 5.0.4
       currently-unhandled: 0.4.1
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       emittery: 1.0.1
       figures: 6.0.1
       globby: 14.0.1
@@ -18509,6 +18522,8 @@ snapshots:
     dependencies:
       debug: 4.3.7(supports-color@9.2.2)
       esbuild: 0.25.4
+      debug: 4.3.7(supports-color@8.1.1)
+      esbuild: 0.25.2
     transitivePeerDependencies:
       - supports-color
 
@@ -18844,7 +18859,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -22509,7 +22524,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 3.6.0
       consola: 3.3.3
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       esbuild: 0.23.1
       execa: 5.1.1
       joycon: 3.1.1
@@ -22948,7 +22963,7 @@ snapshots:
       '@volar/typescript': 2.3.4
       '@vue/language-core': 2.0.29(typescript@5.7.3)
       compare-versions: 6.1.1
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 0.5.0
       magic-string: 0.30.17
@@ -22963,7 +22978,7 @@ snapshots:
 
   vite-tsconfig-paths@4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)):
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.7.3)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2745,6 +2745,30 @@ importers:
         specifier: workspace:*
         version: link:../../../wrangler
 
+  packages/vite-plugin-cloudflare/playground/streaming:
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: workspace:*
+        version: link:../..
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:*
+        version: link:../../../workers-tsconfig
+      '@cloudflare/workers-types':
+        specifier: ^4.20250506.0
+        version: 4.20250506.0
+      '@vitejs/plugin-basic-ssl':
+        specifier: ^2.0.0
+        version: 2.0.0(vite@6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2))
+      typescript:
+        specifier: catalog:default
+        version: 5.7.3
+      vite:
+        specifier: catalog:vite-plugin
+        version: 6.1.0(@types/node@20.17.32)(jiti@2.4.2)(lightningcss@1.29.2)
+      wrangler:
+        specifier: workspace:*
+        version: link:../../../wrangler
+
   packages/vite-plugin-cloudflare/playground/virtual-modules:
     devDependencies:
       '@cloudflare/vite-plugin':
@@ -16504,7 +16528,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -16540,7 +16564,7 @@ snapshots:
       '@typescript-eslint/types': 6.10.0
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.7.3
@@ -16553,7 +16577,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.3
@@ -16739,7 +16763,7 @@ snapshots:
 
   '@verdaccio/loaders@8.0.0-next-8.4':
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -16800,7 +16824,7 @@ snapshots:
 
   '@verdaccio/signature@8.0.0-next-8.1':
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       jsonwebtoken: 9.0.2
     transitivePeerDependencies:
       - supports-color
@@ -17375,7 +17399,7 @@ snapshots:
       common-path-prefix: 3.0.0
       concordance: 5.0.4
       currently-unhandled: 0.4.1
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       emittery: 1.0.1
       figures: 6.0.1
       globby: 14.0.1
@@ -18436,7 +18460,7 @@ snapshots:
 
   esbuild-register@3.5.0(esbuild@0.25.4):
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       esbuild: 0.25.2
     transitivePeerDependencies:
       - supports-color
@@ -18773,7 +18797,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -22428,7 +22452,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 3.6.0
       consola: 3.3.3
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       esbuild: 0.23.1
       execa: 5.1.1
       joycon: 3.1.1
@@ -22865,7 +22889,7 @@ snapshots:
       '@volar/typescript': 2.3.4
       '@vue/language-core': 2.0.29(typescript@5.7.3)
       compare-versions: 6.1.1
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 0.5.0
       magic-string: 0.30.17
@@ -22880,7 +22904,7 @@ snapshots:
 
   vite-tsconfig-paths@4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)):
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.7.3)
     optionalDependencies:


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/9000.

This adds support for HTTPS so that configuring [`server.https`](https://vite.dev/config/server-options#server-https) and/or [`preview.https`](https://vite.dev/config/preview-options#preview-https) in your Vite config now works as expected.

Vite uses HTTP/2 by default when HTTPS is enabled. This was previously broken with our plugin because Undici uses HTTP/1.1 and includes the `transfer-encoding: chunked` header for streamed responses. The presence of this header would cause the dev server to crash. The changes here detect if HTTP/2 is being used and, if so, remove the `transfer-encoding` header.

As part of this PR I've replaced `@hattip/adapter-node` with `@mjackson/node-fetch-server` as it has better compatibility with HTTP/2 and has greater usage. I've also added a new 'streaming' playground so that we have test coverage for streaming responses (with and without HTTPS enabled).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: N/A

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
