### PR TITLE
V3 Backport [#9257]: Revert R2 bucket validation for  commands

### DIFF
--- a/.changeset/great-berries-grow.md
+++ b/.changeset/great-berries-grow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Relax R2 bucket validation for `pages dev` commands

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -115,7 +115,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 					}`,
 			});
 			const worker = helper.runLongLived(
-				`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 test-r2`
+				`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 TEST_R2`
 			);
 			await worker.waitForReady();
 			expect(normalizeOutput(worker.currentOutput)).toContain(
@@ -127,7 +127,7 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 					- D1 Databases:
 					  - TEST_D1: local-TEST_D1 (TEST_D1) [simulated locally]
 					- R2 Buckets:
-					  - test-r2: test-r2 [simulated locally]
+					  - TEST_R2: TEST_R2 [simulated locally]
 					- Services:
 					  - TEST_SERVICE: test-worker [not connected]
 		`

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -1273,7 +1273,7 @@ function getBindingsFromArgs(args: PagesDevArguments): Partial<
 				}
 
 				// The generated `bucket_name` might be invalid as per https://developers.cloudflare.com/r2/buckets/create-buckets/#bucket-level-operations
-				// However this name only applies to the dev environment and is not validated by miniflare.				
+				// However this name only applies to the dev environment and is not validated by miniflare.
 				return { binding, bucket_name: ref || binding.toString() };
 			})
 			.filter(Boolean) as EnvironmentNonInheritable["r2_buckets"];

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -16,7 +16,6 @@ import { logger } from "../logger";
 import * as metrics from "../metrics";
 import { isNavigatorDefined } from "../navigator-user-agent";
 import { getBasePath } from "../paths";
-import { bucketFormatMessage, isValidR2BucketName } from "../r2/helpers";
 import * as shellquote from "../utils/shell-quote";
 import { printWranglerBanner } from "../wrangler-banner";
 import { buildFunctions } from "./buildFunctions";
@@ -1270,15 +1269,6 @@ function getBindingsFromArgs(args: PagesDevArguments): Partial<
 
 				if (!binding) {
 					logger.warn("Could not parse R2 binding:", r2.toString());
-					return;
-				}
-
-				const bucketName = ref || binding.toString();
-
-				if (!isValidR2BucketName(bucketName)) {
-					logger.error(
-						`The bucket name "${bucketName}" is invalid. ${bucketFormatMessage}`
-					);
 					return;
 				}
 

--- a/packages/wrangler/src/pages/dev.ts
+++ b/packages/wrangler/src/pages/dev.ts
@@ -1272,6 +1272,8 @@ function getBindingsFromArgs(args: PagesDevArguments): Partial<
 					return;
 				}
 
+				// The generated `bucket_name` might be invalid as per https://developers.cloudflare.com/r2/buckets/create-buckets/#bucket-level-operations
+				// However this name only applies to the dev environment and is not validated by miniflare.				
 				return { binding, bucket_name: ref || binding.toString() };
 			})
 			.filter(Boolean) as EnvironmentNonInheritable["r2_buckets"];


### PR DESCRIPTION
This is an automatically opened PR to backport patch changes from #9257 to Wrangler v3