### PR TITLE
Temporarily skip Openapi C3 e2e tests

### DIFF
--- a/packages/create-cloudflare/e2e-tests/cli.test.ts
+++ b/packages/create-cloudflare/e2e-tests/cli.test.ts
@@ -281,39 +281,47 @@ describe.skipIf(experimental || frameworkToTest || isQuarantineMode())(
 			},
 		);
 
-		test({ experimental }).skipIf(process.platform === "win32")(
-			"Selecting template by description",
-			async ({ logStream, project }) => {
-				const { output } = await runC3(
-					[project.path, "--no-deploy", "--git=false"],
-					[
-						{
-							matcher: /What would you like to start with\?/,
-							input: {
-								type: "select",
-								target: "Application Starter",
-								assertDescriptionText:
-									"Select from a range of starter applications using various Cloudflare products",
-							},
+		/*
+		 * Skipping in yarn due to node version resolution conflict
+		 * The Openapi C3 template depends on `chanfana`, which has a dependency
+		 * on `yargs-parser`. The latest chanfana version(`2.8.1` at the time
+		 * of this writting) has a dep on `yargs-parser@22` which requires a
+		 * node version of `20.19.0` or higher. Our CI is currently using node
+		 * version `20.11.1`. We currently can't bump the CI node version as other
+		 * tests will fail, therefore skipping for now until we can properly fix
+		 */
+		test({ experimental }).skipIf(
+			process.platform === "win32" || pm === "yarn",
+		)("Selecting template by description", async ({ logStream, project }) => {
+			const { output } = await runC3(
+				[project.path, "--no-deploy", "--git=false"],
+				[
+					{
+						matcher: /What would you like to start with\?/,
+						input: {
+							type: "select",
+							target: "Application Starter",
+							assertDescriptionText:
+								"Select from a range of starter applications using various Cloudflare products",
 						},
-						{
-							matcher: /Which template would you like to use\?/,
-							input: {
-								type: "select",
-								target: "API starter (OpenAPI compliant)",
-								assertDescriptionText:
-									"Get started building a basic API on Workers",
-							},
+					},
+					{
+						matcher: /Which template would you like to use\?/,
+						input: {
+							type: "select",
+							target: "API starter (OpenAPI compliant)",
+							assertDescriptionText:
+								"Get started building a basic API on Workers",
 						},
-					],
-					logStream,
-				);
+					},
+				],
+				logStream,
+			);
 
-				expect(project.path).toExist();
-				expect(output).toContain(`category Application Starter`);
-				expect(output).toContain(`type API starter (OpenAPI compliant)`);
-			},
-		);
+			expect(project.path).toExist();
+			expect(output).toContain(`category Application Starter`);
+			expect(output).toContain(`type API starter (OpenAPI compliant)`);
+		});
 
 		test({ experimental }).skipIf(process.platform === "win32")(
 			"Going back and forth between the category, type, framework and lang prompts",

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -180,10 +180,16 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 			},
 			{
 				template: "openapi",
+				quarantine: true,
 				variants: [],
-				// Temporarily skip due to node versions conflict
-				verifyDeploy: null,
-				verifyPreview: null,
+				verifyDeploy: {
+					route: "/",
+					expectedText: "SwaggerUI",
+				},
+				verifyPreview: {
+					route: "/",
+					expectedText: "SwaggerUI",
+				},
 			},
 		];
 	}

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -178,19 +178,6 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 				verifyDeploy: null,
 				verifyPreview: null,
 			},
-			{
-				template: "openapi",
-				quarantine: true,
-				variants: [],
-				verifyDeploy: {
-					route: "/",
-					expectedText: "SwaggerUI",
-				},
-				verifyPreview: {
-					route: "/",
-					expectedText: "SwaggerUI",
-				},
-			},
 		];
 	}
 }

--- a/packages/create-cloudflare/e2e-tests/workers.test.ts
+++ b/packages/create-cloudflare/e2e-tests/workers.test.ts
@@ -181,14 +181,9 @@ function getWorkerTests(opts: { experimental: boolean }): WorkerTestConfig[] {
 			{
 				template: "openapi",
 				variants: [],
-				verifyDeploy: {
-					route: "/",
-					expectedText: "SwaggerUI",
-				},
-				verifyPreview: {
-					route: "/",
-					expectedText: "SwaggerUI",
-				},
+				// Temporarily skip due to node versions conflict
+				verifyDeploy: null,
+				verifyPreview: null,
 			},
 		];
 	}


### PR DESCRIPTION
Skipping in yarn due to node version resolution conflicts

The Openapi C3 template depends on `chanfana`, which has a dependency on `yargs-parser`. The latest chanfana version (`2.8.1` at the time of this writting) has a dep on `yargs-parser@22` which requires a node version of `20.19.0` or higher. Our CI is currently using node version `20.11.1`. We currently can't bump the CI node version as other tests will fail, therefore skipping for now until we can properly fix

Fixes n/a
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: skips c3 e2e test
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: skips c3 e2e test
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: skips c3 e2e test

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
