### PR TITLE
refactor: do not hardcode a package manager

### DIFF
--- a/packages/wrangler/src/type-generation/runtime/log-runtime-types-message.ts
+++ b/packages/wrangler/src/type-generation/runtime/log-runtime-types-message.ts
@@ -56,7 +56,7 @@ export function logRuntimeTypesMessage(
 		logAction("Install @types/node");
 		logger.log(
 			chalk.dim(
-				`Since you have the \`nodejs_compat\` flag, you should install Node.js types by running "npm i --save-dev @types/node".`
+				"Since you have the `nodejs_compat` flag, you should install Node.js types (`@types/node`)"
 			)
 		);
 		logger.log("");


### PR DESCRIPTION
Support minor PR but I did copy paste `npm i ...` while I'm not using npm. So I think it's better no to specify a package manager.

Note: we could sniff the pm (there is code for that) and display the appropriate command but I feel like it would be overkill here?

![image](https://github.com/user-attachments/assets/27c0eede-67f3-4382-b1be-766d1a1afe14)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: tested locally
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not applicable
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: message update

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
