### PR TITLE
Redesign `wrangler dev`

### DIFF
--- a/.changeset/kind-dots-argue.md
+++ b/.changeset/kind-dots-argue.md
@@ -1,0 +1,7 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Redesign `wrangler dev` to more clearly present information and have a bit of a glow up ✨
+![Screenshot 2025-05-22 at 01 11 43](https://github.com/user-attachments/assets/26cc6209-37a1-4ecb-8e91-daac2f79a095)

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -137,7 +137,7 @@ async function startWranglerDev(args: string[], skipWaitingForReady = false) {
 	if (!skipWaitingForReady) {
 		let readyMatch: RegExpMatchArray | null = null;
 		for await (const line of stdoutInterface) {
-			if ((readyMatch = readyRegexp.exec(line)) !== null) break;
+			if ((readyMatch = readyRegexp.exec(stripAnsi(line))) !== null) break;
 		}
 		assert(readyMatch !== null, "Expected ready message");
 		result.url = readyMatch[1];

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -12,7 +12,7 @@ import { ReadableStream } from "stream/web";
 import util from "util";
 import zlib from "zlib";
 import exitHook from "exit-hook";
-import { $ as colors$ } from "kleur/colors";
+import { $ as colors$, green } from "kleur/colors";
 import stoppable from "stoppable";
 import {
 	Dispatcher,
@@ -1566,7 +1566,7 @@ export class Miniflare {
 			const urlSafeHost = getURLSafeHost(configuredHost);
 			if (this.#sharedOpts.core.logRequests) {
 				this.#log.info(
-					`${ready} on ${secure ? "https" : "http"}://${urlSafeHost}:${entryPort}`
+					`${ready} on ${green(`${secure ? "https" : "http"}://${urlSafeHost}:${entryPort}`)}`
 				);
 			}
 

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -7,11 +7,11 @@ const cwdNodeModules = path.join(cwd, "node_modules");
 
 const LEVEL_PREFIX: { [key in LogLevel]: string } = {
 	[LogLevel.NONE]: "",
-	[LogLevel.ERROR]: "err",
-	[LogLevel.WARN]: "wrn",
-	[LogLevel.INFO]: "inf",
-	[LogLevel.DEBUG]: "dbg",
-	[LogLevel.VERBOSE]: "vrb",
+	[LogLevel.ERROR]: "error",
+	[LogLevel.WARN]: "warn",
+	[LogLevel.INFO]: "info",
+	[LogLevel.DEBUG]: "debug",
+	[LogLevel.VERBOSE]: "verbose",
 };
 
 const LEVEL_COLOUR: { [key in LogLevel]: Colorize } = {
@@ -83,7 +83,7 @@ export class Log {
 	logWithLevel(level: LogLevel, message: string): void {
 		if (level <= this.level) {
 			const prefix = `[${this.#prefix}${LEVEL_PREFIX[level]}${this.#suffix}]`;
-			this.log(LEVEL_COLOUR[level](`${prefix} ${message}`));
+			this.log(`${LEVEL_COLOUR[level](prefix)} ${message}`);
 		}
 	}
 

--- a/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
+++ b/packages/wrangler/e2e/__snapshots__/pages-dev.test.ts.snap
@@ -1,35 +1,28 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Pages 'wrangler pages dev' > should merge (with override) \`wrangler.toml\` configuration with configuration provided via the command line, with command line args taking precedence 1`] = `
+exports[`wrangler pages dev > should merge (with override) \`wrangler.toml\` configuration with configuration provided via the command line, with command line args taking precedence 1`] = `
 "✨ Compiled Worker successfully
-Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
 Your Worker has access to the following bindings:
-- Durable Objects:
-  - DO_BINDING_1_TOML: NEW_DO_1 (defined in NEW_DO_SCRIPT_1 [not connected])
-  - DO_BINDING_2_TOML: DO_2_TOML (defined in DO_SCRIPT_2_TOML [not connected])
-  - DO_BINDING_3_ARGS: DO_3_ARGS (defined in DO_SCRIPT_3_ARGS [not connected])
-- KV Namespaces:
-  - KV_BINDING_1_TOML: NEW_KV_ID_1 [simulated locally]
-  - KV_BINDING_2_TOML: KV_ID_2_TOML [simulated locally]
-  - KV_BINDING_3_ARGS: KV_ID_3_ARGS [simulated locally]
-- D1 Databases:
-  - D1_BINDING_1_TOML: local-D1_BINDING_1_TOML=NEW_D1_NAME_1 (NEW_D1_NAME_1) [simulated locally]
-  - D1_BINDING_2_TOML: D1_NAME_2_TOML (D1_ID_2_TOML) [simulated locally]
-  - D1_BINDING_3_ARGS: local-D1_BINDING_3_ARGS=D1_NAME_3_ARGS (D1_NAME_3_ARGS) [simulated locally]
-- R2 Buckets:
-  - R2_BINDING_1_TOML: new-r2-bucket-1 [simulated locally]
-  - R2_BINDING_2_TOML: r2-bucket-2-toml [simulated locally]
-  - R2_BINDING_3_TOML: r2-bucket-3-args [simulated locally]
-- Services:
-  - SERVICE_BINDING_1_TOML: NEW_SERVICE_NAME_1 [not connected]
-  - SERVICE_BINDING_2_TOML: SERVICE_NAME_2_TOML [not connected]
-  - SERVICE_BINDING_3_TOML: SERVICE_NAME_3_ARGS [not connected]
-- AI:
-  - Name: AI_BINDING_2_TOML [connected to remote resource]
-- Vars:
-  - VAR1: "(hidden)"
-  - VAR2: "VAR_2_TOML"
-  - VAR3: "(hidden)"
+Binding                                                                  Resource                  Mode
+env.DO_BINDING_1_TOML (NEW_DO_1, defined in NEW_DO_SCRIPT_1)             Durable Object            local [not connected]
+env.DO_BINDING_2_TOML (DO_2_TOML, defined in DO_SCRIPT_2_TOML)           Durable Object            local [not connected]
+env.DO_BINDING_3_ARGS (DO_3_ARGS, defined in DO_SCRIPT_3_ARGS)           Durable Object            local [not connected]
+env.KV_BINDING_1_TOML (NEW_KV_ID_1)                                      KV Namespace              local
+env.KV_BINDING_2_TOML (KV_ID_2_TOML)                                     KV Namespace              local
+env.KV_BINDING_3_ARGS (KV_ID_3_ARGS)                                     KV Namespace              local
+env.D1_BINDING_1_TOML (local-D1_BINDING_1_TOML=NEW_D1_NAME_1)            D1 Database               local
+env.D1_BINDING_2_TOML (D1_NAME_2_TOML)                                   D1 Database               local
+env.D1_BINDING_3_ARGS (local-D1_BINDING_3_ARGS=D1_NAME_3_ARGS)           D1 Database               local
+env.R2_BINDING_1_TOML (new-r2-bucket-1)                                  R2 Bucket                 local
+env.R2_BINDING_2_TOML (r2-bucket-2-toml)                                 R2 Bucket                 local
+env.R2_BINDING_3_TOML (r2-bucket-3-args)                                 R2 Bucket                 local
+env.SERVICE_BINDING_1_TOML (NEW_SERVICE_NAME_1)                          Worker                    local [not connected]
+env.SERVICE_BINDING_2_TOML (SERVICE_NAME_2_TOML)                         Worker                    local [not connected]
+env.SERVICE_BINDING_3_TOML (SERVICE_NAME_3_ARGS)                         Worker                    local [not connected]
+env.AI_BINDING_2_TOML                                                    AI                        remote
+env.VAR1 ("(hidden)")                                                    Environment Variable      local
+env.VAR2 ("VAR_2_TOML")                                                  Environment Variable      local
+env.VAR3 ("(hidden)")                                                    Environment Variable      local
 Service bindings, Durable Object bindings, and Tail consumers connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
 ▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
 "

--- a/packages/wrangler/e2e/deployments.test.ts
+++ b/packages/wrangler/e2e/deployments.test.ts
@@ -285,7 +285,6 @@ Uploaded 2 of 3 assets
 Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
-No bindings found.
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 triggers (TIMINGS)
   https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev
@@ -374,8 +373,8 @@ Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
 Your Worker has access to the following bindings:
-- Assets:
-  - Binding: ASSETS
+Binding            Resource
+env.ASSETS         Assets
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 triggers (TIMINGS)
   https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev
@@ -541,8 +540,8 @@ Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
 Your Worker has access to the following bindings:
-- Assets:
-  - Binding: ASSETS
+Binding            Resource
+env.ASSETS         Assets
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 triggers (TIMINGS)
   https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev
@@ -651,7 +650,6 @@ Uploaded 2 of 3 assets
 Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
-No bindings found.
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
   Dispatch Namespace: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
 Current Version ID: 00000000-0000-0000-0000-000000000000`);
@@ -663,8 +661,8 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 			normalizedStdout = normalize(output.stdout);
 			expect(normalizedStdout).toEqual(`Total Upload: xx KiB / gzip: xx KiB
 Your Worker has access to the following bindings:
-- Dispatch Namespaces:
-  - DISPATCH: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
+Binding                                                                   Resource
+env.DISPATCH (tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000)      Dispatch Namespace
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 triggers (TIMINGS)
   https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev
@@ -763,8 +761,8 @@ Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
 Your Worker has access to the following bindings:
-- Assets:
-  - Binding: ASSETS
+Binding            Resource
+env.ASSETS         Assets
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
   Dispatch Namespace: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
 Current Version ID: 00000000-0000-0000-0000-000000000000`);
@@ -776,8 +774,8 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 			normalizedStdout = normalize(output.stdout);
 			expect(normalizedStdout).toEqual(`Total Upload: xx KiB / gzip: xx KiB
 Your Worker has access to the following bindings:
-- Dispatch Namespaces:
-  - DISPATCH: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
+Binding                                                                   Resource
+env.DISPATCH (tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000)      Dispatch Namespace
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 triggers (TIMINGS)
   https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev
@@ -874,8 +872,8 @@ Uploaded 3 of 3 assets
 ✨ Success! Uploaded 3 files (TIMINGS)
 Total Upload: xx KiB / gzip: xx KiB
 Your Worker has access to the following bindings:
-- Assets:
-  - Binding: ASSETS
+Binding            Resource
+env.ASSETS         Assets
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
   Dispatch Namespace: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
 Current Version ID: 00000000-0000-0000-0000-000000000000`);
@@ -887,8 +885,8 @@ Current Version ID: 00000000-0000-0000-0000-000000000000`);
 			normalizedStdout = normalize(output.stdout);
 			expect(normalizedStdout).toEqual(`Total Upload: xx KiB / gzip: xx KiB
 Your Worker has access to the following bindings:
-- Dispatch Namespaces:
-  - DISPATCH: tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000
+Binding                                                                   Resource
+env.DISPATCH (tmp-e2e-dispatch-00000000-0000-0000-0000-000000000000)      Dispatch Namespace
 Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 triggers (TIMINGS)
   https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev

--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -136,14 +136,13 @@ describe("wrangler dev - mixed mode", () => {
 
 		// This should only include logs from the user Wrangler session (i.e. a single list of attached bindings, and only one ready message)
 		expect(normalizeOutput(worker.currentOutput)).toMatchInlineSnapshot(`
-			"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
-			Your Worker has access to the following bindings:
-			- AI:
-			  - Name: AI [connected to remote resource]
-			[wrangler:inf] Ready on http://localhost:<PORT>
+			"Your Worker has access to the following bindings:
+			Binding        Resource      Mode
+			env.AI         AI      remote
+			[wrangler:info] Ready on http://localhost:<PORT>
 			▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
 			⎔ Starting local server...
-			[wrangler:inf] GET / 200 OK (TIMINGS)"
+			[wrangler:info] GET / 200 OK (TIMINGS)"
 		`);
 	});
 

--- a/packages/wrangler/e2e/helpers/normalize.ts
+++ b/packages/wrangler/e2e/helpers/normalize.ts
@@ -86,7 +86,7 @@ function removeKVId(str: string) {
  * Remove the Wrangler version/update check header
  */
 function removeVersionHeader(str: string): string {
-	const header = str.match(/⛅️ wrangler .*\n----+\n/);
+	const header = str.match(/⛅️ wrangler .*\n───+\n/);
 	if (header !== null && header.index) {
 		return str.slice(header.index + header[0].length);
 	} else {
@@ -176,8 +176,8 @@ function normalizeDebugLogFilepath(stdout: string): string {
  */
 function removeLocalPort(stdout: string): string {
 	return stdout.replace(
-		/\[wrangler:inf\] Ready on (https?):\/\/(.+):\d{4,5}/,
-		"[wrangler:inf] Ready on $1://$2:<PORT>"
+		/\[wrangler:info\] Ready on (https?):\/\/(.+):\d{4,5}/,
+		"[wrangler:info] Ready on $1://$2:<PORT>"
 	);
 }
 

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -11,300 +11,297 @@ import { normalizeOutput } from "./helpers/normalize";
 
 const port = await getPort();
 const inspectorPort = await getPort();
-
-describe.sequential.each([{ cmd: "wrangler pages dev" }])(
-	"Pages $cmd",
-	({ cmd }) => {
-		it("should warn if no [--compatibility_date] command line arg was specified", async () => {
-			const helper = new WranglerE2ETestHelper();
-			await helper.seed({
-				"_worker.js": dedent`
+const cmd = "wrangler pages dev";
+describe.sequential("wrangler pages dev", () => {
+	it("should warn if no [--compatibility_date] command line arg was specified", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"_worker.js": dedent`
 					export default {
 						fetch(request, env) {
 							return new Response("Testing [--compatibility_date]")
 						}
 					}`,
-			});
-			const worker = helper.runLongLived(
-				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-			);
-			const { url } = await worker.waitForReady();
-
-			const currentDate = new Date().toISOString().substring(0, 10);
-			const output = worker.currentOutput.replaceAll(
-				currentDate,
-				"<current-date>"
-			);
-			expect(output).toContain(
-				`No compatibility_date was specified. Using today's date: <current-date>.`
-			);
-			expect(output).toContain(
-				`❯❯ Add one to your Wrangler configuration file: compatibility_date = "<current-date>", or`
-			);
-			expect(output).toContain(
-				`❯❯ Pass it in your terminal: wrangler pages dev [<DIRECTORY>] --compatibility-date=<current-date>`
-			);
-
-			const text = await fetchText(url);
-			expect(text).toBe("Testing [--compatibility_date]");
 		});
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+		);
+		const { url } = await worker.waitForReady();
 
-		it("should warn that [--experimental-local] is no longer required, if specified", async () => {
-			const helper = new WranglerE2ETestHelper();
-			const worker = helper.runLongLived(
-				`${cmd} --port ${port} --inspector-port ${inspectorPort} . --experimental-local`
-			);
-			await helper.seed({
-				"_worker.js": dedent`
+		const currentDate = new Date().toISOString().substring(0, 10);
+		const output = worker.currentOutput.replaceAll(
+			currentDate,
+			"<current-date>"
+		);
+		expect(output).toContain(
+			`No compatibility_date was specified. Using today's date: <current-date>.`
+		);
+		expect(output).toContain(
+			`❯❯ Add one to your Wrangler configuration file: compatibility_date = "<current-date>", or`
+		);
+		expect(output).toContain(
+			`❯❯ Pass it in your terminal: wrangler pages dev [<DIRECTORY>] --compatibility-date=<current-date>`
+		);
+
+		const text = await fetchText(url);
+		expect(text).toBe("Testing [--compatibility_date]");
+	});
+
+	it("should warn that [--experimental-local] is no longer required, if specified", async () => {
+		const helper = new WranglerE2ETestHelper();
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort} . --experimental-local`
+		);
+		await helper.seed({
+			"_worker.js": dedent`
 				export default {
 					fetch(request, env) {
 						return new Response("Testing [--experimental-local]")
 					}
 				}`,
-			});
-			const { url } = await worker.waitForReady();
-			const text = await fetchText(url);
-			expect(text).toBe("Testing [--experimental-local]");
-			expect(await worker.currentOutput).toContain(
-				`--experimental-local is no longer required and will be removed in a future version`
-			);
 		});
+		const { url } = await worker.waitForReady();
+		const text = await fetchText(url);
+		expect(text).toBe("Testing [--experimental-local]");
+		expect(await worker.currentOutput).toContain(
+			`--experimental-local is no longer required and will be removed in a future version`
+		);
+	});
 
-		it("should show [--service] related warnings if specified as arg in the command line", async () => {
-			const helper = new WranglerE2ETestHelper();
-			const worker = helper.runLongLived(
-				`${cmd} --port ${port} --inspector-port ${inspectorPort} . --service STAGING_SERVICE=test-worker@staging`
-			);
+	it("should show [--service] related warnings if specified as arg in the command line", async () => {
+		const helper = new WranglerE2ETestHelper();
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort} . --service STAGING_SERVICE=test-worker@staging`
+		);
 
-			await worker.readUntil(
-				/Support for service binding environments is experimental/
-			);
-		});
+		await worker.readUntil(
+			/Support for service binding environments is experimental/
+		);
+	});
 
-		it("should warn if bindings specified as args in the command line are invalid", async () => {
-			const helper = new WranglerE2ETestHelper();
-			const worker = helper.runLongLived(
-				`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service test --kv = --do test --d1 = --r2 =`
-			);
-			await worker.waitForReady();
-			expect(await worker.currentOutput).toContain(
-				`Could not parse Service binding: test`
-			);
-			expect(await worker.currentOutput).toContain(
-				`Could not parse KV binding: =`
-			);
-			expect(await worker.currentOutput).toContain(
-				`Could not parse Durable Object binding: test`
-			);
-			expect(await worker.currentOutput).toContain(
-				`Could not parse R2 binding: =`
-			);
-			expect(await worker.currentOutput).toContain(
-				`Could not parse D1 binding: =`
-			);
-		});
+	it("should warn if bindings specified as args in the command line are invalid", async () => {
+		const helper = new WranglerE2ETestHelper();
+		const worker = helper.runLongLived(
+			`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service test --kv = --do test --d1 = --r2 =`
+		);
+		await worker.waitForReady();
+		expect(await worker.currentOutput).toContain(
+			`Could not parse Service binding: test`
+		);
+		expect(await worker.currentOutput).toContain(
+			`Could not parse KV binding: =`
+		);
+		expect(await worker.currentOutput).toContain(
+			`Could not parse Durable Object binding: test`
+		);
+		expect(await worker.currentOutput).toContain(
+			`Could not parse R2 binding: =`
+		);
+		expect(await worker.currentOutput).toContain(
+			`Could not parse D1 binding: =`
+		);
+	});
 
-		it("should use bindings specified as args in the command line", async () => {
-			const helper = new WranglerE2ETestHelper();
-			await helper.seed({
-				"_worker.js": dedent`
+	it("should use bindings specified as args in the command line", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"_worker.js": dedent`
 					export default {
 						fetch(request, env) {
 							return new Response("Hello world")
 						}
 					}`,
-			});
-			const worker = helper.runLongLived(
-				`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 TEST_R2`
-			);
-			await worker.waitForReady();
-			expect(normalizeOutput(worker.currentOutput)).toContain(
-				dedent`Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - TEST_DO: TestDurableObject (defined in a [not connected])
-					- KV Namespaces:
-					  - TEST_KV: TEST_KV [simulated locally]
-					- D1 Databases:
-					  - TEST_D1: local-TEST_D1 (TEST_D1) [simulated locally]
-					- R2 Buckets:
-					  - TEST_R2: TEST_R2 [simulated locally]
-					- Services:
-					  - TEST_SERVICE: test-worker [not connected]
-		`
-			);
 		});
+		const worker = helper.runLongLived(
+			`${cmd} --inspector-port ${inspectorPort} . --port ${port} --service TEST_SERVICE=test-worker --kv TEST_KV --do TEST_DO=TestDurableObject@a --d1 TEST_D1 --r2 TEST_R2 --compatibility-date=2025-05-21`
+		);
+		await worker.waitForReady();
+		expect(normalizeOutput(worker.currentOutput)).toMatchInlineSnapshot(`
+			"✨ Compiled Worker successfully
+			Your Worker has access to the following bindings:
+			Binding                                                 Resource            Mode
+			env.TEST_DO (TestDurableObject, defined in a)           Durable Object      local [not connected]
+			env.TEST_KV (TEST_KV)                                   KV Namespace        local
+			env.TEST_D1 (local-TEST_D1)                             D1 Database         local
+			env.TEST_R2 (TEST_R2)                                   R2 Bucket           local
+			env.TEST_SERVICE (test-worker)                          Worker              local [not connected]
+			Service bindings, Durable Object bindings, and Tail consumers connect to other \`wrangler dev\` processes running locally, with their connection status indicated by [connected] or [not connected]. For more details, refer to https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/#local-development
+			⎔ Starting local server...
+			[wrangler:info] Ready on http://localhost:<PORT>"
+		`);
+	});
 
-		it("should support wrangler.toml", async () => {
-			const helper = new WranglerE2ETestHelper();
-			await helper.seed({
-				"public/_worker.js": dedent`
+	it("should support wrangler.toml", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"public/_worker.js": dedent`
 						export default {
 							async fetch(request, env) {
 								return new Response("Pages supports wrangler.toml ⚡️⚡️")
 							}
 						}`,
-				"wrangler.toml": dedent`
+			"wrangler.toml": dedent`
 					name = "pages-project"
 					pages_build_output_dir = "public"
 					compatibility_date = "2023-01-01"
 				`,
-			});
-			const worker = helper.runLongLived(
-				`${cmd} --port ${port} --inspector-port ${inspectorPort}`
-			);
-			const { url } = await worker.waitForReady();
-
-			const text = await fetchText(url);
-			expect(text).toBe("Pages supports wrangler.toml ⚡️⚡️");
 		});
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort}`
+		);
+		const { url } = await worker.waitForReady();
 
-		it("should recover from syntax error during dev session (_worker)", async () => {
-			const helper = new WranglerE2ETestHelper();
-			const worker = helper.runLongLived(`${cmd} .`);
+		const text = await fetchText(url);
+		expect(text).toBe("Pages supports wrangler.toml ⚡️⚡️");
+	});
 
-			await helper.seed({
-				"_worker.js": dedent`
+	it("should recover from syntax error during dev session (_worker)", async () => {
+		const helper = new WranglerE2ETestHelper();
+		const worker = helper.runLongLived(`${cmd} .`);
+
+		await helper.seed({
+			"_worker.js": dedent`
 					export default {
 						fetch(request, env) {
 							return new Response("Hello World!")
 						}
 					}`,
-			});
+		});
 
-			const { url } = await worker.waitForReady();
+		const { url } = await worker.waitForReady();
 
-			await expect(fetch(url).then((r) => r.text())).resolves.toBe(
-				"Hello World!"
-			);
+		await expect(fetch(url).then((r) => r.text())).resolves.toBe(
+			"Hello World!"
+		);
 
-			await helper.seed({
-				"_worker.js": dedent`
+		await helper.seed({
+			"_worker.js": dedent`
 					export default {
 						fetch(request, env) {
 							return new Response("Updated Worker!")
 						} // Syntax Error
 						}
 					}`,
-			});
+		});
 
-			await setTimeout(5_000);
+		await setTimeout(5_000);
 
-			await worker.readUntil(/Failed to build/);
+		await worker.readUntil(/Failed to build/);
 
-			// And then make sure Wrangler hasn't crashed
-			await helper.seed({
-				"_worker.js": dedent`
+		// And then make sure Wrangler hasn't crashed
+		await helper.seed({
+			"_worker.js": dedent`
 					export default {
 						fetch(request, env) {
 							return new Response("Updated Worker!")
 						}
 					}`,
-			});
-			await worker.waitForReload();
-
-			await expect(fetch(url).then((r) => r.text())).resolves.toBe(
-				"Updated Worker!"
-			);
 		});
+		await worker.waitForReload();
 
-		it("should recover from syntax error during dev session (Functions)", async () => {
-			const helper = new WranglerE2ETestHelper();
-			const worker = helper.runLongLived(
-				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-			);
+		await expect(fetch(url).then((r) => r.text())).resolves.toBe(
+			"Updated Worker!"
+		);
+	});
 
-			await helper.seed({
-				"functions/_middleware.js": dedent`
+	it("should recover from syntax error during dev session (Functions)", async () => {
+		const helper = new WranglerE2ETestHelper();
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+		);
+
+		await helper.seed({
+			"functions/_middleware.js": dedent`
 					export async function onRequest() {
 						return new Response("Hello World!")
 					}`,
-			});
+		});
 
-			const { url } = await worker.waitForReady();
+		const { url } = await worker.waitForReady();
 
-			await expect(fetch(url).then((r) => r.text())).resolves.toBe(
-				"Hello World!"
-			);
+		await expect(fetch(url).then((r) => r.text())).resolves.toBe(
+			"Hello World!"
+		);
 
-			await helper.seed({
-				"functions/_middleware.js": dedent`
+		await helper.seed({
+			"functions/_middleware.js": dedent`
 						export async function onRequest() {
 							return new Response("Updated Worker!")
 							} // Syntax Error
 						}`,
-			});
+		});
 
-			await setTimeout(5_000);
+		await setTimeout(5_000);
 
-			await worker.readUntil(/Failed to build Functions/);
+		await worker.readUntil(/Failed to build Functions/);
 
-			// And then make sure Wrangler hasn't crashed
-			await helper.seed({
-				"functions/_middleware.js": dedent`
+		// And then make sure Wrangler hasn't crashed
+		await helper.seed({
+			"functions/_middleware.js": dedent`
 					export async function onRequest() {
 						return new Response("Updated Worker!")
 					}`,
-			});
-			await worker.waitForReload();
-
-			await expect(fetch(url).then((r) => r.text())).resolves.toBe(
-				"Updated Worker!"
-			);
 		});
+		await worker.waitForReload();
 
-		it("should validate _routes.json during dev session, and fallback to default value", async () => {
-			const helper = new WranglerE2ETestHelper();
-			await helper.seed({
-				"functions/foo.ts": dedent`
+		await expect(fetch(url).then((r) => r.text())).resolves.toBe(
+			"Updated Worker!"
+		);
+	});
+
+	it("should validate _routes.json during dev session, and fallback to default value", async () => {
+		const helper = new WranglerE2ETestHelper();
+		await helper.seed({
+			"functions/foo.ts": dedent`
 					export async function onRequest() {
 						return new Response("FOO");
 					}`,
-				"_routes.json": dedent`
+			"_routes.json": dedent`
 					{
 						"version": 1,
 						"include": ["/foo"],
 						"exclude": []
 					}
 				`,
-			});
-			const worker = helper.runLongLived(
-				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-			);
+		});
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+		);
 
-			const { url } = await worker.waitForReady();
+		const { url } = await worker.waitForReady();
 
-			const foo = await fetchText(`${url}/foo`);
+		const foo = await fetchText(`${url}/foo`);
 
-			expect(foo).toBe("FOO");
+		expect(foo).toBe("FOO");
 
-			// invalid _routes.json because include rule does not start with `/`
-			await helper.seed({
-				"_routes.json": dedent`
+		// invalid _routes.json because include rule does not start with `/`
+		await helper.seed({
+			"_routes.json": dedent`
 					{
 						"version": 1,
 						"include": ["foo"],
 						"exclude": []
 					}
 				`,
-			});
-
-			await worker.readUntil(/FatalError: Invalid _routes.json file found/);
-			await worker.readUntil(/All rules must start with '\/'/);
 		});
 
-		it("should use top-level configuration specified in `wrangler.toml`", async () => {
-			const helper = new WranglerE2ETestHelper();
-			const worker = helper.runLongLived(
-				`${cmd} --port ${port} --inspector-port ${inspectorPort}`
-			);
-			await helper.seed({
-				"public/_worker.js": dedent`
+		await worker.readUntil(/FatalError: Invalid _routes.json file found/);
+		await worker.readUntil(/All rules must start with '\/'/);
+	});
+
+	it("should use top-level configuration specified in `wrangler.toml`", async () => {
+		const helper = new WranglerE2ETestHelper();
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort}`
+		);
+		await helper.seed({
+			"public/_worker.js": dedent`
 						export default {
 							async fetch(request, env) {
 								return new Response(env.PAGES + " " + "supports wrangler.toml")
 							}
 						}`,
-				"wrangler.toml": dedent`
+			"wrangler.toml": dedent`
 					name = "pages-project"
 					pages_build_output_dir = "public"
 					# commenting this out would result in a warning. If there is no "compatibility_date"
@@ -318,45 +315,47 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 					binding = "KV_BINDING_TOML"
 					id = "KV_ID_TOML"
 				`,
-			});
-			const { url } = await worker.waitForReady();
-
-			const text = await fetchText(url);
-
-			expect(text).toBe("⚡️ Pages ⚡️ supports wrangler.toml");
-			expect(normalizeOutput(worker.currentOutput)).toContain(
-				dedent`Your Worker has access to the following bindings:
-					- KV Namespaces:
-					  - KV_BINDING_TOML: KV_ID_TOML [simulated locally]
-					- Vars:
-					  - PAGES: "⚡️ Pages ⚡️"
-				`
-			);
 		});
+		const { url } = await worker.waitForReady();
 
-		it("should merge (with override) `wrangler.toml` configuration with configuration provided via the command line, with command line args taking precedence", async () => {
-			const helper = new WranglerE2ETestHelper();
+		const text = await fetchText(url);
 
-			const flags = [
-				` --binding VAR1=NEW_VAR_1 VAR3=VAR_3_ARGS`,
-				` --kv KV_BINDING_1_TOML=NEW_KV_ID_1 KV_BINDING_3_ARGS=KV_ID_3_ARGS`,
-				` --do DO_BINDING_1_TOML=NEW_DO_1@NEW_DO_SCRIPT_1 DO_BINDING_3_ARGS=DO_3_ARGS@DO_SCRIPT_3_ARGS`,
-				` --d1 D1_BINDING_1_TOML=NEW_D1_NAME_1 D1_BINDING_3_ARGS=D1_NAME_3_ARGS`,
-				` --r2 R2_BINDING_1_TOML=new-r2-bucket-1 R2_BINDING_3_TOML=r2-bucket-3-args`,
-				` --service SERVICE_BINDING_1_TOML=NEW_SERVICE_NAME_1 SERVICE_BINDING_3_TOML=SERVICE_NAME_3_ARGS`,
-				` --ai AI_BINDING_2_TOML`,
-			];
-			const worker = helper.runLongLived(
-				`${cmd} --port ${port} --inspector-port ${inspectorPort} ${flags.join("")}`
-			);
-			await helper.seed({
-				"public/_worker.js": dedent`
+		expect(text).toBe("⚡️ Pages ⚡️ supports wrangler.toml");
+		expect(normalizeOutput(worker.currentOutput)).toMatchInlineSnapshot(`
+			"✨ Compiled Worker successfully
+			Your Worker has access to the following bindings:
+			Binding                                  Resource                  Mode
+			env.KV_BINDING_TOML (KV_ID_TOML)         KV Namespace              local
+			env.PAGES ("⚡️ Pages ⚡️")                Environment Variable      local
+			⎔ Starting local server...
+			[wrangler:info] Ready on http://localhost:<PORT>
+			[wrangler:info] GET / 200 OK (24ms)"
+		`);
+	});
+
+	it("should merge (with override) `wrangler.toml` configuration with configuration provided via the command line, with command line args taking precedence", async () => {
+		const helper = new WranglerE2ETestHelper();
+
+		const flags = [
+			` --binding VAR1=NEW_VAR_1 VAR3=VAR_3_ARGS`,
+			` --kv KV_BINDING_1_TOML=NEW_KV_ID_1 KV_BINDING_3_ARGS=KV_ID_3_ARGS`,
+			` --do DO_BINDING_1_TOML=NEW_DO_1@NEW_DO_SCRIPT_1 DO_BINDING_3_ARGS=DO_3_ARGS@DO_SCRIPT_3_ARGS`,
+			` --d1 D1_BINDING_1_TOML=NEW_D1_NAME_1 D1_BINDING_3_ARGS=D1_NAME_3_ARGS`,
+			` --r2 R2_BINDING_1_TOML=new-r2-bucket-1 R2_BINDING_3_TOML=r2-bucket-3-args`,
+			` --service SERVICE_BINDING_1_TOML=NEW_SERVICE_NAME_1 SERVICE_BINDING_3_TOML=SERVICE_NAME_3_ARGS`,
+			` --ai AI_BINDING_2_TOML`,
+		];
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort} ${flags.join("")}`
+		);
+		await helper.seed({
+			"public/_worker.js": dedent`
 					export default {
 						async fetch(request, env) {
 							return new Response("Pages supports wrangler.toml ⚡️")
 						}
 					}`,
-				"wrangler.toml": dedent`
+			"wrangler.toml": dedent`
 				name = "pages-project"
 				pages_build_output_dir = "public"
 				compatibility_date = "2023-01-01"
@@ -423,275 +422,275 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 				[ai]
 				binding = "AI_BINDING_1_TOML"
 			`,
-			});
-			await worker.waitForReady();
-
-			// We only care about the list of bindings and warnings, so strip other output
-			const [prestartOutput] = normalizeOutput(worker.currentOutput).split(
-				"⎔ Starting local server..."
-			);
-
-			expect(prestartOutput).toMatchSnapshot();
 		});
+		await worker.waitForReady();
 
-		it("should pick up wrangler.toml configuration even in cases when `pages_build_output_dir` was not specified, but the <directory> command argument was", async () => {
-			const helper = new WranglerE2ETestHelper();
+		// We only care about the list of bindings and warnings, so strip other output
+		const [prestartOutput] = normalizeOutput(worker.currentOutput).split(
+			"⎔ Starting local server..."
+		);
 
-			await helper.seed({
-				"public/_worker.js": dedent`
+		expect(prestartOutput).toMatchSnapshot();
+	});
+
+	it("should pick up wrangler.toml configuration even in cases when `pages_build_output_dir` was not specified, but the <directory> command argument was", async () => {
+		const helper = new WranglerE2ETestHelper();
+
+		await helper.seed({
+			"public/_worker.js": dedent`
 					export default {
 						async fetch(request, env) {
 							return new Response(env.PAGES_EMOJI + " Pages supports wrangler.toml" + " " + env.PAGES_EMOJI)
 						}
 					}`,
-				"wrangler.toml": dedent`
+			"wrangler.toml": dedent`
 				name = "pages-project"
 				compatibility_date = "2023-01-01"
 
 				[vars]
 				PAGES_EMOJI = "⚡️"
 			`,
-			});
-
-			const worker = helper.runLongLived(
-				`${cmd} --port ${port} --inspector-port ${inspectorPort} public`
-			);
-			const { url } = await worker.waitForReady();
-			await expect(fetchText(url)).resolves.toBe(
-				"⚡️ Pages supports wrangler.toml ⚡️"
-			);
 		});
 
-		describe("watch mode", () => {
-			it("should modify worker during dev session (Functions)", async () => {
-				const helper = new WranglerE2ETestHelper();
+		const worker = helper.runLongLived(
+			`${cmd} --port ${port} --inspector-port ${inspectorPort} public`
+		);
+		const { url } = await worker.waitForReady();
+		await expect(fetchText(url)).resolves.toBe(
+			"⚡️ Pages supports wrangler.toml ⚡️"
+		);
+	});
 
-				await helper.seed({
-					"functions/_middleware.js": dedent`
+	describe("watch mode", () => {
+		it("should modify worker during dev session (Functions)", async () => {
+			const helper = new WranglerE2ETestHelper();
+
+			await helper.seed({
+				"functions/_middleware.js": dedent`
 						export async function onRequest() {
 							return new Response("Hello World!")
 						}`,
-				});
+			});
 
-				const worker = helper.runLongLived(
-					`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-				);
-				const { url } = await worker.waitForReady();
+			const worker = helper.runLongLived(
+				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+			);
+			const { url } = await worker.waitForReady();
 
-				let text = await fetchText(url);
-				expect(text).toBe("Hello World!");
+			let text = await fetchText(url);
+			expect(text).toBe("Hello World!");
 
-				await helper.seed({
-					"functions/_middleware.js": dedent`
+			await helper.seed({
+				"functions/_middleware.js": dedent`
 						export async function onRequest() {
 							return new Response("Updated Worker!")
 						}`,
-				});
-
-				await worker.waitForReload();
-
-				text = await fetchText(url);
-				expect(text).toBe("Updated Worker!");
-
-				// Ensure Wrangler doesn't write tmp files in the functions directory—regression test for https://github.com/cloudflare/workers-sdk/issues/7440
-				expect(
-					existsSync(path.join(helper.tmpPath, "functions/.wrangler"))
-				).toBeFalsy();
 			});
 
-			it("should support modifying dependencies during dev session (Functions)", async () => {
-				const helper = new WranglerE2ETestHelper();
+			await worker.waitForReload();
 
-				await helper.seed({
-					"utils/greetings.js": dedent`
+			text = await fetchText(url);
+			expect(text).toBe("Updated Worker!");
+
+			// Ensure Wrangler doesn't write tmp files in the functions directory—regression test for https://github.com/cloudflare/workers-sdk/issues/7440
+			expect(
+				existsSync(path.join(helper.tmpPath, "functions/.wrangler"))
+			).toBeFalsy();
+		});
+
+		it("should support modifying dependencies during dev session (Functions)", async () => {
+			const helper = new WranglerE2ETestHelper();
+
+			await helper.seed({
+				"utils/greetings.js": dedent`
 						export const hello = "Hello World!"
 						export const hi = "Hi there!"
 						`,
-					"functions/greetings/_middleware.js": dedent`
+				"functions/greetings/_middleware.js": dedent`
 						import { hello } from "../../utils/greetings"
 						export async function onRequest() {
 							return new Response(hello)
 						}`,
-					"functions/hi.js": dedent`
+				"functions/hi.js": dedent`
 						import { hi } from "../utils/greetings"
 						export async function onRequest() {
 							return new Response(hi)
 						}`,
-				});
+			});
 
-				const worker = helper.runLongLived(
-					`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-				);
-				const { url } = await worker.waitForReady();
+			const worker = helper.runLongLived(
+				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+			);
+			const { url } = await worker.waitForReady();
 
-				let hello = await fetchText(`${url}/greetings/hello`);
-				expect(hello).toBe("Hello World!");
+			let hello = await fetchText(`${url}/greetings/hello`);
+			expect(hello).toBe("Hello World!");
 
-				let hi = await fetchText(`${url}/hi`);
-				expect(hi).toBe("Hi there!");
+			let hi = await fetchText(`${url}/hi`);
+			expect(hi).toBe("Hi there!");
 
-				await helper.seed({
-					"utils/greetings.js": dedent`
+			await helper.seed({
+				"utils/greetings.js": dedent`
 						export const hello = "Hey World!"
 						export const hi = "Hey there!"
 						`,
-				});
-
-				await worker.waitForReload();
-
-				hello = await fetchText(`${url}/greetings/hello`);
-				expect(hello).toBe("Hey World!");
-
-				hi = await fetchText(`${url}/hi`);
-				expect(hi).toBe("Hey there!");
 			});
 
-			it("should support modifying external modules during dev session (Functions)", async () => {
-				const helper = new WranglerE2ETestHelper();
+			await worker.waitForReload();
 
-				await helper.seed({
-					"modules/my-html.html": dedent`
+			hello = await fetchText(`${url}/greetings/hello`);
+			expect(hello).toBe("Hey World!");
+
+			hi = await fetchText(`${url}/hi`);
+			expect(hi).toBe("Hey there!");
+		});
+
+		it("should support modifying external modules during dev session (Functions)", async () => {
+			const helper = new WranglerE2ETestHelper();
+
+			await helper.seed({
+				"modules/my-html.html": dedent`
 						<h1>Hello HTML World!</h1>
 						`,
-					"functions/hello.js": dedent`
+				"functions/hello.js": dedent`
 						import html from "../modules/my-html.html";
 						export async function onRequest() {
 							return new Response(html);
 						}`,
-				});
-
-				const worker = helper.runLongLived(
-					`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-				);
-				const { url } = await worker.waitForReady();
-
-				let hello = await fetchText(`${url}/hello`);
-				expect(hello).toBe("<h1>Hello HTML World!</h1>");
-
-				await helper.seed({
-					"modules/my-html.html": dedent`
-						<h1>Updated HTML!</h1>
-						`,
-				});
-
-				await worker.waitForReload();
-
-				hello = await fetchText(`${url}/hello`);
-				expect(hello).toBe("<h1>Updated HTML!</h1>");
 			});
 
-			it("should modify worker during dev session (_worker)", async () => {
-				const helper = new WranglerE2ETestHelper();
+			const worker = helper.runLongLived(
+				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+			);
+			const { url } = await worker.waitForReady();
 
-				await helper.seed({
-					"_worker.js": dedent`
+			let hello = await fetchText(`${url}/hello`);
+			expect(hello).toBe("<h1>Hello HTML World!</h1>");
+
+			await helper.seed({
+				"modules/my-html.html": dedent`
+						<h1>Updated HTML!</h1>
+						`,
+			});
+
+			await worker.waitForReload();
+
+			hello = await fetchText(`${url}/hello`);
+			expect(hello).toBe("<h1>Updated HTML!</h1>");
+		});
+
+		it("should modify worker during dev session (_worker)", async () => {
+			const helper = new WranglerE2ETestHelper();
+
+			await helper.seed({
+				"_worker.js": dedent`
 						export default {
 							fetch(request, env) {
 								return new Response("Hello World!")
 							}
 						}`,
-				});
+			});
 
-				const worker = helper.runLongLived(
-					`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-				);
-				const { url } = await worker.waitForReady();
+			const worker = helper.runLongLived(
+				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+			);
+			const { url } = await worker.waitForReady();
 
-				let hello = await fetchText(url);
-				expect(hello).toBe("Hello World!");
+			let hello = await fetchText(url);
+			expect(hello).toBe("Hello World!");
 
-				await helper.seed({
-					"_worker.js": dedent`
+			await helper.seed({
+				"_worker.js": dedent`
 							export default {
 								fetch(request, env) {
 									return new Response("Updated Worker!")
 								}
 							}`,
-				});
-
-				await worker.waitForReload();
-
-				hello = await fetchText(url);
-				expect(hello).toBe("Updated Worker!");
 			});
 
-			it("should support modifying dependencies during dev session (_worker)", async () => {
-				const helper = new WranglerE2ETestHelper();
+			await worker.waitForReload();
 
-				await helper.seed({
-					"pets/bear.js": dedent`
+			hello = await fetchText(url);
+			expect(hello).toBe("Updated Worker!");
+		});
+
+		it("should support modifying dependencies during dev session (_worker)", async () => {
+			const helper = new WranglerE2ETestHelper();
+
+			await helper.seed({
+				"pets/bear.js": dedent`
 						export const bear = "BEAR!"
 						`,
-					"_worker.js": dedent`
+				"_worker.js": dedent`
 						import { bear } from "./pets/bear"
 						export default {
 							fetch(request, env) {
 								return new Response(bear)
 							}
 						}`,
-				});
-
-				const worker = helper.runLongLived(
-					`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-				);
-				const { url } = await worker.waitForReady();
-
-				let bear = await fetchText(url);
-				expect(bear).toBe("BEAR!");
-
-				await helper.seed({
-					"pets/bear.js": dedent`
-						export const bear = "We love BEAR!"
-						`,
-				});
-
-				await worker.waitForReload();
-
-				bear = await fetchText(url);
-				expect(bear).toBe("We love BEAR!");
 			});
 
-			it("should support modifying external modules during dev session (_worker)", async () => {
-				const helper = new WranglerE2ETestHelper();
+			const worker = helper.runLongLived(
+				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+			);
+			const { url } = await worker.waitForReady();
 
-				await helper.seed({
-					"graham.html": dedent`
+			let bear = await fetchText(url);
+			expect(bear).toBe("BEAR!");
+
+			await helper.seed({
+				"pets/bear.js": dedent`
+						export const bear = "We love BEAR!"
+						`,
+			});
+
+			await worker.waitForReload();
+
+			bear = await fetchText(url);
+			expect(bear).toBe("We love BEAR!");
+		});
+
+		it("should support modifying external modules during dev session (_worker)", async () => {
+			const helper = new WranglerE2ETestHelper();
+
+			await helper.seed({
+				"graham.html": dedent`
 						<h1>Graham the dog</h1>
 						`,
-					"_worker.js": dedent`
+				"_worker.js": dedent`
 						import html from "./graham.html"
 						export default {
 							fetch(request, env) {
 								return new Response(html)
 							}
 						}`,
-				});
-
-				const worker = helper.runLongLived(
-					`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-				);
-				const { url } = await worker.waitForReady();
-
-				let graham = await fetchText(url);
-				expect(graham).toBe("<h1>Graham the dog</h1>");
-
-				await helper.seed({
-					"graham.html": dedent`
-						<h1>Graham is the bestest doggo</h1>
-						`,
-				});
-
-				await worker.waitForReload();
-
-				graham = await fetchText(url);
-				expect(graham).toBe("<h1>Graham is the bestest doggo</h1>");
 			});
 
-			it("should support modifying _routes.json during dev session", async () => {
-				const helper = new WranglerE2ETestHelper();
+			const worker = helper.runLongLived(
+				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+			);
+			const { url } = await worker.waitForReady();
 
-				await helper.seed({
-					"_worker.js": dedent`
+			let graham = await fetchText(url);
+			expect(graham).toBe("<h1>Graham the dog</h1>");
+
+			await helper.seed({
+				"graham.html": dedent`
+						<h1>Graham is the bestest doggo</h1>
+						`,
+			});
+
+			await worker.waitForReload();
+
+			graham = await fetchText(url);
+			expect(graham).toBe("<h1>Graham is the bestest doggo</h1>");
+		});
+
+		it("should support modifying _routes.json during dev session", async () => {
+			const helper = new WranglerE2ETestHelper();
+
+			await helper.seed({
+				"_worker.js": dedent`
 						export default {
 							async fetch(request, env) {
 								const url = new URL(request.url);
@@ -704,45 +703,44 @@ describe.sequential.each([{ cmd: "wrangler pages dev" }])(
 								return new Response("Hello _routes.json")
 							}
 						}`,
-					"_routes.json": dedent`
+				"_routes.json": dedent`
 					{
 						"version": 1,
 						"include": ["/foo", "/bar"],
 						"exclude": []
 					}
 				`,
-					"index.html": dedent`
+				"index.html": dedent`
 					hello world
 				`,
-				});
-				const worker = helper.runLongLived(
-					`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
-				);
-				const { url } = await worker.waitForReady();
+			});
+			const worker = helper.runLongLived(
+				`${cmd} --port ${port} --inspector-port ${inspectorPort} .`
+			);
+			const { url } = await worker.waitForReady();
 
-				const foo = await fetchText(`${url}/foo`);
-				expect(foo).toBe("foo");
+			const foo = await fetchText(`${url}/foo`);
+			expect(foo).toBe("foo");
 
-				const bar = await fetchText(`${url}/bar`);
-				expect(bar).toBe("bar");
+			const bar = await fetchText(`${url}/bar`);
+			expect(bar).toBe("bar");
 
-				await helper.seed({
-					"_routes.json": dedent`
+			await helper.seed({
+				"_routes.json": dedent`
 					{
 						"version": 1,
 						"include": ["/foo"],
 						"exclude": ["/bar"]
 					}
 				`,
-				});
-				await worker.waitForReload();
-
-				const foo2 = await fetchText(`${url}/foo`);
-				expect(foo2).toBe("foo");
-
-				const bar2 = await fetchText(`${url}/bar`);
-				expect(bar2).toBe("hello world");
 			});
+			await worker.waitForReload();
+
+			const foo2 = await fetchText(`${url}/foo`);
+			expect(foo2).toBe("foo");
+
+			const bar2 = await fetchText(`${url}/bar`);
+			expect(bar2).toBe("hello world");
 		});
-	}
-);
+	});
+});

--- a/packages/wrangler/e2e/pages-dev.test.ts
+++ b/packages/wrangler/e2e/pages-dev.test.ts
@@ -329,7 +329,7 @@ describe.sequential("wrangler pages dev", () => {
 			env.PAGES ("⚡️ Pages ⚡️")                Environment Variable      local
 			⎔ Starting local server...
 			[wrangler:info] Ready on http://localhost:<PORT>
-			[wrangler:info] GET / 200 OK (24ms)"
+			[wrangler:info] GET / 200 OK (TIMINGS)"
 		`);
 	});
 

--- a/packages/wrangler/e2e/provision.test.ts
+++ b/packages/wrangler/e2e/provision.test.ts
@@ -74,12 +74,10 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 		expect(normalize(output)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			The following bindings need to be provisioned:
-			- KV Namespaces:
-			  - KV
-			- D1 Databases:
-			  - D1
-			- R2 Buckets:
-			  - R2
+			Binding        Resource
+			env.KV         KV Namespace
+			env.D1         D1 Database
+			env.R2         R2 Bucket
 			Provisioning KV (KV Namespace)...
 			🌀 Creating new KV Namespace "tmp-e2e-worker-00000000-0000-0000-0000-000000000000-kv"...
 			✨ KV provisioned 🎉
@@ -91,12 +89,10 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 			✨ R2 provisioned 🎉
 			🎉 All resources provisioned, continuing with deployment...
 			Your Worker has access to the following bindings:
-			- KV Namespaces:
-			  - KV: 00000000000000000000000000000000
-			- D1 Databases:
-			  - D1: 00000000-0000-0000-0000-000000000000
-			- R2 Buckets:
-			  - R2: tmp-e2e-worker-00000000-0000-0000-0000-000000000000-r2
+			Binding                                                              Resource
+			env.KV (00000000000000000000000000000000)                            KV Namespace
+			env.D1 (00000000-0000-0000-0000-000000000000)                        D1 Database
+			env.R2 (tmp-e2e-worker-00000000-0000-0000-0000-000000000000-r2)      R2 Bucket
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 triggers (TIMINGS)
 			  https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev
@@ -108,11 +104,13 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 		assert(urlMatch?.groups);
 		deployedUrl = urlMatch.groups.url;
 
-		const kvMatch = output.match(/- KV: (?<kv>[0-9a-f]{32})/);
+		const kvMatch = output.match(/env.KV \((?<kv>[0-9a-f]{32})/);
 		assert(kvMatch?.groups);
 		kvId = kvMatch.groups.kv;
 
-		const d1Match = output.match(/- D1: (?<d1>\w{8}-\w{4}-\w{4}-\w{4}-\w{12})/);
+		const d1Match = output.match(
+			/env.D1 \((?<d1>\w{8}-\w{4}-\w{4}-\w{4}-\w{12})/
+		);
 		assert(d1Match?.groups);
 		d1Id = d1Match.groups.d1;
 
@@ -133,12 +131,10 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 		expect(normalize(output)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Your Worker has access to the following bindings:
-			- KV Namespaces:
-			  - KV
-			- D1 Databases:
-			  - D1
-			- R2 Buckets:
-			  - R2
+			Binding                 Resource
+			env.KV (inherited)      KV Namespace
+			env.D1 (inherited)      D1 Database
+			env.R2 (inherited)      R2 Bucket
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Deployed tmp-e2e-worker-00000000-0000-0000-0000-000000000000 triggers (TIMINGS)
 			  https://tmp-e2e-worker-00000000-0000-0000-0000-000000000000.SUBDOMAIN.workers.dev
@@ -177,18 +173,17 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 		expect(normalize(output)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			The following bindings need to be provisioned:
-			- KV Namespaces:
-			  - KV2
+			Binding         Resource
+			env.KV2         KV Namespace
 			Provisioning KV2 (KV Namespace)...
 			🌀 Creating new KV Namespace "tmp-e2e-worker-00000000-0000-0000-0000-000000000000-kv2"...
 			✨ KV2 provisioned 🎉
 			🎉 All resources provisioned, continuing with deployment...
 			Worker Startup Time: (TIMINGS)
 			Your Worker has access to the following bindings:
-			- KV Namespaces:
-			  - KV2: 00000000000000000000000000000000
-			- R2 Buckets:
-			  - R2
+			Binding                                         Resource
+			env.KV2 (00000000000000000000000000000000)      KV Namespace
+			env.R2 (inherited)                              R2 Bucket
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Version Preview URL: https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev
@@ -196,7 +191,7 @@ describe("provisioning", { timeout: TIMEOUT }, () => {
 			Changes to non-versioned settings (config properties 'logpush' or 'tail_consumers') take effect after your next deployment using the command wrangler versions deploy
 			Changes to triggers (routes, custom domains, cron schedules, etc) must be applied with the command wrangler triggers deploy"
 		`);
-		const kvMatch = output.match(/- KV2: (?<kv>[0-9a-f]{32})/);
+		const kvMatch = output.match(/env.KV2 \((?<kv>[0-9a-f]{32})/);
 		assert(kvMatch?.groups);
 		kvId2 = kvMatch.groups.kv;
 	});

--- a/packages/wrangler/e2e/versions.test.ts
+++ b/packages/wrangler/e2e/versions.test.ts
@@ -64,7 +64,6 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: (TIMINGS)
-			No bindings found.
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Version Preview URL: https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev
@@ -181,7 +180,6 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 		expect(normalize(upload.stdout)).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: (TIMINGS)
-			No bindings found.
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Version Preview URL: https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev
@@ -584,7 +582,6 @@ describe("versions deploy", { timeout: TIMEOUT }, () => {
 			✨ Success! Uploaded 1 file (TIMINGS)
 			Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: (TIMINGS)
-			No bindings found.
 			Uploaded tmp-e2e-worker-00000000-0000-0000-0000-000000000000 (TIMINGS)
 			Worker Version ID: 00000000-0000-0000-0000-000000000000
 			Version Preview URL: https://tmp-e2e-worker-PREVIEW-URL.SUBDOMAIN.workers.dev

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -264,7 +264,7 @@ describe("Hot Keys", () => {
 					│  [a] first option │
 					│  [b] second option │
 					│  [c] third option │
-					╰───────────────────────────────────────────────────────╯"
+					╰─────────────────────╯"
 				`);
 				unregisterHotKeys();
 			} finally {

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -214,34 +214,28 @@ describe("Hot Keys", () => {
 			const unregisterHotKeys = registerHotKeys(options);
 
 			expect(std.out).toMatchInlineSnapshot(`
-				"╭─────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option │
-				╰─────────────────────────────────────────────────────────╯"
+				"╭───────────────────────────────────────────────────────╮
+				│  [a] first option [b] second option [c] third option │
+				╰───────────────────────────────────────────────────────╯"
 			`);
 
 			logger.log("something 1");
 
 			expect(std.out).toMatchInlineSnapshot(`
-				"╭─────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option │
-				╰─────────────────────────────────────────────────────────╯
-				something 1
-				╭─────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option │
-				╰─────────────────────────────────────────────────────────╯"
+				"╭───────────────────────────────────────────────────────╮
+				│  [a] first option [b] second option [c] third option │
+				╰───────────────────────────────────────────────────────╯
+				something 1"
 			`);
 
 			unregisterHotKeys();
 			logger.log("something 2");
 
 			expect(std.out).toMatchInlineSnapshot(`
-				"╭─────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option │
-				╰─────────────────────────────────────────────────────────╯
+				"╭───────────────────────────────────────────────────────╮
+				│  [a] first option [b] second option [c] third option │
+				╰───────────────────────────────────────────────────────╯
 				something 1
-				╭─────────────────────────────────────────────────────────╮
-				│  [a] first option, [b] second option, [c] third option │
-				╰─────────────────────────────────────────────────────────╯
 				something 2"
 			`);
 		});
@@ -266,11 +260,11 @@ describe("Hot Keys", () => {
 				const unregisterHotKeys = registerHotKeys(options);
 
 				expect(std.out).toMatchInlineSnapshot(`
-					"╭─────────────────────╮
+					"╭───────────────────────────────────────────────────────╮
 					│  [a] first option │
 					│  [b] second option │
 					│  [c] third option │
-					╰─────────────────────╯"
+					╰───────────────────────────────────────────────────────╯"
 				`);
 				unregisterHotKeys();
 			} finally {

--- a/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
+++ b/packages/wrangler/src/__tests__/cli-hotkeys.test.ts
@@ -260,7 +260,7 @@ describe("Hot Keys", () => {
 				const unregisterHotKeys = registerHotKeys(options);
 
 				expect(std.out).toMatchInlineSnapshot(`
-					"╭───────────────────────────────────────────────────────╮
+					"╭─────────────────────╮
 					│  [a] first option │
 					│  [b] second option │
 					│  [c] third option │

--- a/packages/wrangler/src/__tests__/config/configuration.pages.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.pages.test.ts
@@ -792,7 +792,7 @@ describe("normalizeAndValidateConfig()", () => {
 			);
 
 			expect(diagnostics.errors).toEqual([
-				"The name 'ASSETS' is reserved in Pages projects. Please use a different name for your KV Namespaces binding.",
+				"The name 'ASSETS' is reserved in Pages projects. Please use a different name for your KV Namespace binding.",
 			]);
 		});
 
@@ -815,7 +815,7 @@ describe("normalizeAndValidateConfig()", () => {
 			);
 
 			expect(diagnostics.errors).toEqual([
-				"The name 'ASSETS' is reserved in Pages projects. Please use a different name for your Vars binding.",
+				"The name 'ASSETS' is reserved in Pages projects. Please use a different name for your Environment Variable binding.",
 			]);
 		});
 	});

--- a/packages/wrangler/src/__tests__/d1/info.test.ts
+++ b/packages/wrangler/src/__tests__/d1/info.test.ts
@@ -174,8 +174,7 @@ describe("info", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"
 			 ⛅️ wrangler x.x.x
-			------------------
-
+			──────────────────
 			┌─┬─┐
 			│ DB │ d5b1d127-xxxx-xxxx-xxxx-cbc69f0a9e06 │
 			├─┼─┤

--- a/packages/wrangler/src/__tests__/d1/list.test.ts
+++ b/packages/wrangler/src/__tests__/d1/list.test.ts
@@ -71,8 +71,7 @@ describe("list", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"
 			 ⛅️ wrangler x.x.x
-			------------------
-
+			──────────────────
 			┌─┬─┬─┐
 			│ uuid │ name │ binding │
 			├─┼─┼─┤

--- a/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
+++ b/packages/wrangler/src/__tests__/d1/timeTravel.test.ts
@@ -188,8 +188,7 @@ describe("time-travel", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🚧 Restoring database db from bookmark undefined
 
 					⚠️ This will overwrite all data in database db.
@@ -228,8 +227,7 @@ describe("time-travel", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🚧 Time Traveling...
 					⚠️ Timestamp '2011-09-05T14:48:00.000Z' corresponds with bookmark 'undefined'
 					⚡️ To restore to this specific bookmark, run:

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -140,7 +140,6 @@ describe("deploy", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
-			No bindings found.
 			Uploaded test-name (TIMINGS)
 			Deployed test-name triggers (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -198,7 +197,6 @@ describe("deploy", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
-			No bindings found.
 			Uploaded test-name (TIMINGS)
 			Deployed test-name triggers (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -228,7 +226,6 @@ describe("deploy", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
-			No bindings found.
 			Uploaded test-name (TIMINGS)
 			Deployed test-name triggers (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -254,7 +251,6 @@ describe("deploy", () => {
 		expect(std.out).toMatchInlineSnapshot(`
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
-			No bindings found.
 			Uploaded test-name (TIMINGS)
 			Deployed test-name triggers (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -317,8 +313,9 @@ describe("deploy", () => {
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
 			Your Worker has access to the following bindings:
-			- Vars:
-			  - xyz: 123
+			Binding            Resource
+			env.xyz (123)      Environment Variable
+
 			Uploaded test-name (TIMINGS)
 			Deployed test-name triggers (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -357,8 +354,9 @@ describe("deploy", () => {
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
 			Your Worker has access to the following bindings:
-			- Vars:
-			  - xyz: 123
+			Binding            Resource
+			env.xyz (123)      Environment Variable
+
 			Uploaded test-worker (TIMINGS)
 			Deployed test-worker triggers (TIMINGS)
 			  https://test-worker.test-sub-domain.workers.dev
@@ -431,8 +429,9 @@ describe("deploy", () => {
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
 			Your Worker has access to the following bindings:
-			- Vars:
-			  - xyz: 123
+			Binding            Resource
+			env.xyz (123)      Environment Variable
+
 			Uploaded test-worker-jsonc (TIMINGS)
 			Deployed test-worker-jsonc triggers (TIMINGS)
 			  https://test-worker-jsonc.test-sub-domain.workers.dev
@@ -543,7 +542,6 @@ describe("deploy", () => {
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Worker ID:  abc12345
 				Worker ETag:  etag98765
 				Worker PipelineHash:  hash9999
@@ -584,7 +582,6 @@ describe("deploy", () => {
 				Successfully logged in.
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -626,7 +623,6 @@ describe("deploy", () => {
 					Successfully logged in.
 					Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -651,7 +647,6 @@ describe("deploy", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -686,7 +681,6 @@ describe("deploy", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -711,7 +705,6 @@ describe("deploy", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -891,7 +884,6 @@ describe("deploy", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name-some-env (TIMINGS)
 				Deployed test-name-some-env triggers (TIMINGS)
 				  https://test-name-some-env.test-sub-domain.workers.dev
@@ -914,7 +906,6 @@ describe("deploy", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -937,7 +928,6 @@ describe("deploy", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name-some-env (TIMINGS)
 					Deployed test-name-some-env triggers (TIMINGS)
 					  https://test-name-some-env.test-sub-domain.workers.dev
@@ -960,7 +950,6 @@ describe("deploy", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name-some-env (TIMINGS)
 					Deployed test-name-some-env triggers (TIMINGS)
 					  https://test-name-some-env.test-sub-domain.workers.dev
@@ -1032,7 +1021,6 @@ describe("deploy", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -1063,7 +1051,6 @@ describe("deploy", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (some-env) (TIMINGS)
 					Deployed test-name (some-env) triggers (TIMINGS)
 					  https://some-env.test-name.test-sub-domain.workers.dev
@@ -1110,8 +1097,9 @@ describe("deploy", () => {
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
 			Your Worker has access to the following bindings:
-			- Vars:
-			  - xyz: 123
+			Binding            Resource
+			env.xyz (123)      Environment Variable
+
 			Uploaded test-name (TIMINGS)
 			Deployed test-name triggers (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -1149,7 +1137,6 @@ describe("deploy", () => {
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -1199,7 +1186,6 @@ describe("deploy", () => {
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  some-example.com/some-route/*
@@ -1244,7 +1230,6 @@ describe("deploy", () => {
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  partner.com/* (zone name: owned-zone.com)
@@ -1285,7 +1270,6 @@ describe("deploy", () => {
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  subdomain.partner.com/* (zone name: owned-zone.com)
@@ -1347,7 +1331,6 @@ describe("deploy", () => {
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (staging) (TIMINGS)
 				Deployed test-name (staging) triggers (TIMINGS)
 				  some-example.com/some-route/*
@@ -1460,7 +1443,6 @@ describe("deploy", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  example.com/some-route/*
@@ -1838,7 +1820,6 @@ Update them to point to this script instead?`,
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  simple.co.uk/path/*
@@ -1905,7 +1886,6 @@ Update them to point to this script instead?`,
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  example.com/blog/* (zone id: asdfadsf)
@@ -1972,7 +1952,6 @@ Update them to point to this script instead?`,
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  example.com/blog/* (zone id: asdfadsf)
@@ -2052,7 +2031,6 @@ Update them to point to this script instead?`,
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  simple.co.uk/path/*
@@ -2118,7 +2096,6 @@ Update them to point to this script instead?`,
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2141,7 +2118,6 @@ Update them to point to this script instead?`,
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2161,7 +2137,6 @@ Update them to point to this script instead?`,
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2183,7 +2158,6 @@ Update them to point to this script instead?`,
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2202,7 +2176,6 @@ Update them to point to this script instead?`,
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2225,7 +2198,6 @@ Update them to point to this script instead?`,
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2259,7 +2231,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2287,7 +2258,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2307,7 +2277,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2409,7 +2378,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2493,7 +2461,6 @@ addEventListener('fetch', event => {});`
 				  "out": "↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2552,7 +2519,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2809,7 +2775,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2867,7 +2832,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -2932,7 +2896,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3047,7 +3010,6 @@ addEventListener('fetch', event => {});`
 				↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3104,7 +3066,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (some-env) (TIMINGS)
 				Deployed test-name (some-env) triggers (TIMINGS)
 				  https://some-env.test-name.test-sub-domain.workers.dev
@@ -3161,7 +3122,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name-some-env (TIMINGS)
 				Deployed test-name-some-env triggers (TIMINGS)
 				  https://test-name-some-env.test-sub-domain.workers.dev
@@ -3203,7 +3163,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3251,7 +3210,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3299,7 +3257,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3348,7 +3305,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3397,7 +3353,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3446,7 +3401,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3495,7 +3449,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3546,7 +3499,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3601,7 +3553,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3712,7 +3663,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3852,7 +3802,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3913,7 +3862,6 @@ addEventListener('fetch', event => {});`
 				"↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -3959,7 +3907,6 @@ addEventListener('fetch', event => {});`
 				  "out": "↗️  Done syncing assets
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -4175,7 +4122,6 @@ addEventListener('fetch', event => {});`
 					  "out": "↗️  Done syncing assets
 					Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -5398,7 +5344,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -5422,7 +5367,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -5445,7 +5389,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -5469,7 +5412,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -5494,7 +5436,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -5517,7 +5458,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				No deploy targets for test-name (TIMINGS)
 				Current Version ID: Galaxy-Class"
@@ -5540,7 +5480,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				No deploy targets for test-name (TIMINGS)
 				Current Version ID: Galaxy-Class"
@@ -5562,7 +5501,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				No deploy targets for test-name (TIMINGS)
 				Current Version ID: Galaxy-Class"
@@ -5585,7 +5523,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				No deploy targets for test-name (TIMINGS)
 				Current Version ID: Galaxy-Class"
@@ -5614,7 +5551,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (dev) (TIMINGS)
 				No deploy targets for test-name (dev) (TIMINGS)
 				Current Version ID: Galaxy-Class"
@@ -5643,7 +5579,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (dev) (TIMINGS)
 				No deploy targets for test-name (dev) (TIMINGS)
 				Current Version ID: undefined"
@@ -5673,7 +5608,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (dev) (TIMINGS)
 				Deployed test-name (dev) triggers (TIMINGS)
 				  https://dev.test-name.test-sub-domain.workers.dev
@@ -5705,7 +5639,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (dev) (TIMINGS)
 				Deployed test-name (dev) triggers (TIMINGS)
 				  https://dev.test-name.test-sub-domain.workers.dev
@@ -5737,7 +5670,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (dev) (TIMINGS)
 				Deployed test-name (dev) triggers (TIMINGS)
 				  https://dev.test-name.test-sub-domain.workers.dev
@@ -5772,7 +5704,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (dev) (TIMINGS)
 				Deployed test-name (dev) triggers (TIMINGS)
 				  https://dev.test-name.test-sub-domain.workers.dev
@@ -5808,7 +5739,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (dev) (TIMINGS)
 				Deployed test-name (dev) triggers (TIMINGS)
 				  https://dev.test-name.test-sub-domain.workers.dev
@@ -5872,7 +5802,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -5894,7 +5823,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -5974,7 +5902,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  http://example.com/*
@@ -6012,7 +5939,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name-production (TIMINGS)
 				Deployed test-name-production triggers (TIMINGS)
 				  http://production.example.com/*
@@ -6050,7 +5976,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name-production (TIMINGS)
 				Deployed test-name-production triggers (TIMINGS)
 				  http://production.example.com/*
@@ -6082,7 +6007,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -6125,7 +6049,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name-production (TIMINGS)
 				Deployed test-name-production triggers (TIMINGS)
 				  https://test-name-production.test-sub-domain.workers.dev
@@ -6168,7 +6091,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name-production (TIMINGS)
 				Deployed test-name-production triggers (TIMINGS)
 				  https://test-name-production.test-sub-domain.workers.dev
@@ -6208,7 +6130,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name-production (TIMINGS)
 				Deployed test-name-production triggers (TIMINGS)
 				  http://production.example.com/*
@@ -6247,7 +6168,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name-production (TIMINGS)
 				Deployed test-name-production triggers (TIMINGS)
 				  http://production.example.com/*
@@ -6400,7 +6320,6 @@ addEventListener('fetch', event => {});`
 				"[custom build] Running: node -e \\"4+4; require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\\"
 				Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -6428,7 +6347,6 @@ addEventListener('fetch', event => {});`
 					"[custom build] Running: echo \\"export default { fetch(){ return new Response(123) } }\\" > index.js
 					Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -6537,7 +6455,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -6579,7 +6496,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (testEnv) (TIMINGS)
 				Deployed test-name (testEnv) triggers (TIMINGS)
 				  https://testEnv.test-name.test-sub-domain.workers.dev
@@ -6685,8 +6601,9 @@ addEventListener('fetch', event => {});`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Durable Objects:
-				  - SOMENAME: SomeClass
+				Binding                       Resource
+				env.SOMENAME (SomeClass)      Durable Object
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -6738,8 +6655,9 @@ addEventListener('fetch', event => {});`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Durable Objects:
-				  - SOMENAME: SomeClass (defined in some-script)
+				Binding                                               Resource
+				env.SOMENAME (SomeClass, defined in some-script)      Durable Object
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -6784,9 +6702,10 @@ addEventListener('fetch', event => {});`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Durable Objects:
-				  - SOMENAME: SomeClass
-				  - SOMEOTHERNAME: SomeOtherClass
+				Binding                                 Resource
+				env.SOMENAME (SomeClass)                Durable Object
+				env.SOMEOTHERNAME (SomeOtherClass)      Durable Object
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -6839,9 +6758,10 @@ addEventListener('fetch', event => {});`
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Durable Objects:
-				  - SOMENAME: SomeClass
-				  - SOMEOTHERNAME: SomeOtherClass
+				Binding                                 Resource
+				env.SOMENAME (SomeClass)                Durable Object
+				env.SOMEOTHERNAME (SomeOtherClass)      Durable Object
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -6886,9 +6806,10 @@ addEventListener('fetch', event => {});`
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Durable Objects:
-				  - SOMENAME: SomeClass
-				  - SOMEOTHERNAME: SomeOtherClass
+				Binding                                 Resource
+				env.SOMENAME (SomeClass)                Durable Object
+				env.SOMEOTHERNAME (SomeOtherClass)      Durable Object
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -6935,9 +6856,10 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - SOMENAME: SomeClass
-					  - SOMEOTHERNAME: SomeOtherClass
+					Binding                                 Resource
+					env.SOMENAME (SomeClass)                Durable Object
+					env.SOMEOTHERNAME (SomeOtherClass)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -7001,9 +6923,10 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - SOMENAME: SomeClass
-					  - SOMEOTHERNAME: SomeOtherClass
+					Binding                                 Resource
+					env.SOMENAME (SomeClass)                Durable Object
+					env.SOMEOTHERNAME (SomeOtherClass)      Durable Object
+
 					Uploaded test-name (xyz) (TIMINGS)
 					Deployed test-name (xyz) triggers (TIMINGS)
 					  https://xyz.test-name.test-sub-domain.workers.dev
@@ -7066,9 +6989,10 @@ addEventListener('fetch', event => {});`
 					  "out": "Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - SOMENAME: SomeClass
-					  - SOMEOTHERNAME: SomeOtherClass
+					Binding                                 Resource
+					env.SOMENAME (SomeClass)                Durable Object
+					env.SOMEOTHERNAME (SomeOtherClass)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -7139,9 +7063,10 @@ addEventListener('fetch', event => {});`
 					  "out": "Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - SOMENAME: SomeClass
-					  - SOMEOTHERNAME: SomeOtherClass
+					Binding                                 Resource
+					env.SOMENAME (SomeClass)                Durable Object
+					env.SOMEOTHERNAME (SomeOtherClass)      Durable Object
+
 					Uploaded test-name (xyz) (TIMINGS)
 					Deployed test-name (xyz) triggers (TIMINGS)
 					  https://xyz.test-name.test-sub-domain.workers.dev
@@ -7198,9 +7123,10 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - SOMENAME: SomeClass
-					  - SOMEOTHERNAME: SomeOtherClass
+					Binding                                 Resource
+					env.SOMENAME (SomeClass)                Durable Object
+					env.SOMEOTHERNAME (SomeOtherClass)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					  Dispatch Namespace: test-namespace
 					Current Version ID: Galaxy-Class"
@@ -7250,9 +7176,10 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - SOMENAME: SomeClass
-					  - SOMEOTHERNAME: SomeOtherClass
+					Binding                                 Resource
+					env.SOMENAME (SomeClass)                Durable Object
+					env.SOMEOTHERNAME (SomeOtherClass)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					  Dispatch Namespace: test-namespace
 					Current Version ID: Galaxy-Class"
@@ -7282,7 +7209,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Your Worker is sending Tail events to the following Workers:
 				- listener
 				- test-listener
@@ -7310,7 +7236,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -7538,41 +7463,32 @@ addEventListener('fetch', event => {});`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Data Blobs:
-				  - DATA_BLOB_ONE: some-data-blob.bin
-				  - DATA_BLOB_TWO: more-data-blob.bin
-				- Durable Objects:
-				  - DURABLE_OBJECT_ONE: SomeDurableObject (defined in some-durable-object-worker)
-				  - DURABLE_OBJECT_TWO: AnotherDurableObject (defined in another-durable-object-worker)
-				- KV Namespaces:
-				  - KV_NAMESPACE_ONE: kv-ns-one-id
-				  - KV_NAMESPACE_TWO: kv-ns-two-id
-				- R2 Buckets:
-				  - R2_BUCKET_ONE: r2-bucket-one-name
-				  - R2_BUCKET_TWO: r2-bucket-two-name
-				  - R2_BUCKET_ONE_EU: r2-bucket-one-name (eu)
-				  - R2_BUCKET_TWO_EU: r2-bucket-two-name (eu)
-				- logfwdr:
-				  - httplogs: httplogs
-				  - trace: trace
-				- Analytics Engine Datasets:
-				  - AE_DATASET_ONE: ae-dataset-one-name
-				  - AE_DATASET_TWO: ae-dataset-two-name
-				- Text Blobs:
-				  - TEXT_BLOB_ONE: my-entire-app-depends-on-this.cfg
-				  - TEXT_BLOB_TWO: the-entirety-of-human-knowledge.txt
-				- Unsafe Metadata:
-				  - some unsafe thing: UNSAFE_BINDING_ONE
-				  - another unsafe thing: UNSAFE_BINDING_TWO
-				- Vars:
-				  - ENV_VAR_ONE: 123
-				  - ENV_VAR_TWO: \\"Hello, I'm an environment variable\\"
-				- Wasm Modules:
-				  - WASM_MODULE_ONE: some_wasm.wasm
-				  - WASM_MODULE_TWO: more_wasm.wasm
-				- Unsafe Metadata:
-				  - extra_data: \\"interesting value\\"
-				  - more_data: \\"dubious value\\"
+				Binding                                                                                        Resource
+				env.DATA_BLOB_ONE (some-data-blob.bin)                                                         Data Blob
+				env.DATA_BLOB_TWO (more-data-blob.bin)                                                         Data Blob
+				env.DURABLE_OBJECT_ONE (SomeDurableObject, defined in some-durable-object-worker)              Durable Object
+				env.DURABLE_OBJECT_TWO (AnotherDurableObject, defined in another-durable-object-worker)        Durable Object
+				env.KV_NAMESPACE_ONE (kv-ns-one-id)                                                            KV Namespace
+				env.KV_NAMESPACE_TWO (kv-ns-two-id)                                                            KV Namespace
+				env.R2_BUCKET_ONE (r2-bucket-one-name)                                                         R2 Bucket
+				env.R2_BUCKET_TWO (r2-bucket-two-name)                                                         R2 Bucket
+				env.R2_BUCKET_ONE_EU (r2-bucket-one-name (eu))                                                 R2 Bucket
+				env.R2_BUCKET_TWO_EU (r2-bucket-two-name (eu))                                                 R2 Bucket
+				env.httplogs (httplogs)                                                                        logfwdr
+				env.trace (trace)                                                                              logfwdr
+				env.AE_DATASET_ONE (ae-dataset-one-name)                                                       Analytics Engine Dataset
+				env.AE_DATASET_TWO (ae-dataset-two-name)                                                       Analytics Engine Dataset
+				env.TEXT_BLOB_ONE (my-entire-app-depends-on-this.cfg)                                          Text Blob
+				env.TEXT_BLOB_TWO (the-entirety-of-human-knowledge.txt)                                        Text Blob
+				env.some unsafe thing (UNSAFE_BINDING_ONE)                                                     Unsafe Metadata
+				env.another unsafe thing (UNSAFE_BINDING_TWO)                                                  Unsafe Metadata
+				env.ENV_VAR_ONE (123)                                                                          Environment Variable
+				env.ENV_VAR_TWO (\\"Hello, I'm an environment variable\\")                                         Environment Variable
+				env.WASM_MODULE_ONE (some_wasm.wasm)                                                           Wasm Module
+				env.WASM_MODULE_TWO (more_wasm.wasm)                                                           Wasm Module
+				env.extra_data (\\"interesting value\\")                                                           Unsafe Metadata
+				env.more_data (\\"dubious value\\")                                                                Unsafe Metadata
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -7669,10 +7585,10 @@ addEventListener('fetch', event => {});`
 			await expect(runWrangler("deploy index.js")).rejects
 				.toMatchInlineSnapshot(`
 				[Error: Processing wrangler.toml configuration:
-				  - CONFLICTING_NAME_THREE assigned to Data Blobs, R2 Buckets, Text Blobs, Unsafe Metadata, Vars, and Wasm Modules bindings.
-				  - CONFLICTING_NAME_ONE assigned to Durable Objects, KV Namespaces, and R2 Buckets bindings.
-				  - CONFLICTING_NAME_TWO assigned to Durable Objects and KV Namespaces bindings.
-				  - CONFLICTING_NAME_FOUR assigned to Analytics Engine Datasets, Text Blobs, and Unsafe Metadata bindings.
+				  - CONFLICTING_NAME_THREE assigned to Data Blob, R2 Bucket, Text Blob, Unsafe Metadata, Environment Variable, and Wasm Module bindings.
+				  - CONFLICTING_NAME_ONE assigned to Durable Object, KV Namespace, and R2 Bucket bindings.
+				  - CONFLICTING_NAME_TWO assigned to Durable Object and KV Namespace bindings.
+				  - CONFLICTING_NAME_FOUR assigned to Analytics Engine Dataset, Text Blob, and Unsafe Metadata bindings.
 				  - Bindings must have unique names, so that they can all be referenced in the worker.
 				    Please change your bindings to have unique names.]
 			`);
@@ -7680,11 +7596,11 @@ addEventListener('fetch', event => {});`
 			expect(std.err).toMatchInlineSnapshot(`
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
 
-				    - CONFLICTING_NAME_THREE assigned to Data Blobs, R2 Buckets, Text Blobs, Unsafe Metadata, Vars,
-				  and Wasm Modules bindings.
-				    - CONFLICTING_NAME_ONE assigned to Durable Objects, KV Namespaces, and R2 Buckets bindings.
-				    - CONFLICTING_NAME_TWO assigned to Durable Objects and KV Namespaces bindings.
-				    - CONFLICTING_NAME_FOUR assigned to Analytics Engine Datasets, Text Blobs, and Unsafe Metadata
+				    - CONFLICTING_NAME_THREE assigned to Data Blob, R2 Bucket, Text Blob, Unsafe Metadata,
+				  Environment Variable, and Wasm Module bindings.
+				    - CONFLICTING_NAME_ONE assigned to Durable Object, KV Namespace, and R2 Bucket bindings.
+				    - CONFLICTING_NAME_TWO assigned to Durable Object and KV Namespace bindings.
+				    - CONFLICTING_NAME_FOUR assigned to Analytics Engine Dataset, Text Blob, and Unsafe Metadata
 				  bindings.
 				    - Bindings must have unique names, so that they can all be referenced in the worker.
 				      Please change your bindings to have unique names.
@@ -7777,10 +7693,10 @@ addEventListener('fetch', event => {});`
 			await expect(runWrangler("deploy index.js")).rejects
 				.toMatchInlineSnapshot(`
 				[Error: Processing wrangler.toml configuration:
-				  - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Objects bindings.
-				  - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespaces bindings.
-				  - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Buckets bindings.
-				  - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Datasets bindings.
+				  - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
+				  - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
+				  - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
+				  - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Dataset bindings.
 				  - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe Metadata bindings.
 				  - Bindings must have unique names, so that they can all be referenced in the worker.
 				    Please change your bindings to have unique names.]
@@ -7789,10 +7705,10 @@ addEventListener('fetch', event => {});`
 			expect(std.err).toMatchInlineSnapshot(`
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
 
-				    - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Objects bindings.
-				    - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespaces bindings.
-				    - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Buckets bindings.
-				    - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Datasets bindings.
+				    - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
+				    - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
+				    - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
+				    - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Dataset bindings.
 				    - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe Metadata bindings.
 				    - Bindings must have unique names, so that they can all be referenced in the worker.
 				      Please change your bindings to have unique names.
@@ -7927,12 +7843,12 @@ addEventListener('fetch', event => {});`
 			await expect(runWrangler("deploy index.js")).rejects
 				.toMatchInlineSnapshot(`
 				[Error: Processing wrangler.toml configuration:
-				  - CONFLICTING_NAME_THREE assigned to Data Blobs, R2 Buckets, Analytics Engine Datasets, Text Blobs, Unsafe Metadata, Vars, and Wasm Modules bindings.
-				  - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Objects bindings.
-				  - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespaces bindings.
-				  - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Buckets bindings.
-				  - CONFLICTING_NAME_FOUR assigned to R2 Buckets, Analytics Engine Datasets, Text Blobs, and Unsafe Metadata bindings.
-				  - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Datasets bindings.
+				  - CONFLICTING_NAME_THREE assigned to Data Blob, R2 Bucket, Analytics Engine Dataset, Text Blob, Unsafe Metadata, Environment Variable, and Wasm Module bindings.
+				  - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
+				  - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
+				  - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
+				  - CONFLICTING_NAME_FOUR assigned to R2 Bucket, Analytics Engine Dataset, Text Blob, and Unsafe Metadata bindings.
+				  - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Dataset bindings.
 				  - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe Metadata bindings.
 				  - Bindings must have unique names, so that they can all be referenced in the worker.
 				    Please change your bindings to have unique names.]
@@ -7941,14 +7857,14 @@ addEventListener('fetch', event => {});`
 			expect(std.err).toMatchInlineSnapshot(`
 				"[31mX [41;31m[[41;97mERROR[41;31m][0m [1mProcessing wrangler.toml configuration:[0m
 
-				    - CONFLICTING_NAME_THREE assigned to Data Blobs, R2 Buckets, Analytics Engine Datasets, Text
-				  Blobs, Unsafe Metadata, Vars, and Wasm Modules bindings.
-				    - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Objects bindings.
-				    - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespaces bindings.
-				    - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Buckets bindings.
-				    - CONFLICTING_NAME_FOUR assigned to R2 Buckets, Analytics Engine Datasets, Text Blobs, and
-				  Unsafe Metadata bindings.
-				    - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Datasets bindings.
+				    - CONFLICTING_NAME_THREE assigned to Data Blob, R2 Bucket, Analytics Engine Dataset, Text Blob,
+				  Unsafe Metadata, Environment Variable, and Wasm Module bindings.
+				    - CONFLICTING_DURABLE_OBJECT_NAME assigned to multiple Durable Object bindings.
+				    - CONFLICTING_KV_NAMESPACE_NAME assigned to multiple KV Namespace bindings.
+				    - CONFLICTING_R2_BUCKET_NAME assigned to multiple R2 Bucket bindings.
+				    - CONFLICTING_NAME_FOUR assigned to R2 Bucket, Analytics Engine Dataset, Text Blob, and Unsafe
+				  Metadata bindings.
+				    - CONFLICTING_AE_DATASET_NAME assigned to multiple Analytics Engine Dataset bindings.
 				    - CONFLICTING_UNSAFE_NAME assigned to multiple Unsafe Metadata bindings.
 				    - Bindings must have unique names, so that they can all be referenced in the worker.
 				      Please change your bindings to have unique names.
@@ -7989,8 +7905,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Wasm Modules:
-					  - TESTWASMNAME: path/to/test.wasm
+					Binding                                   Resource
+					env.TESTWASMNAME (path/to/test.wasm)      Wasm Module
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8059,8 +7976,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Wasm Modules:
-					  - TESTWASMNAME: path/to/and/the/path/to/test.wasm
+					Binding                                                   Resource
+					env.TESTWASMNAME (path/to/and/the/path/to/test.wasm)      Wasm Module
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8097,7 +8015,6 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8136,8 +8053,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Text Blobs:
-					  - TESTTEXTBLOBNAME: path/to/text.file
+					Binding                                       Resource
+					env.TESTTEXTBLOBNAME (path/to/text.file)      Text Blob
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8210,8 +8128,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Text Blobs:
-					  - TESTTEXTBLOBNAME: path/to/and/the/path/to/text.file
+					Binding                                                       Resource
+					env.TESTTEXTBLOBNAME (path/to/and/the/path/to/text.file)      Text Blob
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8250,8 +8169,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Data Blobs:
-					  - TESTDATABLOBNAME: path/to/data.bin
+					Binding                                      Resource
+					env.TESTDATABLOBNAME (path/to/data.bin)      Data Blob
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8324,8 +8244,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Data Blobs:
-					  - TESTDATABLOBNAME: path/to/and/the/path/to/data.bin
+					Binding                                                      Resource
+					env.TESTDATABLOBNAME (path/to/and/the/path/to/data.bin)      Data Blob
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8364,13 +8285,11 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Vars:
-					  - text: \\"plain ol' string\\"
-					  - count: 1
-					  - complex: {
-					 \\"enabled\\": true,
-					 \\"id\\": 123
-					}
+					Binding                                      Resource
+					env.text (\\"plain ol' string\\")                Environment Variable
+					env.count (1)                                Environment Variable
+					env.complex ({\\"enabled\\":true,\\"id\\":123})      Environment Variable
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8394,9 +8313,10 @@ addEventListener('fetch', event => {});`
 					  "out": "Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Vars:
-					  - TEXT: \\"(hidden)\\"
-					  - COUNT: \\"(hidden)\\"
+					Binding                     Resource
+					env.TEXT (\\"(hidden)\\")       Environment Variable
+					env.COUNT (\\"(hidden)\\")      Environment Variable
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8425,8 +8345,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- R2 Buckets:
-					  - FOO: foo-bucket
+					Binding                   Resource
+					env.FOO (foo-bucket)      R2 Bucket
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8475,9 +8396,10 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- logfwdr:
-					  - httplogs: httplogs
-					  - trace: trace
+					Binding                      Resource
+					env.httplogs (httplogs)      logfwdr
+					env.trace (trace)            logfwdr
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8549,8 +8471,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - EXAMPLE_DO_BINDING: ExampleDurableObject
+					Binding                                            Resource
+					env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8597,8 +8520,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - EXAMPLE_DO_BINDING: ExampleDurableObject
+					Binding                                            Resource
+					env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8640,8 +8564,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - EXAMPLE_DO_BINDING: ExampleDurableObject (defined in example-do-binding-worker)
+					Binding                                                                                  Resource
+					env.EXAMPLE_DO_BINDING (ExampleDurableObject, defined in example-do-binding-worker)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8687,8 +8612,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - EXAMPLE_DO_BINDING: ExampleDurableObject
+					Binding                                            Resource
+					env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8926,8 +8852,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - EXAMPLE_DO_BINDING: ExampleDurableObject
+					Binding                                            Resource
+					env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -8981,10 +8908,10 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - EXAMPLE_DO_BINDING: ExampleDurableObject
-					- D1 Databases:
-					  - DB: test-d1-db (UUID-1-2-3-4), Preview: (UUID-1-2-3-4)
+					Binding                                            Resource
+					env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
+					env.DB (UUID-1-2-3-4)                              D1 Database
+
 					--dry-run: exiting now."
 				`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -9100,8 +9027,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - EXAMPLE_DO_BINDING: ExampleDurableObject
+					Binding                                            Resource
+					env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -9154,10 +9082,10 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Your Worker has access to the following bindings:
-					- Durable Objects:
-					  - EXAMPLE_DO_BINDING: ExampleDurableObject
-					- D1 Databases:
-					  - DB: test-d1-db (UUID-1-2-3-4), Preview: (UUID-1-2-3-4)
+					Binding                                            Resource
+					env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
+					env.DB (UUID-1-2-3-4)                              D1 Database
+
 					--dry-run: exiting now."
 				`);
 				expect(std.err).toMatchInlineSnapshot(`""`);
@@ -9223,8 +9151,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Services:
-					  - FOO: foo-service
+					Binding                    Resource
+					env.FOO (foo-service)      Worker
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -9264,8 +9193,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Services:
-					  - FOO: foo-service#MyHandler
+					Binding                              Resource
+					env.FOO (foo-service#MyHandler)      Worker
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -9303,8 +9233,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Services:
-					  - FOO: foo-service
+					Binding                    Resource
+					env.FOO (foo-service)      Worker
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -9335,8 +9266,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Analytics Engine Datasets:
-					  - FOO: foo-dataset
+					Binding                    Resource
+					env.FOO (foo-dataset)      Analytics Engine Dataset
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -9373,8 +9305,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Dispatch Namespaces:
-					  - foo: Foo
+					Binding            Resource
+					env.foo (Foo)      Dispatch Namespace
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -9431,9 +9364,10 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Dispatch Namespaces:
-					  - foo: Foo (outbound -> foo_outbound)
-					  - bar: Bar (outbound -> bar_outbound)
+					Binding                                       Resource
+					env.foo (Foo (outbound -> foo_outbound))      Dispatch Namespace
+					env.bar (Bar (outbound -> bar_outbound))      Dispatch Namespace
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -9482,8 +9416,9 @@ addEventListener('fetch', event => {});`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
 					Your Worker has access to the following bindings:
-					- Dispatch Namespaces:
-					  - foo: Foo (outbound -> foo_outbound)
+					Binding                                       Resource
+					env.foo (Foo (outbound -> foo_outbound))      Dispatch Namespace
+
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -9526,10 +9461,11 @@ addEventListener('fetch', event => {});`
 						"Total Upload: xx KiB / gzip: xx KiB
 						Worker Startup Time: 100 ms
 						Your Worker has access to the following bindings:
-						- Unsafe Metadata:
-						  - stringify: true
-						  - something: \\"else\\"
-						  - nested: {\\"stuff\\":\\"here\\"}
+						Binding                               Resource
+						env.stringify (true)                  Unsafe Metadata
+						env.something (\\"else\\")                Unsafe Metadata
+						env.nested ({\\"stuff\\":\\"here\\"})         Unsafe Metadata
+
 						Uploaded test-name (TIMINGS)
 						Deployed test-name triggers (TIMINGS)
 						  https://test-name.test-sub-domain.workers.dev
@@ -9567,8 +9503,9 @@ addEventListener('fetch', event => {});`
 						"Total Upload: xx KiB / gzip: xx KiB
 						Worker Startup Time: 100 ms
 						Your Worker has access to the following bindings:
-						- Unsafe Metadata:
-						  - binding-type: my-binding
+						Binding                            Resource
+						env.binding-type (my-binding)      Unsafe Metadata
+
 						Uploaded test-name (TIMINGS)
 						Deployed test-name triggers (TIMINGS)
 						  https://test-name.test-sub-domain.workers.dev
@@ -9614,8 +9551,9 @@ addEventListener('fetch', event => {});`
 						"Total Upload: xx KiB / gzip: xx KiB
 						Worker Startup Time: 100 ms
 						Your Worker has access to the following bindings:
-						- Unsafe Metadata:
-						  - plain_text: my-binding
+						Binding                          Resource
+						env.plain_text (my-binding)      Unsafe Metadata
+
 						Uploaded test-name (TIMINGS)
 						Deployed test-name triggers (TIMINGS)
 						  https://test-name.test-sub-domain.workers.dev
@@ -9656,7 +9594,6 @@ addEventListener('fetch', event => {});`
 					expect(std.out).toMatchInlineSnapshot(`
 						"Total Upload: xx KiB / gzip: xx KiB
 						Worker Startup Time: 100 ms
-						No bindings found.
 						Uploaded test-name (TIMINGS)
 						Deployed test-name triggers (TIMINGS)
 						  https://test-name.test-sub-domain.workers.dev
@@ -9761,7 +9698,6 @@ addEventListener('fetch', event => {});`
 					expect(std.out).toMatchInlineSnapshot(`
 						"Total Upload: xx KiB / gzip: xx KiB
 						Worker Startup Time: 100 ms
-						No bindings found.
 						Uploaded test-name (TIMINGS)
 						Deployed test-name triggers (TIMINGS)
 						  https://test-name.test-sub-domain.workers.dev
@@ -9807,7 +9743,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -9839,7 +9774,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -9877,7 +9811,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -9979,7 +9912,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10011,7 +9943,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10044,7 +9975,6 @@ addEventListener('fetch', event => {});`
 				expect(std.out).toMatchInlineSnapshot(`
 					"Total Upload: xx KiB / gzip: xx KiB
 					Worker Startup Time: 100 ms
-					No bindings found.
 					Uploaded test-name (TIMINGS)
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
@@ -10188,7 +10118,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10220,7 +10149,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10254,7 +10182,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10286,7 +10213,6 @@ addEventListener('fetch', event => {});`
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10331,7 +10257,6 @@ addEventListener('fetch', event => {});`
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10384,7 +10309,6 @@ addEventListener('fetch', event => {});`
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10411,7 +10335,6 @@ addEventListener('fetch', event => {});`
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10469,7 +10392,6 @@ export default{
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10495,7 +10417,6 @@ export default{
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10585,7 +10506,6 @@ export default{
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10678,8 +10598,9 @@ export default{
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- KV Namespaces:
-				  - KV: kv-namespace-id
+				Binding                       Resource
+				env.KV (kv-namespace-id)      KV Namespace
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10705,7 +10626,6 @@ export default{
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10795,7 +10715,6 @@ export default{
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10888,8 +10807,9 @@ export default{
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- KV Namespaces:
-				  - KV: kv-namespace-id
+				Binding                       Resource
+				env.KV (kv-namespace-id)      KV Namespace
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -10928,8 +10848,9 @@ export default{
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Your Worker has access to the following bindings:
-				- Durable Objects:
-				  - NAME: SomeClass
+				Binding                   Resource
+				env.NAME (SomeClass)      Durable Object
+
 				--dry-run: exiting now.",
 				  "warn": "",
 				}
@@ -11191,7 +11112,6 @@ export default{
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -11256,7 +11176,6 @@ export default{
 				  "err": "",
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
-				No bindings found.
 
 				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name/versions) failed.[0m
 
@@ -11329,7 +11248,6 @@ export default{
 				  "err": "",
 				  "info": "",
 				  "out": "Total Upload: xx KiB / gzip: xx KiB
-				No bindings found.
 
 				[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name/versions) failed.[0m
 
@@ -11560,8 +11478,9 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Queues:
-				  - QUEUE_ONE: queue1
+				Binding                     Resource
+				env.QUEUE_ONE (queue1)      Queue
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -11607,8 +11526,9 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Queues:
-				  - MY_QUEUE: queue1
+				Binding                    Resource
+				env.MY_QUEUE (queue1)      Queue
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -11661,7 +11581,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -11715,7 +11634,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded command-line-arg-script-name (TIMINGS)
 				Deployed command-line-arg-script-name triggers (TIMINGS)
 				  https://command-line-arg-script-name.test-sub-domain.workers.dev
@@ -11776,7 +11694,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -11842,7 +11759,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -11895,7 +11811,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -11956,7 +11871,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12017,7 +11931,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12079,7 +11992,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12141,7 +12053,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12357,10 +12268,10 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Browser:
-				  - Name: MYBROWSER
-				- AI:
-				  - Name: AI_BIND
+				Binding               Resource
+				env.MYBROWSER         Browser
+				env.AI_BIND           AI
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12390,8 +12301,9 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Images:
-				  - Name: IMAGES_BIND
+				Binding                 Resource
+				env.IMAGES_BIND         Images
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12421,7 +12333,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12448,7 +12359,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12484,8 +12394,9 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Hyperdrive Configs:
-				  - HYPERDRIVE: 343cd4f1d58c42fbb5bd082592fd7143
+				Binding                                                Resource
+				env.HYPERDRIVE (343cd4f1d58c42fbb5bd082592fd7143)      Hyperdrive Config
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12516,8 +12427,9 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- mTLS Certificates:
-				  - CERT_ONE: 1234
+				Binding                  Resource
+				env.CERT_ONE (1234)      mTLS Certificate
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12553,8 +12465,9 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Pipelines:
-				  - MY_PIPELINE: my-pipeline
+				Binding                            Resource
+				env.MY_PIPELINE (my-pipeline)      Pipeline
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12592,8 +12505,9 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Secrets Store Secrets:
-				  - SECRET: store_id/secret_name
+				Binding                                Resource
+				env.SECRET (store_id/secret_name)      Secrets Store Secret
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12619,7 +12533,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12644,7 +12557,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12671,7 +12583,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12731,7 +12642,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				  Dispatch Namespace: test-dispatch-namespace
 				Current Version ID: undefined"
@@ -12760,7 +12670,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12798,7 +12707,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12822,7 +12730,6 @@ export default{
 			expect(std.out).toMatchInlineSnapshot(`
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
-				No bindings found.
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12887,8 +12794,9 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Workflows:
-				  - WORKFLOW: MyWorkflow
+				Binding                        Resource
+				env.WORKFLOW (MyWorkflow)      Workflow
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -12948,8 +12856,9 @@ export default{
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- Workflows:
-				  - WORKFLOW: MyWorkflow (defined in another-script)
+				Binding                                                    Resource
+				env.WORKFLOW (MyWorkflow (defined in another-script))      Workflow
+
 				Uploaded this-script (TIMINGS)
 				Deployed this-script triggers (TIMINGS)
 				  https://this-script.test-sub-domain.workers.dev

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -888,7 +888,6 @@ describe.sequential("wrangler dev", () => {
 			expect(std.out).toMatchInlineSnapshot(
 				`
 				"[custom build] Running: node -e \\"4+4; require('fs').writeFileSync('index.js', 'export default { fetch(){ return new Response(123) } }')\\"
-				No bindings found.
 				"
 			`
 			);
@@ -913,7 +912,6 @@ describe.sequential("wrangler dev", () => {
 				expect(std.out).toMatchInlineSnapshot(
 					`
 					"[custom build] Running: echo \\"export default { fetch(){ return new Response(123) } }\\" > index.js
-					No bindings found.
 					"
 				`
 				);
@@ -1260,14 +1258,13 @@ describe.sequential("wrangler dev", () => {
 				process.platform === "win32" ? "127.0.0.1" : "localhost"
 			);
 			expect(std.out).toMatchInlineSnapshot(`
-				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				"Your Worker has access to the following bindings:
+				Binding                                        Resource            Mode
+				env.NAME_1 (CLASS_1)                           Durable Object      local
+				env.NAME_2 (CLASS_2, defined in SCRIPT_A)      Durable Object      local [not connected]
+				env.NAME_3 (CLASS_3)                           Durable Object      local
+				env.NAME_4 (CLASS_4, defined in SCRIPT_B)      Durable Object      local [not connected]
 
-				Your Worker has access to the following bindings:
-				- Durable Objects:
-				  - NAME_1: CLASS_1
-				  - NAME_2: CLASS_2 (defined in SCRIPT_A [not connected])
-				  - NAME_3: CLASS_3
-				  - NAME_4: CLASS_4 (defined in SCRIPT_B [not connected])
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -1344,17 +1341,16 @@ describe.sequential("wrangler dev", () => {
 			});
 			expect(std.out).toMatchInlineSnapshot(`
 				"Using vars defined in .dev.vars
-				Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
-
 				Your Worker has access to the following bindings:
-				- Vars:
-				  - VAR_1: \\"(hidden)\\"
-				  - VAR_2: \\"original value 2\\"
-				  - VAR_3: \\"(hidden)\\"
-				  - VAR_MULTI_LINE_1: \\"(hidden)\\"
-				  - VAR_MULTI_LINE_2: \\"(hidden)\\"
-				  - EMPTY: \\"(hidden)\\"
-				  - UNQUOTED: \\"(hidden)\\"
+				Binding                                        Resource                  Mode
+				env.VAR_1 (\\"(hidden)\\")                         Environment Variable      local
+				env.VAR_2 (\\"original value 2\\")                 Environment Variable      local
+				env.VAR_3 (\\"(hidden)\\")                         Environment Variable      local
+				env.VAR_MULTI_LINE_1 (\\"(hidden)\\")              Environment Variable      local
+				env.VAR_MULTI_LINE_2 (\\"(hidden)\\")              Environment Variable      local
+				env.EMPTY (\\"(hidden)\\")                         Environment Variable      local
+				env.UNQUOTED (\\"(hidden)\\")                      Environment Variable      local
+
 				"
 			`);
 		});
@@ -1380,11 +1376,10 @@ describe.sequential("wrangler dev", () => {
 			expect(varBindings).toEqual({ CUSTOM_VAR: "custom" });
 			expect(std.out).toMatchInlineSnapshot(`
 				"Using vars defined in .dev.vars.custom
-				Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
-
 				Your Worker has access to the following bindings:
-				- Vars:
-				  - CUSTOM_VAR: \\"(hidden)\\"
+				Binding                          Resource                  Mode
+				env.CUSTOM_VAR (\\"(hidden)\\")      Environment Variable      local
+
 				"
 			`);
 		});
@@ -1586,12 +1581,11 @@ describe.sequential("wrangler dev", () => {
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				"Your Worker has access to the following bindings:
+				Binding              Resource      Mode
+				env.WorkerA (A)      Worker      local [not connected]
+				env.WorkerB (B)      Worker      local [not connected]
 
-				Your Worker has access to the following bindings:
-				- Services:
-				  - WorkerA: A [not connected]
-				  - WorkerB: B [not connected]
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -1609,12 +1603,11 @@ describe.sequential("wrangler dev", () => {
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				"Your Worker has access to the following bindings:
+				Binding              Resource      Mode
+				env.WorkerA (A)      Worker      local [not connected]
+				env.WorkerB (B)      Worker      local [not connected]
 
-				Your Worker has access to the following bindings:
-				- Services:
-				  - WorkerA: A [not connected]
-				  - WorkerB: B [not connected]
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);
@@ -1638,13 +1631,12 @@ describe.sequential("wrangler dev", () => {
 			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`
 				"Using vars defined in .dev.vars
-				Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
-
 				Your Worker has access to the following bindings:
-				- Vars:
-				  - variable: 123
-				  - overriden: \\"(hidden)\\"
-				  - SECRET: \\"(hidden)\\"
+				Binding                         Resource                  Mode
+				env.variable (123)              Environment Variable      local
+				env.overriden (\\"(hidden)\\")      Environment Variable      local
+				env.SECRET (\\"(hidden)\\")         Environment Variable      local
+
 				"
 			`);
 		});
@@ -1662,7 +1654,7 @@ describe.sequential("wrangler dev", () => {
 			await expect(
 				runWrangler("dev index.js")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				"[Error: Browser Rendering is not supported locally. Please use `wrangler dev --remote` instead.]"
+				`[Error: Browser Rendering is not supported locally. Please use \`wrangler dev --remote\` instead.]`
 			);
 		});
 	});
@@ -1725,21 +1717,15 @@ describe.sequential("wrangler dev", () => {
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWranglerUntilConfig("dev index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				"Your Worker has access to the following bindings:
+				Binding                                          Resource          Mode
+				env.MY_WORKFLOW (myClass)                        Workflow          local
+				env.KV (xxxx-xxxx-xxxx-xxxx)                     KV Namespace      local
+				env.MY_QUEUE_PRODUCES (my-queue)                 Queue             local
+				env.MY_D1 (xxx)                                  D1 Database       local
+				env.MY_R2 (my-bucket)                            R2 Bucket         local
+				env.WorkerA (A)                                  Worker            local [not connected]
 
-				Your Worker has access to the following bindings:
-				- Workflows:
-				  - MY_WORKFLOW: myClass [simulated locally]
-				- KV Namespaces:
-				  - KV: xxxx-xxxx-xxxx-xxxx [simulated locally]
-				- Queues:
-				  - MY_QUEUE_PRODUCES: my-queue [simulated locally]
-				- D1 Databases:
-				  - MY_D1: xxx [simulated locally]
-				- R2 Buckets:
-				  - MY_R2: my-bucket [simulated locally]
-				- Services:
-				  - WorkerA: A [not connected]
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -1759,21 +1745,15 @@ describe.sequential("wrangler dev", () => {
 			fs.writeFileSync("index.js", `export default {};`);
 			await runWranglerUntilConfig("dev --x-mixed-mode index.js");
 			expect(std.out).toMatchInlineSnapshot(`
-				"Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
+				"Your Worker has access to the following bindings:
+				Binding                                          Resource          Mode
+				env.MY_WORKFLOW (myClass)                        Workflow          local
+				env.KV (xxxx-xxxx-xxxx-xxxx)                     KV Namespace      remote
+				env.MY_QUEUE_PRODUCES (my-queue)                 Queue             remote
+				env.MY_D1 (xxx)                                  D1 Database       remote
+				env.MY_R2 (my-bucket)                            R2 Bucket         remote
+				env.WorkerA (A)                                  Worker            remote [connected]
 
-				Your Worker has access to the following bindings:
-				- Workflows:
-				  - MY_WORKFLOW: myClass [connected to remote resource]
-				- KV Namespaces:
-				  - KV: xxxx-xxxx-xxxx-xxxx [connected to remote resource]
-				- Queues:
-				  - MY_QUEUE_PRODUCES: my-queue [connected to remote resource]
-				- D1 Databases:
-				  - MY_D1: xxx [connected to remote resource]
-				- R2 Buckets:
-				  - MY_R2: my-bucket [connected to remote resource]
-				- Services:
-				  - WorkerA: A [connected to remote resource]
 				"
 			`);
 			expect(std.warn).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -511,8 +511,7 @@ describe("pages deployment tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Connected to deployment mock-deployment-id, waiting for logs...
 				GET https://example.org/ - Ok @ [mock event timestamp]"
 			`);
@@ -543,8 +542,7 @@ describe("pages deployment tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Connected to deployment mock-deployment-id, waiting for logs...
 				\\"* * * * *\\" @ [mock timestamp string] - Ok"
 			`);
@@ -575,8 +573,7 @@ describe("pages deployment tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Connected to deployment mock-deployment-id, waiting for logs...
 				Alarm @ [mock scheduled time] - Ok"
 			`);
@@ -607,8 +604,7 @@ describe("pages deployment tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Connected to deployment mock-deployment-id, waiting for logs...
 				Email from:from@example.com to:to@example.com size:45416 @ [mock event timestamp] - Ok"
 			`);
@@ -639,8 +635,7 @@ describe("pages deployment tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Connected to deployment mock-deployment-id, waiting for logs...
 				Queue my-queue123 (7 messages) - Ok @ [mock timestamp string]"
 			`);
@@ -670,8 +665,7 @@ describe("pages deployment tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Connected to deployment mock-deployment-id, waiting for logs...
 				Unknown Event - Ok @ [mock timestamp string]"
 			`);
@@ -703,8 +697,7 @@ describe("pages deployment tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Connected to deployment mock-deployment-id, waiting for logs...
 				GET https://example.org/ - Ok @ [mock event timestamp]"
 			`);
@@ -765,8 +758,7 @@ describe("pages deployment tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Connected to deployment mock-deployment-id, waiting for logs...
 				GET https://example.org/ - Ok @ [mock event timestamp]
 				  (log) some string

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -232,6 +232,9 @@ describe("pages", () => {
 
 				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mSpecifying a \`-- <command>\` or \`--proxy\` is deprecated and will be removed in a future version of Wrangler.[0m
 
+				  Build your application to a directory and run the \`wrangler pages dev <directory>\` instead.
+				  This results in a more faithful emulation of production behavior.
+
 				"
 			`);
 		});

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -220,7 +220,11 @@ describe("pages", () => {
 			await expect(
 				runWrangler("pages dev --script-path=_worker.js -- echo 'hi'")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Could not automatically determine proxy port. Please specify the proxy port with --proxy.]`
+				`
+				[Error: Cannot find module './miniflare-cli/assets'
+				Require stack:
+				- /Users/penalosa/dev/wsdk/packages/wrangler/src/dev.ts]
+			`
 			);
 
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -234,6 +238,14 @@ describe("pages", () => {
 
 				  Build your application to a directory and run the \`wrangler pages dev <directory>\` instead.
 				  This results in a more faithful emulation of production behavior.
+
+
+				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mNo compatibility_date was specified. Using today's date: 2025-05-22.[0m
+
+				  ❯❯ Add one to your Wrangler configuration file: compatibility_date = \\"2025-05-22\\", or
+				  ❯❯ Pass it in your terminal: wrangler pages dev [<DIRECTORY>] --compatibility-date=2025-05-22
+
+				  See [4mhttps://developers.cloudflare.com/workers/platform/compatibility-dates/[0m for more information.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/pages/pages.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages.test.ts
@@ -220,11 +220,7 @@ describe("pages", () => {
 			await expect(
 				runWrangler("pages dev --script-path=_worker.js -- echo 'hi'")
 			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`
-				[Error: Cannot find module './miniflare-cli/assets'
-				Require stack:
-				- /Users/penalosa/dev/wsdk/packages/wrangler/src/dev.ts]
-			`
+				`[Error: Could not automatically determine proxy port. Please specify the proxy port with --proxy.]`
 			);
 
 			expect(std.warn).toMatchInlineSnapshot(`
@@ -235,17 +231,6 @@ describe("pages", () => {
 
 
 				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mSpecifying a \`-- <command>\` or \`--proxy\` is deprecated and will be removed in a future version of Wrangler.[0m
-
-				  Build your application to a directory and run the \`wrangler pages dev <directory>\` instead.
-				  This results in a more faithful emulation of production behavior.
-
-
-				[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mNo compatibility_date was specified. Using today's date: 2025-05-22.[0m
-
-				  ❯❯ Add one to your Wrangler configuration file: compatibility_date = \\"2025-05-22\\", or
-				  ❯❯ Pass it in your terminal: wrangler pages dev [<DIRECTORY>] --compatibility-date=2025-05-22
-
-				  See [4mhttps://developers.cloudflare.com/workers/platform/compatibility-dates/[0m for more information.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/provision.test.ts
+++ b/packages/wrangler/src/__tests__/provision.test.ts
@@ -92,12 +92,11 @@ describe("--x-provision", () => {
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 100 ms
 			Your Worker has access to the following bindings:
-			- KV Namespaces:
-			  - KV
-			- D1 Databases:
-			  - D1
-			- R2 Buckets:
-			  - R2
+			Binding                 Resource
+			env.KV (inherited)      KV Namespace
+			env.D1 (inherited)      D1 Database
+			env.R2 (inherited)      R2 Bucket
+
 			Uploaded test-name (TIMINGS)
 			Deployed test-name triggers (TIMINGS)
 			  https://test-name.test-sub-domain.workers.dev
@@ -177,12 +176,11 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 
 				The following bindings need to be provisioned:
-				- KV Namespaces:
-				  - KV
-				- D1 Databases:
-				  - D1
-				- R2 Buckets:
-				  - R2
+				Binding        Resource
+				env.KV         KV Namespace
+				env.D1         D1 Database
+				env.R2         R2 Bucket
+
 
 				Provisioning KV (KV Namespace)...
 				✨ KV provisioned 🎉
@@ -197,12 +195,11 @@ describe("--x-provision", () => {
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- KV Namespaces:
-				  - KV: existing-kv-id
-				- D1 Databases:
-				  - D1: existing-d1-id
-				- R2 Buckets:
-				  - R2: existing-bucket-name
+				Binding                            Resource
+				env.KV (existing-kv-id)            KV Namespace
+				env.D1 (existing-d1-id)            D1 Database
+				env.R2 (existing-bucket-name)      R2 Bucket
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -296,12 +293,11 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 
 				The following bindings need to be provisioned:
-				- KV Namespaces:
-				  - KV
-				- D1 Databases:
-				  - D1
-				- R2 Buckets:
-				  - R2
+				Binding        Resource
+				env.KV         KV Namespace
+				env.D1         D1 Database
+				env.R2         R2 Bucket
+
 
 				Provisioning KV (KV Namespace)...
 				✨ KV provisioned 🎉
@@ -316,12 +312,11 @@ describe("--x-provision", () => {
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- KV Namespaces:
-				  - KV: existing-kv-id-1
-				- D1 Databases:
-				  - D1: existing-d1-id-1
-				- R2 Buckets:
-				  - R2: existing-bucket-1
+				Binding                         Resource
+				env.KV (existing-kv-id-1)       KV Namespace
+				env.D1 (existing-d1-id-1)       D1 Database
+				env.R2 (existing-bucket-1)      R2 Bucket
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -425,12 +420,11 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 
 				The following bindings need to be provisioned:
-				- KV Namespaces:
-				  - KV
-				- D1 Databases:
-				  - D1
-				- R2 Buckets:
-				  - R2
+				Binding        Resource
+				env.KV         KV Namespace
+				env.D1         D1 Database
+				env.R2         R2 Bucket
+
 
 				Provisioning KV (KV Namespace)...
 				🌀 Creating new KV Namespace \\"new-kv\\"...
@@ -448,12 +442,11 @@ describe("--x-provision", () => {
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- KV Namespaces:
-				  - KV: new-kv-id
-				- D1 Databases:
-				  - D1: new-d1-id
-				- R2 Buckets:
-				  - R2: new-r2
+				Binding                 Resource
+				env.KV (new-kv-id)      KV Namespace
+				env.D1 (new-d1-id)      D1 Database
+				env.R2 (new-r2)         R2 Bucket
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -505,8 +498,9 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 
 				The following bindings need to be provisioned:
-				- D1 Databases:
-				  - D1
+				Binding        Resource
+				env.D1         D1 Database
+
 
 				Provisioning D1 (D1 Database)...
 				Resource name found in config: prefilled-d1-name
@@ -517,8 +511,9 @@ describe("--x-provision", () => {
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- D1 Databases:
-				  - D1: prefilled-d1-name (new-d1-id)
+				Binding                         Resource
+				env.D1 (prefilled-d1-name)      D1 Database
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -559,8 +554,9 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- D1 Databases:
-				  - D1: prefilled-d1-name
+				Binding                 Resource
+				env.D1 (inherited)      D1 Database
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -624,8 +620,9 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 
 				The following bindings need to be provisioned:
-				- D1 Databases:
-				  - D1
+				Binding        Resource
+				env.D1         D1 Database
+
 
 				Provisioning D1 (D1 Database)...
 				Resource name found in config: new-d1-name
@@ -636,8 +633,9 @@ describe("--x-provision", () => {
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- D1 Databases:
-				  - D1: new-d1-name (new-d1-id)
+				Binding                   Resource
+				env.D1 (new-d1-name)      D1 Database
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -697,8 +695,9 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 
 				The following bindings need to be provisioned:
-				- R2 Buckets:
-				  - BUCKET
+				Binding            Resource
+				env.BUCKET         R2 Bucket
+
 
 				Provisioning BUCKET (R2 Bucket)...
 				Resource name found in config: prefilled-r2-name
@@ -709,8 +708,9 @@ describe("--x-provision", () => {
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- R2 Buckets:
-				  - BUCKET: prefilled-r2-name (eu)
+				Binding                                  Resource
+				env.BUCKET (prefilled-r2-name (eu))      R2 Bucket
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -763,8 +763,9 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- R2 Buckets:
-				  - BUCKET: existing-bucket-name (eu)
+				Binding                                     Resource
+				env.BUCKET (existing-bucket-name (eu))      R2 Bucket
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -807,8 +808,9 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- D1 Databases:
-				  - DB_NAME: existing-db-name (existing-d1-id)
+				Binding                             Resource
+				env.DB_NAME (existing-db-name)      D1 Database
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev
@@ -879,8 +881,9 @@ describe("--x-provision", () => {
 				"Total Upload: xx KiB / gzip: xx KiB
 
 				The following bindings need to be provisioned:
-				- R2 Buckets:
-				  - BUCKET
+				Binding            Resource
+				env.BUCKET         R2 Bucket
+
 
 				Provisioning BUCKET (R2 Bucket)...
 				Resource name found in config: existing-bucket-name
@@ -891,8 +894,9 @@ describe("--x-provision", () => {
 
 				Worker Startup Time: 100 ms
 				Your Worker has access to the following bindings:
-				- R2 Buckets:
-				  - BUCKET: existing-bucket-name (eu)
+				Binding                                     Resource
+				env.BUCKET (existing-bucket-name (eu))      R2 Bucket
+
 				Uploaded test-name (TIMINGS)
 				Deployed test-name triggers (TIMINGS)
 				  https://test-name.test-sub-domain.workers.dev

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -167,8 +167,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🌀 Creating the secret for the Worker \\"script-name\\"
 					✨ Success! Uploaded secret secret-name"
 				`);
@@ -187,8 +186,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🌀 Creating the secret for the Worker \\"script-name\\"
 					✨ Success! Uploaded secret the-key"
 				`);
@@ -214,8 +212,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🌀 Creating the secret for the Worker \\"script-name-some-env\\"
 					✨ Success! Uploaded secret the-key"
 				`);
@@ -241,8 +238,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🌀 Creating the secret for the Worker \\"script-name\\" (some-env)
 					✨ Success! Uploaded secret the-key"
 				`);
@@ -259,8 +255,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`
@@ -290,8 +285,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🌀 Creating the secret for the Worker \\"non-existent-worker\\"
 					Aborting. No secrets added."
 				`);
@@ -318,8 +312,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🌀 Creating the secret for the Worker \\"script-name\\"
 					✨ Success! Uploaded secret the-key"
 				`);
@@ -336,8 +329,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🌀 Creating the secret for the Worker \\"script-name\\"
 					✨ Success! Uploaded secret the-key"
 				`);
@@ -357,8 +349,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 
 					[32mIf you think this is a bug then please create an issue at https://github.com/cloudflare/workers-sdk/issues/new/choose[0m"
 				`);
@@ -391,8 +382,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					🌀 Creating the secret for the Worker \\"non-existent-worker\\"
 					✨ Success! Uploaded secret the-key"
 				`);
@@ -433,8 +423,7 @@ describe("wrangler secret", () => {
 					expect(std.out).toMatchInlineSnapshot(`
 						"
 						 ⛅️ wrangler x.x.x
-						------------------
-
+						──────────────────
 						🌀 Creating the secret for the Worker \\"script-name\\"
 						✨ Success! Uploaded secret the-key"
 					`);
@@ -576,8 +565,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Deleting the secret the-key on the Worker script-name
 				✨ Success! Deleted secret the-key"
 			`);
@@ -600,8 +588,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Deleting the secret the-key on the Worker script-name-some-env
 				✨ Success! Deleted secret the-key"
 			`);
@@ -623,8 +610,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Deleting the secret the-key on the Worker script-name (some-env)
 				✨ Success! Deleted secret the-key"
 			`);
@@ -642,8 +628,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				"
 			`);
 			expect(std.err).toMatchInlineSnapshot(`
@@ -784,8 +769,7 @@ describe("wrangler secret", () => {
 				expect(std.out).toMatchInlineSnapshot(`
 					"
 					 ⛅️ wrangler x.x.x
-					------------------
-
+					──────────────────
 					Secret Name: the-secret-name
 					"
 				`);
@@ -856,8 +840,7 @@ describe("wrangler secret", () => {
 				`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"script-name\\" "
 			`
 			);
@@ -884,8 +867,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 				✨ Successfully created secret for key: secret1
 				✨ Successfully created secret for key: password
@@ -913,8 +895,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 				✨ Successfully created secret for key: secret-name-1
 				✨ Successfully created secret for key: secret-name-2
@@ -939,8 +920,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 				✨ Successfully created secret for key: SECRET_NAME_1
 				✨ Successfully created secret for key: SECRET_NAME_2
@@ -1001,8 +981,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 
 				🚨 Secrets failed to upload
@@ -1036,8 +1015,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 
 				🚨 Secrets failed to upload
@@ -1095,8 +1073,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 
 				🚨 Secrets failed to upload
@@ -1191,8 +1168,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 				✨ Successfully created secret for key: secret-name-2
 				✨ Successfully created secret for key: secret-name-3
@@ -1224,8 +1200,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"non-existent-worker\\"
 				Aborting. No secrets added."
 			`);
@@ -1256,8 +1231,7 @@ describe("wrangler secret", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				🌀 Creating the secrets for the Worker \\"script-name\\"
 				✨ Successfully created secret for key: secret-name-1
 				✨ Successfully created secret for key: secret-name-2

--- a/packages/wrangler/src/__tests__/tail.test.ts
+++ b/packages/wrangler/src/__tests__/tail.test.ts
@@ -535,8 +535,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				GET https://example.org/ - Ok @ [mock event timestamp]"
@@ -566,8 +565,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				MyDurableObject.foo - Ok @ [mock event timestamp]"
@@ -594,8 +592,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				\\"* * * * *\\" @ [mock timestamp string] - Ok"
@@ -622,8 +619,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				Alarm @ [mock scheduled time] - Ok"
@@ -650,8 +646,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				Email from:from@example.com to:to@example.com size:45416 @ [mock event timestamp] - Ok"
@@ -681,8 +676,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				Tailing some-worker,other-worker - Ok @ [mock event timestamp]"
@@ -711,8 +705,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				Tail is currently in sampling mode due to the high volume of messages. To prevent messages from being dropped consider adding filters.
@@ -740,8 +733,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				Queue my-queue123 (7 messages) - Ok @ [mock timestamp string]"
@@ -767,8 +759,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				Unknown Event - Ok @ [mock timestamp string]"
@@ -796,8 +787,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				GET https://example.org/ - Ok @ [mock event timestamp]"
@@ -855,8 +845,7 @@ describe("tail", () => {
 			).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
-				------------------
-
+				──────────────────
 				Successfully created tail, expires at [mock expiration date]
 				Connected to test-worker, waiting for logs...
 				GET https://example.org/ - Ok @ [mock event timestamp]

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -94,14 +94,11 @@ describe("versions upload", () => {
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 500 ms
 			Your Worker has access to the following bindings:
-			- KV Namespaces:
-			  - KV: xxxx-xxxx-xxxx-xxxx
-			- Vars:
-			  - TEST: \\"test-string\\"
-			  - JSON: {
-			 \\"abc\\": \\"def\\",
-			 \\"bool\\": true
-			}
+			Binding                                   Resource
+			env.KV (xxxx-xxxx-xxxx-xxxx)              KV Namespace
+			env.TEST (\\"test-string\\")                  Environment Variable
+			env.JSON ({\\"abc\\":\\"def\\",\\"bool\\":true})      Environment Variable
+
 			Uploaded test-name (TIMINGS)
 			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993"
 		`);
@@ -132,8 +129,9 @@ describe("versions upload", () => {
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 500 ms
 			Your Worker has access to the following bindings:
-			- Vars:
-			  - TEST: \\"test-string\\"
+			Binding                       Resource
+			env.TEST (\\"test-string\\")      Environment Variable
+
 			Uploaded test-name (TIMINGS)
 			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993
 			Version Preview URL: https://51e4886e-test-name.test-sub-domain.workers.dev"
@@ -164,8 +162,9 @@ describe("versions upload", () => {
 			"Total Upload: xx KiB / gzip: xx KiB
 			Worker Startup Time: 500 ms
 			Your Worker has access to the following bindings:
-			- Vars:
-			  - TEST: \\"test-string\\"
+			Binding                       Resource
+			env.TEST (\\"test-string\\")      Environment Variable
+
 			Uploaded test-name (TIMINGS)
 			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993"
 		`);

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import path from "node:path";
 import { watch } from "chokidar";
 import { getAssetsOptions, validateAssetsArgsAndConfig } from "../../assets";
 import { readConfig } from "../../config";
@@ -406,6 +407,7 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 				persistent: true,
 				ignoreInitial: true,
 			}).on("change", async (_event) => {
+				logger.debug(`${path.basename(configPath)} changed...`);
 				assert(
 					this.latestInput,
 					"Cannot be watching config without having first set an input"

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert";
-import path from "node:path";
 import { watch } from "chokidar";
 import { getAssetsOptions, validateAssetsArgsAndConfig } from "../../assets";
 import { readConfig } from "../../config";

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -407,7 +407,6 @@ export class ConfigController extends Controller<ConfigControllerEventMap> {
 				persistent: true,
 				ignoreInitial: true,
 			}).on("change", async (_event) => {
-				logger.log(`${path.basename(configPath)} changed...`);
 				assert(
 					this.latestInput,
 					"Cannot be watching config without having first set an input"

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -1,7 +1,8 @@
 import readline from "readline";
-import { Log } from "miniflare";
+import { dim } from "@cloudflare/cli/colors";
+import stripAnsi from "strip-ansi";
 import { unwrapHook } from "./api/startDevWorker/utils";
-import { Logger, logger } from "./logger";
+import { logger } from "./logger";
 import { onKeyPress } from "./utils/onKeyPress";
 import type { Hook } from "./api";
 
@@ -33,14 +34,13 @@ export default function (
 	function formatInstructions() {
 		const instructions = options
 			.filter((option) => !unwrapHook(option.disabled))
-			.map(({ keys, label }) => `[${keys[0]}] ${unwrapHook(label)}`);
+			.map(({ keys, label }) => `[${keys[0]}] ${dim(unwrapHook(label))}`);
 
-		let stringifiedInstructions = instructions.join(", ");
+		let stringifiedInstructions = instructions.join(" ");
+		let length = stripAnsi(stringifiedInstructions).length;
 
 		const ADDITIONAL_CHARS = 6; // 3 chars on each side of the instructions for the box and spacing ("│  " and "  │")
-		const willWrap =
-			stringifiedInstructions.length + ADDITIONAL_CHARS >
-			process.stdout.columns;
+		const willWrap = length + ADDITIONAL_CHARS > process.stdout.columns;
 		if (willWrap) {
 			stringifiedInstructions = instructions.join("\n");
 		}
@@ -55,9 +55,9 @@ export default function (
 			.join("\n");
 
 		return (
-			`╭──${"─".repeat(maxLineLength)}──╮\n` +
+			`╭──${"─".repeat(length)}──╮\n` +
 			stringifiedInstructions +
-			`\n╰──${"─".repeat(maxLineLength)}──╯`
+			`\n╰──${"─".repeat(length)}──╯`
 		);
 	}
 
@@ -109,18 +109,18 @@ export default function (
 		}
 	}
 
-	Logger.registerBeforeLogHook(clearPreviousInstructions);
-	Logger.registerAfterLogHook(printInstructions);
-	Log.unstable_registerBeforeLogHook(clearPreviousInstructions);
-	Log.unstable_registerAfterLogHook(printInstructions);
+	// Logger.registerBeforeLogHook(clearPreviousInstructions);
+	// Logger.registerAfterLogHook(printInstructions);
+	// Log.unstable_registerBeforeLogHook(clearPreviousInstructions);
+	// Log.unstable_registerAfterLogHook(printInstructions);
 	printInstructions();
 
 	return () => {
 		unregisterKeyPress();
-		clearPreviousInstructions();
-		Logger.registerBeforeLogHook(undefined);
-		Logger.registerAfterLogHook(undefined);
-		Log.unstable_registerBeforeLogHook(undefined);
-		Log.unstable_registerAfterLogHook(undefined);
+		// clearPreviousInstructions();
+		// Logger.registerBeforeLogHook(undefined);
+		// Logger.registerAfterLogHook(undefined);
+		// Log.unstable_registerBeforeLogHook(undefined);
+		// Log.unstable_registerAfterLogHook(undefined);
 	};
 }

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -9,7 +9,7 @@ export default function (
 	options: Array<{
 		keys: string[];
 		disabled?: Hook<boolean>;
-		label: Hook<string>;
+		label?: Hook<string>;
 		handler: () => void | Promise<void>;
 	}>
 ) {
@@ -32,7 +32,9 @@ export default function (
 	 */
 	function formatInstructions() {
 		const instructions = options
-			.filter((option) => !unwrapHook(option.disabled))
+			.filter(
+				(option) => !unwrapHook(option.disabled) && option.label !== undefined
+			)
 			.map(({ keys, label }) => `[${keys[0]}] ${dim(unwrapHook(label))}`);
 
 		let stringifiedInstructions = instructions.join(" ");
@@ -45,18 +47,23 @@ export default function (
 		}
 
 		const maxLineLength = Math.max(
-			...stringifiedInstructions.split("\n").map((line) => line.length)
+			...stringifiedInstructions
+				.split("\n")
+				.map((line) => stripAnsi(line).length)
 		);
 
 		stringifiedInstructions = stringifiedInstructions
 			.split("\n")
-			.map((line) => `│  ${line.padEnd(maxLineLength, " ")}  │`)
+			.map(
+				(line) =>
+					`│  ${line + " ".repeat(Math.max(0, maxLineLength - stripAnsi(line).length))}  │`
+			)
 			.join("\n");
 
 		return (
 			`╭──${"─".repeat(maxLineLength)}──╮\n` +
 			stringifiedInstructions +
-			`\n╰──${"─".repeat(length)}──╯`
+			`\n╰──${"─".repeat(maxLineLength)}──╯`
 		);
 	}
 

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -1,4 +1,3 @@
-import readline from "readline";
 import { dim } from "@cloudflare/cli/colors";
 import stripAnsi from "strip-ansi";
 import { unwrapHook } from "./api/startDevWorker/utils";
@@ -37,7 +36,7 @@ export default function (
 			.map(({ keys, label }) => `[${keys[0]}] ${dim(unwrapHook(label))}`);
 
 		let stringifiedInstructions = instructions.join(" ");
-		let length = stripAnsi(stringifiedInstructions).length;
+		const length = stripAnsi(stringifiedInstructions).length;
 
 		const ADDITIONAL_CHARS = 6; // 3 chars on each side of the instructions for the box and spacing ("│  " and "  │")
 		const willWrap = length + ADDITIONAL_CHARS > process.stdout.columns;
@@ -94,33 +93,16 @@ export default function (
 		}
 	});
 
-	let previousInstructionsLineCount = 0;
-	function clearPreviousInstructions() {
-		if (previousInstructionsLineCount) {
-			readline.moveCursor(process.stdout, 0, -previousInstructionsLineCount);
-			readline.clearScreenDown(process.stdout);
-		}
-	}
 	function printInstructions() {
 		const bottomFloat = formatInstructions();
 		if (bottomFloat) {
 			console.log(bottomFloat);
-			previousInstructionsLineCount = bottomFloat.split("\n").length;
 		}
 	}
 
-	// Logger.registerBeforeLogHook(clearPreviousInstructions);
-	// Logger.registerAfterLogHook(printInstructions);
-	// Log.unstable_registerBeforeLogHook(clearPreviousInstructions);
-	// Log.unstable_registerAfterLogHook(printInstructions);
 	printInstructions();
 
 	return () => {
 		unregisterKeyPress();
-		// clearPreviousInstructions();
-		// Logger.registerBeforeLogHook(undefined);
-		// Logger.registerAfterLogHook(undefined);
-		// Log.unstable_registerBeforeLogHook(undefined);
-		// Log.unstable_registerAfterLogHook(undefined);
 	};
 }

--- a/packages/wrangler/src/cli-hotkeys.ts
+++ b/packages/wrangler/src/cli-hotkeys.ts
@@ -54,7 +54,7 @@ export default function (
 			.join("\n");
 
 		return (
-			`╭──${"─".repeat(length)}──╮\n` +
+			`╭──${"─".repeat(maxLineLength)}──╮\n` +
 			stringifiedInstructions +
 			`\n╰──${"─".repeat(length)}──╯`
 		);

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -766,7 +766,8 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			workerBundle = createWorkerUploadForm(worker);
 			printBindings(
 				{ ...withoutStaticAssets, vars: maskedVars },
-				config.tail_consumers
+				config.tail_consumers,
+				{ warnIfNoBindings: true }
 			);
 		} else {
 			assert(accountId, "Missing accountId");

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -30,6 +30,7 @@ import {
 	collectPlainTextVars,
 } from "./utils/collectKeyValues";
 import { mergeWithOverride } from "./utils/mergeWithOverride";
+import { printWranglerBanner } from "./wrangler-banner";
 import { getHostFromRoute } from "./zones";
 import type {
 	AsyncHook,
@@ -63,6 +64,7 @@ export const dev = createCommand({
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
 			MIXED_MODE: args.experimentalMixedMode ?? false,
 		}),
+		printBanner: false,
 	},
 	metadata: {
 		description: "👂 Start a local server for developing your Worker",
@@ -288,6 +290,7 @@ export const dev = createCommand({
 		},
 	},
 	async validateArgs(args) {
+		await printWranglerBanner();
 		if (args.nodeCompat) {
 			throw new UserError(
 				`The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.`
@@ -318,6 +321,8 @@ export const dev = createCommand({
 		}
 	},
 	async handler(args) {
+		logger.console("clear");
+		await printWranglerBanner();
 		const devInstance = await startDev(args);
 		assert(devInstance.devEnv !== undefined);
 		await events.once(devInstance.devEnv, "teardown");

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -64,7 +64,6 @@ export const dev = createCommand({
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
 			MIXED_MODE: args.experimentalMixedMode ?? false,
 		}),
-		printBanner: false,
 	},
 	metadata: {
 		description: "👂 Start a local server for developing your Worker",
@@ -290,7 +289,6 @@ export const dev = createCommand({
 		},
 	},
 	async validateArgs(args) {
-		await printWranglerBanner();
 		if (args.nodeCompat) {
 			throw new UserError(
 				`The --node-compat flag is no longer supported as of Wrangler v4. Instead, use the \`nodejs_compat\` compatibility flag. This includes the functionality from legacy \`node_compat\` polyfills and natively implemented Node.js APIs. See https://developers.cloudflare.com/workers/runtime-apis/nodejs for more information.`
@@ -321,8 +319,6 @@ export const dev = createCommand({
 		}
 	},
 	async handler(args) {
-		logger.console("clear");
-		await printWranglerBanner();
 		const devInstance = await startDev(args);
 		assert(devInstance.devEnv !== undefined);
 		await events.once(devInstance.devEnv, "teardown");

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -614,7 +614,8 @@ export async function startDev(args: StartDevOptions) {
 				if (hotkeysDisplayed) {
 					assert(devEnv !== undefined);
 					unregisterHotKeys = registerDevHotKeys(
-						Array.isArray(devEnv) ? devEnv[0] : devEnv
+						Array.isArray(devEnv) ? devEnv[0] : devEnv,
+						args
 					);
 				}
 			}
@@ -630,7 +631,7 @@ export async function startDev(args: StartDevOptions) {
 			const primaryDevEnv = new DevEnv({ runtimes: [runtime] });
 
 			if (isInteractive() && args.showInteractiveDevSession !== false) {
-				unregisterHotKeys = registerDevHotKeys(primaryDevEnv);
+				unregisterHotKeys = registerDevHotKeys(primaryDevEnv, args);
 			}
 
 			// Set up the primary DevEnv (the one that the ProxyController will connect to)
@@ -712,7 +713,7 @@ export async function startDev(args: StartDevOptions) {
 			}
 
 			if (isInteractive() && args.showInteractiveDevSession !== false) {
-				unregisterHotKeys = registerDevHotKeys(devEnv);
+				unregisterHotKeys = registerDevHotKeys(devEnv, args);
 			}
 
 			await setupDevEnv(devEnv, args.config, authHook, args);

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -30,7 +30,6 @@ import {
 	collectPlainTextVars,
 } from "./utils/collectKeyValues";
 import { mergeWithOverride } from "./utils/mergeWithOverride";
-import { printWranglerBanner } from "./wrangler-banner";
 import { getHostFromRoute } from "./zones";
 import type {
 	AsyncHook,
@@ -615,8 +614,7 @@ export async function startDev(args: StartDevOptions) {
 				if (hotkeysDisplayed) {
 					assert(devEnv !== undefined);
 					unregisterHotKeys = registerDevHotKeys(
-						Array.isArray(devEnv) ? devEnv[0] : devEnv,
-						args
+						Array.isArray(devEnv) ? devEnv[0] : devEnv
 					);
 				}
 			}
@@ -632,7 +630,7 @@ export async function startDev(args: StartDevOptions) {
 			const primaryDevEnv = new DevEnv({ runtimes: [runtime] });
 
 			if (isInteractive() && args.showInteractiveDevSession !== false) {
-				unregisterHotKeys = registerDevHotKeys(primaryDevEnv, args);
+				unregisterHotKeys = registerDevHotKeys(primaryDevEnv);
 			}
 
 			// Set up the primary DevEnv (the one that the ProxyController will connect to)
@@ -714,7 +712,7 @@ export async function startDev(args: StartDevOptions) {
 			}
 
 			if (isInteractive() && args.showInteractiveDevSession !== false) {
-				unregisterHotKeys = registerDevHotKeys(devEnv, args);
+				unregisterHotKeys = registerDevHotKeys(devEnv);
 			}
 
 			await setupDevEnv(devEnv, args.config, authHook, args);

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -4,7 +4,10 @@ import openInBrowser from "../open-in-browser";
 import { openInspector } from "./inspect";
 import type { DevEnv } from "../api";
 
-export default function registerDevHotKeys(devEnv: DevEnv) {
+export default function registerDevHotKeys(
+	devEnv: DevEnv,
+	args: { forceLocal?: boolean }
+) {
 	const unregisterHotKeys = registerHotKeys([
 		{
 			keys: ["b"],
@@ -25,6 +28,20 @@ export default function registerDevHotKeys(devEnv: DevEnv) {
 					parseInt(inspectorUrl.port),
 					devEnv.config.latestConfig?.name
 				);
+			},
+		},
+		{
+			keys: ["l"],
+			disabled: () => args.forceLocal ?? false,
+			label: () =>
+				`turn ${devEnv.config.latestConfig?.dev?.remote ? "on" : "off"} local mode`,
+			handler: async () => {
+				await devEnv.config.patch({
+					dev: {
+						...devEnv.config.latestConfig?.dev,
+						remote: !devEnv.config.latestConfig?.dev?.remote,
+					},
+				});
 			},
 		},
 		{

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -33,8 +33,6 @@ export default function registerDevHotKeys(
 		{
 			keys: ["l"],
 			disabled: () => args.forceLocal ?? false,
-			label: () =>
-				`turn ${devEnv.config.latestConfig?.dev?.remote ? "on" : "off"} local mode`,
 			handler: async () => {
 				await devEnv.config.patch({
 					dev: {

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -4,10 +4,7 @@ import openInBrowser from "../open-in-browser";
 import { openInspector } from "./inspect";
 import type { DevEnv } from "../api";
 
-export default function registerDevHotKeys(
-	devEnv: DevEnv,
-	args: { forceLocal?: boolean }
-) {
+export default function registerDevHotKeys(devEnv: DevEnv) {
 	const unregisterHotKeys = registerHotKeys([
 		{
 			keys: ["b"],

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -31,20 +31,6 @@ export default function registerDevHotKeys(
 			},
 		},
 		{
-			keys: ["l"],
-			disabled: () => args.forceLocal ?? false,
-			label: () =>
-				`turn ${devEnv.config.latestConfig?.dev?.remote ? "on" : "off"} local mode`,
-			handler: async () => {
-				await devEnv.config.patch({
-					dev: {
-						...devEnv.config.latestConfig?.dev,
-						remote: !devEnv.config.latestConfig?.dev?.remote,
-					},
-				});
-			},
-		},
-		{
 			keys: ["c"],
 			label: "clear console",
 			handler: async () => {

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -549,13 +549,13 @@ export function printBindings(
 			title = "Your Worker has access to the following bindings:";
 		}
 
-		let maxValueLength = Math.max(
+		const maxValueLength = Math.max(
 			...output.map((b) =>
 				typeof b.value === "symbol" ? "inherited".length : b.value?.length ?? 0
 			)
 		);
-		let maxNameLength = Math.max(...output.map((b) => b.name.length));
-		let maxTypeLength = Math.max(...output.map((b) => b.type.length));
+		const maxNameLength = Math.max(...output.map((b) => b.name.length));
+		const maxTypeLength = Math.max(...output.map((b) => b.type.length));
 
 		const hasMode = output.some((b) => b.mode);
 		const bindingPrefix = `env.`;
@@ -619,7 +619,7 @@ export function printBindings(
 
 // Exactly the same as String.padEnd, but doesn't miscount ANSI control characters
 function padEndAnsi(str: string, length: number) {
-	return str + " ".repeat(length - stripAnsi(str).length);
+	return str + " ".repeat(Math.max(0, length - stripAnsi(str).length));
 }
 
 /**

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -283,7 +283,7 @@ export function printBindings(
 	if (r2_buckets !== undefined && r2_buckets.length > 0) {
 		output.push(
 			...r2_buckets.map(({ binding, bucket_name, jurisdiction, remote }) => {
-				let value =
+				const value =
 					typeof bucket_name === "symbol"
 						? bucket_name
 						: bucket_name

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -398,7 +398,7 @@ export function printBindings(
 			name: browser.binding,
 			type: friendlyBindingNames.browser,
 			value: undefined,
-			mode: getMode({ isSimulatedLocally: false }),
+			mode: getMode({ isSimulatedLocally: undefined }),
 		});
 	}
 
@@ -636,14 +636,25 @@ function createGetMode({
 	isLocalDev?: boolean;
 }) {
 	return function bindingMode({
-		isSimulatedLocally = false,
+		isSimulatedLocally,
 		connected,
 	}: {
+		// Is this binding running locally?
+		//   local = offline simulator in Miniflare
+		//   remote = some sort of Mixed Mode
+		//   undefined = this binding is not supported in a dev session
 		isSimulatedLocally?: boolean;
+		// If this is an external service/tail/etc... binding, is it connected?
+		//   true = connected via the dev registry
+		//   false = trying to connect via the dev registry, but the target is not found
+		//   undefined =  dev registry is disabled or the binding is in remote mode (which always implies connection)
 		connected?: boolean;
 	} = {}): string | undefined {
 		if (isProvisioning || !isLocalDev) {
 			return undefined;
+		}
+		if (isSimulatedLocally === undefined) {
+			return dim("not supported");
 		}
 
 		return `${isSimulatedLocally ? chalk.blue("local") : chalk.yellow("remote")}${connected === undefined ? "" : connected ? chalk.green(" [connected]") : chalk.red(" [not connected]")}`;

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -1,3 +1,4 @@
+import { brandColor, dim, white } from "@cloudflare/cli/colors";
 import chalk from "chalk";
 import { getFlag } from "../experimental-flags";
 import { logger } from "../logger";
@@ -48,10 +49,11 @@ export function printBindings(
 		imagesLocalMode?: boolean;
 		name?: string;
 		provisioning?: boolean;
+		warnIfNoBindings?: boolean;
 	} = {}
 ) {
 	let hasConnectionStatus = false;
-	const addSuffix = createAddSuffix({
+	const getMode = createGetMode({
 		isProvisioning: context.provisioning,
 		isLocalDev: context.local,
 	});
@@ -67,7 +69,9 @@ export function printBindings(
 
 	const output: {
 		name: string;
-		entries: { key: string; value: string | boolean }[];
+		type: string;
+		value: string | undefined;
+		mode: string | undefined;
 	}[] = [];
 
 	const {
@@ -100,89 +104,92 @@ export function printBindings(
 	} = bindings;
 
 	if (data_blobs !== undefined && Object.keys(data_blobs).length > 0) {
-		output.push({
-			name: friendlyBindingNames.data_blobs,
-			entries: Object.entries(data_blobs).map(([key, value]) => ({
-				key,
+		output.push(
+			...Object.entries(data_blobs).map(([key, value]) => ({
+				name: key,
+				type: friendlyBindingNames.data_blobs,
 				value: typeof value === "string" ? truncate(value) : "<Buffer>",
-			})),
-		});
+				mode: getMode({ isSimulatedLocally: true }),
+			}))
+		);
 	}
 
 	if (durable_objects !== undefined && durable_objects.bindings.length > 0) {
-		output.push({
-			name: friendlyBindingNames.durable_objects,
-			entries: durable_objects.bindings.map(
-				({ name, class_name, script_name }) => {
-					let value = class_name;
-					if (script_name) {
-						if (context.local && context.registry !== null) {
-							const registryDefinition = context.registry?.[script_name];
+		output.push(
+			...durable_objects.bindings.map(({ name, class_name, script_name }) => {
+				let value = class_name;
+				let mode = undefined;
+				if (script_name) {
+					if (context.local && context.registry !== null) {
+						const registryDefinition = context.registry?.[script_name];
 
-							hasConnectionStatus = true;
-							if (
-								registryDefinition &&
-								registryDefinition.durableObjects.some(
-									(d) => d.className === class_name
-								)
-							) {
-								value += ` (defined in ${script_name} ${chalk.green("[connected]")})`;
-							} else {
-								value += ` (defined in ${script_name} ${chalk.red("[not connected]")})`;
-							}
+						hasConnectionStatus = true;
+						if (
+							registryDefinition &&
+							registryDefinition.durableObjects.some(
+								(d) => d.className === class_name
+							)
+						) {
+							value += ` (defined in ${script_name} ${chalk.green("[connected]")})`;
+							mode = getMode({ isSimulatedLocally: true, connected: true });
 						} else {
-							value += ` (defined in ${script_name})`;
+							value += ` (defined in ${script_name} ${chalk.red("[not connected]")})`;
+							mode = getMode({ isSimulatedLocally: true, connected: false });
 						}
+					} else {
+						value += ` (defined in ${script_name})`;
+						mode = getMode({ isSimulatedLocally: false });
 					}
-
-					return {
-						key: name,
-						value: value,
-					};
+				} else {
+					mode = getMode({ isSimulatedLocally: true });
 				}
-			),
-		});
+
+				return {
+					name,
+					type: friendlyBindingNames.durable_objects,
+					value: value,
+					mode: undefined,
+				};
+			})
+		);
 	}
 
 	if (workflows !== undefined && workflows.length > 0) {
-		output.push({
-			name: friendlyBindingNames.workflows,
-			entries: workflows.map(({ class_name, script_name, binding, remote }) => {
+		output.push(
+			...workflows.map(({ class_name, script_name, binding, remote }) => {
 				let value = class_name;
 				if (script_name) {
 					value += ` (defined in ${script_name})`;
 				}
 
 				return {
-					key: binding,
-					value: script_name
-						? value
-						: addSuffix(value, {
-								isSimulatedLocally: !remote,
-							}),
+					name: binding,
+					type: friendlyBindingNames.workflows,
+					value: value,
+					mode: getMode({ isSimulatedLocally: script_name ? !remote : true }),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (kv_namespaces !== undefined && kv_namespaces.length > 0) {
-		output.push({
-			name: friendlyBindingNames.kv_namespaces,
-			entries: kv_namespaces.map(({ binding, id, remote }) => {
+		output.push(
+			...kv_namespaces.map(({ binding, id, remote }) => {
 				return {
-					key: binding,
-					value: addSuffix(id, {
+					name: binding,
+					type: friendlyBindingNames.kv_namespaces,
+					value: typeof id === "string" ? id : undefined,
+					mode: getMode({
 						isSimulatedLocally: !remote,
 					}),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (send_email !== undefined && send_email.length > 0) {
-		output.push({
-			name: friendlyBindingNames.send_email,
-			entries: send_email.map((emailBinding) => {
+		output.push(
+			...send_email.map((emailBinding) => {
 				const destination_address =
 					"destination_address" in emailBinding
 						? emailBinding.destination_address
@@ -192,36 +199,36 @@ export function printBindings(
 						? emailBinding.allowed_destination_addresses
 						: undefined;
 				return {
-					key: emailBinding.name,
-					value: addSuffix(
+					name: emailBinding.name,
+					type: friendlyBindingNames.send_email,
+					value:
 						destination_address ||
-							allowed_destination_addresses?.join(", ") ||
-							"unrestricted",
-						{ isSimulatedLocally: true }
-					),
+						allowed_destination_addresses?.join(", ") ||
+						"unrestricted",
+					mode: getMode({ isSimulatedLocally: true }),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (queues !== undefined && queues.length > 0) {
-		output.push({
-			name: friendlyBindingNames.queues,
-			entries: queues.map(({ binding, queue_name, remote }) => {
+		output.push(
+			...queues.map(({ binding, queue_name, remote }) => {
 				return {
-					key: binding,
-					value: addSuffix(queue_name, {
+					name: binding,
+					type: friendlyBindingNames.queues,
+					value: queue_name,
+					mode: getMode({
 						isSimulatedLocally: !remote,
 					}),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (d1_databases !== undefined && d1_databases.length > 0) {
-		output.push({
-			name: friendlyBindingNames.d1_databases,
-			entries: d1_databases.map(
+		output.push(
+			...d1_databases.map(
 				({
 					binding,
 					database_name,
@@ -241,105 +248,103 @@ export function printBindings(
 						databaseValue = `${databaseValue ? `${databaseValue}, ` : ""}Preview: (${preview_database_id})`;
 					}
 					return {
-						key: binding,
-						value: addSuffix(databaseValue, {
+						name: binding,
+						type: friendlyBindingNames.d1_databases,
+						mode: getMode({
 							isSimulatedLocally: !remote,
 						}),
+						value: databaseValue,
 					};
 				}
-			),
-		});
+			)
+		);
 	}
 
 	if (vectorize !== undefined && vectorize.length > 0) {
-		output.push({
-			name: friendlyBindingNames.vectorize,
-			entries: vectorize.map(({ binding, index_name }) => {
+		output.push(
+			...vectorize.map(({ binding, index_name }) => {
 				return {
-					key: binding,
-					value: addSuffix(index_name),
+					name: binding,
+					type: friendlyBindingNames.vectorize,
+					value: index_name,
+					mode: getMode(),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (hyperdrive !== undefined && hyperdrive.length > 0) {
-		output.push({
-			name: friendlyBindingNames.hyperdrive,
-			entries: hyperdrive.map(({ binding, id }) => {
+		output.push(
+			...hyperdrive.map(({ binding, id }) => {
 				return {
-					key: binding,
-					value: addSuffix(id, {
-						isSimulatedLocally: true,
-					}),
+					name: binding,
+					type: friendlyBindingNames.hyperdrive,
+					value: id,
+					mode: getMode({ isSimulatedLocally: true }),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (r2_buckets !== undefined && r2_buckets.length > 0) {
-		output.push({
-			name: friendlyBindingNames.r2_buckets,
-			entries: r2_buckets.map(
-				({ binding, bucket_name, jurisdiction, remote }) => {
-					let name = typeof bucket_name === "string" ? bucket_name : "";
+		output.push(
+			...r2_buckets.map(({ binding, bucket_name, jurisdiction, remote }) => {
+				let name = typeof bucket_name === "string" ? bucket_name : "";
 
-					if (jurisdiction !== undefined) {
-						name += ` (${jurisdiction})`;
-					}
-
-					return {
-						key: binding,
-						value: addSuffix(name, {
-							isSimulatedLocally: !remote,
-						}),
-					};
+				if (jurisdiction !== undefined) {
+					name += ` (${jurisdiction})`;
 				}
-			),
-		});
+
+				return {
+					name: binding,
+					type: friendlyBindingNames.r2_buckets,
+					value: name,
+					mode: getMode({
+						isSimulatedLocally: !remote,
+					}),
+				};
+			})
+		);
 	}
 
 	if (logfwdr !== undefined && logfwdr.bindings.length > 0) {
-		output.push({
-			name: friendlyBindingNames.logfwdr,
-			entries: logfwdr.bindings.map((binding) => {
+		output.push(
+			...logfwdr.bindings.map(({ name, destination }) => {
 				return {
-					key: binding.name,
-					value: addSuffix(binding.destination),
+					name: name,
+					type: friendlyBindingNames.logfwdr,
+					value: destination,
+					mode: getMode(),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (secrets_store_secrets !== undefined && secrets_store_secrets.length > 0) {
-		output.push({
-			name: friendlyBindingNames.secrets_store_secrets,
-			entries: secrets_store_secrets.map(
-				({ binding, store_id, secret_name }) => {
-					return {
-						key: binding,
-						value: addSuffix(`${store_id}/${secret_name}`, {
-							isSimulatedLocally: true,
-						}),
-					};
-				}
-			),
-		});
+		output.push(
+			...secrets_store_secrets.map(({ binding, store_id, secret_name }) => {
+				return {
+					name: binding,
+					type: friendlyBindingNames.secrets_store_secrets,
+					value: `${store_id}/${secret_name}`,
+					mode: getMode({ isSimulatedLocally: true }),
+				};
+			})
+		);
 	}
 
 	if (services !== undefined && services.length > 0) {
-		output.push({
-			name: friendlyBindingNames.services,
-			entries: services.map(({ binding, service, entrypoint, remote }) => {
+		output.push(
+			...services.map(({ binding, service, entrypoint, remote }) => {
 				let value = service;
+				let mode = undefined;
+
 				if (entrypoint) {
 					value += `#${entrypoint}`;
 				}
 
 				if (remote) {
-					value = addSuffix(value, {
-						isSimulatedLocally: false,
-					});
+					mode = getMode({ isSimulatedLocally: false, connected: true });
 				} else if (context.local && context.registry !== null) {
 					const registryDefinition = context.registry?.[service];
 					hasConnectionStatus = true;
@@ -349,130 +354,119 @@ export function printBindings(
 						(!entrypoint ||
 							registryDefinition.entrypointAddresses?.[entrypoint])
 					) {
-						if (getFlag("MIXED_MODE")) {
-							value =
-								value + " " + chalk.green(`[connected to local resource]`);
-						} else {
-							value = value + " " + chalk.green(`[connected]`);
-						}
+						mode = getMode({ isSimulatedLocally: true, connected: true });
 					} else {
-						value = value + " " + chalk.red("[not connected]");
+						value += " " + chalk.red("[not connected]");
 					}
 				}
 
 				return {
-					key: binding,
+					name: binding,
+					type: friendlyBindingNames.services,
 					value,
+					mode,
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (
 		analytics_engine_datasets !== undefined &&
 		analytics_engine_datasets.length > 0
 	) {
-		output.push({
-			name: friendlyBindingNames.analytics_engine_datasets,
-			entries: analytics_engine_datasets.map(({ binding, dataset }) => {
+		output.push(
+			...analytics_engine_datasets.map(({ binding, dataset }) => {
 				return {
-					key: binding,
-					value: addSuffix(dataset ?? binding, {
-						isSimulatedLocally: true,
-					}),
+					name: binding,
+					type: friendlyBindingNames.analytics_engine_datasets,
+					value: dataset ?? binding,
+					mode: getMode({ isSimulatedLocally: true }),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (text_blobs !== undefined && Object.keys(text_blobs).length > 0) {
-		output.push({
-			name: friendlyBindingNames.text_blobs,
-			entries: Object.entries(text_blobs).map(([key, value]) => ({
-				key,
-				value: addSuffix(truncate(value)),
-			})),
-		});
+		output.push(
+			...Object.entries(text_blobs).map(([key, value]) => ({
+				name: key,
+				type: friendlyBindingNames.text_blobs,
+				value: truncate(value),
+				mode: getMode({ isSimulatedLocally: true }),
+			}))
+		);
 	}
 
 	if (browser !== undefined) {
 		output.push({
-			name: friendlyBindingNames.browser,
-			entries: [{ key: "Name", value: browser.binding }],
+			name: browser.binding,
+			type: friendlyBindingNames.browser,
+			value: undefined,
+			mode: getMode({ isSimulatedLocally: false }),
 		});
 	}
 
 	if (images !== undefined) {
-		const addImagesSuffix = createAddSuffix({
-			isProvisioning: context.provisioning,
-			isLocalDev: !!context.imagesLocalMode,
-		});
 		output.push({
-			name: friendlyBindingNames.images,
-			entries: [
-				{
-					key: "Name",
-					value: addImagesSuffix(images.binding),
-				},
-			],
+			name: images.binding,
+			type: friendlyBindingNames.images,
+			value: undefined,
+			mode: getMode({ isSimulatedLocally: !!context.imagesLocalMode }),
 		});
 	}
 
 	if (ai !== undefined) {
-		const entries: [{ key: string; value: string | boolean }] = [
-			{ key: "Name", value: addSuffix(ai.binding) },
-		];
-		if (ai.staging) {
-			entries.push({
-				key: "Staging",
-				value: addSuffix(ai.staging.toString(), { isSimulatedLocally: false }),
-			});
-		}
-
 		output.push({
-			name: friendlyBindingNames.ai,
-			entries: entries,
+			name: ai.binding,
+			type: friendlyBindingNames.ai,
+			value: ai.staging ? `staging` : undefined,
+			mode: getMode({ isSimulatedLocally: false }),
 		});
 	}
 
 	if (pipelines?.length) {
-		output.push({
-			name: friendlyBindingNames.pipelines,
-			entries: pipelines.map(({ binding, pipeline }) => ({
-				key: binding,
-				value: addSuffix(pipeline),
-			})),
-		});
+		output.push(
+			...pipelines.map(({ binding, pipeline }) => ({
+				name: binding,
+				type: friendlyBindingNames.pipelines,
+				value: pipeline,
+				mode: getMode(),
+			}))
+		);
 	}
 
 	if (assets !== undefined) {
 		output.push({
-			name: friendlyBindingNames.assets,
-			entries: [{ key: "Binding", value: assets.binding }],
+			name: assets.binding,
+			type: friendlyBindingNames.assets,
+			value: undefined,
+			mode: getMode({ isSimulatedLocally: true }),
 		});
 	}
 
 	if (version_metadata !== undefined) {
 		output.push({
-			name: friendlyBindingNames.version_metadata,
-			entries: [{ key: "Name", value: addSuffix(version_metadata.binding) }],
+			name: version_metadata.binding,
+			type: friendlyBindingNames.version_metadata,
+			value: undefined,
+			mode: getMode({ isSimulatedLocally: true }),
 		});
 	}
 
 	if (unsafe?.bindings !== undefined && unsafe.bindings.length > 0) {
-		output.push({
-			name: friendlyBindingNames.unsafe,
-			entries: unsafe.bindings.map(({ name, type }) => ({
-				key: type,
-				value: addSuffix(name),
-			})),
-		});
+		output.push(
+			...unsafe.bindings.map(({ name, type }) => ({
+				name: type,
+				type: friendlyBindingNames.unsafe,
+				value: name,
+				mode: getMode({ isSimulatedLocally: false }),
+			}))
+		);
 	}
 
 	if (vars !== undefined && Object.keys(vars).length > 0) {
-		output.push({
-			name: friendlyBindingNames.vars,
-			entries: Object.entries(vars).map(([key, value]) => {
+		output.push(
+			...Object.entries(vars).map(([key, value]) => {
 				let parsedValue;
 				if (typeof value === "string") {
 					parsedValue = `"${truncate(value)}"`;
@@ -482,76 +476,74 @@ export function printBindings(
 					parsedValue = `${truncate(`${value}`)}`;
 				}
 				return {
-					key,
+					name: key,
+					type: friendlyBindingNames.vars,
 					value: parsedValue,
+					mode: getMode({ isSimulatedLocally: true }),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (wasm_modules !== undefined && Object.keys(wasm_modules).length > 0) {
-		output.push({
-			name: friendlyBindingNames.wasm_modules,
-			entries: Object.entries(wasm_modules).map(([key, value]) => ({
-				key,
-				value: addSuffix(
-					typeof value === "string" ? truncate(value) : "<Wasm>"
-				),
-			})),
-		});
+		output.push(
+			...Object.entries(wasm_modules).map(([key, value]) => ({
+				name: key,
+				type: friendlyBindingNames.wasm_modules,
+				value: typeof value === "string" ? truncate(value) : "<Wasm>",
+				mode: getMode({ isSimulatedLocally: true }),
+			}))
+		);
 	}
 
 	if (dispatch_namespaces !== undefined && dispatch_namespaces.length > 0) {
-		output.push({
-			name: friendlyBindingNames.dispatch_namespaces,
-			entries: dispatch_namespaces.map(({ binding, namespace, outbound }) => {
+		output.push(
+			...dispatch_namespaces.map(({ binding, namespace, outbound }) => {
 				return {
-					key: binding,
-					value: addSuffix(
-						outbound
-							? `${namespace} (outbound -> ${outbound.service})`
-							: namespace
-					),
+					name: binding,
+					type: friendlyBindingNames.dispatch_namespaces,
+					value: outbound
+						? `${namespace} (outbound -> ${outbound.service})`
+						: namespace,
+					mode: getMode(),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (mtls_certificates !== undefined && mtls_certificates.length > 0) {
-		output.push({
-			name: friendlyBindingNames.mtls_certificates,
-			entries: mtls_certificates.map(({ binding, certificate_id }) => {
+		output.push(
+			...mtls_certificates.map(({ binding, certificate_id }) => {
 				return {
-					key: binding,
-					value: addSuffix(certificate_id),
+					name: binding,
+					type: friendlyBindingNames.mtls_certificates,
+					value: certificate_id,
+					mode: getMode(),
 				};
-			}),
-		});
+			})
+		);
 	}
 
 	if (unsafe?.metadata !== undefined) {
-		output.push({
-			name: friendlyBindingNames.unsafe,
-			entries: Object.entries(unsafe.metadata).map(([key, value]) => ({
-				key,
-				value: addSuffix(JSON.stringify(value)),
-			})),
-		});
+		output.push(
+			...Object.entries(unsafe.metadata).map(([key, value]) => ({
+				name: key,
+				type: friendlyBindingNames.unsafe,
+				value: JSON.stringify(value),
+				mode: getMode({ isSimulatedLocally: false }),
+			}))
+		);
 	}
 
 	if (output.length === 0) {
-		if (context.name && getFlag("MULTIWORKER")) {
-			logger.log(`No bindings found for ${chalk.blue(context.name)}`);
-		} else {
-			logger.log("No bindings found.");
+		if (context.warnIfNoBindings) {
+			if (context.name && getFlag("MULTIWORKER")) {
+				logger.log(`No bindings found for ${chalk.blue(context.name)}`);
+			} else {
+				logger.log("No bindings found.");
+			}
 		}
 	} else {
-		if (context.local) {
-			logger.once.log(
-				`Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.\n`
-			);
-		}
-
 		let title: string;
 		if (context.provisioning) {
 			title = "The following bindings need to be provisioned:";
@@ -561,21 +553,38 @@ export function printBindings(
 			title = "Your Worker has access to the following bindings:";
 		}
 
-		const message = [
-			title,
-			...output
-				.map((bindingGroup) => {
-					return [
-						`- ${bindingGroup.name}:`,
-						bindingGroup.entries.map(
-							({ key, value }) => `  - ${key}${value ? ":" : ""} ${value}`
-						),
-					];
-				})
-				.flat(2),
-		].join("\n");
-
-		logger.log(message);
+		let maxNameLength = 0;
+		let maxValueLength = 0;
+		let maxTypeLength = 0;
+		for (const binding of output) {
+			if (
+				typeof binding.value === "string" &&
+				binding.value.length > maxValueLength
+			) {
+				maxValueLength = binding.value.length;
+			}
+			if (binding.type.length > maxTypeLength) {
+				maxTypeLength = binding.type.length;
+			}
+			if (binding.name.length > maxNameLength) {
+				maxNameLength = binding.name.length;
+			}
+		}
+		const hasMode = output.some((b) => b.mode);
+		logger.log(title);
+		logger.log(
+			`${dim("Binding") + " ".repeat(maxValueLength + maxNameLength + 3 + 4 - "Binding".length)}      ${dim("Resource") + " ".repeat(maxTypeLength - "Resource".length)}      ${hasMode ? dim("Mode") : ""}`
+		);
+		for (const binding of output) {
+			const nameValueLength =
+				4 +
+				binding.name.length +
+				(binding.value ? binding.value?.length + 3 : 0);
+			logger.log(
+				`${white(`env.${binding.name}`)}${binding.value ? ` (${dim(binding.value)})` : ""}${" ".repeat(maxNameLength + maxValueLength + 3 + 4 - nameValueLength)}      ${brandColor(binding.type)}${" ".repeat(maxTypeLength - binding.type.length)}      ${hasMode ? binding.mode : ""}`
+			);
+		}
+		logger.log();
 	}
 	let title: string;
 	if (context.name && getFlag("MULTIWORKER")) {
@@ -625,29 +634,38 @@ function normalizeValue(value: string | symbol | undefined) {
  * The suffix is only for local dev so it can be used to determine whether a binding is
  * simulated locally or connected to a remote resource.
  */
-function createAddSuffix({
+function createGetMode({
 	isProvisioning = false,
 	isLocalDev = false,
 }: {
 	isProvisioning?: boolean;
 	isLocalDev?: boolean;
 }) {
-	return function addSuffix(
-		value: string | symbol | undefined,
-		{
-			isSimulatedLocally = false,
-		}: {
-			isSimulatedLocally?: boolean;
-		} = {}
-	) {
-		const normalizedValue = normalizeValue(value);
-
+	return function bindingMode({
+		isSimulatedLocally = false,
+		connected,
+	}: {
+		isSimulatedLocally?: boolean;
+		connected?: boolean;
+	} = {}): string | undefined {
 		if (isProvisioning || !isLocalDev) {
-			return normalizedValue;
+			return undefined;
 		}
 
-		return isSimulatedLocally
-			? `${normalizedValue} [simulated locally]`
-			: `${normalizedValue} [connected to remote resource]`;
+		if (isSimulatedLocally && connected === undefined) {
+			// Local resource binding
+			return chalk.blue("local");
+		} else if (!isSimulatedLocally && connected === undefined) {
+			// Remote resource binding
+			return chalk.yellow("remote");
+		} else if (isSimulatedLocally && connected) {
+			// Local service/tail binding
+			return chalk.green("connected to local resource");
+		} else if (!isSimulatedLocally && connected) {
+			// Remote service/tail binding
+			return chalk.green("connected to remote resource");
+		}
+		// Remote/local service/tail binding that isn't connected
+		return chalk.red("not connected");
 	};
 }

--- a/packages/wrangler/src/wrangler-banner.ts
+++ b/packages/wrangler/src/wrangler-banner.ts
@@ -8,6 +8,7 @@ import { updateCheck } from "./update-check";
 const MIN_NODE_VERSION = "20.0.0";
 
 export async function printWranglerBanner(performUpdateCheck = true) {
+	logger.console("clear");
 	let text = ` ⛅️ wrangler ${wranglerVersion}`;
 	let maybeNewVersion: string | undefined;
 	if (performUpdateCheck) {
@@ -22,9 +23,8 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 			text +
 			"\n" +
 			(supportsColor.stdout
-				? chalk.hex("#FF8800")("-".repeat(text.length))
-				: "-".repeat(text.length)) +
-			"\n"
+				? chalk.hex("#FF8800")("─".repeat(text.length))
+				: "─".repeat(text.length))
 	);
 
 	if (semiver(process.versions.node, MIN_NODE_VERSION) < 0) {

--- a/packages/wrangler/src/wrangler-banner.ts
+++ b/packages/wrangler/src/wrangler-banner.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import semiver from "semiver";
+import stripAnsi from "strip-ansi";
 import supportsColor from "supports-color";
 import { version as wranglerVersion } from "../package.json";
 import { logger } from "./logger";
@@ -22,7 +23,7 @@ export async function printWranglerBanner(performUpdateCheck = true) {
 			text +
 			"\n" +
 			(supportsColor.stdout
-				? chalk.hex("#FF8800")("─".repeat(text.length))
+				? chalk.hex("#FF8800")("─".repeat(stripAnsi(text).length))
 				: "─".repeat(text.length))
 	);
 

--- a/packages/wrangler/src/wrangler-banner.ts
+++ b/packages/wrangler/src/wrangler-banner.ts
@@ -8,7 +8,6 @@ import { updateCheck } from "./update-check";
 const MIN_NODE_VERSION = "20.0.0";
 
 export async function printWranglerBanner(performUpdateCheck = true) {
-	logger.console("clear");
 	let text = ` ⛅️ wrangler ${wranglerVersion}`;
 	let maybeNewVersion: string | undefined;
 	if (performUpdateCheck) {


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1911

A fairly big redesign of `wrangler dev`, mostly around bindings display. Here's an example of what a dev session will look like:
![Screenshot 2025-05-22 at 01 11 43](https://github.com/user-attachments/assets/5cd7c83f-dcf8-4a96-99a2-739102a00e6b)

Additionally, the hotkeys have been shifted to be pinned to the top (I think this looks better, but it's definitely potentially controversial), and I've removed the local/remote toggle (also potentially controversial, but mixed mode provides a much better solution here).

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: I don't think we have any screenshots of this flow in docs?
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: part of the not-being-backported mixed mode feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
