### PR TITLE
Support Mixed Mode Service Bindings in Miniflare

### DIFF
--- a/.changeset/old-trainers-camp.md
+++ b/.changeset/old-trainers-camp.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Support Mixed Mode Service Bindings in Miniflare

--- a/packages/miniflare/src/plugins/ai/index.ts
+++ b/packages/miniflare/src/plugins/ai/index.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert";
 import SCRIPT_MIXED_MODE_CLIENT from "worker:shared/mixed-mode-client";
 import { z } from "zod";
-import { MixedModeConnectionString, Plugin, ProxyNodeBinding } from "../shared";
+import {
+	mixedModeClientWorker,
+	MixedModeConnectionString,
+	Plugin,
+	ProxyNodeBinding,
+} from "../shared";
 
 const AISchema = z.object({
 	binding: z.string(),
@@ -57,25 +62,10 @@ export const AI_PLUGIN: Plugin<typeof AIOptionsSchema> = {
 		return [
 			{
 				name: `${AI_PLUGIN_NAME}:${options.ai.binding}`,
-				worker: {
-					compatibilityDate: "2025-01-01",
-					modules: [
-						{
-							name: "index.worker.js",
-							esModule: SCRIPT_MIXED_MODE_CLIENT(),
-						},
-					],
-					bindings: [
-						{
-							name: "mixedModeConnectionString",
-							text: options.ai.mixedModeConnectionString.href,
-						},
-						{
-							name: "binding",
-							text: options.ai.binding,
-						},
-					],
-				},
+				worker: mixedModeClientWorker(
+					options.ai.mixedModeConnectionString,
+					options.ai.binding
+				),
 			},
 		];
 	},

--- a/packages/miniflare/src/plugins/ai/index.ts
+++ b/packages/miniflare/src/plugins/ai/index.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert";
-import SCRIPT_MIXED_MODE_CLIENT from "worker:shared/mixed-mode-client";
 import { z } from "zod";
 import {
 	mixedModeClientWorker,

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert";
-import SCRIPT_MIXED_MODE_CLIENT from "worker:shared/mixed-mode-client";
 import { z } from "zod";
 import {
 	mixedModeClientWorker,

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert";
 import SCRIPT_MIXED_MODE_CLIENT from "worker:shared/mixed-mode-client";
 import { z } from "zod";
-import { MixedModeConnectionString, Plugin, ProxyNodeBinding } from "../shared";
+import {
+	mixedModeClientWorker,
+	MixedModeConnectionString,
+	Plugin,
+	ProxyNodeBinding,
+} from "../shared";
 
 const BrowserRenderingSchema = z.object({
 	binding: z.string(),
@@ -53,25 +58,10 @@ export const BROWSER_RENDERING_PLUGIN: Plugin<
 		return [
 			{
 				name: `${BROWSER_RENDERING_PLUGIN_NAME}:${options.browserRendering.binding}`,
-				worker: {
-					compatibilityDate: "2025-01-01",
-					modules: [
-						{
-							name: "index.worker.js",
-							esModule: SCRIPT_MIXED_MODE_CLIENT(),
-						},
-					],
-					bindings: [
-						{
-							name: "mixedModeConnectionString",
-							text: options.browserRendering.mixedModeConnectionString.href,
-						},
-						{
-							name: "binding",
-							text: options.browserRendering.binding,
-						},
-					],
-				},
+				worker: mixedModeClientWorker(
+					options.browserRendering.mixedModeConnectionString,
+					options.browserRendering.binding
+				),
 			},
 		];
 	},

--- a/packages/miniflare/src/plugins/shared/constants.ts
+++ b/packages/miniflare/src/plugins/shared/constants.ts
@@ -1,3 +1,4 @@
+import SCRIPT_MIXED_MODE_CLIENT from "worker:shared/mixed-mode-client";
 import SCRIPT_OBJECT_ENTRY from "worker:shared/object-entry";
 import {
 	Worker,
@@ -5,6 +6,7 @@ import {
 	Worker_Binding_DurableObjectNamespaceDesignator,
 } from "../../runtime";
 import { CoreBindings, SharedBindings } from "../../workers";
+import { MixedModeConnectionString } from ".";
 
 export const SOCKET_ENTRY = "entry";
 export const SOCKET_ENTRY_LOCAL = "entry:local";
@@ -66,6 +68,31 @@ export function objectEntryWorker(
 			{
 				name: SharedBindings.DURABLE_OBJECT_NAMESPACE_OBJECT,
 				durableObjectNamespace,
+			},
+		],
+	};
+}
+
+export function mixedModeClientWorker(
+	mixedModeConnectionString: MixedModeConnectionString,
+	binding: string
+) {
+	return {
+		compatibilityDate: "2025-01-01",
+		modules: [
+			{
+				name: "index.worker.js",
+				esModule: SCRIPT_MIXED_MODE_CLIENT(),
+			},
+		],
+		bindings: [
+			{
+				name: "mixedModeConnectionString",
+				text: mixedModeConnectionString.href,
+			},
+			{
+				name: "binding",
+				text: binding,
 			},
 		],
 	};


### PR DESCRIPTION
Continuation of [DEVX-1859](https://jira.cfdata.org/browse/DEVX-1859)

This PR adds support for service bindings to Miniflare's Mixed Mode—both with and without custom entrypoints. Currently only `.fetch()` calls are supported, rather than full JSRPC communication.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by fixture
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: WIP feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
