### PR TITLE
fix: start transferred MessagePort in fetch-sync worker

### DIFF
--- a/.changeset/stupid-files-jog.md
+++ b/.changeset/stupid-files-jog.md
@@ -1,0 +1,9 @@
+---
+"miniflare": patch
+---
+
+fix: ensure the fetch proxy message port is started
+
+While Node.js will start the message port automatically when a `message` event listener is added,
+this diverges from the standard Web API for message ports, which require you to explicitly start
+listening on the port.

--- a/packages/miniflare/src/plugins/core/proxy/fetch-sync.ts
+++ b/packages/miniflare/src/plugins/core/proxy/fetch-sync.ts
@@ -82,6 +82,8 @@ port.addEventListener("message", async (event) => {
   Atomics.store(notifyHandle, /* index */ 0, /* value */ 1);
   Atomics.notify(notifyHandle, /* index */ 0);
 });
+
+port.start();
 `;
 
 // Ideally we would just have a single, shared `unref()`ed `Worker`, and an


### PR DESCRIPTION
This was causing running Miniflare in Bun tests to hang indefinitely.

Fixes https://github.com/oven-sh/bun/issues/16240


- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no effect under node.js
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no effect under node.js
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no public change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/9211
  - [ ] Not necessary because:
