### PR TITLE
Verify docker installation earlier when deploying container

### DIFF
--- a/.changeset/social-dryers-feel.md
+++ b/.changeset/social-dryers-feel.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Fail earlier in the deploy process when deploying a container worker if docker is not detected.

--- a/packages/containers-shared/src/utils.ts
+++ b/packages/containers-shared/src/utils.ts
@@ -50,15 +50,18 @@ export const runDockerCmdWithOutput = async (
 };
 
 /** throws when docker is not installed */
-export const verifyDockerInstalled = async (dockerPath: string) => {
+export const verifyDockerInstalled = async (
+	dockerPath: string,
+	isDev = true
+) => {
 	try {
 		await runDockerCmd(dockerPath, ["info"], ["inherit", "pipe", "pipe"]);
 	} catch {
 		// We assume this command is unlikely to fail for reasons other than the Docker daemon not running, or the Docker CLI not being installed or in the PATH.
 		throw new Error(
-			`The Docker CLI could not be launched. Please ensure that Docker is installed and running. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN.\n` +
-				`Other container tooling that is compatible with the Docker CLI may work, but is not yet guaranteed to do so.\n` +
-				`To suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false.`
+			`The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.\n` +
+				`Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with WRANGLER_DOCKER_HOST.` +
+				`${isDev ? "\nTo suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false." : ""}`
 		);
 	}
 };

--- a/packages/wrangler/e2e/containers.dev.test.ts
+++ b/packages/wrangler/e2e/containers.dev.test.ts
@@ -149,7 +149,10 @@ describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 			const worker = helper.runLongLived("wrangler dev");
 			expect(await worker.exitCode).toBe(1);
 			expect(await worker.output).toContain(
-				`The Docker CLI could not be launched. Please ensure that Docker is installed and running. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN.`
+				`The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.`
+			);
+			expect(await worker.output).toContain(
+				`To suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false.`
 			);
 		});
 	}

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8667,7 +8667,7 @@ addEventListener('fetch', event => {});`
 				expect(std.warn).toMatchInlineSnapshot(`""`);
 			});
 
-			it("should fail early if no docker is detected when using a container worker", async () => {
+			it("should fail early if no docker is detected when deploying a container from a dockerfile", async () => {
 				vi.stubEnv(
 					"WRANGLER_CONTAINERS_DOCKER_PATH",
 					"/usr/bin/bad-docker-path"
@@ -8697,6 +8697,7 @@ addEventListener('fetch', event => {});`
 					"index.js",
 					`export class ExampleDurableObject {}; export default{};`
 				);
+				fs.writeFileSync("./Dockerfile", "blah");
 
 				writeWranglerConfig({
 					durable_objects: {
@@ -8712,7 +8713,7 @@ addEventListener('fetch', event => {});`
 							name: "my-container",
 							instances: 10,
 							class_name: "ExampleDurableObject",
-							configuration: { image: "./Dockerfile" },
+							image: "./Dockerfile",
 						},
 					],
 					migrations: [
@@ -8739,9 +8740,8 @@ addEventListener('fetch', event => {});`
 
 				await expect(runWrangler("deploy index.js")).rejects
 					.toThrowErrorMatchingInlineSnapshot(`
-					[Error: The Docker CLI does not appear to installed. Please ensure that the Docker CLI is installed. You can specify an executable with the environment variable WRANGLER_CONTAINERS_DOCKER_PATH.
-					Other container tooling that is compatible with the Docker CLI may work, but is not yet guaranteed to do so.
-					To suppress this error if you do not intend on triggering any container instances, set dev.enable_containers to false in your Wrangler config or passing in --enable-containers=false.]
+					[Error: The Docker CLI could not be launched. Please ensure that the Docker CLI is installed and the daemon is running.
+					Other container tooling that is compatible with the Docker CLI and engine may work, but is not yet guaranteed to do so. You can specify an executable with the environment variable WRANGLER_DOCKER_BIN and a socket with WRANGLER_DOCKER_HOST.]
 				`);
 			});
 

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -8668,30 +8668,7 @@ addEventListener('fetch', event => {});`
 			});
 
 			it("should fail early if no docker is detected when deploying a container from a dockerfile", async () => {
-				vi.stubEnv(
-					"WRANGLER_CONTAINERS_DOCKER_PATH",
-					"/usr/bin/bad-docker-path"
-				);
-
-				function defaultChildProcess() {
-					return {
-						stderr: Buffer.from([]),
-						stdout: Buffer.from("i promise I am a successful process"),
-						on: function (reason: string, cbPassed: (code: number) => unknown) {
-							if (reason === "close") {
-								cbPassed(0);
-							}
-
-							return this;
-						},
-					} as unknown as ChildProcess;
-				}
-
-				vi.mocked(spawn).mockImplementationOnce((cmd, args) => {
-					expect(cmd).toBe("/usr/bin/docker");
-					expect(args).toEqual(["info"]);
-					return defaultChildProcess();
-				});
+				vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/bad-docker-path");
 
 				fs.writeFileSync(
 					"index.js",
@@ -8745,7 +8722,7 @@ addEventListener('fetch', event => {});`
 				`);
 			});
 
-			it("should support durable object bindings to SQLite classes with containers (docker flow)", async () => {
+			it("should support durable object bindings to SQLite classes with containers (dockerfile flow)", async () => {
 				vi.stubEnv("WRANGLER_DOCKER_BIN", "/usr/bin/docker");
 				function mockGetVersion(versionId: string) {
 					msw.use(
@@ -9141,28 +9118,9 @@ addEventListener('fetch', event => {});`
 				expect(output).toContain("export {\n  ExampleDurableObject,");
 			});
 
-			it("should support durable object bindings to SQLite classes with containers", async () => {
+			it("should support durable object bindings to SQLite classes with containers (image uri flow)", async () => {
 				// note no docker commands have been mocked here!
-				// except docker info so we don't fail early.
-				function defaultChildProcess() {
-					return {
-						stderr: Buffer.from([]),
-						stdout: Buffer.from("i promise I am a successful process"),
-						on: function (reason: string, cbPassed: (code: number) => unknown) {
-							if (reason === "close") {
-								cbPassed(0);
-							}
 
-							return this;
-						},
-					} as unknown as ChildProcess;
-				}
-				vi.stubEnv("WRANGLER_CONTAINERS_DOCKER_PATH", "/usr/bin/docker");
-				vi.mocked(spawn).mockImplementation((cmd, args) => {
-					expect(cmd).toBe("/usr/bin/docker");
-					expect(args).toEqual(["info"]);
-					return defaultChildProcess();
-				});
 				function mockGetVersion(versionId: string) {
 					msw.use(
 						http.get(


### PR DESCRIPTION
When containers are configured we want the container and the worker to be updated together (ideally). Failing earlier when we know docker is not installed keeps us from getting into a disjointed state between the worker and container.



<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: not e2e test
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: improved ux
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> not a v3 feature. 

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
