### PR TITLE
Support version upload for Python Workers

### DIFF
--- a/packages/wrangler/src/__tests__/helpers/assert-request.ts
+++ b/packages/wrangler/src/__tests__/helpers/assert-request.ts
@@ -1,0 +1,38 @@
+import type { mockConsoleMethods } from "./mock-console";
+
+/**
+ * Assert that Wrangler has made a request matching a certain pattern. Unlike MSW (which mocks the return value of the request),
+ * this helper asserts that a request has been made. It should be used in combination with MSW—MSW providing the mock API, and this helper being used
+ * to make sure the right data is sent to the mock API.
+ */
+export function makeRequestAsserter(
+	console: ReturnType<typeof mockConsoleMethods>
+) {
+	beforeEach(() => {
+		vi.stubEnv("WRANGLER_LOG", "debug");
+		vi.stubEnv("WRANGLER_LOG_SANITIZE", "false");
+	});
+	return function assertRequest(
+		url: RegExp,
+		{ method, body }: { method?: string; body?: RegExp }
+	) {
+		const startLine = console.debug.match(
+			new RegExp(`-- START CF API REQUEST: ${method} ` + url.source)
+		);
+		assert(startLine !== null, "Request not made by Wrangler");
+		const requestDetails = console.debug
+			.slice(startLine.index)
+			.match(
+				/HEADERS: (?<headers>(.|\n)*?)\nINIT: (?<init>(.|\n)*?)\n(BODY: (?<bodyMatch>(.|\n)*?)\n)?-- END CF API REQUEST/
+			);
+		const {
+			headers: _headers,
+			init: _init,
+			bodyMatch,
+		} = requestDetails?.groups ?? {};
+
+		if (body) {
+			expect(bodyMatch).toMatch(body);
+		}
+	};
+}

--- a/packages/wrangler/src/__tests__/helpers/write-worker-source.ts
+++ b/packages/wrangler/src/__tests__/helpers/write-worker-source.ts
@@ -7,8 +7,8 @@ export function writeWorkerSource({
 	type = "esm",
 }: {
 	basePath?: string;
-	format?: "js" | "ts" | "jsx" | "tsx" | "mjs";
-	type?: "esm" | "sw";
+	format?: "js" | "ts" | "jsx" | "tsx" | "mjs" | "py";
+	type?: "esm" | "sw" | "python";
 } = {}) {
 	if (basePath !== ".") {
 		fs.mkdirSync(basePath, { recursive: true });
@@ -22,10 +22,15 @@ export function writeWorkerSource({
           return new Response('Hello' + foo);
         },
       };`
-			: `import { foo } from "./another";
+			: type === "sw"
+				? `import { foo } from "./another";
       addEventListener('fetch', event => {
         event.respondWith(new Response('Hello' + foo));
       })`
+				: `from js import Response
+def on_fetch(request):
+  return Response.new("Hello World")
+`
 	);
 	fs.writeFileSync(`${basePath}/another.${format}`, `export const foo = 100;`);
 }

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { generatePreviewAlias } from "../../versions/upload";
+import { makeRequestAsserter } from "../helpers/assert-request";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
 import { useMockIsTTY } from "../helpers/mock-istty";
