### PR TITLE
Update fixture to test for Sec-Fetch-Mode behavior

### DIFF
--- a/fixtures/workers-with-assets-static-routing/package.json
+++ b/fixtures/workers-with-assets-static-routing/package.json
@@ -11,6 +11,7 @@
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@cloudflare/workers-types": "^4.20250508.0",
+		"playwright-chromium": "catalog:default",
 		"typescript": "catalog:default",
 		"undici": "catalog:default",
 		"vitest": "catalog:default",

--- a/fixtures/workers-with-assets-static-routing/spa-assets/_routes.json
+++ b/fixtures/workers-with-assets-static-routing/spa-assets/_routes.json
@@ -1,0 +1,5 @@
+{
+	"version": 1,
+	"include": ["/api/*"],
+	"exclude": ["/api/asset"]
+}

--- a/fixtures/workers-with-assets-static-routing/spa-assets/index.html
+++ b/fixtures/workers-with-assets-static-routing/spa-assets/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+	<head>
+		<title>I'm an index.html for a SPA</title>
+	</head>
+	<body>
+		<h1>Here I am, at <span id="client-rendered">/</span>!</h1>
+	</body>
+	<script>
+		let path = window.location.pathname;
+		let updateme = document.getElementById("client-rendered");
+		updateme.innerText = path;
+	</script>
+</html>

--- a/fixtures/workers-with-assets-static-routing/spa.wrangler.jsonc
+++ b/fixtures/workers-with-assets-static-routing/spa.wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+	"name": "workers-with-assets-static-routing",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-05-20",
+	"assets": {
+		"binding": "ASSETS",
+		"directory": "./spa-assets",
+		"not_found_handling": "single-page-application",
+	},
+}

--- a/fixtures/workers-with-assets-static-routing/src/index.ts
+++ b/fixtures/workers-with-assets-static-routing/src/index.ts
@@ -4,6 +4,14 @@ export type Env = {
 
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
+		const { pathname } = new URL(request.url);
+
+		// api routes
+		if (pathname.startsWith("/api/")) {
+			return Response.json({ some: ["json", "response"] });
+		}
+
+		// asset middleware
 		const assetResp = await env.ASSETS.fetch(request);
 		if (assetResp.ok) {
 			let text = await assetResp.text();
@@ -16,6 +24,8 @@ export default {
 				status: assetResp.status,
 			});
 		}
-		return new Response("Hello from the User Worker");
+
+		// default handling
+		return new Response("404 from the User Worker", { status: 404 });
 	},
 } satisfies ExportedHandler<Env>;

--- a/fixtures/workers-with-assets-static-routing/tests/index.test.ts
+++ b/fixtures/workers-with-assets-static-routing/tests/index.test.ts
@@ -1,58 +1,181 @@
 import { resolve } from "node:path";
