### PR TITLE
feat(miniflare): add dev registry support

### DIFF
--- a/.changeset/wise-rules-march.md
+++ b/.changeset/wise-rules-march.md
@@ -1,0 +1,5 @@
+---
+"miniflare": minor
+---
+
+feat: add Dev Registry support

--- a/.changeset/wise-rules-march.md
+++ b/.changeset/wise-rules-march.md
@@ -3,3 +3,21 @@
 ---
 
 feat: add Dev Registry support
+
+This change introduces two new options to support cross-process service bindings, durable objects and tail consumers via a file-system based registry, with backward compatibility to Wrangler’s implementation:
+
+- **`unsafeDevRegistryPath`** (`string`): Filesystem path to the Dev Registry directory.
+- **`unsafeDevRegistryDurableObjectProxy`** (`boolean`): When enabled, exposes internal Durable Objects to other local dev sessions and allows Workers to connect to external Durable Objects.
+
+Example usage:
+
+```ts
+import { Miniflare } from "miniflare";
+
+const mf = new Miniflare({
+	scriptPath: "./dist/worker.js",
+	unsafeDevRegistryPath: "/registry",
+	unsafeDevRegistryDurableObjectProxy: true,
+	// ...other options
+});
+```

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -76,6 +76,7 @@
 		"@typescript-eslint/parser": "^6.9.0",
 		"ava": "^6.0.1",
 		"capnp-es": "^0.0.7",
+		"chokidar": "^4.0.1",
 		"concurrently": "^8.2.2",
 		"devalue": "^4.3.0",
 		"devtools-protocol": "^0.0.1182435",

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2273,13 +2273,6 @@ export class Miniflare {
 		);
 		// Send to runtime and wait for updates to process
 		await this.#assembleAndUpdateConfig();
