### PR TITLE
fix: wrangler types should default to default entrypoint for service bindings

### DIFF
--- a/.changeset/wise-bananas-grow.md
+++ b/.changeset/wise-bananas-grow.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: wrangler types should assume default entrypoint for service bindings if not otherwise specified

--- a/packages/wrangler/src/__tests__/type-generation.test.ts
+++ b/packages/wrangler/src/__tests__/type-generation.test.ts
@@ -692,7 +692,7 @@ describe("generate types", () => {
 					R2_BUCKET_BINDING: R2Bucket;
 					D1_TESTING_SOMETHING: D1Database;
 					SECRET: SecretsStoreSecret;
-					SERVICE_BINDING: Fetcher /* service_name */;
+					SERVICE_BINDING: Service<import(\\"../b/index\\").default>;
 					OTHER_SERVICE_BINDING: Service /* entrypoint FakeEntrypoint from service_name_2 */;
 					OTHER_SERVICE_BINDING_ENTRYPOINT: Service<import(\\"../c/index\\").RealEntrypoint>;
 					AE_DATASET_BINDING: AnalyticsEngineDataset;

--- a/packages/wrangler/src/deployment-bundle/entry.ts
+++ b/packages/wrangler/src/deployment-bundle/entry.ts
@@ -6,9 +6,9 @@ import { sniffUserAgent } from "../package-manager";
 import guessWorkerFormat from "./guess-worker-format";
 import {
 	resolveEntryWithAssets,
-	resolveEntryWithEntryPoint,
 	resolveEntryWithMain,
 	resolveEntryWithScript,
+	resolveEntryWithSiteEntryPoint,
 } from "./resolve-entry";
 import { runCustomBuild } from "./run-custom-build";
 import type { Config, RawConfig } from "../config";
@@ -52,8 +52,7 @@ export async function getEntry(
 	config: Config,
 	command: "dev" | "deploy" | "versions upload" | "types"
 ): Promise<Entry> {
-	const entryPoint = config.site?.["entry-point"];
-
+	const site_entrypoint = config.site?.["entry-point"];
 	let paths:
 		| { absolutePath: string; relativePath: string; projectRoot?: string }
 		| undefined;
@@ -62,8 +61,8 @@ export async function getEntry(
 		paths = resolveEntryWithScript(args.script);
 	} else if (config.main !== undefined) {
 		paths = resolveEntryWithMain(config.main, config);
-	} else if (entryPoint) {
-		paths = resolveEntryWithEntryPoint(entryPoint, config);
+	} else if (site_entrypoint) {
+		paths = resolveEntryWithSiteEntryPoint(site_entrypoint, config);
 	} else if (args.assets || config.assets) {
 		paths = resolveEntryWithAssets();
 	} else {

--- a/packages/wrangler/src/deployment-bundle/resolve-entry.ts
+++ b/packages/wrangler/src/deployment-bundle/resolve-entry.ts
@@ -29,7 +29,7 @@ export function resolveEntryWithMain(
 	return { absolutePath, relativePath, projectRoot };
 }
 
-export function resolveEntryWithEntryPoint(
+export function resolveEntryWithSiteEntryPoint(
 	entryPoint: string,
 	config: Config
 ): {

--- a/packages/wrangler/src/type-generation/index.ts
+++ b/packages/wrangler/src/type-generation/index.ts
@@ -454,7 +454,7 @@ export async function generateEnvTypes(
 				: undefined;
 
 			const exportExists = serviceEntry?.exports?.some(
-				(e) => e === service.entrypoint
+				(e) => e === (service.entrypoint ?? "default")
 			);
 
 			let typeName: string;


### PR DESCRIPTION
Fixes n/a

When providing wrangler types with multiple config files to correctly type service bindings, you currently have to add 'entrypoint: default' to the service binding config, even though this is implicit everywhere else. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: feature didn't exist in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
