### PR TITLE
Fix D1 export type error when calling `writeFile` with `ReadableStream`

### DIFF
--- a/.changeset/long-bats-scream.md
+++ b/.changeset/long-bats-scream.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix `wrangler d1 export` failing with `ERR_INVALID_ARG_TYPE`

--- a/packages/wrangler/src/d1/export.ts
+++ b/packages/wrangler/src/d1/export.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { Readable } from 'node:stream'
 import { spinner, spinnerWhile } from "@cloudflare/cli/interactive";
 import chalk from "chalk";
 import { Miniflare } from "miniflare";
@@ -200,7 +201,7 @@ async function exportRemotely(
 					`There was an error while downloading from the presigned URL with status code: ${contents.status}`
 				);
 			}
-			await fs.writeFile(output, contents.body || "");
+			await fs.writeFile(output, Readable.fromWeb(contents.body));
 		},
 	});
 	logger.log(`🌀 Downloaded to ${output} successfully!`);


### PR DESCRIPTION
Calling D1 export fails with the following error:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of ReadableStream
    at Object.writeFile (node:fs:2370:5)
```

The `fetch` function in Node.js is implemented by Undici (https://undici.nodejs.org). According to its docs, `response.body` returns an instance of "Web Stream", i.e. `node:stream/web`, while [`node:fs/promises.writeFile`](https://nodejs.org/api/fs.html#fspromiseswritefilefile-data-options) expects a "Node.js Stream" i.e. `node:stream`. To convert between the two, the [`Readable.fromWeb`](https://nodejs.org/api/stream.html#streamreadablefromwebreadablestream-options) function needs to be used. 

See: https://undici.nodejs.org/#/?id=responsebody

Fixes #8465.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
