### PR TITLE
clarify and ensure that for local e2e any account can be used

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,7 +353,8 @@ WRANGLER="node ~/path/to/workers-sdk/packages/wrangler/wrangler-dist/cli.js" CLO
 1. Go to ["My Profile" > "User API Tokens"](https://dash.cloudflare.com/profile/api-tokens)
 1. Click "Create Token"
 1. Use the "Edit Cloudflare Workers" template
-1. Set "Account Resources" to "Include" "DevProd Testing" (you can use any account you have access to)
+1. Set "Account Resources" to "Include" the account you want to use for running the test
+   (Note for the internal wrangler team, here we use the "DevProd Testing" account)
 1. Set "Zone Resources" to "All zones from an account" and the same account as above
 1. Click "Continue to summary"
 1. Verify your token works by running the curl command provided

--- a/packages/wrangler/e2e/validate-environment.ts
+++ b/packages/wrangler/e2e/validate-environment.ts
@@ -15,9 +15,4 @@ assert(
 	"You must provide a CLOUDFLARE_API_TOKEN as an environment variable"
 );
 
-assert(
-	process.env.CLOUDFLARE_ACCOUNT_ID === "8d783f274e1f82dc46744c297b015a2f",
-	"You must run Wrangler's e2e tests against DevProd Testing"
-);
-
 export const setup = () => {};


### PR DESCRIPTION
in the CONTRIBUTING.md document clarify the fact that any account can be used to create an API token for the tests (instead of suggesting to use DevProd Testing account alongise saying that other accounts can be used as well)

as part of this remove the unnecessary validation check that ensures that the account being used for the tests is the DevProd Testing one (since this is not really necessary)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: md change
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: md change
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: md change

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
