### PR TITLE
add e2e container tests

### DIFF
--- a/fixtures/container-app/Dockerfile
+++ b/fixtures/container-app/Dockerfile
@@ -6,4 +6,3 @@ RUN npm install
 
 COPY ./container/simple-node-app.js app.js
 EXPOSE 8080
-CMD [ "node", "app.js" ]

--- a/fixtures/container-app/README.md
+++ b/fixtures/container-app/README.md
@@ -1,3 +1,3 @@
 # HTTP fetch to a container
 
-This example shows a simple HTTP request passthrough the DO to the container.
+This example shows a simple container setup where a DO passes requests through to a node server.

--- a/fixtures/container-app/container/simple-node-app.js
+++ b/fixtures/container-app/container/simple-node-app.js
@@ -10,7 +10,7 @@ const server = createServer(function (req, res) {
 	}
 
 	res.writeHead(200, { "Content-Type": "text/plain" });
-	res.write("Hello World!");
+	res.write("Hello World! Have an env var! " + process.env.MESSAGE);
 	res.end();
 });
 

--- a/fixtures/container-app/package.json
+++ b/fixtures/container-app/package.json
@@ -6,7 +6,11 @@
 		"container:build": "wrangler containers build ./ -t container-fixture",
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",
-		"start": "wrangler dev"
+		"start": "wrangler dev",
+		"test:ci": "vitest run"
+	},
+	"dependencies": {
+		"@cloudflare/containers": "^0.0.13"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-tsconfig": "workspace:*",

--- a/fixtures/container-app/src/index.ts
+++ b/fixtures/container-app/src/index.ts
@@ -6,7 +6,7 @@ export class Container extends DurableObject<Env> {
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
-		this.container = ctx.container!;
+		this.container = ctx.container;
 	}
 
 	async fetch(req: Request) {
@@ -25,7 +25,7 @@ export class Container extends DurableObject<Env> {
 			case "/start":
 				this.container.start({
 					entrypoint: ["node", "app.js"],
-					env: { A: "B", C: "D", L: "F" },
+					env: { MESSAGE: "I'm an env var!" },
 					enableInternet: false,
 				});
 				// this doesn't instantly start, so we will need to poll /fetch
@@ -39,9 +39,6 @@ export class Container extends DurableObject<Env> {
 				return new Response(await res.text());
 
 			case "/destroy-with-monitor":
-				// if (!this.container.running) {
-				// 	throw new Error("Container is not running.");
-				// }
 				const monitor = this.container.monitor();
 				await this.container.destroy();
 				await monitor;

--- a/fixtures/container-app/tests/index.test.ts
+++ b/fixtures/container-app/tests/index.test.ts
@@ -1,0 +1,95 @@
+import { ChildProcess, execSync } from "node:child_process";
+import { resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { runWranglerDev } from "../../shared/src/run-wrangler-long-lived";
+
+describe
+	.skipIf(process.env.platform !== "linux" && process.env.CI === "true")
+	.sequential.each([
+		{ source: "dockerfile (built)", config: "wrangler.jsonc" },
+		{
+			source: "registry uri (pulled)",
+			config: "wrangler.registry.jsonc",
+		},
+	])("container local dev with image from $source", (testCase) => {
+	let ip: string,
+		port: number,
+		stop: (() => Promise<unknown>) | undefined,
+		wranglerProcess: ChildProcess;
+
+	beforeAll(async () => {
+		({ ip, port, stop, wranglerProcess } = await runWranglerDev(
+			resolve(__dirname, ".."),
+			["--port=0", "--inspector-port=0", `-c=${testCase.config}`]
+		));
+		// cleanup any running containers
+		const ids = getContainerIds();
+		if (ids.length > 0) {
+			execSync("docker rm -f " + ids.join(" "), {
+				encoding: "utf8",
+			});
+		}
+	});
+
+	afterAll(async () => {
+		await stop?.();
+		// cleanup any containers that were started during the tests
+		const ids = getContainerIds();
+		if (ids.length > 0) {
+			execSync("docker rm -f " + ids.join(" "), {
+				encoding: "utf8",
+			});
+		}
+	});
+
+	it("should check initial container status (not running)", async () => {
+		const response = await fetch(`http://${ip}:${port}/status`);
+		const status = await response.json();
+		expect(response.status).toBe(200);
+		expect(status).toBe(false);
+	});
+
+	it("should start a container and be able to make requests to it", async () => {
+		let response = await fetch(`http://${ip}:${port}/start`);
+		let text = await response.text();
+		expect(response.status).toBe(200);
+		expect(text).toBe("Container create request sent...");
+
+		// Wait a bit for container to start
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		response = await fetch(`http://${ip}:${port}/status`);
+		const status = await response.json();
+		expect(response.status).toBe(200);
+		expect(status).toBe(true);
+
+		response = await fetch(`http://${ip}:${port}/fetch`);
+		expect(response.status).toBe(200);
+		text = await response.text();
+		expect(text).toBe("Hello World! Have an env var! I'm an env var!");
+		// Check that a container is running using `docker ps`
+		const ids = getContainerIds();
+		expect(ids.length).toBe(1);
+	});
+	it("should clean up any containers that were started", async () => {
+		// we want to give wrangler a chance to clean up, rather than using treekill
+		wranglerProcess.kill("SIGINT");
+		await new Promise<void>((resolve) => {
+			wranglerProcess.once("exit", () => resolve());
+		});
+		vi.waitFor(() => {
+			const remainingIds = getContainerIds();
+			expect(remainingIds.length).toBe(0);
+		});
+	});
+});
+
+const getContainerIds = () => {
+	// note the -a to include stopped containers
+	const ids = execSync("docker ps -a -q");
+	return ids
+		.toString()
+		.trim()
+		.split("\n")
+		.filter((id) => id.trim() !== "");
+};

--- a/fixtures/container-app/tests/tsconfig.json
+++ b/fixtures/container-app/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@cloudflare/workers-tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"types": ["node"]
+	},
+	"include": ["**/*.ts", "../../../node-types.d.ts"]
+}

--- a/fixtures/container-app/worker-configuration.d.ts
+++ b/fixtures/container-app/worker-configuration.d.ts
@@ -1,6 +1,6 @@
 declare namespace Cloudflare {
 	interface Env {
-		CONTAINER: DurableObjectNamespace<import("./src/index").Container>;
+		CONTAINER: DurableObjectNamespace<import("./src").Container>;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/fixtures/container-app/wrangler.jsonc
+++ b/fixtures/container-app/wrangler.jsonc
@@ -1,12 +1,10 @@
 {
 	"name": "container-app",
-	"main": "src/index.ts",
+	"main": "src/do.ts",
 	"compatibility_date": "2025-04-03",
 	"containers": [
 		{
-			"configuration": {
-				"image": "./Dockerfile",
-			},
+			"image": "./Dockerfile",
 			"class_name": "Container",
 			"name": "http2",
 			"max_instances": 2,

--- a/fixtures/container-app/wrangler.registry.jsonc
+++ b/fixtures/container-app/wrangler.registry.jsonc
@@ -1,12 +1,11 @@
 {
 	"name": "container-app-from-registry",
-	"main": "src/index.ts",
+	"main": "src/do.ts",
 	"compatibility_date": "2025-04-03",
 	"containers": [
 		{
-			"configuration": {
-				"image": "registry.cloudflare.com/8d783f274e1f82dc46744c297b015a2f/ci-container-dont-delete:latest",
-			},
+			// This is the same container as built by the dockerfile except it is pulled from the registry
+			"image": "registry.cloudflare.com/8d783f274e1f82dc46744c297b015a2f/ci-container-dont-delete:latest",
 			"class_name": "Container",
 			"name": "http2",
 			"max_instances": 2,

--- a/fixtures/shared/src/run-wrangler-long-lived.ts
+++ b/fixtures/shared/src/run-wrangler-long-lived.ts
@@ -136,5 +136,5 @@ async function runLongLivedWrangler(
 	}
 
 	const { ip, port } = await ready;
-	return { ip, port, stop, getOutput, clearOutput };
+	return { ip, port, stop, getOutput, clearOutput, wranglerProcess };
 }

--- a/packages/wrangler/e2e/containers.dev.test.ts
+++ b/packages/wrangler/e2e/containers.dev.test.ts
@@ -8,11 +8,8 @@ const wranglerConfig = {
 	compatibility_date: "2025-04-03",
 	containers: [
 		{
-			configuration: {
-				image: "./Dockerfile",
-			},
+			image: "./Dockerfile",
 			class_name: "Container",
-			name: "http2",
 			max_instances: 2,
 		},
 	],
@@ -32,6 +29,17 @@ const wranglerConfig = {
 	],
 };
 
+const wranglerConfigWithRegistry = {
+	...wranglerConfig,
+	containers: [
+		{
+			image:
+				"registry.cloudflare.com/8d783f274e1f82dc46744c297b015a2f/ci-container-dont-delete:latest",
+			class_name: "Container",
+			max_instances: 2,
+		},
+	],
+};
 // TODO: docker is not installed by default on macOS runners in github actions.
 // And windows is being difficult.
 // So we skip these tests in CI, and test this locally for now :/
@@ -67,10 +75,20 @@ describe.skipIf(process.platform !== "linux" && process.env.CI === "true")(
 					`,
 			});
 		});
-		it(`will build containers when miniflare starts`, async () => {
+		it(`will build containers when dev starts if image field is a dockerfile`, async () => {
 			const worker = helper.runLongLived("wrangler dev");
 			await worker.readUntil(/Preparing container/);
 			await worker.readUntil(/DONE/);
+			// from miniflare output:
+			await worker.readUntil(/Container image\(s\) ready/);
+		});
+
+		it(`will pull containers when dev starts if image field is a registry uri`, async () => {
+			await helper.seed({
+				"wrangler.json": JSON.stringify(wranglerConfigWithRegistry),
+			});
+			const worker = helper.runLongLived("wrangler dev");
+			await worker.readUntil(/Preparing container/);
 			// from miniflare output:
 			await worker.readUntil(/Container image\(s\) ready/);
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,10 @@ importers:
         version: link:../../packages/wrangler
 
   fixtures/container-app:
+    dependencies:
+      '@cloudflare/containers':
+        specifier: ^0.0.13
+        version: 0.0.13
     devDependencies:
       '@cloudflare/workers-tsconfig':
         specifier: workspace:*
@@ -4125,6 +4129,9 @@ packages:
       '@cloudflare/style-const': ^5.7.2
       '@cloudflare/style-container': ^7.10.0
       react: ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0
+
+  '@cloudflare/containers@0.0.13':
+    resolution: {integrity: sha512-qFO2ApEJGRfLlsOqK3ZkvpU3bl7Pj1SquXHs/uEgmK1FTBf2R908T8v7TUlxZpzaJbMM7rLRoCqT0vfUthRqWA==}
 
   '@cloudflare/elements@3.0.3':
     resolution: {integrity: sha512-s6Sjh+IWJD0xn+4iy6hk/FYwY1gAFLWvpiWUmfDZWrQ09ZOTto8aRwpoEN7jUV6dZCPlCkUqMj4xKwRzDQ72FQ==}
@@ -14149,6 +14156,8 @@ snapshots:
       react: 18.3.1
     transitivePeerDependencies:
       - regenerator-runtime
+
+  '@cloudflare/containers@0.0.13': {}
 
   '@cloudflare/elements@3.0.3(@cloudflare/style-const@5.7.3(react@18.3.1))(@cloudflare/style-container@7.12.2(@cloudflare/style-const@5.7.3(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
adds tests for basic container interactions to containers that are built and pulled.

TODO:
rebuild hotkey tests

would like to test the container class too but maybe best to set something up on that repo directly?

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
