### PR TITLE
test: make custom build bundling tests more robust

### DIFF
--- a/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/BundleController.test.ts
@@ -435,12 +435,13 @@ describe("BundleController", () => {
 				legacy: {},
 			};
 
+			let evCustomPromise = waitForBundleComplete(controller);
 			await controller.onConfigUpdate({
 				type: "configUpdate",
 				config: configDefaults(configCustom),
 			});
+			let evCustom = await evCustomPromise;
 
-			let evCustom = await waitForBundleComplete(controller);
 			expect(findSourceFile(evCustom.bundle.entrypointSource, "out.ts"))
 				.toMatchInlineSnapshot(`
 					"// out.ts
@@ -455,7 +456,9 @@ describe("BundleController", () => {
 					};
 					"
 				`);
+
 			// Make sure custom builds can reload after switching to them
+			evCustomPromise = waitForBundleComplete(controller);
 			await seed({
 				"random_dir/index.ts": dedent/* javascript */ `
 						export default {
@@ -466,7 +469,7 @@ describe("BundleController", () => {
 						}
 					`,
 			});
-			evCustom = await waitForBundleComplete(controller);
+			evCustom = await evCustomPromise;
 			expect(findSourceFile(evCustom.bundle.entrypointSource, "out.ts"))
 				.toMatchInlineSnapshot(`
 					"// out.ts


### PR DESCRIPTION
It is possible that the bundleComplete event happens before `waitForBundleComplete()` is called in the tests. So do that first, capture the promise, trigger the update to the build, then await the promise.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: change to unit test
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: change to unit test
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> change to unit test

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
