### PR TITLE
fix(vite-plugin): Support `__` in additional module IDs

### DIFF
--- a/.changeset/neat-jokes-prove.md
+++ b/.changeset/neat-jokes-prove.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Fix regex to correctly detect additional module imports with \_\_ in path

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/__tests__/additional-modules.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/__tests__/additional-modules.spec.ts
@@ -22,6 +22,11 @@ test("supports Text modules with a '.txt' extension", async () => {
 	expect(result).toBe("Example text content.\n");
 });
 
+test("supports modules with `__`s in the filename", async () => {
+	const result = await getTextResponse("/text2");
+	expect(result).toBe("Example text content 2");
+});
+
 test("supports CompiledWasm modules with a '.wasm' extension", async () => {
 	const result = await getJsonResponse("/wasm");
 	expect(result).toEqual({ result: 7 });

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/src/index.ts
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/src/index.ts
@@ -1,5 +1,6 @@
 import bin from "./modules/bin-example.bin";
 import html from "./modules/html-example.html";
+import text2 from "./modules/text__example__2.txt";
 import text from "./modules/text-example.txt";
 import wasm from "./modules/wasm-example.wasm";
 import init from "./modules/wasm-example.wasm?init";
@@ -18,6 +19,11 @@ export default {
 			}
 			case "/text": {
 				return new Response(text, {
+					headers: { "Content-Type": "text/plain" },
+				});
+			}
+			case "/text2": {
+				return new Response(text2, {
 					headers: { "Content-Type": "text/plain" },
 				});
 			}

--- a/packages/vite-plugin-cloudflare/playground/additional-modules/src/modules/text__example__2.txt
+++ b/packages/vite-plugin-cloudflare/playground/additional-modules/src/modules/text__example__2.txt
@@ -1,0 +1,1 @@
+Example text content 2

--- a/packages/vite-plugin-cloudflare/src/additional-modules.ts
+++ b/packages/vite-plugin-cloudflare/src/additional-modules.ts
@@ -26,5 +26,5 @@ export function matchAdditionalModule(source: string) {
 }
 
 export function createModuleReference(type: AdditionalModuleType, id: string) {
-	return `__CLOUDFLARE_MODULE__${type}__${id}__CLOUDFLARE_MODULE__`;
+	return `__CLOUDFLARE_MODULE__${type}__${id}__`;
 }

--- a/packages/vite-plugin-cloudflare/src/additional-modules.ts
+++ b/packages/vite-plugin-cloudflare/src/additional-modules.ts
@@ -26,5 +26,5 @@ export function matchAdditionalModule(source: string) {
 }
 
 export function createModuleReference(type: AdditionalModuleType, id: string) {
-	return `__CLOUDFLARE_MODULE__${type}__${id}__`;
+	return `__CLOUDFLARE_MODULE__${type}__${id}__CLOUDFLARE_MODULE__`;
 }

--- a/packages/vite-plugin-cloudflare/src/shared.ts
+++ b/packages/vite-plugin-cloudflare/src/shared.ts
@@ -3,7 +3,7 @@ import { ADDITIONAL_MODULE_TYPES } from "./constants";
 export const UNKNOWN_HOST = "http://localhost";
 export const INIT_PATH = "/__vite_plugin_cloudflare_init__";
 
-const ADDITIONAL_MODULE_PATTERN = `__CLOUDFLARE_MODULE__(${ADDITIONAL_MODULE_TYPES.join("|")})__(.*?)__CLOUDFLARE_MODULE__`;
+const ADDITIONAL_MODULE_PATTERN = `__CLOUDFLARE_MODULE__(${ADDITIONAL_MODULE_TYPES.join("|")})__(.*?)__`;
 export const additionalModuleRE = new RegExp(ADDITIONAL_MODULE_PATTERN);
 export const additionalModuleGlobalRE = new RegExp(
 	ADDITIONAL_MODULE_PATTERN,

--- a/packages/vite-plugin-cloudflare/src/shared.ts
+++ b/packages/vite-plugin-cloudflare/src/shared.ts
@@ -3,7 +3,7 @@ import { ADDITIONAL_MODULE_TYPES } from "./constants";
 export const UNKNOWN_HOST = "http://localhost";
 export const INIT_PATH = "/__vite_plugin_cloudflare_init__";
 
-const ADDITIONAL_MODULE_PATTERN = `__CLOUDFLARE_MODULE__(${ADDITIONAL_MODULE_TYPES.join("|")})__(.*?)__`;
+const ADDITIONAL_MODULE_PATTERN = `__CLOUDFLARE_MODULE__(${ADDITIONAL_MODULE_TYPES.join("|")})__(.*?)__CLOUDFLARE_MODULE__`;
 export const additionalModuleRE = new RegExp(ADDITIONAL_MODULE_PATTERN);
 export const additionalModuleGlobalRE = new RegExp(
 	ADDITIONAL_MODULE_PATTERN,

--- a/packages/vite-plugin-cloudflare/src/shared.ts
+++ b/packages/vite-plugin-cloudflare/src/shared.ts
@@ -3,7 +3,7 @@ import { ADDITIONAL_MODULE_TYPES } from "./constants";
 export const UNKNOWN_HOST = "http://localhost";
 export const INIT_PATH = "/__vite_plugin_cloudflare_init__";
 
-const ADDITIONAL_MODULE_PATTERN = `__CLOUDFLARE_MODULE__(${ADDITIONAL_MODULE_TYPES.join("|")})__(.*?)__`;
+const ADDITIONAL_MODULE_PATTERN = `__CLOUDFLARE_MODULE__(${ADDITIONAL_MODULE_TYPES.join("|")})__(.*?)__$`;
 export const additionalModuleRE = new RegExp(ADDITIONAL_MODULE_PATTERN);
 export const additionalModuleGlobalRE = new RegExp(
 	ADDITIONAL_MODULE_PATTERN,

--- a/packages/vite-plugin-cloudflare/src/shared.ts
+++ b/packages/vite-plugin-cloudflare/src/shared.ts
@@ -3,7 +3,7 @@ import { ADDITIONAL_MODULE_TYPES } from "./constants";
 export const UNKNOWN_HOST = "http://localhost";
 export const INIT_PATH = "/__vite_plugin_cloudflare_init__";
 
-const ADDITIONAL_MODULE_PATTERN = `__CLOUDFLARE_MODULE__(${ADDITIONAL_MODULE_TYPES.join("|")})__(.*?)__$`;
+const ADDITIONAL_MODULE_PATTERN = `__CLOUDFLARE_MODULE__(${ADDITIONAL_MODULE_TYPES.join("|")})__(.*?)__CLOUDFLARE_MODULE__`;
 export const additionalModuleRE = new RegExp(ADDITIONAL_MODULE_PATTERN);
 export const additionalModuleGlobalRE = new RegExp(
 	ADDITIONAL_MODULE_PATTERN,


### PR DESCRIPTION
 ## Problem

There's a regex used to detect if certain files (wasm, .bin, .txt, .html) are being imported at runtime. The current regex looks like this:

```ts
const ADDITIONAL_MODULE_PATTERN = `__CLOUDFLARE_MODULE__(${ADDITIONAL_MODULE_TYPES.join("|")})__(.*?)__`;
```

This means if there are files with `__`s in them, those `__`s will get matched first, rather than the final `__` in the module pattern being matched on.

 ## Solution
Add a `$` to the end of the regex so, to anchor to the end of the string.

 ## Background context
`pnpm` stores files for packages in locations like this (note the `__`s), which uncovered this.

```
/path/to/project/node_modules/.pnpm/@prisma+client@6.8.2_prisma@6.8.2_typescript@5.8.3__typescript@5.8.3/node_modules/@prisma/client/runtime/query_engine_bg.sqlite.wasm
```

### Update
Adding the `$` turned out to break the build step - where we need to now match on the entire code string for a chunk, rather than the virtual module path itself as a string: https://github.com/cloudflare/workers-sdk/pull/9322#issuecomment-2897792616

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: No API change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: Not a Wrangler change