### PR TITLE
Support Mixed Mode Dispatch Namespaces

### DIFF
--- a/.changeset/tough-seals-whisper.md
+++ b/.changeset/tough-seals-whisper.md
@@ -1,5 +1,6 @@
 ---
 "miniflare": patch
+"wrangler": patch
 ---
 
 Support Mixed Mode Dispatch Namespaces

--- a/.changeset/tough-seals-whisper.md
+++ b/.changeset/tough-seals-whisper.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Support Mixed Mode Dispatch Namespaces

--- a/packages/miniflare/src/plugins/dispatch-namespace/index.ts
+++ b/packages/miniflare/src/plugins/dispatch-namespace/index.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert";
+import LOCAL_DISPATCH_NAMESPACE from "worker:dispatch-namespace/dispatch-namespace";
+import { z } from "zod";
+import { Worker_Binding } from "../../runtime";
+import {
+	mixedModeClientWorker,
+	MixedModeConnectionString,
+	Plugin,
+	ProxyNodeBinding,
+} from "../shared";
+
+export const DispatchNamespaceOptionsSchema = z.object({
+	dispatchNamespaces: z
+		.record(
+			z.object({
+				namespace: z.string(),
+				mixedModeConnectionString: z
+					.custom<MixedModeConnectionString>()
+					.optional(),
+			})
+		)
+		.optional(),
+});
+
+export const DISPATCH_NAMESPACE_PLUGIN_NAME = "dispatch-namespace";
+
+export const DISPATCH_NAMESPACE_PLUGIN: Plugin<
+	typeof DispatchNamespaceOptionsSchema
+> = {
+	options: DispatchNamespaceOptionsSchema,
+	async getBindings(options) {
+		if (!options.dispatchNamespaces) {
+			return [];
+		}
+
+		const bindings = Object.entries(
+			options.dispatchNamespaces
+		).map<Worker_Binding>(([name, config]) => {
+			return {
+				name,
+				wrapped: {
+					moduleName: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:local-namespace`,
+					innerBindings: [
+						{
+							name: "fetcher",
+							service: {
+								name: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:ns:${config.namespace}`,
+							},
+						},
+					],
+				},
+			};
+		});
+		return bindings;
+	},
+	getNodeBindings(options: z.infer<typeof DispatchNamespaceOptionsSchema>) {
+		if (!options.dispatchNamespaces) {
+			return {};
+		}
+		return Object.fromEntries(
+			Object.keys(options.dispatchNamespaces).map((name) => [
+				name,
+				new ProxyNodeBinding(),
+			])
+		);
+	},
+	async getServices({ options }) {
+		if (!options.dispatchNamespaces) {
+			return [];
+		}
+
+		return {
+			services: Object.entries(options.dispatchNamespaces).map(
+				([name, config]) => {
+					assert(
+						config.mixedModeConnectionString,
+						"Dispatch Namespace bindings only support Mixed Mode"
+					);
+					return {
+						name: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:ns:${config.namespace}`,
+						worker: mixedModeClientWorker(
+							config.mixedModeConnectionString,
+							name
+						),
+					};
+				}
+			),
+			extensions: [
+				{
+					modules: [
+						{
+							name: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:local-namespace`,
+							esModule: LOCAL_DISPATCH_NAMESPACE(),
+							internal: true,
+						},
+					],
+				},
+			],
+		};
+	},
+};

