### PR TITLE
remote unnecessary getStore line

### DIFF
--- a/packages/wrangler/src/logger.ts
+++ b/packages/wrangler/src/logger.ts
@@ -64,8 +64,6 @@ export const runWithLogLevel = <V>(
 	cb: () => V
 ) => overrideLoggerLevel.run({ logLevel: overrideLogLevel }, cb);
 
-overrideLoggerLevel.getStore;
-
 export type TableRow<Keys extends string> = Record<Keys, string>;
 
 function consoleMethodToLoggerLevel(


### PR DESCRIPTION
I just noticed this extra useless line and figured I could just open a quick PR to remove it

Sorry for missing this when reviewing https://github.com/cloudflare/workers-sdk/pull/9329 😓 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: very minor cleanup
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: very minor cleanup
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: very minor code cleanup
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: this line hasn't been backported

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
