### PR TITLE
add mTLS mixed mode support

### DIFF
--- a/.changeset/famous-candies-start.md
+++ b/.changeset/famous-candies-start.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+add workerName option to startMixedModeSession API

--- a/.changeset/lemon-laws-mate.md
+++ b/.changeset/lemon-laws-mate.md
@@ -1,0 +1,6 @@
+---
+"miniflare": patch
+"wrangler": patch
+---
+
+add mixed-mode support for mtls bindings

--- a/packages/miniflare/src/plugins/index.ts
+++ b/packages/miniflare/src/plugins/index.ts
@@ -24,6 +24,7 @@ import { EMAIL_PLUGIN, EMAIL_PLUGIN_NAME } from "./email";
 import { HYPERDRIVE_PLUGIN, HYPERDRIVE_PLUGIN_NAME } from "./hyperdrive";
 import { IMAGES_PLUGIN, IMAGES_PLUGIN_NAME } from "./images";
 import { KV_PLUGIN, KV_PLUGIN_NAME } from "./kv";
+import { MTLS_PLUGIN, MTLS_PLUGIN_NAME } from "./mtls";
 import { PIPELINE_PLUGIN, PIPELINES_PLUGIN_NAME } from "./pipelines";
 import { QUEUES_PLUGIN, QUEUES_PLUGIN_NAME } from "./queues";
 import { R2_PLUGIN, R2_PLUGIN_NAME } from "./r2";
@@ -54,6 +55,7 @@ export const PLUGINS = {
 	[IMAGES_PLUGIN_NAME]: IMAGES_PLUGIN,
 	[VECTORIZE_PLUGIN_NAME]: VECTORIZE_PLUGIN,
 	[CONTAINER_PLUGIN_NAME]: CONTAINER_PLUGIN,
+	[MTLS_PLUGIN_NAME]: MTLS_PLUGIN,
 };
 export type Plugins = typeof PLUGINS;
 
@@ -112,7 +114,8 @@ export type WorkerOptions = z.input<typeof CORE_PLUGIN.options> &
 	z.input<typeof DISPATCH_NAMESPACE_PLUGIN.options> &
 	z.input<typeof IMAGES_PLUGIN.options> &
 	z.input<typeof VECTORIZE_PLUGIN.options> &
-	z.input<typeof CONTAINER_PLUGIN.options>;
+	z.input<typeof CONTAINER_PLUGIN.options> &
+	z.input<typeof MTLS_PLUGIN.options>;
 
 export type SharedOptions = z.input<typeof CORE_PLUGIN.sharedOptions> &
 	z.input<typeof CACHE_PLUGIN.sharedOptions> &
@@ -183,3 +186,4 @@ export * from "./images";
 export * from "./vectorize";
 export * from "./containers";
 export { ContainerController } from "./containers/service";
+export * from "./mtls";

