### PR TITLE
chore: add vitest-ecosystem-ci script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"test:e2e": "dotenv -- turbo test:e2e",
 		"test:e2e:wrangler": "node -r esbuild-register tools/e2e/runIndividualE2EFiles.ts",
 		"test:watch": "turbo test:watch",
-		"type:tests": "dotenv -- turbo type:tests"
+		"type:tests": "dotenv -- turbo type:tests",
+		"vitest-ecosystem-ci": "pnpm test:ci -F @fixture/vitest-pool-workers"
 	},
 	"dependencies": {
 		"@actions/artifact": "^2.2.1",


### PR DESCRIPTION
Fixes n/a.

We renamed the fixtures in https://github.com/cloudflare/workers-sdk/pull/9378 recently which broke our vitest-ecosystem-ci setup: https://github.com/vitest-dev/vitest-ecosystem-ci/actions/runs/15384430303/job/43280381332#step:7:886

This adds a dedicate command in the root package json and I will submit a PR to update it in the vitest-ecosystem-ci repository.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: CI change 
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: CI change 
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: CI change 
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: CI change 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
