### PR TITLE
feat: introduce defaultPersistRoot option

### DIFF
--- a/.changeset/blue-streets-thank.md
+++ b/.changeset/blue-streets-thank.md
@@ -1,0 +1,24 @@
+---
+"miniflare": minor
+---
+
+Add a new `defaultPersistRoot` option to control where plugins persist data when no path is provided.
+
+```js
+// Before this change / No `defaultPersistRoot`
+new Miniflare({
+	kvPersist: undefined, // → "/(tmp)/kv"
+	d1Persist: true, // → "/.mf/d1"
+	r2Persist: false, // → "/(tmp)/d1"
+	cachePersist: "/my-cache", // → "/my-cache"
+});
+
+// With `defaultPersistRoot`
+new Miniflare({
+	defaultPersistRoot: "/storage",
+	kvPersist: undefined, // → "/storage/kv"
+	d1Persist: true, // → "/storage/d1"
+	r2Persist: false, // → "/(tmp)/d1"
+	cachePersist: "/my-cache", // → "/my-cache"
+});
+```

--- a/.changeset/twenty-cats-clap.md
+++ b/.changeset/twenty-cats-clap.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/vite-plugin": minor
+"wrangler": minor
+---
+
+Updated internal configuration to use Miniflare’s new `defaultPersistRoot` instead of per-plugin `persist` flags

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1293,6 +1293,7 @@ export class Miniflare {
 				workerIndex: i,
 				additionalModules,
 				tmpPath: this.#tmpPath,
+				defaultPersistRoot: sharedOpts.core.defaultPersistRoot,
 				workerNames,
 				loopbackPort,
 				unsafeStickyBlobs,

--- a/packages/miniflare/src/plugins/cache/index.ts
+++ b/packages/miniflare/src/plugins/cache/index.ts
@@ -56,6 +56,7 @@ export const CACHE_PLUGIN: Plugin<
 		options,
 		workerIndex,
 		tmpPath,
+		defaultPersistRoot,
 		unsafeStickyBlobs,
 	}) {
 		const cache = options.cache ?? true;
@@ -100,7 +101,12 @@ export const CACHE_PLUGIN: Plugin<
 			const uniqueKey = `miniflare-${CACHE_OBJECT_CLASS_NAME}`;
 
 			const persist = sharedOptions.cachePersist;
-			const persistPath = getPersistPath(CACHE_PLUGIN_NAME, tmpPath, persist);
+			const persistPath = getPersistPath(
+				CACHE_PLUGIN_NAME,
+				tmpPath,
+				defaultPersistRoot,
+				persist
+			);
 			await fs.mkdir(persistPath, { recursive: true });
 			const storageService: Service = {
 				name: CACHE_STORAGE_SERVICE_NAME,
@@ -148,6 +154,6 @@ export const CACHE_PLUGIN: Plugin<
 		return services;
 	},
 	getPersistPath({ cachePersist }, tmpPath) {
-		return getPersistPath(CACHE_PLUGIN_NAME, tmpPath, cachePersist);
+		return getPersistPath(CACHE_PLUGIN_NAME, tmpPath, undefined, cachePersist);
 	},
 };

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -226,6 +226,10 @@ export const CoreSharedOptionsSchema = z.object({
 	unsafeTriggerHandlers: z.boolean().optional(),
 	// Enable logging requests
 	logRequests: z.boolean().default(true),
+
+	// Path to the root directory for persisting data
+	// Used as the default for all plugins with the plugin name as the subdirectory name
+	defaultPersistRoot: z.string().optional(),
 });
 
 export const CORE_PLUGIN_NAME = "core";

--- a/packages/miniflare/src/plugins/d1/index.ts
+++ b/packages/miniflare/src/plugins/d1/index.ts
@@ -99,6 +99,7 @@ export const D1_PLUGIN: Plugin<
 		options,
 		sharedOptions,
 		tmpPath,
