### PR TITLE
fix changeset issue with containers-shared

### DIFF
--- a/packages/containers-shared/package.json
+++ b/packages/containers-shared/package.json
@@ -17,6 +17,7 @@
 	"scripts": {
 		"check:lint": "eslint src --ext ts",
 		"check:type": "tsc -p ./tsconfig.json && pnpm run type:tests",
+		"deploy": "echo 'no deploy'",
 		"test": "vitest",
 		"test:ci": "pnpm run test run",
 		"test:watch": "pnpm run test --testTimeout=50000 --watch",

--- a/tools/deployments/__tests__/validate-changesets.test.ts
+++ b/tools/deployments/__tests__/validate-changesets.test.ts
@@ -30,6 +30,7 @@ describe("findPackageNames()", () => {
 				"@cloudflare/workers-editor-shared",
 				"@cloudflare/workers-shared",
 				"@cloudflare/workflows-shared",
+				"@cloudflare/containers-shared",
 				"@cloudflare/vite-plugin",
 				"cloudflare-workers-bindings-extension",
 				"create-cloudflare",


### PR DESCRIPTION
allows changesets to mention containers-shared. note tools tests only run on linux.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: tooling change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal tooling
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: package doesn't exist in v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
