### PR TITLE
Add support for static routing (i.e. \_routes.json) to Workers Assets

### DIFF
--- a/.changeset/tasty-hoops-own.md
+++ b/.changeset/tasty-hoops-own.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/workers-shared": minor
+---
+
+Adds support for static routing (i.e. \_routes.json) to Workers Assets
+
+Implements the proposal noted here https://github.com/cloudflare/workers-sdk/discussions/9143
+
+In brief: when static routing is present for a Worker with assets, routing via those static rules takes precedence. When a request is evaluated in the Router Worker, the request path is first compared to the "exclude" rules. If any match, the request is forwarded directly to the Asset Worker. If instead any "include" rules match, the request is forwarded directly to the User Worker. If neither match (or static routing was not provided), the existing behavior takes over.
+
+As part of this explicit routing, when static routing is present, the check against "Sec-Fetch-Mode: navigate" (to guess if this should serve an asset or go to the User Worker for not_found_handling) is disabled. Routing can be controlled by uploading a \_routes.json, and asset serving (including when an index.html or 404.html page is served) will be more simple.

--- a/packages/workers-shared/asset-worker/src/configuration.ts
+++ b/packages/workers-shared/asset-worker/src/configuration.ts
@@ -20,6 +20,7 @@ export const normalizeConfiguration = (
 			version: 2,
 			rules: {},
 		},
+		has_static_routing: configuration?.has_static_routing ?? false,
 		account_id: configuration?.account_id ?? -1,
 		script_id: configuration?.script_id ?? -1,
 		debug: configuration?.debug ?? false,

