### PR TITLE
update change version of changest from `patch` to `minor`

### DIFF
--- a/.changeset/thick-dots-sit.md
+++ b/.changeset/thick-dots-sit.md
@@ -1,5 +1,5 @@
 ---
-"wrangler": patch
+"wrangler": minor
 ---
 
 add support for assets bindings to `getPlatformProxy`


### PR DESCRIPTION
This change might be considered a minor / feature addition since it's adding support for assets in `getPlatformProxy`, so I am updating that here (I think it can also be considered a patch since it is fixing assets not working in `getPlatformProxy`, but in that case maybe the changeset needs a bit of a rewording, I am happy with either)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] TODO (before merge)
  - [ ] Tests included
  - [x] Tests not necessary because: changeset change
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [ ] I don't know
  - [ ] Required
  - [x] Not required because: changeset change
- Public documentation
  - [ ] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: changeset change
- Wrangler V3 Backport
  - [ ] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: changeset change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
