### PR TITLE
c3: add extra information about asset serving to hello-world templates

### DIFF
--- a/.changeset/violet-hats-guess.md
+++ b/.changeset/violet-hats-guess.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+add extra information about asset serving to hello-world templates

--- a/packages/create-cloudflare/templates/hello-world-assets-only/templates/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-assets-only/templates/public/index.html
@@ -7,5 +7,6 @@
 	</head>
 	<body>
 		<h1 id="heading">Hello, World!</h1>
+		<p>This page comes from a static asset stored at `public/index.html` as configured in `wrangler.jsonc`.</p>
 	</body>
 </html>

--- a/packages/create-cloudflare/templates/hello-world-assets-only/templates/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hello-world-assets-only/templates/wrangler.jsonc
@@ -2,6 +2,7 @@
   "name": "<TBD>",
   "compatibility_date": "<TBD>",
   "assets": {
+    // The path to the directory containing the `index.html` file to be served at `/`
     "directory": "./public"
   },
   "observability": {

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/js/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/js/public/index.html
@@ -4,6 +4,7 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Hello, World!</title>
+		<p>This page comes from a static asset stored at `public/index.html` as configured in `wrangler.jsonc`.</p>
 	</head>
 	<body>
 		<h1 id="heading"></h1>

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/js/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/js/wrangler.jsonc
@@ -3,7 +3,7 @@
   "main": "src/index.js",
   "compatibility_date": "<TBD>",
   "assets": {
-    "binding": "ASSETS",
+    // The path to the directory containing the `index.html` file to be served at `/`
     "directory": "./public"
   },
   "durable_objects": {

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/py/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/py/public/index.html
@@ -7,6 +7,7 @@
 	</head>
 	<body>
 		<h1 id="heading"></h1>
+		<p>This page comes from a static asset stored at `public/index.html` as configured in `wrangler.jsonc`.</p>
 		<script>
 			fetch('/message')
 				.then((resp) => resp.text())

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/py/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/py/wrangler.jsonc
@@ -6,7 +6,7 @@
     "python_workers"
   ],
   "assets": {
-    "binding": "ASSETS",
+    // The path to the directory containing the `index.html` file to be served at `/`
     "directory": "./public"
   },
   "migrations": [

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/ts/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/ts/public/index.html
@@ -7,6 +7,7 @@
 	</head>
 	<body>
 		<h1 id="heading"></h1>
+		<p>This page comes from a static asset stored at `public/index.html` as configured in `wrangler.jsonc`.</p>
 		<script>
 			fetch('/message')
 				.then((resp) => resp.text())

--- a/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/ts/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hello-world-durable-object-with-assets/ts/wrangler.jsonc
@@ -11,7 +11,7 @@
     }
   ],
   "assets": {
-    "binding": "ASSETS",
+    // The path to the directory containing the `index.html` file to be served at `/`
     "directory": "./public"
   },
   "durable_objects": {

--- a/packages/create-cloudflare/templates/hello-world-with-assets/js/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/js/public/index.html
@@ -7,6 +7,7 @@
 	</head>
 	<body>
 		<h1 id="heading"></h1>
+		<p>This page comes from a static asset stored at `public/index.html` as configured in `wrangler.jsonc`.</p>
 		<button id="button" type="button">Fetch a random UUID</button>
 		<output id="random" for="button"></output>
 		<script>

--- a/packages/create-cloudflare/templates/hello-world-with-assets/js/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/js/wrangler.jsonc
@@ -7,7 +7,7 @@
     "global_fetch_strictly_public"
   ],
   "assets": {
-    "binding": "ASSETS",
+    // The path to the directory containing the `index.html` file to be served at `/`
     "directory": "./public"
   },
   "observability": {

--- a/packages/create-cloudflare/templates/hello-world-with-assets/py/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/py/public/index.html
@@ -7,6 +7,7 @@
 	</head>
 	<body>
 		<h1 id="heading"></h1>
+		<p>This page comes from a static asset stored at `public/index.html` as configured in `wrangler.jsonc`.</p>
 		<button id="button" type="button">Fetch a random UUID</button>
 		<output id="random" for="button"></output>
 		<script>

--- a/packages/create-cloudflare/templates/hello-world-with-assets/py/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/py/wrangler.jsonc
@@ -6,7 +6,7 @@
     "python_workers"
   ],
   "assets": {
-    "binding": "ASSETS",
+    // The path to the directory containing the `index.html` file to be served at `/`
     "directory": "./public"
   },
   "observability": {

--- a/packages/create-cloudflare/templates/hello-world-with-assets/ts/public/index.html
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/ts/public/index.html
@@ -7,6 +7,7 @@
 	</head>
 	<body>
 		<h1 id="heading"></h1>
+		<p>This page comes from a static asset stored at `public/index.html` as configured in `wrangler.jsonc`.</p>
 		<button id="button" type="button">Fetch a random UUID</button>
 		<output id="random" for="button"></output>
 		<script>

--- a/packages/create-cloudflare/templates/hello-world-with-assets/ts/wrangler.jsonc
+++ b/packages/create-cloudflare/templates/hello-world-with-assets/ts/wrangler.jsonc
@@ -3,11 +3,10 @@
   "main": "src/index.ts",
   "compatibility_date": "<TBD>",
   "compatibility_flags": [
-    "nodejs_compat",
     "global_fetch_strictly_public"
   ],
   "assets": {
-    "binding": "ASSETS",
+    // The path to the directory containing the `index.html` file to be served at `/`
     "directory": "./public"
   },
   "observability": {


### PR DESCRIPTION
Fixes #9140

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: template change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not covered by these e2e tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: template tidy up
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> c3 is not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
