### PR TITLE
Update CONTRIBUTING for hotfixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -442,11 +442,12 @@ If a hotfix release of Wrangler, Miniflare, or C3 is required, you should:
 
   - Checkout the previous release of `workers-sdk`
   - Apply the changes that should be in the hotfix
-  - Increment the patch version of the packages that should be released as part of the hotfix
+  - Manually, increment the patch version of the packages that should be released as part of the hotfix
+  - Manually, update the changelog for the package(s) being released.
 
 - Get approvals for that PR, and make sure CI checks are passing
 - Manually trigger a hotfix release from that PR using the ["Release a hotfix"](https://github.com/cloudflare/workers-sdk/actions/workflows/hotfix-release.yml) GitHub action.
   - Make sure you set the dist-tag to `latest`
   - Optionally, you can first publish it to the `hotfix` dist-tag on NPM in order to verify the release.
 - **[CRUCIAL]** Once the hotfix release is out and verified, merge the fixes into main before the next regular release of `workers-sdk`.
-- Make sure that the version number of the next changesets-based release of Wrangler/Miniflare/C3 is greater than the version used for the hotfix by adding a dummy `minor` changeset entry for each of the packages that had a hotfix published.
+  - Make sure that the version number of the released package(s) on `main` are the same as the versions that were released to ensure that any subsequent changesets will bump the version correctly for the next release.


### PR DESCRIPTION
It is not necessary to create a changeset for the hotfix, this would only trigger another release of the package during the next normal release process. If such a release is necessary it would be triggered by the existence of a changeset for the feature/fix that needs releasing.

What is important is that the version in package.json is equal to the latest released version of the package. If it is behind then any changesets for that package that should trigger a release may only bump the version to the hotfix release version and so would not actually trigger a release of that package.

