### PR TITLE
fix default typesPath in c3 templates

### DIFF
--- a/.changeset/funny-trees-drop.md
+++ b/.changeset/funny-trees-drop.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+fix: set `compilerOptions.types` to `./worker-configuration.d.ts` instead of `worker-configuration.d.ts` in tsconfig.json

--- a/packages/create-cloudflare/src/templates.ts
+++ b/packages/create-cloudflare/src/templates.ts
@@ -572,7 +572,7 @@ export const createContext = async (
 
 	template = {
 		workersTypes: "generated",
-		typesPath: "worker-configuration.d.ts",
+		typesPath: "./worker-configuration.d.ts",
 		envInterfaceName: "Env",
 		...template,
 	};


### PR DESCRIPTION
fixes the default for `typesPath` in c3 templates
This ensures `compilerOptions.types` in tsconfig is set correctly - previously this would not be able to find `worker-configuration.d.ts`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: typo fix
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: c3 change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
