### PR TITLE
fix(r2): validate bucket names

### DIFF
--- a/.changeset/lemon-pants-jam.md
+++ b/.changeset/lemon-pants-jam.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+validate r2 bucket names

--- a/fixtures/pages-functions-app/functions/r2/create.ts
+++ b/fixtures/pages-functions-app/functions/r2/create.ts
@@ -1,8 +1,8 @@
 type Env = {
-	BUCKET: R2Bucket;
+	bucket: R2Bucket;
 };
 
 export const onRequestPut: PagesFunction<Env> = async ({ env }) => {
-	const object = await env.BUCKET.put("test", "Hello world!");
+	const object = await env.bucket.put("test", "Hello world!");
 	return new Response(JSON.stringify(object));
 };

--- a/fixtures/pages-functions-app/functions/r2/get.ts
+++ b/fixtures/pages-functions-app/functions/r2/get.ts
@@ -1,8 +1,8 @@
 type Env = {
-	BUCKET: R2Bucket;
+	bucket: R2Bucket;
 };
 
 export const onRequestGet: PagesFunction<Env> = async ({ env }) => {
-	const object = await env.BUCKET.get("test");
+	const object = await env.bucket.get("test");
 	return new Response(JSON.stringify(object));
 };

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -5,7 +5,7 @@
 	"main": "dist/worker.js",
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "wrangler pages dev public --binding=NAME=VALUE --binding=OTHER_NAME=THING=WITH=EQUALS --r2=BUCKET --port 8789",
+		"dev": "wrangler pages dev public --binding=NAME=VALUE --binding=OTHER_NAME=THING=WITH=EQUALS --r2=bucket --port 8789",
 		"test:ci": "vitest run",
 		"test:watch": "vitest",
 		"type:tests": "tsc -p ./tests/tsconfig.json"

