### PR TITLE
[v3] WC-2965 Prevent selecting in-progress deployments when tailing

### DIFF
--- a/.changeset/bumpy-otters-kiss.md
+++ b/.changeset/bumpy-otters-kiss.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Select only successfully deployed deployments when tailing.

--- a/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-deployment-tail.test.ts
@@ -62,16 +62,13 @@ describe("pages deployment tail", () => {
 	mockApiToken();
 	const std = mockConsoleMethods();
 
-	beforeEach(() => {
-		// Force the CLI to be "non-interactive" in test env
-		vi.stubEnv("CF_PAGES", "1");
-	});
-
 	/**
 	 * Interaction with the tailing API, including tail creation,
 	 * deletion, and connection.
 	 */
 	describe("API interaction", () => {
+		const { setIsTTY } = useMockIsTTY();
+
 		it("should throw an error if deployment isn't provided", async () => {
 			api = mockTailAPIs();
 			await expect(
@@ -80,6 +77,22 @@ describe("pages deployment tail", () => {
 				`[Error: Must specify a deployment in non-interactive mode.]`
 			);
 			expect(api.requests.deployments.count).toStrictEqual(0);
+			await api.closeHelper();
+		});
+
+		it("only uses deployments with status=success and name=deploy", async () => {
+			setIsTTY(true);
+			api = mockTailAPIs("mock-deployment-id");
+			expect(api.requests.creation.length).toStrictEqual(0);
+
+			await runWrangler("pages deployment tail --project-name mock-project");
+
+			await expect(api.ws.connected).resolves.toBeTruthy();
+			expect(api.requests.creation.length).toStrictEqual(1);
+			expect(api.requests.deletion.count).toStrictEqual(0);
+
+			await api.closeHelper();
+			expect(api.requests.deletion.count).toStrictEqual(1);
 			await api.closeHelper();
 		});
 
@@ -868,6 +881,24 @@ function mockListDeployments(): RequestLogger {
 						messages: [],
 						result: [
 							{
+								id: "mock-deployment-id-skipped",
+								url: "https://abc123.mock.pages.dev",
+								environment: "production",
+								created_on: "2020-01-17T14:52:26.133835Z",
+								latest_stage: {
+									ended_on: "2020-01-17T14:52:26.133835Z",
+									status: "skipped",
+									name: "deploy",
+								},
+								deployment_trigger: {
+									metadata: {
+										branch: "main",
+										commit_hash: "11122334c4cb32ad4f65b530b9424e8be5bec9d6",
+									},
+								},
+								project_name: "mock-project",
+							},
+							{
 								id: "mock-deployment-id",
 								url: "https://87bbc8fe.mock.pages.dev",
 								environment: "production",
@@ -875,6 +906,7 @@ function mockListDeployments(): RequestLogger {
 								latest_stage: {
 									ended_on: "2021-11-17T14:52:26.133835Z",
 									status: "success",
+									name: "deploy",
 								},
 								deployment_trigger: {
 									metadata: {
@@ -901,11 +933,13 @@ function mockListDeployments(): RequestLogger {
  *
  * @returns a `RequestCounter` for counting how many times the API is hit
  */
-function mockCreateTailRequest(): RequestInit[] {
+function mockCreateTailRequest(
+	deploymentId: string = ":deploymentId"
+): RequestInit[] {
 	const requests: RequestInit[] = [];
 	msw.use(
 		http.post(
-			`*/accounts/:accountId/pages/projects/:projectName/deployments/:deploymentId/tails`,
+			`*/accounts/:accountId/pages/projects/:projectName/deployments/${deploymentId}/tails`,
 			async ({ request }) => {
 				requests.push((await request.json()) as RequestInit);
 				return HttpResponse.json(
@@ -1002,7 +1036,9 @@ const websocketURL = "ws://localhost:1234";
  * @param websocketURL a fake websocket URL for wrangler to connect to
  * @returns a mocked-out version of the API
  */
-function mockTailAPIs(): MockAPI {
+function mockTailAPIs(
+	expectedCreateDeploymentId: string = ":deploymentId"
+): MockAPI {
 	const api: MockAPI = {
 		requests: {
 			deletion: { count: 0 },
@@ -1034,7 +1070,7 @@ function mockTailAPIs(): MockAPI {
 	api.ws = new MockWebSocketServer(websocketURL);
 	mockWebSockets.push(api.ws);
 
-	api.requests.creation = mockCreateTailRequest();
+	api.requests.creation = mockCreateTailRequest(expectedCreateDeploymentId);
 	api.requests.deletion = mockDeleteTailRequest();
 	api.requests.deployments = mockListDeployments();
 

--- a/packages/wrangler/src/pages/deployment-tails.ts
+++ b/packages/wrangler/src/pages/deployment-tails.ts
@@ -169,7 +169,10 @@ export async function Handler({
 	);
 
 	const envDeployments = deployments.filter(
-		(d) => d.environment === environment
+		(d) =>
+			d.environment === environment &&
+			d.latest_stage.name === "deploy" &&
+			d.latest_stage.status === "success"
 	);
 
 	// Deployment is URL


### PR DESCRIPTION
If not provided with a deployment to tail, Wrangler will try to pull the list of deployments and select the most recently created one. However, we do not check whether this deployment has finished. This is causing intermittent errors for users.

Fixes #[insert GH or internal issue link(s)].

_Describe your change..._

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: n/a
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: this is the backport!

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
