### PR TITLE
Include tag and message in assets-only version uploads

### DIFF
--- a/.changeset/quiet-stars-chew.md
+++ b/.changeset/quiet-stars-chew.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+fix: include tag and message in assets-only version uploads

--- a/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
+++ b/packages/wrangler/src/__tests__/versions/versions.upload.test.ts
@@ -211,6 +211,23 @@ describe("versions upload", () => {
 		expect(std.info).toContain("Retrying API call after error...");
 	});
 
+	it("should include annotations in the upload request even if there are only assets", async () => {
+		mockGetScript();
+		mockUploadVersion(true, 1, {
+			"workers/message": "test message",
+			"workers/tag": "test",
+		});
+		mockGetWorkerSubdomain({ enabled: true, previews_enabled: true });
+		mockSubDomainRequest();
+		writeWranglerConfig({
+			name: "test-name",
+			main: "./index.js",
+		});
+		writeWorkerSource();
+
+		await runWrangler("versions upload --tag 'test' --message 'test message'");
+	});
+
 	describe("multi-env warning", () => {
 		it("should warn if the wrangler config contains environments but none was specified in the command", async () => {
 			mockGetScript();

--- a/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
+++ b/packages/wrangler/src/deployment-bundle/create-worker-upload-form.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { File, FormData } from "undici";
 import { UserError } from "../errors";
+import { logger } from "../logger";
 import { INHERIT_SYMBOL } from "./bindings";
 import { handleUnsafeCapnp } from "./capnp";
 import type { Observability } from "../config/environment";
@@ -249,6 +250,7 @@ export function createWorkerUploadForm(worker: CfWorkerInit): FormData {
 				},
 				...(compatibility_date && { compatibility_date }),
 				...(compatibility_flags && { compatibility_flags }),
+				...(annotations && { annotations }),
 			})
 		);
 		return formData;


### PR DESCRIPTION
Fixes #9611 

TODO: refactor so we don't have that short circuit there for asset only uploads to prevent this problem in the future. 

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: bugfix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: went GA after v4

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
