### PR TITLE
allow printing hotkeys conditionally

### DIFF
--- a/.changeset/early-views-pay.md
+++ b/.changeset/early-views-pay.md
@@ -1,0 +1,7 @@
+---
+"wrangler": patch
+---
+
+Move hotkey registration later in dev start up
+
+This should have no functional change, but allows us to conditionally render hotkeys based on config.

--- a/fixtures/interactive-dev-tests/Dockerfile
+++ b/fixtures/interactive-dev-tests/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+CMD ["echo", "hello world"]
+EXPOSE 8080

--- a/fixtures/interactive-dev-tests/index.js
+++ b/fixtures/interactive-dev-tests/index.js
@@ -1,0 +1,1 @@
+export default { }

--- a/fixtures/interactive-dev-tests/index.js
+++ b/fixtures/interactive-dev-tests/index.js
@@ -1,1 +1,1 @@
-export default { }
+export default {};

--- a/fixtures/interactive-dev-tests/src/container.mjs
+++ b/fixtures/interactive-dev-tests/src/container.mjs
@@ -1,0 +1,6 @@
+import { DurableObject } from "cloudflare:workers";
+
+export class Container extends DurableObject {}
+export default {
+	async fetch() {},
+};

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -227,6 +227,38 @@ describe.each(devScripts)("wrangler $args", ({ args, expectedBody }) => {
 			expect(duringProcesses.length).toBeGreaterThan(beginProcesses.length);
 		}
 	});
+	describe("--show-interactive-dev-session", () => {
+		it("should show hotkeys when interactive", async () => {
+			const wrangler = await startWranglerDev(args);
+			wrangler.pty.kill();
+			expect(wrangler.stdout).toContain("open a browser");
+			expect(wrangler.stdout).toContain("open devtools");
+			expect(wrangler.stdout).toContain("clear console");
+			expect(wrangler.stdout).toContain("to exit");
+			expect(wrangler.stdout).not.toContain("rebuild container");
+		});
+		it("should not show hotkeys with --show-interactive-dev-session=false", async () => {
+			const wrangler = await startWranglerDev([
+				...args,
+				"--show-interactive-dev-session=false",
+			]);
+			wrangler.pty.kill();
+			expect(wrangler.stdout).not.toContain("open a browser");
+			expect(wrangler.stdout).not.toContain("open devtools");
+			expect(wrangler.stdout).not.toContain("clear console");
+			expect(wrangler.stdout).not.toContain("to exit");
+			expect(wrangler.stdout).not.toContain("rebuild container");
+		});
+		it("should show rebuild containers hotkey if containers are configured", async () => {
+			const wrangler = await startWranglerDev([
+				"dev",
+				"-c",
+				"wrangler.container.jsonc",
+			]);
+			wrangler.pty.kill();
+			expect(wrangler.stdout).toContain("rebuild container");
+		});
+	});
 });
 
 it.each(exitKeys)("multiworker cleanly exits with $name", async ({ key }) => {

--- a/fixtures/interactive-dev-tests/tests/index.test.ts
+++ b/fixtures/interactive-dev-tests/tests/index.test.ts
@@ -249,15 +249,19 @@ describe.each(devScripts)("wrangler $args", ({ args, expectedBody }) => {
 			expect(wrangler.stdout).not.toContain("to exit");
 			expect(wrangler.stdout).not.toContain("rebuild container");
 		});
-		it("should show rebuild containers hotkey if containers are configured", async () => {
-			const wrangler = await startWranglerDev([
-				"dev",
-				"-c",
-				"wrangler.container.jsonc",
-			]);
-			wrangler.pty.kill();
-			expect(wrangler.stdout).toContain("rebuild container");
-		});
+		// docker isn't installed by default on windows/macos runners
+		it.skipIf(process.env.platform !== "linux" && process.env.CI === "true")(
+			"should show rebuild containers hotkey if containers are configured",
+			async () => {
+				const wrangler = await startWranglerDev([
+					"dev",
+					"-c",
+					"wrangler.container.jsonc",
+				]);
+				wrangler.pty.kill();
+				expect(wrangler.stdout).toContain("rebuild container");
+			}
+		);
 	});
 });
 

--- a/fixtures/interactive-dev-tests/wrangler.container.jsonc
+++ b/fixtures/interactive-dev-tests/wrangler.container.jsonc
@@ -1,0 +1,29 @@
+{
+	"name": "container-app",
+	"main": "src/container.mjs",
+	"compatibility_date": "2025-04-03",
+	"containers": [
+		{
+			"configuration": {
+				"image": "./Dockerfile",
+			},
+			"class_name": "Container",
+			"name": "http2",
+			"max_instances": 2,
+		},
+	],
+	"durable_objects": {
+		"bindings": [
+			{
+				"class_name": "Container",
+				"name": "CONTAINER",
+			},
+		],
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": ["Container"],
+		},
+	],
+}

--- a/packages/wrangler/src/__tests__/dev.test.ts
+++ b/packages/wrangler/src/__tests__/dev.test.ts
@@ -7,7 +7,6 @@ import dedent from "ts-dedent";
 import { vi } from "vitest";
 import { ConfigController } from "../api/startDevWorker/ConfigController";
 import { unwrapHook } from "../api/startDevWorker/utils";
