### PR TITLE
fix: streamed response bodies in Miniflare should not infer non-streaming compression by default

### DIFF
--- a/.changeset/sweet-dodos-taste.md
+++ b/.changeset/sweet-dodos-taste.md
@@ -1,0 +1,12 @@
+---
+"miniflare": patch
+---
+
+fix: streamed response bodies in Miniflare should not infer compression encoding by default
+
+When serving responses that have not defined `content-encoding` explicitly, Miniflare was attempting to infer a compression algorithm from the `accept-encoding` request header.
+This resulted in streamed responses being compressed with an algorithm (usually gzip) that does not stream as expected:
+The compression buffer is big enough that it rarely flushes giving the impression that the response is not streaming
+
+Now Miniflare will prefer to infer the `identity` `content-encoding` response from the `accept-encoding` request header if possible.
+Therefore unless the accept-headers explicitly disallow `identity`, streamed responses will not be compressed by default.

--- a/fixtures/streaming/client-worker/src/index.ts
+++ b/fixtures/streaming/client-worker/src/index.ts
@@ -1,0 +1,67 @@
+interface Env {
+	WORKER: typeof import("../../main-worker/src/index").default;
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+		switch (url.pathname) {
+			case "/streaming":
+			case "/fixed-length":
+				return env.WORKER.fetch(request);
+			case "google": {
+				const response = await fetch("https://google.com", {
+					redirect: "manual",
+					headers: request.headers,
+				});
+				const newResponse = new Response(response.body, {
+					...response,
+					headers: { ...response.headers, "content-encoding": "identity" },
+				});
+				return newResponse;
+			}
+			case "/igor": {
+				const response = await fetch("https://ping.igor-dev.workers.dev/", {
+					redirect: "manual",
+					headers: request.headers,
+				});
+				const newResponse = new Response(response.body, {
+					...response,
+					// headers: { ...response.headers, "content-encoding": "identity" },
+				});
+				return newResponse;
+			}
+			default:
+				return new Response(
+					`
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<meta charset="UTF-8" />
+				<title>Streaming Example</title>
+			</head>
+			<body>
+				<h1>Streaming Example</h1>
+				<p>Use the <code>/streaming</code> endpoint to see streaming responses.</p>
+				<ul>
+					<li><code>compression</code>: Set to <code>gzip</code> for gzip compression, <code>br</code> for no brotli compression, leave empty for no compression.</li>
+					<li><code>iterations</code>: Number of chunks to send (default is 5).</li>
+					<li><code>pause</code>: Time in milliseconds to wait between chunks (default is 500).</li>
+					<li><code>chunksize</code>: Size of each chunk in bytes (default is 500).</li>
+				</ul>
+				<p>Examples:</p>
+				<ul>
+					<li><a href="/streaming">Default - no compression</a></li>
+					<li><a href="/streaming?compression=gzip">gzip compression</a></li>
+					<li><a href="/streaming?compression=gzip&iterations=50&pause=100&chunksize=1000">gzip lots of large chunks</a></li>
+					<li><a href="/streaming?compression=br">brotli compression</a></li>
+					<li><a href="/streaming?compression=br&iterations=50&pause=100&chunksize=1000">brotli lots of large chunks</a></li>
+				</ul>
+			</body>
+			</html>
+			`,
+					{ headers: { "content-type": "text/html" } }
+				);
+		}
+	},
+};

