### PR TITLE
add permissions to github workflows

### DIFF
--- a/.github/workflows/c3-dependabot-versioning-prs.yml
+++ b/.github/workflows/c3-dependabot-versioning-prs.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - "packages/create-cloudflare/src/frameworks/package.json"
 
+permissions:
+  contents: write
+
 jobs:
   generate-changeset:
     runs-on: ubuntu-22.04

--- a/.github/workflows/c3-dependabot-versioning-prs.yml
+++ b/.github/workflows/c3-dependabot-versioning-prs.yml
@@ -5,6 +5,8 @@ on:
       - "packages/create-cloudflare/src/frameworks/package.json"
 
 permissions:
+  # content:write permission needed to update add changesets to dependabot PRs
+  # (see tools/dependabot/generate-dependabot-pr-changesets.ts)
   contents: write
 
 jobs:

--- a/.github/workflows/c3-e2e.yml
+++ b/.github/workflows/c3-e2e.yml
@@ -3,6 +3,9 @@ on:
   merge_group:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   # TODO: switch back to 20.x onces node@20.x includes a fix for https://github.com/nodejs/node/issues/57869
   NODE_VERSION: 22

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 permissions:
+  # content:write and pull-request:write permissions needed to create changeset PRs
   contents: write
   pull-requests: write
 

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -6,9 +6,8 @@ on:
       - main
 
 permissions:
-  # content:write and pull-request:write permissions needed to create changeset PRs
-  contents: write
-  pull-requests: write
+  contents: read
+  # note: no write permissions are needed since the workflow uses GH_ACCESS_TOKEN instead of GITHUB_TOKEN
 
 jobs:
   release:

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     if: ${{ github.repository_owner == 'cloudflare' }}

--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  # pull-request:write permission needed so that the workflow can comment on PRs
   pull-requests: write
 
 jobs:

--- a/.github/workflows/deploy-pages-previews.yml
+++ b/.github/workflows/deploy-pages-previews.yml
@@ -20,6 +20,10 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   deploy-pages-projects:
     # Only run this on PRs that are for the "cloudflare" org and not "from" `main`

--- a/.github/workflows/e2e-project-cleanup.yml
+++ b/.github/workflows/e2e-project-cleanup.yml
@@ -1,10 +1,15 @@
 # This workflow cleans up any leftover projects created by e2e runs.
 
 name: E2E Project Cleanup
+
 on:
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * *" # Run at 3am each day
+
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     timeout-minutes: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,9 @@ on:
   merge_group:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-wrangler-test:
     name: ${{ format('Wrangler ({0})', matrix.description) }}

--- a/.github/workflows/holopin.yml
+++ b/.github/workflows/holopin.yml
@@ -6,6 +6,7 @@ on:
       - labeled
 
 permissions:
+  # pull-request:write permission needed so that the workflow can comment on PRs
   pull-requests: write
 
 jobs:

--- a/.github/workflows/holopin.yml
+++ b/.github/workflows/holopin.yml
@@ -5,6 +5,9 @@ on:
       - closed
       - labeled
 
+permissions:
+  pull-requests: write
+
 jobs:
   issue_lava_lamp_holobyte:
     name: Issue Lava Lamp Holobyte

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -1,4 +1,5 @@
 name: Release a hotfix
+
 on:
   workflow_dispatch:
     inputs:
@@ -14,6 +15,10 @@ on:
         type: string
         default: hotfix
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   hotfix-release:
     name: Hotfix Release

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, transferred]
 
 permissions:
+  # issues:write permission needed so that the workflow can comment on issues
   issues: write
 
 jobs:

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, transferred]
 
+permissions:
+  issues: write
+
 jobs:
   add-to-project:
     name: Add issue to project

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, transferred]
 
 permissions:
-  # issues:write permission needed so that the workflow can comment on issues
+  # issues:write permission needed so that the workflow can manage issues
   issues: write
 
 jobs:

--- a/.github/workflows/miniflare-dependabot-versioning-prs.yml
+++ b/.github/workflows/miniflare-dependabot-versioning-prs.yml
@@ -1,8 +1,13 @@
 name: "Miniflare - Generate changesets for dependabot PRs"
+
 on:
   pull_request_target:
     paths:
       - "packages/miniflare/package.json"
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   generate-changeset:

