### PR TITLE
V3 Backport [#9234]: add no-op  to getPlatformProxy to fix types mismatch

### DIFF
--- a/.changeset/clear-beans-leave.md
+++ b/.changeset/clear-beans-leave.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: add no-op `props` to `ctx` in `getPlatformProxy` to fix type mismatch

--- a/fixtures/get-platform-proxy/tests/get-platform-proxy.ctx.test.ts
+++ b/fixtures/get-platform-proxy/tests/get-platform-proxy.ctx.test.ts
@@ -33,6 +33,7 @@ describe("getPlatformProxy - ctx", () => {
 			expect(ctx.constructor.name).toBe("ExecutionContext");
 			expect(typeof ctx.waitUntil).toBe("function");
 			expect(typeof ctx.passThroughOnException).toBe("function");
+			expect(ctx.props).toEqual({});
 
 			ctx.waitUntil = ((str: string) => `- ${str} -`) as any;
 			expect(ctx.waitUntil("waitUntil can be overridden" as any)).toBe(

--- a/packages/wrangler/src/api/integrations/platform/executionContext.ts
+++ b/packages/wrangler/src/api/integrations/platform/executionContext.ts
@@ -11,5 +11,5 @@ export class ExecutionContext {
 		}
 	}
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	props: any;
+	props: any = {};
 }

--- a/packages/wrangler/src/api/integrations/platform/executionContext.ts
+++ b/packages/wrangler/src/api/integrations/platform/executionContext.ts
@@ -10,5 +10,6 @@ export class ExecutionContext {
 			throw new Error("Illegal invocation");
 		}
 	}
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	props: any;
 }

--- a/packages/wrangler/src/api/integrations/platform/executionContext.ts
+++ b/packages/wrangler/src/api/integrations/platform/executionContext.ts
@@ -10,4 +10,5 @@ export class ExecutionContext {
 			throw new Error("Illegal invocation");
 		}
 	}
+	props: any;
 }


### PR DESCRIPTION
This is an automatically opened PR to backport patch changes from #9234 to Wrangler v3