### PR TITLE
V3 Backport [#9161]: Fix d1 info command showing read_replication: [object Object]

### DIFF
--- a/.changeset/yellow-rabbits-tap.md
+++ b/.changeset/yellow-rabbits-tap.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix d1 info command showing read_replication: [object Object]

--- a/packages/wrangler/src/__tests__/d1/info.test.ts
+++ b/packages/wrangler/src/__tests__/d1/info.test.ts
@@ -137,6 +137,19 @@ describe("info", () => {
 	});
 
 	it("should pretty print by default, incl. the wrangler banner", async () => {
+		setIsTTY(false);
+		mockGetMemberships([
+			{ id: "IG-88", account: { id: "1701", name: "enterprise" } },
+		]);
+		writeWranglerConfig({
+			d1_databases: [
+				{
+					binding: "DB",
+					database_name: "northwind",
+					database_id: "d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06",
+				},
+			],
+		});
 		msw.use(
 			http.get("*/accounts/:accountId/d1/database/*", async () => {
 				return HttpResponse.json(
@@ -180,11 +193,7 @@ describe("info", () => {
 		// pretty print by default
 		await runWrangler("d1 info northwind");
 		expect(std.out).toMatchInlineSnapshot(`
-			"
-			 ⛅️ wrangler x.x.x
-			------------------
-
-			┌───────────────────────┬──────────────────────────────────────┐
+			"┌───────────────────────┬──────────────────────────────────────┐
 			│ DB                    │ d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06 │
 			├───────────────────────┼──────────────────────────────────────┤
 			│ name                  │ northwind                            │

--- a/packages/wrangler/src/d1/info.ts
+++ b/packages/wrangler/src/d1/info.ts
@@ -40,7 +40,7 @@ export const Handler = withConfig<HandlerOptions>(
 
 		const result = await getDatabaseInfoFromIdOrName(accountId, db.uuid);
 
-		const output: Record<string, string | number> = { ...result };
+		const output: Record<string, string | number | object> = { ...result };
 		if (output["file_size"]) {
 			output["database_size"] = output["file_size"];
 			delete output["file_size"];
@@ -116,6 +116,12 @@ export const Handler = withConfig<HandlerOptions>(
 		if (json) {
 			logger.log(JSON.stringify(output, null, 2));
 		} else {
+			// Selectively bring the nested read_replication info at the top level.
+			if (result.read_replication) {
+				output["read_replication.mode"] = result.read_replication.mode;
+				delete output["read_replication"];
+			}
+
 			// Snip off the "uuid" property from the response and use those as the header
 			const entries = Object.entries(output).filter(
 				// also remove any version that isn't "alpha"
@@ -132,6 +138,10 @@ export const Handler = withConfig<HandlerOptions>(
 					k === "rows_written_24h"
 				) {
 					value = v.toLocaleString();
+				} else if (typeof v === "object") {
+					// There shouldn't be any, but in the worst case we missed something
+					// or added a nested object in the response, serialize it instead of showing `[object Object]`.
+					value = JSON.stringify(v);
 				} else {
 					value = String(v);
 				}

--- a/packages/wrangler/src/d1/types.ts
+++ b/packages/wrangler/src/d1/types.ts
@@ -18,10 +18,13 @@ export type DatabaseCreationResult = {
 export type DatabaseInfo = {
 	uuid: string;
 	name: string;
-	version: "alpha" | "beta";
+	version: "alpha" | "beta" | "production";
 	num_tables: number;
 	file_size: number;
 	running_in_region?: string;
+	read_replication?: {
+		mode: "auto" | "disabled";
+	};
 };
 
 export type Backup = {


### PR DESCRIPTION
Fixes CFSQL-1287.

Fix d1 info command showing read_replication: [object Object] in the table output, and also add a fallback to unexpected fields to be JSON serialized at least.

v3 backport for https://github.com/cloudflare/workers-sdk/pull/9161

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functionality changed.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: this PR
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
