### PR TITLE
Wire up mixed-mode remote bindings for multi-worker `wrangler dev`

### DIFF
--- a/.changeset/dull-areas-invent.md
+++ b/.changeset/dull-areas-invent.md
@@ -1,0 +1,9 @@
+---
+"wrangler": patch
+---
+
+Wire up mixed-mode remote bindings for multi-worker `wrangler dev`
+
+Under the `--x-mixed-mode` flag, make sure that bindings configurations with `remote: true` actually generate bindings to remote resources during a multi-worker `wrangler dev` session, currently the bindings included in this are: services, kv_namespaces, r2_buckets, d1_databases, queues and workflows.
+
+Also include the ai binding since the bindings is already remote by default anyways.

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -335,7 +335,7 @@ function maybeGetCustomServiceService(
 		};
 	} else if (
 		typeof service === "object" &&
-		"mixedModeConnectionString" in service
+		service.mixedModeConnectionString !== undefined
 	) {
 		assert(
 			service.mixedModeConnectionString &&

--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -90,6 +90,76 @@ describe("wrangler dev - mixed mode", () => {
 			"
 		`);
 	});
+
+	describe("multi-worker", () => {
+		it("handles both remote and local service bindings at the same time in all workers", async () => {
+			const helper = new WranglerE2ETestHelper();
+			await helper.seed({
+				"wrangler.json": JSON.stringify({
+					name: "mixed-mode-mixed-bindings-multi-worker-test",
+					main: "index.js",
+					compatibility_date: "2025-05-07",
+					services: [
+						{
+							binding: "LOCAL_TEST_WORKER",
+							service: "local-test-worker",
+							remote: false,
+						},
+						{
+							binding: "REMOTE_WORKER",
+							service: "mixed-mode-test-target",
+							remote: true,
+						},
+					],
+				}),
+				"index.js": dedent`
+								export default {
+									async fetch(request, env) {
+										const remoteWorkerText = await (await env.REMOTE_WORKER.fetch(request)).text();
+										const localTestWorkerText = await (await env.LOCAL_TEST_WORKER.fetch(request)).text();
+										return new Response(\`[main-test-worker]REMOTE<WORKER>: \${remoteWorkerText}\\n\${localTestWorkerText}\\n\`);
+									}
+								}`,
+			});
+			const localTest = makeRoot();
+			await seed(localTest, {
+				"wrangler.json": JSON.stringify({
+					name: "local-test-worker",
+					main: "index.js",
+					compatibility_date: "2025-05-07",
+					services: [
+						{
+							// Note: we use the same binding name but bound to a difference service
+							binding: "REMOTE_WORKER",
+							service: "mixed-mode-test-target-alt",
+							remote: true,
+						},
+					],
+				}),
+				"index.js": dedent`
+								export default {
+									async fetch(request, env) {
+										const remoteWorkerText = await (await env.REMOTE_WORKER.fetch(request)).text();
+										return new Response(\`[local-test-worker]REMOTE<WORKER>: \${remoteWorkerText}\`);
+									}
+								}`,
+			});
+
+			const worker = helper.runLongLived(
+				`wrangler dev --x-mixed-mode -c wrangler.json -c ${localTest}/wrangler.json`
+			);
+
+			const { url } = await worker.waitForReady();
+
+			await expect(fetchText(url)).resolves.toMatchInlineSnapshot(
+				`
+				"[main-test-worker]REMOTE<WORKER>: Hello World!
+				[local-test-worker]REMOTE<WORKER>: Hello World! (alternative)
+				"
+			`
+			);
+		});
+	});
 });
 
 async function spawnLocalWorker(helper: WranglerE2ETestHelper): Promise<void> {


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1854

The changes here make it so that the user can set `remote: true` to some of 
their bindings and such bindings will be run remotely via `startMixedModeSession`
when running `wrangler dev` on a multiple workers


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new experimental feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
