### PR TITLE
chore: Force fail e2e tests job if fork PR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,3 +125,25 @@ jobs:
         with:
           name: turbo-runs-${{ matrix.os }}-${{ matrix.node }}
           path: .turbo/runs
+
+  # E2E tests cannot run on pull requests created from forks due to security concerns.
+  # In such cases we require a member of the `workers-sdk` maintainers group to manually
+  # run these tests on behalf of the PR.
+  #
+  # If a PR from a fork specifically requests running the e2e tests, by applying the `e2e`
+  # label, we want CI to fail with a descriptive message, instead of skipping the `e2e-tests`
+  # job altogether, which gives the false optics that CI is green. Having CI intentionally
+  # fail for such use cases will act as a reminder that tests need to be manually run, and
+  # will prevent us from accidentally merging fork PRs that are green, but never ran the
+  # e2e tests.
+  e2e-test-forks:
+    name: "E2E tests on forks"
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.node }}
+    if: github.event_name == 'pull_request' && contains(github.event.*.labels.*.name, 'e2e' ) && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Force Fail
+        run: |
+          echo: "E2E tests cannot run on pull requests created from forks due to security reasons. Please reach out to a workers-sdk maintainer to run the E2E tests on behalf of this PR."
+          exit 1


### PR DESCRIPTION
 E2E tests cannot run on pull requests created from forks due to security concerns. In such cases we require a member of the `workers-sdk` maintainers group to manually run these tests on behalf of the PR.

If a PR from a fork specifically requests running the e2e tests, by applying the `e2e` label, we want CI to fail with a descriptive message, instead of skipping the `e2e-tests` job altogether, which gives the false optics that CI is green. Having 
CI intentionally fail for such use cases will act as a reminder that tests need to be manually run, and will prevent us from accidentally merging fork PRs that are green, but never ran the e2e tests.

Fixes n/a
---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: gh action change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: gh action change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: gh action change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: gh action change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
