### PR TITLE
Support additional mixed mode resources in Wrangler

### DIFF
--- a/.changeset/five-ladybugs-sell.md
+++ b/.changeset/five-ladybugs-sell.md
@@ -3,4 +3,10 @@
 "wrangler": patch
 ---
 
-Support additional Mixed Mode resources in Wrangler
+Support additional Mixed Mode resources in Wrangler:
+
+- AI
+- Browser
+- Images
+- Vectorize
+- Dispatch Namespaces

--- a/.changeset/five-ladybugs-sell.md
+++ b/.changeset/five-ladybugs-sell.md
@@ -1,0 +1,6 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+Support additional Mixed Mode resources in Wrangler

--- a/.changeset/huge-bats-itch.md
+++ b/.changeset/huge-bats-itch.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+Additional option for the Miniflare plugin interface to allow defining workerd extensions without having to include deduplication logic.

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1244,6 +1244,17 @@ export class Miniflare {
 			innerBindings: Worker_Binding[];
 		}[] = [];
 
+		for (const [key, plugin] of PLUGIN_ENTRIES) {
+			const pluginExtensions = await plugin.getExtensions?.({
+				// @ts-expect-error `CoreOptionsSchema` has required options which are
+				//  missing in other plugins' options.
+				options: allWorkerOpts.map((o) => o[key]),
+			});
+			if (pluginExtensions) {
+				extensions.push(...pluginExtensions);
+			}
+		}
+
 		for (let i = 0; i < allWorkerOpts.length; i++) {
 			const previousWorkerOpts = allPreviousWorkerOpts?.[i];
 			const workerOpts = allWorkerOpts[i];

--- a/packages/miniflare/src/plugins/analytics-engine/index.ts
+++ b/packages/miniflare/src/plugins/analytics-engine/index.ts
@@ -60,13 +60,14 @@ export const ANALYTICS_ENGINE_PLUGIN: Plugin<
 		);
 	},
 	async getServices({ options, workerIndex }) {
-		if (!options.analyticsEngineDatasets) {
+		return [];
+	},
+	getExtensions({ options }) {
+		if (!options.some((o) => o.analyticsEngineDatasets)) {
 			return [];
 		}
-		const extensions: Extension[] = [];
-
-		if (workerIndex === 0) {
-			extensions.push({
+		return [
+			{
 				modules: [
 					{
 						name: `${ANALYTICS_ENGINE_PLUGIN_NAME}:local-simulator`,
@@ -74,12 +75,7 @@ export const ANALYTICS_ENGINE_PLUGIN: Plugin<
 						internal: true,
 					},
 				],
-			});
-		}
-
-		return {
-			extensions,
-			services: [],
-		};
+			},
+		];
 	},
 };

--- a/packages/miniflare/src/plugins/analytics-engine/index.ts
+++ b/packages/miniflare/src/plugins/analytics-engine/index.ts
@@ -1,6 +1,6 @@
 import ANALYTICS_ENGINE from "worker:analytics-engine/analytics-engine";
 import { z } from "zod";
-import { Extension, Worker_Binding } from "../../runtime";
+import { Worker_Binding } from "../../runtime";
 import { PersistenceSchema, Plugin, ProxyNodeBinding } from "../shared";
 
 const AnalyticsEngineSchema = z.record(
@@ -59,7 +59,7 @@ export const ANALYTICS_ENGINE_PLUGIN: Plugin<
 			])
 		);
 	},