+		defaultPersistRoot,
 		log,
 		unsafeStickyBlobs,
 	}) {
@@ -115,7 +116,12 @@ export const D1_PLUGIN: Plugin<
 
 		if (databases.length > 0) {
 			const uniqueKey = `miniflare-${D1_DATABASE_OBJECT_CLASS_NAME}`;
-			const persistPath = getPersistPath(D1_PLUGIN_NAME, tmpPath, persist);
+			const persistPath = getPersistPath(
+				D1_PLUGIN_NAME,
+				tmpPath,
+				defaultPersistRoot,
+				persist
+			);
 			await fs.mkdir(persistPath, { recursive: true });
 
 			const storageService: Service = {
@@ -165,6 +171,6 @@ export const D1_PLUGIN: Plugin<
 		return services;
 	},
 	getPersistPath({ d1Persist }, tmpPath) {
-		return getPersistPath(D1_PLUGIN_NAME, tmpPath, d1Persist);
+		return getPersistPath(D1_PLUGIN_NAME, tmpPath, undefined, d1Persist);
 	},
 };

--- a/packages/miniflare/src/plugins/do/index.ts
+++ b/packages/miniflare/src/plugins/do/index.ts
@@ -103,6 +103,7 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin<
 	async getServices({
 		sharedOptions,
 		tmpPath,
+		defaultPersistRoot,
 		durableObjectClassNames,
 		unsafeEphemeralDurableObjects,
 	}) {
@@ -125,6 +126,7 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin<
 		const storagePath = getPersistPath(
 			DURABLE_OBJECTS_PLUGIN_NAME,
 			tmpPath,
+			defaultPersistRoot,
 			sharedOptions.durableObjectsPersist
 		);
 		// `workerd` requires the `disk.path` to exist. Setting `recursive: true`
@@ -145,6 +147,7 @@ export const DURABLE_OBJECTS_PLUGIN: Plugin<
 		return getPersistPath(
 			DURABLE_OBJECTS_PLUGIN_NAME,
 			tmpPath,
+			undefined,
 			durableObjectsPersist
 		);
 	},

--- a/packages/miniflare/src/plugins/kv/index.ts
+++ b/packages/miniflare/src/plugins/kv/index.ts
@@ -106,6 +106,7 @@ export const KV_PLUGIN: Plugin<
 		options,
 		sharedOptions,
 		tmpPath,
+		defaultPersistRoot,
 		log,
 		unsafeStickyBlobs,
 	}) {
@@ -122,7 +123,12 @@ export const KV_PLUGIN: Plugin<
 
 		if (services.length > 0) {
 			const uniqueKey = `miniflare-${KV_NAMESPACE_OBJECT_CLASS_NAME}`;
-			const persistPath = getPersistPath(KV_PLUGIN_NAME, tmpPath, persist);
+			const persistPath = getPersistPath(
+				KV_PLUGIN_NAME,
+				tmpPath,
+				defaultPersistRoot,
+				persist
+			);
 			await fs.mkdir(persistPath, { recursive: true });
 			const storageService: Service = {
 				name: KV_STORAGE_SERVICE_NAME,
@@ -178,7 +184,7 @@ export const KV_PLUGIN: Plugin<
 	},
 
 	getPersistPath({ kvPersist }, tmpPath) {
-		return getPersistPath(KV_PLUGIN_NAME, tmpPath, kvPersist);
+		return getPersistPath(KV_PLUGIN_NAME, tmpPath, undefined, kvPersist);
 	},
 };
 

--- a/packages/miniflare/src/plugins/r2/index.ts
+++ b/packages/miniflare/src/plugins/r2/index.ts
@@ -74,6 +74,7 @@ export const R2_PLUGIN: Plugin<
 		options,
 		sharedOptions,
 		tmpPath,
+		defaultPersistRoot,
 		log,
 		unsafeStickyBlobs,
 	}) {
@@ -90,7 +91,12 @@ export const R2_PLUGIN: Plugin<
 
 		if (buckets.length > 0) {
 			const uniqueKey = `miniflare-${R2_BUCKET_OBJECT_CLASS_NAME}`;
-			const persistPath = getPersistPath(R2_PLUGIN_NAME, tmpPath, persist);
+			const persistPath = getPersistPath(
+				R2_PLUGIN_NAME,
+				tmpPath,
+				defaultPersistRoot,
+				persist
+			);
 			await fs.mkdir(persistPath, { recursive: true });
 			const storageService: Service = {
 				name: R2_STORAGE_SERVICE_NAME,
@@ -139,6 +145,6 @@ export const R2_PLUGIN: Plugin<
 		return services;
 	},
 	getPersistPath({ r2Persist }, tmpPath) {
-		return getPersistPath(R2_PLUGIN_NAME, tmpPath, r2Persist);
+		return getPersistPath(R2_PLUGIN_NAME, tmpPath, undefined, r2Persist);
 	},
 };

--- a/packages/miniflare/src/plugins/secret-store/index.ts
+++ b/packages/miniflare/src/plugins/secret-store/index.ts
@@ -67,7 +67,13 @@ export const SECRET_STORE_PLUGIN: Plugin<
 			])
 		);
 	},
