### PR TITLE
allow wrangler dev to connect to remote mixed-mode bindings

### DIFF
--- a/.changeset/hip-grapes-lay.md
+++ b/.changeset/hip-grapes-lay.md
@@ -2,8 +2,8 @@
 "wrangler": patch
 ---
 
-Wire up mixed-mode remote bindings
+Wire up mixed-mode remote bindings for (single-worker) `wrangler dev`
 
-Under the `--x-mixed-mode` flag, make sure that bindings configurations with `remote: true` actually generate bindings to remote resources, currently the bindings included in this are: services, kv_namespaces, r2_buckets, d1_databases, queues and workflows.
+Under the `--x-mixed-mode` flag, make sure that bindings configurations with `remote: true` actually generate bindings to remote resources during a single-worker `wrangler dev` session, currently the bindings included in this are: services, kv_namespaces, r2_buckets, d1_databases, queues and workflows.
 
 Also include the ai binding since the bindings is already remote by default anyways.

--- a/.changeset/hip-grapes-lay.md
+++ b/.changeset/hip-grapes-lay.md
@@ -2,10 +2,8 @@
 "wrangler": patch
 ---
 
-wire up mixed-mode remote bindings
+Wire up mixed-mode remote bindings
 
-under the `--x-mixed-mode` flag, make sure that bindings configurations with `remote: true`
-actually generate bindings to remote resources, currently the bindings included in this are:
-services, kv_namespaces, r2_buckets, d1_databases, queues and workflows.
+Under the `--x-mixed-mode` flag, make sure that bindings configurations with `remote: true` actually generate bindings to remote resources, currently the bindings included in this are: services, kv_namespaces, r2_buckets, d1_databases, queues and workflows.
 
-also include the ai binding since the bindings is already remote by default anyways.
+Also include the ai binding since the bindings is already remote by default anyways.

--- a/.changeset/hip-grapes-lay.md
+++ b/.changeset/hip-grapes-lay.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+wire up mixed-mode remote bindings
+
+under the `--x-mixed-mode` flag, make sure that bindings configurations with `remote: true`
+actually generate bindings to remote resources, currently the bindings included in this are:
+services, kv_namespaces, r2_buckets, d1_databases, queues and workflows.

--- a/.changeset/hip-grapes-lay.md
+++ b/.changeset/hip-grapes-lay.md
@@ -7,3 +7,5 @@ wire up mixed-mode remote bindings
 under the `--x-mixed-mode` flag, make sure that bindings configurations with `remote: true`
 actually generate bindings to remote resources, currently the bindings included in this are:
 services, kv_namespaces, r2_buckets, d1_databases, queues and workflows.
+
+also include the ai binding since the bindings is already remote by default anyways.

--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -2,20 +2,22 @@ import dedent from "ts-dedent";
 import { describe, expect, it } from "vitest";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
