### PR TITLE
add `experimentalMixedMode` dev option to `unstable_startWorker`

### DIFF
--- a/.changeset/modern-memes-appear.md
+++ b/.changeset/modern-memes-appear.md
@@ -1,0 +1,35 @@
+---
+"wrangler": patch
+---
+
+add `experimentalMixedMode` dev option to `unstable_startWorker`
+
+add an new `experimentalMixedMode` dev option to `unstable_startWorker`
+that allows developers to programmatically start a new mixed mode
+session using startWorker.
+
+Example usage:
+
+```js
+// index.mjs
+import { unstable_startWorker } from "wrangler";
+
+await unstable_startWorker({
+	dev: {
+		experimentalMixedMode: true,
+	},
+});
+```
+
+```json
+// wrangler.jsonc
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "programmatic-start-worker-example",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-06-01",
+	"services": [
+		{ "binding": "REMOTE_WORKER", "service": "remote-worker", "remote": true }
+	]
+}
+```

--- a/packages/wrangler/e2e/start-worker-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/start-worker-mixed-mode.test.ts
@@ -1,0 +1,147 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { setTimeout } from "node:timers/promises";
+import dedent from "ts-dedent";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
+import { generateResourceName } from "./helpers/generate-resource-name";
+
+describe("startWorker - mixed mode", () => {
+	const remoteWorkerName = generateResourceName();
+	const helper = new WranglerE2ETestHelper();
+
+	beforeAll(async () => {
+		await helper.seed(resolve(__dirname, "./seed-files/mixed-mode-workers"));
+		await helper.seed({
+			"remote-worker.js": dedent/* javascript */ `
+					export default {
+						fetch() {
+							return new Response('Hello from a remote worker (startWorker mixed-mode)');
+						}
+					};
+			`,
+		});
+		await helper.run(
+			`wrangler deploy remote-worker.js --name ${remoteWorkerName} --compatibility-date 2025-01-01`
+		);
+	}, 35_000);
+
+	afterAll(async () => {
+		await helper.run(`wrangler delete --name ${remoteWorkerName}`);
+	});
+
+	[true, false].forEach((experimentalMixedMode) => {
+		describe(`with experimentalMixedMode ${experimentalMixedMode}`, () => {
+			const testOpts: NonNullable<Parameters<typeof it>[1]> = {
+				fails: !experimentalMixedMode,
+				retry: !experimentalMixedMode ? 0 : undefined,
+			};
+
+			it("allows connecting to a remote worker", testOpts, async () => {
+				await helper.seed({
+					"wrangler.json": JSON.stringify({
+						name: "mixed-mode-mixed-bindings-test",
+						main: "simple-service-binding.js",
+						compatibility_date: "2025-05-07",
+						services: [
+							{
+								binding: "REMOTE_WORKER",
+								service: remoteWorkerName,
+								remote: true,
+							},
+						],
+					}),
+				});
+
+				const { unstable_startWorker } = await helper.importWrangler();
+				const worker = await unstable_startWorker({
+					config: `${helper.tmpPath}/wrangler.json`,
+					dev: {
+						experimentalMixedMode,
+					},
+				});
+
+				await worker.ready;
+
+				await expect(
+					(await worker.fetch("http://example.com")).text()
+				).resolves.toMatchInlineSnapshot(
+					`"REMOTE<WORKER>: Hello from a remote worker (startWorker mixed-mode)"`
+				);
+
+				await worker.dispose();
+			});
+
+			it("handles code changes during development", testOpts, async () => {
+				await helper.seed({
+					"wrangler.json": JSON.stringify({
+						name: "mixed-mode-mixed-bindings-test",
+						main: "simple-service-binding.js",
+						compatibility_date: "2025-05-07",
+						services: [
+							{
+								binding: "REMOTE_WORKER",
+								service: remoteWorkerName,
+								remote: true,
+							},
+						],
+					}),
+				});
+
+				const { unstable_startWorker } = await helper.importWrangler();
+
+				const worker = await unstable_startWorker({
+					config: `${helper.tmpPath}/wrangler.json`,
+					dev: {
+						experimentalMixedMode,
+					},
+				});
+
+				await worker.ready;
+
+				await expect(
+					(await worker.fetch("http://example.com")).text()
+				).resolves.toMatchInlineSnapshot(
+					`"REMOTE<WORKER>: Hello from a remote worker (startWorker mixed-mode)"`
+				);
+
+				const indexContent = await readFile(
+					`${helper.tmpPath}/simple-service-binding.js`,
+					"utf8"
+				);
+				await writeFile(
+					`${helper.tmpPath}/simple-service-binding.js`,
+					indexContent.replace(
+						"REMOTE<WORKER>:",
+						"The remote worker responded with:"
+					),
+					"utf8"
+				);
+
+				await setTimeout(500);
+
+				await expect(
+					(await worker.fetch("http://example.com")).text()
+				).resolves.toMatchInlineSnapshot(
+					`"The remote worker responded with: Hello from a remote worker (startWorker mixed-mode)"`
+				);
+
+				await writeFile(
+					`${helper.tmpPath}/simple-service-binding.js`,
+					indexContent,
+					"utf8"
+				);
+
+				await setTimeout(500);
+
+				await expect(
+					(await worker.fetch("http://example.com")).text()
+				).resolves.toMatchInlineSnapshot(
+					`"REMOTE<WORKER>: Hello from a remote worker (startWorker mixed-mode)"`
+				);
+
+				await worker.dispose();
+			});
+		});
+	});
+});

