### PR TITLE
chore: delete out-of-date test

### DIFF
--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -256,27 +256,3 @@ it.each(exitKeys)("multiworker cleanly exits with $name", async ({ key }) => {
 		expect(duringProcesses.length).toBeGreaterThan(beginProcesses.length);
 	}
 });
-
-it.runIf(RUN_IF && nodePtySupported)(
-	"hotkeys should be unregistered when the initial build fails",
-	async () => {
-		const wrangler = await startWranglerDev(
-			["dev", "src/startup-error.ts"],
-			true
-		);
-
-		expect(await wrangler.exitPromise).toBe(1);
-
-		const hotkeysRenderCount = [
-			...wrangler.stdout.matchAll(/\[b\] open a browser/g),
-		];
-
-		const clearHotkeysCount = [
-			// This is the control sequence for moving the cursor up and then clearing from the cursor to the end
-			...wrangler.stdout.matchAll(/\[\dA\[0J/g),
-		];
-
-		// The hotkeys should be rendered the same number of times as the control sequence for clearing them from the screen
-		expect(hotkeysRenderCount.length).toBe(clearHotkeysCount.length);
-	}
-);


### PR DESCRIPTION
The behaviour tested by this was intentionally changed in #9335. However, this only actually fails on forks, so its only just been surfaced. The underlying issue is not concerning for the integrity of our CI.


---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: deleting test
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: fixture test change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fixture test change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: corresponding change wasn't backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