+import { Browser, chromium } from "playwright-chromium";
 import { fetch } from "undici";
 import { afterAll, beforeAll, describe, it } from "vitest";
 import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
 
 describe("[Workers + Assets] static routing", () => {
-	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
+	describe("static routing behavior", () => {
+		let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
-	beforeAll(async () => {
-		({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
-			"--port=0",
-			"--inspector-port=0",
-		]));
+		beforeAll(async () => {
+			({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
+				"--port=0",
+				"--inspector-port=0",
+			]));
+		});
+
+		afterAll(async () => {
+			await stop?.();
+		});
+
+		it("should serve assets when they exist for a path", async ({ expect }) => {
+			let response = await fetch(`http://${ip}:${port}/static/page`);
+			expect(response.status).toBe(200);
+			expect(await response.text()).toContain(`<h1>A normal asset</h1>`);
+		});
+
+		it("should run the worker when no assets exist for a path", async ({
+			expect,
+		}) => {
+			let response = await fetch(`http://${ip}:${port}/`);
+			expect(response.status).toBe(404);
+			expect(await response.text()).toContain(`404 from the User Worker`);
+		});
+
+		it("should run the worker when an include rule matches", async ({
+			expect,
+		}) => {
+			let response = await fetch(`http://${ip}:${port}/worker/worker-runs`);
+			expect(response.status).toBe(200);
+			expect(await response.text()).toContain(
+				`<h1>Hello, I'm an asset (and was intercepted by the User Worker)!</h1>`
+			);
+		});
+
+		it("should serve an asset when an exclude rule matches", async ({
+			expect,
+		}) => {
+			let response = await fetch(`http://${ip}:${port}/missing-asset`);
+			expect(response.status).toBe(404);
+		});
+
+		it("should serve an asset when an include and an exclude rule matches", async ({
+			expect,
+		}) => {
+			let response = await fetch(`http://${ip}:${port}/worker/asset`);
+			expect(response.status).toBe(200);
+			expect(await response.text()).toContain(`<h1>Hello, I'm an asset!</h1>`);
+		});
 	});
 
-	afterAll(async () => {
-		await stop?.();
-	});
+	describe("static routing + SPA behavior", async () => {
+		let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
 
-	it("should serve assets when they exist for a path", async ({ expect }) => {
-		let response = await fetch(`http://${ip}:${port}/static/page`);
-		expect(response.status).toBe(200);
-		expect(await response.text()).toContain(`<h1>A normal asset</h1>`);
-	});
+		beforeAll(async () => {
+			({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
+				"-c=spa.wrangler.jsonc",
+				"--port=0",
+				"--inspector-port=0",
+			]));
+		});
 
-	it("should run the worker when no assets exist for a path", async ({
-		expect,
-	}) => {
-		let response = await fetch(`http://${ip}:${port}/`);
-		expect(response.status).toBe(200);
-		expect(await response.text()).toContain(`Hello from the User Worker`);
-	});
+		afterAll(async () => {
+			await stop?.();
+		});
 
-	it("should run the worker when an include rule matches", async ({
-		expect,
-	}) => {
-		let response = await fetch(`http://${ip}:${port}/worker/worker-runs`);
-		expect(response.status).toBe(200);
-		expect(await response.text()).toContain(
-			`<h1>Hello, I'm an asset (and was intercepted by the User Worker)!</h1>`
-		);
-	});
+		describe("browser navigation", () => {
+			let browser: Browser | undefined;
 
-	it("should serve an asset when an exclude rule matches", async ({
-		expect,
-	}) => {
-		let response = await fetch(`http://${ip}:${port}/missing-asset`);
-		expect(response.status).toBe(404);
-	});
+			beforeAll(async () => {
+				browser = await chromium.launch({
+					headless: !process.env.VITE_DEBUG_SERVE,
+					args: process.env.CI
+						? ["--no-sandbox", "--disable-setuid-sandbox"]
+						: undefined,
+				});
+			});
 
-	it("should serve an asset when an include and an exclude rule matches", async ({
-		expect,
-	}) => {
-		let response = await fetch(`http://${ip}:${port}/worker/asset`);
-		expect(response.status).toBe(200);
-		expect(await response.text()).toContain(`<h1>Hello, I'm an asset!</h1>`);
+			afterAll(async () => {
+				await browser?.close();
+			});
+
+			it("renders the root with index.html", async ({ expect }) => {
+				if (!browser) {
+					throw new Error("Browser couldn't be initialized");
+				}
+
+				const page = await browser.newPage({
+					baseURL: `http://${ip}:${port}`,
+				});
+				await page.goto("/");
+				expect(await page.getByRole("heading").innerText()).toBe(
+					"Here I am, at /!"
+				);
+			});
+
+			it("renders another path with index.html", async ({ expect }) => {
+				if (!browser) {
+					throw new Error("Browser couldn't be initialized");
+				}
+
+				const page = await browser.newPage({
+					baseURL: `http://${ip}:${port}`,
+				});
+				await page.goto("/some/page");
+				expect(await page.getByRole("heading").innerText()).toBe(
+					"Here I am, at /some/page!"
+				);
+			});
+
+			it("renders an include path with the User worker", async ({ expect }) => {
+				if (!browser) {
+					throw new Error("Browser couldn't be initialized");
+				}
+
+				const page = await browser.newPage({
+					baseURL: `http://${ip}:${port}`,
+				});
+				const response = await page.goto("/api/route");
+				expect(response?.headers()).toHaveProperty(
+					"content-type",
+					"application/json"
+				);
+				expect(await page.content()).toContain(`{"some":["json","response"]}`);
+			});
+
+			it("renders an exclude path with index.html", async ({ expect }) => {
+				if (!browser) {
+					throw new Error("Browser couldn't be initialized");
+				}
+
+				const page = await browser.newPage({
+					baseURL: `http://${ip}:${port}`,
+				});
+				await page.goto("/api/asset");
+				expect(await page.getByRole("heading").innerText()).toBe(
+					"Here I am, at /api/asset!"
+				);
+			});
+		});
+
+		describe("non-browser navigation", () => {
+			it("renders the root with index.html", async ({ expect }) => {
+				let response = await fetch(`http://${ip}:${port}`);
+				expect(response.status).toBe(200);
+				expect(await response.text()).toContain(`I'm an index.html for a SPA`);
+			});
+
+			it("renders another path with index.html", async ({ expect }) => {
+				let response = await fetch(`http://${ip}:${port}/some/page`);
+				expect(response.status).toBe(200);
+				expect(await response.text()).toContain(`I'm an index.html for a SPA`);
+			});
+
+			it("renders an include path with the User worker", async ({ expect }) => {
+				let response = await fetch(`http://${ip}:${port}/api/route`);
+				expect(response.status).toBe(200);
+				expect(response.headers.get("content-type")).toEqual(
+					"application/json"
+				);
+				expect(await response.text()).toContain(`{"some":["json","response"]}`);
+			});
+
+			it("renders an exclude path with index.html", async ({ expect }) => {
+				let response = await fetch(`http://${ip}:${port}/api/asset`);
+				expect(response.status).toBe(200);
+				expect(await response.text()).toContain(`I'm an index.html for a SPA`);
+			});
+		});
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1197,6 +1197,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20250508.0
         version: 4.20250508.0
+      playwright-chromium:
+        specifier: catalog:default
+        version: 1.49.1
       typescript:
         specifier: catalog:default
         version: 5.7.3


### PR DESCRIPTION
    Tests that the behavior for both browser navigations (observed via
    the 'Sec-Fetch-Mode: navigate' header) and non-browser navigations is
    the same when static routing (via _routes.json) is present.