### PR TITLE
Miniflare: reduce email test flakes

### DIFF
--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -37,7 +37,8 @@
 		"clean": "rimraf ./dist ./dist-types",
 		"dev": "concurrently -n esbuild,typechk,typewrk -c yellow,blue,blue.dim \"node scripts/build.mjs watch\" \"node scripts/types.mjs tsconfig.json watch\" \"node scripts/types.mjs src/workers/tsconfig.json watch\"",
 		"lint:fix": "pnpm run check:lint --fix",
-		"test": "ava && rimraf ./.tmp",
+		"test": "ava",
+		"posttest": "rimraf ./.tmp",
 		"test:ci": "pnpm run test",
 		"types:build": "node scripts/types.mjs tsconfig.json && node scripts/types.mjs src/workers/tsconfig.json"
 	},

--- a/packages/miniflare/test/test-shared/asserts.ts
+++ b/packages/miniflare/test/test-shared/asserts.ts
@@ -1,4 +1,5 @@
-import assert from "assert";
+import assert from "node:assert";
+import { setTimeout as sleep } from "node:timers/promises";
 import { ExecutionContext } from "ava";
 import { Awaitable } from "miniflare";
 
@@ -40,4 +41,24 @@ export function flaky(
 			}
 		}
 	};
+}
+
+/**
+ * Wait for the callback to execute successfully. If the callback throws an error or returns a rejected promise it will continue to wait until it succeeds or times out.
+ */
+export async function waitFor<T>(
+	callback: () => T | Promise<T>,
+	timeout = 5000
+): Promise<T> {
+	const start = Date.now();
+	while (true) {
+		try {
+			return callback();
+		} catch (error) {
+			if (Date.now() < start + timeout) {
+				throw error;
+			}
+		}
+		await sleep(100);
+	}
 }


### PR DESCRIPTION
This test has failed a couple of times. I think it is either that the binding log hasn't arrived in time, or that the logs are a bit out of order. This change should resolve both of those issues.