### PR TITLE
Improve wrapped bindings UI

### DIFF
--- a/.changeset/small-toes-give.md
+++ b/.changeset/small-toes-give.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Improve binding display on narrower terminals

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -174,6 +174,7 @@ async function resolveBindings(
 			local: !input.dev?.remote,
 			imagesLocalMode: input.dev?.imagesLocalMode,
 			name: config.name,
+			vectorizeBindToProd: input.dev?.bindVectorizeToProd,
 		}
 	);
 

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -573,41 +573,46 @@ export function printBindings(
 			maxValueLength +
 			")".length;
 
+		const columnGapSpaces = 6;
+		const columnGapSpacesWrapped = 4;
+
 		const shouldWrap =
-			bindingLength + 6 + maxTypeLength + 6 + maxModeLength >=
+			bindingLength +
+				columnGapSpaces +
+				maxTypeLength +
+				columnGapSpaces +
+				maxModeLength >=
 			process.stdout.columns;
 
 		logger.log(title);
-		if (shouldWrap) {
-			logger.log(
-				`${padEndAnsi(
-					dim("Binding"),
-					bindingPrefix.length + maxNameLength
-				)}    ${padEndAnsi(dim("Resource"), maxTypeLength)}    ${hasMode ? dim("Mode") : ""}`
-			);
-		} else {
-			logger.log(
-				`${padEndAnsi(dim("Binding"), bindingLength)}      ${padEndAnsi(dim("Resource"), maxTypeLength)}      ${hasMode ? dim("Mode") : ""}`
-			);
-		}
+		const columnGap = shouldWrap
+			? " ".repeat(columnGapSpacesWrapped)
+			: " ".repeat(columnGapSpaces);
+
+		logger.log(
+			`${padEndAnsi(dim("Binding"), shouldWrap ? bindingPrefix.length + maxNameLength : bindingLength)}${columnGap}${padEndAnsi(dim("Resource"), maxTypeLength)}${columnGap}${hasMode ? dim("Mode") : ""}`
+		);
+
 		for (const binding of output) {
-			if (shouldWrap) {
-				const bindingString = padEndAnsi(
-					`${white(`env.${binding.name}`)}`,
-					bindingPrefix.length + maxNameLength
-				);
-				logger.log(
-					`${bindingString}    ${brandColor(binding.type.padEnd(maxTypeLength))}    ${hasMode ? binding.mode : ""}${binding.value ? `\n  ${dim(truncate(typeof binding.value === "symbol" ? chalk.italic("inherited") : binding.value ?? "", process.stdout.columns - 2))}` : ""}`
-				);
-			} else {
-				const bindingString = padEndAnsi(
-					`${white(`env.${binding.name}`)}${binding.value ? ` (${dim(typeof binding.value === "symbol" ? chalk.italic("inherited") : binding.value ?? "")})` : ""}`,
-					bindingLength
-				);
-				logger.log(
-					`${bindingString}      ${brandColor(binding.type.padEnd(maxTypeLength))}      ${hasMode ? binding.mode : ""}`
-				);
-			}
+			const bindingValue = dim(
+				typeof binding.value === "symbol"
+					? chalk.italic("inherited")
+					: binding.value ?? ""
+			);
+			const bindingString = padEndAnsi(
+				`${white(`env.${binding.name}`)}${binding.value && !shouldWrap ? ` (${bindingValue})` : ""}`,
+				shouldWrap ? bindingPrefix.length + maxNameLength : bindingLength
+			);
+
+			const suffix = shouldWrap
+				? binding.value
+					? `\n  ${bindingValue}`
+					: ""
+				: "";
+
+			logger.log(
+				`${bindingString}${columnGap}${brandColor(binding.type.padEnd(maxTypeLength))}${columnGap}${hasMode ? binding.mode : ""}${suffix}`
+			);
 		}
 		logger.log();
 	}


### PR DESCRIPTION
Followup to #9335 to improve the display when the terminal is small enough to require wrapping. Additionally, correctly label Vectorive bindings as `not supported`/`remote` depending on the flags provided.

<img width="410" alt="Screenshot 2025-05-23 at 09 21 11" src="https://github.com/user-attachments/assets/4f050c8f-3bdb-42f3-affe-233d0c0d8de4" />


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: should be tested manually
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: small ui change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: change to a v4-only feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
