### PR TITLE
test: fail e2e test if peer dependencies are broken

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -32,6 +32,7 @@ const testEnv = {
 const strictPeerDeps = {
 	pnpm: "--strict-peer-dependencies",
 	npm: "--strict-peer-deps",
+	// yarn does not have an option for strict checks
 	yarn: "",
 };
 

--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -29,6 +29,12 @@ const testEnv = {
 	VITEST: undefined,
 };
 
+const strictPeerDeps = {
+	pnpm: "--strict-peer-dependencies",
+	npm: "--strict-peer-deps",
+	yarn: "",
+};
+
 /** Seed a test project from a fixture. */
 export function seed(fixture: string, pm: "pnpm" | "yarn" | "npm") {
 	const root = inject("root");
@@ -42,7 +48,9 @@ export function seed(fixture: string, pm: "pnpm" | "yarn" | "npm") {
 		debuglog("Fixture copied to " + projectPath);
 		await updateVitePluginVersion(projectPath);
 		debuglog("Updated vite-plugin version in package.json");
-		runCommand(`${pm} install`, projectPath, { attempts: 2 });
+		runCommand(`${pm} install ${strictPeerDeps[pm]}`, projectPath, {
+			attempts: 2,
+		});
 		debuglog("Installed node modules");
 	}, 200_000);
 


### PR DESCRIPTION
Changes the vite-plugin e2e tests so that they fail if there is a mismatch in a peer dependency.
This is to catch problems with the relationship between vite-plugin and unenv-preset.