--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -203,7 +203,9 @@ export const canFetch = async (
 			flagIsEnabled(
 				configuration,
 				SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING
-			) && request.headers.get("Sec-Fetch-Mode") === "navigate"
+			) &&
+			request.headers.get("Sec-Fetch-Mode") === "navigate" &&
+			!configuration.has_static_routing
 		)
 	) {
 		configuration = {

--- a/packages/workers-shared/asset-worker/src/utils/rules-engine.ts
+++ b/packages/workers-shared/asset-worker/src/utils/rules-engine.ts
@@ -28,6 +28,43 @@ export const replacer = (str: string, replacements: Replacements) => {
 	return str;
 };
 
+export const generateGlobOnlyRuleRegExp = (rule: string) => {
+	// Escape all regex characters other than globs (the "*" character) since that's all that's supported.
+	rule = rule.split("*").map(escapeRegex).join(".*");
+
+	// Wrap in line terminators to be safe.
+	rule = "^" + rule + "$";
+
+	return RegExp(rule);
+};
+
+export const generateRuleRegExp = (rule: string) => {
+	// Create :splat capturer then escape.
+	rule = rule.split("*").map(escapeRegex).join("(?<splat>.*)");
+
+	// Create :placeholder capturers (already escaped).
+	// For placeholders in the host, we separate at forward slashes and periods.
+	// For placeholders in the path, we separate at forward slashes.
+	// This matches the behavior of URLPattern.
+	// e.g. https://:subdomain.domain/ -> https://(here).domain/
+	// e.g. /static/:file -> /static/(image.jpg)
+	// e.g. /blog/:post -> /blog/(an-exciting-post)
+	const host_matches = rule.matchAll(HOST_PLACEHOLDER_REGEX);
+	for (const host_match of host_matches) {
+		rule = rule.split(host_match[0]).join(`(?<${host_match[1]}>[^/.]+)`);
+	}
+
+	const path_matches = rule.matchAll(PLACEHOLDER_REGEX);
+	for (const path_match of path_matches) {
+		rule = rule.split(path_match[0]).join(`(?<${path_match[1]}>[^/]+)`);
+	}
+
+	// Wrap in line terminators to be safe.
+	rule = "^" + rule + "$";
+
+	return RegExp(rule);
+};
+
 export const generateRulesMatcher = <T>(
 	rules?: Record<string, T>,
 	replacerFn: (match: T, replacements: Replacements) => T = (match) => match
@@ -40,31 +77,8 @@ export const generateRulesMatcher = <T>(
 		.map(([rule, match]) => {
 			const crossHost = rule.startsWith("https://");
 
-			// Create :splat capturer then escape.
-			rule = rule.split("*").map(escapeRegex).join("(?<splat>.*)");
-
-			// Create :placeholder capturers (already escaped).
-			// For placeholders in the host, we separate at forward slashes and periods.
-			// For placeholders in the path, we separate at forward slashes.
-			// This matches the behavior of URLPattern.
-			// e.g. https://:subdomain.domain/ -> https://(here).domain/
-			// e.g. /static/:file -> /static/(image.jpg)
-			// e.g. /blog/:post -> /blog/(an-exciting-post)
-			const host_matches = rule.matchAll(HOST_PLACEHOLDER_REGEX);
-			for (const host_match of host_matches) {
-				rule = rule.split(host_match[0]).join(`(?<${host_match[1]}>[^/.]+)`);
-			}
-
-			const path_matches = rule.matchAll(PLACEHOLDER_REGEX);
-			for (const path_match of path_matches) {
-				rule = rule.split(path_match[0]).join(`(?<${path_match[1]}>[^/]+)`);
-			}
-
-			// Wrap in line terminators to be safe.
-			rule = "^" + rule + "$";
-
 			try {
-				const regExp = new RegExp(rule);
+				const regExp = generateRuleRegExp(rule);
 				return [{ crossHost, regExp }, match];
 			} catch {}
 		})
@@ -131,3 +145,19 @@ export const generateRedirectsMatcher = (
 			to: replacer(to, replacements),
 		})
 	);
+
+export const generateStaticRoutingRuleMatcher =
+	(rules: string[]) =>
+	({ request }: { request: Request }) => {
+		const { pathname } = new URL(request.url);
+		for (const rule of rules) {
+			try {
+				const regExp = generateGlobOnlyRuleRegExp(rule);
+				if (regExp.test(pathname)) {
+					return true;
+				}
+			} catch {}
+		}
+
+		return false;
+	};

--- a/packages/workers-shared/asset-worker/tests/handler.test.ts
+++ b/packages/workers-shared/asset-worker/tests/handler.test.ts
@@ -1325,29 +1325,41 @@ describe("[Asset Worker] `canFetch`", () => {
 			[{ "Sec-Fetch-Mode": "cors" }, false],
 		] as const;
 
+		const staticRoutingModes = [
+			[false, true],
+			[true, false],
+		] as const;
+
 		const matrix = [];
 		for (const compatibilityOptions of compatibilityOptionsModes) {
 			for (const notFoundHandling of notFoundHandlingModes) {
 				for (const headers of headersModes) {
-					matrix.push({
-						compatibilityDate: compatibilityOptions[0].compatibilityDate,
-						compatibilityFlags: compatibilityOptions[0].compatibilityFlags,
-						notFoundHandling: notFoundHandling[0],
-						headers: headers[0],
-						expected:
-							compatibilityOptions[1] && notFoundHandling[1] && headers[1],
-					});
+					for (const hasStaticRouting of staticRoutingModes) {
+						matrix.push({
+							compatibilityDate: compatibilityOptions[0].compatibilityDate,
+							compatibilityFlags: compatibilityOptions[0].compatibilityFlags,
+							notFoundHandling: notFoundHandling[0],
+							headers: headers[0],
+							hasStaticRouting: hasStaticRouting[0],
+							expected:
+								compatibilityOptions[1] &&
+								notFoundHandling[1] &&
+								headers[1] &&
+								hasStaticRouting[1],
+						});
+					}
 				}
 			}
 		}
 
 		it.each(matrix)(
-			"compatibility_date $compatibilityDate, compatibility_flags $compatibilityFlags, not_found_handling $notFoundHandling, headers: $headers -> $expected",
+			"compatibility_date $compatibilityDate, compatibility_flags $compatibilityFlags, not_found_handling $notFoundHandling, headers: $headers, hasStaticRouting $hasStaticRouting -> $expected",
 			async ({
 				compatibilityDate,
 				compatibilityFlags,
 				notFoundHandling,
 				headers,
+				hasStaticRouting,
 				expected,
 			}) => {
 				expect(
@@ -1355,11 +1367,14 @@ describe("[Asset Worker] `canFetch`", () => {
 						new Request("https://example.com/foo", { headers }),
 						// @ts-expect-error Empty config default to using mocked jaeger
 						mockEnv,
-						normalizeConfiguration({
-							compatibility_date: compatibilityDate,
-							compatibility_flags: compatibilityFlags,
-							not_found_handling: notFoundHandling,
-						}),
+						{
+							...normalizeConfiguration({
+								compatibility_date: compatibilityDate,
+								compatibility_flags: compatibilityFlags,
+								not_found_handling: notFoundHandling,
+								has_static_routing: hasStaticRouting,
+							}),
+						},
 						exists
 					)
 				).toBeTruthy();
@@ -1369,11 +1384,14 @@ describe("[Asset Worker] `canFetch`", () => {
 						new Request("https://example.com/bar", { headers }),
 						// @ts-expect-error Empty config default to using mocked jaeger
 						mockEnv,
-						normalizeConfiguration({
-							compatibility_date: compatibilityDate,
-							compatibility_flags: compatibilityFlags,
-							not_found_handling: notFoundHandling,
-						}),
+						{
+							...normalizeConfiguration({
+								compatibility_date: compatibilityDate,
+								compatibility_flags: compatibilityFlags,
+								not_found_handling: notFoundHandling,
+								has_static_routing: hasStaticRouting,
+							}),
+						},
 						exists
 					)
 				).toBe(expected);
@@ -1383,11 +1401,14 @@ describe("[Asset Worker] `canFetch`", () => {
 						new Request("https://example.com/", { headers }),
 						// @ts-expect-error Empty config default to using mocked jaeger
 						mockEnv,
-						normalizeConfiguration({
-							compatibility_date: compatibilityDate,
-							compatibility_flags: compatibilityFlags,
-							not_found_handling: notFoundHandling,
-						}),
+						{
+							...normalizeConfiguration({
+								compatibility_date: compatibilityDate,
+								compatibility_flags: compatibilityFlags,
+								not_found_handling: notFoundHandling,
+								has_static_routing: hasStaticRouting,
+							}),
+						},
 						exists
 					)
 				).toBeTruthy();
@@ -1397,11 +1418,14 @@ describe("[Asset Worker] `canFetch`", () => {
 						new Request("https://example.com/404", { headers }),
 						// @ts-expect-error Empty config default to using mocked jaeger
 						mockEnv,
-						normalizeConfiguration({
-							compatibility_date: compatibilityDate,
-							compatibility_flags: compatibilityFlags,
-							not_found_handling: notFoundHandling,
-						}),
+						{
+							...normalizeConfiguration({
+								compatibility_date: compatibilityDate,
+								compatibility_flags: compatibilityFlags,
+								not_found_handling: notFoundHandling,
+								has_static_routing: hasStaticRouting,
+							}),
+						},
 						exists
 					)
 				).toBeTruthy();

--- a/packages/workers-shared/asset-worker/tests/rules-engine.test.ts
+++ b/packages/workers-shared/asset-worker/tests/rules-engine.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { generateRulesMatcher, replacer } from "../src/utils/rules-engine";
+import {
+	generateRulesMatcher,
+	generateStaticRoutingRuleMatcher,
+	replacer,
+} from "../src/utils/rules-engine";
 
 describe("rules engine", () => {
 	test("it should match simple pathname hosts", () => {
@@ -113,5 +117,255 @@ describe("replacer", () => {
 		).toEqual(
 			"Link: </assets/js/main.js>; rel=preload; as=script, </assets/js/lang.js>; rel=preload; as=script"
 		);
+	});
+});
+
+describe("static routing rules", () => {
+	test("should return true for a request that matches", () => {
+		expect(
+			generateStaticRoutingRuleMatcher(["/some/path"])({
+				request: new Request("https://site.com/some/path"),
+			})
+		).toEqual(true);
+
+		expect(
+			generateStaticRoutingRuleMatcher(["/some/*"])({
+				request: new Request("https://site.com/some/path"),
+			})
+		).toEqual(true);
+
+		expect(
+			generateStaticRoutingRuleMatcher(["/no/match", "/some/*"])({
+				request: new Request("https://site.com/some/path"),
+			})
+		).toEqual(true);
+	});
+
+	test("should return false for a request that does not match", () => {
+		expect(
+			generateStaticRoutingRuleMatcher(["/some/path"])({
+				request: new Request("https://site.com"),
+			})
+		).toEqual(false);
+
+		expect(
+			generateStaticRoutingRuleMatcher(["/some/*"])({
+				request: new Request("https://site.com/path"),
+			})
+		).toEqual(false);
+
+		expect(
+			generateStaticRoutingRuleMatcher(["/some/path", "/other/path"])({
+				request: new Request("https://site.com/path"),
+			})
+		).toEqual(false);
+
+		expect(
+			generateStaticRoutingRuleMatcher([])({
+				request: new Request("https://site.com/some/path"),
+			})
+		).toEqual(false);
+	});
+
+	test("should ignore regex characters other than a glob", () => {
+		{
+			const matcher = generateStaticRoutingRuleMatcher(["/"]);
+			expect(matcher({ request: new Request("http://example.com/") })).toEqual(
+				true
+			);
+			expect(matcher({ request: new Request("http://example.com") })).toEqual(
+				true
+			);
+			expect(
+				matcher({ request: new Request("http://example.com/?foo=bar") })
+			).toEqual(true);
+			expect(matcher({ request: new Request("https://example.com/") })).toEqual(
+				true
+			);
+			expect(
+				matcher({ request: new Request("http://example.com/foo") })
+			).toEqual(false);
+		}
+
+		{
+			const matcher = generateStaticRoutingRuleMatcher(["/foo"]);
+			expect(
+				matcher({ request: new Request("http://example.com/foo") })
+			).toEqual(true);
+			expect(matcher({ request: new Request("https://example.com/") })).toEqual(
+				false
+			);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/") })
+			).toEqual(false);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/bar") })
+			).toEqual(false);
+			expect(
+				matcher({ request: new Request("https://example.com/baz") })
+			).toEqual(false);
+			expect(
+				matcher({ request: new Request("https://example.com/baz/foo") })
+			).toEqual(false);
+			expect(
+				matcher({ request: new Request("https://example.com/foobar") })
+			).toEqual(false);
+		}
+
+		{
+			const matcher = generateStaticRoutingRuleMatcher(["/foo*"]);
+			expect(
+				matcher({ request: new Request("http://example.com/foo") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/bar") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foobar") })
+			).toEqual(true);
+			expect(matcher({ request: new Request("https://example.com/") })).toEqual(
+				false
+			);
+			expect(
+				matcher({ request: new Request("https://example.com/baz") })
+			).toEqual(false);
+			expect(
+				matcher({ request: new Request("https://example.com/baz/foo") })
+			).toEqual(false);
+		}
+
+		{
+			const matcher = generateStaticRoutingRuleMatcher(["/*.html"]);
+			expect(
+				matcher({ request: new Request("http://example.com/foo.html") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("http://example.com/foo/bar.html") })
+			).toEqual(true);
+			expect(matcher({ request: new Request("http://example.com/") })).toEqual(
+				false
+			);
+			expect(
+				matcher({ request: new Request("http://example.com/foo") })
+			).toEqual(false);
+			expect(
+				matcher({ request: new Request("http://example.com/foo/bar") })
+			).toEqual(false);
+		}
+
+		{
+			const matcher = generateStaticRoutingRuleMatcher(["/login/*"]);
+			expect(
+				matcher({ request: new Request("http://example.com/login/foo") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("http://example2.com/login/foo") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("http://example.com/foo/login/foo") })
+			).toEqual(false);
+			expect(
+				matcher({
+					request: new Request("http://example.com/foo?bar=baz/login/foo"),
+				})
+			).toEqual(false);
+		}
+
+		{
+			const matcher = generateStaticRoutingRuleMatcher(["/*"]);
+			expect(
+				matcher({ request: new Request("http://foo.example.com/bar") })
+			).toEqual(true);
+			expect(
+				matcher({
+					request: new Request("http://example2.com/foo.example.com/baz"),
+				})
+			).toEqual(true);
+			expect(
+				matcher({
+					request: new Request("http://example2.com/?q=foo.example.com/baz"),
+				})
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo.html") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/bar.html") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("http://example.com/foo") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/bar") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foobar") })
+			).toEqual(true);
+			expect(matcher({ request: new Request("http://example.com/") })).toEqual(
+				true
+			);
+			expect(matcher({ request: new Request("https://example.com/") })).toEqual(
+				true
+			);
+			expect(matcher({ request: new Request("http://example.com") })).toEqual(
+				true
+			);
+			expect(matcher({ request: new Request("https://example.com") })).toEqual(
+				true
+			);
+		}
+
+		{
+			const matcher = generateStaticRoutingRuleMatcher(["*/*"]);
+			expect(
+				matcher({ request: new Request("http://foo.example.com/bar") })
+			).toEqual(true);
+			expect(
+				matcher({
+					request: new Request("http://example2.com/foo.example.com/baz"),
+				})
+			).toEqual(true);
+			expect(
+				matcher({
+					request: new Request("http://example2.com/?q=foo.example.com/baz"),
+				})
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo.html") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/bar.html") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("http://example.com/foo") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foo/bar") })
+			).toEqual(true);
+			expect(
+				matcher({ request: new Request("https://example.com/foobar") })
+			).toEqual(true);
+			expect(matcher({ request: new Request("http://example.com/") })).toEqual(
+				true
+			);
+			expect(matcher({ request: new Request("https://example.com/") })).toEqual(
+				true
+			);
+			expect(matcher({ request: new Request("http://example.com") })).toEqual(
+				true
+			);
+			expect(matcher({ request: new Request("https://example.com") })).toEqual(
+				true
+			);
+		}
 	});
 });

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -3,6 +3,13 @@ import type { ReadyAnalytics } from "./types";
 // This will allow us to make breaking changes to the analytic schema
 const VERSION = 1;
 
