### PR TITLE
Add validation to containerAppConfiguration that disk.size is not set

### DIFF
--- a/.changeset/angry-bears-attack.md
+++ b/.changeset/angry-bears-attack.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add validation that the deprecated field containers.disk.size is not set.

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2389,16 +2389,22 @@ const validateContainerAppConfig: ValidatorFn = (
 			diagnostics.errors.push(
 				`"containers.configuration" is defined as an array, it should be an object`
 			);
-		} else if (
-			!isRequiredProperty(
-				containerAppOptional.configuration as UserDeploymentConfiguration,
-				"image",
-				"string"
-			)
-		) {
-			diagnostics.errors.push(
-				`"containers.image" should be defined and a string`
-			);
+		} else {
+			const userDeploymentConfig =
+				containerAppOptional.configuration as UserDeploymentConfiguration;
+			if (!isRequiredProperty(userDeploymentConfig, "image", "string")) {
+				diagnostics.errors.push(
+					`"containers.image" should be defined and a string`
+				);
+			}
+			if (
+				hasProperty(userDeploymentConfig, "disk") &&
+				hasProperty(userDeploymentConfig.disk, "size")
+			) {
+				diagnostics.errors.push(
+					`"containers.disk.size" is deprecated and should not be used. Use "containers.disk.size_mb" instead`
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
disk.size field is deprecated. Add an error pointing the user to the correct field if it is set.

Before this users could get into a weird state when mixing the disk config options.
<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: path is not currently tested.
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: validation change only
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: validation change only for undocumented field
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
