### PR TITLE
Condenses Python vendored modules in output table.

### DIFF
--- a/.changeset/angry-poems-tease.md
+++ b/.changeset/angry-poems-tease.md
@@ -1,0 +1,5 @@
+---
+"wrangler": minor
+---
+
+Condenses Python vendored modules in output table


### PR DESCRIPTION
When many vendored package files are included, wrangler prints a huge table with all of them. This PR condenses these files into a single entry named "Vendored Modules".

CC @hoodmane @danlapid 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ux change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: ux change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
