### PR TITLE
containers: Default scheduling policy should be the default

### DIFF
--- a/.changeset/nasty-cameras-poke.md
+++ b/.changeset/nasty-cameras-poke.md
@@ -1,0 +1,6 @@
+---
+"@cloudflare/containers-shared": patch
+"wrangler": patch
+---
+
+wrangler containers: 'default' scheduling policy should be the default

--- a/packages/containers-shared/package.json
+++ b/packages/containers-shared/package.json
@@ -17,6 +17,7 @@
 	"scripts": {
 		"check:lint": "eslint src --ext ts",
 		"check:type": "tsc -p ./tsconfig.json && pnpm run type:tests",
+		"deploy": "echo 'no deploy'",
 		"test": "vitest",
 		"test:ci": "pnpm run test run",
 		"test:watch": "pnpm run test --testTimeout=50000 --watch",

--- a/packages/containers-shared/src/client/models/SchedulingPolicy.ts
+++ b/packages/containers-shared/src/client/models/SchedulingPolicy.ts
@@ -9,4 +9,6 @@ export enum SchedulingPolicy {
 	MOON = "moon",
 	GPU = "gpu",
 	REGIONAL = "regional",
+	FILL_METALS = "fill_metals",
+	DEFAULT = "default",
 }

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -127,7 +127,7 @@ describe("cloudchamber apply", () => {
 			│   [[containers]]
 			│   name = \\"my-container-app\\"
 			│   instances = 3
-			│   scheduling_policy = \\"regional\\"
+			│   scheduling_policy = \\"default\\"
 			│
 			│   [containers.configuration]
 			│   image = \\"./Dockerfile\\"
@@ -169,7 +169,7 @@ describe("cloudchamber apply", () => {
 				created_at: new Date().toString(),
 				version: 1,
 				account_id: "1",
-				scheduling_policy: SchedulingPolicy.REGIONAL,
+				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile",
 				},
@@ -245,7 +245,7 @@ describe("cloudchamber apply", () => {
 				created_at: new Date().toString(),
 				account_id: "1",
 				version: 1,
-				scheduling_policy: SchedulingPolicy.REGIONAL,
+				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile2",
 				},
@@ -279,7 +279,7 @@ describe("cloudchamber apply", () => {
 			│   [[containers]]
 			│   name = \\"my-container-app-2\\"
 			│   max_instances = 3
-			│   scheduling_policy = \\"regional\\"
+			│   scheduling_policy = \\"default\\"
 			│
 			│   [containers.configuration]
 			│   image = \\"other-app/Dockerfile\\"
@@ -335,7 +335,7 @@ describe("cloudchamber apply", () => {
 				created_at: new Date().toString(),
 				account_id: "1",
 				version: 1,
-				scheduling_policy: SchedulingPolicy.REGIONAL,
+				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile",
 				},
@@ -366,7 +366,7 @@ describe("cloudchamber apply", () => {
 			│   [[containers]]
 			│   name = \\"my-container-app-2\\"
 			│   instances = 1
-			│   scheduling_policy = \\"regional\\"
+			│   scheduling_policy = \\"default\\"
 			│
 			│   [containers.configuration]
 			│   image = \\"other-app/Dockerfile\\"
@@ -416,7 +416,7 @@ describe("cloudchamber apply", () => {
 				created_at: new Date().toString(),
 				account_id: "1",
 				version: 1,
-				scheduling_policy: SchedulingPolicy.REGIONAL,
+				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile",
 				},
@@ -447,7 +447,7 @@ describe("cloudchamber apply", () => {
 			│   [[containers]]
 			│   name = \\"my-container-app-2\\"
 			│   instances = 1
-			│   scheduling_policy = \\"regional\\"
+			│   scheduling_policy = \\"default\\"
 			│
 			│   [containers.configuration]
 			│   image = \\"other-app/Dockerfile\\"
@@ -518,7 +518,7 @@ describe("cloudchamber apply", () => {
 				version: 1,
 				created_at: new Date().toString(),
 				account_id: "1",
-				scheduling_policy: SchedulingPolicy.REGIONAL,
+				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile",
 					labels: [
@@ -601,7 +601,7 @@ describe("cloudchamber apply", () => {
 		/* eslint-enable */
 	});
 
-	test("can apply an application, and there is no changes", async () => {
+	test("can apply an application, and there is no changes (retrocompatibility with regional scheduling policy)", async () => {
 		setIsTTY(false);
 		writeAppConfiguration({
 			class_name: "DurableObjectClass",
@@ -646,7 +646,7 @@ describe("cloudchamber apply", () => {
 				version: 1,
 				created_at: new Date().toString(),
 				account_id: "1",
-				scheduling_policy: SchedulingPolicy.REGIONAL,
+				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile",
 					labels: [
@@ -746,7 +746,7 @@ describe("cloudchamber apply", () => {
 			created_at: new Date().toString(),
 			class_name: "DurableObjectClass",
 			account_id: "1",
-			scheduling_policy: SchedulingPolicy.REGIONAL,
+			scheduling_policy: SchedulingPolicy.DEFAULT,
 			configuration: {
 				image: "./Dockerfile",
 				labels: [
@@ -797,6 +797,105 @@ describe("cloudchamber apply", () => {
 			├ no changes my-container-app
 			│
 			├ no changes my-container-app-2
+			│
+			╰ No changes to be made
+
+			"
+		`);
+		expect(std.stderr).toMatchInlineSnapshot(`""`);
+		/* eslint-enable */
+	});
+
+	test("can apply an application, and there is no changes", async () => {
+		setIsTTY(false);
+		writeAppConfiguration({
+			class_name: "DurableObjectClass",
+			name: "my-container-app",
+			instances: 3,
+			configuration: {
+				image: "./Dockerfile",
+				labels: [
+					{
+						name: "name",
+						value: "value",
+					},
+					{
+						name: "name-2",
+						value: "value-2",
+					},
+				],
+				secrets: [
+					{
+						name: "MY_SECRET",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME",
+					},
+					{
+						name: "MY_SECRET_1",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME_1",
+					},
+					{
+						name: "MY_SECRET_2",
+						type: SecretAccessType.ENV,
+						secret: "SECRET_NAME_2",
+					},
+				],
+			},
+		});
+		mockGetApplications([
+			{
+				id: "abc",
+				name: "my-container-app",
+				instances: 3,
+				version: 1,
+				created_at: new Date().toString(),
+				account_id: "1",
+				scheduling_policy: SchedulingPolicy.REGIONAL,
+				configuration: {
+					image: "./Dockerfile",
+					labels: [
+						{
+							name: "name",
+							value: "value",
+						},
+						{
+							name: "name-2",
+							value: "value-2",
+						},
+					],
+					secrets: [
+						{
+							name: "MY_SECRET",
+							type: SecretAccessType.ENV,
+							secret: "SECRET_NAME",
+						},
+						{
+							name: "MY_SECRET_1",
+							type: SecretAccessType.ENV,
+							secret: "SECRET_NAME_1",
+						},
+						{
+							name: "MY_SECRET_2",
+							type: SecretAccessType.ENV,
+							secret: "SECRET_NAME_2",
+						},
+					],
+				},
+
+				constraints: {
+					tier: 1,
+				},
+			},
+		]);
+		await runWrangler("cloudchamber apply --json");
+		/* eslint-disable */
+		expect(std.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ no changes my-container-app
 			│
 			╰ No changes to be made
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -4,7 +4,10 @@ import { randomFillSync } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { PassThrough, Writable } from "node:stream";
-import { getCloudflareContainerRegistry } from "@cloudflare/containers-shared";
+import {
+	getCloudflareContainerRegistry,
+	SchedulingPolicy,
+} from "@cloudflare/containers-shared";
 import * as TOML from "@iarna/toml";
 import { sync } from "command-exists";
 import * as esbuild from "esbuild";
@@ -9129,6 +9132,7 @@ addEventListener('fetch', event => {});`
 					name: "my-container",
 					instances: 10,
 					durable_objects: { namespace_id: "1" },
+					scheduling_policy: SchedulingPolicy.DEFAULT,
 				});
 
 				fs.writeFileSync(

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -120,7 +120,7 @@ function containerAppToCreateApplication(
 		instances: containerApp.instances ?? 0,
 		scheduling_policy:
 			(containerApp.scheduling_policy as SchedulingPolicy) ??
-			SchedulingPolicy.REGIONAL,
+			SchedulingPolicy.DEFAULT,
 		constraints: {
 			...(containerApp.constraints ??
 				(!skipDefaults ? { tier: 1 } : undefined)),
@@ -392,6 +392,12 @@ export async function apply(
 			const prevApp = sortObjectRecursive<CreateApplicationRequest>(
 				stripUndefined(applicationToCreateApplication(application))
 			);
+
+			// fill up fields that their defaults were changed over-time,
+			// maintaining retrocompatibility with the existing app
+			if (appConfigNoDefaults.scheduling_policy === undefined) {
+				appConfig.scheduling_policy = prevApp.scheduling_policy;
+			}
 
 			if (
 				prevApp.durable_objects !== undefined &&

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -73,7 +73,7 @@ export type ContainerApp = {
 	class_name: string;
 
 	/** The scheduling policy of the application, default is regional */
-	scheduling_policy?: "regional" | "moon";
+	scheduling_policy?: "regional" | "moon" | "default";
 
 	/* Configuration of the container */
 	configuration: {


### PR DESCRIPTION
Makes default scheduling_policy the default

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: default change that does not apply to public docs
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
