### PR TITLE
add no-op `ctx.props` to getPlatformProxy to fix types mismatch

### DIFF
--- a/.changeset/clear-beans-leave.md
+++ b/.changeset/clear-beans-leave.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: add no-op `props` to `ctx` in `getPlatformProxy` to fix type mismatch

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.ctx.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.ctx.test.ts
@@ -33,6 +33,7 @@ describe("getPlatformProxy - ctx", () => {
 			expect(ctx.constructor.name).toBe("ExecutionContext");
 			expect(typeof ctx.waitUntil).toBe("function");
 			expect(typeof ctx.passThroughOnException).toBe("function");
+			expect(ctx.props).toEqual({});
 
 			ctx.waitUntil = ((str: string) => `- ${str} -`) as any;
 			expect(ctx.waitUntil("waitUntil can be overridden" as any)).toBe(

--- a/packages/wrangler/src/api/integrations/platform/executionContext.ts
+++ b/packages/wrangler/src/api/integrations/platform/executionContext.ts
@@ -11,5 +11,5 @@ export class ExecutionContext {
 		}
 	}
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	props: any;
+	props: any = {};
 }

--- a/packages/wrangler/src/api/integrations/platform/executionContext.ts
+++ b/packages/wrangler/src/api/integrations/platform/executionContext.ts
@@ -10,5 +10,6 @@ export class ExecutionContext {
 			throw new Error("Illegal invocation");
 		}
 	}
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	props: any;
 }

--- a/packages/wrangler/src/api/integrations/platform/executionContext.ts
+++ b/packages/wrangler/src/api/integrations/platform/executionContext.ts
@@ -10,4 +10,5 @@ export class ExecutionContext {
 			throw new Error("Illegal invocation");
 		}
 	}
+	props: any;
 }


### PR DESCRIPTION
Fixes #9233

I don't think `props` can be meaningfully used with getPlatformProxy? So this just fixes the types issue. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by fixtures
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/9262
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
