### PR TITLE
fix the Vitest integration to support Workers where Node.js compatibility is only v1 in production

### DIFF
--- a/.changeset/shy-beans-warn.md
+++ b/.changeset/shy-beans-warn.md
@@ -1,0 +1,9 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix the Vitest integration to support Workers that want Node.js compatibility is only v1 in production
+
+It does this by adding the `nodejs_compat_v2` flag (if missing) and removing `no_nodejs_compat_v2` flag (if found).
+
+This does mean that the Vitest tests are running with a slightly different environment to production, but this has always been the case in other ways.

--- a/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/basics-integration-auxiliary/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineWorkersProject({
 					// Configuration for the test runner Worker
 					compatibilityDate: "2024-01-01",
 					compatibilityFlags: [
+						// This illustrates a Worker that in production only wants v1 of Node.js compatibility.
+						// The Vitest pool integration will need to remove this flag since the `MockAgent` requires v2.
+						"no_nodejs_compat_v2",
 						"nodejs_compat",
 						// Required to use `WORKER.scheduled()`. This is an experimental
 						// compatibility flag, and cannot be enabled in production.

--- a/packages/vitest-pool-workers/src/pool/index.ts
+++ b/packages/vitest-pool-workers/src/pool/index.ts
@@ -407,12 +407,18 @@ function buildProjectWorkerOptions(
 		}
 	}
 
-	const { mode } = getNodeCompat(
+	const { hasNoNodejsCompatV2Flag, mode } = getNodeCompat(
 		runnerWorker.compatibilityDate,
 		runnerWorker.compatibilityFlags
 	);
 
 	if (mode !== "v2") {
+		if (hasNoNodejsCompatV2Flag) {
+			runnerWorker.compatibilityFlags.splice(
+				runnerWorker.compatibilityFlags.indexOf("no_nodejs_compat_v2"),
+				1
+			);
+		}
 		runnerWorker.compatibilityFlags.push("nodejs_compat_v2");
 	}
 


### PR DESCRIPTION
It does this by adding the `nodejs_compat_v2` flag (if missing) and removing `no_nodejs_compat_v2` flag (if found).

This does mean that the Vitest tests are running with a slightly different environment to production, but this has always been the case in other ways.

Fixes #8988

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: e2e tests don't exercise the Vitest integration
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> Vitest integration is not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
