### PR TITLE
fix(miniflare): ensure default registry path matches wrangler settings

### DIFF
--- a/.changeset/chatty-turkeys-do.md
+++ b/.changeset/chatty-turkeys-do.md
@@ -1,0 +1,5 @@
+---
+"miniflare": patch
+---
+
+fix: ensure default registry path matches wrangler settings"

--- a/packages/miniflare/src/shared/dev-registry.ts
+++ b/packages/miniflare/src/shared/dev-registry.ts
@@ -282,5 +282,8 @@ export class DevRegistry {
 }
 
 export function getDefaultDevRegistryPath() {
-	return process.env.MINIFLARE_REGISTRY_PATH ?? getGlobalWranglerConfigPath();
+	return (
+		process.env.MINIFLARE_REGISTRY_PATH ??
+		path.join(getGlobalWranglerConfigPath(), "registry")
+	);
 }

--- a/packages/vite-plugin-cloudflare/e2e/helpers.ts
+++ b/packages/vite-plugin-cloudflare/e2e/helpers.ts
@@ -76,7 +76,7 @@ export async function runLongLived(
 	pm: "pnpm" | "yarn" | "npm",
 	command: "dev" | "buildAndPreview" | AnyString,
 	projectPath: string,
-	customEnv: Record<string, string> = {}
+	customEnv: Record<string, string | undefined> = {}
 ) {
 	debuglog(`starting \`${command}\` for ${projectPath}`);
 	const process = childProcess.exec(`${pm} run ${command}`, {


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/issues/8963#issuecomment-2940104201.

Wrangler and vite were saving the worker definition in a different directory and so they can't find each other's workers. This fixes it.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by fixture tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
