### PR TITLE
Enable HTML handling for HTML files in the public directory

### DIFF
--- a/.changeset/odd-queens-enjoy.md
+++ b/.changeset/odd-queens-enjoy.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+Enable HTML handling for HTML files in the public directory.
+
+It is generally encouraged to use [HTML files as entry points](https://vite.dev/guide/features#html) in Vite so that their dependencies are bundled. However, if you have plain HTML files that should simply be copied to the root of the output directory as-is, you can place these in the [public directory](https://vite.dev/guide/assets#the-public-directory) and they will now work as expected in dev.

--- a/packages/vite-plugin-cloudflare/playground/static-mpa/__tests__/static-mpa.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/static-mpa/__tests__/static-mpa.spec.ts
@@ -42,6 +42,12 @@ test("returns the correct nested 404 page", async () => {
 	expect(content).toBe("About 404");
 });
 
+test("returns HTML files in the public directory and prioritizes them over root level HTML files", async () => {
+	await page.goto(`${viteTestUrl}/public-html`);
+	const content = await page.textContent("h1");
+	expect(content).toBe("Public Directory HTML");
+});
+
 test("worker configs warnings are not present in the terminal", async () => {
 	expect(serverLogs.warns).toEqual([]);
 });

--- a/packages/vite-plugin-cloudflare/playground/static-mpa/__tests__/static-mpa.spec.ts
+++ b/packages/vite-plugin-cloudflare/playground/static-mpa/__tests__/static-mpa.spec.ts
@@ -48,8 +48,16 @@ test("returns HTML files in the public directory and prioritizes them over root 
 	expect(content).toBe("Public Directory HTML");
 });
 
