### PR TITLE
test: fix environment variable expansion of Wrangler e2e tests to work on Windows

### DIFF
--- a/packages/wrangler/e2e/vitest.config.mts
+++ b/packages/wrangler/e2e/vitest.config.mts
@@ -10,7 +10,8 @@ export default defineConfig({
 			},
 		},
 		retry: 1,
-		include: ["e2e/**/*.test.ts"],
+		// eslint-disable-next-line turbo/no-undeclared-env-vars
+		include: [process.env.WRANGLER_E2E_TEST_FILE || "e2e/**/*.test.ts"],
 		// eslint-disable-next-line turbo/no-undeclared-env-vars
 		outputFile: process.env.TEST_REPORT_PATH ?? ".e2e-test-report/index.html",
 		globalSetup: path.resolve(__dirname, "./validate-environment.ts"),

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -61,7 +61,7 @@
 		"test": "dotenv -- pnpm run assert-git-version && dotenv -- vitest",
 		"test:ci": "pnpm run test run",
 		"test:debug": "pnpm run test --silent=false --verbose=true",
-		"test:e2e": "dotenv -- vitest run -c ./e2e/vitest.config.mts $WRANGLER_E2E_TEST_FILE",
+		"test:e2e": "dotenv -- vitest run -c ./e2e/vitest.config.mts",
 		"test:watch": "pnpm run test --testTimeout=50000 --watch",
 		"type:tests": "tsc -p ./src/__tests__/tsconfig.json && tsc -p ./e2e/tsconfig.json"
 	},


### PR DESCRIPTION
I couldn't get Windows to expand the environment variable passed to the Vitest runner; tried various approaches including cross-env and cross-env-shell, in various different places and combinations.

This approach here appears to be robust across all the OSes and is quite simple and straightforward.