### PR TITLE
test: correctly delete test d1 databases

### DIFF
--- a/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
+++ b/packages/wrangler/e2e/helpers/e2e-wrangler-test.ts
@@ -127,8 +127,8 @@ export class WranglerE2ETestHelper {
 		assert(match !== null, `Cannot find ID in ${JSON.stringify(result)}`);
 		const id = match[1];
 		onTestFinished(async () => {
-			await this.run(`wrangler d1 delete -y ${id}`);
-		});
+			await this.run(`wrangler d1 delete -y ${name}`);
+		}, 15_000);
 
 		return { id, name };
 	}

--- a/tools/e2e/__tests__/common.test.ts
+++ b/tools/e2e/__tests__/common.test.ts
@@ -46,7 +46,7 @@ describe("listTmpE2EProjects()", () => {
 			.intercept({
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/pages/projects`,
 				query: {
-					per_page: 10,
+					per_page: 100,
 					page: 1,
 				},
 			})
@@ -65,6 +65,13 @@ describe("listTmpE2EProjects()", () => {
 						{ name: "pages-project-5", created_on: nowStr },
 						{ name: "pages-project-6", created_on: oldTimeStr },
 					],
+					result_info: {
+						page: 1,
+						per_page: 10,
+						count: 10,
+						total_count: 12,
+						total_pages: 2,
+					},
 				})
 			);
 
@@ -73,7 +80,7 @@ describe("listTmpE2EProjects()", () => {
 			.intercept({
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/pages/projects`,
 				query: {
-					per_page: 10,
+					per_page: 100,
 					page: 2,
 				},
 			})
@@ -84,6 +91,13 @@ describe("listTmpE2EProjects()", () => {
 						{ name: "tmp-e2e-project-5", created_on: nowStr },
 						{ name: "tmp-e2e-project-6", created_on: oldTimeStr },
 					],
+					result_info: {
+						page: 2,
+						per_page: 10,
+						count: 2,
+						total_count: 12,
+						total_pages: 2,
+					},
 				})
 			);
 
@@ -124,8 +138,6 @@ describe("listTmpKVNamespaces()", () => {
 				query: {
 					per_page: 100,
 					page: 1,
-					direction: "asc",
-					order: "title",
 				},
 			})
 			.reply(
@@ -144,6 +156,13 @@ describe("listTmpKVNamespaces()", () => {
 						{ id: "kv-10", title: "kv-10" },
 						...Array(90).fill({ id: "kv-10", title: "kv-10" }),
 					],
+					result_info: {
+						page: 1,
+						per_page: 10,
+						count: 10,
+						total_count: 11,
+						total_pages: 2,
+					},
 				})
 			);
 		agent
@@ -154,14 +173,19 @@ describe("listTmpKVNamespaces()", () => {
 				query: {
 					per_page: 100,
 					page: 2,
-					direction: "asc",
-					order: "title",
 				},
 			})
 			.reply(
 				200,
 				JSON.stringify({
 					result: [{ id: "kv-tmp-e2e-11", title: "kv-11" }],
+					result_info: {
+						page: 2,
+						per_page: 10,
+						count: 2,
+						total_count: 12,
+						total_pages: 2,
+					},
 				})
 			);
 
@@ -219,6 +243,13 @@ describe("listTmpDatabases()", () => {
 							created_at: oldTimeStr,
 						}),
 					],
+					result_info: {
+						page: 1,
+						per_page: 10,
+						count: 50,
+						total_count: 12,
+						total_pages: 2,
+					},
 				})
 			);
 		agent
@@ -238,6 +269,13 @@ describe("listTmpDatabases()", () => {
 						{ uuid: "11", name: "db-11", created_at: nowStr },
 						{ uuid: "12", name: "db-12", created_at: oldTimeStr },
 					],
+					result_info: {
+						page: 2,
+						per_page: 10,
+						count: 2,
+						total_count: 12,
+						total_pages: 2,
+					},
 				})
 			);
 
