### PR TITLE
fix `startWorker` not respecting `auth` options

### DIFF
--- a/.changeset/violet-bananas-itch.md
+++ b/.changeset/violet-bananas-itch.md
@@ -1,0 +1,38 @@
+---
+"wrangler": patch
+---
+
+fix `startWorker` not respecting `auth` options
+
+fix `startWorker` currently not taking into account the `auth` field
+that can be provided as part of the `dev` options
+
+example:
+
+Given the following
+
+```js
+import { unstable_startWorker } from "wrangler";
+
+const worker = await unstable_startWorker({
+	entrypoint: "./worker.js",
+	bindings: {
+		AI: {
+			type: "ai",
+		},
+	},
+	dev: {
+		auth: {
+			accountId: "<ACCOUNT_ID>",
+			apiToken: {
+				apiToken: "<API_TOKEN>",
+			},
+		},
+	},
+});
+
+await worker.ready;
+```
+
+`wrangler` will use the provided `<ACCOUNT_ID>` and `<API_TOKEN>` to integrate with
+the remote AI binding instead of requiring the user to authenticate.

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -380,18 +380,20 @@ export async function getDevMiniflareOptions(
 								);
 							}
 
-							const miniflareWorkerOptions = unstable_getMiniflareWorkerOptions(
-								{
-									...workerConfig,
-									assets: undefined,
-								},
-								resolvedPluginConfig.cloudflareEnv,
-								{
-									mixedModeConnectionString:
-										mixedModeSessionData?.session?.mixedModeConnectionString,
-									mixedModeEnabled: resolvedPluginConfig.experimental.mixedMode,
-								}
-							);
+							const miniflareWorkerOptions =
+								await unstable_getMiniflareWorkerOptions(
+									{
+										...workerConfig,
+										assets: undefined,
+									},
+									resolvedPluginConfig.cloudflareEnv,
+									{
+										mixedModeConnectionString:
+											mixedModeSessionData?.session?.mixedModeConnectionString,
+										mixedModeEnabled:
+											resolvedPluginConfig.experimental.mixedMode,
+									}
+								);
 
 							const { externalWorkers } = miniflareWorkerOptions;
 
@@ -685,7 +687,7 @@ export async function getPreviewMiniflareOptions(
 					);
 				}
 