-
-		assert(
-			this.#runtimeEntryURL !== undefined,
-			"The runtime entry URL should be defined at this point"
-		);
-		// Register all workers with the dev registry
-		await this.#registerWorkers(this.#runtimeEntryURL);
 	}
 
 	setOptions(opts: MiniflareOptions): Promise<void> {
@@ -2289,7 +2282,17 @@ export class Miniflare {
 		this.#proxyClient?.poisonProxies();
 		// Wait for initial initialisation and other setOptions to complete before
 		// changing options
-		return this.#runtimeMutex.runWith(() => this.#setOptions(opts));
+		return this.#runtimeMutex
+			.runWith(() => this.#setOptions(opts))
+			.then(() => {
+				assert(
+					this.#runtimeEntryURL !== undefined,
+					"The runtime entry URL should be defined at this point"
+				);
+
+				// Register all workers with the dev registry
+				return this.#registerWorkers(this.#runtimeEntryURL);
+			});
 	}
 
 	dispatchFetch: DispatchFetch = async (input, init) => {

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1173,7 +1173,7 @@ export class Miniflare {
 		if (doProxyTarget) {
 			assert(res !== undefined, "No response object provided");
 
-			const address = this.#devRegistry.getExtneralDurableObjectAddress(
+			const address = this.#devRegistry.getExternalDurableObjectAddress(
 				doProxyTarget.scriptName,
 				doProxyTarget.className
 			);

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -399,7 +399,7 @@ function getExternalServiceEntrypoints(
 ) {
 	const externalServices = new Map<
 		string,
-		Map<string | undefined, "service" | "durableObject" | "tail">
+		Map<string | undefined, "service" | "durableObject">
 	>();
 	const allWorkerNames = allWorkerOpts.map((opts) => opts.core.name);
 	const getEntrypoints = (name: string) => {
@@ -408,7 +408,7 @@ function getExternalServiceEntrypoints(
 		if (!externalService) {
 			externalService = new Map<
 				string | undefined,
-				"durableObject" | "service" | "tail"
+				"durableObject" | "service"
 			>();
 			externalServices.set(name, externalService);
 		}
@@ -514,7 +514,7 @@ function getExternalServiceEntrypoints(
 					};
 
 					const entrypoints = getEntrypoints(serviceName);
-					entrypoints.set(entrypoint, "tail");
+					entrypoints.set(entrypoint, "service");
 				}
 			}
 		}
@@ -1754,12 +1754,12 @@ export class Miniflare {
 		) {
 			const isDurableObjectProxyEnabled =
 				this.#devRegistry.isDurableObjectProxyEnabled();
-			const proxyURL = `http://${loopbackHost}:${loopbackPort}`;
+			const loopbackAddress = `http://${loopbackHost}:${loopbackPort}`;
 			for (const [serviceName, entrypoints] of externalServices) {
 				const service = createExternalService({
 					serviceName,
 					entrypoints,
-					proxyURL,
+					loopbackAddress,
 					isDurableObjectProxyEnabled,
 				});
 				assert(service.name !== undefined);

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1379,7 +1379,6 @@ export class Miniflare {
 			// Errors on either side
 			serverSocket.on("error", (err) => {
 				this.#log.error(err);
-				clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
 				clientSocket.end();
 			});
 			clientSocket.on("error", () => serverSocket.end());
@@ -1390,12 +1389,10 @@ export class Miniflare {
 				this.#log.debug(
 					`Closing tunnel as service "${serviceName}" was updated`
 				);
-				clientSocket.write("HTTP/1.1 503 Service Unavailable\r\n\r\n");
 				clientSocket.end();
 			});
 		} catch (ex: any) {
 			this.#log.error(ex);
-			clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
 			clientSocket.end();
 		}
 	};

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -429,7 +429,10 @@ function getExternalServiceEntrypoints(
 				} else if (
 					typeof service === "object" &&
 					"name" in service &&
-					service.name !== kCurrentWorker
+					// Skip if the service refers to the current worker
+					service.name !== kCurrentWorker &&
+					// Skip if it is a remote service
+					service.mixedModeConnectionString === undefined
 				) {
 					serviceName = service.name;
 					entrypoint = service.entrypoint;
@@ -464,6 +467,9 @@ function getExternalServiceEntrypoints(
 					workerName &&
 					typeof designator === "object" &&
 					typeof designator.scriptName !== "undefined" &&
+					// Skip if it is a remote durable object
+					designator.mixedModeConnectionString === undefined &&
+					// Skip if the durable object script name matches one of the workers
 					allWorkerOpts.every(
 						(opts) => opts.core.name !== designator.scriptName
 					)
@@ -500,7 +506,10 @@ function getExternalServiceEntrypoints(
 				} else if (
 					typeof tailService === "object" &&
 					"name" in tailService &&
-					tailService.name !== kCurrentWorker
+					// Skip if the tail service refers to the current worker
+					tailService.name !== kCurrentWorker &&
+					// Skip if the tail worker is a remote service
+					tailService.mixedModeConnectionString === undefined
 				) {
 					serviceName = tailService.name;
 					entrypoint = tailService.entrypoint;
@@ -2121,7 +2130,9 @@ export class Miniflare {
 									// If the scriptName matches one of the workers defined, it is internal as well
 									this.#workerOpts.some(
 										(opts) => opts.core.name === designator.scriptName
-									)
+									) ||
+									// If it is not a remote durable object
+									designator.mixedModeConnectionString === undefined
 								) {
 									internalObjects.push({
 										name: bindingName,

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -219,7 +219,7 @@ export const CoreSharedOptionsSchema = z.object({
 	// Enable auto service / durable objects discovery with the dev registry
 	unsafeDevRegistryPath: z.string().optional(),
 	// Enable External Durable Objects Proxy / Internal DOs registration
-	unsafeDevRegistryDoProxy: z.boolean().default(false),
+	unsafeDevRegistryDurableObjectProxy: z.boolean().default(false),
 	// This is a shared secret between a proxy server and miniflare that can be
 	// passed in a header to prove that the request came from the proxy and not
 	// some malicious attacker.

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -216,6 +216,10 @@ export const CoreSharedOptionsSchema = z.object({
 
 	liveReload: z.boolean().optional(),
 
+	// Enable auto service / durable objects discovery with the dev registry
+	unsafeDevRegistryPath: z.string().optional(),
+	// Enable External Durable Objects Proxy / Internal DOs registration
+	unsafeDevRegistryDoProxy: z.boolean().default(false),
 	// This is a shared secret between a proxy server and miniflare that can be
 	// passed in a header to prove that the request came from the proxy and not
 	// some malicious attacker.

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -48,28 +48,36 @@ export function normaliseDurableObject(
 	>[string]
 ): {
 	className: string;
-	serviceName?: string;
-	enableSql?: boolean;
-	unsafeUniqueKey?: UnsafeUniqueKey;
-	unsafePreventEviction?: boolean;
+	scriptName: string | undefined;
+	serviceName: string | undefined;
+	enableSql: boolean | undefined;
+	unsafeUniqueKey: UnsafeUniqueKey | undefined;
+	unsafePreventEviction: boolean | undefined;
+	mixedModeConnectionString: MixedModeConnectionString | undefined;
 } {
 	const isObject = typeof designator === "object";
 	const className = isObject ? designator.className : designator;
-	const serviceName =
+	const scriptName =
 		isObject && designator.scriptName !== undefined
-			? getUserServiceName(designator.scriptName)
+			? designator.scriptName
 			: undefined;
+	const serviceName = scriptName ? getUserServiceName(scriptName) : undefined;
 	const enableSql = isObject ? designator.useSQLite : undefined;
 	const unsafeUniqueKey = isObject ? designator.unsafeUniqueKey : undefined;
 	const unsafePreventEviction = isObject
 		? designator.unsafePreventEviction
 		: undefined;
+	const mixedModeConnectionString = isObject
+		? designator.mixedModeConnectionString
+		: undefined;
 	return {
 		className,
+		scriptName,
 		serviceName,
 		enableSql,
 		unsafeUniqueKey,
 		unsafePreventEviction,
+		mixedModeConnectionString,
 	};
 }
 

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -177,7 +177,7 @@ export class DevRegistry {
 		return null;
 	}
 
-	public getExtneralDurableObjectAddress(
+	public getExternalDurableObjectAddress(
 		scriptName: string,
 		className: string
 	): {

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -144,7 +144,7 @@ export class DevRegistry {
 
 	public getExternalServiceAddress(
 		service: string,
-		entrypoint: string | undefined = "default"
+		entrypoint: string
 	): {
 		protocol: "http" | "https";
 		host: string;

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -1,0 +1,276 @@
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	unlinkSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { FSWatcher, watch } from "chokidar";
+import { INTERNAL_DO_PROXY_SERVICE_PATH } from "./external-service";
+import { Log } from "./log";
+
+export type WorkerRegistry = Record<string, WorkerDefinition>;
+
+export type WorkerEntrypointsDefinition = Record<
+	"default" | string,
+	{ host: string; port: number } | undefined
+>;
+
+export type WorkerDefinition = {
+	protocol: "http" | "https";
+	host: string;
+	port: number;
+	entrypointAddresses: WorkerEntrypointsDefinition;
+	durableObjects: { name: string; className: string }[];
+};
+
+export class DevRegistry {
+	private heartbeats = new Map<string, NodeJS.Timeout>();
+	private registry: WorkerRegistry = {};
+	private registeredWorkers: Set<string> = new Set();
+	private subscribers: Map<string, Array<() => void>> = new Map();
+	private watcher: FSWatcher | undefined;
+
+	constructor(
+		private registryPath: string | undefined,
+		private enableDurableObjectProxy: boolean,
+		private log: Log
+	) {}
+
+	/**
+	 * Watch files inside the registry directory for changes.
+	 */
+	public watch(): void {
+		if (!this.registryPath || this.watcher) {
+			return;
+		}
+
+		this.watcher = watch(this.registryPath).on("all", () => this.refresh());
+		this.refresh();
+	}
+
+	/**
+	 * Unregister all managed workers and close the watcher.
+	 * This is a sync function that returns a promise
+	 * to ensure all workers are unregistered within the exit hook
+	 */
+	public dispose(): Promise<void> | undefined {
+		for (const worker of this.registeredWorkers) {
+			this.unregister(worker);
+		}
+		this.registeredWorkers.clear();
+		this.subscribers.clear();
+		this.registry = {};
+
+		// Only this step is async and could be awaited
+		return this.watcher?.close();
+	}
+
+	/**
+	 * Unregister worker in the registry.
+	 */
+	private unregister(name: string): void {
+		try {
+			const existingHeartbeat = this.heartbeats.get(name);
+
+			// Clear the check first before removing the files on disk
+			if (existingHeartbeat) {
+				this.heartbeats.delete(name);
+				clearInterval(existingHeartbeat);
+			}
+
+			if (this.registryPath) {
+				unlinkSync(path.join(this.registryPath, name));
+			}
+
+			this.notifySubscribers(name);
+		} catch (e) {
+			this.log?.debug(`Failed to unregister worker "${name}": ${e}`);
+		}
+	}
+
+	public isEnabled(): boolean {
+		return this.registryPath !== undefined;
+	}
+
+	public isDurableObjectProxyEnabled(): boolean {
+		return this.isEnabled() && this.enableDurableObjectProxy;
+	}
+
+	public async updateRegistryPath(
+		registryPath: string | undefined,
+		enableDurableObjectProxy: boolean
+	): Promise<void> {
+		await this.dispose();
+		this.registryPath = registryPath;
+		this.enableDurableObjectProxy = enableDurableObjectProxy;
+		await this.watch();
+	}
+
+	public register(workers: Record<string, WorkerDefinition>) {
+		if (!this.registryPath) {
+			return;
+		}
+
+		for (const [name, definition] of Object.entries(workers)) {
+			const definitionPath = path.join(this.registryPath, name);
+			const existingHeartbeat = this.heartbeats.get(name);
+			if (existingHeartbeat) {
+				clearInterval(existingHeartbeat);
+			}
+			mkdirSync(this.registryPath, { recursive: true });
+
+			// Skip the durable objects in the definition if the proxy is not enabled
+			if (!this.enableDurableObjectProxy) {
+				definition.durableObjects = [];
+			}
+
+			writeFileSync(definitionPath, JSON.stringify(definition, null, 2));
+			this.registeredWorkers.add(name);
+			this.heartbeats.set(
+				name,
+				setInterval(() => {
+					if (existsSync(definitionPath)) {
+						utimesSync(definitionPath, new Date(), new Date());
+					}
+				}, 30_000)
+			);
+		}
+	}
+
+	public getExternalServiceAddress(
+		service: string,
+		entrypoint: string | undefined = "default"
+	): {
+		protocol: "http" | "https";
+		host: string;
+		port: number;
+	} | null {
+		if (!this.isEnabled()) {
+			return null;
+		}
+
+		const target = this.registry?.[service];
+		const entrypointAddress = target?.entrypointAddresses[entrypoint];
+
+		if (entrypointAddress !== undefined) {
+			return {
+				protocol: target.protocol,
+				host: entrypointAddress.host,
+				port: entrypointAddress.port,
+			};
+		}
+
+		if (target && target.protocol !== "https" && entrypoint === "default") {
+			// Fallback to sending requests directly to the entry worker
+			return {
+				protocol: target.protocol,
+				host: target.host,
+				port: target.port,
+			};
+		}
+
+		return null;
+	}
+
+	public getExtneralDurableObjectAddress(
+		scriptName: string,
+		className: string
+	): {
+		protocol: "http" | "https";
+		host: string;
+		port: number;
+		path: string;
+	} | null {
+		if (!this.isDurableObjectProxyEnabled()) {
+			return null;
+		}
+
+		const target = this.registry?.[scriptName];
+
+		if (
+			target?.durableObjects.some(
+				(durableObject) => durableObject.className === className
+			)
+		) {
+			return {
+				...target,
+				path: `/${INTERNAL_DO_PROXY_SERVICE_PATH}`,
+			};
+		}
+
+		return null;
+	}
+
+	public subscribe(workerName: string, callback: () => void): void {
+		let callbacks = this.subscribers.get(workerName);
+
+		if (!callbacks) {
+			callbacks = [];
+			this.subscribers.set(workerName, callbacks);
+		}
+
+		callbacks.push(callback);
+	}
+
+	private notifySubscribers(workerName: string): void {
+		const callbacks = this.subscribers.get(workerName);
+		if (callbacks) {
+			for (const callback of callbacks) {
+				callback();
+			}
+		}
+	}
+
+	private refresh(): void {
+		if (!this.registryPath) {
+			return;
+		}
+
+		// Make sure the registry path exists
+		mkdirSync(this.registryPath, { recursive: true });
+
+		const workerNames = readdirSync(this.registryPath);
+
+		// Cleanup existing definition that are not in the registry anymore
+		for (const existingWorkerName of Object.keys(this.registry)) {
+			if (!workerNames.includes(existingWorkerName)) {
+				delete this.registry[existingWorkerName];
+				this.notifySubscribers(existingWorkerName);
+			}
+		}
+
+		for (const workerName of workerNames) {
+			try {
+				const definitionPath = path.join(this.registryPath, workerName);
+				const file = readFileSync(definitionPath, "utf8");
+				const stats = statSync(definitionPath);
+
+				// Cleanup existing workers older than 5 minutes
+				if (stats.mtime.getTime() < Date.now() - 300_000) {
+					this.unregister(workerName);
+					continue;
+				}
+
+				if (
+					// If the worker is not registered before, or
+					!this.registry[workerName] ||
+					// If the file content is different from the registry
+					file !== JSON.stringify(this.registry[workerName], null, 2)
+				) {
+					this.registry[workerName] = JSON.parse(file);
+					this.notifySubscribers(workerName);
+				}
+			} catch (e) {
+				// This can safely be ignored. It generally indicates the worker was too old and was removed by a parallel process
+				this.log?.debug(
+					`Error while loading worker definition from the registry: ${e}`
+				);
+			}
+		}
+	}
+}

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { FSWatcher, watch } from "chokidar";
-import { INTERNAL_DO_PROXY_SERVICE_PATH } from "./external-service";
+import { INBOUND_DO_PROXY_SERVICE_PATH } from "./external-service";
 import { Log } from "./log";
 
 export type WorkerRegistry = Record<string, WorkerDefinition>;
@@ -199,7 +199,7 @@ export class DevRegistry {
 		) {
 			return {
 				...target,
-				path: `/${INTERNAL_DO_PROXY_SERVICE_PATH}`,
+				path: `/${INBOUND_DO_PROXY_SERVICE_PATH}`,
 			};
 		}
 

--- a/packages/miniflare/src/shared/external-service.ts
+++ b/packages/miniflare/src/shared/external-service.ts
@@ -41,16 +41,12 @@ export function normaliseServiceDesignator(
 	};
 }
 
-export function getProxyFallbackServiceName(service: string) {
-	return `proxy:fallback:${service}`;
-}
-
 export function createProxyFallbackService(
 	serviceName: string,
 	entrypoints: Set<string | undefined>
 ): Service {
 	return {
-		name: getProxyFallbackServiceName(serviceName),
+		name: `proxy:fallback:${serviceName}`,
 		worker: {
 			compatibilityDate: "2025-05-01",
 			modules: [
@@ -185,6 +181,8 @@ export function createOutboundDoProxyService(
 	isProxyEnabled: boolean
 ): Service {
 	return {
+		// The DO plugin will prefix the script name with the user service name
+		// This makes sure it matches the result script name on the worker binding
 		name: getUserServiceName(OUTBOUND_DO_PROXY_SERVICE_NAME),
 		worker: {
 			compatibilityDate: "2025-05-01",
@@ -253,7 +251,7 @@ export function getHttpProxyOptions(
 		// To make sure `request.cf` is set correctly
 		cfBlobHeader: CoreHeaders.CF_BLOB,
 		// Use the service name and entrypoint as the host to proxy RPC calls
-		capnpConnectHost: `${service}:${entrypoint ?? "default"}`,
+		capnpConnectHost: `${encodeURIComponent(service)}:${encodeURIComponent(entrypoint ?? "default")}`,
 		// The headers are injected only for fetch and are used for proxying fetch requests
 		injectRequestHeaders: [
 			{

--- a/packages/miniflare/src/shared/external-service.ts
+++ b/packages/miniflare/src/shared/external-service.ts
@@ -1,0 +1,361 @@
+import assert from "node:assert";
+import http from "node:http";
+import { getUserServiceName } from "../plugins/core";
+import {
+	HttpOptions,
+	kVoid,
+	Service,
+	Worker_DurableObjectNamespace,
+} from "../runtime";
+import { CoreHeaders } from "../workers";
+
+export function getExternalServiceName(service: string) {
+	return `proxy:external:${service}`;
+}
+
+export function createExternalService(options: {
+	serviceName: string;
+	entrypoints: Map<string | undefined, "service" | "durableObject" | "tail">;
+	proxyURL: string;
+	mode: "full-proxy" | "service-proxy" | "no-proxy";
+}): Service {
+	return {
+		name: getUserServiceName(getExternalServiceName(options.serviceName)),
+		worker: {
+			compatibilityDate: "2025-05-01",
+			// Use in-memory storage for the stub object classes *declared* by this
+			// script. They don't need to persist anything, and would end up using the
+			// incorrect unsafe unique key.
+			durableObjectStorage: { inMemory: kVoid },
+			durableObjectNamespaces: Array.from(
+				options.entrypoints
+			).flatMap<Worker_DurableObjectNamespace>(([className, type]) => {
+				if (type === "durableObject") {
+					return [
+						{
+							className,
+							uniqueKey: `${options.serviceName}-${className}`,
+						} satisfies Worker_DurableObjectNamespace,
+					];
+				}
+
+				return [];
+			}),
+			modules: [
+				{
+					name: "fallback-service.mjs",
+					esModule: [
+						`
+                            import { WorkerEntrypoint, DurableObject } from "cloudflare:workers";
+
+                            ${CREATE_PROXY_PROTOTYPE_CLASS_HELPER_SCRIPT}
+
+                            function createFallbackWorkerEntrypointClass({ service, entrypoint }) {
+                                const klass = createProxyPrototypeClass(WorkerEntrypoint, (key) => {
+                                    throw new Error(
+                                        ${
+																					options.mode !== "no-proxy"
+																						? `\`Cannot access "\${key}" as we couldn't find a local dev session for the "\${entrypoint}" entrypoint of service "\${service}" to proxy to.\``
+																						: `\`Worker Entrypoint "\${entrypoint}" of service "\${service}" is not defined in the options. Set the "unsafeDevRegistryPath" option if you would like Miniflare to lookup services from the Dev Registry.\``
+																				}
+                                    );
+                                });
+
+                                // Return regular HTTP response for HTTP requests
+                                klass.prototype.fetch = function(request) {
+                                    const message = ${
+																			options.mode !== "no-proxy"
+																				? `\`Couldn't find a local dev session for the "\${entrypoint}" entrypoint of service "\${service}" to proxy to\``
+																				: `\`Worker Entrypoint "\${entrypoint}" of service "\${service}" is not defined in the options. Set the "unsafeDevRegistryPath" option if you would like Miniflare to lookup services from the Dev Registry.\``
+																		};
+                                    return new Response(message, { status: 503 });
+                                };
+
+                                return klass;
+                            }
+
+                            function createProxyDurableObjectClass({ scriptName, className, proxyUrl }) {
+                                const klass = createProxyPrototypeClass(DurableObject, (key) => {
+                                    throw new Error(${
+																			options.mode === "full-proxy"
+																				? `\`Cannot access "\${key}" as Durable Object RPC is not yet supported between multiple dev sessions.\``
+																				: `\`Durable Object "\${className}" of script "\${scriptName}" is not defined in the options. Set the "unsafeDevRegistryDOProxy" option if you would like Miniflare to lookup services from the Dev Registry.\``
+																		});
+                                });
+
+                                // Forward regular HTTP requests to the other dev session
+                                klass.prototype.fetch = function(request) {
+                                    const proxyRequest = new Request(proxyUrl, request);
+                                    proxyRequest.headers.set("${PROXY_OBJECT_URL_HEADER}", request.url);
+                                    proxyRequest.headers.set("${PROXY_OBJECT_NAME_HEADER}", className);
+                                    proxyRequest.headers.set("${PROXY_OBJECT_SCRIPT_HEADER}", scriptName);
+                                    proxyRequest.headers.set("${PROXY_OBJECT_ID_HEADER}", this.ctx.id.toString());
+                                    proxyRequest.headers.set("${PROXY_OBJECT_CF_BLOB_HEADER}", JSON.stringify(request.cf ?? {}));
+                                    return fetch(proxyRequest);
+                                };
+
+                                return klass;
+                            }
+
+                            function createFallbackTailHandler({ service, entrypoint }) {
+                                return {
+                                    fetch() {
+                                        const message = ${
+																					options.mode !== "no-proxy"
+																						? `\`Couldn't find a local dev session for the "\${entrypoint}" entrypoint of service "\${service}" to proxy to\``
+																						: `\`Fetch Handler "\${entrypoint}" of service "\${service}" is not defined in the options. Set the "unsafeDevRegistryPath" option if you would like Miniflare to lookup services from the Dev Registry.\``
+																				};
+                                        return new Response(message, { status: 503 });
+                                    },
+                                    tail(events) {
+                                        // No-op
+                                    }
+                                };
+                            }
+                        `,
+						...Array.from(options.entrypoints).map(
+							([entrypoint = "default", type]) => {
+								const service = options.serviceName;
+								const proxyURL = options.proxyURL;
+
+								switch (type) {
+									case "service":
+										return `export ${entrypoint === "default" ? "default" : `const ${entrypoint} =`} createFallbackWorkerEntrypointClass({ service: "${service}", entrypoint: "${entrypoint}" });`;
+									case "durableObject":
+										return `export const ${entrypoint} = createProxyDurableObjectClass({ scriptName: "${service}", className: "${entrypoint}", proxyUrl: "${proxyURL}" });`;
+									case "tail":
+										return `export ${entrypoint === "default" ? "default" : `const ${entrypoint} =`} createFallbackTailHandler({ service: "${service}", entrypoint: "${entrypoint}" });`;
+									default:
+										throw new Error(
+											`Unsupported entrypoint type "${type}" for external service "${service}" `
+										);
+								}
+							}
+						),
+					].join("\n"),
+				},
+			],
+		},
+	};
+}
+
+export const INTERNAL_DO_PROXY_SERVICE_NAME = "proxy:internal:do";
+
+/**
+ * A well known URL to the proxy worker
+ * This should match the Wrangler implementation for backwards compatibility
+ *
+ * @see https://github.com/cloudflare/workers-sdk/blob/362cb0be3fa28bbf007491f7156ecb522bd7ee43/packages/wrangler/src/dev/miniflare.ts#L52-L59
+ */
+export const INTERNAL_DO_PROXY_SERVICE_PATH =
+	"__WRANGLER_EXTERNAL_DURABLE_OBJECTS_WORKER";
+
+/*
+ * Create a service that routes fetch requests to the internal durable objects
+ * This is used to support external durable objects with the DevRegistry in which
+ * The a proxy durable object is created and will forward requests to a well known
+ * URL of the other workerd process
+ */
+export function createInternalDoProxyService(
+	internalObjects: Array<[string, string]>
+): Service {
+	return {
+		// This is treated as a user service to support custom routes
+		name: getUserServiceName(INTERNAL_DO_PROXY_SERVICE_NAME),
+		worker: {
+			compatibilityDate: "2025-05-01",
+			// Define bindings for each internal durable objects
+			bindings: internalObjects.map(([scriptName, className]) => ({
+				name: `${scriptName}_${className}`,
+				durableObjectNamespace: {
+					className,
+					serviceName: getUserServiceName(scriptName),
+				},
+			})),
+			modules: [
+				{
+					name: "proxy.mjs",
+					esModule: `
+                        const HEADER_URL = "${PROXY_OBJECT_URL_HEADER}";
+                        const HEADER_NAME = "${PROXY_OBJECT_NAME_HEADER}";
+                        const HEADER_SCRIPT = "${PROXY_OBJECT_SCRIPT_HEADER}";
+                        const HEADER_ID = "${PROXY_OBJECT_ID_HEADER}";
+                        const HEADER_CF_BLOB = "${PROXY_OBJECT_CF_BLOB_HEADER}";
+
+                        export default {
+                            async fetch(request, env) {
+                                const originalUrl = request.headers.get(HEADER_URL);
+                                const className = request.headers.get(HEADER_NAME);
+                                const scriptName = request.headers.get(HEADER_SCRIPT);
+                                const idString = request.headers.get(HEADER_ID);
+                                const cfBlob = request.headers.get(HEADER_CF_BLOB);
+                                if (originalUrl === null || className === null || idString === null || cfBlob === null) {
+                                    return new Response("Received Durable Object proxy request with missing headers", { status: 400 });
+                                }
+                                if (scriptName === null) {
+                                    return new Response("Durable object proxy to a vite dev session requires wrangler v4.x.x or later", { status: 501 });
+                                }
+                                request = new Request(originalUrl, request);
+                                request.headers.delete(HEADER_URL);
+                                request.headers.delete(HEADER_NAME);
+                                request.headers.delete(HEADER_SCRIPT);
+                                request.headers.delete(HEADER_ID);
+                                request.headers.delete(HEADER_CF_BLOB);
+                                const ns = env[scriptName + '_' + className];
+                                const id = ns.idFromString(idString);
+                                const stub = ns.get(id);
+                                return stub.fetch(request, { cf: JSON.parse(cfBlob) });
+                            }
+                        }
+                    `,
+				},
+			],
+		},
+	};
+}
+
+export function getExternalServiceHttpOptions(
+	service: string,
+	entrypoint: string | undefined
+): HttpOptions {
+	return {
+		// To make sure `request.cf` is set correctly
+		cfBlobHeader: CoreHeaders.CF_BLOB,
+		// Use the service name and entrypoint as the host to proxy RPC calls
+		capnpConnectHost: `${service}:${entrypoint ?? "default"}`,
+		// The headers are injected only for fetch and are used for proxying fetch requests
+		injectRequestHeaders: [
+			{
+				name: PROXY_SERVICE_HEADER,
+				value: service,
+			},
+			{
+				name: PROXY_ENTRYPOINT_HEADER,
+				value: entrypoint ?? "default",
+			},
+		],
+	};
+}
+
+export function getExternalServiceSocketName(
+	service: string,
+	entrypoint: string | undefined
+): string {
+	return `external-fallback-${service}-${entrypoint ?? "default"}`;
+}
+
+export function getProtocol(url: URL): "http" | "https" {
+	const protocol = url.protocol.substring(0, url.protocol.length - 1);
+
+	assert(
+		protocol === "http" || protocol === "https",
+		"Expected protocol to be http or https"
+	);
+
+	return protocol;
+}
+
+export function extractExternalServiceFetchProxyTarget(
+	req: http.IncomingMessage
+): {
+	service: string;
+	entrypoint: string;
+} | null {
+	// The parsed headers are always in lowercase
+	const service = req.headers[PROXY_SERVICE_HEADER.toLowerCase()];
+	const entrypoint = req.headers[PROXY_ENTRYPOINT_HEADER.toLowerCase()];
+
+	if (typeof service !== "string" || typeof entrypoint !== "string") {
+		// This is not a external fetch request. No proxying needed.
+		return null;
+	}
+
+	// Remove the headers from the request
+	// to avoid sending them to the target service
+	delete req.headers[PROXY_SERVICE_HEADER.toLowerCase()];
+	delete req.headers[PROXY_ENTRYPOINT_HEADER.toLowerCase()];
+
+	return {
+		service,
+		entrypoint,
+	};
+}
+
+export function extractExternalDoFetchProxyTarget(req: http.IncomingMessage): {
+	scriptName: string;
+	className: string;
+} | null {
+	// The parsed headers are always in lowercase
+	// These headers will be removed by the proxy worker later
+	const url = req.headers[PROXY_OBJECT_URL_HEADER.toLowerCase()];
+	const id = req.headers[PROXY_OBJECT_ID_HEADER.toLowerCase()];
+	const cfBlob = req.headers[PROXY_OBJECT_CF_BLOB_HEADER.toLowerCase()];
+	const scriptName = req.headers[PROXY_OBJECT_SCRIPT_HEADER.toLowerCase()];
+	const className = req.headers[PROXY_OBJECT_NAME_HEADER.toLowerCase()];
+
+	if (
+		typeof url !== "string" ||
+		typeof id !== "string" ||
+		typeof cfBlob !== "string" ||
+		typeof scriptName !== "string" ||
+		typeof className !== "string"
+	) {
+		// This is not a external do fetch request. No proxying needed.
+		return null;
+	}
+
+	return {
+		scriptName,
+		className,
+	};
+}
+
+// These headers must match the wrangler implementation for backwards compatibility
+const PROXY_OBJECT_URL_HEADER = "X-Miniflare-Durable-Object-URL";
+const PROXY_OBJECT_NAME_HEADER = "X-Miniflare-Durable-Object-Name";
+const PROXY_OBJECT_ID_HEADER = "X-Miniflare-Durable-Object-Id";
+const PROXY_OBJECT_CF_BLOB_HEADER = "X-Miniflare-Durable-Object-Cf-Blob";
+// This is added to support fetching external DO with multi workers
+const PROXY_OBJECT_SCRIPT_HEADER = "X-Miniflare-Durable-Object-Script";
+// Theses headers are used to proxy fetch requests to external service bindings
+const PROXY_SERVICE_HEADER = "X-Miniflare-Proxy-Service";
+const PROXY_ENTRYPOINT_HEADER = "X-Miniflare-Proxy-Entrypoint";
+const CREATE_PROXY_PROTOTYPE_CLASS_HELPER_SCRIPT = `
+    const HANDLER_RESERVED_KEYS = new Set([
+        "alarm",
+        "scheduled",
+        "self",
+        "tail",
+        "tailStream",
+        "test",
+        "trace",
+        "webSocketClose",
+        "webSocketError",
+        "webSocketMessage",
+    ]);
+
+    function createProxyPrototypeClass(handlerSuperKlass, getUnknownPrototypeKey) {
+        // Build a class with a "Proxy"-prototype, so we can intercept RPC calls and
+        // throw unsupported exceptions :see_no_evil:
+        function klass(ctx, env) {
+            // Delay proxying prototype until construction, so workerd sees this as a
+            // regular class when introspecting it. This check fails if we don't do this:
+            // https://github.com/cloudflare/workerd/blob/9e915ed637d65adb3c57522607d2cd8b8d692b6b/src/workerd/io/worker.c%2B%2B#L1920-L1921
+            klass.prototype = new Proxy(klass.prototype, {
+                get(target, key, receiver) {
+                    const value = Reflect.get(target, key, receiver);
+                    if (value !== undefined) return value;
+                    if (HANDLER_RESERVED_KEYS.has(key)) return;
+                    return getUnknownPrototypeKey(key);
+                }
+            });
+
+            return Reflect.construct(handlerSuperKlass, [ctx, env], klass);
+        }
+
+        Reflect.setPrototypeOf(klass.prototype, handlerSuperKlass.prototype);
+        Reflect.setPrototypeOf(klass, handlerSuperKlass);
+
+        return klass;
+    }
+`;

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -266,7 +266,7 @@ test("DevRegistry: fetch to durable object with do proxy disabled", async (t) =>
 	const remote = new Miniflare({
 		name: "remote-worker",
 		unsafeDevRegistryPath,
-		unsafeDevRegistryDoProxy: false,
+		unsafeDevRegistryDurableObjectProxy: false,
 		compatibilityFlags: ["experimental"],
 		durableObjects: {
 			DO: {
@@ -296,7 +296,7 @@ test("DevRegistry: fetch to durable object with do proxy disabled", async (t) =>
 	const local = new Miniflare({
 		name: "local-worker",
 		unsafeDevRegistryPath,
-		unsafeDevRegistryDoProxy: false,
+		unsafeDevRegistryDurableObjectProxy: false,
 		durableObjects: {
 			DO: {
 				className: "MyDurableObject",
@@ -329,7 +329,7 @@ test("DevRegistry: RPC to durable object with do proxy disabled", async (t) => {
 	const remote = new Miniflare({
 		name: "remote-worker",
 		unsafeDevRegistryPath,
-		unsafeDevRegistryDoProxy: false,
+		unsafeDevRegistryDurableObjectProxy: false,
 		compatibilityFlags: ["experimental"],
 		durableObjects: {
 			DO: {
@@ -353,7 +353,7 @@ test("DevRegistry: RPC to durable object with do proxy disabled", async (t) => {
 	const local = new Miniflare({
 		name: "local-worker",
 		unsafeDevRegistryPath,
-		unsafeDevRegistryDoProxy: false,
+		unsafeDevRegistryDurableObjectProxy: false,
 		durableObjects: {
 			DO: {
 				className: "MyDurableObject",
@@ -395,7 +395,7 @@ test("DevRegistry: fetch to durable object", async (t) => {
 	const local = new Miniflare({
 		name: "local-worker",
 		unsafeDevRegistryPath,
-		unsafeDevRegistryDoProxy: true,
+		unsafeDevRegistryDurableObjectProxy: true,
 		durableObjects: {
 			DO: {
 				className: "MyDurableObject",
@@ -426,7 +426,7 @@ test("DevRegistry: fetch to durable object", async (t) => {
 	const remote = new Miniflare({
 		name: "remote-worker",
 		unsafeDevRegistryPath,
-		unsafeDevRegistryDoProxy: true,
+		unsafeDevRegistryDurableObjectProxy: true,
 		compatibilityFlags: ["experimental"],
 		durableObjects: {
 			DO: {
@@ -464,7 +464,7 @@ test("DevRegistry: RPC to durable object", async (t) => {
 	const local = new Miniflare({
 		name: "local-worker",
 		unsafeDevRegistryPath,
-		unsafeDevRegistryDoProxy: true,
+		unsafeDevRegistryDurableObjectProxy: true,
 		durableObjects: {
 			DO: {
 				className: "MyDurableObject",
@@ -502,7 +502,7 @@ test("DevRegistry: RPC to durable object", async (t) => {
 	const remote = new Miniflare({
 		name: "remote-worker",
 		unsafeDevRegistryPath,
-		unsafeDevRegistryDoProxy: true,
+		unsafeDevRegistryDurableObjectProxy: true,
 		compatibilityFlags: ["experimental"],
 		durableObjects: {
 			DO: {

--- a/packages/miniflare/test/dev-registry.spec.ts
+++ b/packages/miniflare/test/dev-registry.spec.ts
@@ -1,0 +1,826 @@
+import test from "ava";
+import { Miniflare, MiniflareOptions } from "miniflare";
+import { useTmp, waitUntil } from "./test-shared";
+
+test("DevRegistry: fetch to service worker", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const local = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		serviceBindings: {
+			SERVICE: {
+				name: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+					return await env.SERVICE.fetch(request);
+				}
+			}
+		`,
+	});
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://placeholder");
+
+	t.is(
+		await res.text(),
+		`Couldn\'t find a local dev session for the "default" entrypoint of service "remote-worker" to proxy to`
+	);
+	t.is(res.status, 503);
+
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		compatibilityFlags: ["experimental"],
+		script: `addEventListener("fetch", (event) => {
+			event.respondWith(new Response("Hello from service worker!"));
+		})`,
+	});
+	t.teardown(() => remote.dispose());
+
+	await remote.ready;
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://placeholder");
+
+		t.is(await res.text(), "Hello from service worker!");
+		t.is(res.status, 200);
+	});
+});
+
+test("DevRegistry: fetch to module worker", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const local = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		serviceBindings: {
+			SERVICE: {
+				name: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+					return await env.SERVICE.fetch(request);
+				}
+			}
+		`,
+	});
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://example.com?name=World");
+	t.is(
+		await res.text(),
+		`Couldn\'t find a local dev session for the "default" entrypoint of service "remote-worker" to proxy to`
+	);
+	t.is(res.status, 503);
+
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+                    const url = new URL(request.url, 'http://placeholder');
+                    const name = url.searchParams.get("name") ?? 'anonymous';
+
+					return new Response("Hello " + name);
+				}
+			}
+		`,
+		unsafeDirectSockets: [{}],
+	});
+	t.teardown(() => remote.dispose());
+
+	await remote.ready;
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://example.com?name=World");
+		const result = await res.text();
+		t.is(result, "Hello World");
+		t.is(res.status, 200);
+	});
+});
+
+test("DevRegistry: RPC to default entrypoint", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const local = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		serviceBindings: {
+			SERVICE: {
+				name: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+					try {
+                        const result = await env.SERVICE.ping();
+                        return new Response(result);
+                    } catch (e) {
+                        return new Response(e.message, { status: 500 });
+                    }
+				}
+			}
+		`,
+	});
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://placeholder");
+	t.is(
+		await res.text(),
+		`Cannot access "ping" as we couldn\'t find a local dev session for the "default" entrypoint of service "remote-worker" to proxy to.`
+	);
+	t.is(res.status, 500);
+
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			import { WorkerEntrypoint } from "cloudflare:workers";
+			export default class TestEntrypoint extends WorkerEntrypoint {
+				ping() { return "pong"; }
+			}
+		`,
+		unsafeDirectSockets: [{}],
+	});
+
+	await remote.ready;
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://placeholder");
+		const result = await res.text();
+		t.is(result, "pong");
+	});
+
+	// Kill the remote worker to see if it fails gracefully
+	await remote.dispose();
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://placeholder");
+		t.is(
+			await res.text(),
+			`Cannot access "ping" as we couldn\'t find a local dev session for the "default" entrypoint of service "remote-worker" to proxy to.`
+		);
+		t.is(res.status, 500);
+	});
+});
+
+test("DevRegistry: RPC to custom entrypoint", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const local = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		serviceBindings: {
+			SERVICE: {
+				name: "remote-worker",
+				entrypoint: "TestEntrypoint",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+                    try {
+                        const result = await env.SERVICE.ping();
+                        return new Response(result);
+                    } catch (e) {
+                        return new Response(e.message, { status: 500 });
+                    }
+				}
+			}
+		`,
+	});
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://placeholder");
+	t.is(
+		await res.text(),
+		`Cannot access "ping" as we couldn\'t find a local dev session for the "TestEntrypoint" entrypoint of service "remote-worker" to proxy to.`
+	);
+	t.is(res.status, 500);
+
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			import { WorkerEntrypoint } from "cloudflare:workers";
+			export class TestEntrypoint extends WorkerEntrypoint {
+				ping() { return "pong"; }
+			}
+		`,
+		unsafeDirectSockets: [
+			{
+				entrypoint: "TestEntrypoint",
+			},
+		],
+	});
+
+	await remote.ready;
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://placeholder");
+		const result = await res.text();
+		t.is(result, "pong");
+	});
+
+	await remote.dispose();
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://placeholder");
+		t.is(
+			await res.text(),
+			`Cannot access "ping" as we couldn\'t find a local dev session for the "TestEntrypoint" entrypoint of service "remote-worker" to proxy to.`
+		);
+		t.is(res.status, 500);
+	});
+});
+
+test("DevRegistry: fetch to external worker with dev registry disabled", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+                    const url = new URL(request.url, 'http://placeholder');
+                    const name = url.searchParams.get("name") ?? 'anonymous';
+
+					return new Response("Hello " + name);
+				}
+			}
+		`,
+		unsafeDirectSockets: [{}],
+	});
+	t.teardown(() => remote.dispose());
+
+	// To make sure the remote worker is registered
+	await remote.ready;
+
+	const localWorkerOptions: MiniflareOptions = {
+		name: "local-worker",
+		serviceBindings: {
+			SERVICE: {
+				name: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+                    return await env.SERVICE.fetch(request);
+				}
+			}
+		`,
+	};
+	const local = new Miniflare(localWorkerOptions);
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://placeholder");
+	const result = await res.text();
+	t.is(
+		result,
+		`Worker Entrypoint "default" of service "remote-worker" is not defined in the options. ` +
+			`Set the "unsafeDevRegistryPath" option if you would like Miniflare to lookup services from the Dev Registry.`
+	);
+	t.is(res.status, 503);
+
+	// Enable the dev registry
+	await local.setOptions({
+		...localWorkerOptions,
+		unsafeDevRegistryPath,
+	});
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://placeholder");
+		t.is(await res.text(), "Hello anonymous");
+		t.is(res.status, 200);
+	});
+});
+
+test("DevRegistry: RPC to external worker with dev registry disabled", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			import { WorkerEntrypoint } from "cloudflare:workers";
+			export default class TestEntrypoint extends WorkerEntrypoint {
+				ping() { return "pong"; }
+			}
+		`,
+		unsafeDirectSockets: [{}],
+	});
+	t.teardown(() => remote.dispose());
+
+	// To make sure the remote worker is registered
+	await remote.ready;
+
+	const localWorkerOptions: MiniflareOptions = {
+		name: "local-worker",
+		// The dev registry path is commented out
+		// unsafeDevRegistryPath,
+		serviceBindings: {
+			SERVICE: {
+				name: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+                    try {
+                        const result = await env.SERVICE.ping();
+                        return new Response(result);
+                    } catch (e) {
+                        return new Response(e.message, { status: 500 });
+                    }
+				}
+			}
+		`,
+	};
+
+	const local = new Miniflare(localWorkerOptions);
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://placeholder");
+	t.is(
+		await res.text(),
+		`Worker Entrypoint "default" of service "remote-worker" is not defined in the options. ` +
+			`Set the "unsafeDevRegistryPath" option if you would like Miniflare to lookup services from the Dev Registry.`
+	);
+	t.is(res.status, 500);
+
+	// Enable the dev registry
+	await local.setOptions({
+		...localWorkerOptions,
+		unsafeDevRegistryPath,
+	});
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://placeholder");
+		const result = await res.text();
+		t.is(result, "pong");
+	});
+});
+
+test("DevRegistry: fetch to external durable object with dev registry disabled", async (t) => {
+	const mf = new Miniflare({
+		name: "local-worker",
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+				scriptName: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+                    const ns = env.DO;
+					const id = ns.newUniqueId();
+					const stub = ns.get(id);
+					return stub.fetch(request);
+				}
+			}
+		`,
+	});
+	t.teardown(() => mf.dispose());
+
+	const res = await mf.dispatchFetch("http://placeholder");
+	const result = await res.text();
+	t.is(res.status, 503);
+	t.is(result, "Service Unavailable");
+});
+
+test("DevRegistry: RPC to external durable object with dev registry disabled", async (t) => {
+	const mf = new Miniflare({
+		name: "local-worker",
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+				scriptName: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+					try {
+						const ns = env.DO;
+						const id = ns.newUniqueId();
+						const stub = ns.get(id);
+						const result = await stub.ping();
+						return new Response(result);
+					} catch (ex) {
+						return new Response(ex.message, { status: 500 });
+					}
+				}
+			}
+		`,
+	});
+	t.teardown(() => mf.dispose());
+
+	const res = await mf.dispatchFetch("http://placeholder");
+	const result = await res.text();
+	t.is(
+		result,
+		`Durable Object "MyDurableObject" of script "remote-worker" is not defined in the options. ` +
+			`Set the "unsafeDevRegistryDOProxy" option if you would like Miniflare to lookup services from the Dev Registry.`
+	);
+	t.is(res.status, 500);
+});
+
+test("DevRegistry: fetch to durable object with do proxy disabled", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		unsafeDevRegistryDoProxy: false,
+		compatibilityFlags: ["experimental"],
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+			},
+		},
+		modules: true,
+		script: `
+			import { DurableObject } from "cloudflare:workers";
+			export class MyDurableObject extends DurableObject {
+				fetch() {
+					return new Response('Hello from Durable Object!');
+				}
+			};
+
+			export default {
+				async fetch(request, env, ctx) {
+                    return new Response("Hello from the default Worker Entrypoint!");
+				}
+			}
+		`,
+	});
+	t.teardown(() => remote.dispose());
+
+	await remote.ready;
+
+	const local = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		unsafeDevRegistryDoProxy: false,
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+				scriptName: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+	                const ns = env.DO;
+					const id = ns.newUniqueId();
+					const stub = ns.get(id);
+					return stub.fetch(request);
+				}
+			}
+		`,
+	});
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://placeholder");
+	const result = await res.text();
+	t.is(result, "Service Unavailable");
+	t.is(res.status, 503);
+});
+
+test("DevRegistry: RPC to durable object with do proxy disabled", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		unsafeDevRegistryDoProxy: false,
+		compatibilityFlags: ["experimental"],
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+			},
+		},
+		modules: true,
+		script: `
+			import { DurableObject } from "cloudflare:workers";
+			export class MyDurableObject extends DurableObject {
+				ping() {
+					return "pong";
+				}
+			};
+		`,
+	});
+	t.teardown(() => remote.dispose());
+
+	await remote.ready;
+
+	const local = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		unsafeDevRegistryDoProxy: false,
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+				scriptName: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+					try {
+						const ns = env.DO;
+						const id = ns.newUniqueId();
+						const stub = ns.get(id);
+						const result = await stub.ping();
+
+						return new Response(result);
+					} catch (ex) {
+						return new Response(ex.message, { status: 500 });
+					}
+				}
+			}
+		`,
+	});
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://placeholder");
+	const result = await res.text();
+	t.is(
+		result,
+		`Durable Object "MyDurableObject" of script "remote-worker" is not defined in the options. ` +
+			`Set the "unsafeDevRegistryDOProxy" option if you would like Miniflare to lookup services from the Dev Registry.`
+	);
+	t.is(res.status, 500);
+});
+
+test("DevRegistry: fetch to durable object", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const local = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		unsafeDevRegistryDoProxy: true,
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+				scriptName: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+	                const ns = env.DO;
+					const id = ns.newUniqueId();
+					const stub = ns.get(id);
+					return stub.fetch(request);
+				}
+			}
+		`,
+	});
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://placeholder");
+	t.is(await res.text(), "Service Unavailable");
+	t.is(res.status, 503);
+
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		unsafeDevRegistryDoProxy: true,
+		compatibilityFlags: ["experimental"],
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+			},
+		},
+		modules: true,
+		script: `
+			import { DurableObject } from "cloudflare:workers";
+			export class MyDurableObject extends DurableObject {
+				fetch() {
+					return new Response('Hello from Durable Object!');
+				}
+			};
+
+			export default {
+				async fetch(request, env, ctx) {
+                    return new Response("Hello from the default Worker Entrypoint!");
+				}
+			}
+		`,
+	});
+	t.teardown(() => remote.dispose());
+
+	await remote.ready;
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://placeholder");
+		t.is(await res.text(), "Hello from Durable Object!");
+		t.is(res.status, 200);
+	});
+});
+
+test("DevRegistry: RPC to durable object", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const local = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		unsafeDevRegistryDoProxy: true,
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+				scriptName: "remote-worker",
+			},
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env, ctx) {
+					try {
+						const ns = env.DO;
+						const id = ns.newUniqueId();
+						const stub = ns.get(id);
+						const result = await stub.ping();
+
+						return new Response(result);
+					} catch (ex) {
+						return new Response(ex.message, { status: 500 });
+					}
+				}
+			}
+		`,
+	});
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://placeholder");
+	t.is(
+		await res.text(),
+		`Cannot access "ping" as Durable Object RPC is not yet supported between multiple dev sessions.`
+	);
+	t.is(res.status, 500);
+
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		unsafeDevRegistryDoProxy: true,
+		compatibilityFlags: ["experimental"],
+		durableObjects: {
+			DO: {
+				className: "MyDurableObject",
+			},
+		},
+		modules: true,
+		script: `
+			import { DurableObject } from "cloudflare:workers";
+			export class MyDurableObject extends DurableObject {
+				ping() {
+					return "pong";
+				}
+			};
+		`,
+	});
+	t.teardown(() => remote.dispose());
+
+	await remote.ready;
+	await waitUntil(t, async (t) => {
+		const res = await local.dispatchFetch("http://placeholder");
+		t.is(
+			await res.text(),
+			`Cannot access "ping" as Durable Object RPC is not yet supported between multiple dev sessions.`
+		);
+		t.is(res.status, 500);
+	});
+});
+
+test("DevRegistry: tail to default entrypoint", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const remote = new Miniflare({
+		name: "remote-worker",
+		unsafeDevRegistryPath,
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			let resolve, reject;
+			const promise = new Promise((res, rej) => {
+				resolve = res;
+				reject = rej;
+			});
+			export default {
+				async fetch() {
+					try {
+						const event = await Promise.race([
+							promise,
+							new Promise((_, cancel) => setTimeout(cancel, 1000))
+						]);
+						return Response.json(event[0].logs[0].message);
+					} catch {
+						return new Response("No tail event received", { status: 500 });
+					}
+				},
+				tail(e) {
+					resolve(e);
+				}
+			};
+		`,
+		unsafeDirectSockets: [{}],
+	});
+	t.teardown(() => remote.dispose());
+
+	await remote.ready;
+
+	const local = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		tails: ["remote-worker"],
+		serviceBindings: {
+			remote: "remote-worker",
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env) {
+					if (request.url.includes("remote-worker")) {
+						return env.remote.fetch(request)
+					}
+					console.log("log event")
+					return new Response("Hello from local-worker!");
+				}
+			}
+		`,
+	});
+	t.teardown(() => local.dispose());
+
+	const res = await local.dispatchFetch("http://example.com");
+	const result = await res.text();
+	t.is(result, "Hello from local-worker!");
+
+	const res2 = await local.dispatchFetch("http://example.com/remote-worker");
+	const result2 = await res2.json();
+
+	t.deepEqual(result2, ["log event"]);
+});
+
+test("DevRegistry: tail to unknown worker", async (t) => {
+	const unsafeDevRegistryPath = await useTmp(t);
+	const mf = new Miniflare({
+		name: "local-worker",
+		unsafeDevRegistryPath,
+		tails: ["remote-worker"],
+		serviceBindings: {
+			remote: "remote-worker",
+		},
+		compatibilityFlags: ["experimental"],
+		modules: true,
+		script: `
+			export default {
+				async fetch(request, env) {
+					if (request.url.includes("remote-worker")) {
+						return env.remote.fetch(request)
+					}
+					console.log("log event")
+					return new Response("Hello from local-worker!");
+				}
+			}
+		`,
+	});
+	t.teardown(() => mf.dispose());
+
+	const res = await mf.dispatchFetch("http://example.com");
+	const result = await res.text();
+	t.is(result, "Hello from local-worker!");
+
+	const res2 = await mf.dispatchFetch("http://example.com/remote-worker");
+	const result2 = await res2.text();
+
+	t.deepEqual(
+		result2,
+		`Couldn\'t find a local dev session for the "default" entrypoint of service "remote-worker" to proxy to`
+	);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1683,6 +1683,9 @@ importers:
       capnp-es:
         specifier: ^0.0.7
         version: 0.0.7(typescript@5.7.3)
+      chokidar:
+        specifier: ^4.0.1
+        version: 4.0.1
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2


### PR DESCRIPTION
Fixes [DEVX-1829](https://jira.cfdata.org/browse/DEVX-1829)

This PR introduces two new Miniflare options to streamline auto-service discovery via the Dev Registry with backward compatibility with the Wrangler implementation:

- `unsafeDevRegistryPath` (`string`): Filesystem path to the Dev Registry directory
- `unsafeDevRegistryDurableObjectProxy` (`boolean`): When enabled, exposes internal Durable Objects to other Dev sessions and allows Workers to connect to external Durable Objects

The implementation of the Miniflare Dev Registry is different from the Wrangler implementation. Instead of restarting the Workers runtime with the config updated based on the worker definition in the registry, this solution will setup a proxy in the loopback server to resolve the address of the external services dynamically.

For example, Worker A has a service binding to the default entrypoint of Worker B, Miniflare will look up all workers options and set up a fallback service upfront in case no address is found at runtime, then update the option and point it to its loopback server.

When Worker A calls Worker B over the service bindings, the request will be sent to the loopback server and resolve the address of Worker B dynamically.

![Dev Registry: Service Binding / Tail Handler support](https://github.com/user-attachments/assets/bd32be69-b070-4fb9-b9f3-c439e09be928)

There are two types of proxy involved
- `Fetch`: will send a regular HTTP request to the loopback server with the service and entrypoint injected in the headers. This is handled by `Miniflare.#handleLoopback`
- `RPC methods` will initiate a HTTP Connect request to establish a HTTP tunnel with the connect host customized to the format `{service}:{entrypoint}`. This is handled by `Miniflare.#handleLoopbackConnect`.

While Durable Object support uses a different flow due to missing workerd support, it is restricted to `fetch` only and will requires a few extra proxy services in between to route the request to the Durable object in the other workerd process.

The Entry Worker is involved for compatibility with Wrangler which uses Worker Routes underneath with a well known URL.

![Dev Registry: Durable Objects support](https://github.com/user-attachments/assets/ca6c57f7-e788-46a7-bb3d-c4d1d03b1c84)


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: unsafe miniflare feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
