### PR TITLE
[wrangler] Add --json flag to r2 bucket info command

### DIFF
--- a/.changeset/happy-streets-leave.md
+++ b/.changeset/happy-streets-leave.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
 Add --json flag to r2 bucket info command for machine-readable output.

--- a/.changeset/happy-streets-leave.md
+++ b/.changeset/happy-streets-leave.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add --json flag to r2 bucket info command for machine-readable output.

--- a/packages/wrangler/e2e/unenv-preset/preset.test.ts
+++ b/packages/wrangler/e2e/unenv-preset/preset.test.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { fetch } from "undici";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { CLOUDFLARE_ACCOUNT_ID } from "../helpers/account-id";
 import { WranglerE2ETestHelper } from "../helpers/e2e-wrangler-test";
 import { generateResourceName } from "../helpers/generate-resource-name";
 import { retry } from "../helpers/retry";
@@ -85,6 +86,12 @@ describe.each(testConfigs)(
 		// The "local" and "remote" runtimes do not necessarily use the exact same version
 		// of workerd and we want to make sure the preset works for both.
 		describe.for(["local", "remote"])("%s tests", (localOrRemote) => {
+			// Skip the remote tests if the user is not logged in (e.g. a PR from a forked repo)
+			if (localOrRemote === "remote" && !CLOUDFLARE_ACCOUNT_ID) {
+				test.skip("Remote tests are not supported");
+				return;
+			}
+
 			let url: string;
 			let wrangler: WranglerLongLivedCommand;
 			beforeAll(async () => {

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getR2Bucket, getR2BucketMetrics } from "../../r2/helpers";
+import { requireAuth } from "../../user";
+import { mockConsoleMethods } from "../helpers/mock-console";
+import { runWrangler } from "../helpers/run-wrangler";
+
+vi.unmock("../../wrangler-banner");
+
+vi.mock("../../r2/helpers");
+vi.mock("../../user");
+
+const logs = mockConsoleMethods();
+
+const mockRequireAuth = vi.mocked(requireAuth);
+const mockGetR2Bucket = vi.mocked(getR2Bucket);
+const mockGetR2BucketMetrics = vi.mocked(getR2BucketMetrics);
+
+describe("r2 bucket info", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+
+		mockRequireAuth.mockResolvedValue("test-account-id");
+		mockGetR2Bucket.mockResolvedValue({
+			name: "my-bucket-name",
+			creation_date: "2025-06-07T15:55:22.222Z",
+			location: "APAC",
+			storage_class: "Standard",
+		});
+		mockGetR2BucketMetrics.mockResolvedValue({
+			objectCount: 0,
+			totalSize: "0 B",
+		});
+	});
+
+	it("should output valid JSON format when --json flag is used", async () => {
+		await runWrangler("r2 bucket info my-bucket-name --json");
+
+		const output = logs.out;
+
+		const jsonMatch = output.match(/\{[\s\S]*\}/);
+		if (!jsonMatch) {
+			throw new Error("No JSON found in output");
+		}
+
+		try {
+			const json = JSON.parse(jsonMatch[0]);
+			expect(json.name).toBe("my-bucket-name");
+		} catch (err) {
+			throw new Error("Output contained invalid JSON");
+		}
+
+		expect(output).not.toMatch(/⛅ wrangler/);
+	});
+});

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -16,39 +16,25 @@ const mockGetR2Bucket = vi.mocked(getR2Bucket);
 const mockGetR2BucketMetrics = vi.mocked(getR2BucketMetrics);
 
 describe("r2 bucket info", () => {
-	beforeEach(() => {
-		vi.resetAllMocks();
+  beforeEach(() => {
+    vi.resetAllMocks();
 
-		mockRequireAuth.mockResolvedValue("test-account-id");
-		mockGetR2Bucket.mockResolvedValue({
-			name: "my-bucket-name",
-			creation_date: "2025-06-07T15:55:22.222Z",
-			location: "APAC",
-			storage_class: "Standard",
-		});
-		mockGetR2BucketMetrics.mockResolvedValue({
-			objectCount: 0,
-			totalSize: "0 B",
-		});
-	});
+    mockRequireAuth.mockResolvedValue("test-account-id");
+    mockGetR2Bucket.mockResolvedValue({
+      name: "my-bucket-name",
+      creation_date: "2025-06-07T15:55:22.222Z",
+      location: "APAC",
+      storage_class: "Standard",
+    });
+    mockGetR2BucketMetrics.mockResolvedValue({
+      objectCount: 0,
+      totalSize: "0 B",
+    });
+  });
 
-	it("should output valid JSON format when --json flag is used", async () => {
-		await runWrangler("r2 bucket info my-bucket-name --json");
-
-		const output = logs.out;
-
-		const jsonMatch = output.match(/\{[\s\S]*\}/);
-		if (!jsonMatch) {
-			throw new Error("No JSON found in output");
-		}
-
-		try {
-			const json = JSON.parse(jsonMatch[0]);
-			expect(json.name).toBe("my-bucket-name");
-		} catch (err) {
-			throw new Error("Output contained invalid JSON");
-		}
-
-		expect(output).not.toMatch(/⛅ wrangler/);
-	});
+  it("should output valid JSON format when --json flag is used", async () => {
+    await runWrangler("r2 bucket info my-bucket-name --json");
+    const json = JSON.parse(logs.out);
+    expect(json.name).toBe("my-bucket-name");
+  });
 });

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -16,25 +16,25 @@ const mockGetR2Bucket = vi.mocked(getR2Bucket);
 const mockGetR2BucketMetrics = vi.mocked(getR2BucketMetrics);
 
 describe("r2 bucket info", () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
+	beforeEach(() => {
+		vi.resetAllMocks();
 
-    mockRequireAuth.mockResolvedValue("test-account-id");
-    mockGetR2Bucket.mockResolvedValue({
-      name: "my-bucket-name",
-      creation_date: "2025-06-07T15:55:22.222Z",
-      location: "APAC",
-      storage_class: "Standard",
-    });
-    mockGetR2BucketMetrics.mockResolvedValue({
-      objectCount: 0,
-      totalSize: "0 B",
-    });
-  });
+		mockRequireAuth.mockResolvedValue("test-account-id");
+		mockGetR2Bucket.mockResolvedValue({
+			name: "my-bucket-name",
+			creation_date: "2025-06-07T15:55:22.222Z",
+			location: "APAC",
+			storage_class: "Standard",
+		});
+		mockGetR2BucketMetrics.mockResolvedValue({
+			objectCount: 0,
+			totalSize: "0 B",
+		});
+	});
 
