### PR TITLE
cloudchamber: migrate to typed API fields (v3 backport)

### DIFF
--- a/.changeset/weak-signs-smash.md
+++ b/.changeset/weak-signs-smash.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Use typed fields when interacting with Cloudchamber API

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -20,6 +20,7 @@ const MOCK_DEPLOYMENTS_COMPLEX_RESPONSE = `
 			    \\"account_id\\": \\"123\\",
 			    \\"vcpu\\": 4,
 			    \\"memory\\": \\"400MB\\",
+			    \\"memory_mib\\": 400,
 			    \\"version\\": 1,
 			    \\"image\\": \\"hello\\",
 			    \\"location\\": {
@@ -39,9 +40,26 @@ function mockDeploymentPost() {
 		http.post(
 			"*/deployments/v2",
 			async ({ request }) => {
-				expect(await request.text()).toBe(
-					`{"image":"hello:world","location":"sfo06","ssh_public_key_ids":[],"environment_variables":[{"name":"HELLO","value":"WORLD"},{"name":"YOU","value":"CONQUERED"}],"vcpu":3,"memory":"400GB","network":{"assign_ipv4":"predefined"}}`
-				);
+				expect(await request.json()).toEqual({
+					image: "hello:world",
+					location: "sfo06",
+					ssh_public_key_ids: [],
+					environment_variables: [
+						{
+							name: "HELLO",
+							value: "WORLD",
+						},
+						{
+							name: "YOU",
+							value: "CONQUERED",
+						},
+					],
+					vcpu: 3,
+					memory_mib: 409600,
+					network: {
+						assign_ipv4: "predefined",
+					},
+				});
 				return HttpResponse.json(MOCK_DEPLOYMENTS_COMPLEX[0]);
 			},
 			{ once: true }
@@ -101,7 +119,7 @@ describe("cloudchamber create", () => {
 			      --all-ssh-keys  To add all SSH keys configured on your account to be added to this deployment, set this option to true  [boolean]
 			      --ssh-key-id    ID of the SSH key to add to the deployment  [array]
 			      --vcpu          Number of vCPUs to allocate to this deployment.  [number]
-			      --memory        Amount of memory (GB, MB...) to allocate to this deployment. Ex: 4GB.  [string]
+			      --memory        Amount of memory (GiB, MiB...) to allocate to this deployment. Ex: 4GiB.  [string]
 			      --ipv4          Include an IPv4 in the deployment  [boolean]"
 		`);
 	});
@@ -183,7 +201,7 @@ describe("cloudchamber create", () => {
 			image: "hello:world",
 			ipv4: true,
 			vcpu: 3,
-			memory: "400GB",
+			memory: "400GiB",
 			location: "sfo06",
 		});
 		// if values are not read by wrangler, this mock won't work
