### PR TITLE
Move the AE simulator from JSRPC to a Wrapped binding

### DIFF
--- a/.changeset/tricky-wolves-cry.md
+++ b/.changeset/tricky-wolves-cry.md
@@ -1,0 +1,6 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Move the Analytics Engine simulator implementation from JSRPC to a Wrapped binding

--- a/.changeset/tricky-wolves-cry.md
+++ b/.changeset/tricky-wolves-cry.md
@@ -3,4 +3,4 @@
 "wrangler": patch
 ---
 
-Move the Analytics Engine simulator implementation from JSRPC to a Wrapped binding
+Move the Analytics Engine simulator implementation from JSRPC to a Wrapped binding. This fixes a regression introduced in https://github.com/cloudflare/workers-sdk/pull/8935 that preventing Analytics Engine bindings working in local dev for Workers with a compatibility date prior to JSRPC being enabled.

--- a/packages/miniflare/src/plugins/analytics-engine/index.ts
+++ b/packages/miniflare/src/plugins/analytics-engine/index.ts
@@ -1,6 +1,6 @@
 import ANALYTICS_ENGINE from "worker:analytics-engine/analytics-engine";
 import { z } from "zod";
-import { Worker_Binding } from "../../runtime";
+import { Extension, Worker_Binding } from "../../runtime";
 import { PersistenceSchema, Plugin, ProxyNodeBinding } from "../shared";
 
 const AnalyticsEngineSchema = z.record(
@@ -59,24 +59,27 @@ export const ANALYTICS_ENGINE_PLUGIN: Plugin<
 			])
 		);
 	},
-	async getServices({ options }) {
+	async getServices({ options, workerIndex }) {
 		if (!options.analyticsEngineDatasets) {
 			return [];
 		}
+		const extensions: Extension[] = [];
+
+		if (workerIndex === 0) {
+			extensions.push({
+				modules: [
+					{
+						name: `${ANALYTICS_ENGINE_PLUGIN_NAME}:local-simulator`,
+						esModule: ANALYTICS_ENGINE(),
+						internal: true,
+					},
+				],
+			});
+		}
 
 		return {
+			extensions,
 			services: [],
-			extensions: [
-				{
-					modules: [
-						{
-							name: `${ANALYTICS_ENGINE_PLUGIN_NAME}:local-simulator`,
-							esModule: ANALYTICS_ENGINE(),
-							internal: true,
-						},
-					],
-				},
-			],
 		};
 	},
 };

--- a/packages/miniflare/src/plugins/analytics-engine/index.ts
+++ b/packages/miniflare/src/plugins/analytics-engine/index.ts
@@ -36,8 +36,17 @@ export const ANALYTICS_ENGINE_PLUGIN: Plugin<
 			return {
 				name,
 				service: {
-					name: `${ANALYTICS_ENGINE_PLUGIN_NAME}:${config.dataset}`,
+					name: `${ANALYTICS_ENGINE_PLUGIN_NAME}:local-simulator`,
 					entrypoint: "LocalAnalyticsEngineDataset",
+				},
+				wrapped: {
+					moduleName: `${ANALYTICS_ENGINE_PLUGIN_NAME}:local-simulator`,
+					innerBindings: [
+						{
+							name: "dataset",
+							json: JSON.stringify(config.dataset),
+						},
+					],
 				},
 			};
 		});
@@ -59,29 +68,19 @@ export const ANALYTICS_ENGINE_PLUGIN: Plugin<
 			return [];
 		}
 
-		return [
-			...Object.entries(options.analyticsEngineDatasets).map<Worker_Binding>(
-				([_, config]) => {
-					return {
-						name: `${ANALYTICS_ENGINE_PLUGIN_NAME}:${config.dataset}`,
-						worker: {
-							compatibilityDate: "2025-01-01",
-							modules: [
-								{
-									name: "analytics-engine.worker.js",
-									esModule: ANALYTICS_ENGINE(),
-								},
-							],
-							bindings: [
-								{
-									name: "dataset",
-									json: JSON.stringify(config.dataset),
-								},
-							],
+		return {
+			services: [],
+			extensions: [
+				{
+					modules: [
+						{
+							name: `${ANALYTICS_ENGINE_PLUGIN_NAME}:local-simulator`,
+							esModule: ANALYTICS_ENGINE(),
+							internal: true,
 						},
-					};
-				}
-			),
-		];
+					],
+				},
+			],
+		};
 	},
 };

