### PR TITLE
CC-5521: Revert to "dev" when instance type is absent

### DIFF
--- a/.changeset/easy-walls-raise.md
+++ b/.changeset/easy-walls-raise.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Containers should default to a "dev" instance type when no instance type is specified in the wrangler config

--- a/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/apply.test.ts
@@ -122,6 +122,7 @@ describe("cloudchamber apply", () => {
 			│
 			│   [containers.configuration]
 			│   image = \\"./Dockerfile\\"
+			│   instance_type = \\"dev\\"
 			│
 			│   [containers.constraints]
 			│   tier = 2
@@ -165,6 +166,13 @@ describe("cloudchamber apply", () => {
 				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile",
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 3,
@@ -241,6 +249,13 @@ describe("cloudchamber apply", () => {
 				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile2",
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -263,9 +278,7 @@ describe("cloudchamber apply", () => {
 			│   [containers.configuration]
 			│ - image = \\"./Dockerfile2\\"
 			│ + image = \\"./Dockerfile\\"
-			│
-			│   [containers.constraints]
-			│   ...
+			│   instance_type = \\"dev\\"
 			│
 			├ NEW my-container-app-2
 			│
@@ -276,6 +289,7 @@ describe("cloudchamber apply", () => {
 			│
 			│   [containers.configuration]
 			│   image = \\"other-app/Dockerfile\\"
+			│   instance_type = \\"dev\\"
 			│
 			│   [containers.constraints]
 			│   tier = 1
@@ -331,6 +345,13 @@ describe("cloudchamber apply", () => {
 				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile",
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -363,6 +384,7 @@ describe("cloudchamber apply", () => {
 			│
 			│   [containers.configuration]
 			│   image = \\"other-app/Dockerfile\\"
+			│   instance_type = \\"dev\\"
 			│
 			│   [containers.constraints]
 			│   tier = 1
@@ -412,6 +434,13 @@ describe("cloudchamber apply", () => {
 				scheduling_policy: SchedulingPolicy.DEFAULT,
 				configuration: {
 					image: "./Dockerfile",
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -444,6 +473,7 @@ describe("cloudchamber apply", () => {
 			│
 			│   [containers.configuration]
 			│   image = \\"other-app/Dockerfile\\"
+			│   instance_type = \\"dev\\"
 			│
 			│   [containers.constraints]
 			│   tier = 1
@@ -543,6 +573,13 @@ describe("cloudchamber apply", () => {
 							secret: "SECRET_NAME_2",
 						},
 					],
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -673,6 +710,13 @@ describe("cloudchamber apply", () => {
 							secret: "SECRET_NAME_2",
 						},
 					],
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 
 				constraints: {
@@ -776,6 +820,13 @@ describe("cloudchamber apply", () => {
 						secret: "SECRET_NAME_2",
 					},
 				],
+				disk: {
+					size: "2GB",
+					size_mb: 2000,
+				},
+				vcpu: 0.0625,
+				memory: "256MB",
+				memory_mib: 256,
 			},
 
 			constraints: {
@@ -886,6 +937,13 @@ describe("cloudchamber apply", () => {
 							secret: "SECRET_NAME_2",
 						},
 					],
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 
 				constraints: {
@@ -989,6 +1047,13 @@ describe("cloudchamber apply", () => {
 						secret: "SECRET_NAME_2",
 					},
 				],
+				disk: {
+					size: "2GB",
+					size_mb: 2000,
+				},
+				vcpu: 0.0625,
+				memory: "256MB",
+				memory_mib: 256,
 			},
 
 			constraints: {
@@ -1046,6 +1111,13 @@ describe("cloudchamber apply", () => {
 				scheduling_policy: SchedulingPolicy.REGIONAL,
 				configuration: {
 					image: "./Dockerfile",
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -1063,7 +1135,8 @@ describe("cloudchamber apply", () => {
 			├ EDIT my-container-app
 			│
 			│   [containers.configuration]
-			│   image = \\"./Dockerfile\\"
+			│   ...
+			│   instance_type = \\"dev\\"
 			│
 			│ + [containers.configuration.observability.logs]
 			│ + enabled = true
@@ -1114,6 +1187,13 @@ describe("cloudchamber apply", () => {
 				scheduling_policy: SchedulingPolicy.REGIONAL,
 				configuration: {
 					image: "./Dockerfile",
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -1131,7 +1211,8 @@ describe("cloudchamber apply", () => {
 			├ EDIT my-container-app
 			│
 			│   [containers.configuration]
-			│   image = \\"./Dockerfile\\"
+			│   ...
+			│   instance_type = \\"dev\\"
 			│
 			│ + [containers.configuration.observability.logs]
 			│ + enabled = true
@@ -1187,6 +1268,13 @@ describe("cloudchamber apply", () => {
 							enabled: true,
 						},
 					},
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -1258,6 +1346,13 @@ describe("cloudchamber apply", () => {
 							enabled: true,
 						},
 					},
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -1328,6 +1423,13 @@ describe("cloudchamber apply", () => {
 							enabled: true,
 						},
 					},
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -1401,6 +1503,13 @@ describe("cloudchamber apply", () => {
 							enabled: true,
 						},
 					},
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -1475,6 +1584,13 @@ describe("cloudchamber apply", () => {
 							enabled: true,
 						},
 					},
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -1524,6 +1640,13 @@ describe("cloudchamber apply", () => {
 				scheduling_policy: SchedulingPolicy.REGIONAL,
 				configuration: {
 					image: "./Dockerfile",
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -1581,6 +1704,13 @@ describe("cloudchamber apply", () => {
 							enabled: false,
 						},
 					},
+					disk: {
+						size: "2GB",
+						size_mb: 2000,
+					},
+					vcpu: 0.0625,
+					memory: "256MB",
+					memory_mib: 256,
 				},
 				constraints: {
 					tier: 1,
@@ -1737,6 +1867,88 @@ describe("cloudchamber apply", () => {
 		expect(std.stderr).toMatchInlineSnapshot(`""`);
 		const app = await applicationReqBodyPromise;
 		expect(app.configuration?.instance_type).toEqual("standard");
+		/* eslint-enable */
+	});
+
+	test("falls back on dev instance type when instance type is absent", async () => {
+		setIsTTY(false);
+		writeWranglerConfig({
+			name: "my-container",
+			containers: [
+				{
+					name: "my-container-app",
+					instances: 4,
+					class_name: "DurableObjectClass",
+					configuration: {
+						image: "./Dockerfile",
+					},
+					constraints: {
+						tier: 2,
+					},
+				},
+			],
+		});
+		mockGetApplications([
+			{
+				id: "abc",
+				name: "my-container-app",
+				instances: 3,
+				created_at: new Date().toString(),
+				version: 1,
+				account_id: "1",
+				scheduling_policy: SchedulingPolicy.REGIONAL,
+				configuration: {
+					image: "./Dockerfile",
+					disk: {
+						size: "4GB",
+						size_mb: 4000,
+					},
+					vcpu: 0.25,
+					memory: "1024MB",
+					memory_mib: 1024,
+				},
+				constraints: {
+					tier: 3,
+				},
+			},
+		]);
+		const applicationReqBodyPromise = mockModifyApplication();
+		await runWrangler("cloudchamber apply --json");
+		/* eslint-disable */
+		expect(std.stdout).toMatchInlineSnapshot(`
+			"╭ Deploy a container application deploy changes to your application
+			│
+			│ Container application changes
+			│
+			├ EDIT my-container-app
+			│
+			│   [[containers]]
+			│ - instances = 3
+			│ + instances = 4
+			│   name = \\"my-container-app\\"
+			│
+			│   [containers.configuration]
+			│   image = \\"./Dockerfile\\"
+			│ - instance_type = \\"basic\\"
+			│ + instance_type = \\"dev\\"
+			│
+			│   [containers.constraints]
+			│   ...
+			│ - tier = 3
+			│ + tier = 2
+			│
+			├ Loading
+			│
+			│
+			│  SUCCESS  Modified application my-container-app
+			│
+			╰ Applied changes
+
+			"
+		`);
+		expect(std.stderr).toMatchInlineSnapshot(`""`);
+		const app = await applicationReqBodyPromise;
+		expect(app.configuration?.instance_type).toEqual("dev");
 		/* eslint-enable */
 	});
 });

--- a/packages/wrangler/src/cloudchamber/apply.ts
+++ b/packages/wrangler/src/cloudchamber/apply.ts
@@ -15,6 +15,7 @@ import {
 	ApplicationsService,
 	CreateApplicationRolloutRequest,
 	DeploymentMutationError,
+	InstanceType,
 	RolloutsService,
 	SchedulingPolicy,
 } from "@cloudflare/containers-shared";
@@ -33,7 +34,6 @@ import type {
 	ApplicationID,
 	ApplicationName,
 	CreateApplicationRequest,
-	InstanceType,
 	ModifyApplicationRequestBody,
 	ModifyDeploymentV2RequestBody,
 	Observability as ObservabilityConfiguration,
@@ -173,6 +173,28 @@ function observabilityToConfiguration(
 	}
 }
 
+function containerAppToInstanceType(
+	containerApp: ContainerApp
+): InstanceType | undefined {
+	if (containerApp.instance_type !== undefined) {
+		return containerApp.instance_type as InstanceType;
+	}
+
+	// if no other configuration is set, we fall back to the default "dev" instance type
+	const configuration =
+		containerApp.configuration as UserDeploymentConfiguration;
+	if (
+		configuration.disk === undefined &&
+		configuration.vcpu === undefined &&
+		configuration.memory === undefined &&
+		configuration.memory_mib === undefined
+	) {
+		return InstanceType.DEV;
+	}
+
+	return undefined;
+}
+
 function containerAppToCreateApplication(
 	containerApp: ContainerApp,
 	observability: Observability | undefined,
@@ -183,13 +205,12 @@ function containerAppToCreateApplication(
 		observability,
 		existingApp?.configuration.observability
 	);
+	const instanceType = containerAppToInstanceType(containerApp);
 	const configuration: UserDeploymentConfiguration = {
 		...(containerApp.configuration as UserDeploymentConfiguration),
 		observability: observabilityConfiguration,
+		instance_type: instanceType,
 	};
-	if (containerApp.instance_type !== undefined) {
-		configuration.instance_type = containerApp.instance_type as InstanceType;
-	}
 
 	const app: CreateApplicationRequest = {
 		...containerApp,


### PR DESCRIPTION
When the instance_type field is absent in the wrangler config and no other vcpu, memory, or disk configuration is set, automatically populate the instance_type field with "dev".
This way, deleting instance_type from wrangler.jsonc reverts the deployment back to dev.

Fixes CC-5521

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [X] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [X] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [X] Documentation not necessary because: "dev" as default instance type is already documented
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [X] Not necessary because: We don't need to backport Cloudchamber changes to v3, since it's still private beta

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
