### PR TITLE
Remove confirmation dialog for cloudchamber apply when not interactive

### DIFF
--- a/.changeset/cuddly-sites-doubt.md
+++ b/.changeset/cuddly-sites-doubt.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Remove cloudchamber/container apply confirmation dialog when run non-interactively.

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -135,9 +135,6 @@ describe("cloudchamber apply", () => {
 			│   [containers.constraints]
 			│   tier = 2
 			│
-			├ Do you want to apply these changes?
-			│ yes
-			│
 			│
 			│  SUCCESS  Created application my-container-app (Application ID: abc)
 			│
@@ -196,9 +193,6 @@ describe("cloudchamber apply", () => {
 			│   [containers.constraints]
 			│ - tier = 3
 			│ + tier = 2
-			│
-			├ Do you want to apply these changes?
-			│ yes
 			│
 			├ Loading
 			│
@@ -287,9 +281,6 @@ describe("cloudchamber apply", () => {
 			│   [containers.constraints]
 			│   tier = 1
 			│
-			├ Do you want to apply these changes?
-			│ yes
-			│
 			├ Loading
 			│
 			│
@@ -374,9 +365,6 @@ describe("cloudchamber apply", () => {
 			│   [containers.constraints]
 			│   tier = 1
 			│
-			├ Do you want to apply these changes?
-			│ yes
-			│
 			│
 			│  SUCCESS  Created application my-container-app-2 (Application ID: abc)
 			│
@@ -454,9 +442,6 @@ describe("cloudchamber apply", () => {
 			│
 			│   [containers.constraints]
 			│   tier = 1
-			│
-			├ Do you want to apply these changes?
-			│ yes
 			│
 			├ Loading
 			│
@@ -584,9 +569,6 @@ describe("cloudchamber apply", () => {
 			│
 			│ - [[containers.configuration.secrets]]
 			│   name = \\"MY_SECRET_2\\"
-			│
-			├ Do you want to apply these changes?
-			│ yes
 			│
 			├ Loading
 			│

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -572,19 +572,20 @@ export async function apply(
 		endSection("No changes to be made");
 		return;
 	}
-
-	const yes = await processArgument<boolean>(
-		{ confirm: args.json ? true : undefined },
-		"confirm",
-		{
-			type: "confirm",
-			question: "Do you want to apply these changes?",
-			label: "",
+	if (!args.json) {
+		const yes = await processArgument<boolean>(
+			{ confirm: undefined },
+			"confirm",
+			{
+				type: "confirm",
+				question: "Do you want to apply these changes?",
+				label: "",
+			}
+		);
+		if (!yes) {
+			cancel("Not applying changes");
+			return;
 		}
-	);
-	if (!yes) {
-		cancel("Not applying changes");
-		return;
 	}
 
 	function formatError(err: ApiError): string {


### PR DESCRIPTION
Prior to this the dialog was getting printed but auto-confirmed to yes which is confusing to users.



<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: ux change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ux change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> ux change for newer versions only

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
