### PR TITLE
V3 backport [#9628]: Remove "Cloudchamber" from user facing error messages

### DIFF
--- a/.changeset/thick-ways-visit.md
+++ b/.changeset/thick-ways-visit.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Remove "Cloudchamber" from user facing error messages

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -260,7 +260,7 @@ async function fillOpenAPIConfiguration(config: Config, json: boolean) {
 			message = JSON.stringify(err);
 		}
 
-		crash("loading account failed: " + message);
+		crash("Loading account failed: " + message);
 	}
 }
 

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -260,7 +260,7 @@ async function fillOpenAPIConfiguration(config: Config, json: boolean) {
 			message = JSON.stringify(err);
 		}
 
-		crash("loading Cloudchamber account failed:" + message);
+		crash("loading account failed: " + message);
 	}
 }
 


### PR DESCRIPTION
This PR backports the changes introduced by #9628 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