--- a/fixtures/streaming/client-worker/tests/index.test.ts
+++ b/fixtures/streaming/client-worker/tests/index.test.ts
@@ -1,0 +1,82 @@
+import assert from "assert";
+import { resolve } from "path";
+import { fetch } from "undici";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { runWranglerDev } from "../../../shared/src/run-wrangler-long-lived";
+import type { Response } from "undici";
+
+describe("'wrangler dev' streaming responses", () => {
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
+
+	beforeAll(async () => {
+		({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
+			"--port=0",
+			"--inspector-port=0",
+			"-c main-worker/wrangler.toml",
+		]));
+	});
+
+	afterAll(async () => {
+		await stop?.();
+	});
+
+	describe.concurrent.each(["<default>", "gzip", "br", "identity"])(
+		"encoding set to %s",
+		(compression) => {
+			it("streams response chunks over time", async ({ expect }) => {
+				const compressionParam =
+					compression === "<default>" ? "" : `?compression=${compression}`;
+				const response = await fetch(
+					`http://${ip}:${port}/streaming${compressionParam}`
+				);
+				expect(response.status).toBe(200);
+				expect(response.body).toBeTruthy();
+				expect(response.headers.get("content-encoding")).toEqual(
+					compression === "<default>" ? null : compression
+				);
+
+				const { chunks, timestamps } = await readBody(response);
+
+				const fullContent = chunks.join("");
+
+				// Verify we received the expected content structure
+				expect(fullContent).toContain("<div>START</div>");
+				expect(fullContent).toContain("<div>test 0");
+				expect(fullContent).toContain("<div>test 4");
+				expect(fullContent).toContain("<div>END</div>");
+
+				// The gzip and brotli responses do not fill the streaming buffer so they are sent in a single chunk.
+				if (compression !== "gzip" && compression !== "br") {
+					// Verify we received multiple a chunk for each delayed piece of content.
+					expect(chunks.length).toBeGreaterThan(4);
+
+					// Verify chunks arrived over time (some reads should take longer due to delays)
+					const slowReads = timestamps.filter((time) => time > 50);
+					expect(slowReads.length).toBeGreaterThan(4);
+				}
+			});
+		}
+	);
+});
+
+async function readBody(response: Response) {
+	assert(response.body, "Response body is not readable");
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	const chunks: string[] = [];
+	const timestamps: number[] = [];
+
+	try {
+		while (true) {
+			const start = Date.now();
+			const { done, value } = await reader.read();
+			timestamps.push(Date.now() - start);
+			if (done) break;
+			chunks.push(decoder.decode(value, { stream: true }));
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	return { chunks, timestamps };
+}

--- a/fixtures/streaming/client-worker/wrangler.jsonc
+++ b/fixtures/streaming/client-worker/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+	"$schema": "../../../packages/wrangler/config-schema.json",
+	"name": "client-worker",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-06-01",
+	"services": [
+		{
+			"binding": "WORKER",
+			"service": "main-worker",
+		},
+	],
+}

--- a/fixtures/streaming/main-worker/src/index.ts
+++ b/fixtures/streaming/main-worker/src/index.ts
@@ -1,0 +1,122 @@
+export default {
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+		switch (url.pathname) {
+			case "/fixed-length":
+				return fixedLengthResponse(request);
+			case "/streaming":
+				return streamingResponse(request);
+			default:
+				return new Response(
+					`
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<meta charset="UTF-8" />
+				<title>Streaming Example</title>
+			</head>
+			<body>
+				<h1>Streaming Example</h1>
+				<p>Use the <code>/streaming</code> endpoint to see streaming responses.</p>
+				<ul>
+					<li><code>compression</code>: Set to <code>gzip</code> for gzip compression, <code>br</code> for no brotli compression, leave empty for no compression.</li>
+					<li><code>iterations</code>: Number of chunks to send (default is 5).</li>
+					<li><code>pause</code>: Time in milliseconds to wait between chunks (default is 500).</li>
+					<li><code>chunksize</code>: Size of each chunk in bytes (default is 500).</li>
+				</ul>
+				<p>Examples:</p>
+				<ul>
+					<li><a href="/streaming">Default - no compression</a></li>
+					<li><a href="/streaming?compression=gzip">gzip compression</a></li>
+					<li><a href="/streaming?compression=gzip&iterations=50&pause=100&chunksize=1000">gzip lots of large chunks</a></li>
+					<li><a href="/streaming?compression=br">brotli compression</a></li>
+					<li><a href="/streaming?compression=br&iterations=50&pause=100&chunksize=1000">brotli lots of large chunks</a></li>
+				</ul>
+			</body>
+			</html>
+			`,
+					{ headers: { "content-type": "text/html" } }
+				);
+		}
+	},
+};
+
+function fixedLengthResponse(request: Request): Response {
+	const url = new URL(request.url);
+	const compression = url.searchParams.get("compression") ?? "";
+	const body =
+		'<!DOCTYPE html><html><head><meta charset="UTF-8" /></head><body><p>Fixed length response</p></body></html>';
+	const bodyStream = ReadableStreamFromString(body);
+	const response = new Response(bodyStream, {
+		headers: {
+			"content-type": "text/html",
+			...(compression ? { "content-encoding": compression } : {}),
+			"content-length": body.length.toString(),
+			// "transfer-encoding": "gzip",
+		},
+	});
+	console.log(response);
+	return response;
+}
+
+function streamingResponse(request: Request): Response {
+	const url = new URL(request.url);
+	const compression = url.searchParams.get("compression") ?? "";
+	const iterations = Number(url.searchParams.get("iterations") ?? 5);
+	const pause = Number(url.searchParams.get("pause") ?? 200);
+	const chunksize = Number(url.searchParams.get("chunksize") ?? 500);
+
+	const stream = new ReadableStream({
+		async start(controller) {
+			controller.enqueue(
+				`<!DOCTYPE html><html><head><meta charset="UTF-8" /></head><body><p><a href="/">Home</a></p>\n`
+			);
+			// need certain amount of data to start stream chunking
+			let preamble = "";
+			for (let i = 0; i < 100; i++) {
+				const bytes = new Uint8Array(10);
+				const chars = Array.from(crypto.getRandomValues(bytes))
+					.map((n) => n.toString(36))
+					.join("");
+				preamble += `<!-- preamble ${i} ${chars} -->\n`;
+			}
+			controller.enqueue(preamble);
+			controller.enqueue("<div>START</div>\n");
+
+			for (let i = 0; i < iterations; i++) {
+				await new Promise((r) => setTimeout(r, pause));
+				console.log("writing chunk", i);
+				const bytes = new Uint8Array(chunksize);
+				const chars = Array.from(crypto.getRandomValues(bytes))
+					.map((n) => n.toString(36))
+					.join("");
+				controller.enqueue(
+					`<div>test ${i} (chunk size: ${chars.length})</div><!-- ${chars} -->\n`
+				);
+			}
+			controller.enqueue("<div>END</div>\n");
+			controller.enqueue(`</body></html>`);
+			controller.close();
+		},
+	}).pipeThrough(new TextEncoderStream());
+
+	return new Response(stream, {
+		headers: {
+			"content-type": "text/html",
+			// Setting the content-encoding to gzip tells workerd to compress the response.
+			// Setting it to identity means no compression.
+			...(compression ? { "content-encoding": compression } : {}),
+		},
+	});
+}
+
+function ReadableStreamFromString(str: string): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			const chunk = encoder.encode(str);
+			controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}