--- a/packages/miniflare/src/plugins/mtls/index.ts
+++ b/packages/miniflare/src/plugins/mtls/index.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert";
+import { z } from "zod";
+import {
+	mixedModeClientWorker,
+	MixedModeConnectionString,
+	Plugin,
+	ProxyNodeBinding,
+} from "../shared";
+
+const MtlsSchema = z.object({
+	certificate_id: z.string(),
+	mixedModeConnectionString: z.custom<MixedModeConnectionString>(),
+});
+
+export const MtlsOptionsSchema = z.object({
+	mtlsCertificates: z.record(MtlsSchema).optional(),
+});
+
+export const MTLS_PLUGIN_NAME = "mtls";
+
+export const MTLS_PLUGIN: Plugin<typeof MtlsOptionsSchema> = {
+	options: MtlsOptionsSchema,
+	async getBindings(options) {
+		if (!options.mtlsCertificates) {
+			return [];
+		}
+
+		return Object.entries(options.mtlsCertificates).map(
+			([name, { certificate_id, mixedModeConnectionString }]) => {
+				assert(mixedModeConnectionString, "MTLS only supports Mixed Mode");
+
+				return {
+					name,
+
+					service: {
+						name: `${MTLS_PLUGIN_NAME}:${certificate_id}`,
+					},
+				};
+			}
+		);
+	},
+	getNodeBindings(options: z.infer<typeof MtlsOptionsSchema>) {
+		if (!options.mtlsCertificates) {
+			return {};
+		}
+		return Object.fromEntries(
+			Object.keys(options.mtlsCertificates).map((name) => [
+				name,
+				new ProxyNodeBinding(),
+			])
+		);
+	},
+	async getServices({ options }) {
+		if (!options.mtlsCertificates) {
+			return [];
+		}
+
+		return Object.entries(options.mtlsCertificates).map(
+			([name, { certificate_id, mixedModeConnectionString }]) => {
+				assert(mixedModeConnectionString, "MTLS only supports Mixed Mode");
+
+				return {
+					name: `${MTLS_PLUGIN_NAME}:${certificate_id}`,
+					worker: mixedModeClientWorker(mixedModeConnectionString, name),
+				};
+			}
+		);
+	},
+};

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -725,8 +725,12 @@ async function maybeStartOrUpdateMixedModeSession(
 	//             same we can just leave the mixedModeSession untouched
 	if (mixedModeSession === undefined) {
 		if (Object.keys(workerRemoteBindings).length > 0) {
-			mixedModeSession =
-				await experimental_startMixedModeSession(workerRemoteBindings);
+			mixedModeSession = await experimental_startMixedModeSession(
+				workerRemoteBindings,
+				{
+					workerName: workerConfig.name,
+				}
+			);
 			mixedModeSessionsMap.set(workerConfig.name, mixedModeSession);
 		}
 	} else {

--- a/packages/wrangler/e2e/cert.test.ts
+++ b/packages/wrangler/e2e/cert.test.ts
@@ -1,115 +1,13 @@
-import { randomUUID } from "node:crypto";
-import * as forge from "node-forge";
 import { describe, expect, it } from "vitest";
+import {
+	generateCaCertName,
+	generateLeafCertificate,
+	generateMtlsCertName,
+	generateRootCaCert,
+	generateRootCertificate,
+} from "./helpers/cert";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { normalizeOutput } from "./helpers/normalize";
-
-// Generate X509 self signed root key pair and certificate
-function generateRootCertificate() {
-	const rootKeys = forge.pki.rsa.generateKeyPair(2048);
-	const rootCert = forge.pki.createCertificate();
-	rootCert.publicKey = rootKeys.publicKey;
-	rootCert.serialNumber = "01";
-	rootCert.validity.notBefore = new Date();
-	rootCert.validity.notAfter = new Date();
-	rootCert.validity.notAfter.setFullYear(
-		rootCert.validity.notBefore.getFullYear() + 10
-	); // 10 years validity
-
-	const rootAttrs = [
-		{ name: "commonName", value: "Root CA" },
-		{ name: "countryName", value: "US" },
-		{ shortName: "ST", value: "California" },
-		{ name: "organizationName", value: "Localhost Root CA" },
-	];
-	rootCert.setSubject(rootAttrs);
-	rootCert.setIssuer(rootAttrs); // Self-signed
-
-	rootCert.sign(rootKeys.privateKey, forge.md.sha256.create());
-
-	return { certificate: rootCert, privateKey: rootKeys.privateKey };
-}
-
-// Generate X509 leaf certificate signed by the root
-function generateLeafCertificate(
-	rootCert: forge.pki.Certificate,
-	rootKey: forge.pki.PrivateKey
-) {
-	const leafKeys = forge.pki.rsa.generateKeyPair(2048);
-	const leafCert = forge.pki.createCertificate();
-	leafCert.publicKey = leafKeys.publicKey;
-	leafCert.serialNumber = "02";
-	leafCert.validity.notBefore = new Date();
-	leafCert.validity.notAfter = new Date();
-	leafCert.validity.notAfter.setFullYear(2034, 10, 18);
-
-	const leafAttrs = [
-		{ name: "commonName", value: "example.org" },
-		{ name: "countryName", value: "US" },
-		{ shortName: "ST", value: "California" },
-		{ name: "organizationName", value: "Example Inc" },
-	];
-	leafCert.setSubject(leafAttrs);
-	leafCert.setIssuer(rootCert.subject.attributes); // Signed by root
-
-	leafCert.sign(rootKey, forge.md.sha256.create()); // Signed using root's private key
-
-	const pemLeafCert = forge.pki.certificateToPem(leafCert);
-	const pemLeafKey = forge.pki.privateKeyToPem(leafKeys.privateKey);
-
-	return { certificate: pemLeafCert, privateKey: pemLeafKey };
-}
-
-// Generate self signed X509 CA root certificate
-function generateRootCaCert() {
-	// Create a key pair (private and public keys)
-	const keyPair = forge.pki.rsa.generateKeyPair(2048);
-
-	// Create a new X.509 certificate
-	const cert = forge.pki.createCertificate();
-
-	// Set certificate fields
-	cert.publicKey = keyPair.publicKey;
-	cert.serialNumber = "01";
-	cert.validity.notBefore = new Date();
-	cert.validity.notAfter = new Date();
-	cert.validity.notAfter.setFullYear(2034, 10, 18);
-
-	// Add issuer and subject fields (for a root CA, they are the same)
-	const attrs = [
-		{ name: "commonName", value: "Localhost CA" },
-		{ name: "countryName", value: "US" },
-		{ shortName: "ST", value: "California" },
-		{ name: "localityName", value: "San Francisco" },
-		{ name: "organizationName", value: "Localhost" },
-		{ shortName: "OU", value: "SSL Department" },
-	];
-	cert.setSubject(attrs);
-	cert.setIssuer(attrs);
-
-	// Add basic constraints and key usage extensions
-	cert.setExtensions([
-		{
-			name: "basicConstraints",
-			cA: true,
-		},
-		{
-			name: "keyUsage",
-			keyCertSign: true,
-			digitalSignature: true,
-			cRLSign: true,
-		},
-	]);
-
-	// Self-sign the certificate with the private key
-	cert.sign(keyPair.privateKey, forge.md.sha256.create());
-
-	// Convert the certificate and private key to PEM format
-	const pemCert = forge.pki.certificateToPem(cert);
-	const pemPrivateKey = forge.pki.privateKeyToPem(keyPair.privateKey);
-
-	return { certificate: pemCert, privateKey: pemPrivateKey };
-}
 
 describe("cert", () => {
 	const normalize = (str: string) =>
@@ -125,8 +23,8 @@ describe("cert", () => {
 	const { certificate: caCert } = generateRootCaCert();
 
 	// Generate filenames for concurrent e2e test environment
-	const mtlsCertName = `tmp-e2e-mtls-cert-${randomUUID()}`;
-	const caCertName = `tmp-e2e-ca-cert-${randomUUID()}`;
+	const mtlsCertName = generateMtlsCertName();
+	const caCertName = generateCaCertName();
 
 	it("upload mtls-certificate", async () => {
 		// locally generated certs/key

--- a/packages/wrangler/e2e/helpers/cert.ts
+++ b/packages/wrangler/e2e/helpers/cert.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from "node:crypto";
+import * as forge from "node-forge";
+
+// Generate X509 self signed root key pair and certificate
+export function generateRootCertificate() {
+	const rootKeys = forge.pki.rsa.generateKeyPair(2048);
+	const rootCert = forge.pki.createCertificate();
+	rootCert.publicKey = rootKeys.publicKey;
+	rootCert.serialNumber = "01";
+	rootCert.validity.notBefore = new Date();
+	rootCert.validity.notAfter = new Date();
+	rootCert.validity.notAfter.setFullYear(
+		rootCert.validity.notBefore.getFullYear() + 10
+	); // 10 years validity
+
+	const rootAttrs = [
+		{ name: "commonName", value: "Root CA" },
+		{ name: "countryName", value: "US" },
+		{ shortName: "ST", value: "California" },
+		{ name: "organizationName", value: "Localhost Root CA" },
+	];
+	rootCert.setSubject(rootAttrs);
+	rootCert.setIssuer(rootAttrs); // Self-signed
+
+	rootCert.sign(rootKeys.privateKey, forge.md.sha256.create());
+
+	return { certificate: rootCert, privateKey: rootKeys.privateKey };
+}
+
+// Generate X509 leaf certificate signed by the root
+export function generateLeafCertificate(
+	rootCert: forge.pki.Certificate,
+	rootKey: forge.pki.PrivateKey
+) {
+	const leafKeys = forge.pki.rsa.generateKeyPair(2048);
+	const leafCert = forge.pki.createCertificate();
+	leafCert.publicKey = leafKeys.publicKey;
+	leafCert.serialNumber = "02";
+	leafCert.validity.notBefore = new Date();
+	leafCert.validity.notAfter = new Date();
+	leafCert.validity.notAfter.setFullYear(2034, 10, 18);
+
+	const leafAttrs = [
+		{ name: "commonName", value: "example.org" },
+		{ name: "countryName", value: "US" },
+		{ shortName: "ST", value: "California" },
+		{ name: "organizationName", value: "Example Inc" },
+	];
+	leafCert.setSubject(leafAttrs);
+	leafCert.setIssuer(rootCert.subject.attributes); // Signed by root
+
+	leafCert.sign(rootKey, forge.md.sha256.create()); // Signed using root's private key
+
+	const pemLeafCert = forge.pki.certificateToPem(leafCert);
+	const pemLeafKey = forge.pki.privateKeyToPem(leafKeys.privateKey);
+
+	return { certificate: pemLeafCert, privateKey: pemLeafKey };
+}
+
+// Generate self signed X509 CA root certificate
+export function generateRootCaCert() {
+	// Create a key pair (private and public keys)
+	const keyPair = forge.pki.rsa.generateKeyPair(2048);
+
+	// Create a new X.509 certificate
+	const cert = forge.pki.createCertificate();
+
+	// Set certificate fields
+	cert.publicKey = keyPair.publicKey;
+	cert.serialNumber = "01";
+	cert.validity.notBefore = new Date();
+	cert.validity.notAfter = new Date();
+	cert.validity.notAfter.setFullYear(2034, 10, 18);
+
+	// Add issuer and subject fields (for a root CA, they are the same)
+	const attrs = [
+		{ name: "commonName", value: "Localhost CA" },
+		{ name: "countryName", value: "US" },
+		{ shortName: "ST", value: "California" },
+		{ name: "localityName", value: "San Francisco" },
+		{ name: "organizationName", value: "Localhost" },
+		{ shortName: "OU", value: "SSL Department" },
+	];
+	cert.setSubject(attrs);
+	cert.setIssuer(attrs);
+
+	// Add basic constraints and key usage extensions
+	cert.setExtensions([
+		{
+			name: "basicConstraints",
+			cA: true,
+		},
+		{
+			name: "keyUsage",
+			keyCertSign: true,
+			digitalSignature: true,
+			cRLSign: true,
+		},
+	]);
+
+	// Self-sign the certificate with the private key
+	cert.sign(keyPair.privateKey, forge.md.sha256.create());
+
+	// Convert the certificate and private key to PEM format
+	const pemCert = forge.pki.certificateToPem(cert);
+	const pemPrivateKey = forge.pki.privateKeyToPem(keyPair.privateKey);
+
+	return { certificate: pemCert, privateKey: pemPrivateKey };
+}
+
+export function generateMtlsCertName() {
+	return `tmp-e2e-mtls-cert-${randomUUID()}`;
+}
+
+export function generateCaCertName() {
+	return `tmp-e2e-ca-cert-${randomUUID()}`;
+}

--- a/packages/wrangler/e2e/miniflare-mixed-mode-resources.test.ts
+++ b/packages/wrangler/e2e/miniflare-mixed-mode-resources.test.ts
@@ -1,9 +1,16 @@
+import assert from "node:assert";
 import path from "node:path";
 import dedent from "ts-dedent";
 import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
+import {
+	generateLeafCertificate,
+	generateMtlsCertName,
+	generateRootCertificate,
+} from "./helpers/cert";
 import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
 import { generateResourceName } from "./helpers/generate-resource-name";
-import type { Binding } from "../src/api";
+import type { startMixedModeSession } from "../src/api";
+import type { RawConfig } from "../src/config";
 import type { MixedModeConnectionString, WorkerOptions } from "miniflare";
 import type { ExpectStatic } from "vitest";
 
@@ -11,47 +18,51 @@ type TestCase<T = void> = {
 	name: string;
 	scriptPath: string;
 	mixedModeSessionConfig:
-		| Record<string, Binding>
-		| ((setup: T) => Record<string, Binding>);
+		| Parameters<typeof startMixedModeSession>
+		| ((setup: T) => Parameters<typeof startMixedModeSession>);
 	miniflareConfig: (
 		connection: MixedModeConnectionString,
 		setup: T
 	) => Partial<WorkerOptions>;
 	setup?: (helper: WranglerE2ETestHelper) => Promise<T> | T;
-	match: ExpectStatic;
+	matches: ExpectStatic[];
 };
 const testCases: TestCase<string>[] = [
 	{
 		name: "AI",
 		scriptPath: "ai.js",
-		mixedModeSessionConfig: {
-			AI: {
-				type: "ai",
+		mixedModeSessionConfig: [
+			{
+				AI: {
+					type: "ai",
+				},
 			},
-		},
+		],
 		miniflareConfig: (connection) => ({
 			ai: {
 				binding: "AI",
 				mixedModeConnectionString: connection,
 			},
 		}),
-		match: expect.stringMatching(/This is a response from Workers AI/),
+		matches: [expect.stringMatching(/This is a response from Workers AI/)],
 	},
 	{
 		name: "Browser",
 		scriptPath: "browser.js",
-		mixedModeSessionConfig: {
-			BROWSER: {
-				type: "browser",
+		mixedModeSessionConfig: [
+			{
+				BROWSER: {
+					type: "browser",
+				},
 			},
-		},
+		],
 		miniflareConfig: (connection) => ({
 			browserRendering: {
 				binding: "BROWSER",
 				mixedModeConnectionString: connection,
 			},
 		}),
-		match: expect.stringMatching(/sessionId/),
+		matches: [expect.stringMatching(/sessionId/)],
 	},
 	{
 		name: "Service Binding",
@@ -81,17 +92,19 @@ const testCases: TestCase<string>[] = [
 			});
 			return targetWorkerName;
 		},
-		mixedModeSessionConfig: (target) => ({
-			SERVICE: {
-				type: "service",
-				service: target,
+		mixedModeSessionConfig: (target) => [
+			{
+				SERVICE: {
+					type: "service",
+					service: target,
+				},
+				SERVICE_WITH_ENTRYPOINT: {
+					type: "service",
+					entrypoint: "CustomEntrypoint",
+					service: target,
+				},
 			},
-			SERVICE_WITH_ENTRYPOINT: {
-				type: "service",
-				entrypoint: "CustomEntrypoint",
-				service: target,
-			},
-		}),
+		],
 		miniflareConfig: (connection, target) => ({
 			serviceBindings: {
 				SERVICE: {
@@ -105,12 +118,14 @@ const testCases: TestCase<string>[] = [
 				},
 			},
 		}),
-		match: expect.stringMatching(
-			JSON.stringify({
-				default: "Hello from target worker",
-				entrypoint: "Hello from target worker entrypoint",
-			})
-		),
+		matches: [
+			expect.stringMatching(
+				JSON.stringify({
+					default: "Hello from target worker",
+					entrypoint: "Hello from target worker entrypoint",
+				})
+			),
+		],
 	},
 	{
 		name: "KV",
@@ -122,12 +137,14 @@ const testCases: TestCase<string>[] = [
 			);
 			return ns;
 		},
-		mixedModeSessionConfig: (ns) => ({
-			KV_BINDING: {
-				type: "kv_namespace",
-				id: ns,
+		mixedModeSessionConfig: (ns) => [
+			{
+				KV_BINDING: {
+					type: "kv_namespace",
+					id: ns,
+				},
 			},
-		}),
+		],
 		miniflareConfig: (connection, ns) => ({
 			kvNamespaces: {
 				KV_BINDING: {
@@ -136,7 +153,9 @@ const testCases: TestCase<string>[] = [
 				},
 			},
 		}),
-		match: expect.stringMatching("The pre-existing value is: existing-value"),
+		matches: [
+			expect.stringMatching("The pre-existing value is: existing-value"),
+		],
 	},
 	{
 		name: "R2",
@@ -154,12 +173,14 @@ const testCases: TestCase<string>[] = [
 			});
 			return name;
 		},
-		mixedModeSessionConfig: (name) => ({
-			R2_BINDING: {
-				type: "r2_bucket",
-				bucket_name: name,
+		mixedModeSessionConfig: (name) => [
+			{
+				R2_BINDING: {
+					type: "r2_bucket",
+					bucket_name: name,
+				},
 			},
-		}),
+		],
 		miniflareConfig: (connection, name) => ({
 			r2Buckets: {
 				R2_BINDING: {
@@ -168,7 +189,9 @@ const testCases: TestCase<string>[] = [
 				},
 			},
 		}),
-		match: expect.stringMatching("The pre-existing value is: existing-value"),
+		matches: [
+			expect.stringMatching("The pre-existing value is: existing-value"),
+		],
 	},
 	{
 		name: "D1",
@@ -186,12 +209,14 @@ const testCases: TestCase<string>[] = [
 			);
 			return id;
 		},
-		mixedModeSessionConfig: (id) => ({
-			DB: {
-				type: "d1",
-				database_id: id,
+		mixedModeSessionConfig: (id) => [
+			{
+				DB: {
+					type: "d1",
+					database_id: id,
+				},
 			},
-		}),
+		],
 		miniflareConfig: (connection, id) => ({
 			d1Databases: {
 				DB: {
@@ -200,7 +225,7 @@ const testCases: TestCase<string>[] = [
 				},
 			},
 		}),
-		match: expect.stringMatching("existing-value"),
+		matches: [expect.stringMatching("existing-value")],
 	},
 	{
 		name: "Vectorize",
@@ -213,12 +238,14 @@ const testCases: TestCase<string>[] = [
 			);
 			return name;
 		},
-		mixedModeSessionConfig: (name) => ({
-			VECTORIZE_BINDING: {
-				type: "vectorize",
-				index_name: name,
+		mixedModeSessionConfig: (name) => [
+			{
+				VECTORIZE_BINDING: {
+					type: "vectorize",
+					index_name: name,
+				},
 			},
-		}),
+		],
 		miniflareConfig: (connection, name) => ({
 			vectorize: {
 				VECTORIZE_BINDING: {
@@ -227,25 +254,29 @@ const testCases: TestCase<string>[] = [
 				},
 			},
 		}),
-		match: expect.stringContaining(
-			`[{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","namespace":null,"metadata":{"text":"Peter Piper picked a peck of pickled peppers"},"values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}]`
-		),
+		matches: [
+			expect.stringContaining(
+				`[{"id":"a44706aa-a366-48bc-8cc1-3feffd87d548","namespace":null,"metadata":{"text":"Peter Piper picked a peck of pickled peppers"},"values":[0.2321,0.8121,0.6315,0.6151,0.4121,0.1512,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}]`
+			),
+		],
 	},
 	{
 		name: "Images",
 		scriptPath: "images.js",
-		mixedModeSessionConfig: {
-			IMAGES: {
-				type: "images",
+		mixedModeSessionConfig: [
+			{
+				IMAGES: {
+					type: "images",
+				},
 			},
-		},
+		],
 		miniflareConfig: (connection) => ({
 			images: {
 				binding: "IMAGES",
 				mixedModeConnectionString: connection,
 			},
 		}),
-		match: expect.stringContaining(`image/avif`),
+		matches: [expect.stringContaining(`image/avif`)],
 	},
 	{
 		name: "Dispatch Namespace",
@@ -269,12 +300,14 @@ const testCases: TestCase<string>[] = [
 
 			return namespace;
 		},
-		mixedModeSessionConfig: (namespace) => ({
-			DISPATCH: {
-				type: "dispatch_namespace",
-				namespace: namespace,
+		mixedModeSessionConfig: (namespace) => [
+			{
+				DISPATCH: {
+					type: "dispatch_namespace",
+					namespace: namespace,
+				},
 			},
-		}),
+		],
 		miniflareConfig: (connection, namespace) => ({
 			dispatchNamespaces: {
 				DISPATCH: {
@@ -283,45 +316,100 @@ const testCases: TestCase<string>[] = [
 				},
 			},
 		}),
-		match: expect.stringMatching(/Hello from customer worker/),
+		matches: [expect.stringMatching(/Hello from customer worker/)],
 	},
 ];
-describe.each(testCases)("Mixed Mode for $name", (testCase) => {
+
+const mtlsTest: TestCase<{ certificateId: string; workerName: string }> = {
+	name: "mTLS",
+	scriptPath: "mtls.js",
+	setup: async (helper) => {
+		// Generate root and leaf certificates
+		const { certificate: rootCert, privateKey: rootKey } =
+			generateRootCertificate();
+		const { certificate: leafCert, privateKey: leafKey } =
+			generateLeafCertificate(rootCert, rootKey);
+
+		// Generate filenames for concurrent e2e test environment
+		const mtlsCertName = generateMtlsCertName();
+		// const caCertName = generateCaCertName();
+
+		// locally generated certs/key
+		await helper.seed({ "mtls_client_cert_file.pem": leafCert });
+		await helper.seed({ "mtls_client_private_key_file.pem": leafKey });
+
+		const output = await helper.run(
+			`wrangler cert upload mtls-certificate --name ${mtlsCertName} --cert mtls_client_cert_file.pem --key mtls_client_private_key_file.pem`
+		);
+
+		const match = output.stdout.match(/ID:\s+(?<certId>.*)$/m);
+		const certificateId = match?.groups?.certId;
+		assert(certificateId);
+
+		const workerName = generateResourceName();
+		await helper.seed({
+			"worker.js": dedent/* javascript */ `
+					export default {
+						fetch(request) { return new Response("Hello"); }
+					}
+				`,
+		});
+
+		const wranglerConfig: RawConfig = {
+			name: workerName,
+			mtls_certificates: [
+				{
+					certificate_id: certificateId,
+					binding: "MTLS",
+				},
+			],
+		};
+		await helper.seed({
+			"pre-deployment-wrangler.json": JSON.stringify(wranglerConfig, null, 2),
+		});
+
+		await helper.run(
+			`wrangler deploy worker.js --name ${workerName} -c pre-deployment-wrangler.json --compatibility-date 2025-01-01`
+		);
+		onTestFinished(async () => {
+			await helper.run(`wrangler delete --name ${workerName}`);
+		});
+
+		return { certificateId, workerName };
+	},
+	mixedModeSessionConfig: ({ certificateId, workerName }) => [
+		{
+			MTLS: {
+				type: "mtls_certificate",
+				certificate_id: certificateId,
+			},
+		},
+		{
+			workerName,
+		},
+	],
+	miniflareConfig: (connection, { certificateId }) => ({
+		mtlsCertificates: {
+			MTLS: {
+				certificate_id: certificateId,
+				mixedModeConnectionString: connection,
+			},
+		},
+	}),
+	matches: [
+		// Note: in this test we are making sure that TLS negotiation does work by checking that we get an SSL certificate error
+		expect.stringMatching(/The SSL certificate error/),
+		expect.not.stringMatching(/No required SSL certificate was sent/),
+	],
+};
+
+describe.each([...testCases, mtlsTest])("Mixed Mode for $name", (testCase) => {
 	let helper: WranglerE2ETestHelper;
 	beforeEach(() => {
 		helper = new WranglerE2ETestHelper();
 	});
 	it("enabled", async () => {
-		const { experimental_startMixedModeSession } =
-			await helper.importWrangler();
-		const { Miniflare } = await helper.importMiniflare();
-		await helper.seed(
-			path.resolve(__dirname, "./seed-files/mixed-mode-workers")
-		);
-		const setupResult = await testCase.setup?.(helper);
-
-		const mixedModeSession = await experimental_startMixedModeSession(
-			typeof testCase.mixedModeSessionConfig === "function"
-				? /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-					testCase.mixedModeSessionConfig(setupResult!)
-				: testCase.mixedModeSessionConfig
-		);
-
-		const mf = new Miniflare({
-			compatibilityDate: "2025-01-01",
-			// @ts-expect-error TS doesn't like the spreading of miniflareConfig
-			modules: true,
-			scriptPath: path.resolve(helper.tmpPath, testCase.scriptPath),
-			modulesRoot: helper.tmpPath,
-			...testCase.miniflareConfig(
-				mixedModeSession.mixedModeConnectionString,
-				/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-				setupResult!
-			),
-		});
-		expect(await (await mf.dispatchFetch("http://example.com")).text()).toEqual(
-			testCase.match
-		);
+		await runTestCase(testCase as TestCase<unknown>, helper);
 	});
 	// Ensure the test case _relies_ on Mixed Mode, and fails in regular local dev
 	it(
@@ -329,21 +417,52 @@ describe.each(testCases)("Mixed Mode for $name", (testCase) => {
 		// Turn off retries because this test is expected to fail
 		{ retry: 0, fails: true },
 		async () => {
-			const { Miniflare } = await helper.importMiniflare();
-			await helper.seed(path.resolve(__dirname, "./mixed-mode-test-workers"));
-
-			const mf = new Miniflare({
-				compatibilityDate: "2025-01-01",
-				// @ts-expect-error TS doesn't like the spreading of miniflareConfig
-				modules: true,
-				scriptPath: path.resolve(helper.tmpPath, testCase.scriptPath),
-				modulesRoot: helper.tmpPath,
-				// @ts-expect-error Deliberately passing in undefined here to turn off Mixed Mode
-				...testCase.miniflareConfig(undefined),
+			await runTestCase(testCase as TestCase<unknown>, helper, {
+				disableMixedMode: true,
 			});
-			expect(
-				await (await mf.dispatchFetch("http://example.com")).text()
-			).toStrictEqual(testCase.match);
 		}
 	);
 });
+
+async function runTestCase<T>(
+	testCase: TestCase<T>,
+	helper: WranglerE2ETestHelper,
+	{ disableMixedMode } = { disableMixedMode: false }
+) {
+	const { experimental_startMixedModeSession } = await helper.importWrangler();
+	const { Miniflare } = await helper.importMiniflare();
+	await helper.seed(path.resolve(__dirname, "./seed-files/mixed-mode-workers"));
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	const setupResult = (await testCase.setup?.(helper))!;
+
+	const mixedModeSessionConfig =
+		typeof testCase.mixedModeSessionConfig === "function"
+			? testCase.mixedModeSessionConfig(setupResult)
+			: testCase.mixedModeSessionConfig;
+
+	const mixedModeSession = await experimental_startMixedModeSession(
+		...mixedModeSessionConfig
+	);
+
+	const miniflareConfig = disableMixedMode
+		? // @ts-expect-error Deliberately passing in undefined here to turn off Mixed Mode
+			testCase.miniflareConfig(undefined)
+		: testCase.miniflareConfig(
+				mixedModeSession.mixedModeConnectionString,
+				setupResult
+			);
+
+	const mf = new Miniflare({
+		compatibilityDate: "2025-01-01",
+		// @ts-expect-error TS doesn't like the spreading of miniflareConfig
+		modules: true,
+		scriptPath: path.resolve(helper.tmpPath, testCase.scriptPath),
+		modulesRoot: helper.tmpPath,
+		...miniflareConfig,
+	});
+	const resp = await mf.dispatchFetch("http://example.com");
+	const respText = await resp.text();
+	testCase.matches.forEach((match) => {
+		expect(respText).toEqual(match);
+	});
+}

--- a/packages/wrangler/e2e/seed-files/mixed-mode-workers/mtls.js
+++ b/packages/wrangler/e2e/seed-files/mixed-mode-workers/mtls.js
@@ -1,0 +1,5 @@
+export default {
+	async fetch(request, env, ctx) {
+		return env.MTLS.fetch("https://client-cert-missing.badssl.com/");
+	},
+};

--- a/packages/wrangler/src/api/mixedMode/index.ts
+++ b/packages/wrangler/src/api/mixedMode/index.ts
@@ -15,13 +15,16 @@ export type MixedModeSession = Pick<Worker, "ready" | "dispose"> & {
 	mixedModeConnectionString: MixedModeConnectionString;
 };
 
+export type StartMixedModeSessionOptions = {
+	workerName?: string;
+	auth?: NonNullable<StartDevWorkerInput["dev"]>["auth"];
+	/** If running in a non-public compliance region, set this here. */
+	complianceRegion?: Config["compliance_region"];
+};
+
 export async function startMixedModeSession(
 	bindings: StartDevWorkerInput["bindings"],
-	options?: {
-		auth?: NonNullable<StartDevWorkerInput["dev"]>["auth"];
-		/** If running in a non-public compliance region, set this here. */
-		complianceRegion?: Config["compliance_region"];
-	}
+	options?: StartMixedModeSessionOptions
 ): Promise<MixedModeSession> {
 	const proxyServerWorkerWranglerConfig = path.resolve(
 		getBasePath(),
@@ -37,6 +40,7 @@ export async function startMixedModeSession(
 	);
 
 	const worker = await startWorker({
+		name: options?.workerName,
 		config: proxyServerWorkerWranglerConfig,
 		dev: {
 			remote: "minimal",

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -334,6 +334,7 @@ export async function maybeStartOrUpdateMixedModeSession(
 		const numOfRemoteBindings = Object.keys(remoteBindings ?? {}).length;
 		if (numOfRemoteBindings > 0) {
 			mixedModeSession = await startMixedModeSession(remoteBindings, {
+				workerName: configBundle.name,
 				complianceRegion: configBundle.complianceRegion,
 			});
 		}

--- a/packages/wrangler/src/cli.ts
+++ b/packages/wrangler/src/cli.ts
@@ -66,6 +66,7 @@ export { experimental_patchConfig } from "./config/patch-config";
 
 export {
 	startMixedModeSession as experimental_startMixedModeSession,
+	type StartMixedModeSessionOptions as experimental_StartMixedModeSessionOptions,
 	pickRemoteBindings as experimental_pickRemoteBindings,
 	type MixedModeSession as Experimental_MixedModeSession,
 	convertConfigBindingsToStartWorkerBindings as unstable_convertConfigBindingsToStartWorkerBindings,

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -921,6 +921,8 @@ export interface EnvironmentNonInheritable {
 		binding: string;
 		/** The uuid of the uploaded mTLS certificate */
 		certificate_id: string;
+		/** Whether the mtls fetcher should be remote or not (only available under `--x-mixed-mode`) */
+		remote?: boolean;
 	}[];
 
 	/**

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -3181,7 +3181,12 @@ const validateMTlsCertificateBinding: ValidatorFn = (
 	validateAdditionalProperties(diagnostics, field, Object.keys(value), [
 		"binding",
 		"certificate_id",
+		...(getFlag("MIXED_MODE") ? ["remote"] : []),
 	]);
+
+	if (!isRemoteValid(value, field, diagnostics)) {
+		isValid = false;
+	}
 
 	return isValid;
 };

--- a/packages/wrangler/src/deployment-bundle/worker.ts
+++ b/packages/wrangler/src/deployment-bundle/worker.ts
@@ -258,6 +258,7 @@ export interface CfDispatchNamespace {
 export interface CfMTlsCertificate {
 	binding: string;
 	certificate_id: string;
+	remote?: boolean;
 }
 
 export interface CfLogfwdr {

--- a/packages/wrangler/src/dev/miniflare.ts
+++ b/packages/wrangler/src/dev/miniflare.ts
@@ -496,6 +496,7 @@ type WorkerOptionsBindings = Pick<
 	| "browserRendering"
 	| "vectorize"
 	| "dispatchNamespaces"
+	| "mtlsCertificates"
 >;
 
 type MiniflareBindingsConfig = Pick<
@@ -807,6 +808,12 @@ export function buildMiniflareBindingOptions(
 		warnOrError("browser", bindings.browser.remote, "remote");
 	}
 
+	if (bindings.mtls_certificates && mixedModeEnabled) {
+		for (const mtls of bindings.mtls_certificates) {
+			warnOrError("ai", mtls.remote, "always-remote");
+		}
+	}
+
 	// Uses the implementation in miniflare instead if the users enable local mode
 	if (
 		bindings.images?.binding &&
@@ -1033,6 +1040,25 @@ export function buildMiniflareBindingOptions(
 				?.filter((b) => b.type == "ratelimit")
 				.map(ratelimitEntry) ?? []
 		),
+
+		mtlsCertificates:
+			mixedModeEnabled && mixedModeConnectionString
+				? Object.fromEntries(
+						bindings.mtls_certificates
+							?.filter((d) => {
+								warnOrError("mtls_certificates", d.remote, "remote");
+								return d.remote;
+							})
+							.map((mtlsCertificate) => [
+								mtlsCertificate.binding,
+								{
+									mixedModeConnectionString,
+									certificate_id: mtlsCertificate.certificate_id,
+								},
+							]) ?? []
+					)
+				: undefined,
+
 		serviceBindings,
 		wrappedBindings: wrappedBindings,
 		tails,

--- a/packages/wrangler/src/utils/print-bindings.ts
+++ b/packages/wrangler/src/utils/print-bindings.ts
@@ -539,12 +539,18 @@ export function printBindings(
 
 	if (mtls_certificates !== undefined && mtls_certificates.length > 0) {
 		output.push(
-			...mtls_certificates.map(({ binding, certificate_id }) => {
+			...mtls_certificates.map(({ binding, certificate_id, remote }) => {
 				return {
 					name: binding,
 					type: friendlyBindingNames.mtls_certificates,
 					value: certificate_id,
-					mode: getMode(),
+					mode: getMode({
+						isSimulatedLocally: getFlag("MIXED_MODE")
+							? remote === true || remote === undefined
+								? false
+								: undefined
+							: false,
+					}),
 				};
 			})
 		);


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1900

This PR is adding mTLS support to mixed mode.

As part of this the PR is also adding a `workerName` option to the `startMixedModeSession` API since when starting
the remote preview with an mTLS binding we would normally get the following error:
```
Workers with mTLS bindings need to be deployed before doing edge preview
``` 

having the option to pass the worker's name to `startMixedModeSession` allows us to make the server proxy worker behave like the actual user's worker thus enabling mTLS usage for it (in case the user has already deployed the worker)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not related to a v3 feature
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