@@ -208,9 +226,26 @@ describe("cloudchamber create", () => {
 			http.post(
 				"*/deployments/v2",
 				async ({ request }) => {
-					expect(await request.text()).toMatchInlineSnapshot(
-						`"{\\"image\\":\\"hello:world\\",\\"location\\":\\"sfo06\\",\\"ssh_public_key_ids\\":[\\"1\\"],\\"environment_variables\\":[{\\"name\\":\\"HELLO\\",\\"value\\":\\"WORLD\\"},{\\"name\\":\\"YOU\\",\\"value\\":\\"CONQUERED\\"}],\\"vcpu\\":40,\\"memory\\":\\"300MB\\",\\"network\\":{\\"assign_ipv4\\":\\"predefined\\"}}"`
-					);
+					expect(await request.json()).toEqual({
+						image: "hello:world",
+						location: "sfo06",
+						ssh_public_key_ids: ["1"],
+						environment_variables: [
+							{
+								name: "HELLO",
+								value: "WORLD",
+							},
+							{
+								name: "YOU",
+								value: "CONQUERED",
+							},
+						],
+						vcpu: 40,
+						memory_mib: 300,
+						network: {
+							assign_ipv4: "predefined",
+						},
+					});
 					return HttpResponse.json(MOCK_DEPLOYMENTS_COMPLEX[0]);
 				},
 				{ once: true }

--- a/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/curl.test.ts
@@ -64,9 +64,26 @@ describe("cloudchamber curl", () => {
 				// verify we are hitting the expected url
 				expect(request.url).toEqual(baseRequestUrl + "deployments/v2");
 				// and that the request has the expected content
-				expect(await request.text()).toMatchInlineSnapshot(
-					`"{\\"image\\":\\"hello:world\\",\\"location\\":\\"sfo06\\",\\"ssh_public_key_ids\\":[],\\"environment_variables\\":[{\\"name\\":\\"HELLO\\",\\"value\\":\\"WORLD\\"},{\\"name\\":\\"YOU\\",\\"value\\":\\"CONQUERED\\"}],\\"vcpu\\":3,\\"memory\\":\\"400GB\\",\\"network\\":{\\"assign_ipv4\\":\\"predefined\\"}}"`
-				);
+				expect(await request.json()).toEqual({
+					image: "hello:world",
+					location: "sfo06",
+					ssh_public_key_ids: [],
+					environment_variables: [
+						{
+							name: "HELLO",
+							value: "WORLD",
+						},
+						{
+							name: "YOU",
+							value: "CONQUERED",
+						},
+					],
+					vcpu: 3,
+					memory_mib: 400,
+					network: {
+						assign_ipv4: "predefined",
+					},
+				});
 				return HttpResponse.json(MOCK_DEPLOYMENTS_COMPLEX[0]);
 			})
 		);
@@ -81,7 +98,7 @@ describe("cloudchamber curl", () => {
 				{ name: "YOU", value: "CONQUERED" },
 			],
 			vcpu: 3,
-			memory: "400GB",
+			memory_mib: 400,
 			network: { assign_ipv4: "predefined" },
 		});
 
@@ -97,6 +114,7 @@ describe("cloudchamber curl", () => {
 			    \\"account_id\\": \\"123\\",
 			    \\"vcpu\\": 4,
 			    \\"memory\\": \\"400MB\\",
+			    \\"memory_mib\\": 400,
 			    \\"version\\": 1,
 			    \\"image\\": \\"hello\\",
 			    \\"location\\": {
@@ -164,6 +182,7 @@ describe("cloudchamber curl", () => {
 			        \\"account_id\\": \\"123\\",
 			        \\"vcpu\\": 4,
 			        \\"memory\\": \\"400MB\\",
+			        \\"memory_mib\\": 400,
 			        \\"version\\": 1,
 			        \\"image\\": \\"hello\\",
 			        \\"location\\": {
@@ -183,6 +202,7 @@ describe("cloudchamber curl", () => {
 			        \\"account_id\\": \\"123\\",
 			        \\"vcpu\\": 4,
 			        \\"memory\\": \\"400MB\\",
+			        \\"memory_mib\\": 400,
 			        \\"version\\": 2,
 			        \\"image\\": \\"hello\\",
 			        \\"location\\": {
@@ -212,6 +232,7 @@ describe("cloudchamber curl", () => {
 			        \\"account_id\\": \\"123\\",
 			        \\"vcpu\\": 4,
 			        \\"memory\\": \\"400MB\\",
+			        \\"memory_mib\\": 400,
 			        \\"version\\": 1,
 			        \\"image\\": \\"hello\\",
 			        \\"location\\": {
@@ -231,6 +252,7 @@ describe("cloudchamber curl", () => {
 			        \\"account_id\\": \\"123\\",
 			        \\"vcpu\\": 4,
 			        \\"memory\\": \\"400MB\\",
+			        \\"memory_mib\\": 400,
 			        \\"version\\": 2,
 			        \\"image\\": \\"hello\\",
 			        \\"location\\": {

--- a/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/delete.test.ts
@@ -62,7 +62,7 @@ describe("cloudchamber delete", () => {
 		// so testing the actual UI will be harder than expected
 		// TODO: think better on how to test UI actions
 		expect(std.out).toMatchInlineSnapshot(
-			`"{\\"id\\":\\"1\\",\\"type\\":\\"default\\",\\"created_at\\":\\"123\\",\\"account_id\\":\\"123\\",\\"vcpu\\":4,\\"memory\\":\\"400MB\\",\\"version\\":1,\\"image\\":\\"hello\\",\\"location\\":{\\"name\\":\\"sfo06\\",\\"enabled\\":true},\\"network\\":{\\"ipv4\\":\\"1.1.1.1\\"},\\"placements_ref\\":\\"http://ref\\",\\"node_group\\":\\"metal\\"} null 4"`
+			`"{\\"id\\":\\"1\\",\\"type\\":\\"default\\",\\"created_at\\":\\"123\\",\\"account_id\\":\\"123\\",\\"vcpu\\":4,\\"memory\\":\\"400MB\\",\\"memory_mib\\":400,\\"version\\":1,\\"image\\":\\"hello\\",\\"location\\":{\\"name\\":\\"sfo06\\",\\"enabled\\":true},\\"network\\":{\\"ipv4\\":\\"1.1.1.1\\"},\\"placements_ref\\":\\"http://ref\\",\\"node_group\\":\\"metal\\"} null 4"`
 		);
 	});
 

--- a/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/list.test.ts
@@ -78,6 +78,7 @@ describe("cloudchamber list", () => {
 		        \\"account_id\\": \\"123\\",
 		        \\"vcpu\\": 4,
 		        \\"memory\\": \\"400MB\\",
+		        \\"memory_mib\\": 400,
 		        \\"version\\": 1,
 		        \\"image\\": \\"hello\\",
 		        \\"location\\": {
@@ -97,6 +98,7 @@ describe("cloudchamber list", () => {
 		        \\"account_id\\": \\"123\\",
 		        \\"vcpu\\": 4,
 		        \\"memory\\": \\"400MB\\",
+		        \\"memory_mib\\": 400,
 		        \\"version\\": 2,
 		        \\"image\\": \\"hello\\",
 		        \\"location\\": {
@@ -126,6 +128,7 @@ describe("cloudchamber list", () => {
 		        \\"account_id\\": \\"123\\",
 		        \\"vcpu\\": 4,
 		        \\"memory\\": \\"400MB\\",
+		        \\"memory_mib\\": 400,
 		        \\"version\\": 1,
 		        \\"image\\": \\"hello\\",
 		        \\"location\\": {
@@ -145,6 +148,7 @@ describe("cloudchamber list", () => {
 		        \\"account_id\\": \\"123\\",
 		        \\"vcpu\\": 4,
 		        \\"memory\\": \\"400MB\\",
+		        \\"memory_mib\\": 400,
 		        \\"version\\": 2,
 		        \\"image\\": \\"hello\\",
 		        \\"location\\": {

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -15,7 +15,7 @@ function mockDeployment() {
 			"*/deployments/1234/v2",
 			async ({ request }) => {
 				expect(await request.text()).toBe(
-					`{"image":"hello:modify","location":"sfo06","environment_variables":[{"name":"HELLO","value":"WORLD"},{"name":"YOU","value":"CONQUERED"}],"labels":[{"name":"appname","value":"helloworld"},{"name":"region","value":"wnam"}],"vcpu":3,"memory":"40MB"}`
+					`{"image":"hello:modify","location":"sfo06","environment_variables":[{"name":"HELLO","value":"WORLD"},{"name":"YOU","value":"CONQUERED"}],"labels":[{"name":"appname","value":"helloworld"},{"name":"region","value":"wnam"}],"vcpu":3,"memory_mib":40}`
 				);
 				return HttpResponse.json(MOCK_DEPLOYMENTS_COMPLEX[0]);
 			},
@@ -32,6 +32,7 @@ const EXPECTED_RESULT = `
 		    \\"account_id\\": \\"123\\",
 		    \\"vcpu\\": 4,
 		    \\"memory\\": \\"400MB\\",
+		    \\"memory_mib\\": 400,
 		    \\"version\\": 1,
 		    \\"image\\": \\"hello\\",
 		    \\"location\\": {

--- a/packages/wrangler/src/__tests__/helpers/mock-cloudchamber.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-cloudchamber.ts
@@ -16,6 +16,7 @@ export const MOCK_DEPLOYMENTS: DeploymentV2[] = [
 		account_id: "123",
 		vcpu: 4,
 		memory: "400MB",
+		memory_mib: 400,
 		version: 1,
 		image: "hello",
 		location: {
@@ -35,6 +36,7 @@ export const MOCK_DEPLOYMENTS: DeploymentV2[] = [
 		account_id: "123",
 		vcpu: 4,
 		memory: "400MB",
+		memory_mib: 400,
 		version: 2,
 		image: "hello",
 		location: {
@@ -65,6 +67,7 @@ export const MOCK_DEPLOYMENTS_COMPLEX: DeploymentV2[] = [
 		account_id: "123",
 		vcpu: 4,
 		memory: "400MB",
+		memory_mib: 400,
 		version: 1,
 		image: "hello",
 		location: {
@@ -84,6 +87,7 @@ export const MOCK_DEPLOYMENTS_COMPLEX: DeploymentV2[] = [
 		account_id: "123",
 		vcpu: 4,
 		memory: "400MB",
+		memory_mib: 400,
 		version: 2,
 		image: "hello",
 		location: {
@@ -111,6 +115,7 @@ export const MOCK_DEPLOYMENTS_COMPLEX: DeploymentV2[] = [
 		account_id: "123",
 		vcpu: 4,
 		memory: "400MB",
+		memory_mib: 400,
 		version: 1,
 		image: "hello",
 		location: {
@@ -130,6 +135,7 @@ export const MOCK_DEPLOYMENTS_COMPLEX: DeploymentV2[] = [
 		account_id: "123",
 		vcpu: 4,
 		memory: "400MB",
+		memory_mib: 400,
 		version: 2,
 		image: "hello",
 		location: {

--- a/packages/wrangler/src/__tests__/parse.test.ts
+++ b/packages/wrangler/src/__tests__/parse.test.ts
@@ -1,6 +1,7 @@
 import {
 	formatMessage,
 	indexLocation,
+	parseByteSize,
 	parseJSON,
 	parseJSONC,
 	parseTOML,
@@ -441,5 +442,39 @@ describe("searchLocation", () => {
 			length: undefined,
 			lineText: undefined,
 		});
+	});
+});
+
+describe("parseByteSize", () => {
+	it("should calculate valid byte sizes", () => {
+		const cases: [string, number][] = [
+			["3", 3],
+			["3B", 3],
+			["1.3Kb", 1300],
+			["1.3kib", 1331],
+			["42MB", 42_000_000],
+			["42mib", 44_040_192],
+			["0.8MB", 800_000],
+			["0.8MiB", 838_860],
+			["2 GB", 2_000_000_000],
+
+			// If the b/ib suffix is omitted, assume non-binary units
+			["2G", 2_000_000_000],
+			["2 giB", 2_147_483_648],
+			["2T", 2_000_000_000_000],
+			["2P", 2_000_000_000_000_000],
+		];
+
+		for (const [input, result] of cases) {
+			expect(parseByteSize(input)).toEqual(result);
+		}
+	});
+
+	it("should return NaN for invalid input", () => {
+		expect(parseByteSize("")).toBeNaN();
+		expect(parseByteSize("foo")).toBeNaN();
+		expect(parseByteSize("B")).toBeNaN();
+		expect(parseByteSize("iB")).toBeNaN();
+		expect(parseByteSize(".B")).toBeNaN();
 	});
 });

--- a/packages/wrangler/src/cloudchamber/client/models/AccountDefaults.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/AccountDefaults.ts
@@ -9,5 +9,10 @@ import type { MemorySizeWithUnit } from "./MemorySizeWithUnit";
  */
 export type AccountDefaults = {
 	vcpus: number;
+	memory_mib?: number;
+	/**
+	 * DEPRECATED
+	 * @deprecated
+	 */
 	memory: MemorySizeWithUnit;
 };

--- a/packages/wrangler/src/cloudchamber/client/models/AccountLimit.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/AccountLimit.ts
@@ -14,10 +14,23 @@ import type { NodeGroup } from "./NodeGroup";
 export type AccountLimit = {
 	account_id: AccountID;
 	vcpu_per_deployment: number;
+	/**
+	 * @deprecated
+	 */
 	memory_per_deployment: MemorySizeWithUnit;
+	memory_mib_per_deployment?: number;
+	/**
+	 * @deprecated
+	 */
 	disk_per_deployment: DiskSizeWithUnit;
+	disk_mb_per_deployment?: number;
 	total_vcpu: number;
+	/**
+	 * DEPRECATED
+	 * @deprecated
+	 */
 	total_memory: MemorySizeWithUnit;
+	total_memory_mib?: number;
 	node_group: NodeGroup;
 	/**
 	 * Network modes that will be included in this customer's vm

--- a/packages/wrangler/src/cloudchamber/client/models/AccountLocationLimits.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/AccountLocationLimits.ts
@@ -9,7 +9,15 @@ import type { MemorySizeWithUnit } from "./MemorySizeWithUnit";
  */
 export type AccountLocationLimits = {
 	vcpu_per_deployment: number;
+	/**
+	 * @deprecated
+	 */
 	memory_per_deployment: MemorySizeWithUnit;
+	memory_mib_per_deployment?: number;
 	total_vcpu: number;
+	/**
+	 * @deprecated
+	 */
 	total_memory: MemorySizeWithUnit;
+	total_memory_mib?: number;
 };

--- a/packages/wrangler/src/cloudchamber/client/models/ApplicationJob.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/ApplicationJob.ts
@@ -38,9 +38,13 @@ export type ApplicationJob = {
 	 */
 	memory_mb: number;
 	/**
-	 * Specify the memory to be used for the deployment. The default will be the one configured for the account.
+	 * @deprecated
 	 */
 	memory: MemorySizeWithUnit;
+	/**
+	 * Specify the memory to be used for the deployment, in MiB. The default will be the one configured for the account.
+	 */
+	memory_mib?: number;
 	/**
 	 * The disk configuration for this job expressed in string
 	 */

--- a/packages/wrangler/src/cloudchamber/client/models/CreateApplicationJobRequest.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/CreateApplicationJobRequest.ts
@@ -24,8 +24,13 @@ export type CreateApplicationJobRequest = {
 	vcpus?: number;
 	/**
 	 * Allocate memory for this job. It defaults to the application configuration's vCPU setting, and if that is not specified, it uses the account defaults.
+	 * @deprecated
 	 */
 	memory?: MemorySizeWithUnit;
+	/**
+	 * Amount of memory to allocate for this job, in MiB. It defaults to the application configuration's vCPU setting, and if that is not specified, it uses the account defaults.
+	 */
+	memory_mib?: number;
 	/**
 	 * Set job specific environment vars. If an env var already exists in the application configuration it would be overriden.
 	 */

--- a/packages/wrangler/src/cloudchamber/client/models/DeploymentV2.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/DeploymentV2.ts
@@ -61,9 +61,13 @@ export type DeploymentV2 = {
 	 */
 	vcpu: number;
 	/**
-	 * The memory of this deployment
+	 * @deprecated
 	 */
 	memory: MemorySizeWithUnit;
+	/**
+	 * The memory of this deployment, in MiB
+	 */
+	memory_mib: number;
 	/**
 	 * The node group of this deployment
 	 */
@@ -74,9 +78,13 @@ export type DeploymentV2 = {
 	disk?: Disk;
 	network?: Network;
 	/**
-	 * The GPU memory of this deployment. If deployment is not node_group 'gpu', this will be null
+	 * @deprecated
 	 */
 	gpu_memory?: MemorySizeWithUnit;
+	/**
+	 * The GPU memory of this deployment, in MiB. If deployment is not node_group 'gpu', this will be null
+	 */
+	gpu_memory_mib?: number;
 	command?: Command;
 	entrypoint?: Entrypoint;
 	dns?: DNSConfiguration;

--- a/packages/wrangler/src/cloudchamber/client/models/Disk.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/Disk.ts
@@ -8,5 +8,13 @@ import type { DiskSizeWithUnit } from "./DiskSizeWithUnit";
  * The disk configuration for this deployment. By default, all containers have a disk size of 2GB.
  */
 export type Disk = {
+	/**
+	 * Deprecated in favor of size_mb.
+	 * @deprecated
+	 */
 	size: DiskSizeWithUnit;
+	/**
+	 * Size of the disk, in MB.
+	 */
+	size_mb?: number;
 };

--- a/packages/wrangler/src/cloudchamber/client/models/ModifyDeploymentV2RequestBody.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/ModifyDeploymentV2RequestBody.ts
@@ -38,9 +38,13 @@ export type ModifyDeploymentV2RequestBody = {
 	 */
 	vcpu?: number;
 	/**
-	 * The new memory that the deployment will have from now on
+	 * @deprecated
 	 */
 	memory?: MemorySizeWithUnit;
+	/**
+	 * The new memory that the deployment will have from now on
+	 */
+	memory_mib?: number;
 	/**
 	 * The disk configuration for this deployment
 	 */
@@ -53,6 +57,14 @@ export type ModifyDeploymentV2RequestBody = {
 	 * Deployment labels
 	 */
 	labels?: Array<Label>;
+	/**
+	 * @deprecated
+	 */
+	gpu_memory?: MemorySizeWithUnit;
+	/**
+	 * Specify the GPU memory to be used for the deployment. (Mandatory for gVisor deployments)
+	 */
+	gpu_memory_mib?: number;
 	command?: Command;
 	entrypoint?: Entrypoint;
 	dns?: DNSConfiguration;

--- a/packages/wrangler/src/cloudchamber/client/models/ModifyMeRequestBody.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/ModifyMeRequestBody.ts
@@ -9,7 +9,11 @@ import type { MemorySizeWithUnit } from "./MemorySizeWithUnit";
  */
 export type ModifyMeRequestBody = {
 	defaults?: {
+		/**
+		 * @deprecated
+		 */
 		memory?: MemorySizeWithUnit;
+		memory_mib?: number;
 		vcpus?: number;
 	};
 };

--- a/packages/wrangler/src/cloudchamber/client/models/UserDeploymentConfiguration.ts
+++ b/packages/wrangler/src/cloudchamber/client/models/UserDeploymentConfiguration.ts
@@ -34,9 +34,13 @@ export type UserDeploymentConfiguration = {
 	 */
 	vcpu?: number;
 	/**
-	 * Specify the memory to be used for the deployment. The default will be the one configured for the account.
+	 * @deprecated
 	 */
 	memory?: MemorySizeWithUnit;
+	/**
+	 * Specify the memory to be used for the deployment, in MiB. The default will be the one configured for the account.
+	 */
+	memory_mib?: number;
 	/**
 	 * The disk configuration for this deployment
 	 */
@@ -50,6 +54,14 @@ export type UserDeploymentConfiguration = {
 	 */
 	labels?: Array<Label>;
 	network?: NetworkParameters;
+	/**
+	 * @deprecated
+	 */
+	gpu_memory?: MemorySizeWithUnit;
+	/**
+	 * Specify the GPU memory to be used for the deployment, in MiB. (Mandatory for gVisor deployments)
+	 */
+	gpu_memory_mib?: number;
 	command?: Command;
 	entrypoint?: Entrypoint;
 	dns?: DNSConfiguration;

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -301,7 +301,7 @@ export function renderDeploymentConfiguration(
 		image,
 		location,
 		vcpu,
-		memory,
+		memoryMib,
 		environmentVariables,
 		labels,
 		env,
@@ -310,7 +310,7 @@ export function renderDeploymentConfiguration(
 		image: string;
 		location: string;
 		vcpu: number;
-		memory: string;
+		memoryMib: number;
 		environmentVariables: EnvironmentVariable[] | undefined;
 		labels: Label[] | undefined;
 		env?: string;
@@ -347,7 +347,7 @@ export function renderDeploymentConfiguration(
 		["image", image],
 		["location", idToLocationName(location)],
 		["vCPU", `${vcpu}`],
-		["memory", memory],
+		["memory", `${memoryMib} MiB`],
 		["environment variables", environmentVariablesText],
 		["labels", labelsText],
 		...(network === undefined
@@ -390,15 +390,12 @@ export function renderDeploymentMutationError(
 
 	const details: Record<string, string> = err.body.details ?? {};
 	function renderAccountLimits() {
-		return `${space(2)}${brandColor("Maximum VCPU per deployment")} ${
-			account.limits.vcpu_per_deployment
-		}\n${space(2)}${brandColor("Maximum total VCPU in your account")} ${
-			account.limits.total_vcpu
-		}\n${space(2)}${brandColor("Maximum memory per deployment")} ${
-			account.limits.memory_per_deployment
-		}\n${space(2)}${brandColor("Maximum total memory in your account")} ${
-			account.limits.total_memory
-		}`;
+		return [
+			`${space(2)}${brandColor("Maximum VCPU per deployment")} ${account.limits.vcpu_per_deployment}`,
+			`${space(2)}${brandColor("Maximum total VCPU in your account")} ${account.limits.total_vcpu}`,
+			`${space(2)}${brandColor("Maximum memory per deployment")} ${account.limits.memory_mib_per_deployment} MiB`,
+			`${space(2)}${brandColor("Maximum total memory in your account")} ${account.limits.total_memory_mib} MiB`,
+		].join("\n");
 	}
 
 	function renderInvalidInputDetails(inputDetails: Record<string, string>) {

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -1,6 +1,7 @@
 import { cancel, startSection } from "@cloudflare/cli";
 import { processArgument } from "@cloudflare/cli/args";
 import { inputPrompt, spinner } from "@cloudflare/cli/interactive";
+import { parseByteSize } from "../parse";
 import { pollSSHKeysUntilCondition, waitForPlacement } from "./cli";
 import { pickDeployment } from "./cli/deployments";
 import { getLocation } from "./cli/locations";
@@ -103,6 +104,12 @@ export async function modifyCommand(
 		);
 		const labels = collectLabels(modifyArgs.label);
 
+		const memory = modifyArgs.memory ?? config.cloudchamber.memory;
+		const memoryMib =
+			memory !== undefined
+				? Math.round(parseByteSize(memory, 1024) / (1024 * 1024))
+				: undefined;
+
 		const deployment = await DeploymentsService.modifyDeploymentV2(
 			modifyArgs.deploymentId,
 			{
@@ -112,7 +119,7 @@ export async function modifyCommand(
 				labels: labels,
 				ssh_public_key_ids: modifyArgs.sshPublicKeyId,
 				vcpu: modifyArgs.vcpu ?? config.cloudchamber.vcpu,
-				memory: modifyArgs.memory ?? config.cloudchamber.memory,
+				memory_mib: memoryMib,
 			}
 		);
 		console.log(JSON.stringify(deployment, null, 4));
@@ -228,11 +235,17 @@ async function handleModifyCommand(
 		true
 	);
 
+	const memory = args.memory ?? config.cloudchamber.memory;
+	const memoryMib =
+		memory !== undefined
+			? Math.round(parseByteSize(memory, 1024) / (1024 * 1024))
+			: undefined;
+
 	renderDeploymentConfiguration("modify", {
 		image,
 		location: location ?? deployment.location.name,
 		vcpu: args.vcpu ?? config.cloudchamber.vcpu ?? deployment.vcpu,
-		memory: args.memory ?? config.cloudchamber.memory ?? deployment.memory,
+		memoryMib: memoryMib ?? deployment.memory_mib,
 		env: args.env,
 		environmentVariables:
 			selectedEnvironmentVariables !== undefined
@@ -264,7 +277,7 @@ async function handleModifyCommand(
 			environment_variables: selectedEnvironmentVariables,
 			labels: selectedLabels,
 			vcpu: args.vcpu ?? config.cloudchamber.vcpu,
-			memory: args.memory ?? config.cloudchamber.memory,
+			memory_mib: memoryMib,
 		})
 	);
 	stop();

--- a/packages/wrangler/src/parse.ts
+++ b/packages/wrangler/src/parse.ts
@@ -359,3 +359,39 @@ export function parseNonHyphenedUuid(uuid: string | null): string | null {
 
 	return hyphenated.slice(0, 36);
 }
+
+export function parseByteSize(
+	s: string,
+	base: number | undefined = undefined
+): number {
+	const match = s.match(
+		/^(\d*\.*\d*)\s*([kKmMgGtTpP]{0,1})([i]{0,1}[bB]{0,1})$/
+	);
+	if (!match) {
+		return NaN;
+	}
+
+	const size = match[1];
+	if (size.length === 0 || isNaN(Number(size))) {
+		return NaN;
+	}
+
+	const unit = match[2].toLowerCase();
+	const sizeUnits = {
+		k: 1,
+		m: 2,
+		g: 3,
+		t: 4,
+		p: 5,
+	} as const;
+	if (unit.length !== 0 && !(unit in sizeUnits)) {
+		return NaN;
+	}
+
+	const binary = match[3].toLowerCase() == "ib";
+	const pow = sizeUnits[unit as keyof typeof sizeUnits] || 0;
+
+	return Math.floor(
+		Number(size) * Math.pow(base ?? (binary ? 1024 : 1000), pow)
+	);
+}


### PR DESCRIPTION
Fixes CC-5141.

The Cloudchamber API was updated to prefer typed values for things like memory, disk, etc (while still supporting the older string values). Update Wrangler to use these fields when interacting with the API, leaving the string <-> value conversion to be done in the UI (rather than in the API).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: The user interface to Wrangler (CLI flags and wrangler.toml) is unchanged, this only impacts how Wrangler interacts with the Cloudchamber API.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/9156
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
