### PR TITLE
Support --tag and --message in wrangler deploy

### DIFF
--- a/.changeset/easy-towns-fall.md
+++ b/.changeset/easy-towns-fall.md
@@ -1,0 +1,7 @@
+---
+"wrangler": minor
+---
+
+chore: Added support for --tag and --message in `wrangler deploy` when using the verisons/deployments API (essentially when not using Service Worker format and Durable Objects).
+
+This lets you specify a tag and message for the deployment, which is useful for tracking changes and managing deployments more effectively. This was previously only available on the `wrangler versions upload` command.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -12922,6 +12922,87 @@ export default{
 			`);
 		});
 	});
+
+	describe("tag and message", () => {
+		it("should upload a tag and message", async () => {
+			writeWorkerSource();
+			writeWranglerConfig({});
+			mockUploadWorkerRequest();
+			mockSubDomainRequest();
+			mockGetWorkerSubdomain({ enabled: true });
+
+			await runWrangler(
+				"deploy ./index.js --tag test-tag --message test-message"
+			);
+			expect(std.out).toMatchInlineSnapshot(`
+				"Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				No bindings found.
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should output a warning if uploading a tag with old upload api", async () => {
+			writeWorkerSource({ type: "sw" });
+			writeWranglerConfig({});
+			mockUploadWorkerRequest({
+				expectedType: "sw",
+				useOldUploadApi: true,
+			});
+			mockSubDomainRequest();
+			mockGetWorkerSubdomain({ enabled: true });
+
+			await runWrangler("deploy ./index.js --tag test-tag");
+			expect(std.out).toMatchInlineSnapshot(`
+				"Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				No bindings found.
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWorker does not support Worker Versions, ignoring tag and message.[0m
+
+				"
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should output a warning if uploading a message with old upload api", async () => {
+			writeWorkerSource({ type: "sw" });
+			writeWranglerConfig({});
+			mockUploadWorkerRequest({
+				expectedType: "sw",
+				useOldUploadApi: true,
+			});
+			mockSubDomainRequest();
+			mockGetWorkerSubdomain({ enabled: true });
+
+			await runWrangler("deploy ./index.js --message test-message");
+			expect(std.out).toMatchInlineSnapshot(`
+				"Total Upload: xx KiB / gzip: xx KiB
+				Worker Startup Time: 100 ms
+				No bindings found.
+				Uploaded test-name (TIMINGS)
+				Deployed test-name triggers (TIMINGS)
+				  https://test-name.test-sub-domain.workers.dev
+				Current Version ID: Galaxy-Class"
+			`);
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWorker does not support Worker Versions, ignoring tag and message.[0m
+
+				"
+			`);
+			expect(std.err).toMatchInlineSnapshot(`""`);
+		});
+	});
 });
 
 /** Write mock assets to the file system so they can be uploaded. */

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -211,6 +211,17 @@ export const deployCommand = createCommand({
 			hidden: true,
 			alias: "x-auto-create",
 		},
+		tag: {
+			describe: "A tag for this Worker Gradual Rollouts Version",
+			type: "string",
+			requiresArg: true,
+		},
+		message: {
+			describe:
+				"A descriptive message for this Worker Gradual Rollouts Version",
+			type: "string",
+			requiresArg: true,
+		},
 	},
 	behaviour: {
 		useConfigRedirectIfAvailable: true,
@@ -325,6 +336,8 @@ export const deployCommand = createCommand({
 			projectRoot,
 			dispatchNamespace: args.dispatchNamespace,
 			experimentalAutoCreate: args.experimentalAutoCreate,
+			tag: args.tag,
+			message: args.message,
 		});
 
 		writeOutput({


### PR DESCRIPTION
Fixes N/A

Adds support for specifying `--tag` and/org `--message` in `wrangler deploy` not only `wrangler versions upload`

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: no coverage
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [x] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->
