### PR TITLE
fix wrangler mixed-mode windows e2e test failure

### DIFF
--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -1,3 +1,4 @@
+import getPort from "get-port";
 import dedent from "ts-dedent";
 import { describe, expect, it } from "vitest";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
@@ -107,6 +108,11 @@ async function spawnLocalWorker(helper: WranglerE2ETestHelper): Promise<void> {
 							}
 						}`,
 	});
-	const localWorker = helper.runLongLived("wrangler dev", { cwd: local });
+	const localWorker = helper.runLongLived(
+		// Note: we use a random port here otherwise for some reason in CI windows
+		//       allows the default port to be overridden by other processes
+		`wrangler dev --port ${await getPort()}`,
+		{ cwd: local }
+	);
 	await localWorker.waitForReady();
 }


### PR DESCRIPTION
This is fixing a windows e2e [failure](https://github.com/cloudflare/workers-sdk/actions/runs/15067356448/job/42355090555?pr=9278#step:5:304) we're seeing in the [VP PR](https://github.com/cloudflare/workers-sdk/pull/9278).

I am not sure why windows is behaving as it is and why this change is needed... if anyone has some suggestions/ideas on it I'm all ears 🙏 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this updates an e2e test
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: e2e test update
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: updates e2e test not present in v3 branch

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
