### PR TITLE
feat(containers-shared): Move `isDockerfile` utility function to `containers-shared`

### DIFF
--- a/packages/containers-shared/package.json
+++ b/packages/containers-shared/package.json
@@ -16,14 +16,19 @@
 	"author": "wrangler@cloudflare.com",
 	"scripts": {
 		"check:lint": "eslint src --ext ts",
-		"check:type": "tsc"
+		"check:type": "tsc -p ./tsconfig.json && pnpm run type:tests",
+		"test": "vitest",
+		"test:ci": "pnpm run test run",
+		"test:watch": "pnpm run test --testTimeout=50000 --watch",
+		"type:tests": "tsc -p ./tests/tsconfig.json"
 	},
 	"devDependencies": {
 		"@cloudflare/eslint-config-worker": "workspace:*",
 		"@cloudflare/workers-tsconfig": "workspace:*",
 		"@types/node": "catalog:default",
 		"typescript": "catalog:default",
-		"undici": "catalog:default"
+		"undici": "catalog:default",
+		"vitest": "catalog:default"
 	},
 	"engines": {
 		"node": ">20.0.0"

--- a/packages/containers-shared/tests/tsconfig.json
+++ b/packages/containers-shared/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"module": "CommonJS",
+		"types": ["node", "vitest/globals"]
+	},
+	"include": ["**/*.ts"]
+}

--- a/packages/containers-shared/tests/utils.test.ts
+++ b/packages/containers-shared/tests/utils.test.ts
@@ -1,0 +1,55 @@
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { isDockerfile } from "./../src/utils";
+
+describe("isDockerfile", () => {
+	const dockerfile =
+		'FROM node:18\nWORKDIR /app\nCOPY . .\nRUN npm install\nCMD ["node", "index.js"]';
+
+	beforeEach(() => {
+		mkdirSync("./container-context");
+		writeFileSync("./container-context/Dockerfile", dockerfile);
+	});
+
+	afterEach(() => {
+		rmSync("./container-context", { recursive: true });
+	});
+
+	it("should return true if given a valid dockerfile path", async () => {
+		expect(isDockerfile("./container-context/Dockerfile")).toBe(true);
+	});
+
+	it("should return false if given a valid image registry path", async () => {
+		expect(isDockerfile("docker.io/httpd:1")).toBe(false);
+	});
+
+	it("should error if given a non existant dockerfile", async () => {
+		expect(() => isDockerfile("./FakeDockerfile"))
+			.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The image "./FakeDockerfile" does not appear to be a valid path to a Dockerfile, or a valid image registry path:
+				If this is an image registry path, it needs to include at least a tag ':' (e.g: docker.io/httpd:1)]
+			`);
+	});
+
+	it("should error if given a directory instead of a dockerfile", async () => {
+		expect(() => isDockerfile("./container-context"))
+			.toThrowErrorMatchingInlineSnapshot(`
+			[Error: ./container-context is a directory, you should specify a path to the Dockerfile]
+		`);
+	});
+
+	it("should error if image registry reference contains the protocol part", async () => {
+		expect(() => isDockerfile("http://example.com/image:tag"))
+			.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The image "http://example.com/image:tag" does not appear to be a valid path to a Dockerfile, or a valid image registry path:
+				Image reference should not include the protocol part (e.g: docker.io/httpd:1, not https://docker.io/httpd:1)]
+			`);
+	});
+
+	it("should error if image registry reference does not contain a tag", async () => {
+		expect(() => isDockerfile("docker.io/httpd"))
+			.toThrowErrorMatchingInlineSnapshot(`
+				[Error: The image "docker.io/httpd" does not appear to be a valid path to a Dockerfile, or a valid image registry path:
+				If this is an image registry path, it needs to include at least a tag ':' (e.g: docker.io/httpd:1)]
+			`);
+	});
+});

--- a/packages/containers-shared/vitest.config.mts
+++ b/packages/containers-shared/vitest.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		testTimeout: 15_000,
+		retry: 0,
+		include: ["**/tests/**/*.test.ts"],
+		globals: true,
+	},
+});

--- a/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
@@ -8,7 +8,6 @@ import {
 } from "@cloudflare/containers-shared";
 import { ensureDiskLimits } from "../../cloudchamber/build";
 import { resolveAppDiskSize } from "../../cloudchamber/common";
-import { isDockerfile } from "../../cloudchamber/deploy";
 import { type ContainerApp } from "../../config/environment";
 import { UserError } from "../../errors";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
