### PR TITLE
Remove Cloudchamber/Containers auth customisation

### DIFF
--- a/packages/wrangler/src/cfetch/internal.ts
+++ b/packages/wrangler/src/cfetch/internal.ts
@@ -142,7 +142,7 @@ function cloneHeaders(
 			: { ...headers };
 }
 
-async function requireLoggedIn(
+export async function requireLoggedIn(
 	complianceConfig: ComplianceConfig
 ): Promise<void> {
 	const loggedIn = await loginOrRefreshIfRequired(complianceConfig);
@@ -151,7 +151,7 @@ async function requireLoggedIn(
 	}
 }
 
-function addAuthorizationHeaderIfUnspecified(
+export function addAuthorizationHeaderIfUnspecified(
 	headers: Record<string, string>,
 	auth: ApiCredentials
 ): void {
@@ -165,7 +165,7 @@ function addAuthorizationHeaderIfUnspecified(
 	}
 }
 
-function addUserAgent(headers: Record<string, string>): void {
+export function addUserAgent(headers: Record<string, string>): void {
 	headers["User-Agent"] = `wrangler/${wranglerVersion}`;
 }
 

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -1,5 +1,4 @@
-import { mkdir } from "fs/promises";
-import { logRaw, space, status, updateStatus } from "@cloudflare/cli";
+import { space, updateStatus } from "@cloudflare/cli";
 import { brandColor, dim } from "@cloudflare/cli/colors";
 import { inputPrompt, spinner } from "@cloudflare/cli/interactive";
 import {
@@ -7,31 +6,21 @@ import {
 	DeploymentMutationError,
 	OpenAPI,
 } from "@cloudflare/containers-shared";
-import { version as wranglerVersion } from "../../package.json";
+import {
+	addAuthorizationHeaderIfUnspecified,
+	addUserAgent,
+} from "../cfetch/internal";
 import { readConfig } from "../config";
-import { getConfigCache, purgeConfigCaches } from "../config-cache";
 import { getCloudflareApiBaseUrl } from "../environment-variables/misc-variables";
 import { UserError } from "../errors";
 import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
-import {
-	DefaultScopeKeys,
-	getAccountFromCache,
-	getAccountId,
-	getAPIToken,
-	getAuthFromEnv,
-	getScopes,
-	logout,
-	reinitialiseAuthTokens,
-	requireAuth,
-	setLoginScopeKeys,
-} from "../user";
+import { requireApiToken, requireAuth } from "../user";
 import { parseByteSize } from "./../parse";
 import { wrap } from "./helpers/wrap";
 import { idToLocationName, loadAccount } from "./locations";
 import type { Config } from "../config";
 import type { CloudchamberConfig, ContainerApp } from "../config/environment";
-import type { Scope } from "../user";
 import type {
 	CommonYargsOptions,
 	StrictYargsOptionsToInterfaceJSON,
@@ -142,10 +131,8 @@ export async function loadAccountSpinner({ json }: { json?: boolean }) {
  * Gets the API URL depending if the user is using old/admin based authentication.
  *
  */
-async function getAPIUrl(config: Config) {
+async function getAPIUrl(config: Config, accountId: string) {
 	const api = getCloudflareApiBaseUrl(config);
-	// This one will probably be cache'd already so it won't ask for the accountId again
-	const accountId = config.account_id || (await getAccountId(config));
 	return `${api}/accounts/${accountId}/cloudchamber`;
 }
 
@@ -176,80 +163,15 @@ export async function fillOpenAPIConfiguration(config: Config, json: boolean) {
 	const headers: Record<string, string> =
 		OpenAPI.HEADERS !== undefined ? { ...OpenAPI.HEADERS } : {};
 
-	// if the config cache folder doesn't exist, it means that there is not a node_modules folder in the tree
-	if (Object.keys(getConfigCache("wrangler-account.json")).length === 0) {
-		await wrap(mkdir("node_modules", {}));
-		purgeConfigCaches();
-	}
+	const accountId = await requireAuth(config);
 
-	const scopes = getScopes();
-	const needsCloudchamberToken = !scopes?.find(
-		(scope) => scope === "cloudchamber:write"
-	);
-	const cloudchamberScope: Scope[] = ["cloudchamber:write"];
-	const scopesToSet: Scope[] =
-		scopes == undefined
-			? cloudchamberScope.concat(DefaultScopeKeys)
-			: cloudchamberScope.concat(scopes);
+	const auth = requireApiToken();
+	addAuthorizationHeaderIfUnspecified(headers, auth);
+	addUserAgent(headers);
 
-	if (getAuthFromEnv() && needsCloudchamberToken) {
-		setLoginScopeKeys(scopesToSet);
-		// Wrangler will try to retrieve the oauth token and refresh it
-		// for its internal fetch call even if we have AuthFromEnv.
-		// Let's mock it
-		reinitialiseAuthTokens({
-			expiration_time: "2300-01-01:00:00:00+00:00",
-			oauth_token: "_",
-		});
-	} else {
-		if (needsCloudchamberToken && scopes) {
-			logRaw(
-				status.warning +
-					" We need to re-authenticate to add a cloudchamber token..."
-			);
-			// cache account id
-			await getAccountId(config);
-			const account = getAccountFromCache();
-			config.account_id = account?.id ?? config.account_id;
-			await promiseSpinner(logout(), { json, message: "Revoking token" });
-			purgeConfigCaches();
-			reinitialiseAuthTokens({});
-		}
-
-		setLoginScopeKeys(scopesToSet);
-
-		// Require either login, or environment variables being set to authenticate
-		//
-		// This will prompt the user for an accountId being chosen if they haven't configured the account id yet
-		const [, err] = await wrap(requireAuth(config));
-		if (err) {
-			throw new UserError(
-				`authenticating with the Cloudflare API: ${err.message}`
-			);
-		}
-	}
-
-	// Get the loaded API token
-	const token = getAPIToken();
-	if (!token) {
-		throw new UserError("unexpected apiToken not existing in credentials");
-	}
-
-	const val = "apiToken" in token ? token.apiToken : null;
-	// Don't try to support this method of authentication
-	if (!val) {
-		throw new UserError(
-			"we don't allow for authKey/email credentials, use `wrangler login` or CLOUDFLARE_API_TOKEN env variable to authenticate"
-		);
-	}
-
-	headers["Authorization"] = `Bearer ${val}`;
-	// These are being set by the internal fetch of wrangler, but we are not using it
-	// due to our OpenAPI codegenerated client.
-	headers["User-Agent"] = `wrangler/${wranglerVersion}`;
 	OpenAPI.CREDENTIALS = "omit";
 	if (OpenAPI.BASE.length === 0) {
-		const [base, errApiURL] = await wrap(getAPIUrl(config));
+		const [base, errApiURL] = await wrap(getAPIUrl(config, accountId));
 		if (errApiURL) {
 			throw new UserError("getting the API url: " + errApiURL.message);
 		}

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -361,23 +361,16 @@ const DefaultScopes = {
 		"See and change Cloudflare Pipelines configurations and data",
 	"secrets_store:write":
 		"See and change secrets + stores within the Secrets Store",
-} as const;
-
-const OptionalScopes = {
+	"containers:write": "Manage Workers Containers",
 	"cloudchamber:write": "Manage Cloudchamber",
 } as const;
-
-const AllScopes = {
-	...DefaultScopes,
-	...OptionalScopes,
-};
 
 /**
  * The possible keys for a Scope.
  *
  * "offline_access" is automatically included.
  */
-export type Scope = keyof typeof AllScopes;
+export type Scope = keyof typeof DefaultScopes;
 
 export let DefaultScopeKeys = Object.keys(DefaultScopes) as Scope[];
 
@@ -1215,7 +1208,7 @@ export function listScopes(message = "💁 Available scopes:"): void {
 	logger.log(message);
 	const data = DefaultScopeKeys.map((scope: Scope) => ({
 		Scope: scope,
-		Description: AllScopes[scope],
+		Description: DefaultScopes[scope],
 	}));
 	logger.table(data);
 	// TODO: maybe a good idea to show usage here


### PR DESCRIPTION
Remove custom handling for auth in Cloudchamber/Containers, and use the standard Wrangler auth token & login flow.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: should be covered by existing tests
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: internal refactor
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: v4 only feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
