### PR TITLE
Block requests vulnerable to opennext vulnerability

### DIFF
--- a/.changeset/eleven-fans-smoke.md
+++ b/.changeset/eleven-fans-smoke.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/workers-shared": patch
+---
+
+Block possibly vulnerable requests to the router worker

--- a/packages/workers-shared/router-worker/src/analytics.ts
+++ b/packages/workers-shared/router-worker/src/analytics.ts
@@ -33,6 +33,8 @@ type Data = {
 	userWorkerAhead?: boolean;
 	// double6 - Routing performed based on the _routes.json (if provided)
 	staticRoutingDecision?: STATIC_ROUTING_DECISION;
+	// double7 - Whether the request was blocked by abuse mitigation or not
+	abuseMitigationBlocked?: boolean;
 
 	// -- Blobs --
 	// blob1 - Hostname of the request
@@ -45,6 +47,8 @@ type Data = {
 	version?: string;
 	// blob5 - Region of the colo (e.g. WEUR)
 	coloRegion?: string;
+	// blob6 - URL for analysis
+	abuseMitigationURLHost?: string;
 };
 
 export class Analytics {
@@ -88,6 +92,7 @@ export class Analytics {
 					? -1
 					: Number(this.data.userWorkerAhead),
 				this.data.staticRoutingDecision ?? STATIC_ROUTING_DECISION.NOT_PROVIDED, // double6
+				this.data.abuseMitigationBlocked ? 1 : 0, // double7
 			],
 			blobs: [
 				this.data.hostname?.substring(0, 256), // blob1 - trim to 256 bytes
@@ -95,6 +100,7 @@ export class Analytics {
 				this.data.error?.substring(0, 256), // blob3 - trim to 256 bytes
 				this.data.version, // blob4
 				this.data.coloRegion, // blob5
+				this.data.abuseMitigationURLHost, // blob6
 			],
 		});
 	}


### PR DESCRIPTION
Addresses https://github.com/opennextjs/opennextjs-cloudflare/security/advisories/GHSA-rvpw-p7vw-wj3m

This has already been applied in production, this commit keeps the repository in sync.

Images loaded via the /_next/image?url=<some remote image> were vulnerable to SSRF, and particularly if the user loaded the image in a new tab (instead of forcing the browser to treat it as an image). Thus, if request didn't indicate that the browser was going to treat the resource as an image (via the 'Sec-Fetch-Dest: image' header), we block the request when it doesn't return image content.

Fixes WC-3704.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: limited to router worker
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not public behavior
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> not a wrangler change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
