### PR TITLE
fix(vite-plugin-cloudflare): ensure cross-process service bindings route through asset worker

### DIFF
--- a/.changeset/eight-buckets-bathe.md
+++ b/.changeset/eight-buckets-bathe.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/vite-plugin": patch
+---
+
+fix: cross-process service bindings no longer skip static asset serving and hit the worker directly

--- a/.changeset/eight-buckets-bathe.md
+++ b/.changeset/eight-buckets-bathe.md
@@ -2,4 +2,4 @@
 "@cloudflare/vite-plugin": patch
 ---
 
-fix: cross-process service bindings no longer skip static asset serving and hit the worker directly
+fix: cross-process service bindings no longer skip static asset serving

--- a/.changeset/icy-lands-build.md
+++ b/.changeset/icy-lands-build.md
@@ -1,0 +1,7 @@
+---
+"miniflare": minor
+---
+
+Added an `serviceName` option to `unsafeDirectSockets`
+
+This allows registering the current worker in the dev registry under its own name, but routing to a different service.

--- a/.changeset/icy-lands-build.md
+++ b/.changeset/icy-lands-build.md
@@ -2,6 +2,6 @@
 "miniflare": minor
 ---
 
-Added an `serviceName` option to `unsafeDirectSockets`
+Added a `serviceName` option to `unsafeDirectSockets`
 
 This allows registering the current worker in the dev registry under its own name, but routing to a different service.

--- a/fixtures/dev-registry/assets/example.txt
+++ b/fixtures/dev-registry/assets/example.txt
@@ -1,0 +1,1 @@
+This is an example asset file

