### PR TITLE
Revert "chore: update node versions in various places"

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -39,7 +39,7 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/install-dependencies
         with:
-          node-version: 20
+          node-version: 20.11.1
           turbo-api: ${{ secrets.TURBO_API }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/run-c3-e2e
         with:
-          node-version: 20
+          node-version: 20.11.1
           packageManager: ${{ matrix.pm.name }}
           packageManagerVersion: ${{ matrix.pm.version }}
           quarantine: false
@@ -61,7 +61,7 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/run-c3-e2e
         with:
-          node-version: 20
+          node-version: 20.11.1
           packageManager: ${{ matrix.pm.name }}
           packageManagerVersion: ${{ matrix.pm.version }}
           quarantine: false
@@ -101,7 +101,7 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/install-dependencies
         with:
-          node-version: 20
+          node-version: 20.11.1
           turbo-api: ${{ secrets.TURBO_API }}
           turbo-team: ${{ secrets.TURBO_TEAM }}
           turbo-token: ${{ secrets.TURBO_TOKEN }}
@@ -111,7 +111,7 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/run-c3-e2e
         with:
-          node-version: 20
+          node-version: 20.11.1
           packageManager: ${{ matrix.pm.name }}
           packageManagerVersion: ${{ matrix.pm.version }}
           quarantine: false
@@ -123,7 +123,7 @@ jobs:
         if: steps.changes.outputs.everything_but_markdown == 'true'
         uses: ./.github/actions/run-c3-e2e
         with:
-          node-version: 20
+          node-version: 20.11.1
           packageManager: ${{ matrix.pm.name }}
           packageManagerVersion: ${{ matrix.pm.version }}
           quarantine: false

--- a/fixtures/node-app-pages/package.json
+++ b/fixtures/node-app-pages/package.json
@@ -22,7 +22,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-d1-shim/package.json
+++ b/fixtures/pages-d1-shim/package.json
@@ -17,7 +17,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-dev-proxy-with-script/package.json
+++ b/fixtures/pages-dev-proxy-with-script/package.json
@@ -17,7 +17,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-functions-app/package.json
+++ b/fixtures/pages-functions-app/package.json
@@ -23,7 +23,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-functions-wasm-app/package.json
+++ b/fixtures/pages-functions-wasm-app/package.json
@@ -18,7 +18,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-functions-with-config-file-app/package.json
+++ b/fixtures/pages-functions-with-config-file-app/package.json
@@ -17,7 +17,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-functions-with-routes-app/package.json
+++ b/fixtures/pages-functions-with-routes-app/package.json
@@ -18,7 +18,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-nodejs-v2-compat/package.json
+++ b/fixtures/pages-nodejs-v2-compat/package.json
@@ -19,7 +19,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-plugin-mounted-on-root-app/package.json
+++ b/fixtures/pages-plugin-mounted-on-root-app/package.json
@@ -23,7 +23,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-simple-assets/package.json
+++ b/fixtures/pages-simple-assets/package.json
@@ -19,7 +19,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-workerjs-and-functions-app/package.json
+++ b/fixtures/pages-workerjs-and-functions-app/package.json
@@ -17,7 +17,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-workerjs-app/package.json
+++ b/fixtures/pages-workerjs-app/package.json
@@ -17,7 +17,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-workerjs-directory/package.json
+++ b/fixtures/pages-workerjs-directory/package.json
@@ -16,7 +16,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-workerjs-wasm-app/package.json
+++ b/fixtures/pages-workerjs-wasm-app/package.json
@@ -18,7 +18,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-workerjs-with-config-file-app/package.json
+++ b/fixtures/pages-workerjs-with-config-file-app/package.json
@@ -17,7 +17,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/fixtures/pages-workerjs-with-routes-app/package.json
+++ b/fixtures/pages-workerjs-with-routes-app/package.json
@@ -17,7 +17,7 @@
 		"wrangler": "workspace:*"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
 	},
 	"packageManager": "pnpm@9.12.0",
 	"engines": {
-		"node": ">=20",
+		"node": ">=18.20.0",
 		"pnpm": "^9.12.0"
 	},
 	"volta": {
-		"node": "20.19.2",
+		"node": "18.20.2",
 		"pnpm": "9.12.0"
 	},
 	"pnpm": {

--- a/packages/kv-asset-handler/package.json
+++ b/packages/kv-asset-handler/package.json
@@ -50,7 +50,7 @@
 		"service-worker-mock": "^2.0.5"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/miniflare/package.json
+++ b/packages/miniflare/package.json
@@ -102,7 +102,7 @@
 		"xdg-app-paths": "^8.3.0"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/workers-shared/package.json
+++ b/packages/workers-shared/package.json
@@ -59,7 +59,7 @@
 		"zod": "^3.22.3"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/workflows-shared/package.json
+++ b/packages/workflows-shared/package.json
@@ -51,7 +51,7 @@
 		"vitest": "catalog:default"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/wrangler/package.json
+++ b/packages/wrangler/package.json
@@ -170,7 +170,7 @@
 		"fsevents": "~2.3.2"
 	},
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=18.0.0"
 	},
 	"volta": {
 		"extends": "../../package.json"


### PR DESCRIPTION
Reverts cloudflare/workers-sdk#9451. This was causing C3 E2E failures for React Router on Node.js 20.19.2