### PR TITLE
chore: test hello world binding support in vitest-pool-workers

### DIFF
--- a/packages/vitest-pool-workers/test/bindings.test.ts
+++ b/packages/vitest-pool-workers/test/bindings.test.ts
@@ -1,0 +1,60 @@
+import dedent from "ts-dedent";
+import { test } from "./helpers";
+
+test("hello_world support", async ({ expect, seed, vitestRun }) => {
+	await seed({
+		"vitest.config.mts": dedent`
+			import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+			export default defineWorkersConfig({
+				test: {
+					poolOptions: {
+						workers: {
+							singleWorker: true,
+							wrangler: { configPath: "./wrangler.jsonc" },
+						},
+					},
+				}
+			});
+		`,
+		"wrangler.jsonc": dedent`
+			{
+				"compatibility_date": "2025-01-01",
+				"unsafe_hello_world": [
+					{
+						"binding": "HELLO_WORLD",
+					}
+				]
+			}
+		`,
+		"index.ts": dedent`
+			export default {
+				async fetch(request, env, ctx) {
+					const value = Math.floor(Date.now() * Math.random()).toString(36);
+					await env.HELLO_WORLD.set(value);
+
+					const result = await env.HELLO_WORLD.get();
+					if (value !== result.value) {
+						return new Response("Value mismatch", { status: 500 });
+					}
+
+					return new Response('ok');
+				}
+			}
+		`,
+		"index.test.ts": dedent`
+			import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+			import { it, expect } from "vitest";
+			import worker from "./index";
+			it("works", async () => {
+				const request = new Request("http://example.com");
+				const ctx = createExecutionContext();
+				const response = await worker.fetch(request, env, ctx);
+				await waitOnExecutionContext(ctx);
+				expect(await response.text()).toBe("ok");
+			});
+		`,
+	});
+
+	const result = await vitestRun();
+	await expect(result.exitCode).resolves.toBe(0);
+});


### PR DESCRIPTION
Fixes [DEVX-1775](https://jira.cfdata.org/browse/DEVX-1775)

This adds an example smoke test to verify if the local binding works in vitest-pool-workers

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: only added non e2e test in this PR
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no feature changes
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: only added test

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
