### PR TITLE
Revert R2 bucket validation for `pages dev` commands

### DIFF
--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -115,7 +115,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 					}`,
 			});
 			const worker = helper.runLongLived(
-				`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 test-r2`
+				`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 TEST_R2`
 			);
 			await worker.waitForReady();
 			expect(normalizeOutput(worker.currentOutput)).toContain(
@@ -127,7 +127,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 					- D1 Databases:
 					  - TEST_D1: local-TEST_D1 (TEST_D1) [simulated locally]
 					- R2 Buckets:
-					  - test-r2: test-r2 [simulated locally]
+					  - TEST_R2: TEST_R2 [simulated locally]
 					- Services:
 					  - TEST_SERVICE: test-worker [not connected]
 		`

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -17,7 +17,6 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
 import { getBasePath } from "../paths";
-import { bucketFormatMessage, isValidR2BucketName } from "../r2/helpers";
 import * as shellquote from "../utils/shell-quote";
 import { buildFunctions } from "./buildFunctions";
 import { ROUTES_SPEC_VERSION, SECONDS_TO_WAIT_FOR_PROXY } from "./constants";
@@ -1267,15 +1266,6 @@ function getBindingsFromArgs(args: typeof pagesDevCommand.args): Partial<
 
 				if (!binding) {
 					logger.warn("Could not parse R2 binding:", r2.toString());
-					return;
-				}
-
-				const bucketName = ref || binding.toString();
-
-				if (!isValidR2BucketName(bucketName)) {
-					logger.error(
-						`The bucket name "${bucketName}" is invalid. ${bucketFormatMessage}`
-					);
 					return;
 				}
 


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/9253

Relax R2 bucket validation for `pages dev` commands

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: already documented like this
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: fix to a v3 change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
