### PR TITLE
Bump next template to`@opennextjs/cloudflare@^1.0.2`

### DIFF
--- a/.changeset/many-birds-enjoy.md
+++ b/.changeset/many-birds-enjoy.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+Bump `@opennextjs/cloudflare` to `^1.0.2`

--- a/packages/create-cloudflare/templates/next/workers/c3.ts
+++ b/packages/create-cloudflare/templates/next/workers/c3.ts
@@ -11,7 +11,7 @@ const generate = async (ctx: C3Context) => {
 };
 
 const configure = async (ctx: C3Context) => {
-	await installPackages(["@opennextjs/cloudflare@~1.0.0-beta.0 || ^1.0.0"], {
+	await installPackages(["@opennextjs/cloudflare@^1.0.2"], {
 		startText: "Adding the Cloudflare adapter",
 		doneText: `${brandColor(`installed`)} @opennextjs/cloudflare)}`,
 	});


### PR DESCRIPTION
Bump next template to`@opennextjs/cloudflare@^1.0.2` - removing beta releases.

---

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: already covered
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not affected
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: version bump
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
