### PR TITLE
CC-5418: Set instance_type in wrangler

### DIFF
--- a/.changeset/sad-drinks-relate.md
+++ b/.changeset/sad-drinks-relate.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": minor
+"wrangler": patch
 ---
 
 Add support for setting an instance type for containers in wrangler. This allows users to configure memory, disk, and vCPU by setting instance type when interacting with containers.

--- a/.changeset/sad-drinks-relate.md
+++ b/.changeset/sad-drinks-relate.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Add support for setting an instance type for containers in wrangler. This allows users to configure memory, disk, and vCPU by setting instance type when interacting with containers.

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -112,16 +112,17 @@ describe("cloudchamber create", () => {
 			  -v, --version  Show version number  [boolean]
 
 			OPTIONS
-			      --json          Return output as clean JSON  [boolean] [default: false]
-			      --image         Image to use for your deployment  [string]
-			      --location      Location on Cloudflare's network where your deployment will run  [string]
-			      --var           Container environment variables  [array]
-			      --label         Deployment labels  [array]
-			      --all-ssh-keys  To add all SSH keys configured on your account to be added to this deployment, set this option to true  [boolean]
-			      --ssh-key-id    ID of the SSH key to add to the deployment  [array]
-			      --vcpu          Number of vCPUs to allocate to this deployment.  [number]
-			      --memory        Amount of memory (GiB, MiB...) to allocate to this deployment. Ex: 4GiB.  [string]
-			      --ipv4          Include an IPv4 in the deployment  [boolean]"
+			      --json           Return output as clean JSON  [boolean] [default: false]
+			      --image          Image to use for your deployment  [string]
+			      --location       Location on Cloudflare's network where your deployment will run  [string]
+			      --var            Container environment variables  [array]
+			      --label          Deployment labels  [array]
+			      --all-ssh-keys   To add all SSH keys configured on your account to be added to this deployment, set this option to true  [boolean]
+			      --ssh-key-id     ID of the SSH key to add to the deployment  [array]
+			      --instance-type  Instance type to allocate to this deployment. One of 'dev', 'basic', or 'standard'.  [string]
+			      --vcpu           Number of vCPUs to allocate to this deployment.  [number]
+			      --memory         Amount of memory (GiB, MiB...) to allocate to this deployment. Ex: 4GiB.  [string]
+			      --ipv4           Include an IPv4 in the deployment  [boolean]"
 		`);
 	});
 
@@ -170,12 +171,83 @@ describe("cloudchamber create", () => {
 		);
 	});
 
+	it("should fail with a nice message when instance type is invalid", async () => {
+		setIsTTY(false);
+		fs.writeFileSync(
+			"./wrangler.toml",
+			TOML.stringify({
+				name: "my-container",
+				cloudchamber: {
+					image: "hello:world",
+					location: "sfo06",
+					instance_type: "invalid",
+				},
+			}),
+
+			"utf-8"
+		);
+		await expect(
+			runWrangler("cloudchamber create ")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			` [Error: Processing wrangler.toml configuration:
+  - "cloudchamber" bindings should, optionally, have "instance_type" as 'dev', 'basic', or 'standard', but got invalid]`
+		);
+	});
+
+	it("should fail with a nice message when instance type is set with vcpu", async () => {
+		setIsTTY(false);
+		fs.writeFileSync(
+			"./wrangler.toml",
+			TOML.stringify({
+				name: "my-container",
+				cloudchamber: {
+					image: "hello:world",
+					location: "sfo06",
+					vcpu: 2,
+					instance_type: "dev",
+				},
+			}),
+
+			"utf-8"
+		);
+		await expect(
+			runWrangler("cloudchamber create ")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			` [Error: Processing wrangler.toml configuration:
+  - "cloudchamber" bindings should not set either "memory" or "vcpu" with "instance_type"]`
+		);
+	});
+
 	it("should fail with a nice message when parameters are missing (json)", async () => {
 		setIsTTY(false);
 		setWranglerConfig({});
 		await runWrangler("cloudchamber create --image hello:world --json");
 		expect(std.out).toMatchInlineSnapshot(
 			`"{\\"error\\":\\"location is required but it's not passed as an argument\\"}"`
+		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should fail with a nice message when instance type is invalid (json)", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		await runWrangler(
+			"cloudchamber create --image hello:world --location sfo06 --instance-type invalid --json"
+		);
+		expect(std.out).toMatchInlineSnapshot(
+			`"{\\"error\\":\\"instance_type is expected to be one of 'dev', 'basic', or 'standard', but got invalid\\"}"`
+		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("should fail with a nice message when instance type is set with memory (json)", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		await runWrangler(
+			"cloudchamber create --image hello:world --location sfo06 --instance-type dev --memory 400GB --json"
+		);
+		expect(std.out).toMatchInlineSnapshot(
+			`"{\\"error\\":\\"instance_type is mutually exclusive with 'memory' and 'vcpu'. They cannot be set together.\\"}"`
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
@@ -194,8 +266,31 @@ describe("cloudchamber create", () => {
 		expect(std.out).toMatchInlineSnapshot(MOCK_DEPLOYMENTS_COMPLEX_RESPONSE);
 	});
 
+	it("should create deployment with instance type (detects no interactivity)", async () => {
+		setIsTTY(false);
+		setWranglerConfig({});
+		mockGetKey();
+		msw.use(
+			http.post(
+				"*/deployments/v2",
+				async ({ request }) => {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					const r = (await request.json()) as Record<string, any>;
+					expect(r.instance_type).toEqual("dev");
+					return HttpResponse.json({});
+				},
+				{ once: true }
+			)
+		);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+		await runWrangler(
+			"cloudchamber create --image hello:world --location sfo06 --var HELLO:WORLD --var YOU:CONQUERED --instance-type dev --ipv4 true"
+		);
+		expect(std.out).toMatchInlineSnapshot(`"{}"`);
+	});
+
 	it("properly reads wrangler config", async () => {
-		// This is very similar to the previous test except config
+		// This is very similar to the previous tests except config
 		// is set in wrangler and not overridden by the CLI
 		setIsTTY(false);
 		setWranglerConfig({
@@ -213,6 +308,38 @@ describe("cloudchamber create", () => {
 			"cloudchamber create --var HELLO:WORLD --var YOU:CONQUERED"
 		);
 		expect(std.out).toMatchInlineSnapshot(MOCK_DEPLOYMENTS_COMPLEX_RESPONSE);
+		expect(std.err).toMatchInlineSnapshot(`""`);
+	});
+
+	it("properly reads wrangler config for instance type", async () => {
+		// This is very similar to the previous tests except config
+		// is set in wrangler and not overridden by the CLI
+		setIsTTY(false);
+		setWranglerConfig({
+			image: "hello:world",
+			ipv4: true,
+			instance_type: "dev",
+			location: "sfo06",
+		});
+		// if values are not read by wrangler, this mock won't work
+		// since the wrangler command wont get the right parameters
+		mockGetKey();
+		msw.use(
+			http.post(
+				"*/deployments/v2",
+				async ({ request }) => {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					const r = (await request.json()) as Record<string, any>;
+					expect(r.instance_type).toEqual("dev");
+					return HttpResponse.json({});
+				},
+				{ once: true }
+			)
+		);
+		await runWrangler(
+			"cloudchamber create --var HELLO:WORLD --var YOU:CONQUERED"
+		);
+		expect(std.out).toMatchInlineSnapshot(`"{}"`);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});
 

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -119,7 +119,7 @@ describe("cloudchamber create", () => {
 			      --label          Deployment labels  [array]
 			      --all-ssh-keys   To add all SSH keys configured on your account to be added to this deployment, set this option to true  [boolean]
 			      --ssh-key-id     ID of the SSH key to add to the deployment  [array]
-			      --instance-type  Instance type to allocate to this deployment. One of 'dev', 'basic', or 'standard'.  [choices: \\"dev\\", \\"basic\\", \\"standard\\"]
+			      --instance-type  Instance type to allocate to this deployment  [choices: \\"dev\\", \\"basic\\", \\"standard\\"]
 			      --vcpu           Number of vCPUs to allocate to this deployment.  [number]
 			      --memory         Amount of memory (GiB, MiB...) to allocate to this deployment. Ex: 4GiB.  [string]
 			      --ipv4           Include an IPv4 in the deployment  [boolean]"

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -247,7 +247,7 @@ describe("cloudchamber create", () => {
 			"cloudchamber create --image hello:world --location sfo06 --instance-type dev --memory 400GB --json"
 		);
 		expect(std.out).toMatchInlineSnapshot(
-			`"{\\"error\\":\\"instance_type is mutually exclusive with 'memory' and 'vcpu'. They cannot be set together.\\"}"`
+			`"{\\"error\\":\\"Field /\\"instance_type/\\" is mutually exclusive with /\\"memory/\\" and /\\"vcpu/\\". These fields cannot be set together.\\"}"`
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -119,7 +119,7 @@ describe("cloudchamber create", () => {
 			      --label          Deployment labels  [array]
 			      --all-ssh-keys   To add all SSH keys configured on your account to be added to this deployment, set this option to true  [boolean]
 			      --ssh-key-id     ID of the SSH key to add to the deployment  [array]
-			      --instance-type  Instance type to allocate to this deployment. One of 'dev', 'basic', or 'standard'.  [string]
+			      --instance-type  Instance type to allocate to this deployment. One of 'dev', 'basic', or 'standard'.  [choices: \\"dev\\", \\"basic\\", \\"standard\\"]
 			      --vcpu           Number of vCPUs to allocate to this deployment.  [number]
 			      --memory         Amount of memory (GiB, MiB...) to allocate to this deployment. Ex: 4GiB.  [string]
 			      --ipv4           Include an IPv4 in the deployment  [boolean]"
@@ -190,7 +190,7 @@ describe("cloudchamber create", () => {
 			runWrangler("cloudchamber create ")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			` [Error: Processing wrangler.toml configuration:
-  - "cloudchamber" bindings should, optionally, have "instance_type" as 'dev', 'basic', or 'standard', but got invalid]`
+  - "instance_type" should be one of 'dev', 'basic', or 'standard', but got invalid]`
 		);
 	});
 
@@ -214,7 +214,7 @@ describe("cloudchamber create", () => {
 			runWrangler("cloudchamber create ")
 		).rejects.toThrowErrorMatchingInlineSnapshot(
 			` [Error: Processing wrangler.toml configuration:
-  - "cloudchamber" bindings should not set either "memory" or "vcpu" with "instance_type"]`
+  - "cloudchamber" configuration should not set either "memory" or "vcpu" with "instance_type"]`
 		);
 	});
 
@@ -224,18 +224,6 @@ describe("cloudchamber create", () => {
 		await runWrangler("cloudchamber create --image hello:world --json");
 		expect(std.out).toMatchInlineSnapshot(
 			`"{\\"error\\":\\"location is required but it's not passed as an argument\\"}"`
-		);
-		expect(std.err).toMatchInlineSnapshot(`""`);
-	});
-
-	it("should fail with a nice message when instance type is invalid (json)", async () => {
-		setIsTTY(false);
-		setWranglerConfig({});
-		await runWrangler(
-			"cloudchamber create --image hello:world --location sfo06 --instance-type invalid --json"
-		);
-		expect(std.out).toMatchInlineSnapshot(
-			`"{\\"error\\":\\"/\\"instance_type/\\" field value is expected to be one of /\\"dev/\\", /\\"basic/\\", or /\\"standard/\\", but got /\\"invalid/\\"\\"}"`
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});

--- a/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/create.test.ts
@@ -235,7 +235,7 @@ describe("cloudchamber create", () => {
 			"cloudchamber create --image hello:world --location sfo06 --instance-type invalid --json"
 		);
 		expect(std.out).toMatchInlineSnapshot(
-			`"{\\"error\\":\\"instance_type is expected to be one of 'dev', 'basic', or 'standard', but got invalid\\"}"`
+			`"{\\"error\\":\\"/\\"instance_type/\\" field value is expected to be one of /\\"dev/\\", /\\"basic/\\", or /\\"standard/\\", but got /\\"invalid/\\"\\"}"`
 		);
 		expect(std.err).toMatchInlineSnapshot(`""`);
 	});

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -86,7 +86,7 @@ describe("cloudchamber modify", () => {
 			      --ssh-public-key-id  Public SSH key IDs to include in this container. You can add one to your account with \`wrangler cloudchamber ssh create  [array]
 			      --image              The new image that the deployment will have from now on  [string]
 			      --location           The new location that the deployment will have from now on  [string]
-			      --instance-type      The new instance type that the deployment will have from now on  [string]
+			      --instance-type      The new instance type that the deployment will have from now on  [choices: \\"dev\\", \\"basic\\", \\"standard\\"]
 			      --vcpu               The new vcpu that the deployment will have from now on  [number]
 			      --memory             The new memory that the deployment will have from now on  [string]"
 		`);

--- a/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/modify.test.ts
@@ -86,6 +86,7 @@ describe("cloudchamber modify", () => {
 			      --ssh-public-key-id  Public SSH key IDs to include in this container. You can add one to your account with \`wrangler cloudchamber ssh create  [array]
 			      --image              The new image that the deployment will have from now on  [string]
 			      --location           The new location that the deployment will have from now on  [string]
+			      --instance-type      The new instance type that the deployment will have from now on  [string]
 			      --vcpu               The new vcpu that the deployment will have from now on  [number]
 			      --memory             The new memory that the deployment will have from now on  [string]"
 		`);

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -15,7 +15,6 @@ import {
 	ApplicationsService,
 	CreateApplicationRolloutRequest,
 	DeploymentMutationError,
-	InstanceType,
 	RolloutsService,
 	SchedulingPolicy,
 } from "@cloudflare/containers-shared";
@@ -34,6 +33,7 @@ import type {
 	ApplicationID,
 	ApplicationName,
 	CreateApplicationRequest,
+	InstanceType,
 	ModifyApplicationRequestBody,
 	ModifyDeploymentV2RequestBody,
 	Observability as ObservabilityConfiguration,

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -15,6 +15,7 @@ import {
 	ApplicationsService,
 	CreateApplicationRolloutRequest,
 	DeploymentMutationError,
+	InstanceType,
 	RolloutsService,
 	SchedulingPolicy,
 } from "@cloudflare/containers-shared";
@@ -186,6 +187,9 @@ function containerAppToCreateApplication(
 		...(containerApp.configuration as UserDeploymentConfiguration),
 		observability: observabilityConfiguration,
 	};
+	if (containerApp.instance_type !== undefined) {
+		configuration.instance_type = containerApp.instance_type as InstanceType;
+	}
 
 	const app: CreateApplicationRequest = {
 		...containerApp,
@@ -213,6 +217,7 @@ function containerAppToCreateApplication(
 	delete (app as Record<string, unknown>)["image_vars"];
 	delete (app as Record<string, unknown>)["rollout_step_percentage"];
 	delete (app as Record<string, unknown>)["rollout_kind"];
+	delete (app as Record<string, unknown>)["instance_type"];
 
 	return app;
 }
@@ -739,7 +744,6 @@ export async function apply(
 							action.application.max_instances !== undefined
 								? undefined
 								: action.application.instances,
-						configuration: undefined,
 					})
 				);
 			} catch (err) {

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -20,7 +20,7 @@ import {
 } from "@cloudflare/containers-shared";
 import { formatConfigSnippet } from "../config";
 import { UserError } from "../errors";
-import { promiseSpinner } from "./common";
+import { cleanForInstanceType, promiseSpinner } from "./common";
 import { diffLines } from "./helpers/diff";
 import type { Config } from "../config";
 import type { ContainerApp, Observability } from "../config/environment";
@@ -406,6 +406,7 @@ export async function apply(
 			image: "docker.io/cloudflare/hello-world:1.0",
 			instances: 2,
 			name: config.name ?? "my-containers-application",
+			instance_type: "dev",
 		};
 		const endConfig: JsonMap =
 			args.env !== undefined
@@ -490,20 +491,22 @@ export async function apply(
 				);
 			}
 
+			const prevContainer =
+				appConfig.configuration.instance_type !== undefined
+					? cleanForInstanceType(prevApp)
+					: (prevApp as ContainerApp);
+			const nowContainer = mergeDeep(
+				prevContainer as CreateApplicationRequest,
+				sortObjectRecursive<CreateApplicationRequest>(appConfig)
+			) as ContainerApp;
+
 			const prev = formatConfigSnippet(
-				{ containers: [prevApp as ContainerApp] },
+				{ containers: [prevContainer] },
 				config.configPath
 			);
 
 			const now = formatConfigSnippet(
-				{
-					containers: [
-						mergeDeep(
-							prevApp,
-							sortObjectRecursive<CreateApplicationRequest>(appConfig)
-						) as ContainerApp,
-					],
-				},
+				{ containers: [nowContainer] },
 				config.configPath
 			);
 			const results = diffLines(prev, now);

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -5,6 +5,7 @@ import { inputPrompt, spinner } from "@cloudflare/cli/interactive";
 import {
 	ApiError,
 	DeploymentMutationError,
+	InstanceType,
 	OpenAPI,
 } from "@cloudflare/containers-shared";
 import { version as wranglerVersion } from "../../package.json";
@@ -41,9 +42,11 @@ import type {
 import type { Arg } from "@cloudflare/cli/interactive";
 import type {
 	CompleteAccountCustomer,
+	CreateApplicationRequest,
 	EnvironmentVariable,
 	Label,
 	NetworkParameters,
+	UserDeploymentConfiguration,
 } from "@cloudflare/containers-shared";
 
 export type CommonCloudchamberConfiguration = { json: boolean };
@@ -313,6 +316,7 @@ export function renderDeploymentConfiguration(
 	{
 		image,
 		location,
+		instanceType,
 		vcpu,
 		memoryMib,
 		environmentVariables,
@@ -322,6 +326,7 @@ export function renderDeploymentConfiguration(
 	}: {
 		image: string;
 		location: string;
+		instanceType?: InstanceType;
 		vcpu: number;
 		memoryMib: number;
 		environmentVariables: EnvironmentVariable[] | undefined;
@@ -359,13 +364,17 @@ export function renderDeploymentConfiguration(
 	const containerInformation = [
 		["image", image],
 		["location", idToLocationName(location)],
-		["vCPU", `${vcpu}`],
-		["memory", `${memoryMib} MiB`],
 		["environment variables", environmentVariablesText],
 		["labels", labelsText],
 		...(network === undefined
 			? []
 			: [["IPv4", network.assign_ipv4 === "predefined" ? "yes" : "no"]]),
+		...(instanceType === undefined
+			? [
+					["vCPU", `${vcpu}`],
+					["memory", `${memoryMib} MiB`],
+				]
+			: [["instance type", `${instanceType}`]]),
 	] as const;
 
 	updateStatus(
@@ -645,6 +654,38 @@ export async function promptForLabels(
 	return [];
 }
 
+export async function promptForInstanceType(
+	allowSkipping: boolean
+): Promise<InstanceType | undefined> {
+	let options = [
+		{ label: "dev: 1/16 vCPU, 256 MiB memory, 2 GB disk", value: "dev" },
+		{ label: "basic: 1/4 vCPU, 1 GiB memory, 4 GB disk", value: "basic" },
+		{ label: "standard: 1/2 vCPU, 4 GiB memory, 4 GB disk", value: "standard" },
+	];
+	if (allowSkipping) {
+		options = [{ label: "Do not set", value: "skip" }].concat(options);
+	}
+	const action = await inputPrompt({
+		question: "Which instance type should we use for your container?",
+		label: "",
+		defaultValue: false,
+		helpText: "",
+		type: "select",
+		options,
+	});
+
+	switch (action) {
+		case "dev":
+			return InstanceType.DEV;
+		case "basic":
+			return InstanceType.BASIC;
+		case "standard":
+			return InstanceType.STANDARD;
+		default:
+			return undefined;
+	}
+}
+
 // Return the amount of memory to use (in MiB) for a deployment given the
 // provided arguments and configuration.
 export function resolveMemory(
@@ -674,4 +715,96 @@ export function resolveAppDiskSize(
 	}
 	const disk = app.configuration.disk?.size ?? "2GB";
 	return Math.round(parseByteSize(disk));
+}
+
+// Checks that instance type is one of 'dev', 'basic', or 'standard' and that it is not being set alongside memory or vcpu.
+// Returns the instance type to use if correctly set.
+export function checkInstanceType(
+	args: {
+		instanceType: string | undefined;
+		memory: string | undefined;
+		vcpu: number | undefined;
+	},
+	config: CloudchamberConfig
+): InstanceType | undefined {
+	const instance_type = args.instanceType ?? config.instance_type;
+	if (instance_type === undefined) {
+		return undefined;
+	}
+
+	// If instance_type is specified as an argument, it will override any
+	// memory or vcpu specified in the config
+	if (args.memory !== undefined || args.vcpu !== undefined) {
+		throw new UserError(
+			`instance_type is mutually exclusive with 'memory' and 'vcpu'. They cannot be set together.`
+		);
+	}
+
+	switch (instance_type) {
+		case "dev":
+			return InstanceType.DEV;
+		case "basic":
+			return InstanceType.BASIC;
+		case "standard":
+			return InstanceType.STANDARD;
+		default:
+			throw new UserError(
+				`instance_type is expected to be one of 'dev', 'basic', or 'standard', but got ${instance_type}`
+			);
+	}
+}
+
+// infers the instance type from a given configuration
+function inferInstanceType(
+	configuration: UserDeploymentConfiguration
+): InstanceType | undefined {
+	if (
+		configuration?.disk?.size_mb !== undefined &&
+		configuration?.memory_mib !== undefined &&
+		configuration?.vcpu !== undefined
+	) {
+		if (
+			configuration.disk.size_mb === 2000 &&
+			configuration.memory_mib === 256 &&
+			configuration.vcpu === 0.0625
+		) {
+			return InstanceType.DEV;
+		} else if (
+			configuration.disk.size_mb === 4000 &&
+			configuration.memory_mib === 1024 &&
+			configuration.vcpu === 0.25
+		) {
+			return InstanceType.BASIC;
+		} else if (
+			configuration.disk.size_mb === 4000 &&
+			configuration.memory_mib === 4096 &&
+			configuration.vcpu === 0.5
+		) {
+			return InstanceType.STANDARD;
+		}
+	}
+
+	return undefined;
+}
+
+// removes any disk, memory, or vcpu that have been set in an objects configuration. Used for rendering
+// diffs.
+export function cleanForInstanceType(
+	app: CreateApplicationRequest
+): ContainerApp {
+	if (!("configuration" in app)) {
+		return app as ContainerApp;
+	}
+
+	const instance_type = inferInstanceType(app.configuration);
+	if (instance_type !== undefined) {
+		app.configuration.instance_type = instance_type;
+	}
+
+	delete app.configuration.disk;
+	delete app.configuration.memory;
+	delete app.configuration.memory_mib;
+	delete app.configuration.vcpu;
+
+	return app as ContainerApp;
 }

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -749,7 +749,7 @@ export function checkInstanceType(
 			return InstanceType.STANDARD;
 		default:
 			throw new UserError(
-				`instance_type is expected to be one of 'dev', 'basic', or 'standard', but got ${instance_type}`
+				`"instance_type" field value is expected to be one of "dev", "basic", or "standard", but got "${instance_type}"`
 			);
 	}
 }

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -736,7 +736,7 @@ export function checkInstanceType(
 	// memory or vcpu specified in the config
 	if (args.memory !== undefined || args.vcpu !== undefined) {
 		throw new UserError(
-			`instance_type is mutually exclusive with 'memory' and 'vcpu'. They cannot be set together.`
+			`Field "instance_type" is mutually exclusive with "memory" and "vcpu". These fields cannot be set together.`
 		);
 	}
 

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -729,7 +729,7 @@ export function checkInstanceType(
 ): InstanceType | undefined {
 	const instance_type = args.instanceType ?? config.instance_type;
 	if (instance_type === undefined) {
-		return undefined;
+		return;
 	}
 
 	// If instance_type is specified as an argument, it will override any

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -783,7 +783,6 @@ function inferInstanceType(
 			return InstanceType.STANDARD;
 		}
 	}
-
 }
 
 // removes any disk, memory, or vcpu that have been set in an objects configuration. Used for rendering

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -784,7 +784,6 @@ function inferInstanceType(
 		}
 	}
 
-	return undefined;
 }
 
 // removes any disk, memory, or vcpu that have been set in an objects configuration. Used for rendering

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -47,6 +47,7 @@ import type {
 	Label,
 	SSHPublicKeyID,
 } from "@cloudflare/containers-shared";
+import { logger } from "../logger";
 
 const defaultContainerImage = "docker.io/cloudflare/hello-world:1.0";
 

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -13,6 +13,7 @@ import {
 	AssignIPv6,
 	DeploymentsService,
 } from "@cloudflare/containers-shared";
+import { logger } from "../logger";
 import { parseByteSize } from "./../parse";
 import { pollSSHKeysUntilCondition, waitForPlacement } from "./cli";
 import { getLocation } from "./cli/locations";
@@ -47,7 +48,6 @@ import type {
 	Label,
 	SSHPublicKeyID,
 } from "@cloudflare/containers-shared";
-import { logger } from "../logger";
 
 const defaultContainerImage = "docker.io/cloudflare/hello-world:1.0";
 
@@ -99,8 +99,7 @@ export function createCommandOptionalYargs(yargs: CommonYargsArgvJSON) {
 			requiresArg: true,
 			choices: ["dev", "basic", "standard"] as const,
 			demandOption: false,
-			describe:
-				"Instance type to allocate to this deployment. One of 'dev', 'basic', or 'standard'.",
+			describe: "Instance type to allocate to this deployment",
 		})
 		.option("vcpu", {
 			requiresArg: true,

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -324,7 +324,7 @@ async function handleCreateCommand(
 
 	renderDeploymentConfiguration("create", {
 		image,
-		location: location,
+		location,
 		network: network,
 		instanceType: instanceType,
 		vcpu: vcpu,

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -326,7 +326,7 @@ async function handleCreateCommand(
 		image,
 		location,
 		network,
-		instanceType: instanceType,
+		instanceType,
 		vcpu: vcpu,
 		memoryMib: memoryMib,
 		environmentVariables: selectedEnvironmentVariables,

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -351,7 +351,7 @@ async function handleCreateCommand(
 		location,
 		ssh_public_key_ids: keys,
 		environment_variables: environmentVariables,
-		labels: labels,
+		labels,
 		instance_type: instanceType,
 		vcpu: undefined,
 		memory_mib: undefined,

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -323,7 +323,7 @@ async function handleCreateCommand(
 	const instanceType = await promptForInstanceType(true);
 
 	renderDeploymentConfiguration("create", {
-		image: image,
+		image,
 		location: location,
 		network: network,
 		instanceType: instanceType,

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -328,7 +328,7 @@ async function handleCreateCommand(
 		network,
 		instanceType,
 		vcpu,
-		memoryMib: memoryMib,
+		memoryMib,
 		environmentVariables: selectedEnvironmentVariables,
 		labels: selectedLabels,
 		env: args.env,

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -96,7 +96,7 @@ export function createCommandOptionalYargs(yargs: CommonYargsArgvJSON) {
 		})
 		.option("instance-type", {
 			requiresArg: true,
-			type: "string",
+			choices: ["dev", "basic", "standard"] as const,
 			demandOption: false,
 			describe:
 				"Instance type to allocate to this deployment. One of 'dev', 'basic', or 'standard'.",

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -325,7 +325,7 @@ async function handleCreateCommand(
 	renderDeploymentConfiguration("create", {
 		image,
 		location,
-		network: network,
+		network,
 		instanceType: instanceType,
 		vcpu: vcpu,
 		memoryMib: memoryMib,

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -355,7 +355,7 @@ async function handleCreateCommand(
 		instance_type: instanceType,
 		vcpu: undefined,
 		memory_mib: undefined,
-		network: network,
+		network,
 	};
 	if (instanceType === undefined) {
 		deploymentRequest.vcpu = vcpu;

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -179,7 +179,7 @@ export async function createCommand(
 		}
 		const deployment =
 			await DeploymentsService.createDeploymentV2(deploymentRequest);
-		console.log(JSON.stringify(deployment, null, 4));
+		logger.log(JSON.stringify(deployment, null, 4));
 		return;
 	}
 

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -347,7 +347,7 @@ async function handleCreateCommand(
 	const { start, stop } = spinner();
 	start("Creating your container", "your container will be created shortly");
 	const deploymentRequest: CreateDeploymentV2RequestBody = {
-		image: image,
+		image,
 		location: location,
 		ssh_public_key_ids: keys,
 		environment_variables: environmentVariables,

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -348,7 +348,7 @@ async function handleCreateCommand(
 	start("Creating your container", "your container will be created shortly");
 	const deploymentRequest: CreateDeploymentV2RequestBody = {
 		image,
-		location: location,
+		location,
 		ssh_public_key_ids: keys,
 		environment_variables: environmentVariables,
 		labels: labels,

--- a/packages/wrangler/src/cloudchamber/create.ts
+++ b/packages/wrangler/src/cloudchamber/create.ts
@@ -327,7 +327,7 @@ async function handleCreateCommand(
 		location,
 		network,
 		instanceType,
-		vcpu: vcpu,
+		vcpu,
 		memoryMib: memoryMib,
 		environmentVariables: selectedEnvironmentVariables,
 		labels: selectedLabels,

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -6,12 +6,14 @@ import { pollSSHKeysUntilCondition, waitForPlacement } from "./cli";
 import { pickDeployment } from "./cli/deployments";
 import { getLocation } from "./cli/locations";
 import {
+	checkInstanceType,
 	collectEnvironmentVariables,
 	collectLabels,
 	interactWithUser,
 	loadAccountSpinner,
 	parseImageName,
 	promptForEnvironmentVariables,
+	promptForInstanceType,
 	promptForLabels,
 	renderDeploymentConfiguration,
 	renderDeploymentMutationError,
@@ -27,6 +29,7 @@ import type {
 } from "../yargs-types";
 import type {
 	DeploymentV2,
+	ModifyDeploymentV2RequestBody,
 	SSHPublicKeyID,
 } from "@cloudflare/containers-shared";
 
@@ -71,6 +74,13 @@ export function modifyCommandOptionalYargs(yargs: CommonYargsArgvJSON) {
 			demandOption: false,
 			describe: "The new location that the deployment will have from now on",
 		})
+		.option("instance-type", {
+			requiresArg: true,
+			type: "string",
+			demandOption: false,
+			describe:
+				"The new instance type that the deployment will have from now on",
+		})
 		.option("vcpu", {
 			requiresArg: true,
 			type: "number",
@@ -108,18 +118,26 @@ export async function modifyCommand(
 		const labels = collectLabels(modifyArgs.label);
 
 		const memoryMib = resolveMemory(modifyArgs, config.cloudchamber);
+		const vcpu = modifyArgs.vcpu ?? config.cloudchamber.vcpu;
+		const instanceType = checkInstanceType(modifyArgs, config.cloudchamber);
 
+		const modifyRequest: ModifyDeploymentV2RequestBody = {
+			image: modifyArgs.image ?? config.cloudchamber.image,
+			location: modifyArgs.location ?? config.cloudchamber.location,
+			environment_variables: environmentVariables,
+			labels: labels,
+			ssh_public_key_ids: modifyArgs.sshPublicKeyId,
+			instance_type: instanceType,
+			vcpu: undefined,
+			memory_mib: undefined,
+		};
+		if (instanceType === undefined) {
+			modifyRequest.vcpu = vcpu;
+			modifyRequest.memory_mib = memoryMib;
+		}
 		const deployment = await DeploymentsService.modifyDeploymentV2(
 			modifyArgs.deploymentId,
-			{
-				image: modifyArgs.image ?? config.cloudchamber.image,
-				location: modifyArgs.location ?? config.cloudchamber.location,
-				environment_variables: environmentVariables,
-				labels: labels,
-				ssh_public_key_ids: modifyArgs.sshPublicKeyId,
-				vcpu: modifyArgs.vcpu ?? config.cloudchamber.vcpu,
-				memory_mib: memoryMib,
-			}
+			modifyRequest
 		);
 		console.log(JSON.stringify(deployment, null, 4));
 		return;
@@ -236,10 +254,12 @@ async function handleModifyCommand(
 	);
 
 	const memoryMib = resolveMemory(args, config.cloudchamber);
+	const instanceType = await promptForInstanceType(true);
 
 	renderDeploymentConfiguration("modify", {
 		image,
 		location: location ?? deployment.location.name,
+		instanceType: instanceType,
 		vcpu: args.vcpu ?? config.cloudchamber.vcpu ?? deployment.vcpu,
 		memoryMib: memoryMib ?? deployment.memory_mib,
 		env: args.env,
@@ -265,16 +285,20 @@ async function handleModifyCommand(
 		"Modifying your container",
 		"shortly your container will be modified to a new version"
 	);
+	const modifyRequest: ModifyDeploymentV2RequestBody = {
+		image: image,
+		location: location,
+		ssh_public_key_ids: keys,
+		environment_variables: selectedEnvironmentVariables,
+		labels: selectedLabels,
+		instance_type: instanceType,
+	};
+	if (instanceType === undefined) {
+		modifyRequest.vcpu = args.vcpu ?? config.cloudchamber.vcpu;
+		modifyRequest.memory_mib = memoryMib;
+	}
 	const [newDeployment, err] = await wrap(
-		DeploymentsService.modifyDeploymentV2(deployment.id, {
-			image,
-			location,
-			ssh_public_key_ids: keys,
-			environment_variables: selectedEnvironmentVariables,
-			labels: selectedLabels,
-			vcpu: args.vcpu ?? config.cloudchamber.vcpu,
-			memory_mib: memoryMib,
-		})
+		DeploymentsService.modifyDeploymentV2(deployment.id, modifyRequest)
 	);
 	stop();
 	if (err) {

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -287,7 +287,7 @@ async function handleModifyCommand(
 	);
 	const modifyRequest: ModifyDeploymentV2RequestBody = {
 		image,
-		location: location,
+		location,
 		ssh_public_key_ids: keys,
 		environment_variables: selectedEnvironmentVariables,
 		labels: selectedLabels,

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -76,7 +76,7 @@ export function modifyCommandOptionalYargs(yargs: CommonYargsArgvJSON) {
 		})
 		.option("instance-type", {
 			requiresArg: true,
-			choices: ["dev", "basic", "standard"] as const
+			choices: ["dev", "basic", "standard"] as const,
 			demandOption: false,
 			describe:
 				"The new instance type that the deployment will have from now on",

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -286,7 +286,7 @@ async function handleModifyCommand(
 		"shortly your container will be modified to a new version"
 	);
 	const modifyRequest: ModifyDeploymentV2RequestBody = {
-		image: image,
+		image,
 		location: location,
 		ssh_public_key_ids: keys,
 		environment_variables: selectedEnvironmentVariables,

--- a/packages/wrangler/src/cloudchamber/modify.ts
+++ b/packages/wrangler/src/cloudchamber/modify.ts
@@ -76,7 +76,7 @@ export function modifyCommandOptionalYargs(yargs: CommonYargsArgvJSON) {
 		})
 		.option("instance-type", {
 			requiresArg: true,
-			type: "string",
+			choices: ["dev", "basic", "standard"] as const
 			demandOption: false,
 			describe:
 				"The new instance type that the deployment will have from now on",

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -76,10 +76,12 @@ export type ContainerApp = {
 	/** The scheduling policy of the application, default is regional */
 	scheduling_policy?: "regional" | "moon" | "default";
 
+	/** The instance type to be used for the container */
+	instance_type?: "dev" | "basic" | "standard";
+
 	/* Configuration of the container */
 	configuration: {
 		image: string;
-		instance_type?: "dev" | "basic" | "standard";
 		labels?: { name: string; value: string }[];
 		secrets?: { name: string; type: "env"; secret: string }[];
 		disk?: { size: string };

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -76,7 +76,7 @@ export type ContainerApp = {
 	/** The scheduling policy of the application, default is regional */
 	scheduling_policy?: "regional" | "moon" | "default";
 
-	/** The instance type to be used for the container */
+	/** The instance type to be used for the container. This sets preconfigured options for vcpu and memory */
 	instance_type?: "dev" | "basic" | "standard";
 
 	/* Configuration of the container */

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -34,6 +34,7 @@ export type Route =
 export type CloudchamberConfig = {
 	image?: string;
 	location?: string;
+	instance_type?: "dev" | "basic" | "standard";
 	vcpu?: number;
 	memory?: string;
 	ipv4?: boolean;
@@ -78,6 +79,7 @@ export type ContainerApp = {
 	/* Configuration of the container */
 	configuration: {
 		image: string;
+		instance_type?: "dev" | "basic" | "standard";
 		labels?: { name: string; value: string }[];
 		secrets?: { name: string; type: "env"; secret: string }[];
 		disk?: { size: string };

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2393,7 +2393,9 @@ const validateContainerAppConfig: ValidatorFn = (
 		const containerAppOptional =
 			containerApp as Partial<CreateApplicationRequest> & {
 				image?: string | undefined;
+				instance_type?: "dev" | "basic" | "standard";
 			};
+
 		if (!isRequiredProperty(containerAppOptional, "name", "string")) {
 			diagnostics.errors.push(
 				`"containers.name" should be defined and a string`
@@ -2468,19 +2470,17 @@ const validateContainerAppConfig: ValidatorFn = (
 		}
 
 		if (
-			"configuration" in containerAppOptional &&
-			containerAppOptional.configuration !== undefined &&
-			"instance_type" in containerAppOptional.configuration &&
-			containerAppOptional.configuration?.instance_type !== undefined
+			"instance_type" in containerAppOptional &&
+			containerAppOptional.instance_type !== undefined
 		) {
 			if (
-				typeof containerAppOptional.configuration.instance_type !== "string" ||
+				typeof containerAppOptional.instance_type !== "string" ||
 				!["dev", "basic", "standard"].includes(
-					containerAppOptional.configuration.instance_type
+					containerAppOptional.instance_type
 				)
 			) {
 				diagnostics.errors.push(
-					`"containers.configuration.instance_type" should be either 'dev', 'basic', or 'standard', but got ${containerAppOptional.configuration.instance_type}`
+					`"containers.instance_type" should be either 'dev', 'basic', or 'standard', but got ${containerAppOptional.instance_type}`
 				);
 			}
 		}

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2469,15 +2469,7 @@ const validateContainerAppConfig: ValidatorFn = (
 			);
 		}
 
-		if (
-			"instance_type" in containerAppOptional &&
-			containerAppOptional.instance_type !== undefined
-		) {
-			if (
-				typeof containerAppOptional.instance_type !== "string" ||
-				!["dev", "basic", "standard"].includes(
-					containerAppOptional.instance_type
-				)
+validateOptionalProperty(diagnostics, field, "instance_type",  containerAppOptional.instance_type, "string", ["dev", "basic", "standard"])
 			) {
 				diagnostics.errors.push(
 					`"containers.instance_type" should be either 'dev', 'basic', or 'standard', but got ${containerAppOptional.instance_type}`

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2519,7 +2519,7 @@ const validateCloudchamberConfig: ValidatorFn = (diagnostics, field, value) => {
 			!["dev", "basic", "standard"].includes(value.instance_type)
 		) {
 			diagnostics.errors.push(
-				`"${field}" bindings should, optionally, have "instance_type" as 'dev', 'basic', or 'standard', but got ${value.instance_type}`
+				`"instance_type" should be one of 'dev', 'basic', or 'standard', but got ${value.instance_type}`
 			);
 		}
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2366,11 +2366,7 @@ const validateBindingArray =
 		return isValid;
 	};
 
-const validateContainerAppConfig: ValidatorFn = (
-	diagnostics,
-	_field,
-	value
-) => {
+const validateContainerAppConfig: ValidatorFn = (diagnostics, field, value) => {
 	if (!value) {
 		return true;
 	}
@@ -2469,12 +2465,15 @@ const validateContainerAppConfig: ValidatorFn = (
 			);
 		}
 
-validateOptionalProperty(diagnostics, field, "instance_type",  containerAppOptional.instance_type, "string", ["dev", "basic", "standard"])
-			) {
-				diagnostics.errors.push(
-					`"containers.instance_type" should be either 'dev', 'basic', or 'standard', but got ${containerAppOptional.instance_type}`
-				);
-			}
+		if ("instance_type" in containerAppOptional) {
+			validateOptionalProperty(
+				diagnostics,
+				field,
+				"instance_type",
+				containerAppOptional.instance_type,
+				"string",
+				["dev", "basic", "standard"]
+			);
 		}
 	}
 

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2533,7 +2533,7 @@ const validateCloudchamberConfig: ValidatorFn = (diagnostics, field, value) => {
 
 		if (
 			("memory" in value && value.memory !== undefined) ||
-			("vcpu" in value && value.vcpu !== "undefined")
+			("vcpu" in value && value.vcpu !== undefined)
 		) {
 			diagnostics.errors.push(
 				`"${field}" bindings should not set either "memory" or "vcpu" with "instance_type"`

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2528,7 +2528,7 @@ const validateCloudchamberConfig: ValidatorFn = (diagnostics, field, value) => {
 			("vcpu" in value && value.vcpu !== undefined)
 		) {
 			diagnostics.errors.push(
-				`"${field}" bindings should not set either "memory" or "vcpu" with "instance_type"`
+				`"${field}" configuration should not set either "memory" or "vcpu" with "instance_type"`
 			);
 		}
 	}

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -2466,6 +2466,24 @@ const validateContainerAppConfig: ValidatorFn = (
 				`"containers.image" should be defined and a string`
 			);
 		}
+
+		if (
+			"configuration" in containerAppOptional &&
+			containerAppOptional.configuration !== undefined &&
+			"instance_type" in containerAppOptional.configuration &&
+			containerAppOptional.configuration?.instance_type !== undefined
+		) {
+			if (
+				typeof containerAppOptional.configuration.instance_type !== "string" ||
+				!["dev", "basic", "standard"].includes(
+					containerAppOptional.configuration.instance_type
+				)
+			) {
+				diagnostics.errors.push(
+					`"containers.configuration.instance_type" should be either 'dev', 'basic', or 'standard', but got ${containerAppOptional.configuration.instance_type}`
+				);
+			}
+		}
 	}
 
 	if (diagnostics.errors.length > 0) {
@@ -2502,6 +2520,26 @@ const validateCloudchamberConfig: ValidatorFn = (diagnostics, field, value) => {
 			}
 		});
 	});
+
+	if ("instance_type" in value && value.instance_type !== undefined) {
+		if (
+			typeof value.instance_type !== "string" ||
+			!["dev", "basic", "standard"].includes(value.instance_type)
+		) {
+			diagnostics.errors.push(
+				`"${field}" bindings should, optionally, have "instance_type" as 'dev', 'basic', or 'standard', but got ${value.instance_type}`
+			);
+		}
+
+		if (
+			("memory" in value && value.memory !== undefined) ||
+			("vcpu" in value && value.vcpu !== "undefined")
+		) {
+			diagnostics.errors.push(
+				`"${field}" bindings should not set either "memory" or "vcpu" with "instance_type"`
+			);
+		}
+	}
 
 	return isValid;
 };


### PR DESCRIPTION
The cloudchamber API already supports setting an instance type. This change will allow users to specify an instance type in wrangler. The specified instance type will be used configure vCPU, memory, and disk.

Implements CC-5418.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: The docs are private
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: We don't need to backport Cloudchamber changes to v3, since it's still private beta

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