-	async getServices({ options, workerIndex }) {
+	async getServices() {
 		return [];
 	},
 	getExtensions({ options }) {

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -9,7 +9,7 @@ import {
 
 const BrowserRenderingSchema = z.object({
 	binding: z.string(),
-	mixedModeConnectionString: z.custom<MixedModeConnectionString>().optional(),
+	mixedModeConnectionString: z.custom<MixedModeConnectionString>(),
 });
 
 export const BrowserRenderingOptionsSchema = z.object({

--- a/packages/miniflare/src/plugins/browser-rendering/index.ts
+++ b/packages/miniflare/src/plugins/browser-rendering/index.ts
@@ -9,7 +9,7 @@ import {
 
 const BrowserRenderingSchema = z.object({
 	binding: z.string(),
-	mixedModeConnectionString: z.custom<MixedModeConnectionString>(),
+	mixedModeConnectionString: z.custom<MixedModeConnectionString>().optional(),
 });
 
 export const BrowserRenderingOptionsSchema = z.object({
@@ -53,6 +53,11 @@ export const BROWSER_RENDERING_PLUGIN: Plugin<
 		if (!options.browserRendering) {
 			return [];
 		}
+
+		assert(
+			options.browserRendering.mixedModeConnectionString,
+			"Workers Browser Rendering only supports Mixed Mode"
+		);
 
 		return [
 			{

--- a/packages/miniflare/src/plugins/dispatch-namespace/index.ts
+++ b/packages/miniflare/src/plugins/dispatch-namespace/index.ts
@@ -65,7 +65,6 @@ export const DISPATCH_NAMESPACE_PLUGIN: Plugin<
 		);
 	},
 	async getServices({ options }) {
-		console.log(options.dispatchNamespaces);
 		if (!options.dispatchNamespaces) {
 			return [];
 		}

--- a/packages/miniflare/src/plugins/dispatch-namespace/index.ts
+++ b/packages/miniflare/src/plugins/dispatch-namespace/index.ts
@@ -14,9 +14,7 @@ export const DispatchNamespaceOptionsSchema = z.object({
 		.record(
 			z.object({
 				namespace: z.string(),
-				mixedModeConnectionString: z
-					.custom<MixedModeConnectionString>()
-					.optional(),
+				mixedModeConnectionString: z.custom<MixedModeConnectionString>(),
 			})
 		)
 		.optional(),

--- a/packages/miniflare/src/plugins/dispatch-namespace/index.ts
+++ b/packages/miniflare/src/plugins/dispatch-namespace/index.ts
@@ -65,37 +65,37 @@ export const DISPATCH_NAMESPACE_PLUGIN: Plugin<
 		);
 	},
 	async getServices({ options }) {
+		console.log(options.dispatchNamespaces);
 		if (!options.dispatchNamespaces) {
 			return [];
 		}
 
-		return {
-			services: Object.entries(options.dispatchNamespaces).map(
-				([name, config]) => {
-					assert(
-						config.mixedModeConnectionString,
-						"Dispatch Namespace bindings only support Mixed Mode"
-					);
-					return {
-						name: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:ns:${config.namespace}`,
-						worker: mixedModeClientWorker(
-							config.mixedModeConnectionString,
-							name
-						),
-					};
-				}
-			),
-			extensions: [
-				{
-					modules: [
-						{
-							name: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:local-dispatch-namespace`,
-							esModule: LOCAL_DISPATCH_NAMESPACE(),
-							internal: true,
-						},
-					],
-				},
-			],
-		};
+		return Object.entries(options.dispatchNamespaces).map(([name, config]) => {
+			assert(
+				config.mixedModeConnectionString,
+				"Dispatch Namespace bindings only support Mixed Mode"
+			);
+			return {
+				name: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:ns:${config.namespace}`,
+				worker: mixedModeClientWorker(config.mixedModeConnectionString, name),
+			};
+		});
+	},
+	getExtensions({ options }) {
+		if (!options.some((o) => o.dispatchNamespaces)) {
+			return [];
+		}
+
+		return [
+			{
+				modules: [
+					{
+						name: `${DISPATCH_NAMESPACE_PLUGIN_NAME}:local-dispatch-namespace`,
+						esModule: LOCAL_DISPATCH_NAMESPACE(),
+						internal: true,
+					},
+				],
+			},
+		];
 	},
 };

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -61,20 +61,7 @@ export const EMAIL_PLUGIN: Plugin<typeof EmailOptionsSchema> = {
 		return {};
 	},
 	async getServices(args) {
-		const extensions: Extension[] = [];
 		const services: Service[] = [];
-		// we only want to insert on the first worker as it will be shared between them
-		if (args.workerIndex === 0) {
-			extensions.push({
-				modules: [
-					{
-						name: "cloudflare-internal:email",
-						esModule: EMAIL_MESSAGE(),
-						internal: true,
-					},
-				],
-			});
-		}
 
 		for (const { name, ...config } of args.options.email?.send_email ?? []) {
 			services.push({
@@ -95,9 +82,23 @@ export const EMAIL_PLUGIN: Plugin<typeof EmailOptionsSchema> = {
 			});
 		}
 
-		return {
-			services,
-			extensions,
-		};
+		return services;
+	},
+
+	getExtensions({ options }) {
+		if (!options.some((o) => o.email)) {
+			return [];
+		}
+		return [
+			{
+				modules: [
+					{
+						name: "cloudflare-internal:email",
+						esModule: EMAIL_MESSAGE(),
+						internal: true,
+					},
+				],
+			},
+		];
 	},
 };

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -1,7 +1,7 @@
 import EMAIL_MESSAGE from "worker:email/email";
 import SEND_EMAIL_BINDING from "worker:email/send_email";
 import { z } from "zod";
-import { Extension, Service, Worker_Binding } from "../../runtime";
+import { Service, Worker_Binding } from "../../runtime";
 import { Plugin, WORKER_BINDING_SERVICE_LOOPBACK } from "../shared";
 
 // Define the mutually exclusive schema

--- a/packages/miniflare/src/plugins/email/index.ts
+++ b/packages/miniflare/src/plugins/email/index.ts
@@ -85,10 +85,7 @@ export const EMAIL_PLUGIN: Plugin<typeof EmailOptionsSchema> = {
 		return services;
 	},
 
-	getExtensions({ options }) {
-		if (!options.some((o) => o.email)) {
-			return [];
-		}
+	getExtensions() {
 		return [
 			{
 				modules: [

--- a/packages/miniflare/src/plugins/ratelimit/index.ts
+++ b/packages/miniflare/src/plugins/ratelimit/index.ts
@@ -63,7 +63,7 @@ export const RATELIMIT_PLUGIN: Plugin<typeof RatelimitOptionsSchema> = {
 			])
 		);
 	},
-	async getServices({ options }) {
+	async getServices() {
 		return [];
 	},
 	getExtensions({ options }) {

--- a/packages/miniflare/src/plugins/ratelimit/index.ts
+++ b/packages/miniflare/src/plugins/ratelimit/index.ts
@@ -64,23 +64,22 @@ export const RATELIMIT_PLUGIN: Plugin<typeof RatelimitOptionsSchema> = {
 		);
 	},
 	async getServices({ options }) {
-		if (!options.ratelimits) {
+		return [];
+	},
+	getExtensions({ options }) {
+		if (!options.some((o) => o.ratelimits)) {
 			return [];
 		}
-
-		return {
-			services: [],
-			extensions: [
-				{
-					modules: [
-						{
-							name: SERVICE_RATELIMIT_MODULE,
-							esModule: SCRIPT_RATELIMIT_OBJECT(),
-							internal: true,
-						},
-					],
-				},
-			],
-		};
+		return [
+			{
+				modules: [
+					{
+						name: SERVICE_RATELIMIT_MODULE,
+						esModule: SCRIPT_RATELIMIT_OBJECT(),
+						internal: true,
+					},
+				],
+			},
+		];
 	},
 };

--- a/packages/miniflare/src/plugins/shared/index.ts
+++ b/packages/miniflare/src/plugins/shared/index.ts
@@ -108,6 +108,9 @@ export interface PluginBase<
 		sharedOptions: OptionalZodTypeOf<SharedOptions>,
 		tmpPath: string
 	): string;
+	getExtensions?(options: {
+		options: z.infer<Options>[];
+	}): Awaitable<Extension[]>;
 }
 
 export type Plugin<

--- a/packages/miniflare/src/plugins/vectorize/index.ts
+++ b/packages/miniflare/src/plugins/vectorize/index.ts
@@ -9,7 +9,7 @@ import {
 
 const VectorizeSchema = z.object({
 	index_name: z.string(),
-	mixedModeConnectionString: z.custom<MixedModeConnectionString>().optional(),
+	mixedModeConnectionString: z.custom<MixedModeConnectionString>(),
 });
 
 export const VectorizeOptionsSchema = z.object({

--- a/packages/miniflare/src/plugins/vectorize/index.ts
+++ b/packages/miniflare/src/plugins/vectorize/index.ts
@@ -9,7 +9,7 @@ import {
 
 const VectorizeSchema = z.object({
 	index_name: z.string(),
-	mixedModeConnectionString: z.custom<MixedModeConnectionString>(),
+	mixedModeConnectionString: z.custom<MixedModeConnectionString>().optional(),
 });
 
 export const VectorizeOptionsSchema = z.object({
@@ -73,10 +73,14 @@ export const VECTORIZE_PLUGIN: Plugin<typeof VectorizeOptionsSchema> = {
 		}
 
 		return Object.entries(options.vectorize).map(
-			([name, { mixedModeConnectionString }]) => ({
-				name: `${VECTORIZE_PLUGIN_NAME}:${name}`,
-				worker: mixedModeClientWorker(mixedModeConnectionString, name),
-			})
+			([name, { mixedModeConnectionString }]) => {
+				assert(mixedModeConnectionString, "Vectorize only supports Mixed Mode");
+
+				return {
+					name: `${VECTORIZE_PLUGIN_NAME}:${name}`,
+					worker: mixedModeClientWorker(mixedModeConnectionString, name),
+				};
+			}
 		);
 	},
 };

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -326,6 +326,7 @@ export async function getDevMiniflareOptions(
 								{
 									mixedModeConnectionString:
 										mixedModeSession?.mixedModeConnectionString,
+									mixedModeEnabled: resolvedPluginConfig.experimental.mixedMode,
 								}
 							);
 
@@ -594,6 +595,7 @@ export async function getPreviewMiniflareOptions(
 					{
 						mixedModeConnectionString:
 							mixedModeSession?.mixedModeConnectionString,
+						mixedModeEnabled,
 					}
 				);
 

--- a/packages/wrangler/e2e/dev-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/dev-mixed-mode.test.ts
@@ -140,7 +140,7 @@ describe("wrangler dev - mixed mode", () => {
 			Binding        Resource      Mode
 			env.AI         AI      remote
 			[wrangler:info] Ready on http://<HOST>:<PORT>
-			▲ [WARNING] Using Workers AI always accesses your Cloudflare account in order to run AI models, and so will incur usage charges even in local development.
+			▲ [WARNING] AI bindings always access remote resources, and so may incur usage charges even in local dev. To suppress this warning, set \`remote: true\` for the binding definition in your configuration file.
 			⎔ Starting local server...
 			[wrangler:info] GET / 200 OK (TIMINGS)"
 		`);

--- a/packages/wrangler/e2e/wrangler-mixed-mode-resources.test.ts
+++ b/packages/wrangler/e2e/wrangler-mixed-mode-resources.test.ts
@@ -23,7 +23,7 @@ type TestCase<T = void> = {
 	setup?: (helper: WranglerE2ETestHelper) => Promise<T> | T;
 	generateWranglerConfig: (setupResult: T) => RawConfig;
 	expectedResponseMatch: string | RegExp;
-	// Flag for resources that can work without mixed mode (just AI)
+	// Flag for resources that can work without mixed mode
 	worksWithoutMixedMode?: boolean;
 };
 

--- a/packages/wrangler/e2e/wrangler-mixed-mode-resources.test.ts
+++ b/packages/wrangler/e2e/wrangler-mixed-mode-resources.test.ts
@@ -35,18 +35,18 @@ const testCases: TestCase<Record<string, string>>[] = [
 			const targetWorkerName = generateResourceName();
 			await helper.seed({
 				"target-worker.js": dedent/* javascript */ `
-          import { WorkerEntrypoint } from "cloudflare:workers"
-          export default {
-            fetch(request) {
-              return new Response("Hello from target worker")
-            }
-          }
-          export class CustomEntrypoint extends WorkerEntrypoint {
-            fetch(request) {
-              return new Response("Hello from target worker entrypoint")
-            }
-          }
-        `,
+					import { WorkerEntrypoint } from "cloudflare:workers"
+					export default {
+						fetch(request) {
+						return new Response("Hello from target worker")
+						}
+					}
+					export class CustomEntrypoint extends WorkerEntrypoint {
+						fetch(request) {
+						return new Response("Hello from target worker entrypoint")
+						}
+					}
+					`,
 			});
 			const { stdout } = await helper.run(
 				`wrangler deploy target-worker.js --name ${targetWorkerName} --compatibility-date 2025-01-01`
@@ -110,6 +110,97 @@ const testCases: TestCase<Record<string, string>>[] = [
 		worksWithoutMixedMode: true,
 	},
 	{
+		name: "Browser",
+		scriptPath: "browser.js",
+		generateWranglerConfig: () => ({
+			name: "mixed-mode-browser-test",
+			main: "browser.js",
+			compatibility_date: "2025-01-01",
+			browser: {
+				binding: "BROWSER",
+				remote: true,
+			},
+		}),
+		expectedResponseMatch: /sessionId/,
+	},
+	{
+		name: "Images",
+		scriptPath: "images.js",
+		generateWranglerConfig: () => ({
+			name: "mixed-mode-images-test",
+			main: "images.js",
+			compatibility_date: "2025-01-01",
+			images: {
+				binding: "IMAGES",
+				remote: true,
+			},
+		}),
+		expectedResponseMatch: "image/avif",
+		// The Images binding "works" without mixed mode because the current default is an older mixed-mode-style implementation
+		worksWithoutMixedMode: true,
+	},
+	{
+		name: "Vectorize",
+		scriptPath: "vectorize.js",
+		setup: async (helper) => {
+			const name = await helper.vectorize(
+				32,
+				"euclidean",
+				"well-known-vectorize"
+			);
+			return { name };
+		},
+		generateWranglerConfig: ({ name }) => ({
+			name: "mixed-mode-vectorize-test",
+			main: "vectorize.js",
+			compatibility_date: "2025-01-01",
+			vectorize: [
+				{
+					binding: "VECTORIZE_BINDING",
+					index_name: name,
+					remote: true,
+				},
+			],
+		}),
+		expectedResponseMatch: /a44706aa-a366-48bc-8cc1-3feffd87d548/,
+	},
+	{
+		name: "Dispatch Namespace",
+		scriptPath: "dispatch-namespace.js",
+		setup: async (helper) => {
+			const namespace = await helper.dispatchNamespace(false);
+
+			const customerWorkerName = "mixed-mode-test-customer-worker";
+			await helper.seed({
+				"customer-worker.js": dedent/* javascript */ `
+					export default {
+						fetch(request) {
+							return new Response("Hello from customer worker")
+						}
+					}
+				`,
+			});
+			await helper.run(
+				`wrangler deploy customer-worker.js --name ${customerWorkerName} --compatibility-date 2025-01-01 --dispatch-namespace ${namespace}`
+			);
+
+			return { namespace };
+		},
+		generateWranglerConfig: ({ namespace }) => ({
+			name: "mixed-mode-dispatch-namespace-test",
+			main: "dispatch-namespace.js",
+			compatibility_date: "2025-01-01",
+			dispatch_namespaces: [
+				{
+					binding: "DISPATCH",
+					namespace: namespace,
+					remote: true,
+				},
+			],
+		}),
+		expectedResponseMatch: /Hello from customer worker/,
+	},
+	{
 		name: "KV",
 		scriptPath: "kv.js",
 		setup: async (helper) => {
@@ -169,9 +260,9 @@ const testCases: TestCase<Record<string, string>>[] = [
 		setup: async (helper) => {
 			await helper.seed({
 				"schema.sql": dedent`
-          CREATE TABLE entries (key TEXT PRIMARY KEY, value TEXT);
-          INSERT INTO entries (key, value) VALUES ('test-mixed-mode-key', 'existing-value');
-        `,
+					CREATE TABLE entries (key TEXT PRIMARY KEY, value TEXT);
+					INSERT INTO entries (key, value) VALUES ('test-mixed-mode-key', 'existing-value');
+				`,
 			});
 			const { id, name } = await helper.d1(false);
 			await helper.run(
@@ -221,6 +312,8 @@ describe("Wrangler Mixed Mode E2E Tests", () => {
 
 		it.skipIf(testCase.worksWithoutMixedMode)(
 			"fails when mixed mode is disabled",
+			// Turn off retries because this test is expected to fail
+			{ retry: 0, fails: true },
 			async () => {
 				await helper.seed(
 					path.resolve(__dirname, "./seed-files/mixed-mode-workers")
@@ -233,7 +326,7 @@ describe("Wrangler Mixed Mode E2E Tests", () => {
 				const { url } = await worker.waitForReady();
 
 				const response = await fetchText(url);
-				expect(response).not.toMatch(testCase.expectedResponseMatch);
+				expect(response).toMatch(testCase.expectedResponseMatch);
 			}
 		);
 	});

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1653,11 +1653,13 @@ describe.sequential("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 
-			await expect(
-				runWrangler("dev index.js")
-			).rejects.toThrowErrorMatchingInlineSnapshot(
-				`[Error: Browser Rendering is not supported locally. Please use \`wrangler dev --remote\` instead.]`
-			);
+			await runWranglerUntilConfig("dev index.js");
+
+			expect(std.warn).toMatchInlineSnapshot(`
+				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mBrowser Rendering is not supported locally. Please use \`wrangler dev --remote\` instead.[0m
+
+				"
+			`);
 		});
 	});
 

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -168,18 +168,22 @@ async function getMiniflareOptionsFromConfig(
 		tailConsumers: [],
 	});
 
-	const { bindingOptions, externalWorkers } = buildMiniflareBindingOptions({
-		name: rawConfig.name,
-		complianceRegion: rawConfig.compliance_region,
-		bindings,
-		workerDefinitions,
-		queueConsumers: undefined,
-		services: rawConfig.services,
-		serviceBindings: {},
-		migrations: rawConfig.migrations,
-		imagesLocalMode: false,
-		tails: [],
-	});
+	const { bindingOptions, externalWorkers } = buildMiniflareBindingOptions(
+		{
+			name: rawConfig.name,
+			complianceRegion: rawConfig.compliance_region,
+			bindings,
+			workerDefinitions,
+			queueConsumers: undefined,
+			services: rawConfig.services,
+			serviceBindings: {},
+			migrations: rawConfig.migrations,
+			imagesLocalMode: false,
+			tails: [],
+		},
+		undefined,
+		false
+	);
 
 	const defaultPersistRoot = getMiniflarePersistRoot(options.persist);
 
@@ -255,6 +259,7 @@ export function unstable_getMiniflareWorkerOptions(
 	options?: {
 		imagesLocalMode?: boolean;
 		mixedModeConnectionString?: MixedModeConnectionString;
+		mixedModeEnabled?: boolean;
 		overrides?: {
 			assets?: Partial<AssetsOptions>;
 		};
@@ -266,6 +271,7 @@ export function unstable_getMiniflareWorkerOptions(
 	options?: {
 		imagesLocalMode?: boolean;
 		mixedModeConnectionString?: MixedModeConnectionString;
+		mixedModeEnabled?: boolean;
 		overrides?: {
 			assets?: Partial<AssetsOptions>;
 		};
@@ -277,6 +283,7 @@ export function unstable_getMiniflareWorkerOptions(
 	options?: {
 		imagesLocalMode?: boolean;
 		mixedModeConnectionString?: MixedModeConnectionString;
+		mixedModeEnabled?: boolean;
 		overrides?: {
 			assets?: Partial<AssetsOptions>;
 		};
@@ -309,7 +316,8 @@ export function unstable_getMiniflareWorkerOptions(
 			imagesLocalMode: !!options?.imagesLocalMode,
 			tails: config.tail_consumers,
 		},
-		options?.mixedModeConnectionString
+		options?.mixedModeConnectionString,
+		options?.mixedModeEnabled ?? false
 	);
 
 	// This function is currently only exported for the Workers Vitest pool.

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -336,16 +336,6 @@ async function resolveConfig(
 	} satisfies StartDevWorkerOptions;
 
 	if (
-		extractBindingsOfType("browser", resolved.bindings).length &&
-		!resolved.dev.remote &&
-		!getFlag("MIXED_MODE")
-	) {
-		logger.warn(
-			"Browser Rendering is not supported locally. Please use `wrangler dev --remote` instead."
-		);
-	}
-
-	if (
 		extractBindingsOfType("analytics_engine", resolved.bindings).length &&
 		!resolved.dev.remote &&
 		resolved.build.format === "service-worker"

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -336,6 +336,16 @@ async function resolveConfig(
 	} satisfies StartDevWorkerOptions;
 
 	if (
+		extractBindingsOfType("browser", resolved.bindings).length &&
+		!resolved.dev.remote &&
+		!getFlag("MIXED_MODE")
+	) {
+		logger.warn(
+			"Browser Rendering is not supported locally. Please use `wrangler dev --remote` instead."
+		);
+	}
+
+	if (
 		extractBindingsOfType("analytics_engine", resolved.bindings).length &&
 		!resolved.dev.remote &&
 		resolved.build.format === "service-worker"

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -13,6 +13,7 @@ import {
 import { getClassNamesWhichUseSQLite } from "../../dev/class-names-sqlite";
 import { getLocalPersistencePath } from "../../dev/get-local-persistence-path";
 import { UserError } from "../../errors";
+import { getFlag } from "../../experimental-flags";
 import { logger, runWithLogLevel } from "../../logger";
 import { checkTypesDiff } from "../../type-generation/helpers";
 import {
@@ -336,9 +337,10 @@ async function resolveConfig(
 
 	if (
 		extractBindingsOfType("browser", resolved.bindings).length &&
-		!resolved.dev.remote
+		!resolved.dev.remote &&
+		!getFlag("MIXED_MODE")
 	) {
-		throw new UserError(
+		logger.warn(
 			"Browser Rendering is not supported locally. Please use `wrangler dev --remote` instead."
 		);
 	}

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -171,7 +171,8 @@ export class LocalRuntimeController extends RuntimeController {
 					this.#log,
 					configBundle,
 					this.#proxyToUserWorkerAuthenticationSecret,
-					this.#mixedModeSession?.mixedModeConnectionString
+					this.#mixedModeSession?.mixedModeConnectionString,
+					!!getFlag("MIXED_MODE")
 				);
 			options.liveReload = false; // TODO: set in buildMiniflareOptions once old code path is removed
 			if (this.#mf === undefined) {

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -111,7 +111,9 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 				this.#log,
 				await convertToConfigBundle(data),
 				this.#proxyToUserWorkerAuthenticationSecret,
-				this.#mixedModeSessions.get(data.config.name)?.mixedModeConnectionString
+				this.#mixedModeSessions.get(data.config.name)
+					?.mixedModeConnectionString,
+				!!getFlag("MIXED_MODE")
 			);
 
 			this.#options.set(data.config.name, {

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -717,6 +717,8 @@ export interface EnvironmentNonInheritable {
 		binding: string;
 		/** The name of the index. */
 		index_name: string;
+		/** Whether the Vectorize index should be remote or not (only available under `--x-mixed-mode`) */
+		remote?: boolean;
 	}[];
 
 	/**
@@ -799,6 +801,8 @@ export interface EnvironmentNonInheritable {
 	browser:
 		| {
 				binding: string;
+				/** Whether the Browser binding should be remote or not (only available under `--x-mixed-mode`) */
+				remote?: boolean;
 		  }
 		| undefined;
 
@@ -817,6 +821,8 @@ export interface EnvironmentNonInheritable {
 		| {
 				binding: string;
 				staging?: boolean;
+				/** Whether the AI binding should be remote or not (only available under `--x-mixed-mode`) */
+				remote?: boolean;
 		  }
 		| undefined;
 
@@ -834,6 +840,8 @@ export interface EnvironmentNonInheritable {
 	images:
 		| {
 				binding: string;
+				/** Whether the Images binding should be remote or not (only available under `--x-mixed-mode`) */
+				remote?: boolean;
 		  }
 		| undefined;
 
@@ -938,6 +946,8 @@ export interface EnvironmentNonInheritable {
 		namespace: string;
 		/** Details about the outbound Worker which will handle outbound requests from your namespace */
 		outbound?: DispatchNamespaceOutbound;
+		/** Whether the Dispatch Namespace should be remote or not (only available under `--x-mixed-mode`) */
+		remote?: boolean;
 	}[];
 
 	/**

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2119,8 +2119,13 @@ const validateNamedSimpleBinding =
 			isValid = false;
 		}
 
+		if (!isRemoteValid(value, field, diagnostics)) {
+			isValid = false;
+		}
+
 		validateAdditionalProperties(diagnostics, field, Object.keys(value), [
 			"binding",
+			...(getFlag("MIXED_MODE") ? ["remote"] : []),
 		]);
 
 		return isValid;
@@ -2144,6 +2149,10 @@ const validateAIBinding =
 		let isValid = true;
 		if (!isRequiredProperty(value, "binding", "string")) {
 			diagnostics.errors.push(`binding should have a string "binding" field.`);
+			isValid = false;
+		}
+
+		if (!isRemoteValid(value, field, diagnostics)) {
 			isValid = false;
 		}
 
@@ -2778,9 +2787,14 @@ const validateVectorizeBinding: ValidatorFn = (diagnostics, field, value) => {
 		isValid = false;
 	}
 
+	if (!isRemoteValid(value, field, diagnostics)) {
+		isValid = false;
+	}
+
 	validateAdditionalProperties(diagnostics, field, Object.keys(value), [
 		"binding",
 		"index_name",
+		...(getFlag("MIXED_MODE") ? ["remote"] : []),
 	]);
 
 	return isValid;
@@ -3054,6 +3068,11 @@ const validateWorkerNamespaceBinding: ValidatorFn = (
 			isValid = false;
 		}
 	}
+
+	if (!isRemoteValid(value, field, diagnostics)) {
+		isValid = false;
+	}
+
 	return isValid;
 };
 

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -124,6 +124,7 @@ export interface CfTextBlobBindings {
 export interface CfBrowserBinding {
 	binding: string;
 	raw?: boolean;
+	remote?: boolean;
 }
 
 /**
@@ -133,7 +134,7 @@ export interface CfBrowserBinding {
 export interface CfAIBinding {
 	binding: string;
 	staging?: boolean;
-	remote?: true;
+	remote?: boolean;
 	raw?: boolean;
 }
 
@@ -143,6 +144,7 @@ export interface CfAIBinding {
 export interface CfImagesBinding {
 	binding: string;
 	raw?: boolean;
+	remote?: boolean;
 }
 
 /**
@@ -213,6 +215,7 @@ export interface CfVectorize {
 	binding: string;
 	index_name: string;
 	raw?: boolean;
+	remote?: boolean;
 }
 
 export interface CfSecretsStoreSecrets {
@@ -249,6 +252,7 @@ export interface CfDispatchNamespace {
 		environment?: string;
 		parameters?: string[];
 	};
+	remote?: boolean;
 }
 
 export interface CfMTlsCertificate {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -977,11 +977,6 @@ export function getBindings(
 		}),
 	];
 
-	const workflowsConfig = configParam.workflows.map((workflowConfig) => ({
-		...workflowConfig,
-		remote: mixedModeEnabled && workflowConfig.remote,
-	}));
-
 	const bindings: CfWorkerInit["bindings"] = {
 		// top-level fields
 		wasm_modules: configParam.wasm_modules,
@@ -1001,7 +996,7 @@ export function getBindings(
 		durable_objects: {
 			bindings: mergedDOBindings,
 		},
-		workflows: workflowsConfig,
+		workflows: configParam.workflows,
 		kv_namespaces: mergedKVBindings,
 		queues: queuesBindings,
 		r2_buckets: mergedR2Bindings,

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -426,6 +426,18 @@ function workflowEntry(
 		},
 	];
 }
+function dispatchNamespaceEntry({
+	binding,
+	namespace,
+	remote,
+}: CfDispatchNamespace): [string, { namespace: string }];
+function dispatchNamespaceEntry(
+	{ binding, namespace, remote }: CfDispatchNamespace,
+	mixedModeConnectionString: MixedModeConnectionString
+): [
+	string,
+	{ namespace: string; mixedModeConnectionString: MixedModeConnectionString },
+];
 function dispatchNamespaceEntry(
 	{ binding, namespace, remote }: CfDispatchNamespace,
 	mixedModeConnectionString?: MixedModeConnectionString
@@ -929,51 +941,49 @@ export function buildMiniflareBindingOptions(
 					}
 				: undefined,
 		browserRendering:
-			mixedModeConnectionString && bindings.browser?.remote
+			mixedModeEnabled && mixedModeConnectionString && bindings.browser?.remote
 				? {
 						binding: bindings.browser.binding,
-						mixedModeConnectionString: bindings.browser.remote
-							? mixedModeConnectionString
-							: undefined,
+						mixedModeConnectionString,
 					}
 				: undefined,
 
-		vectorize: mixedModeEnabled
-			? Object.fromEntries(
-					bindings.vectorize
-						?.filter((v) => {
-							warnOrError("vectorize", v.remote, "remote");
-							return v.remote;
-						})
-						.map((vectorize) => {
-							return [
-								vectorize.binding,
-								{
-									index_name: vectorize.index_name,
-									mixedModeConnectionString: vectorize.remote
-										? mixedModeConnectionString
-										: undefined,
-								},
-							];
-						}) ?? []
-				)
-			: undefined,
+		vectorize:
+			mixedModeEnabled && mixedModeConnectionString
+				? Object.fromEntries(
+						bindings.vectorize
+							?.filter((v) => {
+								warnOrError("vectorize", v.remote, "remote");
+								return v.remote;
+							})
+							.map((vectorize) => {
+								return [
+									vectorize.binding,
+									{
+										index_name: vectorize.index_name,
+										mixedModeConnectionString,
+									},
+								];
+							}) ?? []
+					)
+				: undefined,
 
-		dispatchNamespaces: mixedModeEnabled
-			? Object.fromEntries(
-					bindings.dispatch_namespaces
-						?.filter((d) => {
-							warnOrError("dispatch_namespaces", d.remote, "remote");
-							return d.remote;
-						})
-						.map((dispatchNamespace) =>
-							dispatchNamespaceEntry(
-								dispatchNamespace,
-								dispatchNamespace.remote ? mixedModeConnectionString : undefined
-							)
-						) ?? []
-				)
-			: undefined,
+		dispatchNamespaces:
+			mixedModeEnabled && mixedModeConnectionString
+				? Object.fromEntries(
+						bindings.dispatch_namespaces
+							?.filter((d) => {
+								warnOrError("dispatch_namespaces", d.remote, "remote");
+								return d.remote;
+							})
+							.map((dispatchNamespace) =>
+								dispatchNamespaceEntry(
+									dispatchNamespace,
+									mixedModeConnectionString
+								)
+							) ?? []
+					)
+				: undefined,
 
 		durableObjects: Object.fromEntries([
 			...internalObjects.map(({ name, class_name }) => {

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -1218,6 +1218,13 @@ export async function buildMiniflareOptions(
 		logger.warn(
 			"Vectorize local bindings are not supported yet. You may use the `--experimental-vectorize-bind-to-prod` flag to bind to your production index in local dev mode."
 		);
+		if (!getFlag("MIXED_MODE")) {
+			config.bindings.vectorize = [];
+		} else {
+			config.bindings.vectorize = config.bindings.vectorize.filter(
+				(v) => v.remote
+			);
+		}
 	}
 
 	if (config.bindings.vectorize?.length) {

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -434,7 +434,7 @@ function dispatchNamespaceEntry(
 	string,
 	{ namespace: string; mixedModeConnectionString?: MixedModeConnectionString },
 ] {
-	if (!getFlag("MIXED_MODE") || !remote) {
+	if (!mixedModeConnectionString || !remote) {
 		return [binding, { namespace }];
 	}
 	return [binding, { namespace, mixedModeConnectionString }];
@@ -783,11 +783,11 @@ export function buildMiniflareBindingOptions(
 		};
 	}
 
-	if (bindings.ai && mixedModeConnectionString) {
+	if (bindings.ai && getFlag("MIXED_MODE")) {
 		warnOrError("ai", bindings.ai.remote, "always-remote");
 	}
 
-	if (bindings.browser && mixedModeConnectionString) {
+	if (bindings.browser && getFlag("MIXED_MODE")) {
 		warnOrError("browser", bindings.browser.remote, "remote");
 	}
 
@@ -929,7 +929,7 @@ export function buildMiniflareBindingOptions(
 					}
 				: undefined,
 		browserRendering:
-			bindings.browser && mixedModeConnectionString
+			mixedModeConnectionString && bindings.browser?.remote
 				? {
 						binding: bindings.browser.binding,
 						mixedModeConnectionString: bindings.browser.remote

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -927,22 +927,22 @@ export function buildMiniflareBindingOptions(
 					}
 				: undefined,
 
-		vectorize: Object.fromEntries(
-			bindings.vectorize?.map((vectorize) => {
-				return [
-					vectorize.binding,
-					{
-						index_name: vectorize.index_name,
-						mixedModeConnectionString:
-							getFlag("MIXED_MODE") &&
-							mixedModeConnectionString &&
-							vectorize.remote
-								? mixedModeConnectionString
-								: undefined,
-					},
-				];
-			}) ?? []
-		),
+		vectorize:
+			getFlag("MIXED_MODE") && mixedModeConnectionString
+				? Object.fromEntries(
+						bindings.vectorize?.map((vectorize) => {
+							return [
+								vectorize.binding,
+								{
+									index_name: vectorize.index_name,
+									mixedModeConnectionString: vectorize.remote
+										? mixedModeConnectionString
+										: undefined,
+								},
+							];
+						}) ?? []
+					)
+				: undefined,
 
 		dispatchNamespaces:
 			getFlag("MIXED_MODE") && mixedModeConnectionString

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -739,7 +739,7 @@ export function warnOrError(
 	}
 	if (remote === undefined && supports === "remote") {
 		logger.warn(
-			`${friendlyBindingNames[type]} bindings do not support local development, and so parts of your Worker may not worker correctly. You may be able to set \`remote: true\` for the binding definition in your configuration file to access a remote version of the resource.`
+			`${friendlyBindingNames[type]} bindings do not support local development, and so parts of your Worker may not work correctly. You may be able to set \`remote: true\` for the binding definition in your configuration file to access a remote version of the resource.`
 		);
 	}
 	if (remote === undefined && supports === "always-remote") {

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -257,15 +257,19 @@ export function printBindings(
 
 	if (vectorize !== undefined && vectorize.length > 0) {
 		output.push(
-			...vectorize.map(({ binding, index_name }) => {
+			...vectorize.map(({ binding, index_name, remote }) => {
 				return {
 					name: binding,
 					type: friendlyBindingNames.vectorize,
 					value: index_name,
 					mode: getMode({
-						isSimulatedLocally: context.vectorizeBindToProd
-							? false
-							: /* Vectorize doesn't support local mode */ undefined,
+						isSimulatedLocally: getFlag("MIXED_MODE")
+							? remote
+								? false
+								: undefined
+							: context.vectorizeBindToProd
+								? false
+								: /* Vectorize doesn't support local mode */ undefined,
 					}),
 				};
 			})
@@ -402,7 +406,10 @@ export function printBindings(
 			name: browser.binding,
 			type: friendlyBindingNames.browser,
 			value: undefined,
-			mode: getMode({ isSimulatedLocally: undefined }),
+			mode: getMode({
+				isSimulatedLocally:
+					getFlag("MIXED_MODE") && browser.remote ? false : undefined,
+			}),
 		});
 	}
 
@@ -411,7 +418,13 @@ export function printBindings(
 			name: images.binding,
 			type: friendlyBindingNames.images,
 			value: undefined,
-			mode: getMode({ isSimulatedLocally: !!context.imagesLocalMode }),
+			mode: getMode({
+				isSimulatedLocally: getFlag("MIXED_MODE")
+					? images.remote === true || images.remote === undefined
+						? false
+						: undefined
+					: !!context.imagesLocalMode,
+			}),
 		});
 	}
 
@@ -420,7 +433,13 @@ export function printBindings(
 			name: ai.binding,
 			type: friendlyBindingNames.ai,
 			value: ai.staging ? `staging` : undefined,
-			mode: getMode({ isSimulatedLocally: false }),
+			mode: getMode({
+				isSimulatedLocally: getFlag("MIXED_MODE")
+					? ai.remote === true || ai.remote === undefined
+						? false
+						: undefined
+					: false,
+			}),
 		});
 	}
 
@@ -498,14 +517,20 @@ export function printBindings(
 
 	if (dispatch_namespaces !== undefined && dispatch_namespaces.length > 0) {
 		output.push(
-			...dispatch_namespaces.map(({ binding, namespace, outbound }) => {
+			...dispatch_namespaces.map(({ binding, namespace, outbound, remote }) => {
 				return {
 					name: binding,
 					type: friendlyBindingNames.dispatch_namespaces,
 					value: outbound
 						? `${namespace} (outbound -> ${outbound.service})`
 						: namespace,
-					mode: getMode(),
+					mode: getMode({
+						isSimulatedLocally: getFlag("MIXED_MODE")
+							? remote
+								? false
+								: undefined
+							: undefined,
+					}),
 				};
 			})
 		);


### PR DESCRIPTION
Fixes DEVX-1879

Implement `remote: true` behaviour & tests for:
- Images
- AI (already partially implemented)
- Vectorize
- Browser
- Dispatch Namespaces

Claude 🤖 helped a bit, but had a tendency to see a test failure and then go off in completely the wrong direction (skipping the test, deleting warnings/errors)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: WIP feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: v4 only feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
