### PR TITLE
[unenv/preset] Use crypto.constants from workerd

### DIFF
--- a/.changeset/solid-sides-join.md
+++ b/.changeset/solid-sides-join.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/unenv-preset": patch
+---
+
+Use crypto.constants from workerd

--- a/fixtures/nodejs-hybrid-app/src/index.ts
+++ b/fixtures/nodejs-hybrid-app/src/index.ts
@@ -250,6 +250,14 @@ async function testCrypto() {
 	data += decipher.final();
 	assert.strictEqual(data, "Hello World");
 
+	assert.strictEqual(crypto.constants.DH_UNABLE_TO_CHECK_GENERATOR, 4);
+	assert.strictEqual(crypto.constants.RSA_PSS_SALTLEN_DIGEST, -1);
+	assert.strictEqual(
+		crypto.constants.SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION,
+		262144
+	);
+	assert.strictEqual(crypto.constants.SSL_OP_NO_TICKET, 16384);
+
 	return new Response("OK");
 }
 

--- a/packages/unenv-preset/src/runtime/node/crypto.ts
+++ b/packages/unenv-preset/src/runtime/node/crypto.ts
@@ -2,7 +2,6 @@
 // so extract it separately from the other exports
 import {
 	Cipher,
-	constants,
 	createCipher,
 	createDecipher,
 	Decipher,
@@ -11,7 +10,7 @@ import {
 } from "unenv/node/crypto";
 import type nodeCrypto from "node:crypto";
 
-export { Cipher, constants, Decipher } from "unenv/node/crypto";
+export { Cipher, Decipher } from "unenv/node/crypto";
 
 const workerdCrypto = process.getBuiltinModule("node:crypto");
 
@@ -19,6 +18,7 @@ export const {
 	Certificate,
 	checkPrime,
 	checkPrimeSync,
+	constants,
 	// @ts-expect-error
 	Cipheriv,
 	createCipheriv,
@@ -106,7 +106,6 @@ export default {
 	Sign,
 	Verify,
 	X509Certificate,
-	// @ts-expect-error @types/node is out of date - this is a bug in typings
 	constants,
 	createCipheriv,
 	createDecipheriv,


### PR DESCRIPTION
While investigating bundle size, I noticed that we were using the constants from unenv (>2kB) while they are available in workerd.

Ref:
- [unenv](https://github.com/unjs/unenv/blob/main/src/runtime/node/internal/crypto/constants.ts)
- [workerd](https://github.com/cloudflare/workerd/blob/9329b49451d9fb1822839c5b9687aa078e2b825e/src/node/crypto.ts#L228)

I did check that all the values from unenv are available in workerd.

The test will test unenv until the preset is released and used by workerd and vite at which point it will test the new code path. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no behavior change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: we don't backport workerd/unenv related stuff

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->

