### PR TITLE
Bump `@cloudflare/unenv-preset` to 2.3.3

### DIFF
--- a/.changeset/shy-cups-float.md
+++ b/.changeset/shy-cups-float.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/vite-plugin": patch
+"wrangler": patch
+---
+
+Bump `@cloudflare/unenv-preset` to 2.3.3

--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -42,7 +42,7 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"@cloudflare/unenv-preset": "2.3.2",
+		"@cloudflare/unenv-preset": "2.3.3",
 		"@mjackson/node-fetch-server": "^0.6.1",
 		"@rollup/plugin-replace": "^6.0.1",
 		"get-port": "^7.1.0",

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -67,7 +67,7 @@
 	},
 	"dependencies": {
 		"@cloudflare/kv-asset-handler": "workspace:*",
-		"@cloudflare/unenv-preset": "2.3.2",
+		"@cloudflare/unenv-preset": "2.3.3",
 		"blake3-wasm": "2.1.5",
 		"esbuild": "catalog:default",
 		"miniflare": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2033,8 +2033,8 @@ importers:
   packages/vite-plugin-cloudflare:
     dependencies:
       '@cloudflare/unenv-preset':
-        specifier: 2.3.2
-        version: 2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250612.0)
+        specifier: 2.3.3
+        version: 2.3.3(unenv@2.0.0-rc.17)(workerd@1.20250604.0)
       '@mjackson/node-fetch-server':
         specifier: ^0.6.1
         version: 0.6.1
@@ -3332,8 +3332,8 @@ importers:
         specifier: workspace:*
         version: link:../kv-asset-handler
       '@cloudflare/unenv-preset':
-        specifier: 2.3.2
-        version: 2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250612.0)
+        specifier: 2.3.3
+        version: 2.3.3(unenv@2.0.0-rc.17)(workerd@1.20250604.0)
       blake3-wasm:
         specifier: 2.1.5
         version: 2.1.5
@@ -4206,8 +4206,8 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/unenv-preset@2.3.2':
-    resolution: {integrity: sha512-MtUgNl+QkQyhQvv5bbWP+BpBC1N0me4CHHuP2H4ktmOMKdB/6kkz/lo+zqiA4mEazb4y+1cwyNjVrQ2DWeE4mg==}
+  '@cloudflare/unenv-preset@2.3.3':
+    resolution: {integrity: sha512-/M3MEcj3V2WHIRSW1eAQBPRJ6JnGQHc6JKMAPLkDb7pLs3m6X9ES/+K3ceGqxI6TKeF32AWAi7ls0AYzVxCP0A==}
     peerDependencies:
       unenv: 2.0.0-rc.17
       workerd: ^1.20250508.0
@@ -14278,7 +14278,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250417.0
 
-  '@cloudflare/unenv-preset@2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250612.0)':
+  '@cloudflare/unenv-preset@2.3.3(unenv@2.0.0-rc.17)(workerd@1.20250604.0)':
     dependencies:
       unenv: 2.0.0-rc.17
     optionalDependencies:


### PR DESCRIPTION
`@cloudflare/unenv-preset@2.3.3` pulls `node:crypto` constants from workerd instead of `unenv` (size optimization).

See https://github.com/cloudflare/workers-sdk/blob/main/packages/unenv-preset/CHANGELOG.md#233

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: no behavior change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no user facing change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: unenv not backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