-import registerDevHotKeys from "../dev/hotkeys";
 import { getWorkerAccountAndContext } from "../dev/remote";
 import { COMPLIANCE_REGION_CONFIG_UNKNOWN } from "../environment-variables/misc-variables";
 import { FatalError } from "../errors";
@@ -1555,23 +1554,6 @@ describe.sequential("wrangler dev", () => {
 					'^The directory specified by the "assets.directory" field in your configuration file does not exist:[Ss]*'
 				)
 			);
-		});
-	});
-
-	describe("--show-interactive-dev-session", () => {
-		it("should show interactive dev session with --show-interactive-dev-session", async () => {
-			fs.writeFileSync("index.js", `export default { }`);
-			await runWranglerUntilConfig(
-				"dev index.js --show-interactive-dev-session"
-			);
-			expect(vi.mocked(registerDevHotKeys).mock.calls.length).toBe(1);
-		});
-		it("should not show interactive dev session with --show-interactive-dev-session=false", async () => {
-			fs.writeFileSync("index.js", `export default { }`);
-			await runWranglerUntilConfig(
-				"dev index.js --show-interactive-dev-session=false"
-			);
-			expect(vi.mocked(registerDevHotKeys).mock.calls.length).toBe(0);
 		});
 	});
 

--- a/packages/wrangler/src/dev.ts
+++ b/packages/wrangler/src/dev.ts
@@ -638,10 +638,6 @@ export async function startDev(args: StartDevOptions) {
 
 			const primaryDevEnv = new DevEnv({ runtimes: [runtime] });
 
-			if (isInteractive() && args.showInteractiveDevSession !== false) {
-				unregisterHotKeys = registerDevHotKeys(primaryDevEnv, args);
-			}
-
 			// Set up the primary DevEnv (the one that the ProxyController will connect to)
 			devEnv = [
 				await setupDevEnv(primaryDevEnv, args.config[0], authHook, {
@@ -670,6 +666,9 @@ export async function startDev(args: StartDevOptions) {
 					})
 				))
 			);
+			if (isInteractive() && args.showInteractiveDevSession !== false) {
+				unregisterHotKeys = registerDevHotKeys(primaryDevEnv, args);
+			}
 		} else {
 			devEnv = new DevEnv();
 
@@ -720,11 +719,11 @@ export async function startDev(args: StartDevOptions) {
 				});
 			}
 
+			await setupDevEnv(devEnv, args.config, authHook, args);
+
 			if (isInteractive() && args.showInteractiveDevSession !== false) {
 				unregisterHotKeys = registerDevHotKeys(devEnv, args);
 			}
-
-			await setupDevEnv(devEnv, args.config, authHook, args);
 		}
 
 		return {

--- a/packages/wrangler/src/dev/hotkeys.ts
+++ b/packages/wrangler/src/dev/hotkeys.ts
@@ -36,6 +36,30 @@ export default function registerDevHotKeys(
 			},
 		},
 		{
+			keys: ["r"],
+			label: "rebuild container(s)",
+			disabled: () => {
+				return (
+					!devEnv.config.latestConfig?.dev?.enableContainers ||
+					!devEnv.config.latestConfig?.containers?.length
+				);
+			},
+			handler: async () => {
+				const newContainerBuildId = randomUUID().slice(0, 8);
+				// cleanup any existing containers
+				devEnv.runtimes.map(async (runtime) => {
+					if (runtime instanceof LocalRuntimeController) {
+						await runtime.cleanupContainers();
+					}
+				});
+
+				// updating the build ID will trigger a rebuild of the containers
+				await devEnv.config.patch({
+					dev: { containerBuildId: newContainerBuildId },
+				});
+			},
+		},
+		{
 			keys: ["l"],
 			disabled: () => args.forceLocal ?? false,
 			handler: async () => {
@@ -59,31 +83,6 @@ export default function registerDevHotKeys(
 			label: "to exit",
 			handler: async () => {
 				await devEnv.teardown();
-			},
-		},
-		{
-			keys: ["r"],
-			// omitting the label means it won't be printed but is still enabled
-			// label: "rebuild container",
-			handler: async () => {
-				if (
-					!devEnv.config.latestConfig?.dev?.enableContainers ||
-					!devEnv.config.latestConfig?.containers?.length
-				) {
-					return;
-				}
-				const newContainerBuildId = randomUUID().slice(0, 8);
-				// cleanup any existing containers
-				devEnv.runtimes.map(async (runtime) => {
-					if (runtime instanceof LocalRuntimeController) {
-						await runtime.cleanupContainers();
-					}
-				});
-
-				// updating the build ID will trigger a rebuild of the containers
-				await devEnv.config.patch({
-					dev: { containerBuildId: newContainerBuildId },
-				});
 			},
 		},
 	]);


### PR DESCRIPTION
This prints the hotkeys after the dev env has been set up, so that we can access the config and register hotkeys conditionally based on that. 

Looks like this: 

![Screenshot 2025-06-20 at 14 08 02](https://github.com/user-attachments/assets/bbb38ae3-fccf-436e-993c-c142d9a930ae)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: no functional change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: hotkey printing has changed since v3

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
