### PR TITLE
add warning about env not specified to potentially risky wrangler commands

### DIFF
--- a/.changeset/some-cloths-move.md
+++ b/.changeset/some-cloths-move.md
@@ -19,5 +19,5 @@ of the following commands:
 - wrangler secret delete
 - wrangler triggers deploy (TODO: manually test)
 
-this is a measure we're putting in place to try to prevent developers from accidentally apply
+this is a measure we're putting in place to try to prevent developers from accidentally applying
 changes to an incorrect (potentially even production) environment

--- a/.changeset/some-cloths-move.md
+++ b/.changeset/some-cloths-move.md
@@ -1,0 +1,23 @@
+---
+"wrangler": patch
+---
+
+add warning about env not specified to potentially risky wrangler commands
+
+add a warning suggesting users to specify their target environment (via `-e` or `--env`)
+when their wrangler config file contains some environments and they are calling one
+of the following commands:
+
+- wrangler deploy
+- wrangler versions upload
+- wrangler versions deploy
+- wrangler versions secret bulk
+- wrangler versions secret put
+- wrangler versions secret delete
+- wrangler secret bulk
+- wrangler secret put
+- wrangler secret delete
+- wrangler triggers deploy (TODO: manually test)
+
+this is a measure we're putting in place to try to prevent developers from accidentally apply
+changes to an incorrect (potentially even production) environment

--- a/.changeset/spotty-worlds-rest.md
+++ b/.changeset/spotty-worlds-rest.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+allow passing an empty string to the `-e|--env` flag to target the top-level environment

--- a/packages/wrangler/src/__tests__/config/findWranglerConfig.test.ts
+++ b/packages/wrangler/src/__tests__/config/findWranglerConfig.test.ts
@@ -223,7 +223,7 @@ describe("config findWranglerConfig()", () => {
 			expect(std).toEqual(NO_LOGS);
 		});
 
