### PR TITLE
[miniflare] custom serialization for RegExp object

### DIFF
--- a/.changeset/beige-llamas-punch.md
+++ b/.changeset/beige-llamas-punch.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vitest-pool-workers": patch
+---
+
+fix test filtering by pattern that contains non-ascii characters.

--- a/packages/miniflare/src/workers/core/devalue.ts
+++ b/packages/miniflare/src/workers/core/devalue.ts
@@ -60,6 +60,13 @@ export const structuredSerializableReducers: ReducersRevivers = {
 			];
 		}
 	},
+	RegExp(value) {
+		if (value instanceof RegExp) {
+			const { source, flags } = value;
+			const encoded = Buffer.from(source).toString("base64");
+			return flags ? ["RegExp", encoded, flags] : ["RegExp", encoded];
+		}
+	},
 	Error(value) {
 		for (const ctor of ALLOWED_ERROR_CONSTRUCTORS) {
 			if (value instanceof ctor && value.name === ctor.name) {
@@ -96,6 +103,14 @@ export const structuredSerializableRevivers: ReducersRevivers = {
 		let length = byteLength;
 		if ("BYTES_PER_ELEMENT" in ctor) length /= ctor.BYTES_PER_ELEMENT;
 		return new ctor(buffer as ArrayBuffer, byteOffset, length);
+	},
+	RegExp(value) {
+		assert(Array.isArray(value));
+		const [name, encoded, flags] = value;
+		assert(typeof name === "string");
+		assert(typeof encoded === "string");
+		const source = Buffer.from(encoded, "base64").toString("utf-8");
+		return new RegExp(source, flags);
 	},
 	Error(value) {
 		assert(Array.isArray(value));

--- a/packages/miniflare/test/workers/core/serialize.spec.ts
+++ b/packages/miniflare/test/workers/core/serialize.spec.ts
@@ -1,0 +1,26 @@
+import test from "ava";
+import { parse, stringify } from "devalue";
+import {
+	structuredSerializableReducers,
+	structuredSerializableRevivers,
+} from "miniflare";
+
+test("serialize RegExp object consisting of only ascii chars", (t) => {
+	const input = new RegExp(/HelloWorld/);
+
+	const serialized = stringify(input, structuredSerializableReducers);
+	t.is(serialized, '[["RegExp",1],[2,3],"RegExp","SGVsbG9Xb3JsZA=="]');
+
+	const deserialized = parse(serialized, structuredSerializableRevivers);
+	t.deepEqual(deserialized, input);
+});
+
+test("serialize RegExp object containing non-ascii chars", (t) => {
+	const input = new RegExp(/こんにちは/);
+
+	const serialized = stringify(input, structuredSerializableReducers);
+	t.is(serialized, '[["RegExp",1],[2,3],"RegExp","44GT44KT44Gr44Gh44Gv"]');
+
+	const deserialized = parse(serialized, structuredSerializableRevivers);
+	t.deepEqual(deserialized, input);
+});

--- a/packages/vitest-pool-workers/test/filtering.test.ts
+++ b/packages/vitest-pool-workers/test/filtering.test.ts
@@ -1,0 +1,30 @@
+import dedent from "ts-dedent";
+import { minimalVitestConfig, test } from "./helpers";
+
+test("filter test suite by pattern includes non-ascii string", async ({
+	expect,
+	seed,
+	vitestRun,
+}) => {
+	// Check with no entrypoint
+	await seed({
+		"vitest.config.mts": minimalVitestConfig,
+		"index.test.ts": dedent`
+            import { it, expect } from "vitest";
+
+            it("test includes 日本語", async () => {
+                expect(1).toBe(1)
+            });
+
+            it("test not includes 日本語", async () => {
+                expect(1).toBe(2)
+            });
+        `,
+	});
+
+	const result = await vitestRun({
+		flags: ["--testNamePattern='test includes 日本語'"],
+	});
+
+	expect(await result.exitCode).toBe(0);
+});

--- a/packages/vitest-pool-workers/test/filtering.test.ts
+++ b/packages/vitest-pool-workers/test/filtering.test.ts
@@ -6,7 +6,6 @@ test("filter test suite by pattern includes non-ascii string", async ({
 	seed,
 	vitestRun,
 }) => {
-	// Check with no entrypoint
 	await seed({
 		"vitest.config.mts": minimalVitestConfig,
 		"index.test.ts": dedent`


### PR DESCRIPTION
## Summary

add custom serializer for `RegExp` object.

## Problem

vitest can filter test suites that contain non-ascii chars in its name.

```ts
test("test suite that contains 日本語", ()=>{
  expect(1).toBe(1)
})
```

```
npx vitest -t '日本語' # test suites can be filtered by non-ascii strings
```

but with `vitest-pool-workers`, errors are reported:

```
TypeError: Cannot convert argument to a ByteString because the character at index 1404 has a value of 21336 which is greater than 255.
 ❯ webidl.converters.ByteString ../node_modules/undici/lib/fetch/webidl.js:431:13
 ❯ Object.record<ByteString, ByteString> ../node_modules/undici/lib/fetch/webidl.js:281:28
 ❯ webidl.converters.HeadersInit ../node_modules/undici/lib/fetch/headers.js:579:63
 ❯ Object.RequestInit ../node_modules/undici/lib/fetch/webidl.js:370:17
 ❯ new Request ../node_modules/undici/lib/fetch/request.js:54:30
 ❯ new _Request ../node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare/dist/src/index.js:1879:5
 ❯ #fetcherFetchCall ../node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare/dist/src/index.js:12025:21
 ❯ #call ../node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare/dist/src/index.js:11943:71
 ❯ Proxy.fetch ../node_modules/@cloudflare/vitest-pool-workers/node_modules/miniflare/dist/src/index.js:11933:34
 ❯ runTests ../node_modules/@cloudflare/vitest-pool-workers/dist/pool/index.mjs:1517:26
```

## Cause

it caused by serialization process of `devalue`.

when option `-t` (`--testNamePattern` to be exact) was specified, test pattern strings will be passed as `RegExp` object (to metadata).

metadatas for tests are passed as request header `MF-Vitest-Worker-Data`, but `devalue` operates `RegExp` object as set of pattern and flags without any encoding.

therefore, when non-ascii chars are included in `testNamePattern`, it will be passed to request header directly.
request header cannot contain any non-ascii chars, so the problems will be caused.

## Solution

added custom reducer/revivers of `devalue` that encode/decode source strings of `RegExp` object as base64.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: vitest is not covered by the e2e tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: it is maybe internal fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
