### PR TITLE
allow `startWorker` to accept `false` as an `inspector` option (to disable the inspector server)

### DIFF
--- a/.changeset/true-cities-try.md
+++ b/.changeset/true-cities-try.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+allow `startWorker` to accept `false` as an `inspector` option (to disable the inspector server)

--- a/fixtures/start-worker-node-test/src/config-errors.test.js
+++ b/fixtures/start-worker-node-test/src/config-errors.test.js
@@ -54,7 +54,7 @@ describe("startWorker - configuration errors", () => {
 				server: {
 					port: await getPort(),
 				},
-				inspector: { port: await getPort() },
+				inspector: false,
 			},
 		});
 
@@ -80,7 +80,7 @@ describe("startWorker - configuration errors", () => {
 				server: {
 					port: await getPort(),
 				},
-				inspector: { port: await getPort() },
+				inspector: false,
 			},
 		});
 

--- a/packages/wrangler/e2e/startWorker.test.ts
+++ b/packages/wrangler/e2e/startWorker.test.ts
@@ -108,10 +108,12 @@ describe.each(OPTIONS)("DevEnv (remote: $remote)", ({ remote }) => {
 		});
 
 		const inspectorUrl = await worker.inspectorUrl;
+		assert(inspectorUrl, "missing inspectorUrl");
 		const res = await undici.fetch(`http://${inspectorUrl.host}/json`);
 
 		await expect(res.json()).resolves.toBeInstanceOf(Array);
 
+		assert(inspectorUrl, "missing inspectorUrl");
 		const ws = new WebSocket(inspectorUrl.href);
 		const openPromise = events.once(ws, "open");
 
