### PR TITLE
test: re-enable the Vite plugin basic e2e tests  on Windows

### DIFF
--- a/packages/vite-plugin-cloudflare/e2e/basic.test.ts
+++ b/packages/vite-plugin-cloudflare/e2e/basic.test.ts
@@ -11,7 +11,7 @@ describe("basic e2e tests", () => {
 
 		describe.each(commands)('with "%s" command', (command) => {
 			describe("node compatibility", () => {
-				test.skipIf(isWindows && command === "buildAndPreview")(
+				test.skipIf(command === "buildAndPreview")(
 					"can serve a Worker request",
 					async ({ expect }) => {
 						const proc = await runLongLived(pm, command, projectPath);
@@ -28,7 +28,7 @@ describe("basic e2e tests", () => {
 			describe.skipIf(
 				!process.env.CLOUDFLARE_ACCOUNT_ID || !process.env.CLOUDFLARE_API_TOKEN
 			)("Workers AI", () => {
-				test.skipIf(isWindows && command === "buildAndPreview")(
+				test.skipIf(command === "buildAndPreview")(
 					"can serve a Worker request",
 					async ({ expect }) => {
 						const proc = await runLongLived(pm, command, projectPath);


### PR DESCRIPTION
We disabled these because they seemed to be failing (a lot?) on Windows. But I have run them numerous time locally now and they pass every time.

The mixed mode ones are still disabled though.

Fixes DEVX-1748

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> Vite is not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
