### PR TITLE
chore: run ci for external forks by commit sha

### DIFF
--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -5,6 +5,9 @@ on:
       pr-number:
         description: "The PR number to run CI on behalf of"
         required: true
+      commit-sha:
+        description: "The specific commit SHA from the PR branch to run CI on"
+        required: true
       reviewed:
         description: "Confirm that the PR has been reviewed for use/leakage of secrets"
         type: boolean
@@ -32,13 +35,15 @@ jobs:
           team: wrangler
 
       - name: Stop workflow if user is not a team member
-        if: ${{ steps.teamAffiliation.outputs.isTeamMember == false }}
+        if: ${{ steps.teamAffiliation.outputs.isTeamMember == 'false' }}
         run: |
-          echo "You must be on the "wrangler" team to trigger this job."
+          echo "You must be on the \"wrangler\" team to trigger this job."
           exit 1
 
       - name: "Checkout PR"
-        run: gh pr checkout ${{ inputs.pr-number }} -b run-ci-on-behalf-of-${{ inputs.pr-number }} -f
+        run: |
+          gh pr checkout ${{ inputs.pr-number }} --branch run-ci-on-behalf-of-${{ inputs.pr-number }}
+          git reset --hard ${{ inputs.commit-sha }}
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
@@ -47,6 +52,13 @@ jobs:
 
       - name: "Create Draft PR"
         run: |
-          gh pr create --head run-ci-on-behalf-of-${{ inputs.pr-number }} --draft --label "e2e" --title "Run CI on behalf of #${{ inputs.pr-number }}" --body "This PR is created to run CI on behalf of \#${{ inputs.pr-number }}. It can be closed after the CI run is complete."
+          TITLE="Run CI on behalf of #${{ inputs.pr-number }} @${{ inputs.commit-sha }}"
+          BODY="This PR runs CI on behalf of #${{ inputs.pr-number }} at commit ${{ inputs.commit-sha }}. It can be closed after the CI run is complete."
+          gh pr create \
+            --head run-ci-on-behalf-of-${{ inputs.pr-number }} \
+            --draft \
+            --label "e2e" \
+            --title "$TITLE" \
+            --body "$BODY"
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -18,6 +18,7 @@ jobs:
     if: ${{ inputs.reviewed == true }}
     runs-on: ubuntu-latest
     permissions:
+      # We use the default token to create the draft PR only
       pull-requests: write
       contents: write
     steps:
@@ -27,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check user for team affiliation
-        uses: tspascoal/get-user-teams-membership@v2
+        uses: tspascoal/get-user-teams-membership@ba78054988f58bea69b7c6136d563236f8ed2fc0
         id: teamAffiliation
         with:
           GITHUB_TOKEN: ${{ secrets.READ_ONLY_ORG_GITHUB_TOKEN }}
@@ -42,23 +43,27 @@ jobs:
 
       - name: "Checkout PR"
         run: |
-          gh pr checkout ${{ inputs.pr-number }} --branch run-ci-on-behalf-of-${{ inputs.pr-number }}
-          git reset --hard ${{ inputs.commit-sha }}
+          gh pr checkout "$PR_NUM" --branch "run-ci-on-behalf-of-$PR_NUM"
+          git reset --hard "$COMMIT_SHA"
         env:
+          # We need a PAT to checkout the fork
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          PR_NUM: ${{ inputs.pr-number }}
+          COMMIT_SHA: ${{ inputs.commit-sha }}
 
       - name: Push Branch
         run: git push origin HEAD --force
 
       - name: "Create Draft PR"
         run: |
-          TITLE="Run CI on behalf of #${{ inputs.pr-number }} @${{ inputs.commit-sha }}"
-          BODY="This PR runs CI on behalf of #${{ inputs.pr-number }} at commit ${{ inputs.commit-sha }}. It can be closed after the CI run is complete."
           gh pr create \
-            --head run-ci-on-behalf-of-${{ inputs.pr-number }} \
+            --head "run-ci-on-behalf-of-$PR_NUM" \
             --draft \
             --label "e2e" \
             --title "$TITLE" \
             --body "$BODY"
         env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ inputs.pr-number }}
+          TITLE: "Run CI on behalf of #${{ inputs.pr-number }} @${{ inputs.commit-sha }}"
+          BODY: "This PR runs CI on behalf of #${{ inputs.pr-number }} at commit ${{ inputs.commit-sha }}. It can be closed after the CI run is complete."

--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -36,7 +36,7 @@ jobs:
           team: wrangler
 
       - name: Stop workflow if user is not a team member
-        if: ${{ steps.teamAffiliation.outputs.isTeamMember == 'false' }}
+        if: ${{ steps.teamAffiliation.outputs.isTeamMember != 'true' }}
         run: |
           echo "You must be on the \"wrangler\" team to trigger this job."
           exit 1


### PR DESCRIPTION
Fixes n/a.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ci change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: ci change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: ci change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
