### PR TITLE
Consider disk limits when building containers

### DIFF
--- a/.changeset/empty-shirts-judge.md
+++ b/.changeset/empty-shirts-judge.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Enforce disk limits on container builds

--- a/packages/wrangler/src/__tests__/cloudchamber/utils.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/utils.ts
@@ -21,7 +21,11 @@ export function mockAccount() {
 		http.get(
 			"*/me",
 			async () => {
-				return HttpResponse.json({});
+				return HttpResponse.json({
+					limits: {
+						disk_mb_per_deployment: 2000,
+					},
+				});
 			},
 			{ once: true }
 		)

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -26,7 +26,7 @@ import { ApiError, DeploymentMutationError, OpenAPI } from "./client";
 import { wrap } from "./helpers/wrap";
 import { idToLocationName, loadAccount } from "./locations";
 import type { Config } from "../config";
-import type { CloudchamberConfig } from "../config/environment";
+import type { CloudchamberConfig, ContainerApp } from "../config/environment";
 import type { Scope } from "../user";
 import type {
 	CommonYargsOptions,
@@ -648,4 +648,19 @@ export function resolveMemory(
 	}
 
 	return undefined;
+}
+
+// Return the amount of disk size in (MB) for an application, falls back to the account limits if the app config doesn't exist
+// sometimes the user wants to just build a container here, we should allow checking those based on the account limits if
+// app.configuration is not set
+// ordering: app.configuration.disk.size -> account.limits.disk_mb_per_deployment -> default fallback to 2GB in bytes
+export function resolveAppDiskSize(
+	account: CompleteAccountCustomer,
+	app: ContainerApp | undefined
+): number | undefined {
+	if (app === undefined) {
+		return undefined;
+	}
+	const disk = app.configuration.disk?.size ?? "2GB";
+	return Math.round(parseByteSize(disk));
 }

--- a/packages/wrangler/src/cloudchamber/deploy.ts
+++ b/packages/wrangler/src/cloudchamber/deploy.ts
@@ -175,6 +175,7 @@ export function getBuildArguments(
 		dockerfileContents: dockerfile,
 		isDockerImage: true,
 		args: container.image_vars,
+		container,
 	} as const;
 	return buildOptions;
 }

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -80,6 +80,7 @@ export type ContainerApp = {
 		image: string;
 		labels?: { name: string; value: string }[];
 		secrets?: { name: string; type: "env"; secret: string }[];
+		disk?: { size: string };
 	};
 
 	/** Scheduling constraints */


### PR DESCRIPTION
Fixes #CC-5270

When building container images during docker build, we'd want to ensure the current docker image can be run under the current account. This enforces an useful check that improves DX without having to be denied during application creation with the specific image.

There is also a fix for stuck container builds in some cases where we were not inheriting the right stdio flags for the node spawn.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: this path is already checked in unit tests and the default paths are tested in E2E Tests.
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s):  <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: The docs are private and already talks about limits.
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: these are new features <!--e.g. not a patch change, not a Wrangler change...--> Not needed because these are new product features in beta.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
