### PR TITLE
Make Wrangler warn more loudly if you're missing auth scopes

### DIFF
--- a/.changeset/thick-meals-cheat.md
+++ b/.changeset/thick-meals-cheat.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Make Wrangler warn more loudly if you're missing auth scopes

--- a/packages/wrangler/src/__tests__/whoami.test.ts
+++ b/packages/wrangler/src/__tests__/whoami.test.ts
@@ -246,8 +246,30 @@ describe("whoami", () => {
 			├─┼─┤
 			│ Account Three │ account-3 │
 			└─┴─┘
-			🔓 Token Permissions: If scopes are missing, you may need to logout and re-login.
+			🔓 Token Permissions:
 			Scope (Access)
+
+			[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWrangler is missing some expected Oauth scopes. To fix this, run \`wrangler login\` to refresh your token. The missing scopes are:[0m
+
+			  - account:read
+			  - user:read
+			  - workers:write
+			  - workers_kv:write
+			  - workers_routes:write
+			  - workers_scripts:write
+			  - workers_tail:read
+			  - d1:write
+			  - pages:write
+			  - zone:read
+			  - ssl_certs:write
+			  - ai:write
+			  - queues:write
+			  - pipelines:write
+			  - secrets_store:write
+			  - containers:write
+			  - cloudchamber:write
+
+
 			🎢 Membership roles in \\"Account Two\\": Contact account super admin to change your permissions.
 			- Test role"
 		`);
@@ -280,8 +302,30 @@ describe("whoami", () => {
 			├─┼─┤
 			│ Account Three │ account-3 │
 			└─┴─┘
-			🔓 Token Permissions: If scopes are missing, you may need to logout and re-login.
+			🔓 Token Permissions:
 			Scope (Access)
+
+			[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mWrangler is missing some expected Oauth scopes. To fix this, run \`wrangler login\` to refresh your token. The missing scopes are:[0m
+
+			  - account:read
+			  - user:read
+			  - workers:write
+			  - workers_kv:write
+			  - workers_routes:write
+			  - workers_scripts:write
+			  - workers_tail:read
+			  - d1:write
+			  - pages:write
+			  - zone:read
+			  - ssl_certs:write
+			  - ai:write
+			  - queues:write
+			  - pipelines:write
+			  - secrets_store:write
+			  - containers:write
+			  - cloudchamber:write
+
+
 			🎢 Unable to get membership roles. Make sure you have permissions to read the account. Are you missing the \`User->Memberships->Read\` permission?"
 		`);
 	});

--- a/packages/wrangler/src/cloudchamber/build.ts
+++ b/packages/wrangler/src/cloudchamber/build.ts
@@ -190,7 +190,7 @@ export async function buildAndMaybePush(
 		return { image: imageTag, pushed: pushed };
 	} catch (error) {
 		if (error instanceof Error) {
-			throw new UserError(error.message);
+			throw new UserError(error.message, { cause: error });
 		}
 		throw new UserError("An unknown error occurred");
 	}

--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import os from "node:os";
 import { setTimeout } from "node:timers/promises";
 import { ApiError } from "@cloudflare/containers-shared";
@@ -1513,7 +1514,7 @@ export async function main(argv: string[]): Promise<void> {
 		} else if (
 			isAuthenticationError(e) ||
 			// Is this a Containers/Cloudchamber-based auth error?
-			// This is different because
+			// This is different because it uses a custom OpenAPI-based generated client
 			(e instanceof UserError &&
 				e.cause instanceof ApiError &&
 				e.cause.status === 403)
@@ -1523,6 +1524,7 @@ export async function main(argv: string[]): Promise<void> {
 			if (e.cause instanceof ApiError) {
 				logger.error(e.cause);
 			} else {
+				assert(isAuthenticationError(e));
 				logger.log(formatMessage(e));
 			}
 			const envAuth = getAuthFromEnv();

--- a/packages/wrangler/src/user/whoami.ts
+++ b/packages/wrangler/src/user/whoami.ts
@@ -3,9 +3,10 @@ import { fetchPagedListResult, fetchResult } from "../cfetch";
 import { isAuthenticationError } from "../deploy/deploy";
 import { getCloudflareComplianceRegion } from "../environment-variables/misc-variables";
 import { logger } from "../logger";
+import { formatMessage } from "../parse";
 import { fetchMembershipRoles } from "./membership";
-import { getAPIToken, getAuthFromEnv, getScopes } from ".";
-import type { ApiCredentials } from ".";
+import { DefaultScopeKeys, getAPIToken, getAuthFromEnv, getScopes } from ".";
+import type { ApiCredentials, Scope } from ".";
 import type { ComplianceConfig } from "../environment-variables/misc-variables";
 
 export async function whoami(
@@ -80,12 +81,29 @@ function printTokenPermissions(user: UserInfo) {
 			`🔓 To see token permissions visit https://dash.cloudflare.com/${user.authType === "User API Token" ? "profile" : user.accounts[0].id}/api-tokens.`
 		);
 	}
-	logger.log(
-		`🔓 Token Permissions: If scopes are missing, you may need to logout and re-login.`
-	);
+	logger.log(`🔓 Token Permissions:`);
 	logger.log(`Scope (Access)`);
+
+	// This Set contains all the scopes we expect to see (that Wrangler requests by default)
+	const expectedScopes = new Set(DefaultScopeKeys);
 	for (const [scope, access] of permissions) {
+		// We'll remove scopes from the set of scopes that we expect to see when we see them in the API response
+		expectedScopes.delete(`${scope}:${access}` as Scope);
 		logger.log(`- ${scope} ${access ? `(${access})` : ``}`);
+	}
+
+	// If we've iterated through all scopes in the API response and there are still expected scopes remaining,
+	// then we know that Wrangler may not behave as expected since the current token doesn't have all the expected scopes
+	// Warn, and tell the user how to fix it
+	if (expectedScopes.size > 0) {
+		logger.log("");
+		logger.log(
+			formatMessage({
+				text: "Wrangler is missing some expected Oauth scopes. To fix this, run `wrangler login` to refresh your token. The missing scopes are:",
+				kind: "warning",
+				notes: [...expectedScopes.values()].map((s) => ({ text: `- ${s}` })),
+			})
+		);
 	}
 }
 


### PR DESCRIPTION
Previously, when an authentication error was thrown, Wrangler would print out your Oauth token scopes with the passive message "If scopes are missing, you may need to logout and re-login." However, it was hard for users to know if scopes were missing, because users don't necessarily know what the right set of scopes are. 

As it turns out, Wrangler _does_ know what the set of scopes should be, so now we print out a much more actionable warning:
```
Wrangler is missing some expected Oauth scopes. To fix this, run \`wrangler login\` to refresh your token. The missing scopes are:
  - containers:write
```

Additionally, this fixes an issue where auth errors from Containers & Cloudchamber were not handled the same as other auth errors, because of the custom API client that those code paths use.

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [x] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: covered by unit tests
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: messaging improvement
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: in progress, but I don't want to block this PR
<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