--- a/fixtures/streaming/main-worker/tests/index.test.ts
+++ b/fixtures/streaming/main-worker/tests/index.test.ts
@@ -1,0 +1,106 @@
+import { resolve } from "path";
+import { fetch } from "undici";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { runWranglerDev } from "../../../shared/src/run-wrangler-long-lived";
+import type { Response } from "undici";
+
+describe("'wrangler dev' streaming responses", () => {
+	let ip: string, port: number, stop: (() => Promise<unknown>) | undefined;
+
+	beforeAll(async () => {
+		({ ip, port, stop } = await runWranglerDev(resolve(__dirname, ".."), [
+			"--port=0",
+			"--inspector-port=0",
+		]));
+	});
+
+	afterAll(async () => {
+		await stop?.();
+	});
+
+	describe.concurrent.each([
+		{ encoding: null },
+		{ encoding: "gzip" },
+		{ encoding: "br" },
+		{ encoding: "identity" },
+	])("worker encoding set to $encoding", ({ encoding }) => {
+		it("uses the content-encoding provided by the Worker, if acceptable", async ({
+			expect,
+		}) => {
+			const compressionParam =
+				encoding === null ? "" : `?compression=${encoding}`;
+			const response = await fetch(
+				`http://${ip}:${port}/streaming${compressionParam}`,
+				{ headers: { "accept-encoding": "br,gzip,deflate,zstd" } }
+			);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("content-encoding")).toEqual(
+				encoding === "identity" ? null : encoding
+			);
+		});
+
+		it("uses identity encoding if only identity is acceptable", async ({
+			expect,
+		}) => {
+			const compressionParam =
+				encoding === null ? "" : `?compression=${encoding}`;
+			const response = await fetch(
+				`http://${ip}:${port}/streaming${compressionParam}`,
+				{ headers: { "accept-encoding": "" } }
+			);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("content-encoding")).toEqual(null);
+		});
+
+		it("sends the content in small chunks if identity encoded", async ({
+			expect,
+		}) => {
+			const response = await fetch(`http://${ip}:${port}/streaming`, {
+				headers: { "accept-encoding": encoding },
+			});
+			expect(response.status).toBe(200);
+			expect(response.headers.get("content-encoding")).toBe(null);
+
+			const { chunks, timestamps } = await readBody(response);
+
+			const fullContent = chunks.join("");
+
+			// Verify we received the expected content structure
+			expect(fullContent).toContain("<div>START</div>");
+			expect(fullContent).toContain("<div>test 0");
+			expect(fullContent).toContain("<div>test 4");
+			expect(fullContent).toContain("<div>END</div>");
+
+			// The gzip and brotli responses do not fill the streaming buffer so they are sent in a single chunk.
+			if (encoding !== "gzip" && encoding !== "br") {
+				// Verify we received multiple a chunk for each delayed piece of content.
+				expect(chunks.length).toBeGreaterThan(4);
+
+				// Verify chunks arrived over time (some reads should take longer due to delays)
+				const slowReads = timestamps.filter((time) => time > 50);
+				expect(slowReads.length).toBeGreaterThan(4);
+			}
+		});
+	});
+});
+
+async function readBody(response: Response) {
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	const chunks: string[] = [];
+	const timestamps: number[] = [];
+
+	try {
+		while (true) {
+			const start = Date.now();
+			const { done, value } = await reader.read();
+			timestamps.push(Date.now() - start);
+			if (done) break;
+			chunks.push(decoder.decode(value, { stream: true }));
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	return { chunks, timestamps };
+}

--- a/fixtures/streaming/main-worker/wrangler.jsonc
+++ b/fixtures/streaming/main-worker/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+	"name": "main-worker",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-06-01",
+}

--- a/fixtures/streaming/package.json
+++ b/fixtures/streaming/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "@fixture/streaming",
+	"private": true,
+	"scripts": {
+		"deploy": "wrangler deploy",
+		"start": "wrangler dev",
+		"test:ci": "vitest run"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-tsconfig": "workspace:^",
+		"undici": "catalog:default",
+		"vitest": "catalog:default",
+		"wrangler": "workspace:*"
+	},
+	"volta": {
+		"extends": "../../package.json"
+	}
+}

