### PR TITLE
Support Node.js style custom handlers for service bindings and outbound services

### DIFF
--- a/.changeset/yummy-pillows-send.md
+++ b/.changeset/yummy-pillows-send.md
@@ -1,0 +1,17 @@
+---
+"miniflare": minor
+---
+
+Add support for Node.js style custom handlers for service bindings and outbound services. This makes it easier to integrate Miniflare with existing Node.js middleware and libraries as `req` and `res` objects can be used directly.
+
+```js
+new Miniflare({
+	serviceBindings: {
+		CUSTOM: {
+			node: (req, res) => {
+				res.end(`Hello world`);
+			},
+		},
+	},
+});
+```

--- a/packages/miniflare/README.md
+++ b/packages/miniflare/README.md
@@ -328,7 +328,7 @@ parameter in module format Workers.
   Record mapping binding name to paths containing arbitrary binary data to
   inject as `ArrayBuffer` bindings into this Worker.
 
-- `serviceBindings?: Record<string, string | typeof kCurrentWorker | { name: string | typeof kCurrentWorker, entrypoint?: string } | { network: Network } | { external: ExternalServer } | { disk: DiskDirectory } | (request: Request, instance: Miniflare) => Awaitable<Response>>`
+- `serviceBindings?: Record<string, string | typeof kCurrentWorker | { name: string | typeof kCurrentWorker, entrypoint?: string } | { network: Network } | { external: ExternalServer } | { disk: DiskDirectory } | { node: (req: http.IncomingMessage, res: http.ServerResponse, miniflare: Miniflare) => Awaitable<void> } | (request: Request, miniflare: Miniflare) => Awaitable<Response>>`
 
   Record mapping binding name to service designators to inject as
   `{ fetch: typeof fetch }`