@@ -274,6 +312,7 @@ describe("listTmpE2EWorkers()", () => {
 			.get("https://api.cloudflare.com")
 			.intercept({
 				path: `/client/v4/accounts/${MOCK_CLOUDFLARE_ACCOUNT_ID}/workers/scripts`,
+				query: { per_page: 100, page: 1 },
 				method: "GET",
 			})
 			.reply(

--- a/tools/e2e/common.ts
+++ b/tools/e2e/common.ts
@@ -64,43 +64,112 @@ class ApiError extends Error {
 	}
 }
 
-class FatalError extends Error {
-	constructor(readonly exitCode: number) {
-		super();
-	}
-}
-
-const apiFetchResponse = async (
+async function apiFetchResponse(
 	path: string,
 	init = { method: "GET" },
-	failSilently = false,
 	queryParams = {}
-): Promise<Response | false> => {
+): Promise<Response | false> {
+	const baseUrl = `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}`;
+	let queryString = new URLSearchParams(queryParams).toString();
+	if (queryString) {
+		queryString = "?" + queryString;
+	}
+	const url = `${baseUrl}${path}${queryString}`;
+
+	const response = await fetch(url, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
+		},
+	});
+
+	if (response.status >= 400) {
+		throw { url, init, response };
+	}
+
+	return response;
+}
+
+async function apiFetch<T>(
+	path: string,
+	method: string,
+	failSilently = false
+): Promise<false | T> {
 	try {
-		const baseUrl = `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}`;
-		let queryString = new URLSearchParams(queryParams).toString();
-		if (queryString) {
-			queryString = "?" + queryString;
-		}
-		const url = `${baseUrl}${path}${queryString}`;
+		const response = await apiFetchResponse(path, { method });
 
-		const response = await fetch(url, {
-			...init,
-			headers: {
-				Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
-			},
-		});
-
-		if (response.status >= 400) {
-			throw { url, init, response };
-		}
-
-		return response;
-	} catch (e) {
-		if (failSilently) {
+		if (!response || response.ok === false) {
 			return false;
 		}
 
+		const json = (await response.json()) as ApiSuccessBody;
+		return json.result as T;
+	} catch (e) {
+		if (!failSilently) {
+			if (e instanceof ApiError) {
+				console.error(e.url, e.init);
+				console.error(`(${e.response.status}) ${e.response.statusText}`);
+				const body = (await e.response.json()) as ApiErrorBody;
+				console.error(body.errors);
+			} else {
+				console.error(e);
+			}
+		}
+		return false;
+	}
+}
+
+async function apiFetchList<T>(path: string, queryParams = {}): Promise<T[]> {
+	try {
+		let page = 1;
+		let totalCount = 0;
+		let result: unknown[] = [];
+		// eslint-disable-next-line no-constant-condition
+		while (true) {
+			const response = await apiFetchResponse(
+				path,
+				{ method: "GET" },
+				{
+					page,
+					per_page: 100,
+					...queryParams,
+				}
+			);
+
+			if (!response || response.ok === false) {
+				return [];
+			}
+
+			const json = (await response.json()) as ApiSuccessBody;
+			if ("result_info" in json && Array.isArray(json.result)) {
+				const result_info = json.result_info as {
+					page: number;
+					count: number;
+					total_count?: number;
+					total_pages?: number;
+				};
+				console.log(path, result_info);
+
+				result = [...result, ...json.result];
+
+				if (result_info.count === 0) {
+					return result as T[];
+				}
+
+				totalCount += result_info.count;
+				if (totalCount === result_info.total_count) {
+					return result as T[];
+				}
+
+				if (page === result_info.total_pages) {
+					return result as T[];
+				}
+				page = result_info.page + 1;
+			} else {
+				return json.result as T[];
+			}
+		}
+	} catch (e) {
 		if (e instanceof ApiError) {
 			console.error(e.url, e.init);
 			console.error(`(${e.response.status}) ${e.response.statusText}`);
@@ -109,65 +178,12 @@ const apiFetchResponse = async (
 		} else {
 			console.error(e);
 		}
-		throw new FatalError(1);
-	}
-};
-
-async function apiFetch(
-	path: string,
-	init = { method: "GET" },
-	failSilently = false,
-	queryParams = {}
-) {
-	let page = 1;
-	let result: unknown[] = [];
-	// eslint-disable-next-line no-constant-condition
-	while (true) {
-		const response = await apiFetchResponse(path, init, failSilently, {
-			...queryParams,
-			page,
-		});
-
-		if (!response || response.ok === false) {
-			return false;
-		}
-
-		const json = (await response.json()) as ApiSuccessBody;
-		if ("result_info" in json && Array.isArray(json.result)) {
-			const result_info = json.result_info as {
-				page: number;
-				count: number;
-			};
-			if (result_info.count === 0) {
-				return result;
-			}
-			result = [...result, ...json.result];
-			console.log(result_info, result_info.page, result_info.count);
-			page = result_info.page + 1;
-		} else {
-			return json.result;
-		}
+		return [];
 	}
 }
 
 export const listTmpE2EProjects = async () => {
-	const pageSize = 10;
-	let page = 1;
-
-	const projects: Project[] = [];
-	while (projects.length % pageSize === 0) {
-		const res = (await apiFetch(`/pages/projects`, { method: "GET" }, false, {
-			per_page: pageSize,
-			page,
-		})) as Project[];
-		projects.push(...res);
-		page++;
-		if (res.length < pageSize) {
-			break;
-		}
-	}
-
-	return projects.filter(
+	return (await apiFetchList<Project>(`/pages/projects`)).filter(
 		(p) =>
 			p.name.startsWith("tmp-e2e-") &&
 			// Projects are more than an hour old
@@ -176,25 +192,20 @@ export const listTmpE2EProjects = async () => {
 };
 
 export const deleteProject = async (project: string) => {
-	return await apiFetch(
-		`/pages/projects/${project}`,
-		{
-			method: "DELETE",
-		},
-		true
-	);
+	return await apiFetch(`/pages/projects/${project}`, "DELETE");
 };
 
 export const listTmpE2EWorkers = async () => {
-	const res = (await apiFetch(`/workers/scripts`, {
-		method: "GET",
-	})) as Worker[];
-	return res.filter(
+	return (await apiFetchList<Worker>(`/workers/scripts`)).filter(
 		(p) =>
 			p.id.startsWith("tmp-e2e-") &&
 			// Workers are more than an hour old
 			Date.now() - new Date(p.created_on).valueOf() > 1000 * 60 * 60
 	);
+};
+
+export const deleteWorker = async (id: string) => {
+	return await apiFetch(`/workers/scripts/${id}`, "DELETE");
 };
 
 export const listTmpE2EContainerApplications = async () => {
@@ -219,48 +230,13 @@ export const listTmpE2EContainerApplications = async () => {
 };
 
 export const deleteContainerApplication = async (app: ContainerApplication) => {
-	return await apiFetchResponse(
-		`/cloudchamber/applications/${app.id}`,
-		{
-			method: "DELETE",
-		},
-		true
-	);
-};
-
-export const deleteWorker = async (id: string) => {
-	return await apiFetch(
-		`/workers/scripts/${id}`,
-		{
-			method: "DELETE",
-		},
-		true
-	);
+	return await apiFetchResponse(`/cloudchamber/applications/${app.id}`, {
+		method: "DELETE",
+	});
 };
 
 export const listTmpKVNamespaces = async () => {
-	const pageSize = 100;
-	let page = 1;
-	const results: KVNamespaceInfo[] = [];
-	while (results.length % pageSize === 0) {
-		const res = (await apiFetch(
-			`/storage/kv/namespaces`,
-			{ method: "GET" },
-			false,
-			new URLSearchParams({
-				per_page: pageSize.toString(),
-				order: "title",
-				direction: "asc",
-				page: page.toString(),
-			})
-		)) as KVNamespaceInfo[];
-		page++;
-		results.push(...res);
-		if (res.length < pageSize || page > 5) {
-			break;
-		}
-	}
-	return results.filter(
+	return (await apiFetchList<KVNamespaceInfo>(`/storage/kv/namespaces`)).filter(
 		(kv) => kv.title.includes("tmp-e2e") || kv.title.includes("tmp_e2e")
 	);
 };
@@ -268,35 +244,13 @@ export const listTmpKVNamespaces = async () => {
 export const deleteKVNamespace = async (id: string) => {
 	return await apiFetch(
 		`/storage/kv/namespaces/${id}`,
-		{
-			method: "DELETE",
-		},
-		true
+		"DELETE",
+		/* failSilently */ true
 	);
 };
 
 export const listTmpDatabases = async () => {
-	const pageSize = 100;
-	let page = 1;
-	const results: Database[] = [];
-	while (results.length % pageSize === 0) {
-		const res = (await apiFetch(
-			`/d1/database`,
-			{ method: "GET" },
-			false,
-			new URLSearchParams({
-				per_page: pageSize.toString(),
-				page: page.toString(),
-			})
-		)) as Database[];
-		page++;
-		results.push(...res);
-
-		if (res.length < pageSize || page > 5) {
-			break;
-		}
-	}
-	return results.filter(
+	return (await apiFetchList<Database>(`/d1/database`)).filter(
 		(db) =>
 			db.name.includes("tmp-e2e") && // Databases are more than an hour old
 			Date.now() - new Date(db.created_at).valueOf() > 1000 * 60 * 60
@@ -304,39 +258,11 @@ export const listTmpDatabases = async () => {
 };
 
 export const deleteDatabase = async (id: string) => {
-	return (
-		(await apiFetch(
-			`/d1/database/${id}`,
-			{
-				method: "DELETE",
-			},
-			true
-		)) !== false
-	);
+	return (await apiFetch(`/d1/database/${id}`, "DELETE")) !== false;
 };
 
 export const listHyperdriveConfigs = async () => {
-	const pageSize = 100;
-	let page = 1;
-	const results: HyperdriveConfig[] = [];
-	while (results.length % pageSize === 0) {
-		const res = (await apiFetch(
-			`/hyperdrive/configs`,
-			{ method: "GET" },
-			false,
-			new URLSearchParams({
-				per_page: pageSize.toString(),
-				page: page.toString(),
-			})
-		)) as HyperdriveConfig[];
-		page++;
-		results.push(...res);
-
-		if (res.length < pageSize || page > 5) {
-			break;
-		}
-	}
-	return results.filter(
+	return (await apiFetchList<HyperdriveConfig>(`/hyperdrive/configs`)).filter(
 		(config) =>
 			config.name.includes("tmp-e2e") && // Databases are more than an hour old
 			Date.now() - new Date(config.created_on).valueOf() > 1000 * 60 * 60
@@ -344,21 +270,13 @@ export const listHyperdriveConfigs = async () => {
 };
 
 export const deleteHyperdriveConfig = async (id: string) => {
-	return await apiFetch(
-		`/hyperdrive/configs/${id}`,
-		{
-			method: "DELETE",
-		},
-		true
-	);
+	return await apiFetch(`/hyperdrive/configs/${id}`, "DELETE");
 };
 
 export const listCertificates = async () => {
-	const results = (await apiFetch(`/mtls_certificates`, {
-		method: "GET",
-	})) as MTlsCertificateResponse[];
-
-	return results.filter(
+	return (
+		await apiFetchList<MTlsCertificateResponse>(`/mtls_certificates`)
+	).filter(
 		(cert) =>
 			cert.name?.includes("tmp-e2e") && // Certs are more than an hour old
 			Date.now() - new Date(cert.uploaded_on).valueOf() > 1000 * 60 * 60
@@ -366,11 +284,5 @@ export const listCertificates = async () => {
 };
 
 export const deleteCertificate = async (id: string) => {
-	await apiFetch(
-		`/mtls_certificates/${id}`,
-		{
-			method: "DELETE",
-		},
-		true
-	);
+	await apiFetch(`/mtls_certificates/${id}`, "DELETE");
 };


### PR DESCRIPTION
The d1 e2e tests sometimes timeout but also regularly have the following error/warning:

```
wrangler:test:e2e: [wrangler-smoke-QSaF1q] X [ERROR] Couldn't find DB with name 'e12af046-17a4-49a6-90c5-b33d5f09c633'
```

This is because we were passing the id rather than the name to the d1 delete command.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: test
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> test

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
