### PR TITLE
R2-3164: ETags are now MD5

### DIFF
--- a/packages/miniflare/src/workers/r2/schemas.worker.ts
+++ b/packages/miniflare/src/workers/r2/schemas.worker.ts
@@ -32,8 +32,7 @@ export type MultipartPartRow = {
 	part_number: number;
 	blob_id: string;
 	size: number; // NOTE: used to identify which parts to read for range requests
-	etag: string; // NOTE: multipart part ETag's are not MD5 checksums
-	checksum_md5: string; // NOTE: used in construction of final object's ETag
+	etag: string;
 	object_key: string | null; // null if in-progress upload
 };
 export const SQL_SCHEMA = `
@@ -61,7 +60,6 @@ CREATE TABLE IF NOT EXISTS _mf_multipart_parts (
     blob_id TEXT NOT NULL,
     size INTEGER NOT NULL,
     etag TEXT NOT NULL,
-    checksum_md5 TEXT NOT NULL,
     object_key TEXT REFERENCES _mf_objects(key) DEFERRABLE INITIALLY DEFERRED,
     PRIMARY KEY (upload_id, part_number)
 );

--- a/packages/miniflare/test/plugins/r2/index.spec.ts
+++ b/packages/miniflare/test/plugins/r2/index.spec.ts
@@ -1237,6 +1237,15 @@ test("completeMultipartUpload", async (t) => {
 		message:
 			"completeMultipartUpload: One or more of the specified parts could not be found. (10025)",
 	};
+	// Check completing with multiple parts of same part number
+	const uploady = await r2.createMultipartUpload("key");
+	const part1a = await uploady.uploadPart(1, "1".repeat(PART_SIZE));
+	const part1b = await uploady.uploadPart(1, "2".repeat(PART_SIZE));
+	const part1c = await uploady.uploadPart(1, "3".repeat(PART_SIZE));
+	await t.throwsAsync(
+		uploady.complete([part1a, part1b, part1c]),
+		internalErrorExpectations("completeMultipartUpload")
+	);
 	// Check completing with out-of-order parts
 	const upload5a = await r2.createMultipartUpload("key");
 	part1 = await upload5a.uploadPart(1, "1".repeat(PART_SIZE));


### PR DESCRIPTION
Fixes R2-3164.

ETags have been Hex-encoded MD5 hashes of the object since [June 21, 2023](https://developers.cloudflare.com/r2/objects/multipart-objects/#etags). This change makes Miniflare use the MD5 hash it already computes as the ETag, rather than a random value it generates.

---

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: Not a Wrangler/Vite change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): 
  - [x] Documentation not necessary because: This change is to match documented behaviour
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR:
  - [x] Not necessary because: Not a Wrangler change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/workers-sdk/pull/9715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->