### PR TITLE
Add details to v3 maintenance worflow error message

### DIFF
--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -52,6 +52,10 @@ jobs:
 
             Depending on your changes, running `git rebase --onto v3-maintenance main ${{ github.head_ref }}` might be a good starting point.
 
+            Notes:
+            - your PR branch should be named `v3-backport-${{ github.event.number }}`
+            - add the `skip-v3-pr` label to the current PR to stop this workflow from failing
+
       - name: "Comment on PR with backport PR details"
         if: steps.open_pr.outputs.has_wrangler_patch == 'true' && success()
         uses: marocchino/sticky-pull-request-comment@daa4a82a0a3f6c162c02b83fa44b3ab83946f7cb


### PR DESCRIPTION
Fixes my frustartion (WIP).

- The v3 backport PR branch is expected to follow a given pattern so document that
- The v3 workflow will keep failing until you had `skip-v3-pr` so document that

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: CI
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: CI
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Do we ever need doc :)
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: CI

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