-				const miniflareWorkerOptions = unstable_getMiniflareWorkerOptions(
+				const miniflareWorkerOptions = await unstable_getMiniflareWorkerOptions(
 					workerConfig,
 					undefined,
 					{

--- a/packages/vitest-pool-workers/src/pool/config.ts
+++ b/packages/vitest-pool-workers/src/pool/config.ts
@@ -269,7 +269,7 @@ async function parseCustomPoolOptions(
 		}
 
 		const { workerOptions, externalWorkers, define, main } =
-			wrangler.unstable_getMiniflareWorkerOptions(
+			await wrangler.unstable_getMiniflareWorkerOptions(
 				configPath,
 				options.wrangler.environment,
 				{

--- a/packages/wrangler/e2e/dev-env.test.ts
+++ b/packages/wrangler/e2e/dev-env.test.ts
@@ -52,7 +52,7 @@ describe("switching runtimes", () => {
                             remote: firstRemote,
                             auth: {
                                 accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
-                                apiToken: process.env.CLOUDFLARE_API_TOKEN,
+                                apiToken: { apiToken: process.env.CLOUDFLARE_API_TOKEN },
                             },
                         },
                     });

--- a/packages/wrangler/e2e/seed-files/start-worker-auth/index.mjs
+++ b/packages/wrangler/e2e/seed-files/start-worker-auth/index.mjs
@@ -1,0 +1,24 @@
+const { unstable_startWorker } = await import(process.env.WRANGLER_IMPORT);
+
+const worker = await unstable_startWorker({
+	entrypoint: "./worker.js",
+	bindings: {
+		AI: {
+			type: "ai",
+		},
+	},
+	dev: {
+		auth: {
+			accountId: process.env._START_WORKER_TESTING_AUTH_ID,
+			apiToken: {
+				apiToken: process.env._START_WORKER_TESTING_AUTH_TOKEN,
+			},
+		},
+	},
+});
+
+console.log(
+	`worker response: ${await (await worker.fetch("http://example.com")).text()}`
+);
+
+await worker.dispose();

--- a/packages/wrangler/e2e/seed-files/start-worker-auth/worker.js
+++ b/packages/wrangler/e2e/seed-files/start-worker-auth/worker.js
@@ -1,0 +1,18 @@
+export default {
+	async fetch(_request, env) {
+		const messages = [
+			{
+				role: "user",
+				// Doing snapshot testing against AI responses can be flaky, but this prompt generates the same output relatively reliably
+				content:
+					"Respond with the exact text 'This is a response from Workers AI.'. Do not include any other text",
+			},
+		];
+
+		const content = await env.AI.run("@hf/thebloke/zephyr-7b-beta-awq", {
+			messages,
+		});
+
+		return new Response(content.response);
+	},
+};

--- a/packages/wrangler/e2e/start-worker-auth-opts.test.ts
+++ b/packages/wrangler/e2e/start-worker-auth-opts.test.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import { WranglerE2ETestHelper } from "./helpers/e2e-wrangler-test";
+
+describe("startWorker - auth options", () => {
+	const helper = new WranglerE2ETestHelper();
+
+	beforeAll(async () => {
+		await helper.seed(resolve(__dirname, "./seed-files/start-worker-auth"));
+	});
+
+	it("correctly connects to remote resources (AI) if correct auth data is provided", async () => {
+		// eslint-disable-next-line unused-imports/no-unused-vars
+		const {
+			CLOUDFLARE_ACCOUNT_ID: _START_WORKER_TESTING_AUTH_ID,
+			CLOUDFLARE_API_TOKEN: _START_WORKER_TESTING_AUTH_TOKEN,
+			...env
+		} = process.env;
+		const spawnResult = spawnSync("node", ["index.mjs"], {
+			cwd: helper.tmpPath,
+			env: {
+				...env,
+				_START_WORKER_TESTING_AUTH_ID,
+				_START_WORKER_TESTING_AUTH_TOKEN,
+			},
+		});
+
+		expect(`${spawnResult.status}`).toBe("0");
+		expect(`${spawnResult.stdout}`).toContain(
+			'worker response: "This is a response from Workers AI."'
+		);
+	});
+
+	it("fails to use remote resources (AI) if no auth data is provided", async () => {
+		// eslint-disable-next-line unused-imports/no-unused-vars
+		const { CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, ...env } = process.env;
+		const spawnResult = spawnSync("node", ["index.mjs"], {
+			cwd: helper.tmpPath,
+			env,
+		});
+
+		expect(`${spawnResult.status}`).not.toBe("0");
+		expect(`${spawnResult.stdout}`).not.toContain(
+			'worker response: "This is a response from Workers AI."'
+		);
+	});
+});

--- a/packages/wrangler/src/__tests__/ai.local.test.ts
+++ b/packages/wrangler/src/__tests__/ai.local.test.ts
@@ -6,7 +6,10 @@ import * as internal from "../cfetch/internal";
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "../environment-variables/misc-variables";
 import * as user from "../user";
 
-const AIFetcher = getAIFetcher(COMPLIANCE_REGION_CONFIG_UNKNOWN);
+const AIFetcher = getAIFetcher(
+	COMPLIANCE_REGION_CONFIG_UNKNOWN,
+	() => "mock-account-id"
+);
 
 describe("ai", () => {
 	describe("fetcher", () => {
@@ -16,7 +19,6 @@ describe("ai", () => {
 
 		describe("local", () => {
 			it("should send x-forwarded header", async () => {
-				vi.spyOn(user, "getAccountId").mockImplementation(async () => "123");
 				vi.spyOn(internal, "performApiFetch").mockImplementation(
 					async (config, resource, init = {}) => {
 						const headers = new Headers(init.headers);
@@ -64,7 +66,7 @@ describe("ai", () => {
 				);
 
 				expect(await resp.json()).toEqual({
-					resource: "/accounts/123/ai/run/proxy",
+					resource: "/accounts/mock-account-id/ai/run/proxy",
 				});
 			});
 		});

--- a/packages/wrangler/src/ai/fetcher.ts
+++ b/packages/wrangler/src/ai/fetcher.ts
@@ -1,6 +1,6 @@
 import { Headers, Response } from "miniflare";
 import { performApiFetch } from "../cfetch";
-import { getAccountId } from "../user";
+import type { MaybePromise } from "../api/startDevWorker/utils";
 import type { ComplianceConfig } from "../environment-variables/misc-variables";
 import type { Request } from "miniflare";
 
@@ -14,14 +14,17 @@ export default function (env) {
 }
 `;
 
-export function getAIFetcher(complianceConfig: ComplianceConfig) {
+export function getAIFetcher(
+	complianceConfig: ComplianceConfig,
+	getAccountId: () => MaybePromise<string>
+) {
 	return async function (request: Request): Promise<Response> {
-		const accountId = await getAccountId(complianceConfig);
-
 		const reqHeaders = new Headers(request.headers);
 		reqHeaders.delete("Host");
 		reqHeaders.delete("Content-Length");
 		reqHeaders.set("X-Forwarded", request.url);
+
+		const accountId = await getAccountId();
 
 		const res = await performApiFetch(
 			complianceConfig,

--- a/packages/wrangler/src/api/integrations/platform/index.ts
+++ b/packages/wrangler/src/api/integrations/platform/index.ts
@@ -168,23 +168,24 @@ async function getMiniflareOptionsFromConfig(
 		tailConsumers: [],
 	});
 
-	const { bindingOptions, externalWorkers } = buildMiniflareBindingOptions(
-		{
-			name: rawConfig.name,
-			complianceRegion: rawConfig.compliance_region,
-			bindings,
-			workerDefinitions,
-			queueConsumers: undefined,
-			services: rawConfig.services,
-			serviceBindings: {},
-			migrations: rawConfig.migrations,
-			imagesLocalMode: false,
-			tails: [],
-			containers: {},
-		},
-		undefined,
-		false
-	);
+	const { bindingOptions, externalWorkers } =
+		await buildMiniflareBindingOptions(
+			{
+				name: rawConfig.name,
+				complianceRegion: rawConfig.compliance_region,
+				bindings,
+				workerDefinitions,
+				queueConsumers: undefined,
+				services: rawConfig.services,
+				serviceBindings: {},
+				migrations: rawConfig.migrations,
+				imagesLocalMode: false,
+				tails: [],
+				containers: {},
+			},
+			undefined,
+			false
+		);
 
 	const defaultPersistRoot = getMiniflarePersistRoot(options.persist);
 
@@ -254,7 +255,7 @@ export interface Unstable_MiniflareWorkerOptions {
 	externalWorkers: WorkerOptions[];
 }
 
-export function unstable_getMiniflareWorkerOptions(
+export async function unstable_getMiniflareWorkerOptions(
 	configPath: string,
 	env?: string,
 	options?: {
@@ -265,8 +266,8 @@ export function unstable_getMiniflareWorkerOptions(
 			assets?: Partial<AssetsOptions>;
 		};
 	}
-): Unstable_MiniflareWorkerOptions;
-export function unstable_getMiniflareWorkerOptions(
+): Promise<Unstable_MiniflareWorkerOptions>;
+export async function unstable_getMiniflareWorkerOptions(
 	config: Config,
 	env?: string,
 	options?: {
@@ -277,8 +278,8 @@ export function unstable_getMiniflareWorkerOptions(
 			assets?: Partial<AssetsOptions>;
 		};
 	}
-): Unstable_MiniflareWorkerOptions;
-export function unstable_getMiniflareWorkerOptions(
+): Promise<Unstable_MiniflareWorkerOptions>;
+export async function unstable_getMiniflareWorkerOptions(
 	configOrConfigPath: string | Config,
 	env?: string,
 	options?: {
@@ -289,7 +290,7 @@ export function unstable_getMiniflareWorkerOptions(
 			assets?: Partial<AssetsOptions>;
 		};
 	}
-): Unstable_MiniflareWorkerOptions {
+): Promise<Unstable_MiniflareWorkerOptions> {
 	const config =
 		typeof configOrConfigPath === "string"
 			? readConfig({ config: configOrConfigPath, env })
@@ -304,23 +305,24 @@ export function unstable_getMiniflareWorkerOptions(
 		}));
 
 	const bindings = getBindings(config, env, true, {}, true);
-	const { bindingOptions, externalWorkers } = buildMiniflareBindingOptions(
-		{
-			name: config.name,
-			complianceRegion: config.compliance_region,
-			bindings,
-			workerDefinitions: null,
-			queueConsumers: config.queues.consumers,
-			services: [],
-			serviceBindings: {},
-			migrations: config.migrations,
-			imagesLocalMode: !!options?.imagesLocalMode,
-			tails: config.tail_consumers,
-			containers: {},
-		},
-		options?.mixedModeConnectionString,
-		options?.mixedModeEnabled ?? false
-	);
+	const { bindingOptions, externalWorkers } =
+		await buildMiniflareBindingOptions(
+			{
+				name: config.name,
+				complianceRegion: config.compliance_region,
+				bindings,
+				workerDefinitions: null,
+				queueConsumers: config.queues.consumers,
+				services: [],
+				serviceBindings: {},
+				migrations: config.migrations,
+				imagesLocalMode: !!options?.imagesLocalMode,
+				tails: config.tail_consumers,
+				containers: {},
+			},
+			options?.mixedModeConnectionString,
+			options?.mixedModeEnabled ?? false
+		);
 
 	// This function is currently only exported for the Workers Vitest pool.
 	// In tests, we don't want to rely on the dev registry, as we can't guarantee

--- a/packages/wrangler/src/api/startDevWorker/index.ts
+++ b/packages/wrangler/src/api/startDevWorker/index.ts
@@ -1,7 +1,5 @@
-import { readConfig } from "../../config";
 import { runWithAuth } from "../../user";
 import { DevEnv } from "./DevEnv";
-import { unwrapHook } from "./utils";
 import type { StartDevWorkerInput, Worker } from "./types";
 
 export { convertConfigBindingsToStartWorkerBindings } from "./utils";
@@ -13,23 +11,16 @@ export * from "./events";
 export async function startWorker(
 	options: StartDevWorkerInput
 ): Promise<Worker> {
-	const startWorkerImpl = () => {
-		const devEnv = new DevEnv();
-		return devEnv.startWorker(options);
-	};
-
-	if (options.dev?.auth) {
-		const inputAuth = await unwrapHook(options.dev.auth, readConfig(options));
-		if (inputAuth) {
-			return runWithAuth(
-				{
-					accountId: inputAuth.accountId,
-					apiCredentials: inputAuth.apiToken,
-				},
-				startWorkerImpl
-			);
+	return runWithAuth(
+		// Note: we set up the auth info as undefined since
+		//       these will be updated in the ConfigController
+		{
+			accountId: undefined,
+			apiCredentials: undefined,
+		},
+		() => {
+			const devEnv = new DevEnv();
+			return devEnv.startWorker(options);
 		}
-	}
-
-	return startWorkerImpl();
+	);
 }

--- a/packages/wrangler/src/api/startDevWorker/types.ts
+++ b/packages/wrangler/src/api/startDevWorker/types.ts
@@ -143,7 +143,7 @@ export interface StartDevWorkerInput {
 		/** Whether the worker runs on the edge or locally. Can also be set to "minimal" for minimal mode. */
 		remote?: boolean | "minimal";
 		/** Cloudflare Account credentials. Can be provided upfront or as a function which will be called only when required. */
-		auth?: AsyncHook<CfAccount, [Pick<Config, "account_id">]>; // provide config.account_id as a hook param
+		auth?: AsyncHook<CfAccount, [Partial<Pick<Config, "account_id">>]>; // provide config.account_id as a hook param
 		/** Whether local storage (KV, Durable Objects, R2, D1, etc) is persisted. You can also specify the directory to persist data to. */
 		persist?: string;
 		/** Controls which logs are logged 🤙. */

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -462,7 +462,7 @@ async function getPagesAssetsFetcher(
 async function setupDevEnv(
 	devEnv: DevEnv,
 	configPath: string | undefined,
-	auth: AsyncHook<CfAccount, [Pick<Config, "account_id">]>,
+	auth: AsyncHook<CfAccount, [Partial<Pick<Config, "account_id">>]>,
 	args: Partial<StartDevOptions> & { multiworkerPrimary?: boolean }
 ) {
 	await devEnv.config.set(
@@ -603,9 +603,10 @@ export async function startDev(args: StartDevOptions) {
 			logger.loggerLevel = args.logLevel;
 		}
 
-		const authHook: AsyncHook<CfAccount, [Pick<Config, "account_id">]> = async (
-			config
-		) => {
+		const authHook: AsyncHook<
+			CfAccount,
+			[Partial<Pick<Config, "account_id">>]
+		> = async (config) => {
 			const hotkeysDisplayed = !!unregisterHotKeys;
 			let accountId = args.accountId;
 			if (!accountId) {

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -459,18 +459,34 @@ export function reinitialiseAuthTokens(config?: UserAuthConfig): void {
 }
 
 const authLocalStorage = new AsyncLocalStorage<{
-	accountId: string;
-	apiCredentials: ApiCredentials;
+	accountId: string | undefined;
+	apiCredentials: ApiCredentials | undefined;
 }>();
 
 export const runWithAuth = <V>(
-	auth: { accountId: string; apiCredentials: ApiCredentials },
+	auth: {
+		accountId: string | undefined;
+		apiCredentials: ApiCredentials | undefined;
+	},
 	cb: () => V
 ) => authLocalStorage.run(auth, cb);
 
+export function updateScopedAuth(auth: {
+	accountId: string | undefined;
+	apiCredentials: ApiCredentials | undefined;
+}) {
+	const authLocalStore = authLocalStorage.getStore();
+	assert(
+		authLocalStore,
+		"Trying to update the auth local store but none was found"
+	);
+	authLocalStore.accountId = auth.accountId;
+	authLocalStore.apiCredentials = auth.apiCredentials;
+}
+
 export function getAPIToken(): ApiCredentials | undefined {
 	const authLocalStore = authLocalStorage.getStore();
-	if (authLocalStore) {
+	if (authLocalStore?.apiCredentials) {
 		return authLocalStore.apiCredentials;
 	}
 
@@ -1241,7 +1257,7 @@ export async function getAccountId(
 	complianceConfig: ComplianceConfig
 ): Promise<string> {
 	const authLocalStore = authLocalStorage.getStore();
-	if (authLocalStore) {
+	if (authLocalStore?.accountId) {
 		return authLocalStore.accountId;
 	}
 


### PR DESCRIPTION
Fixes https://jira.cfdata.org/browse/DEVX-1857

This PR makes sure that `startWorker` takes into account the potential `auth` options

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: startWorker is not documented at this level of details
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: changes only effecting experimental features

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