--- a/packages/miniflare/src/plugins/analytics-engine/index.ts
+++ b/packages/miniflare/src/plugins/analytics-engine/index.ts
@@ -35,10 +35,6 @@ export const ANALYTICS_ENGINE_PLUGIN: Plugin<
 		).map<Worker_Binding>(([name, config]) => {
 			return {
 				name,
-				service: {
-					name: `${ANALYTICS_ENGINE_PLUGIN_NAME}:local-simulator`,
-					entrypoint: "LocalAnalyticsEngineDataset",
-				},
 				wrapped: {
 					moduleName: `${ANALYTICS_ENGINE_PLUGIN_NAME}:local-simulator`,
 					innerBindings: [

--- a/packages/miniflare/src/workers/analytics-engine/analytics-engine.worker.ts
+++ b/packages/miniflare/src/workers/analytics-engine/analytics-engine.worker.ts
@@ -1,10 +1,9 @@
-import { WorkerEntrypoint } from "cloudflare:workers";
-
-export class LocalAnalyticsEngineDataset
-	extends WorkerEntrypoint
-	implements AnalyticsEngineDataset
-{
+export class LocalAnalyticsEngineDataset implements AnalyticsEngineDataset {
 	writeDataPoint(_event?: AnalyticsEngineDataPoint): void {
 		// no op in dev
 	}
+}
+
+export default function () {
+	return new LocalAnalyticsEngineDataset();
 }

--- a/packages/miniflare/src/workers/analytics-engine/analytics-engine.worker.ts
+++ b/packages/miniflare/src/workers/analytics-engine/analytics-engine.worker.ts
@@ -1,9 +1,13 @@
-export class LocalAnalyticsEngineDataset implements AnalyticsEngineDataset {
+interface Env {
+	dataset: string;
+}
+class LocalAnalyticsEngineDataset implements AnalyticsEngineDataset {
+	constructor(private env: Env) {}
 	writeDataPoint(_event?: AnalyticsEngineDataPoint): void {
 		// no op in dev
 	}
 }
 
-export default function () {
-	return new LocalAnalyticsEngineDataset();
+export default function (env: Env) {
+	return new LocalAnalyticsEngineDataset(env);
 }

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -830,7 +830,7 @@ describe("analytics engine", () => {
 						"wrangler.toml": dedent`
 				name = "${workerName}"
 				main = "src/index.ts"
-				compatibility_date = "2024-08-08"
+				compatibility_date = "2022-08-08"
 
 				[[analytics_engine_datasets]]
 				binding = "ANALYTICS_BINDING"

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -820,7 +820,7 @@ describe("writes debug logs to hidden file", () => {
 });
 
 describe.only("analytics engine", () => {
-	describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --remote" }])(
+	describe.each([{ cmd: "wrangler dev" }])(
 		"mock analytics engine datasets: $cmd",
 		({ cmd }) => {
 			describe("module worker", () => {
@@ -868,8 +868,8 @@ describe.only("analytics engine", () => {
 				});
 			});
 
-			describe.skip("service worker", async () => {
-				it("analytics engine datasets are mocked in dev", async () => {
+			describe("service worker", async () => {
+				it("using analytics engine datasets logs a warning in dev", async () => {
 					const helper = new WranglerE2ETestHelper();
 					await helper.seed({
 						"wrangler.toml": dedent`
@@ -903,11 +903,8 @@ describe.only("analytics engine", () => {
 					});
 					const worker = helper.runLongLived(cmd);
 
-					const { url } = await worker.waitForReady();
-
-					const text = await fetchText(url);
-					expect(text).toContain(
-						`successfully wrote datapoint from service worker`
+					await worker.readUntil(
+						/Analytics Engine is not supported locally when using the service-worker format/
 					);
 				});
 			});

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -819,7 +819,7 @@ describe("writes debug logs to hidden file", () => {
 	});
 });
 
-describe("analytics engine", () => {
+describe.only("analytics engine", () => {
 	describe.each([{ cmd: "wrangler dev" }, { cmd: "wrangler dev --remote" }])(
 		"mock analytics engine datasets: $cmd",
 		({ cmd }) => {
@@ -868,7 +868,7 @@ describe("analytics engine", () => {
 				});
 			});
 
-			describe("service worker", async () => {
+			describe.skip("service worker", async () => {
 				it("analytics engine datasets are mocked in dev", async () => {
 					const helper = new WranglerE2ETestHelper();
 					await helper.seed({

--- a/packages/wrangler/e2e/dev.test.ts
+++ b/packages/wrangler/e2e/dev.test.ts
@@ -819,7 +819,7 @@ describe("writes debug logs to hidden file", () => {
 	});
 });
 
-describe.only("analytics engine", () => {
+describe("analytics engine", () => {
 	describe.each([{ cmd: "wrangler dev" }])(
 		"mock analytics engine datasets: $cmd",
 		({ cmd }) => {

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -328,6 +328,16 @@ async function resolveConfig(
 		);
 	}
 
+	if (
+		extractBindingsOfType("analytics_engine", resolved.bindings).length &&
+		!resolved.dev.remote &&
+		resolved.build.format === "service-worker"
+	) {
+		logger.warn(
+			"Analytics Engine is not supported locally when using the service-worker format. Please migrate to the module worker format: https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/"
+		);
+	}
+
 	validateAssetsArgsAndConfig(resolved);
 
 	const services = extractBindingsOfType("service", resolved.bindings);

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -377,7 +377,9 @@ export function printBindings(
 			entries: analytics_engine_datasets.map(({ binding, dataset }) => {
 				return {
 					key: binding,
-					value: addSuffix(dataset ?? binding),
+					value: addSuffix(dataset ?? binding, {
+						isSimulatedLocally: true,
+					}),
 				};
 			}),
 		});


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/9254

Because AE was available before JSRPC, using JSRPC for it's local simulator causes failures for Workers with a compat date before the JSRPC flag was enabled. Shifting to a Wrapped binding should resolve this. 

Note: AE is still a no-op in local dev—this PR changes no functionality.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: bugfix to change made in v4 (https://github.com/cloudflare/workers-sdk/pull/8935)
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
