### PR TITLE
c3: use "cloudflare" image processing in astro projects

### DIFF
--- a/.changeset/quick-snails-follow.md
+++ b/.changeset/quick-snails-follow.md
@@ -1,0 +1,5 @@
+---
+"create-cloudflare": patch
+---
+
+configure images processing to use "cloudflare" strategy in Astro projects

--- a/packages/create-cloudflare/templates/astro/pages/c3.ts
+++ b/packages/create-cloudflare/templates/astro/pages/c3.ts
@@ -44,11 +44,19 @@ const updateAstroConfig = () => {
 			const b = recast.types.builders;
 			n.node.arguments = [
 				b.objectExpression([
+					// platformProxy: {
+					//   enabled: true,
+					// },
 					b.objectProperty(
 						b.identifier("platformProxy"),
 						b.objectExpression([
 							b.objectProperty(b.identifier("enabled"), b.booleanLiteral(true)),
 						]),
+					),
+					// imageService: "cloudflare",
+					b.objectProperty(
+						b.identifier("imageService"),
+						b.stringLiteral("cloudflare"),
 					),
 				]),
 			];

--- a/packages/create-cloudflare/templates/astro/workers/c3.ts
+++ b/packages/create-cloudflare/templates/astro/workers/c3.ts
@@ -44,11 +44,19 @@ const updateAstroConfig = () => {
 			const b = recast.types.builders;
 			n.node.arguments = [
 				b.objectExpression([
+					// platformProxy: {
+					//   enabled: true,
+					// },
 					b.objectProperty(
 						b.identifier("platformProxy"),
 						b.objectExpression([
 							b.objectProperty(b.identifier("enabled"), b.booleanLiteral(true)),
 						]),
+					),
+					// imageService: "cloudflare",
+					b.objectProperty(
+						b.identifier("imageService"),
+						b.stringLiteral("cloudflare"),
 					),
 				]),
 			];


### PR DESCRIPTION
The Astro cloudflare adaptor requires image processing to be marked with "cloudflare" strategy for it to work with yarn.

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: the PR fixes current tests that were failing
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: c3
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bug fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> c3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
