### PR TITLE
Fix bug causing generation of preview alias for all branches.

### DIFF
--- a/.changeset/ten-cities-like.md
+++ b/.changeset/ten-cities-like.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fix bug causing preview alias to always be generated.

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -335,7 +335,9 @@ export const versionsUploadCommand = createCommand({
 
 		const previewAlias =
 			args.previewAlias ??
-			(getCIGeneratePreviewAlias() ? generatePreviewAlias(name) : undefined);
+			(getCIGeneratePreviewAlias() === "true"
+				? generatePreviewAlias(name)
+				: undefined);
 
 		if (!args.dryRun) {
 			assert(accountId, "Missing account ID");


### PR DESCRIPTION
Fixes a bug where a stringified value was forcing us to generate an alias for every version upload. 

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [X] Tests not necessary because: This is behind a gate. This is hard to test because of how we need to mock this.
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [X] Not required because: Introducing an e2e will break CI when this becomes ungated.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: not yet public
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: Not part of v3; introduced only in v4