-	async getServices({ options, sharedOptions, tmpPath, unsafeStickyBlobs }) {
+	async getServices({
+		options,
+		sharedOptions,
+		tmpPath,
+		defaultPersistRoot,
+		unsafeStickyBlobs,
+	}) {
 		const configs = options.secretsStoreSecrets
 			? Object.values(options.secretsStoreSecrets)
 			: [];
@@ -79,6 +85,7 @@ export const SECRET_STORE_PLUGIN: Plugin<
 		const persistPath = getPersistPath(
 			SECRET_STORE_PLUGIN_NAME,
 			tmpPath,
+			defaultPersistRoot,
 			sharedOptions.secretsStorePersist
 		);
 

--- a/packages/miniflare/src/plugins/secret-store/index.ts
+++ b/packages/miniflare/src/plugins/secret-store/index.ts
@@ -169,4 +169,12 @@ export const SECRET_STORE_PLUGIN: Plugin<
 
 		return [...services, storageService, objectService];
 	},
+	getPersistPath({ secretsStorePersist }, tmpPath) {
+		return getPersistPath(
+			SECRET_STORE_PLUGIN_NAME,
+			tmpPath,
+			undefined,
+			secretsStorePersist
+		);
+	},
 };

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -71,6 +71,7 @@ export interface PluginServicesOptions<
 	workerIndex: number;
 	additionalModules: Worker_Module[];
 	tmpPath: string;
+	defaultPersistRoot: string | undefined;
 	workerNames: string[];
 	loopbackPort: number;
 	unsafeStickyBlobs: boolean;
