### PR TITLE
Fix Vite plugin e2e windows failures

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/basic.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/basic.test.ts
@@ -1,5 +1,5 @@
 import { describe, test } from "vitest";
-import { fetchJson, runLongLived, testSeed, waitForReady } from "./helpers.js";
+import { fetchJson, runLongLived, seed, waitForReady } from "./helpers.js";
 
 const isWindows = process.platform === "win32";
 const packageManagers = ["pnpm", , "npm", "yarn"] as const;
@@ -7,7 +7,7 @@ const commands = ["dev", "buildAndPreview"] as const;
 
 describe("basic e2e tests", () => {
 	describe.each(packageManagers)('with "%s" package manager', async (pm) => {
-		const projectPath = testSeed("basic", pm);
+		const projectPath = seed("basic", pm);
 
 		describe.each(commands)('with "%s" command', (command) => {
 			describe("node compatibility", () => {

--- a/packages/vite-plugin-cloudflare/e2e/dynamic.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/dynamic.test.ts
@@ -1,11 +1,11 @@
 import { describe, test } from "vitest";
-import { fetchJson, runLongLived, testSeed, waitForReady } from "./helpers.js";
+import { fetchJson, runLongLived, seed, waitForReady } from "./helpers.js";
 
 const packageManagers = ["pnpm", "npm", "yarn"] as const;
 
 describe("prebundling Node.js compatibility", () => {
 	describe.each(packageManagers)('with "%s" package manager', (pm) => {
-		const projectPath = testSeed("dynamic", pm);
+		const projectPath = seed("dynamic", pm);
 
 		test("will not cause a reload on a dynamic import of a Node.js module", async ({
 			expect,

--- a/packages/vite-plugin-cloudflare/e2e/invalid-worker-env-configs.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/invalid-worker-env-configs.test.ts
@@ -1,11 +1,11 @@
 import { describe, test } from "vitest";
-import { runLongLived, testSeed } from "./helpers";
+import { runLongLived, seed } from "./helpers";
 
 // Note: the test here just makes sure that the validation does take place, for more fine grained
 //       testing regarding the validation there are unit tests in src/__tests__/validate_worker_environments_resolved_configs.spec.ts
 
 describe("during development wrangler config files are validated", () => {
-	const projectPath = testSeed("invalid-worker-env-configs", "pnpm");
+	const projectPath = seed("invalid-worker-env-configs", "pnpm");
 	test("for the entry worker", async ({ expect }) => {
 		const proc = await runLongLived("pnpm", "dev", projectPath);
 		expect(await proc.exitCode).not.toBe(0);

--- a/packages/vite-plugin-cloudflare/e2e/mixed-mode.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/mixed-mode.test.ts
@@ -4,61 +4,108 @@ import { readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { setTimeout } from "node:timers/promises";
 import { afterAll, beforeAll, describe, test } from "vitest";
-import {
-	fetchJson,
-	prepareSeed,
-	runLongLived,
-	testSeed,
-	waitForReady,
-} from "./helpers.js";
+import { fetchJson, runLongLived, seed, waitForReady } from "./helpers.js";
 
 const commands = ["dev", "buildAndPreview"] as const;
 
 // These tests focus on mixed mode which require an authed connection to the CF API
 // They are skipped if you have not provided the necessary account id and api token.
-describe.skipIf(
-	!process.env.CLOUDFLARE_ACCOUNT_ID || !process.env.CLOUDFLARE_API_TOKEN
-)("mixed-mode tests", () => {
-	const remoteWorkerName = "tmp-e2e-vite-plugin-mixed-mode-remote-worker";
-	const alternativeRemoteWorkerName =
-		"tmp-e2e-vite-plugin-mixed-mode-remote-worker-alt";
+describe
+	.skipIf(
+		!process.env.CLOUDFLARE_ACCOUNT_ID || !process.env.CLOUDFLARE_API_TOKEN
+	)
+	// Note: the reload test applies changes to the fixture files, so we do want the
+	//       tests to run sequentially in order to avoid race conditions
+	.sequential("mixed-mode tests", () => {
+		const remoteWorkerName = "tmp-e2e-vite-plugin-mixed-mode-remote-worker";
+		const alternativeRemoteWorkerName =
+			"tmp-e2e-vite-plugin-mixed-mode-remote-worker-alt";
 
-	const projectPath = testSeed("mixed-mode", "pnpm");
+		const projectPath = seed("mixed-mode", "pnpm");
 
-	beforeAll(() => {
-		const tmp = fs.mkdtempSync(`${os.tmpdir()}/vite-plugin-e2e-tmp`);
-		[
-			{
-				name: remoteWorkerName,
-				content:
-					"export default { fetch() { return new Response('Hello from a remote worker'); } };",
-			},
-			{
-				name: alternativeRemoteWorkerName,
-				content:
-					"export default { fetch() { return new Response('Hello from an alternative remote worker'); } };",
-			},
-		].forEach((worker) => {
-			fs.writeFileSync(`${tmp}/index.js`, worker.content);
-			execSync(
-				`npx wrangler deploy index.js --name ${worker.name} --compatibility-date 2025-01-01`,
-				{ cwd: tmp }
-			);
+		beforeAll(() => {
+			const tmp = fs.mkdtempSync(`${os.tmpdir()}/vite-plugin-e2e-tmp`);
+			[
+				{
+					name: remoteWorkerName,
+					content:
+						"export default { fetch() { return new Response('Hello from a remote worker'); } };",
+				},
+				{
+					name: alternativeRemoteWorkerName,
+					content:
+						"export default { fetch() { return new Response('Hello from an alternative remote worker'); } };",
+				},
+			].forEach((worker) => {
+				fs.writeFileSync(`${tmp}/index.js`, worker.content);
+				execSync(
+					`npx wrangler deploy index.js --name ${worker.name} --compatibility-date 2025-01-01`,
+					{ cwd: tmp }
+				);
+			});
+		}, 35_000);
+
+		afterAll(() => {
+			[remoteWorkerName, alternativeRemoteWorkerName].forEach((worker) => {
+				execSync(`npx wrangler delete --name ${worker}`);
+			});
 		});
-	}, 35_000);
 
-	afterAll(() => {
-		[remoteWorkerName, alternativeRemoteWorkerName].forEach((worker) => {
-			execSync(`npx wrangler delete --name ${worker}`);
+		describe.each(commands)('with "%s" command', (command) => {
+			test("can fetch from both local (/auxiliary) and remote workers", async ({
+				expect,
+			}) => {
+				const proc = await runLongLived("pnpm", command, projectPath);
+				const url = await waitForReady(proc);
+				expect(await fetchJson(url)).toEqual({
+					localWorkerResponse: {
+						remoteWorkerResponse: "Hello from an alternative remote worker",
+					},
+					remoteWorkerResponse: "Hello from a remote worker",
+				});
+			});
 		});
-	});
 
-	describe.each(commands)('with "%s" command', (command) => {
-		test("can fetch from both local (/auxiliary) and remote workers", async ({
-			expect,
-		}) => {
-			const proc = await runLongLived("pnpm", command, projectPath);
+		test("reflects changes applied during dev", async ({ expect }) => {
+			const proc = await runLongLived("pnpm", "dev", projectPath);
 			const url = await waitForReady(proc);
+			expect(await fetchJson(url)).toEqual({
+				localWorkerResponse: {
+					remoteWorkerResponse: "Hello from an alternative remote worker",
+				},
+				remoteWorkerResponse: "Hello from a remote worker",
+			});
+
+			const entryWorkerPath = `${projectPath}/entry-worker/src/index.ts`;
+			const entryWorkerContent = await readFile(entryWorkerPath, "utf8");
+
+			await writeFile(
+				entryWorkerPath,
+				entryWorkerContent
+					.replace(
+						"localWorkerResponse: await",
+						"localWorkerResponseJson: await"
+					)
+					.replace(
+						"remoteWorkerResponse: await",
+						"remoteWorkerResponseText: await"
+					),
+				"utf8"
+			);
+
+			await setTimeout(500);
+
+			expect(await fetchJson(url)).toEqual({
+				localWorkerResponseJson: {
+					remoteWorkerResponse: "Hello from an alternative remote worker",
+				},
+				remoteWorkerResponseText: "Hello from a remote worker",
+			});
+
+			await writeFile(entryWorkerPath, entryWorkerContent, "utf8");
+
+			await setTimeout(500);
+
 			expect(await fetchJson(url)).toEqual({
 				localWorkerResponse: {
 					remoteWorkerResponse: "Hello from an alternative remote worker",
@@ -67,43 +114,3 @@ describe.skipIf(
 			});
 		});
 	});
-
-	test("reflects changes applied during dev", async ({ expect }) => {
-		const seedObj = prepareSeed("mixed-mode", "pnpm");
-		await seedObj.seed();
-
-		const proc = await runLongLived("pnpm", "dev", seedObj.projectPath);
-		const url = await waitForReady(proc);
-		expect(await fetchJson(url)).toEqual({
-			localWorkerResponse: {
-				remoteWorkerResponse: "Hello from an alternative remote worker",
-			},
-			remoteWorkerResponse: "Hello from a remote worker",
-		});
-
-		const entryWorkerPath = `${seedObj.projectPath}/entry-worker/src/index.ts`;
-		const entryWorkerContent = await readFile(entryWorkerPath, "utf8");
-
-		await writeFile(
-			entryWorkerPath,
-			entryWorkerContent
-				.replace("localWorkerResponse: await", "localWorkerResponseJson: await")
-				.replace(
-					"remoteWorkerResponse: await",
-					"remoteWorkerResponseText: await"
-				),
-			"utf8"
-		);
-
-		await setTimeout(500);
-
-		expect(await fetchJson(url)).toEqual({
-			localWorkerResponseJson: {
-				remoteWorkerResponse: "Hello from an alternative remote worker",
-			},
-			remoteWorkerResponseText: "Hello from a remote worker",
-		});
-
-		await seedObj.cleanup();
-	});
-});

--- a/packages/vite-plugin-cloudflare/e2e/wrangler-configs-validation.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/wrangler-configs-validation.test.ts
@@ -1,11 +1,11 @@
 import { describe, test } from "vitest";
-import { runLongLived, testSeed } from "./helpers";
+import { runLongLived, seed } from "./helpers";
 
 // Note: the tests here just make sure that the validation does take place, for more fine grained
 //       testing regarding the validation there are unit tests in src/__tests__/get-validated-wrangler-config-path.spec.ts
 
 describe("during development wrangler config files are validated", () => {
-	const noWranglerConfigProjectPath = testSeed("no-wrangler-config", "pnpm");
+	const noWranglerConfigProjectPath = seed("no-wrangler-config", "pnpm");
 	test("for the entry worker", async ({ expect }) => {
 		const proc = await runLongLived("pnpm", "dev", noWranglerConfigProjectPath);
 		expect(await proc.exitCode).not.toBe(0);
@@ -14,7 +14,7 @@ describe("during development wrangler config files are validated", () => {
 		);
 	});
 
-	const noWranglerConfigAuxProjectPath = testSeed(
+	const noWranglerConfigAuxProjectPath = seed(
 		"no-wrangler-config-for-auxiliary-worker",
 		"pnpm"
 	);


### PR DESCRIPTION
Fixes the e2e windows failures that have been introduced by https://github.com/cloudflare/workers-sdk/pull/9308

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: tests change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
