### PR TITLE
warn instead of erroring if no exposed ports. and remove unused dev_exposed_ports

### DIFF
--- a/packages/miniflare/src/plugins/containers/service/index.ts
+++ b/packages/miniflare/src/plugins/containers/service/index.ts
@@ -75,7 +75,7 @@ export class ContainerController {
 		if (output === "0" && process.platform !== "linux") {
 			throw new Error(
 				`The container "${imageTag.replace(MF_CONTAINER_PREFIX + "/", "")}" does not expose any ports.\n` +
-					"To develop containers locally on non-Linux platforms, you must expose any ports that you call with `getTCPPort() in your Dockerfile."
+					"To develop containers locally on non-Linux platforms, you must expose any ports that you call with `getTCPPort()` in your Dockerfile."
 			);
 		}
 	}

--- a/packages/wrangler/e2e/containers.dev.test.ts
+++ b/packages/wrangler/e2e/containers.dev.test.ts
@@ -37,7 +37,7 @@ const wranglerConfig = {
 // So we skip these tests in CI, and test this locally for now :/
 describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 	"containers local dev tests",
-	{ timeout: 10_000 },
+	{ timeout: 90_000 },
 	() => {
 		let helper: WranglerE2ETestHelper;
 

--- a/packages/wrangler/src/api/startDevWorker/ConfigController.ts
+++ b/packages/wrangler/src/api/startDevWorker/ConfigController.ts
@@ -435,7 +435,6 @@ function resolveContainerConfig(
 			image: container.image ?? container.configuration.image,
 			maxInstances: container.max_instances,
 			imageBuildContext: container.image_build_context,
-			exposedPorts: container.dev_exposed_ports,
 			name: container.name,
 		};
 	}

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -104,11 +104,6 @@ export type ContainerApp = {
 	 *  - manual: The container application will be rollout fully by manually actioning progress steps.
 	 */
 	rollout_kind?: "full_auto" | "none" | "full_manual";
-
-	/**
-	 * Ports to be exposed by the container application. Only applies to dev, on non-linux machines, and if the Dockerfile doesn't already declare exposed ports.
-	 */
-	dev_exposed_ports?: number[];
 };
 
 /**


### PR DESCRIPTION
we will recommend exposing in dockerfile instead of wrangler config so dev_exposed_ports is unnecessary.

also technically you don't have to call getTCPPort so you don't _have_ to expose ports.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: wip feature
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
