### PR TITLE
fix CallSite.toString() not to throw

### DIFF
--- a/.changeset/every-results-behave.md
+++ b/.changeset/every-results-behave.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix CallSite.toString() not to throw

--- a/packages/wrangler/src/sourcemap.ts
+++ b/packages/wrangler/src/sourcemap.ts
@@ -265,10 +265,6 @@ class CallSite implements NodeJS.CallSite {
 	getPosition(): number {
 		throw new Error("Method not implemented.");
 	}
-	toString(): string {
-		throw new Error("Method not implemented.");
-	}
-
 	getThis(): unknown {
 		return null;
 	}


### PR DESCRIPTION
There was a regression in Wrangler 4.14.2, due to the update to Node.js 20 (#9112).
When there was an error with a call stack that had to be rendered to a string, it would call `CallSite.toString()` but this was overridden to throw an error. This override was unnecessary, so this PR just removes that.

The reproduction involved trying to deploy a broken Python worker. I couldn't work out how to reproduce in a simple local test. Broken JS Workers didn't seem to trigger the `toString()` call. Moreover the source-map-support library actually overrides the `toString()` itself, so it is not clear (even by stepping through with the debugger) what is causing this bad `toString()` to be called.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: couldn't work out how to create a failing test
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: e2e do not cover this
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> original bump to v20 was not backported.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
