### PR TITLE
containers: Throw a better error when there is no containers scope in the API token

### DIFF
--- a/.changeset/busy-planets-accept.md
+++ b/.changeset/busy-planets-accept.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+containers: Check for container scopes before running a container command to give a better error

--- a/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/build.test.ts
@@ -42,7 +42,6 @@ describe("buildAndMaybePush", () => {
 	runInTempDir();
 	mockApiToken();
 	mockAccountId();
-	mockAccount();
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -51,6 +50,7 @@ describe("buildAndMaybePush", () => {
 		mkdirSync("./container-context");
 
 		writeFileSync("./container-context/Dockerfile", dockerfile);
+		mockAccount();
 	});
 	afterEach(() => {
 		vi.clearAllMocks();

--- a/packages/wrangler/src/__tests__/cloudchamber/utils.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/utils.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as TOML from "@iarna/toml";
 import { http, HttpResponse } from "msw";
+import * as user from "../../user";
 import { msw } from "../helpers/msw";
 import type { CloudchamberConfig } from "../../config/environment";
 
@@ -17,6 +18,9 @@ export function setWranglerConfig(cloudchamber: CloudchamberConfig) {
 }
 
 export function mockAccount() {
+	const spy = vi.spyOn(user, "getScopes");
+	spy.mockImplementationOnce(() => ["cloudchamber:write", "containers:write"]);
+
 	msw.use(
 		http.get(
 			"*/me",
@@ -33,7 +37,10 @@ export function mockAccount() {
 	);
 }
 
-export function mockAccountV4() {
+export function mockAccountV4(scopes: user.Scope[] = ["containers:write"]) {
+	const spy = vi.spyOn(user, "getScopes");
+	spy.mockImplementationOnce(() => scopes);
+
 	msw.use(
 		http.get(
 			"*/me",

--- a/packages/wrangler/src/__tests__/containers/info.test.ts
+++ b/packages/wrangler/src/__tests__/containers/info.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import patchConsole from "patch-console";
+import * as user from "../../user";
 import { mockAccount, setWranglerConfig } from "../cloudchamber/utils";
 import { mockAccountId, mockApiToken } from "../helpers/mock-account-id";
 import { mockConsoleMethods } from "../helpers/mock-console";
@@ -43,6 +44,19 @@ describe("containers info", () => {
 			OPTIONS
 			      --json  Return output as clean JSON  [boolean] [default: false]"
 		`);
+	});
+
+	it("should show the correct authentication error", async () => {
+		const spy = vi.spyOn(user, "getScopes");
+		spy.mockReset();
+		spy.mockImplementationOnce(() => []);
+		setIsTTY(false);
+		setWranglerConfig({});
+		await expect(
+			runWrangler("containers info asdf")
+		).rejects.toThrowErrorMatchingInlineSnapshot(
+			`[Error: You need 'containers:write', try logging in again or creating an appropiate API token]`
+		);
 	});
 
 	it("should show a single container when given an ID (json)", async () => {

--- a/packages/wrangler/src/cloudchamber/common.ts
+++ b/packages/wrangler/src/cloudchamber/common.ts
@@ -17,7 +17,7 @@ import { getCloudflareApiBaseUrl } from "../environment-variables/misc-variables
 import { UserError } from "../errors";
 import { isNonInteractiveOrCI } from "../is-interactive";
 import { logger } from "../logger";
-import { requireApiToken, requireAuth } from "../user";
+import { getScopes, printScopes, requireApiToken, requireAuth } from "../user";
 import { printWranglerBanner } from "../wrangler-banner";
 import { parseByteSize } from "./../parse";
 import { wrap } from "./helpers/wrap";
@@ -200,6 +200,15 @@ export async function fillOpenAPIConfiguration(
 
 	const accountId = await requireAuth(config);
 	const auth = requireApiToken();
+	const scopes = getScopes();
+	if (!scopes?.includes(scope)) {
+		logger.error(`You don't have '${scope}' in your list of scopes`);
+		printScopes(scopes ?? []);
+		throw new UserError(
+			`You need '${scope}', try logging in again or creating an appropiate API token`
+		);
+	}
+
 	addAuthorizationHeaderIfUnspecified(headers, auth);
 	addUserAgent(headers);
 

--- a/packages/wrangler/src/user/user.ts
+++ b/packages/wrangler/src/user/user.ts
@@ -1206,11 +1206,7 @@ export async function logout(): Promise<void> {
 
 export function listScopes(message = "💁 Available scopes:"): void {
 	logger.log(message);
-	const data = DefaultScopeKeys.map((scope: Scope) => ({
-		Scope: scope,
-		Description: DefaultScopes[scope],
-	}));
-	logger.table(data);
+	printScopes(DefaultScopeKeys);
 	// TODO: maybe a good idea to show usage here
 }
 
@@ -1322,6 +1318,15 @@ export function getAccountFromCache():
  */
 export function getScopes(): Scope[] | undefined {
 	return LocalState.scopes;
+}
+
+export function printScopes(scopes: Scope[]) {
+	const data = scopes.map((scope: Scope) => ({
+		Scope: scope,
+		Description: DefaultScopes[scope],
+	}));
+
+	logger.table(data);
 }
 
 /**


### PR DESCRIPTION
Fixes CC-5532

Show a more descriptive error when scopes are not present in the API token.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [x] Required
  - [ ] Not required because:
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: fix
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: containers is not in v3
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
