### PR TITLE
Fix the v3 backport message to use v3-backport-PR

### DIFF
--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           header: v3-backport
           message: |
-            These changes have been automatically backported to Wrangler v3 :tada: You can view the automatically updated PR at https://github.com/cloudflare/workers-sdk/compare/v3-maintenance...v3-maintenance-${{ github.event.number }}. Please check that PR for correctness, and make sure it's merged after this one. Thank you for helping us keep Wrangler v3 supported!
+            These changes have been automatically backported to Wrangler v3 :tada: You can view the v3 changes at https://github.com/cloudflare/workers-sdk/compare/v3-maintenance...v3-backport-${{ github.event.number }}. Please check that diff for correctness, create a PR if it looks good, and make sure it's merged after this one. Thank you for helping us keep Wrangler v3 supported!

--- a/.github/workflows/open-v3-maintenance-prs.yml
+++ b/.github/workflows/open-v3-maintenance-prs.yml
@@ -63,4 +63,4 @@ jobs:
         with:
           header: v3-backport
           message: |
-            These changes have been automatically backported to Wrangler v3 :tada: You can view the v3 changes at https://github.com/cloudflare/workers-sdk/compare/v3-maintenance...v3-backport-${{ github.event.number }}. Please check that diff for correctness, create a PR if it looks good, and make sure it's merged after this one. Thank you for helping us keep Wrangler v3 supported!
+            These changes have been automatically backported to Wrangler v3 :tada: You can view the automatically updated PR at https://github.com/cloudflare/workers-sdk/compare/v3-maintenance...v3-backport-${{ github.event.number }}. Please check that PR for correctness, and make sure it's merged after this one. Thank you for helping us keep Wrangler v3 supported!

--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -6,11 +6,10 @@ import parseChangeset from "@changesets/parse";
 if (require.main === module) {
 	if (isWranglerPatch(process.env.FILES as string)) {
 		// Create a new branch for the v3 maintenance PR
-		execSync(`git checkout -b v3-backport-${process.env.PR_NUMBER} -f`);
+		const branch = `v3-backport-${process.env.PR_NUMBER}`;
+		execSync(`git checkout -b ${branch} -f`);
 
-		execSync(
-			`git rebase --onto origin/v3-maintenance origin/main v3-backport-${process.env.PR_NUMBER}`
-		);
+		execSync(`git rebase --onto origin/v3-maintenance origin/main ${branch}`);
 
 		execSync(`git push origin HEAD --force`);
 
@@ -23,7 +22,7 @@ if (require.main === module) {
 					`create`,
 					`--base`,
 					`v3-maintenance`,
-					`--head v3-backport-${process.env.PR_NUMBER}`,
+					`--head ${branch}`,
 					`--label "skip-pr-description-validation"`,
 					`--label "skip-v3-pr"`,
 					`--label "v3-backport"`,

--- a/tools/deployments/open-v3-pr.ts
+++ b/tools/deployments/open-v3-pr.ts
@@ -23,7 +23,7 @@ if (require.main === module) {
 					`create`,
 					`--base`,
 					`v3-maintenance`,
-					`--head v3-maintenance-${process.env.PR_NUMBER}`,
+					`--head v3-backport-${process.env.PR_NUMBER}`,
 					`--label "skip-pr-description-validation"`,
 					`--label "skip-v3-pr"`,
 					`--label "v3-backport"`,


### PR DESCRIPTION
Ref the correct branch + ~clarify that the PR should be manually created.~(that was a bug fixed in the follow up commit - we tried to create a PR from the wrong branch using v3-maintenance-... instead of v3-backport-...)

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because: CI
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: not needed
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: CI

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->