### PR TITLE
Containers: Ensure updating only the image URI updates app config

### DIFF
--- a/.changeset/metal-aliens-tell.md
+++ b/.changeset/metal-aliens-tell.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Containers: Fix issue where setting an image URI instead of dockerfile would incorrectly not update the image

--- a/packages/wrangler/src/__tests__/cloudchamber/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/cloudchamber/deploy.test.ts
@@ -1,0 +1,18 @@
+import { maybeBuildContainer } from "../../cloudchamber/deploy";
+
+describe("maybeBuildContainer", () => {
+	it("Should return imageUpdate: true if using an image URI", async () => {
+		const config = {
+			image: "registry.cloudflare.com/some-account-id/some-image:uri",
+			class_name: "Test",
+		};
+		const result = await maybeBuildContainer(
+			config,
+			"some-tag:thing",
+			false,
+			"/usr/bin/docker"
+		);
+		expect(result.image).toEqual(config.image);
+		expect(result.imageUpdated).toEqual(true);
+	});
+});

--- a/packages/wrangler/src/cloudchamber/deploy.ts
+++ b/packages/wrangler/src/cloudchamber/deploy.ts
@@ -18,7 +18,7 @@ export async function maybeBuildContainer(
 	imageTag: string,
 	dryRun: boolean,
 	pathToDocker: string
-): Promise<{ image: string; pushed: boolean }> {
+): Promise<{ image: string; imageUpdated: boolean }> {
 	try {
 		if (
 			!isDockerfile(
@@ -27,7 +27,10 @@ export async function maybeBuildContainer(
 		) {
 			return {
 				image: containerConfig.image ?? containerConfig.configuration?.image,
-				pushed: false,
+				// We don't know at this point whether the image was updated or not
+				// but we need to make sure downstream checks if it was updated so
+				// we set this to true.
+				imageUpdated: true,
 			};
 		}
 	} catch (err) {
@@ -46,7 +49,8 @@ export async function maybeBuildContainer(
 		!dryRun,
 		containerConfig
 	);
-	return buildResult;
+
+	return { image: buildResult.image, imageUpdated: buildResult.pushed };
 }
 
 export type DeployContainersArgs = {
@@ -128,7 +132,7 @@ export async function deployContainers(
 				skipDefaults: false,
 				json: true,
 				env,
-				imageUpdateRequired: buildResult.pushed,
+				imageUpdateRequired: buildResult.imageUpdated,
 			},
 			configuration
 		);


### PR DESCRIPTION
It was incorrectly marking the image as un-updated before resulting in being unable to update the image for a container application when using an image URI directly.

Added some basic unit tests to cover this behavior.

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] Tests included
  - [ ] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Bug fix
- Wrangler V3 Backport
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [x] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...--> v4 only feature.

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
