### PR TITLE
Fix/wrangler oauth2 url callback host

### DIFF
--- a/.changeset/curly-peas-hunt.md
+++ b/.changeset/curly-peas-hunt.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix the login oauth2 url when callback host param is provided with 0.0.0.0 or 127.0.0.1, defaults value for callback host param updated from localhost to 0.0.0.0

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -578,6 +578,7 @@ describe("deploy", () => {
 
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
+				Temporary login server listening on 0.0.0.0:8976
 				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in.
 				Total Upload: xx KiB / gzip: xx KiB
@@ -619,6 +620,7 @@ describe("deploy", () => {
 
 				expect(std.out).toMatchInlineSnapshot(`
 					"Attempting to login via OAuth...
+					Temporary login server listening on 0.0.0.0:8976
 					Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 					Successfully logged in.
 					Total Upload: xx KiB / gzip: xx KiB

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -69,6 +69,7 @@ describe("User", () => {
 			expect(counter).toBe(1);
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
+				Temporary login server listening on 0.0.0.0:8976
 				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in."
 			`);
@@ -185,7 +186,7 @@ describe("User", () => {
 			expect(counter).toBe(1);
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
-				Temporary login server listening on localhost:8787
+				Temporary login server listening on 0.0.0.0:8787
 				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8787%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in."
 			`);
@@ -225,6 +226,7 @@ describe("User", () => {
 			expect(counter).toBe(1);
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
+				Temporary login server listening on 0.0.0.0:8976
 				Opening a link in your default browser: https://dash.staging.cloudflare.com/oauth2/auth?response_type=code&client_id=4b2ea6cc-9421-4761-874b-ce550e0e3def&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in."
 			`);
@@ -341,6 +343,7 @@ describe("User", () => {
 		expect(counter).toBe(1);
 		expect(std.out).toMatchInlineSnapshot(`
 			"Attempting to login via OAuth...
+			Temporary login server listening on 0.0.0.0:8976
 			Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 			Successfully logged in."
 		`);

--- a/packages/wrangler/src/__tests__/user.test.ts
+++ b/packages/wrangler/src/__tests__/user.test.ts
@@ -81,7 +81,7 @@ describe("User", () => {
 			});
 		});
 
-		it("should login a user when `wrangler login` is run with custom callbackHost param", async () => {
+		it("should login a user when `wrangler login` is run with custom callbackHost param '0.0.0.0'", async () => {
 			mockOAuthServerCallback("success");
 
 			let counter = 0;
@@ -108,7 +108,46 @@ describe("User", () => {
 			expect(std.out).toMatchInlineSnapshot(`
 				"Attempting to login via OAuth...
 				Temporary login server listening on 0.0.0.0:8976
-				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2F0.0.0.0%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
+				Successfully logged in."
+			`);
+			expect(readAuthConfigFile()).toEqual<UserAuthConfig>({
+				api_token: undefined,
+				oauth_token: "test-access-token",
+				refresh_token: "test-refresh-token",
+				expiration_time: expect.any(String),
+				scopes: ["account:read"],
+			});
+		});
+
+		it("should login a user when `wrangler login` is run with custom callbackHost param", async () => {
+			mockOAuthServerCallback("success");
+
+			let counter = 0;
+			msw.use(
+				http.post(
+					"*/oauth2/token",
+					async () => {
+						counter += 1;
+
+						return HttpResponse.json({
+							access_token: "test-access-token",
+							expires_in: 100000,
+							refresh_token: "test-refresh-token",
+							scope: "account:read",
+						});
+					},
+					{ once: true }
+				)
+			);
+
+			await runWrangler("login --callback-host='mylocalhost.local'");
+
+			expect(counter).toBe(1);
+			expect(std.out).toMatchInlineSnapshot(`
+				"Attempting to login via OAuth...
+				Temporary login server listening on mylocalhost.local:8976
+				Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?response_type=code&client_id=54d11594-84e4-41aa-b438-e81b8fa78ee7&redirect_uri=http%3A%2F%2Fmylocalhost.local%3A8976%2Foauth%2Fcallback&scope=account%3Aread%20user%3Aread%20workers%3Awrite%20workers_kv%3Awrite%20workers_routes%3Awrite%20workers_scripts%3Awrite%20workers_tail%3Aread%20d1%3Awrite%20pages%3Awrite%20zone%3Aread%20ssl_certs%3Awrite%20ai%3Awrite%20queues%3Awrite%20pipelines%3Awrite%20secrets_store%3Awrite%20offline_access&state=MOCK_STATE_PARAM&code_challenge=MOCK_CODE_CHALLENGE&code_challenge_method=S256
 				Successfully logged in."
 			`);
 			expect(readAuthConfigFile()).toEqual<UserAuthConfig>({

--- a/packages/wrangler/src/user/commands.ts
+++ b/packages/wrangler/src/user/commands.ts
@@ -33,7 +33,7 @@ export const loginCommand = createCommand({
 				"Use the ip or host address for the temporary login callback server.",
 			type: "string",
 			requiresArg: false,
-			default: "localhost",
+			default: "0.0.0.0",
 		},
 		"callback-port": {
 			describe: "Use the port for the temporary login callback server.",

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -392,6 +392,15 @@ export function validateScopeKeys(
 }
 
 function getCallbackUrl(host = "localhost", port = 8976) {
+	if (
+		host === "localhost" ||
+		host === "0.0.0.0" ||
+		host === "::" ||
+		host === "::1" ||
+		host === "127.0.0.1"
+	) {
+		return `http://localhost:${port}/oauth/callback`;
+	}
 	return `http://${host}:${port}/oauth/callback`;
 }
 
@@ -1071,7 +1080,7 @@ export async function login(
 	complianceConfig: ComplianceConfig,
 	props: LoginProps = {
 		browser: true,
-		callbackHost: "localhost",
+		callbackHost: "localhost", // "0.0.0.0",
 		callbackPort: 8976,
 	}
 ): Promise<boolean> {

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1059,11 +1059,9 @@ export async function getOauthToken(options: {
 			}
 		});
 
-		if (options.callbackHost !== "localhost" || options.callbackPort !== 8976) {
-			logger.log(
-				`Temporary login server listening on ${options.callbackHost}:${options.callbackPort}`
-			);
-		}
+		logger.log(
+			`Temporary login server listening on ${options.callbackHost}:${options.callbackPort}`
+		);
 		server.listen(options.callbackPort, options.callbackHost);
 	});
 	if (options.browser) {
@@ -1080,7 +1078,7 @@ export async function login(
 	complianceConfig: ComplianceConfig,
 	props: LoginProps = {
 		browser: true,
-		callbackHost: "localhost", // "0.0.0.0",
+		callbackHost: "0.0.0.0",
 		callbackPort: 8976,
 	}
 ): Promise<boolean> {


### PR DESCRIPTION
Fixes regression in both #5937 #9065 .

fix the login oauth2 url when callback host param is provided with 0.0.0.0 or 127.0.0.1, defaults value for callback host param updated from localhost to 0.0.0.0 thus in addition in fixing regressions improving DX.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [x] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->