+test("does not return HTML files in the public directory if the public directory is included in the path", async () => {
+	await page.goto(`${viteTestUrl}/public/public-html`);
+	const content = await page.textContent("h1");
+	expect(content).toBe("Root 404");
+});
+
 test("worker configs warnings are not present in the terminal", async () => {
-	expect(serverLogs.warns).toEqual([]);
+	expect(serverLogs.warns.join()).not.toContain(
+		"contains the following configuration options which are ignored since they are not applicable when using Vite"
+	);
 });
 
 describe.runIf(isBuild)("_headers", () => {

--- a/packages/vite-plugin-cloudflare/playground/static-mpa/public-html.html
+++ b/packages/vite-plugin-cloudflare/playground/static-mpa/public-html.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Static MPA - Unreachable HTML</title>
+	</head>
+	<body>
+		<h1>This file should never be reached</h1>
+	</body>
+</html>

--- a/packages/vite-plugin-cloudflare/playground/static-mpa/public/public-html.html
+++ b/packages/vite-plugin-cloudflare/playground/static-mpa/public/public-html.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Static MPA - Public Directory HTML</title>
+	</head>
+	<body>
+		<h1>Public Directory HTML</h1>
+	</body>
+</html>

--- a/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
+++ b/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
@@ -3,8 +3,8 @@ import { UNKNOWN_HOST } from "../shared";
 import type { Env as _Env } from "@cloudflare/workers-shared/asset-worker";
 
 interface Env extends _Env {
-	__VITE_ASSET_EXISTS__: Fetcher;
-	__VITE_FETCH_ASSET__: Fetcher;
+	__VITE_GET_RESOLVED_HTML_PATH__: Fetcher;
+	__VITE_FETCH_HTML__: Fetcher;
 }
 
 export default class CustomAssetWorker extends AssetWorker<Env> {
@@ -18,7 +18,7 @@ export default class CustomAssetWorker extends AssetWorker<Env> {
 	}
 	override async unstable_getByETag(eTag: string) {
 		const url = new URL(eTag, UNKNOWN_HOST);
-		const response = await this.env.__VITE_FETCH_ASSET__.fetch(url);
+		const response = await this.env.__VITE_FETCH_HTML__.fetch(url);
 
 		if (!response.body) {
 			throw new Error(`Unexpected error. No HTML found for "${eTag}".`);
@@ -33,10 +33,9 @@ export default class CustomAssetWorker extends AssetWorker<Env> {
 	override async unstable_exists(pathname: string) {
 		// We need this regex to avoid getting `//` as a pathname, which results in an invalid URL. Should this be fixed upstream?
 		const url = new URL(pathname.replace(/^\/{2,}/, "/"), UNKNOWN_HOST);
-		const response = await this.env.__VITE_ASSET_EXISTS__.fetch(url);
-		const exists = await response.json();
+		const response = await this.env.__VITE_GET_RESOLVED_HTML_PATH__.fetch(url);
 
-		return exists ? pathname : null;
+		return response.json() as Promise<string | null>;
 	}
 	override async unstable_canFetch(request: Request) {
 		// the 'sec-fetch-mode: navigate' header is stripped by something on its way into this worker

--- a/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
+++ b/packages/vite-plugin-cloudflare/src/asset-workers/asset-worker.ts
@@ -3,7 +3,7 @@ import { UNKNOWN_HOST } from "../shared";
 import type { Env as _Env } from "@cloudflare/workers-shared/asset-worker";
 
 interface Env extends _Env {
-	__VITE_GET_RESOLVED_HTML_PATH__: Fetcher;
+	__VITE_HTML_EXISTS__: Fetcher;
 	__VITE_FETCH_HTML__: Fetcher;
 }
 
@@ -33,7 +33,7 @@ export default class CustomAssetWorker extends AssetWorker<Env> {
 	override async unstable_exists(pathname: string) {
 		// We need this regex to avoid getting `//` as a pathname, which results in an invalid URL. Should this be fixed upstream?
 		const url = new URL(pathname.replace(/^\/{2,}/, "/"), UNKNOWN_HOST);
-		const response = await this.env.__VITE_GET_RESOLVED_HTML_PATH__.fetch(url);
+		const response = await this.env.__VITE_HTML_EXISTS__.fetch(url);
 
 		return response.json() as Promise<string | null>;
 	}
@@ -41,9 +41,11 @@ export default class CustomAssetWorker extends AssetWorker<Env> {
 		// the 'sec-fetch-mode: navigate' header is stripped by something on its way into this worker
 		// so we restore it from 'x-mf-sec-fetch-mode'
 		const secFetchMode = request.headers.get("X-Mf-Sec-Fetch-Mode");
+
 		if (secFetchMode) {
 			request.headers.set("Sec-Fetch-Mode", secFetchMode);
 		}
+
 		return await super.unstable_canFetch(request);
 	}
 }

--- a/packages/vite-plugin-cloudflare/src/constants.ts
+++ b/packages/vite-plugin-cloudflare/src/constants.ts
@@ -8,6 +8,8 @@ export const ADDITIONAL_MODULE_TYPES = [
 	"Text",
 ] as const;
 
+export const PUBLIC_DIR_PREFIX = "/__vite_public_dir__";
+
 export const DEFAULT_INSPECTOR_PORT = 9229;
 
 export const kRequestType = Symbol("kRequestType");

--- a/packages/vite-plugin-cloudflare/src/constants.ts
+++ b/packages/vite-plugin-cloudflare/src/constants.ts
@@ -8,6 +8,7 @@ export const ADDITIONAL_MODULE_TYPES = [
 	"Text",
 ] as const;
 
+// Used to mark HTML assets as being in the public directory so that they can be resolved from their root relative paths
 export const PUBLIC_DIR_PREFIX = "/__vite_public_dir__";
 
 export const DEFAULT_INSPECTOR_PORT = 9229;

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -50,5 +50,5 @@ export function getFirstAvailablePort(start: number) {
 }
 
 export function withTrailingSlash(path: string): string {
-	return path[path.length - 1] !== "/" ? `${path}/` : path;
+	return path.endsWith("/") ? path : `${path}/`;
 }

--- a/packages/vite-plugin-cloudflare/src/utils.ts
+++ b/packages/vite-plugin-cloudflare/src/utils.ts
@@ -48,3 +48,7 @@ export type Defined<T> = Exclude<T, undefined>;
 export function getFirstAvailablePort(start: number) {
 	return getPort({ port: portNumbers(start, 65535) });
 }
+
+export function withTrailingSlash(path: string): string {
+	return path[path.length - 1] !== "/" ? `${path}/` : path;
+}


### PR DESCRIPTION
Fixes #9362.

Enable HTML handling for HTML files in the public directory.

HTML files in the public directory are prioritized over those at the root. This is consistent with Vite's internal behaviour, which places the `servePublicMiddleware` first. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because: N/A
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: N/A
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a Wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