+import { makeRoot, seed } from "./helpers/setup";
 
 describe("wrangler dev - mixed mode", () => {
 	it("can handle both remote and local service bindings at the same time", async () => {
 		const helper = new WranglerE2ETestHelper();
-		await helper.seed({
-			"local/wrangler.json": JSON.stringify({
+		const local = makeRoot();
+		await seed(local, {
+			"wrangler.json": JSON.stringify({
 				name: "local-worker",
 				main: "index.js",
 				compatibility_date: "2025-05-07",
 			}),
-			"local/index.js": dedent`
+			"index.js": dedent`
 							export default {
 								fetch(request) {
-									return new Response("Hello from local worker!");
+										return new Response("Hello from a local worker!");
 								}
 							}`,
 		});
@@ -42,7 +44,7 @@ describe("wrangler dev - mixed mode", () => {
 								}
 							}`,
 		});
-		const localWorker = helper.runLongLived("wrangler dev");
+		const localWorker = helper.runLongLived("wrangler dev", { cwd: local });
 		await localWorker.waitForReady();
 
 		const worker = helper.runLongLived("wrangler dev --x-mixed-mode");

--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -5,22 +5,9 @@ import { fetchText } from "./helpers/fetch-text";
 import { makeRoot, seed } from "./helpers/setup";
 
 describe("wrangler dev - mixed mode", () => {
-	it("can handle both remote and local service bindings at the same time", async () => {
+	it("handles both remote and local service bindings at the same time", async () => {
 		const helper = new WranglerE2ETestHelper();
-		const local = makeRoot();
-		await seed(local, {
-			"wrangler.json": JSON.stringify({
-				name: "local-worker",
-				main: "index.js",
-				compatibility_date: "2025-05-07",
-			}),
-			"index.js": dedent`
-							export default {
-								fetch(request) {
-										return new Response("Hello from a local worker!");
-								}
-							}`,
-		});
+		await spawnLocalWorker(helper);
 		await helper.seed({
 			"wrangler.json": JSON.stringify({
 				name: "mixed-mode-mixed-bindings-test",
@@ -40,21 +27,86 @@ describe("wrangler dev - mixed mode", () => {
 								async fetch(request, env) {
 									const localWorkerText = await (await env.LOCAL_WORKER.fetch(request)).text();
 									const remoteWorkerText = await (await env.REMOTE_WORKER.fetch(request)).text();
-									return new Response(\`LOCAL: \${localWorkerText}\\nREMOTE: \${remoteWorkerText}\n\`);
+									return new Response(\`LOCAL<WORKER>: \${localWorkerText}\\nREMOTE<WORKER>: \${remoteWorkerText}\n\`);
 								}
 							}`,
 		});
-		const localWorker = helper.runLongLived("wrangler dev", { cwd: local });
-		await localWorker.waitForReady();
 
 		const worker = helper.runLongLived("wrangler dev --x-mixed-mode");
 
 		const { url } = await worker.waitForReady();
 
 		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
-			"LOCAL: Hello from a local worker!
-			REMOTE: Hello World!
+			"LOCAL<WORKER>: Hello from a local worker!
+			REMOTE<WORKER>: Hello World!
+			"
+		`);
+	});
+
+	it("handles workers AI alongside a local service binding", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await spawnLocalWorker(helper);
+		await helper.seed({
+			"wrangler.json": JSON.stringify({
+				name: "mixed-mode-mixed-bindings-test",
+				main: "index.js",
+				compatibility_date: "2025-05-07",
+				ai: {
+					binding: "AI",
+				},
+				services: [
+					{ binding: "LOCAL_WORKER", service: "local-worker", remote: false },
+				],
+			}),
+			"index.js": dedent`
+							export default {
+								async fetch(request, env) {
+									const localWorkerText = await (await env.LOCAL_WORKER.fetch(request)).text();
+
+									const messages = [
+										{
+											role: "user",
+											// Doing snapshot testing against AI responses can be flaky, but this prompt generates the same output relatively reliably
+											content: "Respond with the exact text 'This is a response from Workers AI.'. Do not include any other text",
+										},
+									];
+
+									const { response } = await env.AI.run("@hf/thebloke/zephyr-7b-beta-awq", {
+										messages,
+									});
+
+									return new Response(\`LOCAL<WORKER>: \${localWorkerText}\\nREMOTE<AI>: \${response}\n\`);
+								}
+							}`,
+		});
+
+		const worker = helper.runLongLived("wrangler dev --x-mixed-mode");
+
+		const { url } = await worker.waitForReady();
+
+		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
+			"LOCAL<WORKER>: Hello from a local worker!
+			REMOTE<AI>: "This is a response from Workers AI."
 			"
 		`);
 	});
 });
+
+async function spawnLocalWorker(helper: WranglerE2ETestHelper): Promise<void> {
+	const local = makeRoot();
+	await seed(local, {
+		"wrangler.json": JSON.stringify({
+			name: "local-worker",
+			main: "index.js",
+			compatibility_date: "2025-05-07",
+		}),
+		"index.js": dedent`
+						export default {
+							fetch(request) {
+									return new Response("Hello from a local worker!");
+							}
+						}`,
+	});
+	const localWorker = helper.runLongLived("wrangler dev", { cwd: local });
+	await localWorker.waitForReady();
+}

--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -1,0 +1,58 @@
+import dedent from "ts-dedent";
+import { describe, expect, it } from "vitest";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
+import { fetchText } from "./helpers/fetch-text";
+
+describe("wrangler dev - mixed mode", () => {
+	it("can handle both remote and local service bindings at the same time", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"local/wrangler.json": JSON.stringify({
+				name: "local-worker",
+				main: "index.js",
+				compatibility_date: "2025-05-07",
+			}),
+			"local/index.js": dedent`
+							export default {
+								fetch(request) {
+									return new Response("Hello from local worker");
+								}
+							}`,
+		});
+		await helper.seed({
+			"wrangler.json": JSON.stringify({
+				name: "mixed-mode-mixed-bindings-test",
+				main: "index.js",
+				compatibility_date: "2025-05-07",
+				services: [
+					{ binding: "LOCAL_WORKER", service: "local-worker", remote: false },
+					{
+						binding: "REMOTE_WORKER",
+						service: "mixed-mode-test-target",
+						remote: true,
+					},
+				],
+			}),
+			"index.js": dedent`
+							export default {
+								async fetch(request, env) {
+									const localWorkerText = await (await env.LOCAL_WORKER.fetch(request)).text();
+									const remoteWorkerText = await (await env.REMOTE_WORKER.fetch(request)).text();
+									return new Response(\`LOCAL:\${localWorkerText}\\nREMOTE: \${remoteWorkerText}\n\`);
+								}
+							}`,
+		});
+		const localWorker = helper.runLongLived("wrangler dev");
+		await localWorker.waitForReady();
+
+		const worker = helper.runLongLived("wrangler dev --x-mixed-mode");
+
+		const { url } = await worker.waitForReady();
+
+		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
+			"LOCAL:Hello from a local worker
+			REMOTE: Hello World
+			"
+		`);
+	});
+});

--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -15,7 +15,7 @@ describe("wrangler dev - mixed mode", () => {
 			"local/index.js": dedent`
 							export default {
 								fetch(request) {
-									return new Response("Hello from local worker");
+									return new Response("Hello from local worker!");
 								}
 							}`,
 		});
@@ -38,7 +38,7 @@ describe("wrangler dev - mixed mode", () => {
 								async fetch(request, env) {
 									const localWorkerText = await (await env.LOCAL_WORKER.fetch(request)).text();
 									const remoteWorkerText = await (await env.REMOTE_WORKER.fetch(request)).text();
-									return new Response(\`LOCAL:\${localWorkerText}\\nREMOTE: \${remoteWorkerText}\n\`);
+									return new Response(\`LOCAL: \${localWorkerText}\\nREMOTE: \${remoteWorkerText}\n\`);
 								}
 							}`,
 		});
@@ -50,8 +50,8 @@ describe("wrangler dev - mixed mode", () => {
 		const { url } = await worker.waitForReady();
 
 		await expect(fetchText(url)).resolves.toMatchInlineSnapshot(`
-			"LOCAL:Hello from a local worker
-			REMOTE: Hello World
+			"LOCAL: Hello from a local worker!
+			REMOTE: Hello World!
 			"
 		`);
 	});

--- a/packages/wrangler/src/api/mixedMode/index.ts
+++ b/packages/wrangler/src/api/mixedMode/index.ts
@@ -8,7 +8,7 @@ import type { MixedModeConnectionString } from "miniflare";
 type BindingsOpt = StartDevWorkerInput["bindings"];
 
 export type MixedModeSession = Pick<Worker, "ready" | "dispose"> & {
-	["setConfig"]: (bindings: BindingsOpt) => Promise<void>;
+	["patchConfig"]: (bindings: BindingsOpt) => Promise<void>;
 	["mixedModeConnectionString"]: MixedModeConnectionString;
 };
 
@@ -44,14 +44,14 @@ export async function startMixedModeSession(
 	const mixedModeConnectionString =
 		(await worker.url) as MixedModeConnectionString;
 
-	const setConfig = async (newBindings: BindingsOpt) => {
-		await worker.setConfig({ bindings: newBindings });
+	const patchConfig = async (newBindings: BindingsOpt) => {
+		await worker.patchConfig({ bindings: newBindings });
 	};
 
 	return {
 		ready: worker.ready,
 		mixedModeConnectionString,
-		setConfig,
+		patchConfig,
 		dispose: worker.dispose,
 	};
 }

--- a/packages/wrangler/src/api/mixedMode/index.ts
+++ b/packages/wrangler/src/api/mixedMode/index.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import getPort from "get-port";
 import { getBasePath } from "../../paths";
 import { startWorker } from "../startDevWorker";
 import type { StartDevWorkerInput, Worker } from "../startDevWorker/types";
@@ -6,7 +7,7 @@ import type { MixedModeConnectionString } from "miniflare";
 
 type BindingsOpt = StartDevWorkerInput["bindings"];
 
-type MixedModeSession = Pick<Worker, "ready" | "dispose"> & {
+export type MixedModeSession = Pick<Worker, "ready" | "dispose"> & {
 	["setConfig"]: (bindings: BindingsOpt) => Promise<void>;
 	["mixedModeConnectionString"]: MixedModeConnectionString;
 };
@@ -27,6 +28,15 @@ export async function startMixedModeSession(
 		dev: {
 			remote: true,
 			auth: options?.auth,
+			server: {
+				port: await getPort(),
+			},
+			// TODO(DEVX-1861): we set this to a random port so that it doesn't conflict with the
+			//                  default one, we should ideally add an option to actually disable
+			//                  the inspector
+			inspector: {
+				port: await getPort(),
+			},
 		},
 		bindings,
 	});

--- a/packages/wrangler/src/api/mixedMode/index.ts
+++ b/packages/wrangler/src/api/mixedMode/index.ts
@@ -8,8 +8,8 @@ import type { MixedModeConnectionString } from "miniflare";
 type BindingsOpt = StartDevWorkerInput["bindings"];
 
 export type MixedModeSession = Pick<Worker, "ready" | "dispose"> & {
-	["patchConfig"]: (bindings: BindingsOpt) => Promise<void>;
-	["mixedModeConnectionString"]: MixedModeConnectionString;
+	updateBindings: (bindings: BindingsOpt) => Promise<void>;
+	mixedModeConnectionString: MixedModeConnectionString;
 };
 
 export async function startMixedModeSession(
@@ -44,14 +44,14 @@ export async function startMixedModeSession(
 	const mixedModeConnectionString =
 		(await worker.url) as MixedModeConnectionString;
 
-	const patchConfig = async (newBindings: BindingsOpt) => {
+	const updateBindings = async (newBindings: BindingsOpt) => {
 		await worker.patchConfig({ bindings: newBindings });
 	};
 
 	return {
 		ready: worker.ready,
 		mixedModeConnectionString,
-		patchConfig,
+		updateBindings,
 		dispose: worker.dispose,
 	};
 }

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -30,7 +30,7 @@ import { getZoneIdForPreview } from "../../zones";
 import { Controller } from "./BaseController";
 import { castErrorCause } from "./events";
 import {
-	convertCfWorkerInitBindingstoBindings,
+	convertCfWorkerInitBindingsToBindings,
 	extractBindingsOfType,
 	unwrapHook,
 } from "./utils";
@@ -180,7 +180,7 @@ async function resolveBindings(
 	return {
 		bindings: {
 			...input.bindings,
-			...convertCfWorkerInitBindingstoBindings(bindings),
+			...convertCfWorkerInitBindingsToBindings(bindings),
 		},
 		unsafe: bindings.unsafe,
 	};

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -185,6 +185,8 @@ export class LocalRuntimeController extends RuntimeController {
 				}
 			}
 
+			await this.#mixedModeSession?.ready;
+
 			const { options, internalObjects, entrypointNames } =
 				await MF.buildMiniflareOptions(
 					this.#log,

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -173,7 +173,7 @@ export class LocalRuntimeController extends RuntimeController {
 					})
 				);
 
-				// TODO(perf): here we can save the converted remote bindings
+				// TODO(DEVX-1893): here we can save the converted remote bindings
 				//             and on new iterations we can diff the old and new
 				//             converted remote bindings, if they are all the
 				//             same we can just leave the mixedModeSession untouched

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -163,9 +163,14 @@ export class LocalRuntimeController extends RuntimeController {
 					configBundle.bindings
 				);
 				const convertedRemoteBindings = Object.fromEntries(
-					Object.entries(remoteBindings ?? []).filter(
-						([, b]) => "remote" in b && b["remote"]
-					)
+					Object.entries(remoteBindings ?? []).filter(([, b]) => {
+						if (b.type === "ai") {
+							// AI is always remote
+							return true;
+						}
+
+						return "remote" in b && b["remote"];
+					})
 				);
 
 				// TODO(perf): here we can save the converted remote bindings

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -178,7 +178,7 @@ export class LocalRuntimeController extends RuntimeController {
 							);
 					}
 				} else {
-					// Note: we always call setConfig even when there are zero remote bindings, in these
+					// Note: we always call pathConfig even when there are zero remote bindings, in these
 					//       cases we could terminate the remote session if we wanted, that's probably
 					//       something to consider down the line
 					await this.#mixedModeSession.patchConfig(convertedRemoteBindings);

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -178,10 +178,10 @@ export class LocalRuntimeController extends RuntimeController {
 							);
 					}
 				} else {
-					// Note: we always call pathConfig even when there are zero remote bindings, in these
+					// Note: we always call updateBindings even when there are zero remote bindings, in these
 					//       cases we could terminate the remote session if we wanted, that's probably
 					//       something to consider down the line
-					await this.#mixedModeSession.patchConfig(convertedRemoteBindings);
+					await this.#mixedModeSession.updateBindings(convertedRemoteBindings);
 				}
 			}
 

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -5,7 +5,6 @@ import { Miniflare, Mutex } from "miniflare";
 import * as MF from "../../dev/miniflare";
 import { getFlag } from "../../experimental-flags";
 import { logger } from "../../logger";
-import { startMixedModeSession } from "../mixedMode";
 import { RuntimeController } from "./BaseController";
 import { castErrorCause } from "./events";
 import {
@@ -169,9 +168,14 @@ export class LocalRuntimeController extends RuntimeController {
 						convertedRemoteBindings ?? {}
 					).length;
 					if (numOfRemoteBindings > 0) {
-						this.#mixedModeSession = await startMixedModeSession(
-							convertedRemoteBindings
-						);
+						// Note: we import the mixedMode module dynamically to avoid circular
+						//       import issues (since mixed mode uses startWorker which uses
+						//       LocalRuntimeController)
+						const mixedModeModule = await import("../../api/mixedMode");
+						this.#mixedModeSession =
+							await mixedModeModule.startMixedModeSession(
+								convertedRemoteBindings
+							);
 					}
 				} else {
 					// Note: we always call setConfig even when there are zero remote bindings, in these

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -181,7 +181,7 @@ export class LocalRuntimeController extends RuntimeController {
 					// Note: we always call setConfig even when there are zero remote bindings, in these
 					//       cases we could terminate the remote session if we wanted, that's probably
 					//       something to consider down the line
-					await this.#mixedModeSession.setConfig(convertedRemoteBindings);
+					await this.#mixedModeSession.patchConfig(convertedRemoteBindings);
 				}
 			}
 

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -323,7 +323,7 @@ export class LocalRuntimeController extends RuntimeController {
 	}
 }
 
-type RemoveBindingsConfigs = Partial<
+type RemoteBindingsConfigs = Partial<
 	Pick<
 		MF.ConfigBundle["bindings"],
 		| "services"
@@ -338,8 +338,8 @@ type RemoveBindingsConfigs = Partial<
 
 function extractRemoteBindings(
 	bindings: MF.ConfigBundle["bindings"]
-): RemoveBindingsConfigs {
-	const remoteBindings: RemoveBindingsConfigs = {};
+): RemoteBindingsConfigs {
+	const remoteBindings: RemoteBindingsConfigs = {};
 
 	if (bindings.ai) {
 		// AI is always remote

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -163,6 +163,11 @@ export class LocalRuntimeController extends RuntimeController {
 				const convertedRemoteBindings =
 					convertCfWorkerInitBindingsToBindings(remoteBindings);
 
+				// TODO(perf): here we can save the converted remote bindings
+				//             and on new iterations we can diff the old and new
+				//             converted remote bindings, if they are all the
+				//             same we can just leave the mixedModeSession untouched
+
 				if (this.#mixedModeSession === undefined) {
 					const numOfRemoteBindings = Object.keys(
 						convertedRemoteBindings ?? {}

--- a/packages/wrangler/src/api/startDevWorker/utils.ts
+++ b/packages/wrangler/src/api/startDevWorker/utils.ts
@@ -75,14 +75,14 @@ async function getBinaryFileContents(file: File<string | Uint8Array>) {
 	return readFile(file.path);
 }
 
-export function convertCfWorkerInitBindingstoBindings(
-	inputBindings: CfWorkerInit["bindings"]
+export function convertCfWorkerInitBindingsToBindings(
+	inputBindings: Partial<CfWorkerInit["bindings"]>
 ): StartDevWorkerOptions["bindings"] {
 	const output: StartDevWorkerOptions["bindings"] = {};
 
 	// required to retain type information
 	type Entries<T> = { [K in keyof T]: [K, T[K]] }[keyof T][];
-	type BindingsIterable = Entries<typeof inputBindings>;
+	type BindingsIterable = Entries<Required<typeof inputBindings>>;
 	const bindingsIterable = Object.entries(inputBindings) as BindingsIterable;
 
 	for (const [type, info] of bindingsIterable) {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -7,7 +7,7 @@ import { DevEnv } from "./api";
 import { MultiworkerRuntimeController } from "./api/startDevWorker/MultiworkerRuntimeController";
 import { NoOpProxyController } from "./api/startDevWorker/NoOpProxyController";
 import {
-	convertCfWorkerInitBindingstoBindings,
+	convertCfWorkerInitBindingsToBindings,
 	extractBindingsOfType,
 } from "./api/startDevWorker/utils";
 import { getAssetsOptions } from "./assets";
@@ -503,7 +503,7 @@ async function setupDevEnv(
 			bindings: {
 				...(await getPagesAssetsFetcher(args.enablePagesAssetsServiceBinding)),
 				...collectPlainTextVars(args.var),
-				...convertCfWorkerInitBindingstoBindings({
+				...convertCfWorkerInitBindingsToBindings({
 					kv_namespaces: args.kv,
 					vars: args.vars,
 					send_email: undefined,


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1853

The changes here make it so that the user can set `remote: true` to some of 
their bindings and such bindings will be run remotely via `startMixedModeSession`
when running `wrangler dev` on a single worker

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new experimental feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