--- a/.github/workflows/miniflare-dependabot-versioning-prs.yml
+++ b/.github/workflows/miniflare-dependabot-versioning-prs.yml
@@ -6,8 +6,9 @@ on:
       - "packages/miniflare/package.json"
 
 permissions:
+  # content:write permission needed to update add changesets to dependabot PRs
+  # (see tools/dependabot/generate-dependabot-pr-changesets.ts)
   contents: write
-  pull-requests: write
 
 jobs:
   generate-changeset:

--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -9,6 +9,7 @@ on:
       - ".changeset/**.md"
 
 permissions:
+  # content:write and pull-request:write permissions needed to create PRs
   contents: write
   pull-requests: write
 

--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -9,9 +9,8 @@ on:
       - ".changeset/**.md"
 
 permissions:
-  # content:write and pull-request:write permissions needed to create PRs
-  contents: write
-  pull-requests: write
+  contents: read
+  # note: no write permissions are needed since the workflow uses GH_ACCESS_TOKEN instead of GITHUB_TOKEN
 
 jobs:
   open-pr:

--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - ".changeset/**.md"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   open-pr:
     if: ${{

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,6 +10,9 @@ on:
       - next
       - v3-maintenance
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: ${{ github.repository_owner == 'cloudflare' }}

--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -1,4 +1,5 @@
 name: Run CI on behalf of External Forks
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,15 +13,16 @@ on:
         description: "Confirm that the PR has been reviewed for use/leakage of secrets"
         type: boolean
         required: true
+
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   create-draft-pr:
     name: Create Draft PR
     if: ${{ inputs.reviewed == true }}
     runs-on: ubuntu-latest
-    permissions:
-      # We use the default token to create the draft PR only
-      pull-requests: write
-      contents: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -15,6 +15,7 @@ on:
         required: true
 
 permissions:
+  # content:write and pull-request:write permissions needed to create PRs
   pull-requests: write
   contents: write
 

--- a/.github/workflows/run-ci-for-external-forks.yml
+++ b/.github/workflows/run-ci-for-external-forks.yml
@@ -15,9 +15,8 @@ on:
         required: true
 
 permissions:
-  # content:write and pull-request:write permissions needed to create PRs
-  pull-requests: write
-  contents: write
+  contents: read
+  # note: no write permissions are needed since the workflow uses GH_ACCESS_TOKEN instead of GITHUB_TOKEN
 
 jobs:
   create-draft-pr:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,8 +1,13 @@
+name: Semgrep config
+
 on:
   workflow_dispatch: {}
   schedule:
     - cron: "0 0 * * *"
-name: Semgrep config
+
+permissions:
+  contents: read
+
 jobs:
   semgrep:
     name: semgrep/ci

--- a/.github/workflows/test-and-check.yml
+++ b/.github/workflows/test-and-check.yml
@@ -4,6 +4,9 @@ on:
   merge_group:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     if: github.head_ref != 'changeset-release/main'

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -14,6 +14,9 @@ on:
         converted_to_draft,
       ]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     # Don't check the Version Packages PR

--- a/.github/workflows/worker-playground-preview-testing-env-deploy-and-test.yml
+++ b/.github/workflows/worker-playground-preview-testing-env-deploy-and-test.yml
@@ -16,9 +16,11 @@ on:
       - main
     paths:
       - "packages/playground-preview-worker/**"
-
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
 
 jobs:
   e2e-test:

--- a/.github/workflows/workers-shared-deploy-production.yml
+++ b/.github/workflows/workers-shared-deploy-production.yml
@@ -3,6 +3,9 @@ name: Deploy Workers Shared Production
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy-workers:
     name: Deploy Workers Shared Production

--- a/.github/workflows/workers-shared-deploy-staging.yml
+++ b/.github/workflows/workers-shared-deploy-staging.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - "packages/workers-shared/**"
 
+permissions:
+  contents: read
+
 jobs:
   deploy-workers:
     name: "Deploy Workers Shared Staging"


### PR DESCRIPTION
Fixes https://github.com/cloudflare/workers-sdk/security/code-scanning/173

update all the github workflows to specify the set of permissions they require, ensuring that each workflow includes the least privileges it required to complete the task

> [!Note]
> Hopefully I got everything right but it's tough to test the changes and be 100% sure (since the changes also only apply after merge), so there is a non zero chance that this might break some workflows, I'll monitor things for a few days after the PR is merged and if something does break I'll fix it right away

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: ci change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: ci change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: ci change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: ci change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