@@ -178,6 +180,7 @@ describe.each(OPTIONS)("DevEnv (remote: $remote)", ({ remote }) => {
 
 		const inspectorUrl = await worker.inspectorUrl;
 
+		assert(inspectorUrl, "missing inspectorUrl");
 		let ws = new WebSocket(inspectorUrl.href, {
 			setHost: false,
 			headers: { Host: "example.com" },
@@ -187,6 +190,7 @@ describe.each(OPTIONS)("DevEnv (remote: $remote)", ({ remote }) => {
 		await expect(openPromise).rejects.toThrow("Unexpected server response");
 
 		// Check validates `Origin` header
+		assert(inspectorUrl, "missing inspectorUrl");
 		ws = new WebSocket(inspectorUrl.href, { origin: "https://example.com" });
 		openPromise = events.once(ws, "open");
 		await expect(openPromise).rejects.toThrow("Unexpected server response");
@@ -236,6 +240,7 @@ describe.each(OPTIONS)("DevEnv (remote: $remote)", ({ remote }) => {
 		});
 
 		const inspectorUrl = await worker.inspectorUrl;
+		assert(inspectorUrl, "missing inspectorUrl");
 		const ws = new WebSocket(inspectorUrl.href);
 
 		const consoleApiMessages: DevToolsEvent<"Runtime.consoleAPICalled">[] =
@@ -357,7 +362,7 @@ describe.each(OPTIONS)("DevEnv (remote: $remote)", ({ remote }) => {
 			dev: {
 				remote,
 				server: { port: await getPort() },
-				inspector: { port: await getPort() },
+				inspector: false,
 			},
 		});
 
@@ -373,7 +378,7 @@ describe.each(OPTIONS)("DevEnv (remote: $remote)", ({ remote }) => {
 				...worker.config.dev,
 				remote,
 				server: { port: await getPort() },
-				inspector: { port: await getPort() },
+				inspector: false,
 			},
 		});
 		const newPort = worker.config.dev?.server?.port;

--- a/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
+++ b/packages/wrangler/src/__tests__/api/startDevWorker/LocalRuntimeController.test.ts
@@ -535,6 +535,7 @@ describe("LocalRuntimeController", () => {
 			});
 			const event = await waitForReloadComplete(controller);
 			const url = urlFromParts(event.proxyData.userWorkerUrl);
+			assert(event.proxyData.userWorkerInspectorUrl);
 			const inspectorUrl = urlFromParts(event.proxyData.userWorkerInspectorUrl);
 
 			// Connect inspector WebSocket

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -1122,6 +1122,7 @@ describe.sequential("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			const config = await runWranglerUntilConfig("dev");
+			assert(typeof config.dev.inspector === "object");
 			expect(config.dev.inspector?.port).toEqual(9229);
 		});
 
@@ -1132,6 +1133,7 @@ describe.sequential("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			const config = await runWranglerUntilConfig("dev --inspector-port=9999");
+			assert(typeof config.dev.inspector === "object");
 			expect(config.dev.inspector?.port).toEqual(9999);
 		});
 
@@ -1144,6 +1146,7 @@ describe.sequential("wrangler dev", () => {
 			});
 			fs.writeFileSync("index.js", `export default {};`);
 			const config = await runWranglerUntilConfig("dev");
+			assert(typeof config.dev.inspector === "object");
 			expect(config.dev.inspector?.port).toEqual(9999);
 		});
 

--- a/packages/wrangler/src/api/mixedMode/index.ts
+++ b/packages/wrangler/src/api/mixedMode/index.ts
@@ -48,12 +48,7 @@ export async function startMixedModeSession(
 			server: {
 				port: await getPort(),
 			},
-			// TODO(DEVX-1861): we set this to a random port so that it doesn't conflict with the
-			//                  default one, we should ideally add an option to actually disable
-			//                  the inspector
-			inspector: {
-				port: await getPort(),
-			},
+			inspector: false,
 			logLevel: "error",
 		},
 		bindings: rawBindings,

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -128,12 +128,15 @@ async function resolveDevConfig(
 			httpsKeyPath: input.dev?.server?.httpsKeyPath,
 			httpsCertPath: input.dev?.server?.httpsCertPath,
 		},
-		inspector: {
-			port:
-				input.dev?.inspector?.port ??
-				config.dev.inspector_port ??
-				(await getInspectorPort()),
-		},
+		inspector:
+			input.dev?.inspector === false
+				? false
+				: {
+						port:
+							input.dev?.inspector?.port ??
+							config.dev.inspector_port ??
+							(await getInspectorPort()),
+					},
 		origin: {
 			secure:
 				input.dev?.origin?.secure ?? config.dev.upstream_protocol === "https",

--- a/packages/wrangler/src/api/startDevWorker/events.ts
+++ b/packages/wrangler/src/api/startDevWorker/events.ts
@@ -87,7 +87,7 @@ export type ReadyEvent = {
 	type: "ready";
 	proxyWorker: Miniflare;
 	url: URL;
-	inspectorUrl: URL;
+	inspectorUrl: URL | undefined;
 };
 
 // ProxyWorker
@@ -148,7 +148,7 @@ export type UrlOriginAndPathnameParts = Pick<
 
 export type ProxyData = {
 	userWorkerUrl: UrlOriginParts;
-	userWorkerInspectorUrl: UrlOriginAndPathnameParts;
+	userWorkerInspectorUrl?: UrlOriginAndPathnameParts;
 	userWorkerInnerUrlOverrides?: Partial<UrlOriginParts>;
 	headers: Record<string, string>;
 	liveReload?: boolean;

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -50,7 +50,7 @@ type MiniflareWorker = Awaited<ReturnType<Miniflare["getWorker"]>>;
 export interface Worker {
 	ready: Promise<void>;
 	url: Promise<URL>;
-	inspectorUrl: Promise<URL>;
+	inspectorUrl: Promise<URL | undefined>;
 	config: StartDevWorkerOptions;
 	setConfig: ConfigController["set"];
 	patchConfig: ConfigController["patch"];
@@ -138,8 +138,8 @@ export interface StartDevWorkerInput {
 
 	/** Options applying to the worker's development preview environment. */
 	dev?: {
-		/** Options applying to the worker's inspector server. */
-		inspector?: { hostname?: string; port?: number; secure?: boolean };
+		/** Options applying to the worker's inspector server. False disables the inspector server. */
+		inspector?: { hostname?: string; port?: number; secure?: boolean } | false;
 		/** Whether the worker runs on the edge or locally. Can also be set to "minimal" for minimal mode. */
 		remote?: boolean | "minimal";
 		/** Cloudflare Account credentials. Can be provided upfront or as a function which will be called only when required. */

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import registerHotKeys from "../cli-hotkeys";
 import { logger } from "../logger";
 import openInBrowser from "../open-in-browser";
@@ -22,6 +23,8 @@ export default function registerDevHotKeys(
 			label: "open devtools",
 			handler: async () => {
 				const { inspectorUrl } = await devEnv.proxy.ready.promise;
+
+				assert(inspectorUrl, "Error: no inspectorUrl available");
 
 				// TODO: refactor this function to accept a whole URL (not just .port and assuming .hostname)
 				await openInspector(


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1861

Allows `startWorker` to accept `inspector: false` to disable the inspector, this can be useful
when callers do not want/need to have an inspector server.

One example of this is `startMixedModeSession` which calls `startWorker` but it not need an
inspector server associated to the worker and prior to these changes it needed to set a random port
for the inspector in order to avoid port collisions.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included (the updated tests would not work without the code changes)
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: the [`startWorker` documentation](https://developers.cloudflare.com/workers/wrangler/api/#unstable_startworker) doesn't go into details about this sort of information
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: changes to an experimental feature
