### PR TITLE
Don't crash Vitest when started with a non-existent tail consumer

### DIFF
--- a/.changeset/warm-dingos-lay.md
+++ b/.changeset/warm-dingos-lay.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+Don't crash Vitest when started with a non-existent tail consumer

--- a/fixtures/vitest-pool-workers-examples/multiple-workers/api-service/wrangler.jsonc
+++ b/fixtures/vitest-pool-workers-examples/multiple-workers/api-service/wrangler.jsonc
@@ -12,4 +12,8 @@
 			"service": "database-service",
 		},
 	],
+	"tail_consumers": [
+		{ "service": "this-tail-does-not-exist" },
+		{ "service": "tail-consumer" },
+	],
 }

--- a/fixtures/vitest-pool-workers-examples/multiple-workers/vitest.config.ts
+++ b/fixtures/vitest-pool-workers-examples/multiple-workers/vitest.config.ts
@@ -94,6 +94,23 @@ export default defineWorkersProject({
 							compatibilityFlags: ["nodejs_compat"],
 							kvNamespaces: ["KV_NAMESPACE"],
 						},
+						{
+							name: "tail-consumer",
+							modules: [
+								{
+									path: "index.js",
+									type: "ESModule",
+									contents: /* javascript */ `
+										export default {
+											tail(event) {
+											console.log("tail event received")
+											}
+										}
+										`,
+								},
+							],
+							compatibilityDate: "2024-01-01",
+						},
 					],
 				},
 			},


### PR DESCRIPTION
Fixes #9343 

Apply https://github.com/cloudflare/workers-sdk/pull/9115 to the Vitest integration. This is a bit hacky—once the dev registry is landed and stable in Miniflare I expect we can inject a not found external service for this. cc @edmundhung 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by fixture tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: bugfix to v4 only feature (tail consumer in local dev)

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