--- a/fixtures/pages-functions-app/tests/index.test.ts
+++ b/fixtures/pages-functions-app/tests/index.test.ts
@@ -16,7 +16,7 @@ describe("Pages Functions", () => {
 			[
 				"--binding=NAME=VALUE",
 				"--binding=OTHER_NAME=THING=WITH=EQUALS",
-				"--r2=BUCKET",
+				"--r2=bucket",
 				"--port=0",
 				"--inspector-port=0",
 			]
@@ -58,7 +58,7 @@ describe("Pages Functions", () => {
 		const env = await response.json();
 		expect(env).toEqual({
 			ASSETS: {},
-			BUCKET: {},
+			bucket: {},
 			NAME: "VALUE",
 			OTHER_NAME: "THING=WITH=EQUALS",
 			VAR_1: "var #1 value",

--- a/fixtures/pages-workerjs-directory/package.json
+++ b/fixtures/pages-workerjs-directory/package.json
@@ -4,7 +4,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"check:type": "tsc",
-		"dev": "wrangler pages dev public --d1=D1 --d1=PUT=elsewhere --kv KV --kv KV_REF=other_kv --r2 R2 --r2=R2_REF=other_r2 --port 8794",
+		"dev": "wrangler pages dev public --d1=D1 --d1=PUT=elsewhere --kv KV --kv KV_REF=other_kv --r2 r2bucket --r2=R2_REF=other-r2 --port 8794",
 		"test:ci": "vitest run",
 		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},

--- a/fixtures/pages-workerjs-directory/public/_worker.js/index.js
+++ b/fixtures/pages-workerjs-directory/public/_worker.js/index.js
@@ -42,7 +42,7 @@ export default {
 		}
 
 		if (pathname === "/r2") {
-			await env.R2.put("key", "value");
+			await env.r2bucket.put("key", "value");
 
 			await env.R2_REF.put("key", "value");
 

--- a/fixtures/pages-workerjs-directory/tests/index.test.ts
+++ b/fixtures/pages-workerjs-directory/tests/index.test.ts
@@ -23,8 +23,8 @@ describe("Pages _worker.js/ directory", () => {
 				"--d1=PUT=elsewhere",
 				"--kv=KV",
 				"--kv=KV_REF=other_kv",
-				"--r2=R2",
-				"--r2=R2_REF=other_r2",
+				"--r2=r2bucket",
+				"--r2=R2_REF=other-r2",
 			]
 		);
 		try {

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -17,9 +17,9 @@ Your Worker has access to the following bindings:
   - D1_BINDING_2_TOML: D1_NAME_2_TOML (D1_ID_2_TOML) [simulated locally]
   - D1_BINDING_3_ARGS: local-D1_BINDING_3_ARGS=D1_NAME_3_ARGS (D1_NAME_3_ARGS) [simulated locally]
 - R2 Buckets:
-  - R2_BINDING_1_TOML: NEW_R2_BUCKET_1 [simulated locally]
-  - R2_BINDING_2_TOML: R2_BUCKET_2_TOML [simulated locally]
-  - R2_BINDING_3_TOML: R2_BUCKET_3_ARGS [simulated locally]
+  - R2_BINDING_1_TOML: new-r2-bucket-1 [simulated locally]
+  - R2_BINDING_2_TOML: r2-bucket-2-toml [simulated locally]
+  - R2_BINDING_3_TOML: r2-bucket-3-args [simulated locally]
 - Services:
   - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1 [not connected]
   - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML [not connected]

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -115,7 +115,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 					}`,
 			});
 			const worker = helper.runLongLived(
-				`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 TEST_R2`
+				`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 test-r2`
 			);
 			await worker.waitForReady();
 			expect(normalizeOutput(worker.currentOutput)).toContain(
@@ -127,7 +127,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 					- D1 Databases:
 					  - TEST_D1: local-TEST_D1 (TEST_D1) [simulated locally]
 					- R2 Buckets:
-					  - TEST_R2: TEST_R2 [simulated locally]
+					  - test-r2: test-r2 [simulated locally]
 					- Services:
 					  - TEST_SERVICE: test-worker [not connected]
 		`
@@ -342,7 +342,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 				` --kv KV_BINDING_1_TOML=NEW_KV_ID_1 KV_BINDING_3_ARGS=KV_ID_3_ARGS`,
 				` --do DO_BINDING_1_TOML=NEW_DO_1@NEW_DO_SCRIPT_1 DO_BINDING_3_ARGS=DO_3_ARGS@DO_SCRIPT_3_ARGS`,
 				` --d1 D1_BINDING_1_TOML=NEW_D1_NAME_1 D1_BINDING_3_ARGS=D1_NAME_3_ARGS`,
-				` --r2 R2_BINDING_1_TOML=NEW_R2_BUCKET_1 R2_BINDING_3_TOML=R2_BUCKET_3_ARGS`,
+				` --r2 R2_BINDING_1_TOML=new-r2-bucket-1 R2_BINDING_3_TOML=r2-bucket-3-args`,
 				` --service SERVICE_BINDING_1_TOML=NEW_SERVICE_NAME_1 SERVICE_BINDING_3_TOML=SERVICE_NAME_3_ARGS`,
 				` --ai AI_BINDING_2_TOML`,
 			];
@@ -402,12 +402,12 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 				# to override
 				[[r2_buckets]]
 				binding = 'R2_BINDING_1_TOML'
-				bucket_name = 'R2_BUCKET_1_TOML'
+				bucket_name = 'r2-bucket-1-toml'
 
 				# to merge as is
 				[[r2_buckets]]
 				binding = 'R2_BINDING_2_TOML'
-				bucket_name = 'R2_BUCKET_2_TOML'
+				bucket_name = 'r2-bucket-2-toml'
 
 				# to override
 				[[services]]

--- a/packages/wrangler/src/__tests__/config/configuration.pages.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.pages.test.ts
@@ -87,7 +87,7 @@ describe("normalizeAndValidateConfig()", () => {
 						r2_buckets: [
 							{
 								binding: "TEST_R2_BINDING",
-								bucket_name: "TEST_R2_BUCKET_NAME",
+								bucket_name: "test-r2-bucket-name",
 							},
 						],
 						d1_databases: [
@@ -188,7 +188,7 @@ describe("normalizeAndValidateConfig()", () => {
 						r2_buckets: [
 							{
 								binding: "TEST_R2_BINDING",
-								bucket_name: "TEST_R2_BUCKET_NAME_preview",
+								bucket_name: "test-r2-bucket-name-preview",
 							},
 						],
 						d1_databases: [
@@ -289,7 +289,7 @@ describe("normalizeAndValidateConfig()", () => {
 						r2_buckets: [
 							{
 								binding: "TEST_R2_BINDING",
-								bucket_name: "TEST_R2_BUCKET_NAME_production",
+								bucket_name: "test-r2-bucket-name-production",
 							},
 						],
 						d1_databases: [
@@ -409,7 +409,7 @@ describe("normalizeAndValidateConfig()", () => {
 						r2_buckets: [
 							{
 								binding: "TEST_R2_BINDING",
-								bucket_name: "TEST_R2_BUCKET_NAME_unsupported-env-name",
+								bucket_name: "test-r2-bucket-name-unsupported-env-name",
 							},
 						],
 						d1_databases: [
@@ -518,7 +518,7 @@ describe("normalizeAndValidateConfig()", () => {
 						r2_buckets: [
 							{
 								binding: "TEST_R2_BINDING",
-								bucket_name: "TEST_R2_BUCKET_NAME",
+								bucket_name: "test-r2-bucket-name",
 							},
 						],
 						d1_databases: [
@@ -627,7 +627,7 @@ describe("normalizeAndValidateConfig()", () => {
 						r2_buckets: [
 							{
 								binding: "TEST_R2_BINDING",
-								bucket_name: "TEST_R2_BUCKET_NAME",
+								bucket_name: "test-r2-bucket-name",
 							},
 						],
 						d1_databases: [
@@ -734,7 +734,7 @@ describe("normalizeAndValidateConfig()", () => {
 						r2_buckets: [
 							{
 								binding: "TEST_R2_BINDING",
-								bucket_name: "TEST_R2_BUCKET_NAME",
+								bucket_name: "test-r2-bucket-name",
 							},
 						],
 						d1_databases: [

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -2884,10 +2884,8 @@ describe("normalizeAndValidateConfig()", () => {
 					  - \\"r2_buckets[2]\\" bindings should have a string \\"binding\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
 					  - \\"r2_buckets[2]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
 					  - \\"r2_buckets[3]\\" bindings should, optionally, have a string \\"preview_bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_2\\",\\"bucket_name\\":\\"r2-bucket-2\\",\\"preview_bucket_name\\":2555}.
-					  - \\"r2_buckets[4].bucket_name\\" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-),\\" +
-					    			\\" and be between 3 and 63 characters long. but got \\"INVALID-NAME\\".
-					  - \\"r2_buckets[5].preview_bucket_name\\" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-),\\" +
-					    			\\" and be between 3 and 63 characters long. but got \\"INVALID-NAME\\".
+					  - r2_buckets[4].bucket_name=\\"INVALID-NAME\\" is invalid. Bucket names must begin and end with an alphanumeric character, only contain lowercase letters, numbers, and hyphens, and be between 3 and 63 characters long.
+					  - r2_buckets[5].preview_bucket_name= \\"INVALID-NAME\\" is invalid. Bucket names must begin and end with an alphanumeric character, only contain lowercase letters, numbers, and hyphens, and be between 3 and 63 characters long.
 					  - \\"r2_buckets[6]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_5\\",\\"bucket_name\\":\\"\\"}."
 				`);
 			});
@@ -5255,8 +5253,7 @@ describe("normalizeAndValidateConfig()", () => {
 					    - \\"env.ENV1.r2_buckets[1]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_1\\"}.
 					    - \\"env.ENV1.r2_buckets[2]\\" bindings should have a string \\"binding\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
 					    - \\"env.ENV1.r2_buckets[2]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
-					    - \\"env.ENV1.r2_buckets[3].bucket_name\\" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-),\\" +
-					      			\\" and be between 3 and 63 characters long. but got \\"R2_BUCKET_2\\".
+					    - env.ENV1.r2_buckets[3].bucket_name=\\"R2_BUCKET_2\\" is invalid. Bucket names must begin and end with an alphanumeric character, only contain lowercase letters, numbers, and hyphens, and be between 3 and 63 characters long.
 					    - \\"env.ENV1.r2_buckets[3]\\" bindings should, optionally, have a string \\"preview_bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_2\\",\\"bucket_name\\":\\"R2_BUCKET_2\\",\\"preview_bucket_name\\":2555}."
 				`);
 			});

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -973,11 +973,11 @@ describe("normalizeAndValidateConfig()", () => {
 					},
 				],
 				r2_buckets: [
-					{ binding: "R2_BINDING_1", bucket_name: "R2_BUCKET_1" },
+					{ binding: "R2_BINDING_1", bucket_name: "r2-bucket-1" },
 					{
 						binding: "R2_BINDING_2",
-						bucket_name: "R2_BUCKET_2",
-						preview_bucket_name: "R2_PREVIEW_2",
+						bucket_name: "r2-bucket-2",
+						preview_bucket_name: "r2-preview-2",
 					},
 				],
 				services: [
@@ -2858,10 +2858,16 @@ describe("normalizeAndValidateConfig()", () => {
 							{ binding: 2333, bucket_name: 2444 },
 							{
 								binding: "R2_BINDING_2",
-								bucket_name: "R2_BUCKET_2",
+								bucket_name: "r2-bucket-2",
 								preview_bucket_name: 2555,
 							},
-							{ binding: "R2_BINDING_1", bucket_name: "" },
+							{ binding: "R2_BINDING_3", bucket_name: "INVALID-NAME" },
+							{
+								binding: "R2_BINDING_4",
+								bucket_name: "bucket",
+								preview_bucket_name: "INVALID-NAME",
+							},
+							{ binding: "R2_BINDING_5", bucket_name: "" },
 						],
 					} as unknown as RawConfig,
 					undefined,
@@ -2871,15 +2877,19 @@ describe("normalizeAndValidateConfig()", () => {
 
 				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
-			            - \\"r2_buckets[0]\\" bindings should have a string \\"binding\\" field but got {}.
-			            - \\"r2_buckets[0]\\" bindings should have a string \\"bucket_name\\" field but got {}.
-			            - \\"r2_buckets[1]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_1\\"}.
-			            - \\"r2_buckets[2]\\" bindings should have a string \\"binding\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
-			            - \\"r2_buckets[2]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
-			            - \\"r2_buckets[3]\\" bindings should, optionally, have a string \\"preview_bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_2\\",\\"bucket_name\\":\\"R2_BUCKET_2\\",\\"preview_bucket_name\\":2555}.
-			            - \\"r2_buckets[4]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_1\\",\\"bucket_name\\":\\"\\"}."
-		        `);
+					"Processing wrangler configuration:
+					  - \\"r2_buckets[0]\\" bindings should have a string \\"binding\\" field but got {}.
+					  - \\"r2_buckets[0]\\" bindings should have a string \\"bucket_name\\" field but got {}.
+					  - \\"r2_buckets[1]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_1\\"}.
+					  - \\"r2_buckets[2]\\" bindings should have a string \\"binding\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
+					  - \\"r2_buckets[2]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
+					  - \\"r2_buckets[3]\\" bindings should, optionally, have a string \\"preview_bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_2\\",\\"bucket_name\\":\\"r2-bucket-2\\",\\"preview_bucket_name\\":2555}.
+					  - \\"r2_buckets[4].bucket_name\\" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-),\\" +
+					    			\\" and be between 3 and 63 characters long. but got \\"INVALID-NAME\\".
+					  - \\"r2_buckets[5].preview_bucket_name\\" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-),\\" +
+					    			\\" and be between 3 and 63 characters long. but got \\"INVALID-NAME\\".
+					  - \\"r2_buckets[6]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_5\\",\\"bucket_name\\":\\"\\"}."
+				`);
 			});
 
 			it("should allow the bucket_name field to be omitted when the RESOURCES_PROVISION experimental flag is enabled", () => {
@@ -5237,16 +5247,18 @@ describe("normalizeAndValidateConfig()", () => {
 
 				expect(diagnostics.hasWarnings()).toBe(false);
 				expect(diagnostics.renderErrors()).toMatchInlineSnapshot(`
-			          "Processing wrangler configuration:
+					"Processing wrangler configuration:
 
-			            - \\"env.ENV1\\" environment configuration
-			              - \\"env.ENV1.r2_buckets[0]\\" bindings should have a string \\"binding\\" field but got {}.
-			              - \\"env.ENV1.r2_buckets[0]\\" bindings should have a string \\"bucket_name\\" field but got {}.
-			              - \\"env.ENV1.r2_buckets[1]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_1\\"}.
-			              - \\"env.ENV1.r2_buckets[2]\\" bindings should have a string \\"binding\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
-			              - \\"env.ENV1.r2_buckets[2]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
-			              - \\"env.ENV1.r2_buckets[3]\\" bindings should, optionally, have a string \\"preview_bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_2\\",\\"bucket_name\\":\\"R2_BUCKET_2\\",\\"preview_bucket_name\\":2555}."
-		        `);
+					  - \\"env.ENV1\\" environment configuration
+					    - \\"env.ENV1.r2_buckets[0]\\" bindings should have a string \\"binding\\" field but got {}.
+					    - \\"env.ENV1.r2_buckets[0]\\" bindings should have a string \\"bucket_name\\" field but got {}.
+					    - \\"env.ENV1.r2_buckets[1]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_1\\"}.
+					    - \\"env.ENV1.r2_buckets[2]\\" bindings should have a string \\"binding\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
+					    - \\"env.ENV1.r2_buckets[2]\\" bindings should have a string \\"bucket_name\\" field but got {\\"binding\\":2333,\\"bucket_name\\":2444}.
+					    - \\"env.ENV1.r2_buckets[3].bucket_name\\" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-),\\" +
+					      			\\" and be between 3 and 63 characters long. but got \\"R2_BUCKET_2\\".
+					    - \\"env.ENV1.r2_buckets[3]\\" bindings should, optionally, have a string \\"preview_bucket_name\\" field but got {\\"binding\\":\\"R2_BINDING_2\\",\\"bucket_name\\":\\"R2_BUCKET_2\\",\\"preview_bucket_name\\":2555}."
+				`);
 			});
 		});
 

--- a/packages/wrangler/src/__tests__/helpers/generate-wrangler-config.ts
+++ b/packages/wrangler/src/__tests__/helpers/generate-wrangler-config.ts
@@ -63,7 +63,7 @@ export function generateRawConfigForPages(
 		r2_buckets: [
 			{
 				binding: "TEST_R2_BINDING",
-				bucket_name: "TEST_R2_BUCKET_NAME",
+				bucket_name: "test-r2-bucket-name",
 			},
 		],
 		d1_databases: [
@@ -167,7 +167,7 @@ export function generateRawEnvConfigForPages(
 		r2_buckets: [
 			{
 				binding: `TEST_R2_BINDING`,
-				bucket_name: `TEST_R2_BUCKET_NAME_${envName}`,
+				bucket_name: `test-r2-bucket-name-${envName}`,
 			},
 		],
 		d1_databases: [

--- a/packages/wrangler/src/__tests__/r2.local.test.ts
+++ b/packages/wrangler/src/__tests__/r2.local.test.ts
@@ -17,7 +17,7 @@ describe("r2", () => {
 			it("should put R2 object from local bucket", async () => {
 				await expect(() =>
 					runWrangler(
-						`r2 object get bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
+						`r2 object get bucket-object-test/wormhole-img.png --file ./wormhole-img.png `
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
 					`[Error: The specified key does not exist.]`
@@ -25,39 +25,39 @@ describe("r2", () => {
 
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				await runWrangler(
-					`r2 object put bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
+					`r2 object put bucket-object-test/wormhole-img.png --file ./wormhole-img.png `
 				);
 				expect(std.out).toMatchInlineSnapshot(`
 					"Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					Downloading \\"wormhole-img.png\\" from \\"bucket-object-test\\".
 
 					Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucket-object-test\\".
 					Upload complete."
 				`);
 
 				await runWrangler(
-					`r2 object get bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
+					`r2 object get bucket-object-test/wormhole-img.png --file ./wormhole-img.png `
 				);
 				expect(std.out).toMatchInlineSnapshot(`
 					"Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					Downloading \\"wormhole-img.png\\" from \\"bucket-object-test\\".
 
 					Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucket-object-test\\".
 					Upload complete.
 					Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					Downloading \\"wormhole-img.png\\" from \\"bucket-object-test\\".
 					Download complete."
 				`);
 			});
@@ -65,50 +65,50 @@ describe("r2", () => {
 			it("should delete R2 object from local bucket", async () => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				await runWrangler(
-					`r2 object put bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
+					`r2 object put bucket-object-test/wormhole-img.png --file ./wormhole-img.png `
 				);
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 
 				await runWrangler(
-					`r2 object get bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
+					`r2 object get bucket-object-test/wormhole-img.png --file ./wormhole-img.png `
 				);
 				expect(std.out).toMatchInlineSnapshot(`
 					"Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucket-object-test\\".
 					Upload complete.
 					Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					Downloading \\"wormhole-img.png\\" from \\"bucket-object-test\\".
 					Download complete."
 				`);
 
 				await runWrangler(
-					`r2 object delete bucketName-object-test/wormhole-img.png `
+					`r2 object delete bucket-object-test/wormhole-img.png `
 				);
 				expect(std.out).toMatchInlineSnapshot(`
 					"Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Creating object \\"wormhole-img.png\\" in bucket \\"bucketName-object-test\\".
+					Creating object \\"wormhole-img.png\\" in bucket \\"bucket-object-test\\".
 					Upload complete.
 					Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Downloading \\"wormhole-img.png\\" from \\"bucketName-object-test\\".
+					Downloading \\"wormhole-img.png\\" from \\"bucket-object-test\\".
 					Download complete.
 					Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Deleting object \\"wormhole-img.png\\" from bucket \\"bucketName-object-test\\".
+					Deleting object \\"wormhole-img.png\\" from bucket \\"bucket-object-test\\".
 					Delete complete."
 				`);
 
 				await expect(() =>
 					runWrangler(
-						`r2 object get bucketName-object-test/wormhole-img.png --file ./wormhole-img.png `
+						`r2 object get bucket-object-test/wormhole-img.png --file ./wormhole-img.png `
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
 					`[Error: The specified key does not exist.]`
@@ -118,44 +118,44 @@ describe("r2", () => {
 			it("should follow persist-to for object bucket", async () => {
 				fs.writeFileSync("wormhole-img.png", "passageway");
 				await runWrangler(
-					`r2 object put bucketName-object-test/file-one --file ./wormhole-img.png `
+					`r2 object put bucket-object-test/file-one --file ./wormhole-img.png `
 				);
 
 				await runWrangler(
-					`r2 object put bucketName-object-test/file-two --file ./wormhole-img.png  --persist-to ./different-dir`
+					`r2 object put bucket-object-test/file-two --file ./wormhole-img.png  --persist-to ./different-dir`
 				);
 
 				await expect(() =>
 					runWrangler(
-						`r2 object get bucketName-object-test/file-one --file ./wormhole-img.png  --persist-to ./different-dir`
+						`r2 object get bucket-object-test/file-one --file ./wormhole-img.png  --persist-to ./different-dir`
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
 					`[Error: The specified key does not exist.]`
 				);
 
 				await runWrangler(
-					`r2 object get bucketName-object-test/file-two --file ./wormhole-img.png  --persist-to ./different-dir`
+					`r2 object get bucket-object-test/file-two --file ./wormhole-img.png  --persist-to ./different-dir`
 				);
 				expect(std.out).toMatchInlineSnapshot(`
 					"Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Creating object \\"file-one\\" in bucket \\"bucketName-object-test\\".
+					Creating object \\"file-one\\" in bucket \\"bucket-object-test\\".
 					Upload complete.
 					Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Creating object \\"file-two\\" in bucket \\"bucketName-object-test\\".
+					Creating object \\"file-two\\" in bucket \\"bucket-object-test\\".
 					Upload complete.
 					Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Downloading \\"file-one\\" from \\"bucketName-object-test\\".
+					Downloading \\"file-one\\" from \\"bucket-object-test\\".
 
 					Resource location: local
 					Use --remote if you want to access the remote instance.
 
-					Downloading \\"file-two\\" from \\"bucketName-object-test\\".
+					Downloading \\"file-two\\" from \\"bucket-object-test\\".
 					Download complete."
 				`);
 			});

--- a/packages/wrangler/src/__tests__/r2.test.ts
+++ b/packages/wrangler/src/__tests__/r2.test.ts
@@ -588,7 +588,7 @@ describe("r2", () => {
 				await expect(
 					runWrangler("r2 bucket create abc_def")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: The bucket name "abc_def" is invalid. Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long.]`
+					`[Error: The bucket name "abc_def" is invalid. Bucket names must begin and end with an alphanumeric character, only contain lowercase letters, numbers, and hyphens, and be between 3 and 63 characters long.]`
 				);
 			});
 
@@ -604,7 +604,7 @@ describe("r2", () => {
 				await expect(
 					runWrangler("r2 bucket create abc-")
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: The bucket name "abc-" is invalid. Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long.]`
+					`[Error: The bucket name "abc-" is invalid. Bucket names must begin and end with an alphanumeric character, only contain lowercase letters, numbers, and hyphens, and be between 3 and 63 characters long.]`
 				);
 			});
 
@@ -612,7 +612,7 @@ describe("r2", () => {
 				await expect(
 					runWrangler("r2 bucket create " + "a".repeat(64))
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: The bucket name "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is invalid. Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long.]`
+					`[Error: The bucket name "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is invalid. Bucket names must begin and end with an alphanumeric character, only contain lowercase letters, numbers, and hyphens, and be between 3 and 63 characters long.]`
 				);
 			});
 
@@ -3280,7 +3280,7 @@ For more details, refer to: https://developers.cloudflare.com/r2/api/s3/tokens/"
 						`r2 object put --remote BUCKET/wormhole-img.png --file ./wormhole-img.png`
 					)
 				).rejects.toThrowErrorMatchingInlineSnapshot(
-					`[Error: The bucket name "BUCKET" is invalid. Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long.]`
+					`[Error: The bucket name "BUCKET" is invalid. Bucket names must begin and end with an alphanumeric character, only contain lowercase letters, numbers, and hyphens, and be between 3 and 63 characters long.]`
 				);
 			});
 

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -137,7 +137,7 @@ const bindingsConfigMock: Omit<
 	r2_buckets: [
 		{
 			binding: "R2_BUCKET_BINDING",
-			bucket_name: "R2BUCKET_NAME_TEST",
+			bucket_name: "r2bucket-name-test",
 		},
 	],
 	d1_databases: [

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { dedent } from "ts-dedent";
 import { UserError } from "../errors";
 import { getFlag } from "../experimental-flags";
+import { isValidR2BucketName } from "../r2/helpers";
 import { friendlyBindingNames } from "../utils/print-bindings";
 import { Diagnostics } from "./diagnostics";
 import {
@@ -2561,6 +2562,18 @@ const validateR2Binding: ValidatorFn = (diagnostics, field, value) => {
 		);
 		isValid = false;
 	}
+	if (
+		isValid &&
+		hasProperty(value, "bucket_name") &&
+		!isValidR2BucketName(value.bucket_name)
+	) {
+		diagnostics.errors.push(
+			`"${field}.bucket_name" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-)," +
+			" and be between 3 and 63 characters long. but got ${JSON.stringify(value.bucket_name)}.`
+		);
+		isValid = false;
+	}
+
 	if (!isOptionalProperty(value, "preview_bucket_name", "string")) {
 		diagnostics.errors.push(
 			`"${field}" bindings should, optionally, have a string "preview_bucket_name" field but got ${JSON.stringify(
@@ -2569,6 +2582,18 @@ const validateR2Binding: ValidatorFn = (diagnostics, field, value) => {
 		);
 		isValid = false;
 	}
+	if (
+		isValid &&
+		hasProperty(value, "preview_bucket_name") &&
+		!isValidR2BucketName(value.preview_bucket_name)
+	) {
+		diagnostics.errors.push(
+			`"${field}.preview_bucket_name" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-)," +
+			" and be between 3 and 63 characters long. but got ${JSON.stringify(value.preview_bucket_name)}.`
+		);
+		isValid = false;
+	}
+
 	if (!isOptionalProperty(value, "jurisdiction", "string")) {
 		diagnostics.errors.push(
 			`"${field}" bindings should, optionally, have a string "jurisdiction" field but got ${JSON.stringify(

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { dedent } from "ts-dedent";
 import { UserError } from "../errors";
 import { getFlag } from "../experimental-flags";
-import { isValidR2BucketName } from "../r2/helpers";
+import { bucketFormatMessage, isValidR2BucketName } from "../r2/helpers";
 import { friendlyBindingNames } from "../utils/print-bindings";
 import { Diagnostics } from "./diagnostics";
 import {
@@ -2568,8 +2568,7 @@ const validateR2Binding: ValidatorFn = (diagnostics, field, value) => {
 		!isValidR2BucketName(value.bucket_name)
 	) {
 		diagnostics.errors.push(
-			`"${field}.bucket_name" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-)," +
-			" and be between 3 and 63 characters long. but got ${JSON.stringify(value.bucket_name)}.`
+			`${field}.bucket_name=${JSON.stringify(value.bucket_name)} is invalid. ${bucketFormatMessage}`
 		);
 		isValid = false;
 	}
@@ -2588,8 +2587,7 @@ const validateR2Binding: ValidatorFn = (diagnostics, field, value) => {
 		!isValidR2BucketName(value.preview_bucket_name)
 	) {
 		diagnostics.errors.push(
-			`"${field}.preview_bucket_name" must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-)," +
-			" and be between 3 and 63 characters long. but got ${JSON.stringify(value.preview_bucket_name)}.`
+			`${field}.preview_bucket_name= ${JSON.stringify(value.preview_bucket_name)} is invalid. ${bucketFormatMessage}`
 		);
 		isValid = false;
 	}

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -17,6 +17,7 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
 import { getBasePath } from "../paths";
+import { isValidR2BucketName } from "../r2/helpers";
 import * as shellquote from "../utils/shell-quote";
 import { buildFunctions } from "./buildFunctions";
 import { ROUTES_SPEC_VERSION, SECONDS_TO_WAIT_FOR_PROXY } from "./constants";
@@ -1266,6 +1267,16 @@ function getBindingsFromArgs(args: typeof pagesDevCommand.args): Partial<
 
 				if (!binding) {
 					logger.warn("Could not parse R2 binding:", r2.toString());
+					return;
+				}
+
+				const bucketName = ref || binding.toString();
+
+				if (!isValidR2BucketName(bucketName)) {
+					logger.error(
+						`The bucket name "${bucketName}" is invalid. ` +
+							"Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long."
+					);
 					return;
 				}
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -17,7 +17,7 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
 import { getBasePath } from "../paths";
-import { isValidR2BucketName } from "../r2/helpers";
+import { bucketFormatMessage, isValidR2BucketName } from "../r2/helpers";
 import * as shellquote from "../utils/shell-quote";
 import { buildFunctions } from "./buildFunctions";
 import { ROUTES_SPEC_VERSION, SECONDS_TO_WAIT_FOR_PROXY } from "./constants";
@@ -1274,8 +1274,7 @@ function getBindingsFromArgs(args: typeof pagesDevCommand.args): Partial<
 
 				if (!isValidR2BucketName(bucketName)) {
 					logger.error(
-						`The bucket name "${bucketName}" is invalid. ` +
-							"Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long."
+						`The bucket name "${bucketName}" is invalid. ${bucketFormatMessage}`
 					);
 					return;
 				}

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -2,7 +2,7 @@ import { formatConfigSnippet } from "../../config";
 import { createCommand } from "../../core/create-command";
 import { FatalError, UserError } from "../../errors";
 import { logger } from "../../logger";
-import { isValidR2BucketName } from "../../r2/helpers";
+import { bucketFormatMessage, isValidR2BucketName } from "../../r2/helpers";
 import { requireAuth } from "../../user";
 import { getValidBindingName } from "../../utils/getValidBindingName";
 import { createPipeline } from "../client";
@@ -159,8 +159,9 @@ export const pipelinesCreateCommand = createCommand({
 	async handler(args, { config }) {
 		const bucket = args.r2Bucket;
 		if (!isValidR2BucketName(bucket)) {
-			`The bucket name "${bucket}" is invalid. ` +
-				"Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long.";
+			throw new UserError(
+				`The bucket name "${bucket}" is invalid. ${bucketFormatMessage}`
+			);
 		}
 		const name = args.pipeline;
 		const compression = args.compression;

--- a/packages/wrangler/src/pipelines/cli/create.ts
+++ b/packages/wrangler/src/pipelines/cli/create.ts
@@ -2,6 +2,7 @@ import { formatConfigSnippet } from "../../config";
 import { createCommand } from "../../core/create-command";
 import { FatalError, UserError } from "../../errors";
 import { logger } from "../../logger";
+import { isValidR2BucketName } from "../../r2/helpers";
 import { requireAuth } from "../../user";
 import { getValidBindingName } from "../../utils/getValidBindingName";
 import { createPipeline } from "../client";
@@ -157,6 +158,10 @@ export const pipelinesCreateCommand = createCommand({
 
 	async handler(args, { config }) {
 		const bucket = args.r2Bucket;
+		if (!isValidR2BucketName(bucket)) {
+			`The bucket name "${bucket}" is invalid. ` +
+				"Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long.";
+		}
 		const name = args.pipeline;
 		const compression = args.compression;
 
@@ -182,7 +187,7 @@ export const pipelinesCreateCommand = createCommand({
 				},
 				batch: batch,
 				path: {
-					bucket: bucket,
+					bucket,
 				},
 				credentials: {
 					endpoint: getAccountR2Endpoint(accountId),

--- a/packages/wrangler/src/r2/bucket.ts
+++ b/packages/wrangler/src/r2/bucket.ts
@@ -67,7 +67,7 @@ export const r2BucketCreateCommand = createCommand({
 		if (!isValidR2BucketName(name)) {
 			throw new UserError(
 				`The bucket name "${name}" is invalid. ` +
-					"Bucket names must begin and end with an alphanumeric and can only contain letters (a-z), numbers (0-9), and hyphens (-)."
+					"Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long."
 			);
 		}
 

--- a/packages/wrangler/src/r2/bucket.ts
+++ b/packages/wrangler/src/r2/bucket.ts
@@ -9,6 +9,7 @@ import { getValidBindingName } from "../utils/getValidBindingName";
 import formatLabelledValues from "../utils/render-labelled-values";
 import { LOCATION_CHOICES } from "./constants";
 import {
+	bucketFormatMessage,
 	createR2Bucket,
 	deleteR2Bucket,
 	getR2Bucket,
@@ -66,8 +67,7 @@ export const r2BucketCreateCommand = createCommand({
 
 		if (!isValidR2BucketName(name)) {
 			throw new UserError(
-				`The bucket name "${name}" is invalid. ` +
-					"Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long."
+				`The bucket name "${name}" is invalid. ${bucketFormatMessage}`
 			);
 		}
 

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -256,8 +256,7 @@ export function bucketAndKeyFromObjectPath(objectPath = ""): {
 	const { bucket, key } = match.groups;
 	if (!isValidR2BucketName(bucket)) {
 		throw new UserError(
-			`The bucket name "${bucket}" is invalid. ` +
-				"Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long."
+			`The bucket name "${bucket}" is invalid. ${bucketFormatMessage}`
 		);
 	}
 
@@ -1348,7 +1347,10 @@ export async function deleteCORSPolicy(
 }
 
 /**
- * R2 bucket names must only contain alphanumeric and - characters.
+ * R2 bucket names must:
+ * - contain lower case letters, numbers, and `-`
+ * - start and end with with a lower case letter or number
+ * - be between 6 and 63 characters long
  *
  * See https://developers.cloudflare.com/r2/buckets/create-buckets/#bucket-level-operations
  */
@@ -1357,6 +1359,8 @@ export function isValidR2BucketName(name: string | undefined): name is string {
 		typeof name === "string" && /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/.test(name)
 	);
 }
+
+export const bucketFormatMessage = `Bucket names must begin and end with an alphanumeric character, only contain lowercase letters, numbers, and hyphens, and be between 3 and 63 characters long.`;
 
 const CHUNK_SIZE = 1024;
 export async function createFileReadableStream(filePath: string) {

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -246,14 +246,22 @@ export function bucketAndKeyFromObjectPath(objectPath = ""): {
 	bucket: string;
 	key: string;
 } {
-	const match = /^([^/]+)\/(.*)/.exec(objectPath);
-	if (match === null) {
+	// Path format is `<bucket>/<key>`
+	const match = /^(?<bucket>[^/]+)\/(?<key>.*)/.exec(objectPath);
+	if (match === null || !match.groups) {
 		throw new UserError(
 			`The object path must be in the form of {bucket}/{key} you provided ${objectPath}`
 		);
 	}
+	const { bucket, key } = match.groups;
+	if (!isValidR2BucketName(bucket)) {
+		throw new UserError(
+			`The bucket name "${bucket}" is invalid. ` +
+				"Bucket names must begin and end with an alphanumeric, only contain letters (a-z), numbers (0-9), and hyphens (-), and be between 3 and 63 characters long."
+		);
+	}
 
-	return { bucket: match[1], key: match[2] };
+	return { bucket, key };
 }
 
 /**
@@ -1341,6 +1349,8 @@ export async function deleteCORSPolicy(
 
 /**
  * R2 bucket names must only contain alphanumeric and - characters.
+ *
+ * See https://developers.cloudflare.com/r2/buckets/create-buckets/#bucket-level-operations
  */
 export function isValidR2BucketName(name: string | undefined): name is string {
 	return (


### PR DESCRIPTION
Fixes #9148

Before this PR, bucket names were only validated when creating a bucket (via `wrangler r2 create bucket_name`)

This PR adds validation to:
- wrangler config
- object commands - when trying to put, get, delete an object
- pages dev CLI command
- pipeline config

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: names are documented
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/9172
  - [ ] Not necessary because: patch

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