--- a/fixtures/streaming/tsconfig.json
+++ b/fixtures/streaming/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/fixtures/streaming/tsconfig.node.json
+++ b/fixtures/streaming/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"esModuleInterop": true,
+		"module": "CommonJS",
+		"lib": ["ES2020"],
+		"types": ["node"],
+		"skipLibCheck": true,
+		"moduleResolution": "node",
+		"noEmit": true
+	},
+	"include": ["main-worker/tests", "../../node-types.d.ts"]
+}

--- a/fixtures/streaming/tsconfig.worker.json
+++ b/fixtures/streaming/tsconfig.worker.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "es2021",
+		"lib": ["es2021"],
+		"module": "es2022",
+		"types": ["@cloudflare/workers-types/experimental"],
+		"noEmit": true,
+		"isolatedModules": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true
+	},
+	"include": ["main-worker/src/**/*.ts"]
+}

--- a/fixtures/streaming/vitest.config.mts
+++ b/fixtures/streaming/vitest.config.mts
@@ -1,0 +1,12 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import configShared from "../../vitest.shared";
+
+export default mergeConfig(
+	configShared,
+	defineProject({
+		test: {
+			include: ["main-worker/**/*.test.ts"],
+			retry: 0,
+		},
+	})
+);

--- a/packages/miniflare/src/index.ts
+++ b/packages/miniflare/src/index.ts
@@ -2393,11 +2393,13 @@ export class Miniflare {
 		// This can cause problems for client implementations which rely
 		// on the Content-Encoding header rather than trying to infer it from the body.
 		// Technically, at this point, this a malformed response so let's remove the header
-		// Retain it as MF-Content-Encoding so we can tell the body was actually compressed.
+		// Retain it as MF-Content-Encoding so we can tell the body was previously compressed.
 		const contentEncoding = response.headers.get("Content-Encoding");
 		if (contentEncoding)
 			response.headers.set("MF-Content-Encoding", contentEncoding);
 		response.headers.delete("Content-Encoding");
+		response.headers.delete("Content-Length");
+		response.headers.delete("Transfer-Encoding");
 
 		if (
 			process.env.MINIFLARE_ASSERT_BODIES_CONSUMED === "true" &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -997,6 +997,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wrangler
 
+  fixtures/streaming:
+    devDependencies:
+      '@cloudflare/workers-tsconfig':
+        specifier: workspace:^
+        version: link:../../packages/workers-tsconfig
+      undici:
+        specifier: catalog:default
+        version: 5.28.5
+      vitest:
+        specifier: catalog:default
+        version: 3.2.3(@types/node@20.17.32)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.4.3(typescript@5.7.3))(supports-color@9.2.2)
+      wrangler:
+        specifier: workspace:*
+        version: link:../../packages/wrangler
+
   fixtures/unstable_dev:
     devDependencies:
       wrangler:
@@ -1058,7 +1073,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ~3.0.7
-        version: 3.0.9(@types/node@20.17.32)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2)
+        version: 3.0.9(@types/node@20.17.32)(@vitest/ui@3.2.3(vitest@3.2.3))(jiti@2.4.2)(lightningcss@1.29.2)
       wrangler:
         specifier: workspace:*
         version: link:../../packages/wrangler
