### PR TITLE
update containers command to be open-beta

### DIFF
--- a/.changeset/thick-forks-press.md
+++ b/.changeset/thick-forks-press.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Make `wrangler container` commands print `open-beta` status

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -119,7 +119,10 @@ export function handleFailure<
 		try {
 			if (!args.json) {
 				await printWranglerBanner();
-				logger.warn(constructStatusMessage(command, "alpha"));
+				const commandStatus = command.includes("cloudchamber")
+					? "alpha"
+					: "open-beta";
+				logger.warn(constructStatusMessage(command, commandStatus));
 			}
 			const config = readConfig(args);
 			await fillOpenAPIConfiguration(config, args.json);


### PR DESCRIPTION
Fixes DEVX-2026

Containers will shortly be in open-beta. Cloudchamber commands remain private/internal.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: logging change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: logging change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: logging change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: new feature

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