--- a/packages/miniflare/src/plugins/dispatch-namespace/index.ts
+++ b/packages/miniflare/src/plugins/dispatch-namespace/index.ts
@@ -39,7 +39,7 @@ export const DISPATCH_NAMESPACE_PLUGIN: Plugin<
 			return {
 				name,
 				wrapped: {
-					moduleName: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:local-namespace`,
+					moduleName: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:local-dispatch-namespace`,
 					innerBindings: [
 						{
 							name: "fetcher",
@@ -89,7 +89,7 @@ export const DISPATCH_NAMESPACE_PLUGIN: Plugin<
 				{
 					modules: [
 						{
-							name: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:local-namespace`,
+							name: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:local-dispatch-namespace`,
 							esModule: LOCAL_DISPATCH_NAMESPACE(),
 							internal: true,
 						},

--- a/packages/miniflare/src/plugins/index.ts
+++ b/packages/miniflare/src/plugins/index.ts
@@ -14,6 +14,10 @@ import {
 import { CACHE_PLUGIN, CACHE_PLUGIN_NAME } from "./cache";
 import { CORE_PLUGIN, CORE_PLUGIN_NAME } from "./core";
 import { D1_PLUGIN, D1_PLUGIN_NAME } from "./d1";
+import {
+	DISPATCH_NAMESPACE_PLUGIN,
+	DISPATCH_NAMESPACE_PLUGIN_NAME,
+} from "./dispatch-namespace";
 import { DURABLE_OBJECTS_PLUGIN, DURABLE_OBJECTS_PLUGIN_NAME } from "./do";
 import { EMAIL_PLUGIN, EMAIL_PLUGIN_NAME } from "./email";
 import { HYPERDRIVE_PLUGIN, HYPERDRIVE_PLUGIN_NAME } from "./hyperdrive";
@@ -43,6 +47,7 @@ export const PLUGINS = {
 	[ANALYTICS_ENGINE_PLUGIN_NAME]: ANALYTICS_ENGINE_PLUGIN,
 	[AI_PLUGIN_NAME]: AI_PLUGIN,
 	[BROWSER_RENDERING_PLUGIN_NAME]: BROWSER_RENDERING_PLUGIN,
+	[DISPATCH_NAMESPACE_PLUGIN_NAME]: DISPATCH_NAMESPACE_PLUGIN,
 };
 export type Plugins = typeof PLUGINS;
 
@@ -97,7 +102,8 @@ export type WorkerOptions = z.input<typeof CORE_PLUGIN.options> &
 	z.input<typeof SECRET_STORE_PLUGIN.options> &
 	z.input<typeof ANALYTICS_ENGINE_PLUGIN.options> &
 	z.input<typeof AI_PLUGIN.options> &
-	z.input<typeof BROWSER_RENDERING_PLUGIN.options>;
+	z.input<typeof BROWSER_RENDERING_PLUGIN.options> &
+	z.input<typeof DISPATCH_NAMESPACE_PLUGIN.options>;
 
 export type SharedOptions = z.input<typeof CORE_PLUGIN.sharedOptions> &
 	z.input<typeof CACHE_PLUGIN.sharedOptions> &
@@ -162,3 +168,4 @@ export * from "./email";
 export * from "./analytics-engine";
 export * from "./ai";
 export * from "./browser-rendering";
+export * from "./dispatch-namespace";

--- a/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace.worker.ts
+++ b/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace.worker.ts
@@ -1,0 +1,30 @@
+interface Env {
+	fetcher: Fetcher;
+}
+class LocalDispatchNamespace implements DispatchNamespace {
+	constructor(private env: Env) {}
+	get(
+		name: string,
+		args?: { [key: string]: any },
+		options?: DynamicDispatchOptions
+	): Fetcher {
+		return {
+			...this.env.fetcher,
+			fetch: (
+				input: RequestInfo | URL,
+				init?: RequestInit
+			): Promise<Response> => {
+				const request = new Request(input, init);
+				request.headers.set(
+					"MF-Dispatch-Namespace-Options",
+					JSON.stringify({ name, args, options })
+				);
+				return this.env.fetcher.fetch(request);
+			},
+		};
+	}
+}
+
+export default function (env: Env) {
+	return new LocalDispatchNamespace(env);
+}

--- a/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace.worker.ts
+++ b/packages/miniflare/src/workers/dispatch-namespace/dispatch-namespace.worker.ts
@@ -1,6 +1,7 @@
 interface Env {
 	fetcher: Fetcher;
 }
+
 class LocalDispatchNamespace implements DispatchNamespace {
 	constructor(private env: Env) {}
 	get(

--- a/packages/miniflare/src/workers/shared/mixed-mode-client.worker.ts
+++ b/packages/miniflare/src/workers/shared/mixed-mode-client.worker.ts
@@ -1,24 +1,26 @@
-export default {
-	async fetch(request, env) {
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+export default class Client extends WorkerEntrypoint<{
+	mixedModeConnectionString: string;
+	binding: string;
+}> {
+	async fetch(request: Request) {
 		const proxiedHeaders = new Headers();
 		for (const [name, value] of request.headers) {
 			// The `Upgrade` header needs to be special-cased to prevent:
 			//   TypeError: Worker tried to return a WebSocket in a response to a request which did not contain the header "Upgrade: websocket"
-			if (name === "upgrade") {
+			if (name === "upgrade" || name.startsWith("MF-")) {
 				proxiedHeaders.set(name, value);
 			} else {
 				proxiedHeaders.set(`MF-Header-${name}`, value);
 			}
 		}
 		proxiedHeaders.set("MF-URL", request.url);
-		proxiedHeaders.set("MF-Binding", env.binding);
+		proxiedHeaders.set("MF-Binding", this.env.binding);
 		const req = new Request(request, {
 			headers: proxiedHeaders,
 		});
 
-		return fetch(env.mixedModeConnectionString, req);
-	},
-} satisfies ExportedHandler<{
-	mixedModeConnectionString: string;
-	binding: string;
-}>;
+		return fetch(this.env.mixedModeConnectionString, req);
+	}
+}


### PR DESCRIPTION
Continuation of DEVX-1859

Support Dispatch Namespaces in Mixed Mode dev. These are _similar_ to service bindings, but have a synchronous `.get()` method that a user calls first to retrieve the `Fetcher`. As such, they've been special cased so that the `.get()` is implemented as a Wrapped Binding that attaches a special header encoding the `.get()` arguments. The Mixed Mode Server uses that to call `.get()` on the actual Dispatch Namespace binding when the `Fetcher` is used.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by fixture
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: WIP feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a patch

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
