### PR TITLE
Prevent leaking Miniflare server logs

### DIFF
--- a/.changeset/dull-plants-act.md
+++ b/.changeset/dull-plants-act.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Add `logReady` method to Miniflare `Log` class. This makes it possible to override the messages printed on server start.

--- a/.changeset/dull-plants-act.md
+++ b/.changeset/dull-plants-act.md
@@ -1,5 +1,5 @@
 ---
-"miniflare": patch
+"miniflare": minor
 ---
 
 Add `logReady` method to Miniflare `Log` class. This makes it possible to override the messages printed on server start.

--- a/.changeset/hot-tips-do.md
+++ b/.changeset/hot-tips-do.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Prevent leaking Miniflare server logs. Logs that were previously filtered were leaking as they were changed to include colors. We now strip ANSI escape codes before filtering.

--- a/.changeset/hot-tips-do.md
+++ b/.changeset/hot-tips-do.md
@@ -2,4 +2,4 @@
 "@cloudflare/vite-plugin": patch
 ---
 
-Prevent leaking Miniflare server logs. Logs that were previously filtered were leaking as they were changed to include colors. We now strip ANSI escape codes before filtering.
+Prevent leaking Miniflare server logs. Logs that were previously filtered were leaking as they were changed to include colors. We now explicitly opt out of Miniflare request logging in dev and have modified the filtering in preview.

--- a/.changeset/hot-tips-do.md
+++ b/.changeset/hot-tips-do.md
@@ -2,4 +2,4 @@
 "@cloudflare/vite-plugin": patch
 ---
 
-Prevent leaking Miniflare server logs. Logs that were previously filtered were leaking as they were changed to include colors. We now explicitly opt out of Miniflare request logging in dev and have modified the filtering in preview.
+Prevent leaking Miniflare server logs. Logs that were previously filtered were leaking as they were changed to include colors. We now override the new Miniflare `Log.logReady` method with a noop rather than filtering the logs.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1624,7 +1624,7 @@ export class Miniflare {
 
 			const urlSafeHost = getURLSafeHost(configuredHost);
 			if (this.#sharedOpts.core.logRequests) {
-				this.#log.info(
+				this.#log.logReady(
 					`${ready} on ${green(`${secure ? "https" : "http"}://${urlSafeHost}:${entryPort}`)}`
 				);
 			}
@@ -1644,7 +1644,9 @@ export class Miniflare {
 				}
 
 				for (const h of hosts) {
-					this.#log.info(`- ${secure ? "https" : "http"}://${h}:${entryPort}`);
+					this.#log.logReady(
+						`- ${secure ? "https" : "http"}://${h}:${entryPort}`
+					);
 				}
 			}
 

--- a/packages/miniflare/src/shared/log.ts
+++ b/packages/miniflare/src/shared/log.ts
@@ -87,6 +87,10 @@ export class Log {
 		}
 	}
 
+	logReady(message: string): void {
+		this.info(message);
+	}
+
 	error(message: Error): void {
 		if (this.level < LogLevel.ERROR) {
 			// Ignore message if it won't get logged

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import * as util from "node:util";
 import {
 	kCurrentWorker,
 	Log,
@@ -618,8 +619,10 @@ class ViteMiniflareLogger extends Log {
 	}
 
 	override logWithLevel(level: LogLevel, message: string) {
+		const strippedMessage = util.stripVTControlCharacters(message);
+
 		for (const removedMessage of removedMessages) {
-			if (removedMessage.test(message)) {
+			if (removedMessage.test(strippedMessage)) {
 				return;
 			}
 		}

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -585,7 +585,7 @@ export function getPreviewMiniflareOptions(
 		];
 	});
 
-	const logger = new ViteMiniflareLogger(resolvedViteConfig);
+	const logger = new ViteMiniflareLogger(resolvedViteConfig, true);
 
 	return {
 		log: logger,
@@ -611,13 +611,16 @@ export function getPreviewMiniflareOptions(
  */
 class ViteMiniflareLogger extends Log {
 	private logger: vite.Logger;
-	constructor(config: vite.ResolvedConfig) {
+	constructor(
+		config: vite.ResolvedConfig,
+		private isPreview = false
+	) {
 		super(miniflareLogLevelFromViteLogLevel(config.logLevel));
 		this.logger = config.logger;
 	}
 
 	override logWithLevel(level: LogLevel, message: string) {
-		if (/^Ready on/.test(message)) {
+		if (this.isPreview && /^Ready on/.test(message)) {
 			return;
 		}
 

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -585,7 +585,7 @@ export function getPreviewMiniflareOptions(
 		];
 	});
 
-	const logger = new ViteMiniflareLogger(resolvedViteConfig, true);
+	const logger = new ViteMiniflareLogger(resolvedViteConfig);
 
 	return {
 		log: logger,
@@ -611,19 +611,12 @@ export function getPreviewMiniflareOptions(
  */
 class ViteMiniflareLogger extends Log {
 	private logger: vite.Logger;
-	constructor(
-		config: vite.ResolvedConfig,
-		private isPreview = false
-	) {
+	constructor(config: vite.ResolvedConfig) {
 		super(miniflareLogLevelFromViteLogLevel(config.logLevel));
 		this.logger = config.logger;
 	}
 
 	override logWithLevel(level: LogLevel, message: string) {
-		if (this.isPreview && /^Ready on/.test(message)) {
-			return;
-		}
-
 		switch (level) {
 			case LogLevel.ERROR:
 				return this.logger.error(message);
@@ -632,6 +625,10 @@ class ViteMiniflareLogger extends Log {
 			case LogLevel.INFO:
 				return this.logger.info(message);
 		}
+	}
+
+	override logReady() {
+		// Noop so that Miniflare server start messages are not logged
 	}
 }
 

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -3,7 +3,6 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import * as util from "node:util";
 import {
 	kCurrentWorker,
 	Log,
@@ -391,6 +390,7 @@ export function getDevMiniflareOptions(
 
 	return {
 		log: logger,
+		logRequests: false,
 		inspectorPort: inspectorPort === false ? undefined : inspectorPort,
 		unsafeInspectorProxy: inspectorPort !== false,
 		handleRuntimeStdio(stdout, stderr) {
@@ -606,8 +606,6 @@ export function getPreviewMiniflareOptions(
 	};
 }
 
-const removedMessages = [/^Ready on http/, /^Updated and ready on http/];
-
 /**
  * A Miniflare logger that forwards messages onto a Vite logger.
  */
@@ -619,12 +617,8 @@ class ViteMiniflareLogger extends Log {
 	}
 
 	override logWithLevel(level: LogLevel, message: string) {
-		const strippedMessage = util.stripVTControlCharacters(message);
-
-		for (const removedMessage of removedMessages) {
-			if (removedMessage.test(strippedMessage)) {
-				return;
-			}
+		if (/^Ready on/.test(message)) {
+			return;
 		}
 
 		switch (level) {


### PR DESCRIPTION
Fixes #000.

With the changes introduced in #9335, the Vite plugin no longer filters `Read on http` etc. logged by Miniflare as the string contains additional characters for colour encoding:

https://github.com/cloudflare/workers-sdk/blob/d9d937ab6f2868271dde5a8da625773085eaec85/packages/miniflare/src/index.ts#L1628

We now explicitly opt out of Miniflare request logging in dev and have modified the filtering in preview.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Miniflare changes covered by existing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