@@ -182,6 +183,7 @@ export function maybeParseURL(url: Persistence): URL | undefined {
 export function getPersistPath(
 	pluginName: string,
 	tmpPath: string,
+	defaultPersistRoot: string | undefined,
 	persist: Persistence
 ): string {
 	// If persistence is disabled, use "memory" storage. Note we're still
@@ -191,8 +193,13 @@ export function getPersistPath(
 	// keep Miniflare 2's behaviour, so persist to a temporary path which we
 	// destroy on `dispose()`.
 	const memoryishPath = path.join(tmpPath, pluginName);
-	if (persist === undefined || persist === false) {
+	if (persist === false) {
 		return memoryishPath;
+	}
+
+	// If `persist` is undefined, use either the default path or fallback to the tmpPath
+	if (persist === undefined) {
+		return path.join(defaultPersistRoot ?? tmpPath, pluginName);
 	}
 
 	// Try parse `persist` as a URL
@@ -211,7 +218,7 @@ export function getPersistPath(
 
 	// Otherwise, fallback to file storage
 	return persist === true
-		? path.join(DEFAULT_PERSIST_ROOT, pluginName)
+		? path.join(defaultPersistRoot ?? DEFAULT_PERSIST_ROOT, pluginName)
 		: persist;
 }
 

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -199,7 +199,9 @@ export function getPersistPath(
 
 	// If `persist` is undefined, use either the default path or fallback to the tmpPath
 	if (persist === undefined) {
-		return defaultPersistRoot === undefined ? memoryishPath : path.join(defaultPersistRoot, pluginName);
+		return defaultPersistRoot === undefined
+			? memoryishPath
+			: path.join(defaultPersistRoot, pluginName);
 	}
 
 	// Try parse `persist` as a URL

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -199,7 +199,7 @@ export function getPersistPath(
 
 	// If `persist` is undefined, use either the default path or fallback to the tmpPath
 	if (persist === undefined) {
-		return path.join(defaultPersistRoot ?? tmpPath, pluginName);
+		return defaultPersistRoot === undefined ? memoryishPath : path.join(defaultPersistRoot, pluginName);
 	}
 
 	// Try parse `persist` as a URL

--- a/packages/miniflare/src/plugins/workflows/index.ts
+++ b/packages/miniflare/src/plugins/workflows/index.ts
@@ -59,10 +59,11 @@ export const WORKFLOWS_PLUGIN: Plugin<
 		);
 	},
 
-	async getServices({ options, sharedOptions, tmpPath }) {
+	async getServices({ options, sharedOptions, tmpPath, defaultPersistRoot }) {
 		const persistPath = getPersistPath(
 			WORKFLOWS_PLUGIN_NAME,
 			tmpPath,
+			defaultPersistRoot,
 			sharedOptions.workflowsPersist
 		);
 		await fs.mkdir(persistPath, { recursive: true });
@@ -130,6 +131,11 @@ export const WORKFLOWS_PLUGIN: Plugin<
 	},
 
 	getPersistPath({ workflowsPersist }, tmpPath) {
-		return getPersistPath(WORKFLOWS_PLUGIN_NAME, tmpPath, workflowsPersist);
+		return getPersistPath(
+			WORKFLOWS_PLUGIN_NAME,
+			tmpPath,
+			undefined,
+			workflowsPersist
+		);
 	},
 };

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -175,7 +175,7 @@ async function getMiniflareOptionsFromConfig(
 		tails: [],
 	});
 
-	const persistOptions = getMiniflarePersistOptions(options.persist);
+	const defaultPersistRoot = getMiniflarePersistRoot(options.persist);
 
 	const serviceBindings = await getServiceBindings(bindings.services);
 
@@ -193,7 +193,7 @@ async function getMiniflareOptionsFromConfig(
 			},
 			...externalWorkers,
 		],
-		...persistOptions,
+		defaultPersistRoot,
 	};
 
 	return miniflareOptions;
@@ -205,39 +205,19 @@ async function getMiniflareOptionsFromConfig(
  * @param persist The user provided persistence option
  * @returns an object containing the properties to pass to miniflare
  */
-function getMiniflarePersistOptions(
+function getMiniflarePersistRoot(
 	persist: GetPlatformProxyOptions["persist"]
-): Pick<
-	MiniflareOptions,
-	| "kvPersist"
-	| "durableObjectsPersist"
-	| "r2Persist"
-	| "d1Persist"
-	| "workflowsPersist"
-> {
+): string | undefined {
 	if (persist === false) {
 		// the user explicitly asked for no persistance
-		return {
-			kvPersist: false,
-			durableObjectsPersist: false,
-			r2Persist: false,
-			d1Persist: false,
-			workflowsPersist: false,
-		};
+		return;
 	}
 
 	const defaultPersistPath = ".wrangler/state/v3";
-
 	const persistPath =
 		typeof persist === "object" ? persist.path : defaultPersistPath;
 
-	return {
-		kvPersist: `${persistPath}/kv`,
-		durableObjectsPersist: `${persistPath}/do`,
-		r2Persist: `${persistPath}/r2`,
-		d1Persist: `${persistPath}/d1`,
-		workflowsPersist: `${persistPath}/workflows`,
-	};
+	return persistPath;
 }
 
 function deepFreeze<T extends Record<string | number | symbol, unknown>>(

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -949,25 +949,12 @@ export function buildMiniflareBindingOptions(
 	};
 }
 
-type PickTemplate<T, K extends string> = {
-	[P in keyof T & K]: T[P];
-};
-type PersistOptions = PickTemplate<MiniflareOptions, `${string}Persist`>;
-export function buildPersistOptions(
+export function getDefaultPersistRoot(
 	localPersistencePath: ConfigBundle["localPersistencePath"]
-): PersistOptions | undefined {
+): string | undefined {
 	if (localPersistencePath !== null) {
 		const v3Path = path.join(localPersistencePath, "v3");
-		return {
-			cachePersist: path.join(v3Path, "cache"),
-			durableObjectsPersist: path.join(v3Path, "do"),
-			kvPersist: path.join(v3Path, "kv"),
-			r2Persist: path.join(v3Path, "r2"),
-			d1Persist: path.join(v3Path, "d1"),
-			workflowsPersist: path.join(v3Path, "workflows"),
-			secretsStorePersist: path.join(v3Path, "secrets-store"),
-			analyticsEngineDatasetsPersist: path.join(v3Path, "analytics-engine"),
-		};
+		return v3Path;
 	}
 }
 
@@ -1188,7 +1175,7 @@ export async function buildMiniflareOptions(
 	const { bindingOptions, internalObjects, externalWorkers } =
 		buildMiniflareBindingOptions(config, mixedModeConnectionString);
 	const sitesOptions = buildSitesOptions(config);
-	const persistOptions = buildPersistOptions(config.localPersistencePath);
+	const defaultPersistRoot = getDefaultPersistRoot(config.localPersistencePath);
 	const assetOptions = buildAssetOptions(config);
 
 	const options: MiniflareOptions = {
@@ -1210,8 +1197,7 @@ export async function buildMiniflareOptions(
 		log,
 		verbose: logger.loggerLevel === "debug",
 		handleRuntimeStdio,
-
-		...persistOptions,
+		defaultPersistRoot,
 		workers: [
 			{
 				name: getName(config),

--- a/packages/wrangler/src/kv/helpers.ts
+++ b/packages/wrangler/src/kv/helpers.ts
@@ -4,7 +4,7 @@ import { Miniflare } from "miniflare";
 import { FormData } from "undici";
 import { fetchKVGetValue, fetchListResult, fetchResult } from "../cfetch";
 import { getLocalPersistencePath } from "../dev/get-local-persistence-path";
-import { buildPersistOptions } from "../dev/miniflare";
+import { getDefaultPersistRoot } from "../dev/miniflare";
 import { UserError } from "../errors";
 import { logger } from "../logger";
 import type { Config } from "../config";
@@ -467,11 +467,11 @@ export async function usingLocalNamespace<T>(
 	closure: (namespace: ReplaceWorkersTypes<KVNamespace>) => Promise<T>
 ): Promise<T> {
 	const persist = getLocalPersistencePath(persistTo, config);
-	const persistOptions = buildPersistOptions(persist);
+	const defaultPersistRoot = getDefaultPersistRoot(persist);
 	const mf = new Miniflare({
 		script:
 			'addEventListener("fetch", (e) => e.respondWith(new Response(null, { status: 404 })))',
-		...persistOptions,
+		defaultPersistRoot,
 		kvNamespaces: { NAMESPACE: namespaceId },
 	});
 	const namespace = await mf.getKVNamespace("NAMESPACE");

--- a/packages/wrangler/src/r2/helpers.ts
+++ b/packages/wrangler/src/r2/helpers.ts
@@ -5,7 +5,7 @@ import prettyBytes from "pretty-bytes";
 import { fetchGraphqlResult, fetchResult } from "../cfetch";
 import { fetchR2Objects } from "../cfetch/internal";
 import { getLocalPersistencePath } from "../dev/get-local-persistence-path";
-import { buildPersistOptions } from "../dev/miniflare";
+import { getDefaultPersistRoot } from "../dev/miniflare";
 import { UserError } from "../errors";
 import { logger } from "../logger";
 import { getQueue, getQueueById } from "../queues/client";
@@ -365,7 +365,7 @@ export async function usingLocalBucket<T>(
 	) => Promise<T>
 ): Promise<T> {
 	const persist = getLocalPersistencePath(persistTo, config);
-	const persistOptions = buildPersistOptions(persist);
+	const defaultPersistRoot = getDefaultPersistRoot(persist);
 	const mf = new Miniflare({
 		modules: true,
 		// TODO(soon): import `reduceError()` from `miniflare:shared`
@@ -397,7 +397,7 @@ export async function usingLocalBucket<T>(
 				}
 			}
 		}`,
-		...persistOptions,
+		defaultPersistRoot,
 		r2Buckets: { BUCKET: bucketName },
 	});
 	const bucket = await mf.getR2Bucket("BUCKET");

--- a/packages/wrangler/src/secrets-store/commands.ts
+++ b/packages/wrangler/src/secrets-store/commands.ts
@@ -1,7 +1,7 @@
 import { Miniflare } from "miniflare";
 import { createCommand } from "../core/create-command";
 import { getLocalPersistencePath } from "../dev/get-local-persistence-path";
-import { buildPersistOptions } from "../dev/miniflare";
+import { getDefaultPersistRoot } from "../dev/miniflare";
 import { confirm, prompt } from "../dialogs";
 import { FatalError, UserError } from "../errors";
 import { logger } from "../logger";
@@ -33,11 +33,11 @@ export async function usingLocalSecretsStoreSecretAPI<T>(
 	) => Promise<T>
 ): Promise<T> {
 	const persist = getLocalPersistencePath(persistTo, config);
-	const persistOptions = buildPersistOptions(persist);
+	const defaultPersistRoot = getDefaultPersistRoot(persist);
 	const mf = new Miniflare({
 		script:
 			'addEventListener("fetch", (e) => e.respondWith(new Response(null, { status: 404 })))',
-		...persistOptions,
+		defaultPersistRoot,
 		secretsStoreSecrets: {
 			SECRET: {
 				store_id: storeId,


### PR DESCRIPTION
Fixes [DEVX-1828](https://jira.cfdata.org/browse/DEVX-1828)

This introduces a `defaultPersistRoot` setting that, when provided, is used as the base directory for any plugin (i.e. `path.join(defaultPersistRoot, pluginName)`) whose persist option is `undefined` or `true`. Explicit string values for a plugin’s persist path are still honored.

This removes the need for both Wrangler and the Vite plugin to set individual persist options as long as all the miniflare plugins continue to derive the persist path using the `getPersistPath` helper. This will not break existing users as well as the result paths match current settings on both Wrangler / Vite plugin.

Example:
```tsx
// Without `defaultPersistRoot` / Before this change:
new Miniflare({
  kvPersist: undefined,       // → "/(tmp)/kv"
  d1Persist: true,            // → "/.mf/d1"
  r2Persist: false,           // → "/(tmp)/d1"
  cachePersist: "/my-cache",  // → "/my-cache"
});

// With `defaultPersistRoot`
new Miniflare({
  defaultPersistRoot: "/storage",
  kvPersist: undefined,       // → "/storage/kv"
  d1Persist: true,            // → "/storage/d1"
  r2Persist: false,           // → "/(tmp)/d1"
  cachePersist: "/my-cache",  // → "/my-cache"
});
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: refactor
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not patch

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