-  it("should output valid JSON format when --json flag is used", async () => {
-    await runWrangler("r2 bucket info my-bucket-name --json");
-    const json = JSON.parse(logs.out);
-    expect(json.name).toBe("my-bucket-name");
-  });
+	it("should output valid JSON format when --json flag is used", async () => {
+		await runWrangler("r2 bucket info my-bucket-name --json");
+		const json = JSON.parse(logs.out);
+		expect(json.name).toBe("my-bucket-name");
+	});
 });

--- a/packages/wrangler/src/r2/bucket.ts
+++ b/packages/wrangler/src/r2/bucket.ts
@@ -198,7 +198,7 @@ export const r2BucketInfoCommand = createCommand({
 	positionalArgs: ["bucket"],
 	args: {
 		bucket: {
-			describe: "The name of the bucket to delete",
+			describe: "The name of the bucket to retrieve info for",
 			type: "string",
 			demandOption: true,
 		},
@@ -208,11 +208,22 @@ export const r2BucketInfoCommand = createCommand({
 			requiresArg: true,
 			type: "string",
 		},
+		json: {
+			describe: "Return the bucket information as JSON",
+			type: "boolean",
+			default: false,
+		},
 	},
+	behaviour: {
+		printBanner: (args) => !args.json,
+	},
+
 	async handler(args, { config }) {
 		const accountId = await requireAuth(config);
 
-		logger.log(`Getting info for '${args.bucket}'...`);
+		if (!args.json) {
+			logger.log(`Getting info for '${args.bucket}'...`);
+		}
 
 		const bucketInfo = await getR2Bucket(
 			config,
@@ -220,6 +231,7 @@ export const r2BucketInfoCommand = createCommand({
 			args.bucket,
 			args.jurisdiction
 		);
+
 		const bucketMetrics = await getR2BucketMetrics(
 			config,
 			accountId,
@@ -236,7 +248,11 @@ export const r2BucketInfoCommand = createCommand({
 			bucket_size: bucketMetrics.totalSize,
 		};
 
-		logger.log(formatLabelledValues(output));
+		if (args.json) {
+			console.log(JSON.stringify(output, null, 2));
+		} else {
+			logger.log(formatLabelledValues(output));
+		}
 	},
 });
 

--- a/packages/wrangler/src/r2/bucket.ts
+++ b/packages/wrangler/src/r2/bucket.ts
@@ -249,7 +249,7 @@ export const r2BucketInfoCommand = createCommand({
 		};
 
 		if (args.json) {
-			console.log(JSON.stringify(output, null, 2));
+			logger.json(output);
 		} else {
 			logger.log(formatLabelledValues(output));
 		}


### PR DESCRIPTION
Fixes #9433

## What

Adds a `--json` flag to the `wrangler r2 bucket info` command, returning the bucket info in clean JSON format.

## Why

The current output is not machine-readable.  
Adding this flag makes the output usable in scripts and consistent with D1 commands that already support `--json`.  

## How

- Adds a `--json` flag to `r2 bucket info`
- Omits verbose output when `--json` is passed
- Suppresses the Wrangler banner when `--json` is used
- Adds a unit test verifying valid JSON output
- Linting fixed with `pnpm fix`
- Added a changeset as per contribution guidelines

## Test Plan

- ✅ `pnpm exec vitest run packages/wrangler/src/__tests__/r2/bucket.test.ts` passed
- ✅ Manual output verified
- ✅ Verified that banner is suppressed when `--json` is passed

## Example

### With `--json`:
```bash
$ wrangler r2 bucket info my-bucket-name --json

{
  "name": "my-bucket-name",
  "created": "2025-06-07T15:55:22.222Z",
  "location": "APAC",
  "default_storage_class": "Standard",
  "object_count": "0",
  "bucket_size": "0 B"
}
```

### Without `--json`:
```bash
$ wrangler r2 bucket info my-bucket-name

(⛅️ wrangler 4.18.0)
Bucket Name: my-bucket-name  
Created At: 2025-06-07T15:55:22.222Z  
Location: APAC  
Storage Class: Standard  
Object Count: 0  
Size: 0 B
```

---

<!--  
Please don't delete the checkboxes <3  
The following selections do not need to be completed if this PR only contains changes to .md files  
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [x] Cloudflare docs PR(s): https://github.com/cloudflare/cloudflare-docs/pull/24120
  - [ ] Documentation not necessary because: 
- Wrangler V3 Backport
  - [ ] Wrangler PR:
  - [x] Not necessary because: New features are not backported

<!--  
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?  
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.  
-->