@@ -358,9 +358,10 @@ parameter in module format Workers.
     [`workerd` `DiskDirectory` struct](https://github.com/cloudflare/workerd/blob/bdbd6075c7c53948050c52d22f2dfa37bf376253/src/workerd/server/workerd.capnp#L600-L643),
     requests will be dispatched to an HTTP service backed by an on-disk
     directory.
-  - If the designator is a function, requests will be dispatched to your custom
-    handler. This allows you to access data and functions defined in Node.js
-    from your Worker. Note `instance` will be the `Miniflare` instance
+  - If the designator is an object of the form `{ node: (req: http.IncomingMessage, res: http.ServerResponse, miniflare: Miniflare) => Awaitable<void> }`, requests will be dispatched to your custom Node handler. This allows you to access data and functions defined in Node.js from your Worker using Node.js `req` and `res` objects. Note, `miniflare` will be the `Miniflare` instance dispatching the request.
+  - If the designator is a function with the signature `(request: Request, miniflare: Miniflare) => Response`, requests will be dispatched to your custom
+    fetch handler. This allows you to access data and functions defined in Node.js
+    from your Worker using fetch `Request` and `Response` objects. Note, `miniflare` will be the `Miniflare` instance
     dispatching the request.
 
 <!--prettier-ignore-start-->
@@ -471,7 +472,7 @@ parameter in module format Workers.
 
 <!--prettier-ignore-end-->
 
-- `outboundService?: string | { network: Network } | { external: ExternalServer } | { disk: DiskDirectory } | (request: Request) => Awaitable<Response>`
+- `outboundService?: string | { network: Network } | { external: ExternalServer } | { disk: DiskDirectory } | { node: (req: http.IncomingMessage, res: http.ServerResponse, miniflare: Miniflare) => Awaitable<void> } | (request: Request, miniflare: Miniflare) => Awaitable<Response>`
 
   Dispatch this Worker's global `fetch()` and `connect()` requests to the
   configured service. Service designators follow the same rules above for

--- a/packages/miniflare/src/plugins/core/constants.ts
+++ b/packages/miniflare/src/plugins/core/constants.ts
@@ -7,7 +7,9 @@ const SERVICE_USER_PREFIX = `${CORE_PLUGIN_NAME}:user`;
 // Service prefix for `workerd`'s builtin services (network, external, disk)
 const SERVICE_BUILTIN_PREFIX = `${CORE_PLUGIN_NAME}:builtin`;
 // Service prefix for custom fetch functions defined in `serviceBindings` option
-const SERVICE_CUSTOM_PREFIX = `${CORE_PLUGIN_NAME}:custom`;
+const SERVICE_CUSTOM_FETCH_PREFIX = `${CORE_PLUGIN_NAME}:custom-fetch`;
+// Service prefix for custom Node functions defined in `serviceBindings` option
+const SERVICE_CUSTOM_NODE_PREFIX = `${CORE_PLUGIN_NAME}:custom-node`;
 
 export function getUserServiceName(workerName = "") {
 	return `${SERVICE_USER_PREFIX}:${workerName}`;
@@ -30,10 +32,18 @@ export function getBuiltinServiceName(
 	return `${SERVICE_BUILTIN_PREFIX}:${workerIndex}:${kind}${bindingName}`;
 }
 
-export function getCustomServiceName(
+export function getCustomFetchServiceName(
 	workerIndex: number,
 	kind: CustomServiceKind,
 	bindingName: string
 ) {
-	return `${SERVICE_CUSTOM_PREFIX}:${workerIndex}:${kind}${bindingName}`;
+	return `${SERVICE_CUSTOM_FETCH_PREFIX}:${workerIndex}:${kind}${bindingName}`;
+}
+
+export function getCustomNodeServiceName(
+	workerIndex: number,
+	kind: CustomServiceKind,
+	bindingName: string
+) {
+	return `${SERVICE_CUSTOM_NODE_PREFIX}:${workerIndex}:${kind}${bindingName}`;
 }

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -50,7 +50,8 @@ import {
 	CUSTOM_SERVICE_KNOWN_OUTBOUND,
 	CustomServiceKind,
 	getBuiltinServiceName,
-	getCustomServiceName,
+	getCustomFetchServiceName,
+	getCustomNodeServiceName,
 	getUserServiceName,
 	SERVICE_ENTRY,
 } from "./constants";
@@ -64,9 +65,9 @@ import {
 } from "./modules";
 import { PROXY_SECRET } from "./proxy";
 import {
+	CustomFetchServiceSchema,
 	kCurrentWorker,
 	ServiceDesignatorSchema,
-	ServiceFetchSchema,
 } from "./services";
 
 // `workerd`'s `trustBrowserCas` should probably be named `trustSystemCas`.
@@ -219,7 +220,7 @@ export const CoreSharedOptionsSchema = z.object({
 	// passed in a header to prove that the request came from the proxy and not
 	// some malicious attacker.
 	unsafeProxySharedSecret: z.string().optional(),
-	unsafeModuleFallbackService: ServiceFetchSchema.optional(),
+	unsafeModuleFallbackService: CustomFetchServiceSchema.optional(),
 	// Keep blobs when deleting/overwriting keys, required for stacked storage
 	unsafeStickyBlobs: z.boolean().optional(),
 	// Enable directly triggering user Worker handlers with paths like `/cdn-cgi/handler/scheduled`
@@ -254,9 +255,16 @@ const LIVE_RELOAD_SCRIPT_TEMPLATE = (
 })();
 </script>`;
 
-export const SCRIPT_CUSTOM_SERVICE = `addEventListener("fetch", (event) => {
+export const SCRIPT_CUSTOM_FETCH_SERVICE = `addEventListener("fetch", (event) => {
   const request = new Request(event.request);
-  request.headers.set("${CoreHeaders.CUSTOM_SERVICE}", ${CoreBindings.TEXT_CUSTOM_SERVICE});
+  request.headers.set("${CoreHeaders.CUSTOM_FETCH_SERVICE}", ${CoreBindings.TEXT_CUSTOM_SERVICE});
+  request.headers.set("${CoreHeaders.ORIGINAL_URL}", request.url);
+  event.respondWith(${CoreBindings.SERVICE_LOOPBACK}.fetch(request));
+})`;
+
+export const SCRIPT_CUSTOM_NODE_SERVICE = `addEventListener("fetch", (event) => {
+  const request = new Request(event.request);
+  request.headers.set("${CoreHeaders.CUSTOM_NODE_SERVICE}", ${CoreBindings.TEXT_CUSTOM_SERVICE});
   request.headers.set("${CoreHeaders.ORIGINAL_URL}", request.url);
   event.respondWith(${CoreBindings.SERVICE_LOOPBACK}.fetch(request));
 })`;
@@ -274,9 +282,11 @@ function getCustomServiceDesignator(
 	let props: { json: string } | undefined;
 	if (typeof service === "function") {
 		// Custom `fetch` function
-		serviceName = getCustomServiceName(workerIndex, kind, name);
+		serviceName = getCustomFetchServiceName(workerIndex, kind, name);
 	} else if (typeof service === "object") {
-		if ("mixedModeConnectionString" in service) {
+		if ("node" in service) {
+			serviceName = getCustomNodeServiceName(workerIndex, kind, name);
+		} else if ("mixedModeConnectionString" in service) {
 			assert("name" in service && typeof service.name === "string");
 			serviceName = `${CORE_PLUGIN_NAME}:mixed-mode-service:${workerIndex}:${name}`;
 		}
@@ -318,9 +328,25 @@ function maybeGetCustomServiceService(
 	if (typeof service === "function") {
 		// Custom `fetch` function
 		return {
-			name: getCustomServiceName(workerIndex, kind, name),
+			name: getCustomFetchServiceName(workerIndex, kind, name),
 			worker: {
-				serviceWorkerScript: SCRIPT_CUSTOM_SERVICE,
+				serviceWorkerScript: SCRIPT_CUSTOM_FETCH_SERVICE,
+				compatibilityDate: "2022-09-01",
+				bindings: [
+					{
+						name: CoreBindings.TEXT_CUSTOM_SERVICE,
+						text: `${workerIndex}/${kind}${name}`,
+					},
+					WORKER_BINDING_SERVICE_LOOPBACK,
+				],
+			},
+		};
+	} else if (typeof service === "object" && "node" in service) {
+		// Custom Node.js style handler
+		return {
+			name: getCustomNodeServiceName(workerIndex, kind, name),
+			worker: {
+				serviceWorkerScript: SCRIPT_CUSTOM_NODE_SERVICE,
 				compatibilityDate: "2022-09-01",
 				bindings: [
 					{

--- a/packages/miniflare/src/plugins/core/services.ts
+++ b/packages/miniflare/src/plugins/core/services.ts
@@ -11,7 +11,7 @@ import {
 	TlsOptions_Version,
 } from "../../runtime";
 import type { Awaitable } from "../../workers";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type * as http from "node:http";
 
 // Zod validators for types in runtime/config/workerd.ts.
 // All options should be optional except where specifically stated.
@@ -86,11 +86,15 @@ const DiskDirectorySchema = z.object({
 });
 
 const CustomNodeServiceSchema = z.custom<
-	(req: IncomingMessage, res: ServerResponse, mf: Miniflare) => Awaitable<void>
+	(
+		req: http.IncomingMessage,
+		res: http.ServerResponse,
+		miniflare: Miniflare
+	) => Awaitable<void>
 >((v) => typeof v === "function");
 
 export const CustomFetchServiceSchema = z.custom<
-	(request: Request, mf: Miniflare) => Awaitable<Response>
+	(request: Request, miniflare: Miniflare) => Awaitable<Response>
 >((v) => typeof v === "function");
 
 export const ServiceDesignatorSchema = z.union([

--- a/packages/miniflare/src/plugins/core/services.ts
+++ b/packages/miniflare/src/plugins/core/services.ts
@@ -11,6 +11,7 @@ import {
 	TlsOptions_Version,
 } from "../../runtime";
 import type { Awaitable } from "../../workers";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 // Zod validators for types in runtime/config/workerd.ts.
 // All options should be optional except where specifically stated.
@@ -84,7 +85,11 @@ const DiskDirectorySchema = z.object({
 	writable: z.oboolean(),
 });
 
-export const ServiceFetchSchema = z.custom<
+const CustomNodeServiceSchema = z.custom<
+	(req: IncomingMessage, res: ServerResponse, mf: Miniflare) => Awaitable<void>
+>((v) => typeof v === "function");
+
+export const CustomFetchServiceSchema = z.custom<
 	(request: Request, mf: Miniflare) => Awaitable<Response>
 >((v) => typeof v === "function");
 
@@ -100,5 +105,6 @@ export const ServiceDesignatorSchema = z.union([
 	z.object({ network: NetworkSchema }),
 	z.object({ external: ExternalServerSchema }),
 	z.object({ disk: DiskDirectorySchema }),
-	ServiceFetchSchema,
+	z.object({ node: CustomNodeServiceSchema }),
+	CustomFetchServiceSchema,
 ]);

--- a/packages/miniflare/src/plugins/images/index.ts
+++ b/packages/miniflare/src/plugins/images/index.ts
@@ -12,7 +12,7 @@ const IMAGES_LOCAL_FETCHER = /* javascript */ `
 	export default {
 		fetch(req, env) {
 			const request = new Request(req);
-			request.headers.set("${CoreHeaders.CUSTOM_SERVICE}", "${CoreBindings.IMAGES_SERVICE}");
+			request.headers.set("${CoreHeaders.CUSTOM_FETCH_SERVICE}", "${CoreBindings.IMAGES_SERVICE}");
 			request.headers.set("${CoreHeaders.ORIGINAL_URL}", request.url);
 			return env.${CoreBindings.SERVICE_LOOPBACK}.fetch(request)
 		}

--- a/packages/miniflare/src/workers/core/constants.ts
+++ b/packages/miniflare/src/workers/core/constants.ts
@@ -1,5 +1,6 @@
 export const CoreHeaders = {
-	CUSTOM_SERVICE: "MF-Custom-Service",
+	CUSTOM_FETCH_SERVICE: "MF-Custom-Fetch-Service",
+	CUSTOM_NODE_SERVICE: "MF-Custom-Node-Service",
 	ORIGINAL_URL: "MF-Original-URL",
 	PROXY_SHARED_SECRET: "MF-Proxy-Shared-Secret",
 	DISABLE_PRETTY_ERROR: "MF-Disable-Pretty-Error",


### PR DESCRIPTION
Fixes #000.

Adds support for Node.js style custom handlers for service bindings and outbound services. This makes it easier to integrate Miniflare with existing Node.js middleware and libraries as `req` and `res` objects can be used directly.

```js
new Miniflare({
	serviceBindings: {
		CUSTOM: {
			node: (req, res) => {
				res.end(`Hello world`);
			},
		},
	},
});
```

Note: I initially tried implementing this with Claude but the code it produced was quite hacky and confusing so I removed it and started again.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): updated README
  - [x] Documentation not necessary because: updated README
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
