### PR TITLE
fix: remove unnecessary remote warnings for mixed mode in the vite plugin

### DIFF
--- a/.changeset/mean-news-sell.md
+++ b/.changeset/mean-news-sell.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+silence `remote` wrangler config warnings when mixed mode is enabled

--- a/.changeset/mean-news-throw.md
+++ b/.changeset/mean-news-throw.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+enable consumers of `unstable_readConfig` to silence `remote` warnings

--- a/packages/vite-plugin-cloudflare/src/__tests__/get-worker-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/get-worker-config.spec.ts
@@ -6,7 +6,8 @@ describe("getWorkerConfig", () => {
 	test("should return a simple raw config", () => {
 		const { raw } = getWorkerConfig(
 			fileURLToPath(new URL("fixtures/simple-wrangler.jsonc", import.meta.url)),
-			undefined
+			undefined,
+			false
 		);
 		expect(typeof raw).toEqual("object");
 
@@ -34,7 +35,8 @@ describe("getWorkerConfig", () => {
 	test("should return a simple config without non-applicable fields", () => {
 		const { config } = getWorkerConfig(
 			fileURLToPath(new URL("fixtures/simple-wrangler.jsonc", import.meta.url)),
-			undefined
+			undefined,
+			false
 		);
 		expect(typeof config).toEqual("object");
 
@@ -44,7 +46,8 @@ describe("getWorkerConfig", () => {
 	test("should not return any non-applicable config when there isn't any", () => {
 		const { nonApplicable } = getWorkerConfig(
 			fileURLToPath(new URL("fixtures/simple-wrangler.jsonc", import.meta.url)),
-			undefined
+			undefined,
+			false
 		);
 		expect(nonApplicable).toEqual({
 			replacedByVite: new Set(),
@@ -55,7 +58,8 @@ describe("getWorkerConfig", () => {
 	test("should read a simple wrangler.toml file", () => {
 		const { config, raw, nonApplicable } = getWorkerConfig(
 			fileURLToPath(new URL("fixtures/simple-wrangler.jsonc", import.meta.url)),
-			undefined
+			undefined,
+			false
 		);
 		expect(typeof config).toEqual("object");
 
@@ -89,7 +93,8 @@ describe("getWorkerConfig", () => {
 					import.meta.url
 				)
 			),
-			undefined
+			undefined,
+			false
 		);
 
 		expect(typeof config).toEqual("object");
@@ -164,7 +169,8 @@ describe("getWorkerConfig", () => {
 							import.meta.url
 						)
 					),
-					undefined
+					undefined,
+					false
 				)
 			).toThrowError(
 				/The provided Wrangler config main field \(.*?index\.ts\) doesn't point to an existing file/
@@ -180,7 +186,8 @@ describe("getWorkerConfig", () => {
 							import.meta.url
 						)
 					),
-					undefined
+					undefined,
+					false
 				)
 			).toThrowError(
 				/The provided Wrangler config main field \(.*?fixtures\) points to a directory, it needs to point to a file instead/

--- a/packages/vite-plugin-cloudflare/src/deploy-config.ts
+++ b/packages/vite-plugin-cloudflare/src/deploy-config.ts
@@ -14,7 +14,7 @@ function getDeployConfigPath(root: string) {
 	return path.resolve(root, ".wrangler", "deploy", "config.json");
 }
 
-export function getWorkerConfigs(root: string) {
+export function getWorkerConfigs(root: string, mixedModeEnabled: boolean) {
 	const deployConfigPath = getDeployConfigPath(root);
 	const deployConfig = JSON.parse(
 		fs.readFileSync(deployConfigPath, "utf-8")
@@ -28,7 +28,10 @@ export function getWorkerConfigs(root: string) {
 			path.dirname(deployConfigPath),
 			configPath
 		);
-		return unstable_readConfig({ config: resolvedConfigPath });
+		return unstable_readConfig(
+			{ config: resolvedConfigPath },
+			{ experimental: { mixedModeEnabled } }
+		);
 	});
 }
 

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -386,7 +386,10 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				};
 			},
 			async configurePreviewServer(vitePreviewServer) {
-				const workerConfigs = getWorkerConfigs(vitePreviewServer.config.root);
+				const workerConfigs = getWorkerConfigs(
+					vitePreviewServer.config.root,
+					pluginConfig.experimental?.mixedMode ?? false
+				);
 
 				const inputInspectorPort = await getInputInspectorPortOption(
 					pluginConfig,
@@ -716,7 +719,10 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin[] {
 				});
 			},
 			async configurePreviewServer(vitePreviewServer) {
-				const workerConfigs = getWorkerConfigs(vitePreviewServer.config.root);
+				const workerConfigs = getWorkerConfigs(
+					vitePreviewServer.config.root,
+					pluginConfig.experimental?.mixedMode ?? false
+				);
 
 				if (workerConfigs.length >= 1 && pluginConfig.inspectorPort !== false) {
 					addDebugToVitePrintUrls(vitePreviewServer);

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -108,6 +108,7 @@ export function resolvePluginConfig(
 	const entryWorkerResolvedConfig = getWorkerConfig(
 		entryWorkerConfigPath,
 		cloudflareEnv,
+		pluginConfig.experimental?.mixedMode ?? false,
 		{
 			visitedConfigPaths: configPaths,
 			isEntryWorker: true,
@@ -149,6 +150,7 @@ export function resolvePluginConfig(
 		const workerResolvedConfig = getWorkerConfig(
 			workerConfigPath,
 			cloudflareEnv,
+			pluginConfig.experimental?.mixedMode ?? false,
 			{
 				visitedConfigPaths: configPaths,
 			}

--- a/packages/vite-plugin-cloudflare/src/workers-configs.ts
+++ b/packages/vite-plugin-cloudflare/src/workers-configs.ts
@@ -112,7 +112,8 @@ const nullableNonApplicable = [
 
 function readWorkerConfig(
 	configPath: string,
-	env: string | undefined
+	env: string | undefined,
+	mixedModeEnabled: boolean
 ): {
 	raw: RawWorkerConfig;
 	config: SanitizedWorkerConfig;
@@ -123,7 +124,10 @@ function readWorkerConfig(
 		notRelevant: new Set(),
 	};
 	const config: Optional<RawWorkerConfig, "build" | "define"> =
-		unstable_readConfig({ config: configPath, env }, {});
+		unstable_readConfig(
+			{ config: configPath, env },
+			{ experimental: { mixedModeEnabled } }
+		);
 	const raw = structuredClone(config) as RawWorkerConfig;
 
 	nullableNonApplicable.forEach((prop) => {
@@ -275,6 +279,7 @@ function missingFieldErrorMessage(
 export function getWorkerConfig(
 	configPath: string,
 	env: string | undefined,
+	mixedModeEnabled: boolean,
 	opts?: {
 		visitedConfigPaths?: Set<string>;
 		isEntryWorker?: boolean;
@@ -284,7 +289,11 @@ export function getWorkerConfig(
 		throw new Error(`Duplicate Wrangler config path found: ${configPath}`);
 	}
 
-	const { raw, config, nonApplicable } = readWorkerConfig(configPath, env);
+	const { raw, config, nonApplicable } = readWorkerConfig(
+		configPath,
+		env,
+		mixedModeEnabled
+	);
 
 	opts?.visitedConfigPaths?.add(configPath);
 

--- a/packages/wrangler/src/config/index.ts
+++ b/packages/wrangler/src/config/index.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import TOML from "@iarna/toml";
 import dotenv from "dotenv";
 import { FatalError, UserError } from "../errors";
+import { getFlag, run } from "../experimental-flags";
 import { logger } from "../logger";
 import { EXIT_CODE_INVALID_PAGES_CONFIG } from "../pages/errors";
 import { parseJSONC, parseTOML, readFileSync } from "../parse";
@@ -71,6 +72,9 @@ export type ReadConfigCommandArgs = NormalizeAndValidateConfigArgs & {
 
 export type ReadConfigOptions = ResolveConfigPathOptions & {
 	hideWarnings?: boolean;
+	experimental?: {
+		mixedModeEnabled?: boolean;
+	};
 };
 
 export type ConfigBindingOptions = Pick<
@@ -101,11 +105,25 @@ export function readConfig(
 		options
 	);
 
-	const { config, diagnostics } = normalizeAndValidateConfig(
-		rawConfig,
-		configPath,
-		userConfigPath,
-		args
+	// TODO: here we're overriding the MIXED_MODE flag based on options.experimental?.mixedModeEnabled,
+	//       once the MIXED_MODE flag is removed we should just normally call normalizeAndValidateConfig
+	const { diagnostics, config } = run(
+		{
+			RESOURCES_PROVISION: getFlag("RESOURCES_PROVISION") ?? false,
+			MULTIWORKER: getFlag("MULTIWORKER") ?? false,
+			MIXED_MODE:
+				options.experimental?.mixedModeEnabled ??
+				getFlag("MIXED_MODE") ??
+				false,
+		},
+		() => {
+			return normalizeAndValidateConfig(
+				rawConfig,
+				configPath,
+				userConfigPath,
+				args
+			);
+		}
 	);
 
 	if (diagnostics.hasWarnings() && !options?.hideWarnings) {


### PR DESCRIPTION
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: this minor behavior is not currently being tested (I can add tests for this but it feels a bit overkill? 🤔)
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: non-v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
