### PR TITLE
docs: include links to the docs in the wrangler config schema

### DIFF
--- a/.changeset/social-carpets-start.md
+++ b/.changeset/social-carpets-start.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+docs: add documentation links to individual config properties in the JSON schema of the Wrangler config file

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -65,6 +65,8 @@ export interface ConfigFields<Dev extends RawDevConfig> {
 
 	/**
 	 * Options to configure the development server that your worker will use.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#local-development-settings
 	 */
 	dev: Dev;
 
@@ -73,6 +75,8 @@ export interface ConfigFields<Dev extends RawDevConfig> {
 	 * static assets with your Worker.
 	 *
 	 * More details at https://developers.cloudflare.com/workers/platform/sites
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#workers-sites
 	 */
 	site:
 		| {
@@ -152,6 +156,8 @@ export interface ConfigFields<Dev extends RawDevConfig> {
 	/**
 	 * A map of module aliases. Lets you swap out a module for any others.
 	 * Corresponds with esbuild's `alias` config
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#module-aliasing
 	 */
 	alias: { [key: string]: string } | undefined;
 

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -200,6 +200,7 @@ interface EnvironmentInheritable {
 	 * Whether we use <name>.<subdomain>.workers.dev to
 	 * test and deploy your Worker.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#workersdev
 	 *
 	 * @default true
 	 * @breaking
@@ -222,6 +223,8 @@ interface EnvironmentInheritable {
 	 * Only one of `routes` or `route` is required.
 	 *
 	 * Only required when workers_dev is false, and there's no scheduled Worker (see `triggers`)
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#types-of-routes
 	 *
 	 * @inheritable
 	 */
@@ -280,6 +283,8 @@ interface EnvironmentInheritable {
 	 *
 	 * More details here https://developers.cloudflare.com/workers/platform/cron-triggers
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#triggers
+	 *
 	 * @default {crons:[]}
 	 * @inheritable
 	 */
@@ -288,6 +293,8 @@ interface EnvironmentInheritable {
 	/**
 	 * Specify limits for runtime behavior.
 	 * Only supported for the "standard" Usage Model
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#limits
 	 *
 	 * @inheritable
 	 */
@@ -299,6 +306,8 @@ interface EnvironmentInheritable {
 	 * to use Text, Data, and CompiledWasm modules, or when you wish to
 	 * have a .js file be treated as an ESModule instead of CommonJS.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#bundling
+	 *
 	 * @inheritable
 	 */
 	rules: Rule[];
@@ -308,6 +317,8 @@ interface EnvironmentInheritable {
 	 *
 	 * Refer to the [custom builds documentation](https://developers.cloudflare.com/workers/cli-wrangler/configuration#build)
 	 * for more details.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#custom-builds
 	 *
 	 * @default {watch_dir:"./src"}
 	 */
@@ -376,6 +387,9 @@ interface EnvironmentInheritable {
 
 	/**
 	 * Include source maps when uploading this worker.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#source-maps
+	 *
 	 * @inheritable
 	 */
 	upload_source_maps: boolean | undefined;
@@ -394,12 +408,16 @@ interface EnvironmentInheritable {
 	 *
 	 * More details at https://developers.cloudflare.com/workers/frameworks/
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#assets
+	 *
 	 * @inheritable
 	 */
 	assets: Assets | undefined;
 
 	/**
 	 * Specify the observability behavior of the Worker.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#observability
 	 *
 	 * @inheritable
 	 */
@@ -454,6 +472,8 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
+	 *
 	 * @default {}
 	 * @nonInheritable
 	 */
@@ -467,6 +487,8 @@ export interface EnvironmentNonInheritable {
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#durable-objects
 	 *
 	 * @default {bindings:[]}
 	 * @nonInheritable
@@ -515,6 +537,8 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#kv-namespaces
+	 *
 	 * @default []
 	 * @nonInheritable
 	 */
@@ -535,6 +559,8 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#email-bindings
+	 *
 	 * @default []
 	 * @nonInheritable
 	 */
@@ -552,6 +578,8 @@ export interface EnvironmentNonInheritable {
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#queues
 	 *
 	 * @default {consumers:[],producers:[]}
 	 * @nonInheritable
@@ -609,6 +637,8 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#r2-buckets
+	 *
 	 * @default []
 	 * @nonInheritable
 	 */
@@ -630,6 +660,8 @@ export interface EnvironmentNonInheritable {
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#d1-databases
 	 *
 	 * @default []
 	 * @nonInheritable
@@ -659,6 +691,8 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#vectorize-indexes
+	 *
 	 * @default []
 	 * @nonInheritable
 	 */
@@ -674,6 +708,8 @@ export interface EnvironmentNonInheritable {
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#hyperdrive
 	 *
 	 * @default []
 	 * @nonInheritable
@@ -692,6 +728,8 @@ export interface EnvironmentNonInheritable {
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#service-bindings
 	 *
 	 * @default []
 	 * @nonInheritable
@@ -719,6 +757,8 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#analytics-engine-datasets
+	 *
 	 * @default []
 	 * @nonInheritable
 	 */
@@ -735,6 +775,8 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#browser-rendering
+	 *
 	 * @default {}
 	 * @nonInheritable
 	 */
@@ -749,6 +791,8 @@ export interface EnvironmentNonInheritable {
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#workers-ai
 	 *
 	 * @default {}
 	 * @nonInheritable
@@ -765,6 +809,8 @@ export interface EnvironmentNonInheritable {
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#images
 	 *
 	 * @default {}
 	 * @nonInheritable
@@ -835,6 +881,8 @@ export interface EnvironmentNonInheritable {
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
 	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#mtls-certificates
+	 *
 	 * @default []
 	 * @nonInheritable
 	 */
@@ -861,6 +909,8 @@ export interface EnvironmentNonInheritable {
 	 *
 	 * NOTE: This field is not automatically inherited from the top level environment,
 	 * and so must be specified in every named environment.
+	 *
+	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#dispatch-namespace-bindings-workers-for-platforms
 	 *
 	 * @default []
 	 * @nonInheritable


### PR DESCRIPTION
Fixes n/a.

This adds a link to the docs in the wrangler config json schema. We don't have an entry in the docs for every individual config so I have only included those I found on https://developers.cloudflare.com/workers/wrangler/configuration

<img width="597" alt="Screenshot 2025-05-15 at 15 11 10" src="https://github.com/user-attachments/assets/ce3518fa-25dd-4ccf-9aeb-517c30b77631" />

Suggested by @Ankcorn 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: comment change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: comment change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: comment change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: comment change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