+export enum STATIC_ROUTING_DECISION {
+	NOT_PROVIDED = 0,
+	NOT_ROUTED = 1,
+	EXCLUDE = 2,
+	INCLUDE = 3,
+}
+
 export enum DISPATCH_TYPE {
 	ASSETS = "asset",
 	WORKER = "worker",
@@ -25,6 +32,8 @@ type Data = {
 	coloTier?: number;
 	// double5 - Run user worker ahead of assets
 	userWorkerAhead?: boolean;
+	// double6 - Routing performed based on the _routes.json (if provided)
+	staticRoutingDecision?: STATIC_ROUTING_DECISION;
 
 	// -- Blobs --
 	// blob1 - Hostname of the request
@@ -79,6 +88,7 @@ export class Analytics {
 				this.data.userWorkerAhead === undefined // double5
 					? -1
 					: Number(this.data.userWorkerAhead),
+				this.data.staticRoutingDecision ?? STATIC_ROUTING_DECISION.NOT_PROVIDED, // double6
 			],
 			blobs: [
 				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes

--- a/packages/workers-shared/router-worker/src/configuration.ts
+++ b/packages/workers-shared/router-worker/src/configuration.ts
@@ -10,5 +10,9 @@ export const applyConfigurationDefaults = (
 		account_id: configuration?.account_id ?? -1,
 		script_id: configuration?.script_id ?? -1,
 		debug: configuration?.debug ?? false,
+		static_routing: configuration?.static_routing ?? {
+			version: 1,
+			include: [],
+		},
 	};
 };

--- a/packages/workers-shared/router-worker/src/index.ts
+++ b/packages/workers-shared/router-worker/src/index.ts
@@ -1,7 +1,8 @@
+import { generateStaticRoutingRuleMatcher } from "../../asset-worker/src/utils/rules-engine";
 import { PerformanceTimer } from "../../utils/performance";
 import { setupSentry } from "../../utils/sentry";
 import { mockJaegerBinding } from "../../utils/tracing";
-import { Analytics, DISPATCH_TYPE } from "./analytics";
+import { Analytics, DISPATCH_TYPE, STATIC_ROUTING_DECISION } from "./analytics";
 import { applyConfigurationDefaults } from "./configuration";
 import type AssetWorker from "../../asset-worker/src/index";
 import type {
@@ -53,6 +54,7 @@ export default {
 				env.CONFIG?.script_id
 			);
 
+			const hasStaticRouting = env.CONFIG.static_routing !== undefined;
 			const config = applyConfigurationDefaults(env.CONFIG);
 
 			const url = new URL(request.url);
@@ -74,6 +76,69 @@ export default {
 			}
 
 			const maybeSecondRequest = request.clone();
+
+			if (config.static_routing) {
+				// evaluate "exclude" rules
+				const excludeRulesMatcher = generateStaticRoutingRuleMatcher(
+					config.static_routing.exclude ?? []
+				);
+				if (
+					excludeRulesMatcher({
+						request,
+					})
+				) {
+					// direct to asset worker
+					analytics.setData({
+						dispatchtype: DISPATCH_TYPE.ASSETS,
+						staticRoutingDecision: STATIC_ROUTING_DECISION.EXCLUDE,
+					});
+					return await env.JAEGER.enterSpan("dispatch_assets", async (span) => {
+						span.setTags({
+							hasUserWorker: config.has_user_worker,
+							asset: "static_routing",
+							dispatchType: DISPATCH_TYPE.ASSETS,
+						});
+
+						return env.ASSET_WORKER.fetch(maybeSecondRequest);
+					});
+				}
+				// evaluate "include" rules
+				const includeRulesMatcher = generateStaticRoutingRuleMatcher(
+					config.static_routing.include
+				);
+				if (
+					includeRulesMatcher({
+						request,
+					})
+				) {
+					if (!config.has_user_worker) {
+						throw new Error(
+							"Fetch for user worker without having a user worker binding"
+						);
+					}
+					// direct to user worker
+					analytics.setData({
+						dispatchtype: DISPATCH_TYPE.WORKER,
+						staticRoutingDecision: STATIC_ROUTING_DECISION.INCLUDE,
+					});
+					return await env.JAEGER.enterSpan("dispatch_worker", async (span) => {
+						span.setTags({
+							hasUserWorker: true,
+							asset: "static_routing",
+							dispatchType: DISPATCH_TYPE.WORKER,
+						});
+
+						userWorkerInvocation = true;
+						return env.USER_WORKER.fetch(maybeSecondRequest);
+					});
+				}
+
+				analytics.setData({
+					staticRoutingDecision: hasStaticRouting
+						? STATIC_ROUTING_DECISION.NOT_ROUTED
+						: STATIC_ROUTING_DECISION.NOT_PROVIDED,
+				});
+			}
 
 			// User's configuration indicates they want user-Worker to run ahead of any
 			// assets. Do not provide any fallback logic.

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -15,7 +15,7 @@ describe("unit tests", async () => {
 			},
 		} as Env;
 
-		void expect(
+		await expect(
 			async () => await worker.fetch(request, env, ctx)
 		).rejects.toThrowError(
 			"Fetch for user worker without having a user worker binding"

--- a/packages/workers-shared/router-worker/tests/index.test.ts
+++ b/packages/workers-shared/router-worker/tests/index.test.ts
@@ -94,4 +94,161 @@ describe("unit tests", async () => {
 		const response = await worker.fetch(request, env, ctx);
 		expect(await response.text()).toEqual("hello from asset worker");
 	});
+
+	it("it returns fetch from user worker when static_routing include rule matches", async () => {
+		const request = new Request("https://example.com/api/includeme");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				has_user_worker: true,
+				static_routing: {
+					version: 1,
+					include: ["/api/*"],
+				},
+			},
+			USER_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from user worker");
+				},
+			},
+			ASSET_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from asset worker");
+				},
+				async unstable_canFetch(_: Request): Promise<boolean> {
+					return true;
+				},
+			},
+		} as Env;
+
+		const response = await worker.fetch(request, env, ctx);
+		expect(await response.text()).toEqual("hello from user worker");
+	});
+
+	it("it returns fetch from asset worker when static_routing exclude rule matches", async () => {
+		const request = new Request("https://example.com/api/excludeme");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				has_user_worker: true,
+				static_routing: {
+					version: 1,
+					include: ["/api/includeme"],
+					exclude: ["/api/excludeme"],
+				},
+			},
+			USER_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from user worker");
+				},
+			},
+			ASSET_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from asset worker");
+				},
+				async unstable_canFetch(_: Request): Promise<boolean> {
+					return true;
+				},
+			},
+		} as Env;
+
+		const response = await worker.fetch(request, env, ctx);
+		expect(await response.text()).toEqual("hello from asset worker");
+	});
+
+	it("it returns fetch from asset worker when static_routing exclude and include rule matches", async () => {
+		const request = new Request("https://example.com/api/excludeme");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				has_user_worker: true,
+				static_routing: {
+					version: 1,
+					include: ["/api/*"],
+					exclude: ["/api/excludeme"],
+				},
+			},
+			USER_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from user worker");
+				},
+			},
+			ASSET_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from asset worker");
+				},
+				async unstable_canFetch(_: Request): Promise<boolean> {
+					return true;
+				},
+			},
+		} as Env;
+
+		const response = await worker.fetch(request, env, ctx);
+		expect(await response.text()).toEqual("hello from asset worker");
+	});
+
+	it("it returns fetch from asset worker when no static_routing rule matches but asset exists", async () => {
+		const request = new Request("https://example.com/someasset");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				has_user_worker: true,
+				static_routing: {
+					version: 1,
+					include: ["/api/*"],
+				},
+			},
+			USER_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from user worker");
+				},
+			},
+			ASSET_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from asset worker");
+				},
+				async unstable_canFetch(_: Request): Promise<boolean> {
+					return true;
+				},
+			},
+		} as Env;
+
+		const response = await worker.fetch(request, env, ctx);
+		expect(await response.text()).toEqual("hello from asset worker");
+	});
+
+	it("it returns fetch from user worker when no static_routing rule matches and no asset exists", async () => {
+		const request = new Request("https://example.com/somemissingasset");
+		const ctx = createExecutionContext();
+
+		const env = {
+			CONFIG: {
+				has_user_worker: true,
+				static_routing: {
+					version: 1,
+					include: ["/api/*"],
+				},
+			},
+			USER_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from user worker");
+				},
+			},
+			ASSET_WORKER: {
+				async fetch(_: Request): Promise<Response> {
+					return new Response("hello from asset worker");
+				},
+				async unstable_canFetch(_: Request): Promise<boolean> {
+					return false;
+				},
+			},
+		} as Env;
+
+		const response = await worker.fetch(request, env, ctx);
+		expect(await response.text()).toEqual("hello from user worker");
+	});
 });

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -74,6 +74,7 @@ export const AssetConfigSchema = z.object({
 		.optional(),
 	redirects: RedirectsSchema,
 	headers: HeadersSchema,
+	has_static_routing: z.boolean().optional(),
 	...InternalConfigSchema.shape,
 });
 

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -6,8 +6,15 @@ const InternalConfigSchema = z.object({
 	debug: z.boolean().optional(),
 });
 
