### PR TITLE
ensure that `startWorker` honors the `logLevel` option

### DIFF
--- a/.changeset/purple-paws-wink.md
+++ b/.changeset/purple-paws-wink.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+ensure that `startWorker` honors the `logLevel` option

--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -3,6 +3,7 @@ import path from "path";
 import dedent from "ts-dedent";
 import { test as base, describe } from "vitest";
 import { BundlerController } from "../../../api/startDevWorker/BundlerController";
+import { Logger, run } from "../../../logger";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { seed } from "../../helpers/seed";
@@ -19,11 +20,15 @@ function findSourceFile(source: string, name: string): string {
 const test = base.extend<{ controller: BundlerController }>({
 	// eslint-disable-next-line no-empty-pattern
 	controller: async ({}, use) => {
-		const controller = new BundlerController();
+		const testLogger = new Logger();
+		testLogger.loggerLevel = "none";
+		await run(testLogger, async () => {
+			const controller = new BundlerController();
 
-		await use(controller);
+			await use(controller);
 
-		await controller.teardown();
+			await controller.teardown();
+		});
 	},
 });
 

--- a/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/ConfigController.test.ts
@@ -4,6 +4,7 @@ import dedent from "ts-dedent";
 import { describe, it } from "vitest";
 import { ConfigController } from "../../../api/startDevWorker/ConfigController";
 import { unwrapHook } from "../../../api/startDevWorker/utils";
+import { Logger, run } from "../../../logger";
 import { mockAccountId, mockApiToken } from "../../helpers/mock-account-id";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { runInTempDir } from "../../helpers/run-in-tmp";
@@ -17,6 +18,15 @@ async function waitForConfigUpdate(
 	return event;
 }
 
+function getConfigController() {
+	const testLogger = new Logger();
+	testLogger.loggerLevel = "none";
+	return run(testLogger, () => {
+		const controller = new ConfigController();
+		return controller;
+	});
+}
+
 describe("ConfigController", () => {
 	runInTempDir();
 	mockConsoleMethods();
@@ -24,7 +34,7 @@ describe("ConfigController", () => {
 	mockApiToken();
 
 	it("should emit configUpdate events with defaults applied", async () => {
-		const controller = new ConfigController();
+		const controller = getConfigController();
 		const event = waitForConfigUpdate(controller);
 		await seed({
 			"src/index.ts": dedent/* javascript */ `
@@ -58,7 +68,7 @@ describe("ConfigController", () => {
 	});
 
 	it("should apply module root to parent if main is nested from base_dir", async () => {
-		const controller = new ConfigController();
+		const controller = getConfigController();
 		const event = waitForConfigUpdate(controller);
 		await seed({
 			"some/base_dir/nested/index.js": dedent/* javascript */ `
@@ -93,7 +103,7 @@ base_dir = \"./some/base_dir\"`,
 		});
 	});
 	it("should shallow merge patched config", async () => {
-		const controller = new ConfigController();
+		const controller = getConfigController();
 		const event1 = waitForConfigUpdate(controller);
 		await seed({
 			"src/index.ts": dedent/* javascript */ `
@@ -187,7 +197,7 @@ base_dir = \"./some/base_dir\"`,
 	});
 
 	it("should use account_id from config file before env var", async () => {
-		const controller = new ConfigController();
+		const controller = getConfigController();
 		await seed({
 			"src/index.ts": dedent/* javascript */ `
                 export default {}

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -12,6 +12,7 @@ import WebSocket from "ws";
 import { LocalRuntimeController } from "../../../api/startDevWorker/LocalRuntimeController";
 import { urlFromParts } from "../../../api/startDevWorker/utils";
 import { RuleTypeToModuleType } from "../../../deployment-bundle/module-collection";
+import { Logger, run } from "../../../logger";
 import { mockConsoleMethods } from "../../helpers/mock-console";
 import { runInTempDir } from "../../helpers/run-in-tmp";
 import { useTeardown } from "../../helpers/teardown";
@@ -137,6 +138,15 @@ function configDefaults(
 	};
 }
 
+function getLocalRuntimeController() {
+	const testLogger = new Logger();
+	testLogger.loggerLevel = "none";
+	return run(testLogger, () => {
+		const controller = new LocalRuntimeController();
+		return controller;
+	});
+}
+
 describe("LocalRuntimeController", () => {
 	const teardown = useTeardown();
 	mockConsoleMethods();
@@ -144,7 +154,7 @@ describe("LocalRuntimeController", () => {
 
 	describe("Core", () => {
 		it("should start Miniflare with module worker", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const config = {
@@ -298,7 +308,7 @@ describe("LocalRuntimeController", () => {
 			}
 		});
 		it("should start Miniflare with service worker", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const config = {
@@ -393,7 +403,7 @@ describe("LocalRuntimeController", () => {
 			}
 		});
 		it("should update the running Miniflare instance", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			function update(version: number) {
@@ -444,7 +454,7 @@ describe("LocalRuntimeController", () => {
 			expect(await res.json()).toEqual({ binding: 5, bundle: 5 });
 		});
 		it("should start Miniflare with configured compatibility settings", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			// `global_navigator` was enabled by default on `2022-03-21`:
@@ -508,7 +518,7 @@ describe("LocalRuntimeController", () => {
 			expect(await res.text()).toBe("object");
 		});
 		it("should start inspector on random port and allow debugging", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const config: Partial<StartDevWorkerOptions> = {
@@ -576,7 +586,7 @@ describe("LocalRuntimeController", () => {
 
 	describe("Bindings", () => {
 		it("should expose basic bindings", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const config: Partial<StartDevWorkerOptions> = {
@@ -623,7 +633,7 @@ describe("LocalRuntimeController", () => {
 			});
 		});
 		it("should expose WebAssembly module bindings in service workers", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const config: Partial<StartDevWorkerOptions> = {
@@ -658,7 +668,7 @@ describe("LocalRuntimeController", () => {
 			expect(await res.text()).toBe("3");
 		});
 		it("should persist cached data", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const config: Partial<StartDevWorkerOptions> = {
@@ -728,7 +738,7 @@ describe("LocalRuntimeController", () => {
 			expect(await res.text()).toBe("miss");
 		});
 		it("should expose KV namespace bindings", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const config: Partial<StartDevWorkerOptions> = {
@@ -790,7 +800,7 @@ describe("LocalRuntimeController", () => {
 			expect(await res.text()).toBe("");
 		});
 		it("should support Workers Sites bindings", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			fs.writeFileSync("company.txt", "👨‍👩‍👧‍👦");
@@ -861,7 +871,7 @@ describe("LocalRuntimeController", () => {
 			expect(res.status).toBe(404);
 		});
 		it("should expose R2 bucket bindings", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const config: Partial<StartDevWorkerOptions> = {
@@ -924,7 +934,7 @@ describe("LocalRuntimeController", () => {
 			expect(await res.text()).toBe("");
 		});
 		it("should expose D1 database bindings", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const config: Partial<StartDevWorkerOptions> = {
@@ -992,7 +1002,7 @@ describe("LocalRuntimeController", () => {
 			expect(await res.json()).toEqual([]);
 		});
 		it("should expose queue producer bindings and consume queue messages", async () => {
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const reportPromise = new DeferredPromise<unknown>();
@@ -1055,7 +1065,7 @@ describe("LocalRuntimeController", () => {
 			const port = address.port;
 
 			// Start runtime with hyperdrive binding
-			const controller = new LocalRuntimeController();
+			const controller = getLocalRuntimeController();
 			teardown(() => controller.teardown());
 
 			const localConnectionString = `postgres://username:password@127.0.0.1:${port}/db`;

--- a/packages/wrangler/src/api/dev.ts
+++ b/packages/wrangler/src/api/dev.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import events from "node:events";
 import { fetch, Request } from "undici";
 import { startDev } from "../dev";
@@ -237,6 +238,7 @@ export async function unstable_dev(
 		port,
 		address,
 		stop: async () => {
+			assert(devServer.devEnv !== undefined);
 			await devServer.devEnv.teardown.bind(devServer.devEnv)();
 			const teardownRegistry = await devServer.teardownRegistryPromise;
 			await teardownRegistry?.(devServer.devEnv.config.latestConfig?.name);
@@ -249,6 +251,7 @@ export async function unstable_dev(
 			);
 		},
 		waitUntilExit: async () => {
+			assert(devServer.devEnv !== undefined);
 			await events.once(devServer.devEnv, "teardown");
 		},
 	};

--- a/packages/wrangler/src/api/mixedMode/index.ts
+++ b/packages/wrangler/src/api/mixedMode/index.ts
@@ -25,6 +25,7 @@ export async function startMixedModeSession(
 	const worker = await startWorker({
 		config: proxyServerWorkerWranglerConfig,
 		dev: {
+			logLevel: "none",
 			remote: true,
 			auth: options?.auth,
 		},

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -36,6 +36,7 @@ import {
 } from "./utils";
 import type { Config } from "../../config";
 import type { CfUnsafe } from "../../deployment-bundle/worker";
+import type { Logger } from "../../logger";
 import type { ControllerEventMap } from "./BaseController";
 import type { ConfigUpdateEvent } from "./events";
 import type {
@@ -229,7 +230,8 @@ async function resolveTriggers(
 
 async function resolveConfig(
 	config: Config,
-	input: StartDevWorkerInput
+	input: StartDevWorkerInput,
+	logger: Logger
 ): Promise<StartDevWorkerOptions> {
 	if (
 		config.pages_build_output_dir &&
@@ -329,8 +331,6 @@ async function resolveConfig(
 	}
 
 	validateAssetsArgsAndConfig(resolved);
-
-	const logger = getScopedLogger();
 
 	const services = extractBindingsOfType("service", resolved.bindings);
 	if (services && services.length > 0 && resolved.dev?.remote) {
@@ -462,7 +462,11 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 				void this.#ensureWatchingConfig(fileConfig.configPath);
 			}
 
-			const resolvedConfig = await resolveConfig(fileConfig, input);
+			const resolvedConfig = await resolveConfig(
+				fileConfig,
+				input,
+				this.#logger
+			);
 			if (signal.aborted) {
 				return;
 			}

--- a/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/RemoteRuntimeController.ts
@@ -11,7 +11,7 @@ import {
 	handlePreviewSessionUploadError,
 } from "../../dev/remote";
 import { MissingConfigError } from "../../errors";
-import { logger } from "../../logger";
+import { getScopedLogger } from "../../logger";
 import { getAccessToken } from "../../user/access";
 import { RuntimeController } from "./BaseController";
 import { castErrorCause } from "./events";
@@ -39,6 +39,8 @@ export class RemoteRuntimeController extends RuntimeController {
 	#mutex = new Mutex();
 
 	#session?: CfPreviewSession;
+
+	#logger = getScopedLogger();
 
 	async #previewSession(
 		props: Parameters<typeof getWorkerAccountAndContext>[0]
@@ -157,7 +159,7 @@ export class RemoteRuntimeController extends RuntimeController {
 	}
 
 	async #onBundleComplete({ config, bundle }: BundleCompleteEvent, id: number) {
-		logger.log(chalk.dim("⎔ Starting remote preview..."));
+		this.#logger.log(chalk.dim("⎔ Starting remote preview..."));
 
 		try {
 			const routes = config.triggers
@@ -185,7 +187,7 @@ export class RemoteRuntimeController extends RuntimeController {
 			const auth = await unwrapHook(config.dev.auth);
 
 			if (this.#session) {
-				logger.log(chalk.dim("⎔ Detected changes, restarted server."));
+				this.#logger.log(chalk.dim("⎔ Detected changes, restarted server."));
 			}
 
 			this.#session ??= await this.#previewSession({
@@ -323,12 +325,12 @@ export class RemoteRuntimeController extends RuntimeController {
 
 	async teardown() {
 		if (this.#session) {
-			logger.log(chalk.dim("⎔ Shutting down remote preview..."));
+			this.#logger.log(chalk.dim("⎔ Shutting down remote preview..."));
 		}
-		logger.debug("RemoteRuntimeController teardown beginning...");
+		this.#logger.debug("RemoteRuntimeController teardown beginning...");
 		this.#session = undefined;
 		this.#abortController.abort();
-		logger.debug("RemoteRuntimeController teardown complete");
+		this.#logger.debug("RemoteRuntimeController teardown complete");
 	}
 
 	// *********************

--- a/packages/wrangler/src/api/startDevWorker/index.ts
+++ b/packages/wrangler/src/api/startDevWorker/index.ts
@@ -1,3 +1,4 @@
+import { Logger, run } from "../../logger";
 import { DevEnv } from "./DevEnv";
 import type { StartDevWorkerInput, Worker } from "./types";
 
@@ -8,7 +9,9 @@ export * from "./events";
 export async function startWorker(
 	options: StartDevWorkerInput
 ): Promise<Worker> {
-	const devEnv = new DevEnv();
+	return run(new Logger(), () => {
+		const devEnv = new DevEnv();
 
-	return devEnv.startWorker(options);
+		return devEnv.startWorker(options);
+	});
 }

--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { format } from "node:util";
 import chalk from "chalk";
 import CLITable from "cli-table3";
@@ -216,3 +217,20 @@ export function logBuildFailure(errors: Message[], warnings: Message[]) {
 
 	logBuildWarnings(warnings);
 }
+
+const scopedLoggers = new AsyncLocalStorage<Logger>();
+
+export const run = <V>(scopedLogger: Logger, cb: () => V) =>
+	scopedLoggers.run(scopedLogger, cb);
+
+export const getScopedLogger = () => {
+	const store = scopedLoggers.getStore();
+	if (store === undefined) {
+		throw new Error("No scoped logger store instantiated");
+	}
+	const value = scopedLoggers.getStore();
+	if (value === undefined) {
+		throw new Error("No scoped logger found in store");
+	}
+	return value;
+};

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { execSync, spawn } from "node:child_process";
 import events from "node:events";
 import { existsSync, lstatSync, readFileSync } from "node:fs";
@@ -966,6 +967,7 @@ export const pagesDevCommand = createCommand({
 		process.on("SIGINT", CLEANUP);
 		process.on("SIGTERM", CLEANUP);
 
+		assert(devServer.devEnv !== undefined);
 		await events.once(devServer.devEnv, "teardown");
 		const teardownRegistry = await devServer.teardownRegistryPromise;
 		await teardownRegistry?.(devServer.devEnv.config.latestConfig?.name);


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1858

Just an idea for fixing `startWorker` not using the provided `logLevel`

Suggested improvements:
 - [ ] remove `getScopedLogger` and keep the controllers use the `logger` export (without storing a `#logger` prop), that could detect whether or not it should be scoped
 - [ ] the logger needs to be updated in the `ConfigController` so that it works with `DevEnv` in general

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: bugfix on an experimental feature
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