-		it("should error if deploy config file and user config file do not have the same base path", async () => {
+		it.skip("should error if deploy config file and user config file do not have the same base path", async () => {
 			await seed({
 				[`foo/wrangler.toml`]: "DUMMY",
 				["foo/bar/.wrangler/deploy/config.json"]: `{ "configPath": "../../dist/wrangler.json" }`,

--- a/packages/wrangler/src/__tests__/config/findWranglerConfig.test.ts
+++ b/packages/wrangler/src/__tests__/config/findWranglerConfig.test.ts
@@ -223,7 +223,7 @@ describe("config findWranglerConfig()", () => {
 			expect(std).toEqual(NO_LOGS);
 		});
 
-		it.skip("should error if deploy config file and user config file do not have the same base path", async () => {
+		it("should error if deploy config file and user config file do not have the same base path", async () => {
 			await seed({
 				[`foo/wrangler.toml`]: "DUMMY",
 				["foo/bar/.wrangler/deploy/config.json"]: `{ "configPath": "../../dist/wrangler.json" }`,

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -13021,7 +13021,7 @@ export default{
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
 				  If your intention is to use the top-level environment of your configuration simply pass an empty
-				  string to the flag to target such environment. For example `--env=""`.
+				  string to the flag to target such environment. For example \`--env=\\"\\"\`.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -13000,6 +13000,63 @@ export default{
 			await runWrangler("deploy ./index.js");
 		});
 	});
+
+	describe("multi-env warning", () => {
+		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+			writeWorkerSource();
+			writeWranglerConfig({
+				main: "./index.js",
+				env: {
+					test: {},
+				},
+			});
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the deploy command.[0m
+
+				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
+				  the target environment using the \`-e|--env\` flag.
+
+				"
+			`);
+		});
+
+		it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+			writeWorkerSource();
+			writeWranglerConfig({
+				main: "./index.js",
+				env: {
+					test: {},
+				},
+			});
+			mockSubDomainRequest();
+			mockUploadWorkerRequest({
+				env: "test",
+				legacyEnv: true,
+			});
+
+			await runWrangler("deploy -e test");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+			writeWorkerSource();
+			writeWranglerConfig({
+				main: "./index.js",
+			});
+			mockSubDomainRequest();
+			mockUploadWorkerRequest();
+
+			await runWrangler("deploy");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+	});
 });
 
 /** Write mock assets to the file system so they can be uploaded. */

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -13020,6 +13020,8 @@ export default{
 
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
+				  If your intention is to use the top-level environment of your configuration simply pass an empty
+				  string to the flag to target such environment.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -13021,7 +13021,7 @@ export default{
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
 				  If your intention is to use the top-level environment of your configuration simply pass an empty
-				  string to the flag to target such environment.
+				  string to the flag to target such environment. For example `--env=""`.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -475,6 +475,8 @@ describe("wrangler secret", () => {
 
 						  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 						  the target environment using the \`-e|--env\` flag.
+						  If your intention is to use the top-level environment of your configuration simply pass an empty
+						  string to the flag to target such environment.
 
 						"
 					`);
@@ -701,6 +703,8 @@ describe("wrangler secret", () => {
 
 					  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 					  the target environment using the \`-e|--env\` flag.
+					  If your intention is to use the top-level environment of your configuration simply pass an empty
+					  string to the flag to target such environment.
 
 					"
 				`);
@@ -1356,6 +1360,8 @@ describe("wrangler secret", () => {
 
 					  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 					  the target environment using the \`-e|--env\` flag.
+					  If your intention is to use the top-level environment of your configuration simply pass an empty
+					  string to the flag to target such environment.
 
 					"
 				`);

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -476,7 +476,7 @@ describe("wrangler secret", () => {
 						  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 						  the target environment using the \`-e|--env\` flag.
 						  If your intention is to use the top-level environment of your configuration simply pass an empty
-						  string to the flag to target such environment.
+						  string to the flag to target such environment. For example \`--env=\\"\\"\`.
 
 						"
 					`);
@@ -704,7 +704,7 @@ describe("wrangler secret", () => {
 					  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 					  the target environment using the \`-e|--env\` flag.
 					  If your intention is to use the top-level environment of your configuration simply pass an empty
-					  string to the flag to target such environment.
+					  string to the flag to target such environment. For example \`--env=\\"\\"\`.
 
 					"
 				`);
@@ -1361,7 +1361,7 @@ describe("wrangler secret", () => {
 					  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 					  the target environment using the \`-e|--env\` flag.
 					  If your intention is to use the top-level environment of your configuration simply pass an empty
-					  string to the flag to target such environment.
+					  string to the flag to target such environment. For example \`--env=\\"\\"\`.
 
 					"
 				`);

--- a/packages/wrangler/src/__tests__/secret.test.ts
+++ b/packages/wrangler/src/__tests__/secret.test.ts
@@ -14,6 +14,7 @@ import { useMockStdin } from "./helpers/mock-stdin";
 import { msw } from "./helpers/msw";
 import { runInTempDir } from "./helpers/run-in-tmp";
 import { runWrangler } from "./helpers/run-wrangler";
+import { writeWranglerConfig } from "./helpers/write-wrangler-config";
 import type { Interface } from "node:readline";
 
 function createFetchResult(
@@ -458,6 +459,47 @@ describe("wrangler secret", () => {
 					`);
 				});
 			});
+
+			describe("multi-env warning", () => {
+				it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+					writeWranglerConfig({
+						env: {
+							test: {},
+						},
+					});
+					mockStdIn.send("the-secret");
+					mockPutRequest({ name: "the-key", text: "the-secret" });
+					await runWrangler("secret put the-key --name script-name");
+					expect(std.warn).toMatchInlineSnapshot(`
+						"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the secret put command.[0m
+
+						  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
+						  the target environment using the \`-e|--env\` flag.
+
+						"
+					`);
+				});
+
+				it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+					writeWranglerConfig({
+						env: {
+							test: {},
+						},
+					});
+					mockStdIn.send("the-secret");
+					mockPutRequest({ name: "the-key", text: "the-secret" }, "test", true);
+					await runWrangler("secret put the-key --name script-name -e test");
+					expect(std.warn).toMatchInlineSnapshot(`""`);
+				});
+
+				it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+					writeWranglerConfig();
+					mockStdIn.send("the-secret");
+					mockPutRequest({ name: "the-key", text: "the-secret" });
+					await runWrangler("secret put the-key --name script-name");
+					expect(std.warn).toMatchInlineSnapshot(`""`);
+				});
+			});
 		});
 
 		it("should error if the latest version is not deployed", async () => {
@@ -639,6 +681,60 @@ describe("wrangler secret", () => {
 			expect(error).toMatchInlineSnapshot(
 				`[Error: Required Worker name missing. Please specify the Worker name in your Wrangler configuration file, or pass it as an argument with \`--name <worker-name>\`]`
 			);
+		});
+
+		describe("multi-env warning", () => {
+			it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+				writeWranglerConfig({
+					env: {
+						test: {},
+					},
+				});
+				mockDeleteRequest({ scriptName: "script-name", secretName: "the-key" });
+				mockConfirm({
+					text: "Are you sure you want to permanently delete the secret the-key on the Worker script-name?",
+					result: true,
+				});
+				await runWrangler("secret delete the-key --name script-name");
+				expect(std.warn).toMatchInlineSnapshot(`
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the secret delete command.[0m
+
+					  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
+					  the target environment using the \`-e|--env\` flag.
+
+					"
+				`);
+			});
+
+			it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+				writeWranglerConfig({
+					env: {
+						test: {},
+					},
+				});
+				mockDeleteRequest(
+					{ scriptName: "script-name", secretName: "the-key" },
+					"test",
+					true
+				);
+				mockConfirm({
+					text: "Are you sure you want to permanently delete the secret the-key on the Worker script-name-test?",
+					result: true,
+				});
+				await runWrangler("secret delete the-key --name script-name -e test");
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
+
+			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+				writeWranglerConfig();
+				mockDeleteRequest({ scriptName: "script-name", secretName: "the-key" });
+				mockConfirm({
+					text: "Are you sure you want to permanently delete the secret the-key on the Worker script-name?",
+					result: true,
+				});
+				await runWrangler("secret delete the-key --name script-name");
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
 		});
 	});
 
@@ -1239,6 +1335,62 @@ describe("wrangler secret", () => {
 				Finished processing secrets file:
 				✨ 2 secrets successfully uploaded"
 			`);
+		});
+
+		describe("multi-env warning", () => {
+			it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+				writeWranglerConfig({
+					name: "test-name",
+					main: "./index.js",
+					env: {
+						test: {},
+					},
+				});
+				writeFileSync("secret.json", JSON.stringify({}));
+
+				mockBulkRequest();
+
+				await runWrangler("secret bulk ./secret.json --name script-name");
+				expect(std.warn).toMatchInlineSnapshot(`
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the secret bulk command.[0m
+
+					  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
+					  the target environment using the \`-e|--env\` flag.
+
+					"
+				`);
+			});
+
+			it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+				writeWranglerConfig({
+					name: "test-name",
+					main: "./index.js",
+					env: {
+						test: {},
+					},
+				});
+				writeFileSync("secret.json", JSON.stringify({}));
+
+				mockBulkRequest();
+
+				await runWrangler(
+					"secret bulk ./secret.json --name script-name -e test"
+				);
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
+
+			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+				writeWranglerConfig({
+					name: "test-name",
+					main: "./index.js",
+				});
+				writeFileSync("secret.json", JSON.stringify({}));
+
+				mockBulkRequest();
+
+				await runWrangler("secret bulk ./secret.json --name script-name");
+				expect(std.warn).toMatchInlineSnapshot(`""`);
+			});
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -279,4 +279,64 @@ describe("versions secret bulk", () => {
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
+
+	describe("multi-env warning", () => {
+		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+			vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
+					JSON.stringify({
+						SECRET_1: "secret-1",
+					}) as unknown as Interface
+			);
+
+			writeWranglerConfig({ env: { test: {} } });
+			mockSetupApiCalls();
+			mockPostVersion();
+
+			await runWrangler(`versions secret bulk --name script-name`);
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the versions secret bulk command.[0m
+
+				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
+				  the target environment using the \`-e|--env\` flag.
+
+				"
+			`);
+		});
+
+		it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+			vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
+					JSON.stringify({
+						SECRET_1: "secret-1",
+					}) as unknown as Interface
+			);
+
+			writeWranglerConfig({ env: { test: {} } });
+			mockSetupApiCalls();
+			mockPostVersion();
+
+			await runWrangler(`versions secret bulk --name script-name --env test`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+			vi.spyOn(readline, "createInterface").mockImplementation(
+				() =>
+					// `readline.Interface` is an async iterator: `[Symbol.asyncIterator](): AsyncIterableIterator<string>`
+					JSON.stringify({
+						SECRET_1: "secret-1",
+					}) as unknown as Interface
+			);
+
+			writeWranglerConfig();
+			mockSetupApiCalls();
+			mockPostVersion();
+
+			await runWrangler(`versions secret bulk --name script-name`);
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -300,6 +300,8 @@ describe("versions secret bulk", () => {
 
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
+				  If your intention is to use the top-level environment of your configuration simply pass an empty
+				  string to the flag to target such environment.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/bulk.test.ts
@@ -301,7 +301,7 @@ describe("versions secret bulk", () => {
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
 				  If your intention is to use the top-level environment of your configuration simply pass an empty
-				  string to the flag to target such environment.
+				  string to the flag to target such environment. For example \`--env=\\"\\"\`.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -117,4 +117,58 @@ describe("versions secret delete", () => {
 		expect(std.warn).toMatchInlineSnapshot(`""`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
+
+	describe("multi-env warning", () => {
+		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+			setIsTTY(false);
+
+			writeWranglerConfig({
+				env: { test: {} },
+			});
+			mockSetupApiCalls();
+			mockGetVersion();
+			mockPostVersion();
+
+			await runWrangler("versions secret delete SECRET --name script-name");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the versions secret delete command.[0m
+
+				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
+				  the target environment using the \`-e|--env\` flag.
+
+				"
+			`);
+		});
+
+		it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+			setIsTTY(false);
+
+			writeWranglerConfig({
+				env: { test: {} },
+			});
+			mockSetupApiCalls();
+			mockGetVersion();
+			mockPostVersion();
+
+			await runWrangler(
+				"versions secret delete SECRET --name script-name -e test"
+			);
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+			setIsTTY(false);
+
+			writeWranglerConfig();
+			mockSetupApiCalls();
+			mockGetVersion();
+			mockPostVersion();
+
+			await runWrangler("versions secret delete SECRET --name script-name");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -137,7 +137,7 @@ describe("versions secret delete", () => {
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
 				  If your intention is to use the top-level environment of your configuration simply pass an empty
-				  string to the flag to target such environment.
+				  string to the flag to target such environment. For example \`--env=\\"\\"\`.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/delete.test.ts
@@ -136,6 +136,8 @@ describe("versions secret delete", () => {
 
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
+				  If your intention is to use the top-level environment of your configuration simply pass an empty
+				  string to the flag to target such environment.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -450,6 +450,8 @@ describe("versions secret put", () => {
 
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
+				  If your intention is to use the top-level environment of your configuration simply pass an empty
+				  string to the flag to target such environment.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -425,4 +425,71 @@ describe("versions secret put", () => {
 		`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
+
+	describe("multi-env warning", () => {
+		const mockStdIn = useMockStdin({ isTTY: false });
+
+		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+			writeWranglerConfig({
+				name: "script-name",
+				env: { test: {} },
+			});
+			mockSetupApiCalls();
+			mockPostVersion();
+
+			mockStdIn.send(
+				`the`,
+				`-`,
+				`secret
+			` // whitespace & newline being removed
+			);
+			await runWrangler("versions secret put NEW_SECRET");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the versions secret put command.[0m
+
+				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
+				  the target environment using the \`-e|--env\` flag.
+
+				"
+			`);
+		});
+
+		it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+			writeWranglerConfig({
+				name: "script-name",
+				env: { test: {} },
+			});
+			mockSetupApiCalls();
+			mockPostVersion();
+
+			mockStdIn.send(
+				`the`,
+				`-`,
+				`secret
+			` // whitespace & newline being removed
+			);
+			await runWrangler("versions secret put NEW_SECRET -e test");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+			writeWranglerConfig({
+				name: "script-name",
+			});
+			mockSetupApiCalls();
+			mockPostVersion();
+
+			mockStdIn.send(
+				`the`,
+				`-`,
+				`secret
+			` // whitespace & newline being removed
+			);
+			await runWrangler("versions secret put NEW_SECRET");
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+	});
 });

--- a/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/put.test.ts
@@ -451,7 +451,7 @@ describe("versions secret put", () => {
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
 				  If your intention is to use the top-level environment of your configuration simply pass an empty
-				  string to the flag to target such environment.
+				  string to the flag to target such environment. For example \`--env=\\"\\"\`.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/versions/secrets/utils.ts
+++ b/packages/wrangler/src/__tests__/versions/secrets/utils.ts
@@ -10,7 +10,7 @@ function mockGetVersions() {
 			`*/accounts/:accountId/workers/scripts/:scriptName/versions`,
 			async ({ params }) => {
 				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toEqual("script-name");
+				expect(params.scriptName).toMatch(/script-name(-test)?/);
 
 				return HttpResponse.json(
 					createFetchResult({
@@ -38,7 +38,7 @@ export function mockGetVersion(versionInfo?: VersionDetails) {
 			`*/accounts/:accountId/workers/scripts/:scriptName/versions/ce15c78b-cc43-4f60-b5a9-15ce4f298c2a`,
 			async ({ params }) => {
 				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toEqual("script-name");
+				expect(params.scriptName).toMatch(/script-name(-test)?/);
 
 				return HttpResponse.json(
 					createFetchResult(
@@ -94,7 +94,7 @@ function mockGetVersionContent() {
 					"ce15c78b-cc43-4f60-b5a9-15ce4f298c2a"
 				);
 				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toEqual("script-name");
+				expect(params.scriptName).toMatch(/script-name(-test)?/);
 
 				const formData = new FormData();
 				formData.set(
@@ -120,7 +120,7 @@ function mockGetWorkerSettings() {
 			`*/accounts/:accountId/workers/scripts/:scriptName/script-settings`,
 			async ({ params }) => {
 				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toEqual("script-name");
+				expect(params.scriptName).toMatch(/script-name(-test)?/);
 
 				return HttpResponse.json(
 					createFetchResult({
@@ -142,7 +142,7 @@ export function mockPostVersion(
 			`*/accounts/:accountId/workers/scripts/:scriptName/versions`,
 			async ({ request, params }) => {
 				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toEqual("script-name");
+				expect(params.scriptName).toMatch(/script-name(-test)?/);
 
 				const formData = await request.formData();
 				const metadata = JSON.parse(

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -935,7 +935,7 @@ describe("versions deploy", () => {
 					  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 					  the target environment using the \`-e|--env\` flag.
 					  If your intention is to use the top-level environment of your configuration simply pass an empty
-					  string to the flag to target such environment.
+					  string to the flag to target such environment. For example \`--env=\\"\\"\`.
 
 					"
 				`);

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -34,7 +34,8 @@ describe("versions deploy", () => {
 	mockApiToken();
 	runInTempDir();
 	mockConsoleMethods();
-	const std = collectCLIOutput();
+	const consoleStd = mockConsoleMethods();
+	const cliStd = collectCLIOutput();
 	const { setIsTTY } = useMockIsTTY();
 
 	beforeEach(() => {
@@ -63,7 +64,7 @@ describe("versions deploy", () => {
 
 			await runWrangler("deploy ./index");
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭  WARNING  Your last deployment has multiple versions. To progress that deployment use \\"wrangler versions deploy\\" instead.
 				│
 				├ Your last deployment has 2 version(s):
@@ -94,7 +95,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toMatchInlineSnapshot(`undefined`);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -133,7 +134,7 @@ describe("versions deploy", () => {
 				╰  SUCCESS  Deployed named-worker version 00000000-0000-0000-0000-000000000000 at 100% (TIMINGS)"
 			`);
 
-			expect(normalizeOutput(std.out)).toContain(
+			expect(normalizeOutput(cliStd.out)).toContain(
 				"No non-versioned settings to sync. Skipping..."
 			);
 		});
@@ -159,7 +160,7 @@ describe("versions deploy", () => {
 				`[Error: You must select at least 1 version to deploy.]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -191,7 +192,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -238,7 +239,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -285,7 +286,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -340,7 +341,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -387,7 +388,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -442,7 +443,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -500,7 +501,7 @@ describe("versions deploy", () => {
 					`[Error: You must select at most 2 versions to deploy.]`
 				);
 
-				expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+				expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 					"╭ Deploy Worker Versions by splitting traffic between multiple versions
 					│
 					├ Fetching latest deployment
@@ -547,7 +548,7 @@ describe("versions deploy", () => {
 
 				await expect(result).resolves.toBeUndefined();
 
-				expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+				expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 					"╭ Deploy Worker Versions by splitting traffic between multiple versions
 					│
 					├ Fetching latest deployment
@@ -602,7 +603,7 @@ describe("versions deploy", () => {
 					╰  SUCCESS  Deployed test-name version 00000000-0000-0000-0000-000000000000 at 33.333%, version 00000000-0000-0000-0000-000000000000 at 33.334%, and version 00000000-0000-0000-0000-000000000000 at 33.333% (TIMINGS)"
 				`);
 
-				expect(normalizeOutput(std.err)).toMatchInlineSnapshot(`""`);
+				expect(normalizeOutput(cliStd.err)).toMatchInlineSnapshot(`""`);
 			});
 		});
 
@@ -613,7 +614,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -665,7 +666,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -723,7 +724,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -788,7 +789,7 @@ describe("versions deploy", () => {
 
 			await expect(result).resolves.toBeUndefined();
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -846,7 +847,7 @@ describe("versions deploy", () => {
 				`[APIError: A request to the Cloudflare API (/accounts/some-account-id/workers/scripts/test-name/versions/ffffffff-ffff-ffff-ffff-ffffffffffff) failed.]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`
 				"╭ Deploy Worker Versions by splitting traffic between multiple versions
 				│
 				├ Fetching latest deployment
@@ -877,7 +878,7 @@ describe("versions deploy", () => {
 				`[Error: Percentage value (101%) must be between 0 and 100.]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`""`);
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
 		});
 
 		test("fails if --percentage < 0", async () => {
@@ -889,7 +890,7 @@ describe("versions deploy", () => {
 				`[Error: Percentage value (-1%) must be between 0 and 100.]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`""`);
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
 		});
 
 		test("fails if version-spec percentage > 100", async () => {
@@ -901,7 +902,7 @@ describe("versions deploy", () => {
 				`[Error: Percentage value (101%) must be between 0 and 100.]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`""`);
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
 		});
 
 		test("fails if version-spec percentage < 0", async () => {
@@ -913,7 +914,54 @@ describe("versions deploy", () => {
 				`[Error: Percentage value (-1%) must be between 0 and 100.]`
 			);
 
-			expect(normalizeOutput(std.out)).toMatchInlineSnapshot(`""`);
+			expect(normalizeOutput(cliStd.out)).toMatchInlineSnapshot(`""`);
+		});
+
+		describe("multi-env warning", () => {
+			it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+				writeWranglerConfig({
+					env: {
+						test: {},
+					},
+				});
+
+				await runWrangler(
+					"versions deploy 10000000-0000-0000-0000-000000000000 --yes"
+				);
+
+				expect(consoleStd.warn).toMatchInlineSnapshot(`
+					"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the versions deploy command.[0m
+
+					  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
+					  the target environment using the \`-e|--env\` flag.
+
+					"
+				`);
+			});
+
+			it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+				writeWranglerConfig({
+					env: {
+						test: {},
+					},
+				});
+
+				await runWrangler(
+					"versions deploy 10000000-0000-0000-0000-000000000000 --yes --env test"
+				);
+
+				expect(consoleStd.warn).toMatchInlineSnapshot(`""`);
+			});
+
+			it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+				writeWranglerConfig();
+
+				await runWrangler(
+					"versions deploy 10000000-0000-0000-0000-000000000000 --yes"
+				);
+
+				expect(consoleStd.warn).toMatchInlineSnapshot(`""`);
+			});
 		});
 	});
 });

--- a/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.deploy.test.ts
@@ -934,6 +934,8 @@ describe("versions deploy", () => {
 
 					  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 					  the target environment using the \`-e|--env\` flag.
+					  If your intention is to use the top-level environment of your configuration simply pass an empty
+					  string to the flag to target such environment.
 
 					"
 				`);

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -237,6 +237,8 @@ describe("versions upload", () => {
 
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
+				  If your intention is to use the top-level environment of your configuration simply pass an empty
+				  string to the flag to target such environment.
 
 				"
 			`);

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -27,7 +27,7 @@ describe("versions upload", () => {
 			http.get(
 				`*/accounts/:accountId/workers/services/:scriptName`,
 				({ params }) => {
-					expect(params.scriptName).toEqual("test-name");
+					expect(params.scriptName).toMatch(/^test-name(-test)?/);
 
 					return HttpResponse.json(
 						createFetchResult({
@@ -66,7 +66,7 @@ describe("versions upload", () => {
 						return HttpResponse.error();
 					}
 
-					expect(params.scriptName).toEqual("test-name");
+					expect(params.scriptName).toMatch(/^test-name(-test)?/);
 
 					return HttpResponse.json(
 						createFetchResult({
@@ -209,6 +209,86 @@ describe("versions upload", () => {
 		`);
 
 		expect(std.info).toContain("Retrying API call after error...");
+	});
+
+	describe("multi-env warning", () => {
+		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
+			mockGetScript();
+			mockUploadVersion(true);
+			mockGetWorkerSubdomain({ enabled: true, previews_enabled: false });
+
+			// Setup
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+				env: {
+					test: {},
+				},
+			});
+			writeWorkerSource();
+			setIsTTY(false);
+
+			const result = runWrangler("versions upload");
+
+			await expect(result).resolves.toBeUndefined();
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mMultiple environments are defined in the Wrangler configuration file, but no target environment was specified for the versions upload command.[0m
+
+				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
+				  the target environment using the \`-e|--env\` flag.
+
+				"
+			`);
+		});
+
+		it("should not warn if the wrangler config contains environments and one was specified in the command", async () => {
+			mockGetScript();
+			mockUploadVersion(true);
+			mockGetWorkerSubdomain({
+				enabled: true,
+				previews_enabled: false,
+				legacyEnv: true,
+				env: "test",
+			});
+
+			// Setup
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+				env: {
+					test: {},
+				},
+			});
+			writeWorkerSource();
+			setIsTTY(false);
+
+			const result = runWrangler("versions upload -e test");
+
+			await expect(result).resolves.toBeUndefined();
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
+
+		it("should not warn if the wrangler config doesn't contain environments and none was specified in the command", async () => {
+			mockGetScript();
+			mockUploadVersion(true);
+			mockGetWorkerSubdomain({ enabled: true, previews_enabled: false });
+
+			// Setup
+			writeWranglerConfig({
+				name: "test-name",
+				main: "./index.js",
+			});
+			writeWorkerSource();
+			setIsTTY(false);
+
+			const result = runWrangler("versions upload");
+
+			await expect(result).resolves.toBeUndefined();
+
+			expect(std.warn).toMatchInlineSnapshot(`""`);
+		});
 	});
 });
 

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -238,7 +238,7 @@ describe("versions upload", () => {
 				  To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify
 				  the target environment using the \`-e|--env\` flag.
 				  If your intention is to use the top-level environment of your configuration simply pass an empty
-				  string to the flag to target such environment.
+				  string to the flag to target such environment. For example \`--env=\\"\\"\`.
 
 				"
 			`);

--- a/packages/wrangler/src/config/config-helpers.ts
+++ b/packages/wrangler/src/config/config-helpers.ts
@@ -123,10 +123,6 @@ function findRedirectedWranglerConfig(
 					Found both a user configuration file at "${path.relative(".", userConfigPath)}"
 					and a deploy configuration file at "${path.relative(".", deployConfigPath)}".
 					But these do not share the same base path so it is not clear which should be used.
-
-
-					===a= ${path.join(path.dirname(userConfigPath), PATH_TO_DEPLOY_CONFIG)}
-					===b= ${deployConfigPath}
 				`);
 			}
 		}

--- a/packages/wrangler/src/config/config-helpers.ts
+++ b/packages/wrangler/src/config/config-helpers.ts
@@ -123,6 +123,10 @@ function findRedirectedWranglerConfig(
 					Found both a user configuration file at "${path.relative(".", userConfigPath)}"
 					and a deploy configuration file at "${path.relative(".", deployConfigPath)}".
 					But these do not share the same base path so it is not clear which should be used.
+
+
+					===a= ${path.join(path.dirname(userConfigPath), PATH_TO_DEPLOY_CONFIG)}
+					===b= ${deployConfigPath}
 				`);
 			}
 		}

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -178,11 +178,13 @@ export function normalizeAndValidateConfig(
 
 	//TODO: find a better way to define the type of Args that can be passed to the normalizeAndValidateConfig()
 	const envName = args.env;
-	assert(envName === undefined || typeof envName === "string");
+	assert(
+		envName === undefined || envName === "" || typeof envName === "string"
+	);
 
 	let activeEnv = topLevelEnv;
 
-	if (envName !== undefined) {
+	if (envName) {
 		if (isRedirectedConfig) {
 			// Note: we error if the user is specifying an environment, but not for pages
 			//       commands where the environment is always set (to either "preview" or "production")

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -178,9 +178,7 @@ export function normalizeAndValidateConfig(
 
 	//TODO: find a better way to define the type of Args that can be passed to the normalizeAndValidateConfig()
 	const envName = args.env;
-	assert(
-		envName === undefined || envName === "" || typeof envName === "string"
-	);
+	assert(envName === undefined || typeof envName === "string");
 
 	let activeEnv = topLevelEnv;
 

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -169,7 +169,7 @@ function createHandler(def: CommandDefinition, commandName: string) {
 						: defaultWranglerConfig;
 
 				if (def.behaviour?.warnIfMultipleEnvsConfiguredButNoneSpecified) {
-					if (!args.env && config.configPath) {
+					if (!("env" in args) && config.configPath) {
 						const { rawConfig } = experimental_readRawConfig(
 							{
 								config: config.configPath,
@@ -182,6 +182,7 @@ function createHandler(def: CommandDefinition, commandName: string) {
 								dedent`
 										Multiple environments are defined in the Wrangler configuration file, but no target environment was specified for the ${commandName.replace(/^wrangler\s+/, "")} command.
 										To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify the target environment using the \`-e|--env\` flag.
+										If your intention is to use the top-level environment of your configuration simply pass an empty string to the flag to target such environment.
 									`
 							);
 						}

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -2,7 +2,6 @@ import chalk from "chalk";
 import { fetchResult } from "../cfetch";
 import { experimental_readRawConfig, readConfig } from "../config";
 import { defaultWranglerConfig } from "../config/config";
-import { findWranglerConfig } from "../config/config-helpers";
 import { FatalError, UserError } from "../errors";
 import { run } from "../experimental-flags";
 import { logger } from "../logger";

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -170,14 +170,10 @@ function createHandler(def: CommandDefinition) {
 						: defaultWranglerConfig;
 
 				if (def.behaviour?.warnIfMultipleEnvsConfiguredButNoneSpecified) {
-					if (!args.env) {
-						const { configPath } = findWranglerConfig(process.cwd(), {
-							useRedirectIfAvailable: true,
-						});
-
+					if (!args.env && config.configPath) {
 						const { rawConfig } = experimental_readRawConfig(
 							{
-								config: configPath,
+								config: config.configPath,
 							},
 							{ hideWarnings: true }
 						);

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -90,12 +90,12 @@ export function createRegisterYargsCommand(
 				registerSubTreeCallback();
 			},
 			// Only attach the handler for commands, not namespaces
-			def.type === "command" ? createHandler(def) : undefined
+			def.type === "command" ? createHandler(def, def.command) : undefined
 		);
 	};
 }
 
-function createHandler(def: CommandDefinition) {
+function createHandler(def: CommandDefinition, commandName: string) {
 	return async function handler(args: HandlerArgs<NamedArgDefinitions>) {
 		// eslint-disable-next-line no-useless-catch
 		try {
@@ -180,7 +180,7 @@ function createHandler(def: CommandDefinition) {
 						if (availableEnvs.length > 0) {
 							logger.warn(
 								dedent`
-										Multiple environments are defined in the Wrangler configuration file, but no target environment was specified for the${def.metadata.displayName ? ` ${def.metadata.displayName}` : ""} command.
+										Multiple environments are defined in the Wrangler configuration file, but no target environment was specified for the ${commandName.replace(/^wrangler\s+/, "")} command.
 										To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify the target environment using the \`-e|--env\` flag.
 									`
 							);

--- a/packages/wrangler/src/core/register-yargs-command.ts
+++ b/packages/wrangler/src/core/register-yargs-command.ts
@@ -182,7 +182,7 @@ function createHandler(def: CommandDefinition, commandName: string) {
 								dedent`
 										Multiple environments are defined in the Wrangler configuration file, but no target environment was specified for the ${commandName.replace(/^wrangler\s+/, "")} command.
 										To avoid unintentional changes to the wrong environment, it is recommended to explicitly specify the target environment using the \`-e|--env\` flag.
-										If your intention is to use the top-level environment of your configuration simply pass an empty string to the flag to target such environment.
+										If your intention is to use the top-level environment of your configuration simply pass an empty string to the flag to target such environment. For example \`--env=""\`.
 									`
 							);
 						}

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -21,8 +21,6 @@ export type DeepFlatten<T> = T extends object
 
 export type Command = `wrangler${string}`;
 export type Metadata = {
-	/** The name of the command to be used for logs */
-	displayName?: string;
 	description: string;
 	status: "experimental" | "alpha" | "private-beta" | "open-beta" | "stable";
 	statusMessage?: string;

--- a/packages/wrangler/src/core/types.ts
+++ b/packages/wrangler/src/core/types.ts
@@ -21,6 +21,8 @@ export type DeepFlatten<T> = T extends object
 
 export type Command = `wrangler${string}`;
 export type Metadata = {
+	/** The name of the command to be used for logs */
+	displayName?: string;
 	description: string;
 	status: "experimental" | "alpha" | "private-beta" | "open-beta" | "stable";
 	statusMessage?: string;
@@ -135,6 +137,12 @@ export type CommandDefinition<
 		printResourceLocation?:
 			| ((args?: HandlerArgs<NamedArgDefs>) => boolean)
 			| boolean;
+
+		/**
+		 * If true, check for environments in the wrangler config, if there are some and the user hasn't specified an environment
+		 * using the `-e|--env` cli flag, show a warning suggesting that one should instead be specified.
+		 */
+		warnIfMultipleEnvsConfiguredButNoneSpecified?: boolean;
 	};
 
 	/**

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -20,6 +20,7 @@ import deploy from "./deploy";
 
 export const deployCommand = createCommand({
 	metadata: {
+		displayName: "deploy",
 		description: "🆙 Deploy a Worker to Cloudflare",
 		owner: "Workers: Deploy and Config",
 		status: "stable",
@@ -222,6 +223,7 @@ export const deployCommand = createCommand({
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
 			MIXED_MODE: false,
 		}),
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 	validateArgs(args) {
 		if (args.nodeCompat) {

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -20,7 +20,6 @@ import deploy from "./deploy";
 
 export const deployCommand = createCommand({
 	metadata: {
-		displayName: "deploy",
 		description: "🆙 Deploy a Worker to Cloudflare",
 		owner: "Workers: Deploy and Config",
 		status: "stable",

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -137,11 +137,15 @@ export const secretNamespace = createNamespace({
 });
 export const secretPutCommand = createCommand({
 	metadata: {
+		displayName: "secret put",
 		description: "Create or update a secret variable for a Worker",
 		status: "stable",
 		owner: "Workers: Deploy and Config",
 	},
 	positionalArgs: ["key"],
+	behaviour: {
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+	},
 	args: {
 		key: {
 			describe: "The variable name to be accessible in the Worker",
@@ -250,11 +254,15 @@ export const secretPutCommand = createCommand({
 
 export const secretDeleteCommand = createCommand({
 	metadata: {
+		displayName: "secret delete",
 		description: "Delete a secret variable from a Worker",
 		status: "stable",
 		owner: "Workers: Deploy and Config",
 	},
 	positionalArgs: ["key"],
+	behaviour: {
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+	},
 	args: {
 		key: {
 			describe: "The variable name to be accessible in the Worker",
@@ -386,11 +394,15 @@ export const secretListCommand = createCommand({
 
 export const secretBulkCommand = createCommand({
 	metadata: {
+		displayName: "secret bulk",
 		description: "Bulk upload secrets for a Worker",
 		status: "stable",
 		owner: "Workers: Deploy and Config",
 	},
 	positionalArgs: ["file"],
+	behaviour: {
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
+	},
 	args: {
 		file: {
 			describe: `The file of key-value pairs to upload, as JSON in form {"key": value, ...} or .dev.vars file in the form KEY=VALUE`,

--- a/packages/wrangler/src/secret/index.ts
+++ b/packages/wrangler/src/secret/index.ts
@@ -137,7 +137,6 @@ export const secretNamespace = createNamespace({
 });
 export const secretPutCommand = createCommand({
 	metadata: {
-		displayName: "secret put",
 		description: "Create or update a secret variable for a Worker",
 		status: "stable",
 		owner: "Workers: Deploy and Config",
@@ -254,7 +253,6 @@ export const secretPutCommand = createCommand({
 
 export const secretDeleteCommand = createCommand({
 	metadata: {
-		displayName: "secret delete",
 		description: "Delete a secret variable from a Worker",
 		status: "stable",
 		owner: "Workers: Deploy and Config",
@@ -394,7 +392,6 @@ export const secretListCommand = createCommand({
 
 export const secretBulkCommand = createCommand({
 	metadata: {
-		displayName: "secret bulk",
 		description: "Bulk upload secrets for a Worker",
 		status: "stable",
 		owner: "Workers: Deploy and Config",

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -15,7 +15,6 @@ export const triggersNamespace = createNamespace({
 });
 export const triggersDeployCommand = createCommand({
 	metadata: {
-		displayName: "triggers deploy",
 		description: "Updates the triggers of your current deployment",
 		status: "experimental",
 		owner: "Workers: Authoring and Testing",

--- a/packages/wrangler/src/triggers/index.ts
+++ b/packages/wrangler/src/triggers/index.ts
@@ -15,6 +15,7 @@ export const triggersNamespace = createNamespace({
 });
 export const triggersDeployCommand = createCommand({
 	metadata: {
+		displayName: "triggers deploy",
 		description: "Updates the triggers of your current deployment",
 		status: "experimental",
 		owner: "Workers: Authoring and Testing",
@@ -48,6 +49,9 @@ export const triggersDeployCommand = createCommand({
 			describe: "Use legacy environments",
 			hidden: true,
 		},
+	},
+	behaviour: {
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 	async handler(args, { config }) {
 		const assetsOptions = getAssetsOptions({ assets: undefined }, config);

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -42,6 +42,7 @@ type OptionalPercentage = number | null; // null means automatically assign (eve
 
 export const versionsDeployCommand = createCommand({
 	metadata: {
+		displayName: "versions deploy",
 		description:
 			"Safely roll out new Versions of your Worker by splitting traffic between multiple Versions",
 		owner: "Workers: Authoring and Testing",
@@ -49,6 +50,7 @@ export const versionsDeployCommand = createCommand({
 	},
 	behaviour: {
 		useConfigRedirectIfAvailable: true,
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 
 	args: {

--- a/packages/wrangler/src/versions/deploy.ts
+++ b/packages/wrangler/src/versions/deploy.ts
@@ -42,7 +42,6 @@ type OptionalPercentage = number | null; // null means automatically assign (eve
 
 export const versionsDeployCommand = createCommand({
 	metadata: {
-		displayName: "versions deploy",
 		description:
 			"Safely roll out new Versions of your Worker by splitting traffic between multiple Versions",
 		owner: "Workers: Authoring and Testing",

--- a/packages/wrangler/src/versions/secrets/bulk.ts
+++ b/packages/wrangler/src/versions/secrets/bulk.ts
@@ -11,12 +11,14 @@ import type { WorkerVersion } from "./index";
 
 export const versionsSecretBulkCommand = createCommand({
 	metadata: {
+		displayName: "versions secret bulk",
 		description: "Create or update a secret variable for a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
 	},
 	behaviour: {
 		printConfigWarnings: false,
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 	args: {
 		file: {

--- a/packages/wrangler/src/versions/secrets/bulk.ts
+++ b/packages/wrangler/src/versions/secrets/bulk.ts
@@ -11,7 +11,6 @@ import type { WorkerVersion } from "./index";
 
 export const versionsSecretBulkCommand = createCommand({
 	metadata: {
-		displayName: "versions secret bulk",
 		description: "Create or update a secret variable for a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",

--- a/packages/wrangler/src/versions/secrets/delete.ts
+++ b/packages/wrangler/src/versions/secrets/delete.ts
@@ -12,12 +12,14 @@ import type { VersionDetails, WorkerVersion } from "./index";
 
 export const versionsSecretDeleteCommand = createCommand({
 	metadata: {
+		displayName: "versions secret delete",
 		description: "Delete a secret variable from a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
 	},
 	behaviour: {
 		printConfigWarnings: false,
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 	args: {
 		key: {

--- a/packages/wrangler/src/versions/secrets/delete.ts
+++ b/packages/wrangler/src/versions/secrets/delete.ts
@@ -12,7 +12,6 @@ import type { VersionDetails, WorkerVersion } from "./index";
 
 export const versionsSecretDeleteCommand = createCommand({
 	metadata: {
-		displayName: "versions secret delete",
 		description: "Delete a secret variable from a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",

--- a/packages/wrangler/src/versions/secrets/put.ts
+++ b/packages/wrangler/src/versions/secrets/put.ts
@@ -12,12 +12,14 @@ import type { WorkerVersion } from "./index";
 
 export const versionsSecretPutCommand = createCommand({
 	metadata: {
+		displayName: "versions secret put",
 		description: "Create or update a secret variable for a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
 	},
 	behaviour: {
 		printConfigWarnings: false,
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 	args: {
 		key: {

--- a/packages/wrangler/src/versions/secrets/put.ts
+++ b/packages/wrangler/src/versions/secrets/put.ts
@@ -12,7 +12,6 @@ import type { WorkerVersion } from "./index";
 
 export const versionsSecretPutCommand = createCommand({
 	metadata: {
-		displayName: "versions secret put",
 		description: "Create or update a secret variable for a Worker",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -101,7 +101,6 @@ type Props = {
 
 export const versionsUploadCommand = createCommand({
 	metadata: {
-		displayName: "versions upload",
 		description: "Uploads your Worker code and config as a new Version",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -101,6 +101,7 @@ type Props = {
 
 export const versionsUploadCommand = createCommand({
 	metadata: {
+		displayName: "versions upload",
 		description: "Uploads your Worker code and config as a new Version",
 		owner: "Workers: Authoring and Testing",
 		status: "stable",
@@ -266,6 +267,7 @@ export const versionsUploadCommand = createCommand({
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
 			MIXED_MODE: false,
 		}),
+		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},
 	handler: async function versionsUploadHandler(args, { config }) {
 		const entry = await getEntry(args, config, "versions upload");


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1785.

add warning about env not specified to potentially risky wrangler commands (for more details check the changeset)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: DX improvement
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: this change can't easily be backported, so I think that not doing so here is valid, I'm happy to reconsider if someone disagrees[^1]

[^1]: The main issue is that this change is built upon the changes made in https://github.com/cloudflare/workers-sdk/pull/8966 (where `createCommand` is being introduced for the various commands) which is not backported, so potentially a different solution would need to be implemented for this in order to do a v3 backport
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
