### PR TITLE
test: remove `verifyBuildScript` logic from c3 e2e tests

### DIFF
--- a/packages/create-cloudflare/e2e-tests/frameworks/framework-test-config.ts
+++ b/packages/create-cloudflare/e2e-tests/frameworks/framework-test-config.ts
@@ -31,12 +31,6 @@ export default function getFrameworkTestConfig(pm: string) {
 				route: "/test",
 				expectedText: "C3_TEST",
 			},
-			verifyBuild: {
-				outputDir: "./dist",
-				script: "build",
-				route: "/test",
-				expectedText: "C3_TEST",
-			},
 			nodeCompat: true,
 			flags: [
 				"--skip-houston",
@@ -57,12 +51,6 @@ export default function getFrameworkTestConfig(pm: string) {
 				expectedText: "Hello, Astronaut!",
 			},
 			verifyPreview: {
-				route: "/test",
-				expectedText: "C3_TEST",
-			},
-			verifyBuild: {
-				outputDir: "./dist",
-				script: "build",
 				route: "/test",
 				expectedText: "C3_TEST",
 			},
@@ -140,12 +128,6 @@ export default function getFrameworkTestConfig(pm: string) {
 				expectedText: "The fullstack meta-framework for Angular!",
 			},
 			verifyPreview: {
-				route: "/api/v1/test",
-				expectedText: "C3_TEST",
-			},
-			verifyBuild: {
-				outputDir: "./dist/analog/public",
-				script: "build",
 				route: "/api/v1/test",
 				expectedText: "C3_TEST",
 			},
@@ -325,12 +307,6 @@ export default function getFrameworkTestConfig(pm: string) {
 				route: "/test",
 				expectedText: "C3_TEST",
 			},
-			verifyBuild: {
-				outputDir: "./build/client",
-				script: "build",
-				route: "/test",
-				expectedText: "C3_TEST",
-			},
 			nodeCompat: false,
 			flags: ["--typescript", "--no-install", "--no-git-init"],
 		},
@@ -409,12 +385,6 @@ export default function getFrameworkTestConfig(pm: string) {
 			},
 			nodeCompat: false,
 			verifyPreview: {
-				route: "/test",
-				expectedText: "C3_TEST",
-			},
-			verifyBuild: {
-				outputDir: "./dist",
-				script: "build",
 				route: "/test",
 				expectedText: "C3_TEST",
 			},
@@ -531,12 +501,6 @@ export default function getFrameworkTestConfig(pm: string) {
 				expectedText: "SvelteKit app",
 			},
 			verifyPreview: {
-				route: "/test",
-				expectedText: "C3_TEST",
-			},
-			verifyBuild: {
-				outputDir: ".svelte-kit/cloudflare",
-				script: "build",
 				route: "/test",
 				expectedText: "C3_TEST",
 			},


### PR DESCRIPTION
This was incorrect for Workers+Assets projects (since it was using `wrangler pages dev` and is redundant because it is testing the same functionality as `verifyPreviewScript`.

This should also speed up our C3 e2e tests a little bit.
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: removing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: c3
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: removing tests
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> removing tests

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
