### PR TITLE
remove todo comment left in changelog by mistake

### DIFF
--- a/.changeset/some-cloths-move.md
+++ b/.changeset/some-cloths-move.md
@@ -17,7 +17,7 @@ of the following commands:
 - wrangler secret bulk
 - wrangler secret put
 - wrangler secret delete
-- wrangler triggers deploy (TODO: manually test)
+- wrangler triggers deploy
 
 this is a measure we're putting in place to try to prevent developers from accidentally applying
 changes to an incorrect (potentially even production) environment


### PR DESCRIPTION

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: changelog fix
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: changelog fix
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: changelog fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: changelog fix

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