+const StaticRoutingSchema = z.object({
+	version: z.literal(1),
+	include: z.array(z.string()),
+	exclude: z.array(z.string()).optional(),
+});
+
 export const RouterConfigSchema = z.object({
 	invoke_user_worker_ahead_of_assets: z.boolean().optional(),
+	static_routing: StaticRoutingSchema.optional(),
 	has_user_worker: z.boolean().optional(),
 	...InternalConfigSchema.shape,
 });


### PR DESCRIPTION
For WC-3583

Adds support for static routing (i.e. \_routes.json) to Workers Assets

Implements the proposal noted here https://github.com/cloudflare/workers-sdk/discussions/9143

In brief: when static routing is present for a Worker with assets, routing via those static rules takes precedence. When a request is evaluated in the Router Worker, the request path is first compared to the "exclude" rules. If any match, the request is forwarded directly to the Asset Worker. If instead any "include" rules match, the request is forwarded directly to the User Worker. If neither match (or static routing was not provided), the existing behavior takes over.

As part of this explicit routing, when static routing is present, the check against "Sec-Fetch-Mode: navigate" (to guess if this should serve an asset or go to the User Worker for not\_found\_handling) is disabled. Routing can be controlled by uploading a \_routes.json, and asset serving (including when an index.html or 404.html page is served) will be more simple.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not a wrangler/vite change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: will be handled separately
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
