### PR TITLE
improve wrangler dev mixed mode tests

### DIFF
--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -79,7 +79,7 @@ describe("wrangler dev - mixed mode", () => {
 
 	it("allows code changes during development", async () => {
 		await spawnLocalWorker(helper);
-		const path = await helper.seed({
+		await helper.seed({
 			"wrangler.json": JSON.stringify({
 				name: "mixed-mode-mixed-bindings-test",
 				main: "simple-service-binding.js",
@@ -103,11 +103,11 @@ describe("wrangler dev - mixed mode", () => {
 		);
 
 		const indexContent = await readFile(
-			`${path}/simple-service-binding.js`,
+			`${helper.tmpPath}/simple-service-binding.js`,
 			"utf8"
 		);
 		await writeFile(
-			`${path}/simple-service-binding.js`,
+			`${helper.tmpPath}/simple-service-binding.js`,
 			indexContent.replace(
 				"REMOTE<WORKER>:",
 				"The remote worker responded with:"
@@ -121,7 +121,11 @@ describe("wrangler dev - mixed mode", () => {
 			`"The remote worker responded with: Hello from a remote worker (wrangler dev mixed-mode)"`
 		);
 
-		await writeFile(`${path}/simple-service-binding.js`, indexContent, "utf8");
+		await writeFile(
+			`${helper.tmpPath}/simple-service-binding.js`,
+			indexContent,
+			"utf8"
+		);
 
 		await setTimeout(500);
 

--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -7,13 +7,13 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { runCommand } from "./helpers/command";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { fetchText } from "./helpers/fetch-text";
+import { generateResourceName } from "./helpers/generate-resource-name";
 import { normalizeOutput } from "./helpers/normalize";
 import { makeRoot, seed } from "./helpers/setup";
 
 describe("wrangler dev - mixed mode", () => {
-	const remoteWorkerName = "tmp-wrangler-dev-mixed-mode-remote-worker";
-	const alternativeRemoteWorkerName =
-		"tmp-wrangler-dev-mixed-mode-remote-worker-alt";
+	const remoteWorkerName = generateResourceName();
+	const alternativeRemoteWorkerName = generateResourceName();
 
 	beforeAll(async () => {
 		const tmp = await mkdtemp(`${tmpdir()}/wrangler-dev-mixed-mode-tmp`);

--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -19,16 +19,18 @@ import type { WranglerCommandOptions } from "./wrangler";
 export class WranglerE2ETestHelper {
 	tmpPath = makeRoot();
 
-	async seed(files: Record<string, string | Uint8Array>): Promise<void>;
-	async seed(sourceDir: string): Promise<void>;
+	async seed(files: Record<string, string | Uint8Array>): Promise<string>;
+	async seed(sourceDir: string): Promise<string>;
 	async seed(
 		filesOrSourceDir: Record<string, string | Uint8Array> | string
-	): Promise<void> {
+	): Promise<string> {
 		if (typeof filesOrSourceDir === "string") {
 			await cp(filesOrSourceDir, this.tmpPath, { recursive: true });
 		} else {
 			await seed(this.tmpPath, filesOrSourceDir);
 		}
+
+		return this.tmpPath;
 	}
 
 	async removeFiles(files: string[]) {

--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -19,18 +19,16 @@ import type { WranglerCommandOptions } from "./wrangler";
 export class WranglerE2ETestHelper {
 	tmpPath = makeRoot();
 
-	async seed(files: Record<string, string | Uint8Array>): Promise<string>;
-	async seed(sourceDir: string): Promise<string>;
+	async seed(files: Record<string, string | Uint8Array>): Promise<void>;
+	async seed(sourceDir: string): Promise<void>;
 	async seed(
 		filesOrSourceDir: Record<string, string | Uint8Array> | string
-	): Promise<string> {
+	): Promise<void> {
 		if (typeof filesOrSourceDir === "string") {
 			await cp(filesOrSourceDir, this.tmpPath, { recursive: true });
 		} else {
 			await seed(this.tmpPath, filesOrSourceDir);
 		}
-
-		return this.tmpPath;
 	}
 
 	async removeFiles(files: string[]) {

--- a/packages/wrangler/e2e/seed-files/mixed-mode-workers/local-and-remote-service-bindings.js
+++ b/packages/wrangler/e2e/seed-files/mixed-mode-workers/local-and-remote-service-bindings.js
@@ -1,0 +1,13 @@
+export default {
+	async fetch(request, env) {
+		const localWorkerText = await (
+			await env.LOCAL_WORKER.fetch(request)
+		).text();
+		const remoteWorkerText = await (
+			await env.REMOTE_WORKER.fetch(request)
+		).text();
+		return new Response(
+			`LOCAL<WORKER>: ${localWorkerText}\nREMOTE<WORKER>: ${remoteWorkerText}\n`
+		);
+	},
+};

--- a/packages/wrangler/e2e/seed-files/mixed-mode-workers/local-service-binding-and-remote-ai.js
+++ b/packages/wrangler/e2e/seed-files/mixed-mode-workers/local-service-binding-and-remote-ai.js
@@ -1,0 +1,24 @@
+export default {
+	async fetch(request, env) {
+		const localWorkerText = await (
+			await env.LOCAL_WORKER.fetch(request)
+		).text();
+
+		const messages = [
+			{
+				role: "user",
+				// Doing snapshot testing against AI responses can be flaky, but this prompt generates the same output relatively reliably
+				content:
+					"Respond with the exact text 'This is a response from Workers AI.'. Do not include any other text",
+			},
+		];
+
+		const { response } = await env.AI.run("@hf/thebloke/zephyr-7b-beta-awq", {
+			messages,
+		});
+
+		return new Response(
+			`LOCAL<WORKER>: ${localWorkerText}\nREMOTE<AI>: ${response}\n`
+		);
+	},
+};

--- a/packages/wrangler/e2e/seed-files/mixed-mode-workers/simple-service-binding.js
+++ b/packages/wrangler/e2e/seed-files/mixed-mode-workers/simple-service-binding.js
@@ -1,0 +1,8 @@
+export default {
+	async fetch(request, env) {
+		const remoteWorkerText = await (
+			await env.REMOTE_WORKER.fetch(request)
+		).text();
+		return new Response(`REMOTE<WORKER>: ${remoteWorkerText}`);
+	},
+};

--- a/packages/wrangler/e2e/wrangler-mixed-mode-resources.test.ts
+++ b/packages/wrangler/e2e/wrangler-mixed-mode-resources.test.ts
@@ -60,7 +60,7 @@ const testCases: TestCase<Record<string, string>>[] = [
 			await vi.waitFor(
 				async () => {
 					const resp = await fetch(deployedUrl);
-					await expect(await resp.text()).toBe("Hello from target worker");
+					expect(await resp.text()).toBe("Hello from target worker");
 				},
 				{ interval: 1_000, timeout: 40_000 }
 			);


### PR DESCRIPTION
This PR:
 - adds an e2e reload test that I missed in https://github.com/cloudflare/workers-sdk/pull/9231
 - removes the e2e dependency from DevProd Testing deployed workers (final part of https://jira.cfdata.org/browse/DEVX-1902)
 - (minor) removes an extra unnecessary `await`

Each change is made in its own commit 🙂 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tests change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: changes related to the experimental mixed-mode feature