--- a/fixtures/dev-registry/vite.worker-entrypoint-b.config.ts
+++ b/fixtures/dev-registry/vite.worker-entrypoint-b.config.ts
@@ -2,6 +2,9 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+	// Override the default public directory to use the assets directory
+	// so that other vite projects won't share the same assets
+	publicDir: "./assets",
 	plugins: [
 		cloudflare({
 			configPath: "./wrangler.worker-entrypoint-b.jsonc",

--- a/fixtures/dev-registry/wrangler.service-worker.jsonc
+++ b/fixtures/dev-registry/wrangler.service-worker.jsonc
@@ -1,4 +1,5 @@
 {
+	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "service-worker",
 	"main": "./workers/service-worker.ts",
 	"compatibility_date": "2025-05-01",

--- a/fixtures/dev-registry/wrangler.worker-entrypoint-a.jsonc
+++ b/fixtures/dev-registry/wrangler.worker-entrypoint-a.jsonc
@@ -1,4 +1,5 @@
 {
+	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "worker-entrypoint-a",
 	"main": "./workers/worker-entrypoint.ts",
 	"compatibility_date": "2025-05-01",

--- a/fixtures/dev-registry/wrangler.worker-entrypoint-b.jsonc
+++ b/fixtures/dev-registry/wrangler.worker-entrypoint-b.jsonc
@@ -1,7 +1,11 @@
 {
+	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "worker-entrypoint-b",
 	"main": "./workers/worker-entrypoint.ts",
 	"compatibility_date": "2025-05-01",
+	"assets": {
+		"directory": "./assets",
+	},
 	"services": [
 		{
 			"binding": "SERVICE_WORKER",

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -1799,6 +1799,7 @@ export class Miniflare {
 			for (let j = 0; j < directSockets.length; j++) {
 				const previousDirectSocket = previousDirectSockets[j];
 				const directSocket = directSockets[j];
+				const serviceName = directSocket.serviceName ?? workerName;
 				const entrypoint = directSocket.entrypoint ?? "default";
 				const name = getDirectSocketName(i, entrypoint);
 				const address = this.#getSocketAddress(
@@ -1815,7 +1816,7 @@ export class Miniflare {
 								name: `${RPC_PROXY_SERVICE_NAME}:${workerOpts.core.name}`,
 							}
 						: {
-								name: getUserServiceName(workerName),
+								name: getUserServiceName(serviceName),
 								entrypoint: entrypoint === "default" ? undefined : entrypoint,
 							};
 

--- a/packages/miniflare/src/plugins/core/index.ts
+++ b/packages/miniflare/src/plugins/core/index.ts
@@ -118,6 +118,7 @@ const UnusableStringSchema = z.string().transform(() => undefined);
 export const UnsafeDirectSocketSchema = z.object({
 	host: z.ostring(),
 	port: z.onumber(),
+	serviceName: z.ostring(),
 	entrypoint: z.ostring(),
 	proxy: z.oboolean(),
 });

--- a/packages/vite-plugin-cloudflare/src/constants.ts
+++ b/packages/vite-plugin-cloudflare/src/constants.ts
@@ -1,5 +1,6 @@
 export const ROUTER_WORKER_NAME = "__router-worker__";
 export const ASSET_WORKER_NAME = "__asset-worker__";
+export const ASSET_PROXY_WORKER_NAME = "__asset_proxy_worker__";
 export const ASSET_WORKERS_COMPATIBILITY_DATE = "2024-10-04";
 
 export const ADDITIONAL_MODULE_TYPES = [

--- a/packages/vite-plugin-cloudflare/src/constants.ts
+++ b/packages/vite-plugin-cloudflare/src/constants.ts
@@ -1,6 +1,6 @@
 export const ROUTER_WORKER_NAME = "__router-worker__";
 export const ASSET_WORKER_NAME = "__asset-worker__";
-export const ASSET_PROXY_WORKER_NAME = "__asset_proxy_worker__";
+export const VITE_PROXY_WORKER_NAME = "__vite_proxy_worker__";
 export const ASSET_WORKERS_COMPATIBILITY_DATE = "2024-10-04";
 
 export const ADDITIONAL_MODULE_TYPES = [

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -369,6 +369,15 @@ export async function getDevMiniflareOptions(config: {
 							async fetch(request) {
 								return this.env.FETCHER.fetch(request);
 							}
+
+							tail(event) {
+								// Temporary workaround: the tail event is not serializable,
+								// so we are serializing it to JSON and parsing it back to make it transferable.
+								// This loses non-serializable data, but allows us to forward basic info
+								// to the target worker until native support is available.
+							    return this.env.RPC_WORKER.tail(JSON.parse(JSON.stringify(event)));
+							}
+
 							constructor(ctx, env) {
 								super(ctx, env);
 								return new Proxy(this, {

--- a/packages/vite-plugin-cloudflare/src/vite-proxy-worker/index.ts
+++ b/packages/vite-plugin-cloudflare/src/vite-proxy-worker/index.ts
@@ -1,0 +1,53 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+interface Env {
+	ENTRY_USER_WORKER: Service<WorkerEntrypoint>;
+	__VITE_MIDDLEWARE__: Fetcher;
+}
+
+export default class ViteProxyWorker extends WorkerEntrypoint<Env> {
+	constructor(ctx: ExecutionContext, env: Env) {
+		super(ctx, env);
+		return new Proxy(this, {
+			get(target, prop) {
+				if (Reflect.has(target, prop)) {
+					return Reflect.get(target, prop);
+				}
+
+				return Reflect.get(target.env.ENTRY_USER_WORKER, prop);
+			},
+		});
+	}
+
+	override async fetch(request: Request) {
+		return this.env.__VITE_MIDDLEWARE__.fetch(request);
+	}
+
+	override tail(events: TraceItem[]) {
+		// Temporary workaround: the tail events is not serializable over capnproto yet
+		// But they are effectively JSON, so we are serializing them to JSON and parsing it back to make it transferable.
+		// @ts-expect-error FIXME when https://github.com/cloudflare/workerd/pull/4595 lands
+		return this.env.ENTRY_USER_WORKER.tail(
+			JSON.parse(JSON.stringify(events, tailEventsReplacer), tailEventsReviver)
+		);
+	}
+}
+
+const serializedDate = "___serialized_date___";
+
+function tailEventsReplacer(_: string, value: any) {
+	// The tail events might contain Date objects which will not be restored directly
+	if (value instanceof Date) {
+		return { [serializedDate]: value.toISOString() };
+	}
+	return value;
+}
+
+function tailEventsReviver(_: string, value: any) {
+	// To restore Date objects from the serialized events
+	if (value && typeof value === "object" && serializedDate in value) {
+		return new Date(value[serializedDate]);
+	}
+
+	return value;
+}

--- a/packages/vite-plugin-cloudflare/tsup.config.ts
+++ b/packages/vite-plugin-cloudflare/tsup.config.ts
@@ -33,4 +33,12 @@ export default defineConfig([
 		noExternal: ["vite/module-runner"],
 		tsconfig: "tsconfig.worker.json",
 	},
+	{
+		entry: ["src/vite-proxy-worker/index.ts"],
+		format: "esm",
+		platform: "neutral",
+		outDir: "dist/vite-proxy-worker",
+		external: ["cloudflare:workers"],
+		tsconfig: "tsconfig.worker.json",
+	},
 ]);


### PR DESCRIPTION
Fixes [DEVX-2120](https://jira.cfdata.org/browse/DEVX-2120)

This adds an asset proxy worker in front of the user worker when registering the worker in the dev registry which route the request through the vite dev server for assets.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: no impact to wrangler

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
