### PR TITLE
fix: setting triggers.crons:[] in Wrangler config should delete deployed cron schedules

### DIFF
--- a/.changeset/shaky-planets-feel.md
+++ b/.changeset/shaky-planets-feel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: setting triggers.crons:[] in Wrangler config should delete deployed cron schedules

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -114,7 +114,7 @@ describe("normalizeAndValidateConfig()", () => {
 			ai: undefined,
 			version_metadata: undefined,
 			triggers: {
-				crons: [],
+				crons: undefined,
 			},
 			unsafe: {
 				bindings: undefined,

--- a/packages/wrangler/src/__tests__/metrics.test.ts
+++ b/packages/wrangler/src/__tests__/metrics.test.ts
@@ -30,9 +30,9 @@ import { writeWranglerConfig } from "./helpers/write-wrangler-config";
 import type { MockInstance } from "vitest";
 
 vi.mock("../metrics/helpers");
-vi.unmock("../metrics/metrics-config");
 vi.mock("../metrics/send-event");
 vi.mock("../package-manager");
+vi.mocked(getMetricsConfig).mockReset();
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 declare module globalThis {
@@ -44,7 +44,7 @@ describe("metrics", () => {
 	let isCISpy: MockInstance;
 	const std = mockConsoleMethods();
 	const { setIsTTY } = useMockIsTTY();
-	runInTempDir();
+	runInTempDir({ homedir: "foo" });
 
 	beforeEach(async () => {
 		isCISpy = vi.spyOn(CI, "isCI").mockReturnValue(false);

--- a/packages/wrangler/src/__tests__/vitest.setup.ts
+++ b/packages/wrangler/src/__tests__/vitest.setup.ts
@@ -162,18 +162,16 @@ vi.mock("xdg-app-paths", () => {
 vi.mock("../metrics/metrics-config", async (importOriginal) => {
 	const realModule =
 		await importOriginal<typeof import("../metrics/metrics-config")>();
-	const fakeModule = {
-		...realModule,
-		getMetricsConfig: () => async () => {
-			return {
-				enabled: false,
-				deviceId: "mock-device",
-				userId: undefined,
-			};
-		},
-	};
-	return fakeModule;
+	vi.spyOn(realModule, "getMetricsConfig").mockImplementation(() => {
+		return {
+			enabled: false,
+			deviceId: "mock-device",
+			userId: undefined,
+		};
+	});
+	return realModule;
 });
+
 vi.mock("prompts", () => {
 	return {
 		__esModule: true,

--- a/packages/wrangler/src/config/config.ts
+++ b/packages/wrangler/src/config/config.ts
@@ -332,7 +332,7 @@ export const defaultWranglerConfig: Config = {
 	jsx_fragment: "React.Fragment",
 	migrations: [],
 	triggers: {
-		crons: [],
+		crons: undefined,
 	},
 	rules: [],
 	build: { command: undefined, watch_dir: "./src", cwd: undefined },

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -285,10 +285,10 @@ interface EnvironmentInheritable {
 	 *
 	 * For reference, see https://developers.cloudflare.com/workers/wrangler/configuration/#triggers
 	 *
-	 * @default {crons:[]}
+	 * @default {crons: undefined}
 	 * @inheritable
 	 */
-	triggers: { crons: string[] };
+	triggers: { crons: string[] | undefined };
 
 	/**
 	 * Specify limits for runtime behavior.

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -17,7 +17,6 @@ import {
 	inheritableInLegacyEnvironments,
 	isBoolean,
 	isMutuallyExclusiveWith,
-	isObjectWith,
 	isOptionalProperty,
 	isRequiredProperty,
 	isString,
@@ -1122,8 +1121,8 @@ function normalizeAndValidateEnvironment(
 			topLevelEnv,
 			rawEnv,
 			"triggers",
-			isObjectWith("crons"),
-			{ crons: [] }
+			validateTriggers,
+			{ crons: undefined }
 		),
 		assets: normalizeAndValidateAssets(diagnostics, topLevelEnv, rawEnv),
 		limits: normalizeAndValidateLimits(diagnostics, topLevelEnv, rawEnv),
@@ -1507,6 +1506,44 @@ const validateAndNormalizeRules = (
 		validateRules(envName),
 		[]
 	);
+};
+
+const validateTriggers: ValidatorFn = (
+	diagnostics,
+	triggersFieldName,
+	triggersValue
+) => {
+	if (triggersValue === undefined || triggersValue === null) {
+		return true;
+	}
+
+	if (typeof triggersValue !== "object") {
+		diagnostics.errors.push(
+			`Expected "${triggersFieldName}" to be of type object but got ${JSON.stringify(
+				triggersValue
+			)}.`
+		);
+		return false;
+	}
+
+	let isValid = true;
+
+	if ("crons" in triggersValue && !Array.isArray(triggersValue.crons)) {
+		diagnostics.errors.push(
+			`Expected "${triggersFieldName}.crons" to be of type array, but got ${JSON.stringify(triggersValue)}.`
+		);
+		isValid = false;
+	}
+
+	isValid =
+		validateAdditionalProperties(
+			diagnostics,
+			triggersFieldName,
+			Object.keys(triggersValue),
+			["crons"]
+		) && isValid;
+
+	return isValid;
 };
 
 const validateRules =

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -1138,7 +1138,7 @@ export async function buildMiniflareOptions(
 	internalObjects: CfDurableObject[];
 	entrypointNames: string[];
 }> {
-	if (config.crons.length > 0 && !config.testScheduled) {
+	if (config.crons?.length && !config.testScheduled) {
 		if (!didWarnMiniflareCronSupport) {
 			didWarnMiniflareCronSupport = true;
 			logger.warn(

--- a/packages/wrangler/src/triggers/deploy.ts
+++ b/packages/wrangler/src/triggers/deploy.ts
@@ -38,7 +38,7 @@ export default async function triggersDeploy(
 ): Promise<string[] | void> {
 	const { config, accountId, name: scriptName } = props;
 
-	const triggers = props.triggers || config.triggers?.crons;
+	const schedules = props.triggers || config.triggers?.crons;
 	const routes =
 		props.routes ?? config.routes ?? (config.route ? [config.route] : []) ?? [];
 	const routesOnly: Array<Route> = [];
@@ -258,17 +258,18 @@ export default async function triggersDeploy(
 	}
 
 	// Configure any schedules for the script.
-	// TODO: rename this to `schedules`?
-	if (triggers && triggers.length) {
+	// If schedules is not defined then we just leave whatever is previously deployed alone.
+	// If it is an empty array we will remove all schedules.
+	if (schedules) {
 		deployments.push(
 			fetchResult(`${workerUrl}/schedules`, {
 				// Note: PUT will override previous schedules on this script.
 				method: "PUT",
-				body: JSON.stringify(triggers.map((cron) => ({ cron }))),
+				body: JSON.stringify(schedules.map((cron) => ({ cron }))),
 				headers: {
 					"Content-Type": "application/json",
 				},
-			}).then(() => triggers.map((trigger) => `schedule: ${trigger}`))
+			}).then(() => schedules.map((trigger) => `schedule: ${trigger}`))
 		);
 	}
 


### PR DESCRIPTION
Fixes #9180

Previously if the array was empty it would just not touch the deployed schedules.
Providing either `triggers: { crons: undefined }` or no `triggers` property in your Wrangler configuration will continue to leave the deployed schedules untouched.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/22462
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [x] Wrangler PR: https://github.com/cloudflare/workers-sdk/pull/9267
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