@@ -21,6 +22,7 @@ describe("versions upload", () => {
 	mockApiToken();
 	const { setIsTTY } = useMockIsTTY();
 	const std = mockConsoleMethods();
+	const assertRequest = makeRequestAsserter(std);
 
 	function mockGetScript() {
 		msw.use(
@@ -209,6 +211,45 @@ describe("versions upload", () => {
 		`);
 
 		expect(std.info).toContain("Retrying API call after error...");
+	});
+
+	test("correctly detects python workers", async () => {
+		mockGetScript();
+		mockUploadVersion(true);
+		mockGetWorkerSubdomain({ enabled: true, previews_enabled: true });
+		mockSubDomainRequest();
+
+		// Setup
+		writeWranglerConfig({
+			name: "test-name",
+			main: "./index.py",
+			compatibility_flags: ["python_workers"],
+		});
+		writeWorkerSource({ type: "python", format: "py" });
+		setIsTTY(false);
+
+		await runWrangler("versions upload");
+
+		assertRequest(/.*?workers\/scripts\/test-name\/versions/, {
+			method: "POST",
+			// Make sure the main module (index.py) has a text/x-python content type
+			body: /Content-Disposition: form-data; name="index.py"; filename="index.py"\nContent-Type: text\/x-python/,
+		});
+
+		expect(std.out).toMatchInlineSnapshot(`
+			"┌─┬─┬─┐
+			│ Name │ Type │ Size │
+			├─┼─┼─┤
+			│ another.py │ python │ xx KiB │
+			├─┼─┼─┤
+			│ Total (1 module) │ │ xx KiB │
+			└─┴─┴─┘
+			Total Upload: xx KiB / gzip: xx KiB
+			Worker Startup Time: 500 ms
+			Uploaded test-name (TIMINGS)
+			Worker Version ID: 51e4886e-2db7-4900-8d38-fbfecfeab993
+			Version Preview URL: https://51e4886e-test-name.test-sub-domain.workers.dev"
+		`);
 	});
 
 	describe("multi-env warning", () => {

--- a/packages/wrangler/src/api/startDevWorker/BundlerController.ts
+++ b/packages/wrangler/src/api/startDevWorker/BundlerController.ts
@@ -2,13 +2,13 @@ import assert from "assert";
 import { readFileSync, realpathSync, writeFileSync } from "fs";
 import path from "path";
 import { watch } from "chokidar";
-import { noBundleWorker } from "../../deploy/deploy";
 import { bundleWorker, shouldCheckFetch } from "../../deployment-bundle/bundle";
 import { getBundleType } from "../../deployment-bundle/bundle-type";
 import {
 	createModuleCollector,
 	getWrangler1xLegacyModuleReferences,
 } from "../../deployment-bundle/module-collection";
+import { noBundleWorker } from "../../deployment-bundle/no-bundle-worker";
 import { runCustomBuild } from "../../deployment-bundle/run-custom-build";
 import { getAssetChangeMessage } from "../../dev";
 import { runBuild } from "../../dev/use-esbuild";

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -12,17 +12,13 @@ import { configFileName, formatConfigSnippet } from "../config";
 import { getBindings, provisionBindings } from "../deployment-bundle/bindings";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
-import { getBundleType } from "../deployment-bundle/bundle-type";
 import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
 import { logBuildOutput } from "../deployment-bundle/esbuild-plugins/log-build-output";
-import {
-	findAdditionalModules,
-	writeAdditionalModules,
-} from "../deployment-bundle/find-additional-modules";
 import {
 	createModuleCollector,
 	getWrangler1xLegacyModuleReferences,
 } from "../deployment-bundle/module-collection";
+import { noBundleWorker } from "../deployment-bundle/no-bundle-worker";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
 import { loadSourceMaps } from "../deployment-bundle/source-maps";
 import { confirm } from "../dialogs";
@@ -1345,23 +1341,4 @@ export async function updateQueueConsumers(
 	}
 
 	return updateConsumers;
-}
-
-export async function noBundleWorker(
-	entry: Entry,
-	rules: Rule[],
-	outDir: string | undefined
-) {
-	const modules = await findAdditionalModules(entry, rules);
-	if (outDir) {
-		await writeAdditionalModules(modules, outDir);
-	}
-
-	const bundleType = getBundleType(entry.format, entry.file);
-	return {
-		modules,
-		dependencies: {} as { [path: string]: { bytesInOutput: number } },
-		resolvedEntryPointPath: entry.file,
-		bundleType,
-	};
 }

--- a/packages/wrangler/src/deployment-bundle/no-bundle-worker.ts
+++ b/packages/wrangler/src/deployment-bundle/no-bundle-worker.ts
@@ -1,0 +1,26 @@
+import { getBundleType } from "./bundle-type";
+import {
+	findAdditionalModules,
+	writeAdditionalModules,
+} from "./find-additional-modules";
+import type { Rule } from "../config/environment";
+import type { Entry } from "./entry";
+
+export async function noBundleWorker(
+	entry: Entry,
+	rules: Rule[],
+	outDir: string | undefined
+) {
+	const modules = await findAdditionalModules(entry, rules);
+	if (outDir) {
+		await writeAdditionalModules(modules, outDir);
+	}
+
+	const bundleType = getBundleType(entry.format, entry.file);
+	return {
+		modules,
+		dependencies: {} as { [path: string]: { bytesInOutput: number } },
+		resolvedEntryPointPath: entry.file,
+		bundleType,
+	};
+}

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -14,18 +14,14 @@ import { createCommand } from "../core/create-command";
 import { getBindings, provisionBindings } from "../deployment-bundle/bindings";
 import { bundleWorker } from "../deployment-bundle/bundle";
 import { printBundleSize } from "../deployment-bundle/bundle-reporter";
-import { getBundleType } from "../deployment-bundle/bundle-type";
 import { createWorkerUploadForm } from "../deployment-bundle/create-worker-upload-form";
 import { getEntry } from "../deployment-bundle/entry";
 import { logBuildOutput } from "../deployment-bundle/esbuild-plugins/log-build-output";
 import {
-	findAdditionalModules,
-	writeAdditionalModules,
-} from "../deployment-bundle/find-additional-modules";
-import {
 	createModuleCollector,
 	getWrangler1xLegacyModuleReferences,
 } from "../deployment-bundle/module-collection";
+import { noBundleWorker } from "../deployment-bundle/no-bundle-worker";
 import { validateNodeCompatMode } from "../deployment-bundle/node-compat";
 import { loadSourceMaps } from "../deployment-bundle/source-maps";
 import { confirm } from "../dialogs";
@@ -898,24 +894,6 @@ Changes to triggers (routes, custom domains, cron schedules, etc) must be applie
 
 function formatTime(duration: number) {
 	return `(${(duration / 1000).toFixed(2)} sec)`;
-}
-
-async function noBundleWorker(
-	entry: Entry,
-	rules: Rule[],
-	outDir: string | undefined
-) {
-	const modules = await findAdditionalModules(entry, rules);
-	if (outDir) {
-		await writeAdditionalModules(modules, outDir);
-	}
-
-	return {
-		modules,
-		dependencies: {} as { [path: string]: { bytesInOutput: number } },
-		resolvedEntryPointPath: entry.file,
-		bundleType: getBundleType(entry.format),
-	};
 }
 
 /**


### PR DESCRIPTION
Previously, Python Workers couldn't be used with `version upload` because there was a difference in module type detection between `deploy` and `version upload`. This PR fixes that bug and unifies the two code paths.

After banging my head against the wall trying to figure out how to nicely test this, this PR _also_ introduces a test helper for making assertions against the content of HTTP requests that Wrangler makes. This will work in tandem with MSW (which provides the mock APIs). The issue with our current setup (MSW interceptors making assertions on the content of requests) is that 1) MSW strongly [recommends against this style](https://mswjs.io/docs/best-practices/avoid-request-assertions/), and 2) probably because MSW recommends against it, it works pretty badly (in particular, stack traces and mismatches in assertions show up strangely)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [x] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
