### PR TITLE
Remove ORIGINAL_URL header from custom Node service

### DIFF
--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -265,7 +265,6 @@ export const SCRIPT_CUSTOM_FETCH_SERVICE = `addEventListener("fetch", (event) =>
 export const SCRIPT_CUSTOM_NODE_SERVICE = `addEventListener("fetch", (event) => {
   const request = new Request(event.request);
   request.headers.set("${CoreHeaders.CUSTOM_NODE_SERVICE}", ${CoreBindings.TEXT_CUSTOM_SERVICE});
-  request.headers.set("${CoreHeaders.ORIGINAL_URL}", request.url);
   event.respondWith(${CoreBindings.SERVICE_LOOPBACK}.fetch(request));
 })`;
 


### PR DESCRIPTION
Fixes #000.

Fix for changes introduced in https://github.com/cloudflare/workers-sdk/pull/9376. The `ORIGINAL_URL` header isn't needed for custom Node services and leads to unexpected behaviour if it is unintentionally sent back into a Worker.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: covered by existing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