@@ -16753,7 +16768,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/utils': 6.10.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -16773,7 +16788,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.10.0(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/utils': 6.10.0(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -16809,7 +16824,7 @@ snapshots:
       '@typescript-eslint/types': 6.10.0
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.7.3
@@ -16822,7 +16837,7 @@ snapshots:
       '@typescript-eslint/types': 6.10.0
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 6.10.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.8.2
@@ -16835,7 +16850,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.3
@@ -17061,7 +17076,7 @@ snapshots:
 
   '@verdaccio/loaders@8.0.0-next-8.4':
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -17122,7 +17137,7 @@ snapshots:
 
   '@verdaccio/signature@8.0.0-next-8.1':
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       jsonwebtoken: 9.0.2
     transitivePeerDependencies:
       - supports-color
@@ -17753,7 +17768,7 @@ snapshots:
       common-path-prefix: 3.0.0
       concordance: 5.0.4
       currently-unhandled: 0.4.1
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       emittery: 1.0.1
       figures: 6.0.1
       globby: 14.0.1
@@ -18814,7 +18829,7 @@ snapshots:
 
   esbuild-register@3.5.0(esbuild@0.25.4):
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       esbuild: 0.25.4
     transitivePeerDependencies:
       - supports-color
@@ -19151,7 +19166,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -23299,7 +23314,7 @@ snapshots:
       '@volar/typescript': 2.3.4
       '@vue/language-core': 2.0.29(typescript@5.8.2)
       compare-versions: 6.1.1
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 0.5.0
       magic-string: 0.30.17
@@ -23314,7 +23329,7 @@ snapshots:
 
   vite-tsconfig-paths@4.2.0(typescript@5.7.3)(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2)):
     dependencies:
-      debug: 4.3.7(supports-color@9.2.2)
+      debug: 4.3.7(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.1.1(typescript@5.7.3)
     optionalDependencies:
@@ -23386,7 +23401,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.0.9(@types/node@20.17.32)(@vitest/ui@3.2.3)(jiti@2.4.2)(lightningcss@1.29.2):
+  vitest@3.0.9(@types/node@20.17.32)(@vitest/ui@3.2.3(vitest@3.2.3))(jiti@2.4.2)(lightningcss@1.29.2):
     dependencies:
       '@vitest/expect': 3.0.9
       '@vitest/mocker': 3.0.9(vite@5.4.14(@types/node@20.17.32)(lightningcss@1.29.2))


### PR DESCRIPTION
Fixes #8004
Fixes #6577 

When serving responses that have not defined `content-encoding` explicitly, Miniflare was attempting to infer a compression algorithm from the `accept-encoding` request header.
This resulted in streamed responses being compressed with an algorithm (usually gzip) that does not support streaming; so the entire response was buffered in memory and not streamed to the client.

Now Miniflare will only try to infer the `content-encoding` response from the `accept-encoding` request header if the `inferContentEncoding` option is set to `true` - the default is `false`.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [x] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