@@ -173,43 +172,6 @@ describe("buildAndMaybePush", () => {
 		await expect(
 			runWrangler("containers build ./container-context -t test-app:tag -p")
 		).rejects.toThrow(new UserError(errorMessage));
-	});
-
-	describe("isDockerfile", () => {
-		it("should return true if given a valid dockerfile path", async () => {
-			expect(isDockerfile("./container-context/Dockerfile")).toBe(true);
-		});
-		it("should return false if given a valid image registry path", async () => {
-			expect(isDockerfile("docker.io/httpd:1")).toBe(false);
-		});
-
-		it("should error if given a non existant dockerfile", async () => {
-			expect(() => isDockerfile("./FakeDockerfile"))
-				.toThrowErrorMatchingInlineSnapshot(`
-					[Error: The image "./FakeDockerfile" does not appear to be a valid path to a Dockerfile, or a valid image registry path:
-					If this is an image registry path, it needs to include at least a tag ':' (e.g: docker.io/httpd:1)]
-				`);
-		});
-		it("should error if given a directory instead of a dockerfile", async () => {
-			expect(() => isDockerfile("./container-context"))
-				.toThrowErrorMatchingInlineSnapshot(`
-				[Error: ./container-context is a directory, you should specify a path to the Dockerfile]
-			`);
-		});
-		it("should error if image registry reference contains the protocol part", async () => {
-			expect(() => isDockerfile("http://example.com/image:tag"))
-				.toThrowErrorMatchingInlineSnapshot(`
-					[Error: The image "http://example.com/image:tag" does not appear to be a valid path to a Dockerfile, or a valid image registry path:
-					Image reference should not include the protocol part (e.g: docker.io/httpd:1, not https://docker.io/httpd:1)]
-				`);
-		});
-		it("should error if image registry reference does not contain a tag", async () => {
-			expect(() => isDockerfile("docker.io/httpd"))
-				.toThrowErrorMatchingInlineSnapshot(`
-					[Error: The image "docker.io/httpd" does not appear to be a valid path to a Dockerfile, or a valid image registry path:
-					If this is an image registry path, it needs to include at least a tag ':' (e.g: docker.io/httpd:1)]
-				`);
-		});
 	});
 
 	describe("ensureDiskLimits", () => {

--- a/packages/wrangler/src/cloudchamber/build.ts
+++ b/packages/wrangler/src/cloudchamber/build.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from "fs";
+import { existsSync } from "fs";
 import { join } from "path";
 import {
 	constructBuildCommand,
@@ -6,6 +6,7 @@ import {
 	dockerImageInspect,
 	dockerLoginManagedRegistry,
 	DOMAIN,
+	isDir,
 	runDockerCmd,
 } from "@cloudflare/containers-shared";
 import {
@@ -70,11 +71,6 @@ export function pushYargs(yargs: CommonYargsArgvJSON) {
 			demandOption: false,
 		})
 		.positional("TAG", { type: "string", demandOption: true });
-}
-
-export function isDir(path: string) {
-	const stats = statSync(path);
-	return stats.isDirectory();
 }
 
 export async function buildAndMaybePush(

--- a/packages/wrangler/src/cloudchamber/deploy.ts
+++ b/packages/wrangler/src/cloudchamber/deploy.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "fs";
+import { isDockerfile } from "@cloudflare/containers-shared";
 import { type Config } from "../config";
 import { type ContainerApp } from "../config/environment";
 import { getDockerPath } from "../environment-variables/misc-variables";
@@ -7,7 +7,7 @@ import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
 import { fetchVersion } from "../versions/api";
 import { apply } from "./apply";
-import { buildAndMaybePush, isDir } from "./build";
+import { buildAndMaybePush } from "./build";
 import { fillOpenAPIConfiguration } from "./common";
 import type { BuildArgs } from "@cloudflare/containers-shared/src/types";
 
@@ -126,43 +126,3 @@ export function getBuildArguments(
 		args: container.image_vars,
 	};
 }
-
-export const isDockerfile = (image: string): boolean => {
-	// TODO: move this into config validation
-	if (existsSync(image)) {
-		if (isDir(image)) {
-			throw new UserError(
-				`${image} is a directory, you should specify a path to the Dockerfile`
-			);
-		}
-		return true;
-	}
-
-	const errorPrefix = `The image "${image}" does not appear to be a valid path to a Dockerfile, or a valid image registry path:\n`;
-	// not found, not a dockerfile, let's try parsing the image ref as an URL?
-	try {
-		new URL(`https://${image}`);
-	} catch (e) {
-		if (e instanceof Error) {
-			throw new UserError(errorPrefix + e.message);
-		}
-		throw e;
-	}
-	const imageParts = image.split("/");
-
-	if (!imageParts[imageParts.length - 1].includes(":")) {
-		throw new UserError(
-			errorPrefix +
-				`If this is an image registry path, it needs to include at least a tag ':' (e.g: docker.io/httpd:1)`
-		);
-	}
-
-	// validate URL
-	if (image.includes("://")) {
-		throw new UserError(
-			errorPrefix +
-				`Image reference should not include the protocol part (e.g: docker.io/httpd:1, not https://docker.io/httpd:1)`
-		);
-	}
-	return false;
-};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1401,6 +1401,9 @@ importers:
       undici:
         specifier: catalog:default
         version: 5.28.5
+      vitest:
+        specifier: catalog:default
+        version: 3.2.3(@types/node@20.17.32)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
 
   packages/create-cloudflare:
     devDependencies:


### PR DESCRIPTION
As part of DEVX-1966, we are moving the `isDockerfile` utility function and its corresponding tests to `containers-shared`. To support running tests for this package, this PR also adds some of the necessary vitest config.

Fixes DEVX-1966

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because: just a refactor
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: this is an experimental feature still

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
