### PR TITLE
make workers created with `startWorker` await the `ready` promise on `dispose`

### DIFF
--- a/.changeset/five-shoes-call.md
+++ b/.changeset/five-shoes-call.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+make workers created with `startWorker` await the `ready` promise on `dispose`

--- a/fixtures/start-worker-node-test/src/config-errors.test.js
+++ b/fixtures/start-worker-node-test/src/config-errors.test.js
@@ -58,8 +58,6 @@ describe("startWorker - configuration errors", () => {
 			}
 		);
 
-		// TODO: worker.dispose() should itself await worker.ready
-		await worker.ready;
 		await worker.dispose();
 	});
 
@@ -86,8 +84,6 @@ describe("startWorker - configuration errors", () => {
 			}
 		);
 
-		// TODO: worker.dispose() should itself await worker.ready
-		await worker.ready;
 		await worker.dispose();
 	});
 });

--- a/packages/wrangler/src/api/startDevWorker/ProxyController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ProxyController.ts
@@ -48,7 +48,7 @@ type ProxyControllerEventMap = ControllerEventMap & {
 	previewTokenExpired: [PreviewTokenExpiredEvent];
 };
 export class ProxyController extends Controller<ProxyControllerEventMap> {
-	public ready = createDeferred<ReadyEvent>();
+	public ready = createDeferred<ReadyEvent | null>();
 
 	public proxyWorker?: Miniflare;
 	proxyWorkerOptions?: MiniflareOptions;
@@ -186,7 +186,7 @@ export class ProxyController extends Controller<ProxyControllerEventMap> {
 
 			// this creates a new .ready promise that will be resolved when both ProxyWorkers are ready
 			// it also respects any await-ers of the existing .ready promise
-			this.ready = createDeferred<ReadyEvent>(this.ready);
+			this.ready = createDeferred<ReadyEvent | null>(this.ready);
 		}
 
 		// store the non-null versions for callbacks
@@ -303,7 +303,9 @@ export class ProxyController extends Controller<ProxyControllerEventMap> {
 
 		try {
 			await this.runtimeMessageMutex.runWith(async () => {
-				const { proxyWorker } = await this.ready.promise;
+				const readyEvent = await this.ready.promise;
+				assert(readyEvent);
+				const { proxyWorker } = readyEvent;
 
 				const ready = await proxyWorker.ready.catch(() => undefined);
 				if (!ready) {

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -665,7 +665,9 @@ export async function startDev(args: StartDevOptions) {
 			devEnv = new DevEnv();
 
 			// The ProxyWorker will have a stable host and port, so only listen for the first update
-			void devEnv.proxy.ready.promise.then(({ url }) => {
+			void devEnv.proxy.ready.promise.then((ev) => {
+				assert(ev);
+				const { url } = ev;
 				if (args.onReady) {
 					args.onReady(url.hostname, parseInt(url.port));
 				}
@@ -697,7 +699,9 @@ export async function startDev(args: StartDevOptions) {
 						async (reloadEvent: ReloadCompleteEvent) => {
 							if (!reloadEvent.config.dev?.remote) {
 								assert(devEnv !== undefined && !Array.isArray(devEnv));
-								const { url } = await devEnv.proxy.ready.promise;
+								const ev = await devEnv.proxy.ready.promise;
+								assert(ev);
+								const { url } = ev;
 
 								await maybeRegisterLocalWorker(
 									url,


### PR DESCRIPTION
The changes in this PR make sure that when calling `worker.dispose();` dispose automatically awaits for the `worker.ready` promise instead of requiring the caller to do that.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included (the updated tests would fail without the code changes)
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the [`startWorker` documentation](https://developers.cloudflare.com/workers/wrangler/api/#unstable_startworker) doesn't go into details about this sort of information
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: changes to an experimental feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