--- a/packages/wrangler/e2e/start-worker-mixed-mode.test.ts
+++ b/packages/wrangler/e2e/start-worker-mixed-mode.test.ts
@@ -30,8 +30,9 @@ describe("startWorker - mixed mode", () => {
 		await helper.run(`wrangler delete --name ${remoteWorkerName}`);
 	});
 
-	[true, false].forEach((experimentalMixedMode) => {
-		describe(`with experimentalMixedMode ${experimentalMixedMode}`, () => {
+	describe.each([true, false])(
+		`with experimentalMixedMode %s`,
+		(experimentalMixedMode) => {
 			const testOpts: NonNullable<Parameters<typeof it>[1]> = {
 				fails: !experimentalMixedMode,
 				retry: !experimentalMixedMode ? 0 : undefined,
@@ -65,8 +66,8 @@ describe("startWorker - mixed mode", () => {
 
 				await expect(
 					(await worker.fetch("http://example.com")).text()
-				).resolves.toMatchInlineSnapshot(
-					`"REMOTE<WORKER>: Hello from a remote worker (startWorker mixed-mode)"`
+				).resolves.toContain(
+					"REMOTE<WORKER>: Hello from a remote worker (startWorker mixed-mode)"
 				);
 
 				await worker.dispose();
@@ -101,8 +102,8 @@ describe("startWorker - mixed mode", () => {
 
 				await expect(
 					(await worker.fetch("http://example.com")).text()
-				).resolves.toMatchInlineSnapshot(
-					`"REMOTE<WORKER>: Hello from a remote worker (startWorker mixed-mode)"`
+				).resolves.toContain(
+					"REMOTE<WORKER>: Hello from a remote worker (startWorker mixed-mode)"
 				);
 
 				const indexContent = await readFile(
@@ -122,8 +123,8 @@ describe("startWorker - mixed mode", () => {
 
 				await expect(
 					(await worker.fetch("http://example.com")).text()
-				).resolves.toMatchInlineSnapshot(
-					`"The remote worker responded with: Hello from a remote worker (startWorker mixed-mode)"`
+				).resolves.toContain(
+					"The remote worker responded with: Hello from a remote worker (startWorker mixed-mode)"
 				);
 
 				await writeFile(
@@ -136,12 +137,12 @@ describe("startWorker - mixed mode", () => {
 
 				await expect(
 					(await worker.fetch("http://example.com")).text()
-				).resolves.toMatchInlineSnapshot(
-					`"REMOTE<WORKER>: Hello from a remote worker (startWorker mixed-mode)"`
+				).resolves.toContain(
+					"REMOTE<WORKER>: Hello from a remote worker (startWorker mixed-mode)"
 				);
 
 				await worker.dispose();
 			});
-		});
-	});
+		}
+	);
 });

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -146,6 +146,8 @@ async function resolveDevConfig(
 		bindVectorizeToProd: input.dev?.bindVectorizeToProd ?? false,
 		multiworkerPrimary: input.dev?.multiworkerPrimary,
 		imagesLocalMode: input.dev?.imagesLocalMode ?? false,
+		experimentalMixedMode:
+			input.dev?.experimentalMixedMode ?? getFlag("MIXED_MODE"),
 	} satisfies StartDevWorkerOptions["dev"];
 }
 
@@ -153,27 +155,33 @@ async function resolveBindings(
 	config: Config,
 	input: StartDevWorkerInput
 ): Promise<{ bindings: StartDevWorkerOptions["bindings"]; unsafe?: CfUnsafe }> {
-	const bindings = getBindings(config, input.env, !input.dev?.remote, {
-		kv: extractBindingsOfType("kv_namespace", input.bindings),
-		vars: Object.fromEntries(
-			extractBindingsOfType("plain_text", input.bindings).map((b) => [
-				b.binding,
-				b.value,
-			])
-		),
-		durableObjects: extractBindingsOfType(
-			"durable_object_namespace",
-			input.bindings
-		),
-		r2: extractBindingsOfType("r2_bucket", input.bindings),
-		services: extractBindingsOfType("service", input.bindings),
-		d1Databases: extractBindingsOfType("d1", input.bindings),
-		ai: extractBindingsOfType("ai", input.bindings)?.[0],
-		version_metadata: extractBindingsOfType(
-			"version_metadata",
-			input.bindings
-		)?.[0],
-	});
+	const bindings = getBindings(
+		config,
+		input.env,
+		!input.dev?.remote,
+		{
+			kv: extractBindingsOfType("kv_namespace", input.bindings),
+			vars: Object.fromEntries(
+				extractBindingsOfType("plain_text", input.bindings).map((b) => [
+					b.binding,
+					b.value,
+				])
+			),
+			durableObjects: extractBindingsOfType(
+				"durable_object_namespace",
+				input.bindings
+			),
+			r2: extractBindingsOfType("r2_bucket", input.bindings),
+			services: extractBindingsOfType("service", input.bindings),
+			d1Databases: extractBindingsOfType("d1", input.bindings),
+			ai: extractBindingsOfType("ai", input.bindings)?.[0],
+			version_metadata: extractBindingsOfType(
+				"version_metadata",
+				input.bindings
+			)?.[0],
+		},
+		input.dev?.experimentalMixedMode
+	);
 
 	const maskedVars = maskVars(bindings, config);
 

--- a/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/LocalRuntimeController.ts
@@ -3,7 +3,6 @@ import { readFile } from "node:fs/promises";
 import chalk from "chalk";
 import { Miniflare, Mutex } from "miniflare";
 import * as MF from "../../dev/miniflare";
-import { getFlag } from "../../experimental-flags";
 import { logger } from "../../logger";
 import { RuntimeController } from "./BaseController";
 import { castErrorCause } from "./events";
@@ -160,7 +159,10 @@ export class LocalRuntimeController extends RuntimeController {
 		try {
 			const configBundle = await convertToConfigBundle(data);
 
-			if (getFlag("MIXED_MODE") && !data.config.dev?.remote) {
+			const experimentalMixedMode =
+				data.config.dev.experimentalMixedMode ?? false;
+
+			if (experimentalMixedMode && !data.config.dev?.remote) {
 				this.#mixedModeSession = await maybeStartOrUpdateMixedModeSession(
 					configBundle,
 					this.#mixedModeSession
@@ -173,7 +175,7 @@ export class LocalRuntimeController extends RuntimeController {
 					configBundle,
 					this.#proxyToUserWorkerAuthenticationSecret,
 					this.#mixedModeSession?.mixedModeConnectionString,
-					!!getFlag("MIXED_MODE")
+					!!experimentalMixedMode
 				);
 			options.liveReload = false; // TODO: set in buildMiniflareOptions once old code path is removed
 			if (this.#mf === undefined) {

--- a/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
+++ b/packages/wrangler/src/api/startDevWorker/MultiworkerRuntimeController.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import chalk from "chalk";
 import { Miniflare, Mutex } from "miniflare";
 import * as MF from "../../dev/miniflare";
-import { getFlag } from "../../experimental-flags";
 import { logger } from "../../logger";
 import { castErrorCause } from "./events";
 import {
@@ -99,7 +98,9 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 		try {
 			const configBundle = await convertToConfigBundle(data);
 
-			if (getFlag("MIXED_MODE") && !data.config.dev?.remote) {
+			const experimentalMixedMode = data.config.dev.experimentalMixedMode;
+
+			if (experimentalMixedMode && !data.config.dev?.remote) {
 				const mixedModeSession = await maybeStartOrUpdateMixedModeSession(
 					configBundle,
 					this.#mixedModeSessions.get(data.config.name)
@@ -113,7 +114,7 @@ export class MultiworkerRuntimeController extends LocalRuntimeController {
 				this.#proxyToUserWorkerAuthenticationSecret,
 				this.#mixedModeSessions.get(data.config.name)
 					?.mixedModeConnectionString,
-				!!getFlag("MIXED_MODE")
+				!!experimentalMixedMode
 			);
 
 			this.#options.set(data.config.name, {

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -180,6 +180,9 @@ export interface StartDevWorkerInput {
 
 		/** Treat this as the primary worker in a multiworker setup (i.e. the first Worker in Miniflare's options) */
 		multiworkerPrimary?: boolean;
+
+		/** Whether the experimental mixed mode feature should be enabled */
+		experimentalMixedMode?: boolean;
 	};
 	legacy?: {
 		site?: Hook<Config["site"], [Config]>;


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1958

This PR adds an `experimentalMixedMode` dev option to `unstable_startWorker` so that developers
can programmatically start a mixed mode session using startWorker, for more details please see the
changeset

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: experimental feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler v3 feature

