### PR TITLE
update devprod-status-bot message and cron

### DIFF
--- a/packages/devprod-status-bot/src/index.ts
+++ b/packages/devprod-status-bot/src/index.ts
@@ -382,7 +382,12 @@ async function sendUpcomingReleaseMessage(pat: string, webhookUrl: string) {
 								widgets: [
 									{
 										textParagraph: {
-											text: "There's an upcoming workers-sdk release today. The `main` branch will be locked shortly before to allow the release to be checked. Review the release PR linked below for the full details, and let the ANT team know (by responding in this thread) if for any reason you'd like us to delay this release.",
+											text:
+												"A new workers-sdk release is scheduled for tomorrow." +
+												" The `main` branch will be locked shortly to allow the release to be checked beforehand." +
+												" Review the release PR linked below for the full details, and let the ANT team know" +
+												" (by responding in this thread) if for any reason you'd like us to delay this release." +
+												"\n\nThe `main` branch will be unlocked tomorrow after the release is completed.",
 										},
 									},
 									{
@@ -641,7 +646,7 @@ export default {
 		if (controller.cron === "0 10 * * MON-FRI") {
 			await sendStartThreadMessage(env.GITHUB_PAT, env.PROD_WEBHOOK, env.AI);
 		}
-		if (controller.cron === "0 10 * * TUE,THU") {
+		if (controller.cron === "0 17 * * MON,WED") {
 			await sendUpcomingReleaseMessage(
 				env.GITHUB_PAT,
 				env.PROD_WRANGLER_CONTRIBUTORS_WEBHOOK


### PR DESCRIPTION
As discussed the current devprod-status-bot message is sent at the wrong time, so this PR is updating the time the bot sends the message as well as adjusting the message accordingly

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: infra/bot update
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: infra/bot update
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: infra/bot update
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: infra/bot update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
