### PR TITLE
chore: Run C3 e2e tests on every OS only if both `every-os` and `c3-e2e` labels are applied

### DIFF
--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -7,7 +7,7 @@ jobs:
   e2e-vp:
     # Note: please keep this job in sync with the e2e-only-dependabot-bumped-framework one
     #       in .github/workflows/c3-e2e-dependabot.yml
-    if: github.head_ref == 'changeset-release/main' || contains(github.event.*.labels.*.name, 'every-os' )
+    if: github.head_ref == 'changeset-release/main' || (contains(github.event.*.labels.*.name, 'c3-e2e' ) && contains(github.event.*.labels.*.name, 'every-os' ))
     timeout-minutes: 45
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.pm.name }}-${{ matrix.pm.version }}


### PR DESCRIPTION
e2e tests are run on every OS if both the `e2e` and `every-os` labels are set. The same is not true atm for C3 e2e tests. This PR fixes that.

Fixes n/a

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: GH workflow changes
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: GH workflow changes
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: GH workflow changes
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because:  GH workflow changes

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
