### PR TITLE
fix: ensure that wrangler deploy and version upload don't override the remote-bindings flag

### DIFF
--- a/.changeset/better-rings-heal.md
+++ b/.changeset/better-rings-heal.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: ensure that wrangler deploy and version upload don't override the remote-bindings flag

--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -13068,6 +13068,42 @@ export default{
 		});
 	});
 
+	it("should warn about unexpected experimental_remote fields", async () => {
+		writeWorkerSource();
+		writeWranglerConfig({
+			main: "./index.js",
+			kv_namespaces: [
+				{ binding: "MY_KV", id: "kv-id-xxx", experimental_remote: true },
+			],
+		});
+		mockSubDomainRequest();
+		mockUploadWorkerRequest();
+
+		await runWrangler("deploy");
+
+		expect(std.warn).toContain(
+			'Unexpected fields found in kv_namespaces[0] field: "experimental_remote"'
+		);
+	});
+
+	it("should not warn about experimental_remote fields when --x-remote-bindings is provided", async () => {
+		writeWorkerSource();
+		writeWranglerConfig({
+			main: "./index.js",
+			kv_namespaces: [
+				{ binding: "MY_KV", id: "kv-id-xxx", experimental_remote: true },
+			],
+		});
+		mockSubDomainRequest();
+		mockUploadWorkerRequest();
+
+		await runWrangler("deploy --x-remote-bindings");
+
+		expect(std.warn).not.toContain(
+			'Unexpected fields found in kv_namespaces[0] field: "experimental_remote"'
+		);
+	});
+
 	describe("multi-env warning", () => {
 		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
 			writeWorkerSource();

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -211,6 +211,56 @@ describe("versions upload", () => {
 		expect(std.info).toContain("Retrying API call after error...");
 	});
 
+	it("should warn about unexpected experimental_remote fields", async () => {
+		mockGetScript();
+		mockUploadVersion(true);
+		mockGetWorkerSubdomain({ enabled: true, previews_enabled: false });
+
+		// Setup
+		writeWranglerConfig({
+			name: "test-name",
+			main: "./index.js",
+			kv_namespaces: [
+				{ binding: "MY_KV", id: "kv-id-xxx", experimental_remote: true },
+			],
+		});
+		writeWorkerSource();
+		setIsTTY(false);
+
+		const result = runWrangler("versions upload");
+
+		await expect(result).resolves.toBeUndefined();
+
+		expect(std.warn).toContain(
+			'Unexpected fields found in kv_namespaces[0] field: "experimental_remote"'
+		);
+	});
+
+	it("should not warn about experimental_remote fields when --x-remote-bindings is provided", async () => {
+		mockGetScript();
+		mockUploadVersion(true);
+		mockGetWorkerSubdomain({ enabled: true, previews_enabled: false });
+
+		// Setup
+		writeWranglerConfig({
+			name: "test-name",
+			main: "./index.js",
+			kv_namespaces: [
+				{ binding: "MY_KV", id: "kv-id-xxx", experimental_remote: true },
+			],
+		});
+		writeWorkerSource();
+		setIsTTY(false);
+
+		const result = runWrangler("versions upload --x-remote-bindings");
+
+		await expect(result).resolves.toBeUndefined();
+
+		expect(std.warn).not.toContain(
+			'Unexpected fields found in kv_namespaces[0] field: "experimental_remote"'
+		);
+	});
+
 	describe("multi-env warning", () => {
 		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
 			mockGetScript();

--- a/packages/wrangler/src/deploy/index.ts
+++ b/packages/wrangler/src/deploy/index.ts
@@ -220,7 +220,7 @@ export const deployCommand = createCommand({
 		overrideExperimentalFlags: (args) => ({
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
-			REMOTE_BINDINGS: false,
+			REMOTE_BINDINGS: args.experimentalRemoteBindings ?? false,
 		}),
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},

--- a/packages/wrangler/src/versions/upload.ts
+++ b/packages/wrangler/src/versions/upload.ts
@@ -264,7 +264,7 @@ export const versionsUploadCommand = createCommand({
 		overrideExperimentalFlags: (args) => ({
 			MULTIWORKER: false,
 			RESOURCES_PROVISION: args.experimentalProvision ?? false,
-			REMOTE_BINDINGS: false,
+			REMOTE_BINDINGS: args.experimentalRemoteBindings ?? false,
 		}),
 		warnIfMultipleEnvsConfiguredButNoneSpecified: true,
 	},


### PR DESCRIPTION
Currently `wrangler deploy --x-remote-bindings` shows incorrect warnings regarding `experimental_remote` fields:

![Screenshot 2025-06-19 at 10 01 47](https://github.com/user-attachments/assets/b22a33c5-53fa-4049-99e9-3dcc04c338ac)

The changes here are addressing this

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because: I'd love it to land this in the next release I can add the tests as a followup if that's ok
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: I need to discuss this with the team
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: not a wrangler v3 feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
