### PR TITLE
chore: backport changes to v3 with "v3-backport" branch prefix and label

### DIFF
--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -6,10 +6,10 @@ import parseChangeset from "@changesets/parse";
 if (require.main === module) {
 	if (isWranglerPatch(process.env.FILES as string)) {
 		// Create a new branch for the v3 maintenance PR
-		execSync(`git checkout -b v3-maintenance-${process.env.PR_NUMBER} -f`);
+		execSync(`git checkout -b v3-backport-${process.env.PR_NUMBER} -f`);
 
 		execSync(
-			`git rebase --onto origin/v3-maintenance origin/main v3-maintenance-${process.env.PR_NUMBER}`
+			`git rebase --onto origin/v3-maintenance origin/main v3-backport-${process.env.PR_NUMBER}`
 		);
 
 		execSync(`git push origin HEAD --force`);
@@ -26,6 +26,7 @@ if (require.main === module) {
 					`--head v3-maintenance-${process.env.PR_NUMBER}`,
 					`--label "skip-pr-description-validation"`,
 					`--label "skip-v3-pr"`,
+					`--label "v3-backport"`,
 					`--title "V3 Backport [#${process.env.PR_NUMBER}]: ${process.env.PR_TITLE?.slice(1, -1)}"`,
 					`--body "This is an automatically opened PR to backport patch changes from #${process.env.PR_NUMBER} to Wrangler v3"`,
 					`--draft`,


### PR DESCRIPTION
Fixes n/a.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ci update
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: ci update
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci update
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: ci update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
