### PR TITLE
V3 Backport [#9246]: fix: strips CF-Connecting-IP header within Wrangler

### DIFF
--- a/.changeset/public-cameras-thank.md
+++ b/.changeset/public-cameras-thank.md
@@ -1,0 +1,8 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+fix: strip `CF-Connecting-IP` header within `fetch`
+
+In v4.15.0, Miniflare began stripping the `CF-Connecting-IP` header via a global outbound service, which led to a TCP connection regression due to a bug in Workerd. This PR patches the `fetch` API to strip the header during local `wrangler dev` sessions as a temporary workaround until the underlying issue is resolved.

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -163,7 +163,9 @@ const CoreOptionsSchemaInput = z.intersection(
 		unsafeEnableAssetsRpc: z.boolean().optional(),
 
 		// Strip the CF-Connecting-IP header from outbound fetches
-		stripCfConnectingIp: z.boolean().default(true),
+		// There is an issue with the connect() API and the globalOutbound workerd setting that impacts TCP ingress
+		// We should default it to true once https://github.com/cloudflare/workerd/pull/4145 is resolved
+		stripCfConnectingIp: z.boolean().default(false),
 	})
 );
 export const CoreOptionsSchema = CoreOptionsSchemaInput.transform((value) => {

--- a/packages/miniflare/test/index.spec.ts
+++ b/packages/miniflare/test/index.spec.ts
@@ -2715,6 +2715,7 @@ test("Miniflare: strips CF-Connecting-IP", async (t) => {
 	const client = new Miniflare({
 		script: `export default { fetch(request) { return fetch('${url.href}', {headers: {"CF-Connecting-IP":"fake-value"}}) } }`,
 		modules: true,
+		stripCfConnectingIp: true,
 	});
 	t.teardown(() => client.dispose());
 	t.teardown(() => server.dispose());

--- a/packages/wrangler/src/__tests__/api/startDevWorker/startWorker.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/startWorker.test.ts
@@ -1,0 +1,51 @@
+import path from "node:path";
+import { Response } from "miniflare";
+import dedent from "ts-dedent";
+import { startWorker } from "../../../api/startDevWorker";
+import { runInTempDir } from "../../helpers/run-in-tmp";
+import { seed } from "../../helpers/seed";
+
+describe("startWorker", () => {
+	runInTempDir();
+
+	// We do not inject the `CF-Connecting-IP` header on Windows at the moment.
+	// See https://github.com/cloudflare/workerd/issues/3310
+	it.skipIf(process.platform === "win32")(
+		"strips the CF-Connecting-IP header from all outbound requests",
+		async (t) => {
+			t.onTestFinished(() => worker?.dispose());
+
+			await seed({
+				"src/index.ts": dedent`
+					export default {
+						fetch(request) {
+							if (request.headers.has('CF-Connecting-IP')) {
+								return fetch(request);
+							}
+
+							return new Response("No CF-Connecting-IP header");
+						}
+					}
+				`,
+			});
+
+			const worker = await startWorker({
+				name: "test-worker",
+				entrypoint: path.resolve("src/index.ts"),
+				dev: {
+					outboundService(request) {
+						return new Response(
+							request.headers.get("CF-Connecting-IP") ??
+								"CF-Connecting-IP header stripped"
+						);
+					},
+				},
+			});
+
+			const response = await worker.fetch("http://example.com");
+			await expect(response.text()).resolves.toEqual(
+				"CF-Connecting-IP header stripped"
+			);
+		}
+	);
+});

--- a/packages/wrangler/src/deployment-bundle/bundle.ts
+++ b/packages/wrangler/src/deployment-bundle/bundle.ts
@@ -304,9 +304,11 @@ export async function bundleWorker(
 		inject.push(checkedFetchFileToInject);
 	}
 
-	// We injected the `CF-Connecting-IP` header in the entry worker on Miniflare
-	// This was previously stripped within miniflare but this causes an issue with TCP ingress
-	// due to the global outbound setup. This is a workaround until a fix is in place in workerd.
+	// We injected the `CF-Connecting-IP` header in the entry worker on Miniflare.
+	// It used to be stripped by Miniflare, but that caused TCP ingress failures
+	// because of the global outbound setup. This is a temporary workaround until
+	// a proper fix is landed in Workerd.
+	// See https://github.com/cloudflare/workers-sdk/issues/9238 for more details.
 	if (targetConsumer === "dev" && local) {
 		const stripCfConnectingIpHeaderFileToInject = path.join(
 			tmpDir.path,

--- a/packages/wrangler/templates/strip-cf-connecting-ip-header.js
+++ b/packages/wrangler/templates/strip-cf-connecting-ip-header.js
@@ -1,0 +1,13 @@
+function stripCfConnectingIPHeader(input, init) {
+	const request = new Request(input, init);
+	request.headers.delete("CF-Connecting-IP");
+	return request;
+}
+
+globalThis.fetch = new Proxy(globalThis.fetch, {
+	apply(target, thisArg, argArray) {
+		return Reflect.apply(target, thisArg, [
+			stripCfConnectingIPHeader.apply(null, argArray),
+		]);
+	},
+});


### PR DESCRIPTION
This is an automatically opened PR to backport patch changes from #9246 to Wrangler v3