### PR TITLE
Adds implicit rule for vendor/** in Python Workers.

### DIFF
--- a/.changeset/hip-experts-smile.md
+++ b/.changeset/hip-experts-smile.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Python Workers now automatically bundle .so files from vendored packages

--- a/packages/wrangler/src/__tests__/config/configuration.test.ts
+++ b/packages/wrangler/src/__tests__/config/configuration.test.ts
@@ -29,6 +29,12 @@ describe("readConfig()", () => {
 			    ],
 			    "type": "PythonModule",
 			  },
+			  Object {
+			    "globs": Array [
+			      "vendor/**/*.so",
+			    ],
+			    "type": "Data",
+			  },
 			]
 		`);
 	});

--- a/packages/wrangler/src/config/validation.ts
+++ b/packages/wrangler/src/config/validation.ts
@@ -339,6 +339,16 @@ function applyPythonConfig(
 		if (!config.rules.some((rule) => rule.type === "PythonModule")) {
 			config.rules.push({ type: "PythonModule", globs: ["**/*.py"] });
 		}
+		// When vendoring packages they may include certain files that will not be automatically uploaded,
+		// this would require specifying rules in the wrangler configuration of each worker. Instead of
+		// requiring that, we include the config implicitly here.
+		if (
+			!config.rules.some(
+				(rule) => rule.type === "Data" && rule.globs.includes("vendor/**/*.so")
+			)
+		) {
+			config.rules.push({ type: "Data", globs: ["vendor/**/*.so"] });
+		}
 		if (!config.compatibility_flags.includes("python_workers")) {
 			throw new UserError(
 				"The `python_workers` compatibility flag is required to use Python."


### PR DESCRIPTION
Python Workers can now have vendored packages in a `vendor` dir. These packages can contain files which won't ordinarily be uploaded automatically, this PR fixes that.

CC @hoodmane @danlapid 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: small change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: vendor feature not documented yet
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new Python feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
