### PR TITLE
Reorder deploy output when deploying a container worker

### DIFF
--- a/.changeset/rich-bottles-hug.md
+++ b/.changeset/rich-bottles-hug.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Reorder deploy output when deploying a container worker so the worker url is printed last and the worker triggers aren't deployed until the container has been built and deployed successfully.

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8893,9 +8893,9 @@ addEventListener('fetch', event => {});`
 					env.EXAMPLE_DO_BINDING (ExampleDurableObject)      Durable Object
 
 					Uploaded test-name (TIMINGS)
+					Building image my-container:Galaxy
 					Deployed test-name triggers (TIMINGS)
 					  https://test-name.test-sub-domain.workers.dev
-					Building image my-container:Galaxy
 					Current Version ID: Galaxy-Class"
 				`);
 				expect(std.err).toMatchInlineSnapshot(`""`);

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -1007,9 +1007,6 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 		return { versionId, workerTag };
 	}
 
-	// deploy triggers
-	const targets = await triggersDeploy(props);
-
 	if (config.containers) {
 		assert(versionId && accountId);
 		await deployContainers(config, {
@@ -1020,6 +1017,9 @@ See https://developers.cloudflare.com/workers/platform/compatibility-dates for m
 			env: props.env,
 		});
 	}
+
+	// deploy triggers
+	const targets = await triggersDeploy(props);
 
 	logger.log("Current Version ID:", versionId);
 


### PR DESCRIPTION
Reorder the deploy output when using a container worker so that:

* We can fail to trigger the new worker if the container build or deploy fails
* The url for the worker is at the bottom of the output instead of the top



<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: Reordering of actions. Related tests were updated.
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: No relevant e2e tests afaik
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ux change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> New feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
