### PR TITLE
allow --name and --env args on wrangler deploy

### DIFF
--- a/.changeset/six-rockets-show.md
+++ b/.changeset/six-rockets-show.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+allow --name and --env args on wrangler deploy

--- a/.changeset/six-rockets-show.md
+++ b/.changeset/six-rockets-show.md
@@ -3,3 +3,26 @@
 ---
 
 allow --name and --env args on wrangler deploy
+
+Previously it was not possible to provide a Worker nam as a command line argument at the same time as setting the Wrangler environment.
+Now specifying `--name` is supported and will override any names set in the Wrangler config:
+
+**wrangler.json**
+
+```json
+{
+	"name": "config-worker"
+	"env": {
+		"staging": { "name": "config-worker-env" }
+	}
+}
+```
+
+| Command                                          | Previous (Worker name) | Proposed (Worker name) | Comment                               |
+| ------------------------------------------------ | ---------------------- | ---------------------- | ------------------------------------- |
+| wrangler deploy --name=args-worker               | "args-worker"          | "args-worker"          | CLI arg used                          |
+| wrangler deploy --name=args-worker --env=staging | _Error_                | "args-worker"          | CLI arg used                          |
+| wrangler deploy --name=args-worker --env=prod    | _Error_                | "args-worker"          | CLI arg used                          |
+| wrangler deploy                                  | "config-worker"        | "config-worker"        | Top-level config used                 |
+| wrangler deploy --env=staging                    | "config-worker-env"    | "config-worker-env"    | Named env config used                 |
+| wrangler deploy --env=prod                       | "config-worker-prod"   | "config-worker-prod"   | CLI arg and top-level config combined |

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -1004,19 +1004,17 @@ describe("deploy", () => {
 				`);
 			});
 
-			it("should throw an error w/ helpful message when using --env --name", async () => {
+			it("should allow --env and --name to be used together", async () => {
 				writeWranglerConfig({ env: { "some-env": {} } });
 				writeWorkerSource();
 				mockSubDomainRequest();
+				mockUploadWorkerRequest({
+					env: "some-env",
+					expectedScriptName: "voyager",
+					legacyEnv: true,
+				});
 				await runWrangler(
 					"deploy index.js --name voyager --env some-env --legacy-env true"
-				).catch((err) =>
-					expect(err).toMatchInlineSnapshot(`
-						[Error: In legacy environment mode you cannot use --name and --env together. If you want to specify a Worker name for a specific environment you can add the following to your wrangler.toml file:
-						[env.some-env]
-						name = "voyager"
-						]
-					`)
 				);
 			});
 		});

--- a/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-upload-worker.ts
@@ -42,13 +42,10 @@ export function mockUploadWorkerRequest(
 		expectedContainers?: { class_name: string }[];
 	} = {}
 ) {
-	const expectedScriptName = (options.expectedScriptName ??= "test-name");
 	const handleUpload: HttpResponseResolver = async ({ params, request }) => {
 		const url = new URL(request.url);
 		expect(params.accountId).toEqual("some-account-id");
-		expect(params.scriptName).toEqual(
-			legacyEnv && env ? `${expectedScriptName}-${env}` : expectedScriptName
-		);
+		expect(params.scriptName).toEqual(expectedScriptName);
 		if (!legacyEnv) {
 			expect(params.envName).toEqual(env);
 		}
@@ -185,6 +182,11 @@ export function mockUploadWorkerRequest(
 		expectedObservability,
 		expectedSettingsPatch,
 	} = options;
+
+	const expectedScriptName =
+		options.expectedScriptName ??
+		"test-name" + (legacyEnv && env ? `-${env}` : "");
+
 	if (env && !legacyEnv) {
 		msw.use(
 			http.put(

--- a/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-workers-subdomain.ts
@@ -39,7 +39,7 @@ export function mockGetWorkerSubdomain({
 	previews_enabled = true,
 	env,
 	legacyEnv = false,
-	expectedScriptName = "test-name",
+	expectedScriptName = "test-name" + (legacyEnv && env ? `-${env}` : ""),
 }: {
 	enabled: boolean;
 	previews_enabled?: boolean;
@@ -56,9 +56,7 @@ export function mockGetWorkerSubdomain({
 			url,
 			({ params }) => {
 				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toEqual(
-					legacyEnv && env ? `${expectedScriptName}-${env}` : expectedScriptName
-				);
+				expect(params.scriptName).toEqual(expectedScriptName);
 				if (!legacyEnv) {
 					expect(params.envName).toEqual(env);
 				}

--- a/packages/wrangler/src/utils/getScriptName.ts
+++ b/packages/wrangler/src/utils/getScriptName.ts
@@ -1,27 +1,8 @@
-import { configFileName, formatConfigSnippet } from "../config";
-import { CommandLineArgsError } from "../errors";
-import { isLegacyEnv } from "./isLegacyEnv";
 import type { Config } from "../config";
 
 export function getScriptName(
 	args: { name: string | undefined; env: string | undefined },
 	config: Config
 ): string | undefined {
-	if (args.name && isLegacyEnv(config) && args.env) {
-		throw new CommandLineArgsError(
-			`In legacy environment mode you cannot use --name and --env together. If you want to specify a Worker name for a specific environment you can add the following to your ${configFileName(config.configPath)} file:\n` +
-				formatConfigSnippet(
-					{
-						env: {
-							[args.env]: {
-								name: args.name,
-							},
-						},
-					},
-					config.configPath
-				)
-		);
-	}
-
 	return args.name ?? config.name;
 }


### PR DESCRIPTION
Fixes #4123

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the old restriction was not documented
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
